### PR TITLE
 LibWeb: Handle duplicate animation-name entries

### DIFF
--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -273,11 +273,6 @@ void Animatable::Impl::visit_edges(JS::Cell::Visitor& visitor)
     }
 }
 
-void Animatable::set_has_css_defined_animations()
-{
-    ensure_impl().has_css_defined_animations = true;
-}
-
 bool Animatable::has_css_defined_animations() const
 {
     if (!m_impl)
@@ -315,6 +310,7 @@ void Animatable::set_css_defined_animations(Optional<CSS::PseudoElement> pseudo_
                      .value_or(0);
 
     impl.css_defined_animations[index] = make<Vector<GC::Ref<CSS::CSSAnimation>>>(move(animations));
+    impl.has_css_defined_animations = true;
 }
 
 Animatable::Impl& Animatable::ensure_impl() const

--- a/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Libraries/LibWeb/Animations/Animatable.cpp
@@ -286,7 +286,7 @@ bool Animatable::has_css_defined_animations() const
     return m_impl->has_css_defined_animations;
 }
 
-HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* Animatable::css_defined_animations(Optional<CSS::PseudoElement> pseudo_element)
+Vector<GC::Ref<CSS::CSSAnimation>> const* Animatable::css_defined_animations(Optional<CSS::PseudoElement> pseudo_element)
 {
     auto& impl = ensure_impl();
 
@@ -298,9 +298,23 @@ HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* Animatable::css_defined_ani
                      .value_or(0);
 
     if (!impl.css_defined_animations[index])
-        impl.css_defined_animations[index] = make<HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>>();
+        impl.css_defined_animations[index] = make<Vector<GC::Ref<CSS::CSSAnimation>>>();
 
     return impl.css_defined_animations[index];
+}
+
+void Animatable::set_css_defined_animations(Optional<CSS::PseudoElement> pseudo_element, Vector<GC::Ref<CSS::CSSAnimation>>&& animations)
+{
+    auto& impl = ensure_impl();
+
+    if (pseudo_element.has_value() && !CSS::Selector::PseudoElementSelector::is_known_pseudo_element_type(pseudo_element.value()))
+        return;
+
+    auto index = pseudo_element
+                     .map([](CSS::PseudoElement pseudo_element_value) { return to_underlying(pseudo_element_value) + 1; })
+                     .value_or(0);
+
+    impl.css_defined_animations[index] = make<Vector<GC::Ref<CSS::CSSAnimation>>>(move(animations));
 }
 
 Animatable::Impl& Animatable::ensure_impl() const

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -49,7 +49,6 @@ public:
     void disassociate_with_animation(GC::Ref<Animation>);
     void on_document_changed(DOM::Document& old_document, DOM::Document& new_document);
 
-    void set_has_css_defined_animations();
     bool has_css_defined_animations() const;
     Vector<GC::Ref<CSS::CSSAnimation>> const* css_defined_animations(Optional<CSS::PseudoElement>);
     void set_css_defined_animations(Optional<CSS::PseudoElement>, Vector<GC::Ref<CSS::CSSAnimation>>&&);

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -53,7 +53,6 @@ public:
     bool has_css_defined_animations() const;
     HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* css_defined_animations(Optional<CSS::PseudoElement>);
     void add_css_animation(Utf16FlyString name, Optional<CSS::PseudoElement>, GC::Ref<CSS::CSSAnimation>);
-    void remove_css_animation(Utf16FlyString name, Optional<CSS::PseudoElement>);
 
     void add_transitioned_properties(Optional<CSS::PseudoElement>, Vector<CSS::TransitionProperties> const& transitions);
     Vector<CSS::PropertyID> property_ids_with_matching_transition_property_entry(Optional<CSS::PseudoElement>) const;

--- a/Libraries/LibWeb/Animations/Animatable.h
+++ b/Libraries/LibWeb/Animations/Animatable.h
@@ -51,8 +51,8 @@ public:
 
     void set_has_css_defined_animations();
     bool has_css_defined_animations() const;
-    HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* css_defined_animations(Optional<CSS::PseudoElement>);
-    void add_css_animation(Utf16FlyString name, Optional<CSS::PseudoElement>, GC::Ref<CSS::CSSAnimation>);
+    Vector<GC::Ref<CSS::CSSAnimation>> const* css_defined_animations(Optional<CSS::PseudoElement>);
+    void set_css_defined_animations(Optional<CSS::PseudoElement>, Vector<GC::Ref<CSS::CSSAnimation>>&&);
 
     void add_transitioned_properties(Optional<CSS::PseudoElement>, Vector<CSS::TransitionProperties> const& transitions);
     Vector<CSS::PropertyID> property_ids_with_matching_transition_property_entry(Optional<CSS::PseudoElement>) const;
@@ -74,7 +74,7 @@ private:
         bool is_sorted_by_composite_order { true };
         bool has_css_defined_animations { false };
 
-        mutable Array<OwnPtr<HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount) + 1> css_defined_animations;
+        mutable Array<OwnPtr<Vector<GC::Ref<CSS::CSSAnimation>>>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount) + 1> css_defined_animations;
         mutable Array<OwnPtr<Transition>, to_underlying(CSS::PseudoElement::KnownPseudoElementCount) + 1> transitions;
 
         ~Impl();

--- a/Libraries/LibWeb/Animations/Animation.h
+++ b/Libraries/LibWeb/Animations/Animation.h
@@ -136,9 +136,6 @@ public:
 
     TimeValue associated_effect_end() const;
 
-    Optional<CSS::AnimationPlayState> last_css_animation_play_state() const { return m_last_css_animation_play_state; }
-    void set_last_css_animation_play_state(CSS::AnimationPlayState state) { m_last_css_animation_play_state = state; }
-
 protected:
     Animation(JS::Realm&);
 
@@ -234,8 +231,6 @@ private:
     Optional<HTML::TaskID> m_pending_finish_microtask_id;
 
     Optional<TimeValue> m_saved_cancel_time;
-
-    Optional<CSS::AnimationPlayState> m_last_css_animation_play_state;
 };
 
 }

--- a/Libraries/LibWeb/CSS/CSSAnimation.cpp
+++ b/Libraries/LibWeb/CSS/CSSAnimation.cpp
@@ -50,8 +50,7 @@ int CSSAnimation::class_specific_composite_order(GC::Ref<Animations::Animation> 
 
         // 2. Otherwise, sort A and B based on their position in the computed value of the animation-name property of the
         //    (common) owning element.
-        // FIXME: Do this when animation-name supports multiple values
-        return 0;
+        return m_animation_name_index - other->m_animation_name_index;
     }
 
     // The composite order of CSS Animations without an owning element is based on their position in the global animation list.

--- a/Libraries/LibWeb/CSS/CSSAnimation.h
+++ b/Libraries/LibWeb/CSS/CSSAnimation.h
@@ -33,6 +33,9 @@ public:
 
     virtual void set_timeline_for_bindings(GC::Ptr<Animations::AnimationTimeline> timeline) override;
 
+    Optional<CSS::AnimationPlayState> last_css_animation_play_state() const { return m_last_css_animation_play_state; }
+    void set_last_css_animation_play_state(CSS::AnimationPlayState state) { m_last_css_animation_play_state = state; }
+
 private:
     explicit CSSAnimation(JS::Realm&);
 
@@ -48,6 +51,8 @@ private:
     EasingFunction m_default_easing { EasingFunction::ease() };
 
     HashTable<CSS::PropertyID> m_ignored_css_properties;
+
+    Optional<CSS::AnimationPlayState> m_last_css_animation_play_state;
 };
 
 }

--- a/Libraries/LibWeb/CSS/CSSAnimation.h
+++ b/Libraries/LibWeb/CSS/CSSAnimation.h
@@ -29,6 +29,8 @@ public:
 
     void apply_css_properties(AnimationProperties const&);
 
+    void set_animation_name_index(size_t index) { m_animation_name_index = index; }
+
     EasingFunction const& default_easing() const { return m_default_easing; }
 
     virtual void set_timeline_for_bindings(GC::Ptr<Animations::AnimationTimeline> timeline) override;
@@ -53,6 +55,8 @@ private:
     HashTable<CSS::PropertyID> m_ignored_css_properties;
 
     Optional<CSS::AnimationPlayState> m_last_css_animation_play_state;
+
+    size_t m_animation_name_index { 0 };
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1477,7 +1477,6 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
         effect->set_key_frame_set(resolve_keyframes());
 
         effect->set_target(abstract_element);
-        abstract_element.set_has_css_defined_animations();
         new_animations.append(animation);
     }
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1401,7 +1401,8 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
 
     HashTable<Utf16FlyString> defined_animation_names;
 
-    for (auto const& animation_properties : animation_definitions) {
+    for (size_t i = 0; i < animation_definitions.size(); ++i) {
+        auto const& animation_properties = animation_definitions[i];
         auto const& animation_name = animation_properties.name;
         defined_animation_names.set(animation_name);
 
@@ -1435,6 +1436,7 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
         if (auto const& existing_animation = element_animations->get(animation_properties.name); existing_animation.has_value()) {
             as<Animations::KeyframeEffect>(*existing_animation.value()->effect()).set_key_frame_set(resolve_keyframes());
             existing_animation.value()->apply_css_properties(animation_properties);
+            existing_animation.value()->set_animation_name_index(i);
             continue;
         }
 
@@ -1451,6 +1453,7 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
         animation->set_effect(effect);
 
         animation->apply_css_properties(animation_properties);
+        animation->set_animation_name_index(i);
 
         effect->set_key_frame_set(resolve_keyframes());
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1367,7 +1367,7 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
 
     auto& document = abstract_element.document();
 
-    auto* element_animations = abstract_element.css_defined_animations();
+    auto const* element_animations = abstract_element.css_defined_animations();
 
     // If we have a nullptr for element_animations it means that the pseudo element was invalid and thus we shouldn't apply animations
     if (!element_animations)
@@ -1399,12 +1399,21 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
         return in_display_none_subtree.value();
     };
 
-    HashTable<Utf16FlyString> defined_animation_names;
+    // The same @keyframes rule name may be repeated within an animation-name. Changes to the animation-name update
+    // existing animations by iterating over the new list of animations from last to first, and, for each animation,
+    // finding the last matching animation in the list of existing animations. If a match is found, the existing
+    // animation is updated using the animation properties corresponding to its position in the new list of animations,
+    // whilst maintaining its current playback time as described above. The matching animation is removed from the
+    // existing list of animations such that it will not match twice. If a match is not found, a new animation is
+    // created. As a result, updating animation-name from ‘a’ to ‘a, a’ will cause the existing animation for ‘a’ to
+    // become the second animation in the list and a new animation will be created for the first item in the list.
 
-    for (size_t i = 0; i < animation_definitions.size(); ++i) {
+    auto existing_animations = *element_animations;
+    Vector<GC::Ref<CSSAnimation>> new_animations;
+
+    for (size_t i = animation_definitions.size(); i-- > 0;) {
         auto const& animation_properties = animation_definitions[i];
         auto const& animation_name = animation_properties.name;
-        defined_animation_names.set(animation_name);
 
         auto find_keyframes = [&](GC::Ptr<DOM::ShadowRoot const> shadow_root) -> RefPtr<Animations::KeyframeEffect::KeyFrameSet const> {
             if (auto const* rule_cache = rule_cache_for_cascade_origin(CascadeOrigin::Author, {}, shadow_root)) {
@@ -1431,12 +1440,22 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
             return find_keyframes(nullptr);
         };
 
-        // Changes to the values of animation properties while the animation is running apply as if the animation had
-        // those values from when it began
-        if (auto const& existing_animation = element_animations->get(animation_properties.name); existing_animation.has_value()) {
-            as<Animations::KeyframeEffect>(*existing_animation.value()->effect()).set_key_frame_set(resolve_keyframes());
-            existing_animation.value()->apply_css_properties(animation_properties);
-            existing_animation.value()->set_animation_name_index(i);
+        Optional<size_t> existing_animation_index;
+
+        for (size_t i = existing_animations.size(); i-- > 0;) {
+            if (existing_animations[i]->animation_name() == animation_name) {
+                existing_animation_index = i;
+                break;
+            }
+        }
+
+        if (existing_animation_index.has_value()) {
+            auto existing_animation = existing_animations.take(*existing_animation_index);
+
+            as<Animations::KeyframeEffect>(*existing_animation->effect()).set_key_frame_set(resolve_keyframes());
+            existing_animation->apply_css_properties(animation_properties);
+            existing_animation->set_animation_name_index(i);
+            new_animations.append(existing_animation);
             continue;
         }
 
@@ -1459,17 +1478,19 @@ void StyleComputer::process_animation_definitions(ComputedProperties const& comp
 
         effect->set_target(abstract_element);
         abstract_element.set_has_css_defined_animations();
-        element_animations->set(animation_properties.name, animation);
+        new_animations.append(animation);
     }
 
     // Once an animation has started it continues until it ends or the animation-name is removed
-    for (auto const& existing_animation_name : element_animations->keys()) {
-        if (defined_animation_names.contains(existing_animation_name))
-            continue;
+    // NB: All animations that are matched by the new set of animations have been removed from `existing_animations` by
+    //     this point so any still in the Vector have had their animation-name entries removed.
+    for (auto const& existing_animation : existing_animations)
+        existing_animation->cancel(Animations::Animation::ShouldInvalidate::No);
 
-        element_animations->get(existing_animation_name).value()->cancel(Animations::Animation::ShouldInvalidate::No);
-        element_animations->remove(existing_animation_name);
-    }
+    // NB: We create animations in reverse definition order so flip it back.
+    new_animations.reverse();
+
+    abstract_element.set_css_defined_animations(move(new_animations));
 }
 
 static void collect_dimension_attribute(Vector<StyleProperty>& properties, DOM::Element const& element, Utf16FlyString const& attribute_name, CSS::PropertyID property_id)

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -237,11 +237,6 @@ Vector<GC::Ref<CSS::CSSAnimation>> const* AbstractElement::css_defined_animation
     return m_element->css_defined_animations(m_pseudo_element);
 }
 
-void AbstractElement::set_has_css_defined_animations()
-{
-    m_element->set_has_css_defined_animations();
-}
-
 void AbstractElement::set_css_defined_animations(Vector<GC::Ref<CSS::CSSAnimation>>&& animations)
 {
     m_element->set_css_defined_animations(m_pseudo_element, move(animations));

--- a/Libraries/LibWeb/DOM/AbstractElement.cpp
+++ b/Libraries/LibWeb/DOM/AbstractElement.cpp
@@ -232,7 +232,7 @@ CSS::StyleScope const& AbstractElement::style_scope() const
     return m_element->style_scope();
 }
 
-HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* AbstractElement::css_defined_animations() const
+Vector<GC::Ref<CSS::CSSAnimation>> const* AbstractElement::css_defined_animations() const
 {
     return m_element->css_defined_animations(m_pseudo_element);
 }
@@ -240,6 +240,11 @@ HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* AbstractElement::css_define
 void AbstractElement::set_has_css_defined_animations()
 {
     m_element->set_has_css_defined_animations();
+}
+
+void AbstractElement::set_css_defined_animations(Vector<GC::Ref<CSS::CSSAnimation>>&& animations)
+{
+    m_element->set_css_defined_animations(m_pseudo_element, move(animations));
 }
 
 }

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -58,8 +58,9 @@ public:
     CSS::CountersSet& ensure_counters_set();
     void set_counters_set(OwnPtr<CSS::CountersSet>&&);
 
-    HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>* css_defined_animations() const;
+    Vector<GC::Ref<CSS::CSSAnimation>> const* css_defined_animations() const;
     void set_has_css_defined_animations();
+    void set_css_defined_animations(Vector<GC::Ref<CSS::CSSAnimation>>&&);
 
     void visit(GC::Cell::Visitor& visitor) const;
 

--- a/Libraries/LibWeb/DOM/AbstractElement.h
+++ b/Libraries/LibWeb/DOM/AbstractElement.h
@@ -59,7 +59,6 @@ public:
     void set_counters_set(OwnPtr<CSS::CountersSet>&&);
 
     Vector<GC::Ref<CSS::CSSAnimation>> const* css_defined_animations() const;
-    void set_has_css_defined_animations();
     void set_css_defined_animations(Vector<GC::Ref<CSS::CSSAnimation>>&&);
 
     void visit(GC::Cell::Visitor& visitor) const;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5160,8 +5160,8 @@ void Element::play_or_cancel_animations_after_display_property_change()
 
     auto has_inclusive_ancestor_with_display_none_ignoring_animations = this->has_inclusive_ancestor_with_display_none_ignoring_animations();
 
-    auto play_or_cancel_depending_on_display = [&](HashMap<Utf16FlyString, GC::Ref<CSS::CSSAnimation>>& animations) {
-        for (auto& [_, animation] : animations) {
+    auto play_or_cancel_depending_on_display = [&](Vector<GC::Ref<CSS::CSSAnimation>> const& animations) {
+        for (auto& animation : animations) {
             if (has_inclusive_ancestor_with_display_none_ignoring_animations) {
                 animation->cancel();
             } else {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/CSSAnimation-compositeOrder.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/CSSAnimation-compositeOrder.tentative.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
-Fail	Animations are composited by their order in the animation-name property.
+2 Pass
+Pass	Animations are composited by their order in the animation-name property.
 Pass	Web-animation replaces CSS animation

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/CSSAnimation-compositeOrder.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/CSSAnimation-compositeOrder.tentative.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 2 tests
+
+1 Pass
+1 Fail
+Fail	Animations are composited by their order in the animation-name property.
+Pass	Web-animation replaces CSS animation

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Document-getAnimations.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Document-getAnimations.tentative.txt
@@ -2,15 +2,15 @@ Harness status: OK
 
 Found 18 tests
 
-11 Pass
-7 Fail
+12 Pass
+6 Fail
 Pass	getAnimations for non-animated content
 Pass	getAnimations for CSS Animations
 Pass	Order of CSS Animations - within an element unaffected by start time
 Pass	Order of CSS Animations - within an element
 Fail	Order of CSS Animations - across elements
 Fail	Order of CSS Animations - across and within elements
-Fail	Order of CSS Animations - markup-bound vs free animations
+Pass	Order of CSS Animations - markup-bound vs free animations
 Fail	Order of CSS Animations - free animation vs CSS Transitions
 Fail	Order of CSS Animations - free animations
 Fail	Order of CSS Animations and CSS Transitions

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Document-getAnimations.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Document-getAnimations.tentative.txt
@@ -1,0 +1,24 @@
+Harness status: OK
+
+Found 18 tests
+
+10 Pass
+8 Fail
+Pass	getAnimations for non-animated content
+Pass	getAnimations for CSS Animations
+Fail	Order of CSS Animations - within an element unaffected by start time
+Pass	Order of CSS Animations - within an element
+Fail	Order of CSS Animations - across elements
+Fail	Order of CSS Animations - across and within elements
+Fail	Order of CSS Animations - markup-bound vs free animations
+Fail	Order of CSS Animations - free animation vs CSS Transitions
+Fail	Order of CSS Animations - free animations
+Fail	Order of CSS Animations and CSS Transitions
+Pass	Finished but filling CSS Animations are returned
+Pass	Finished but not filling CSS Animations are not returned
+Pass	Yet-to-start CSS Animations are returned
+Pass	CSS Animations canceled via the API are not returned
+Pass	CSS Animations canceled and restarted via the API are returned
+Pass	pseudo element with replaced target does not affect animation ordering
+Pass	CSS Animations targetting (pseudo-)elements should have correct order after sorting
+Fail	CSS Animations targetting (pseudo-)elements should have correct order after sorting (::marker)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Document-getAnimations.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Document-getAnimations.tentative.txt
@@ -2,11 +2,11 @@ Harness status: OK
 
 Found 18 tests
 
-10 Pass
-8 Fail
+11 Pass
+7 Fail
 Pass	getAnimations for non-animated content
 Pass	getAnimations for CSS Animations
-Fail	Order of CSS Animations - within an element unaffected by start time
+Pass	Order of CSS Animations - within an element unaffected by start time
 Pass	Order of CSS Animations - within an element
 Fail	Order of CSS Animations - across elements
 Fail	Order of CSS Animations - across and within elements

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations-dynamic-changes.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations-dynamic-changes.tentative.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+2 Pass
+3 Fail
+Pass	Animations preserve their startTime when changed
+Pass	Updated Animations maintain their order in the list
+Fail	Only the startTimes of existing animations are preserved
+Fail	Animations are removed from the start of the list while preserving the state of existing Animations
+Fail	Animation state is preserved when interleaving animations in list

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations-dynamic-changes.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations-dynamic-changes.tentative.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-2 Pass
-3 Fail
+5 Pass
 Pass	Animations preserve their startTime when changed
 Pass	Updated Animations maintain their order in the list
-Fail	Only the startTimes of existing animations are preserved
-Fail	Animations are removed from the start of the list while preserving the state of existing Animations
-Fail	Animation state is preserved when interleaving animations in list
+Pass	Only the startTimes of existing animations are preserved
+Pass	Animations are removed from the start of the list while preserving the state of existing Animations
+Pass	Animation state is preserved when interleaving animations in list

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations.tentative.txt
@@ -1,0 +1,28 @@
+Harness status: OK
+
+Found 22 tests
+
+15 Pass
+7 Fail
+Pass	getAnimations for non-animated content
+Pass	getAnimations for CSS Animations
+Pass	getAnimations returns CSSAnimation objects for CSS Animations
+Pass	getAnimations for multi-property animations
+Fail	getAnimations for both CSS Animations and CSS Transitions at once
+Pass	getAnimations for CSS Animations that have finished
+Pass	getAnimations for CSS Animations that have finished but are forwards filling
+Pass	getAnimations for CSS Animations with animation-name: none
+Fail	getAnimations for CSS Animations with animation-name: missing
+Fail	getAnimations for CSS Animations where the @keyframes rule is added later
+Fail	getAnimations for CSS Animations with duplicated animation-name
+Pass	getAnimations for CSS Animations with empty keyframes rule
+Pass	getAnimations for CSS animations in delay phase
+Pass	getAnimations for zero-duration CSS Animations
+Pass	getAnimations returns objects with the same identity
+Pass	getAnimations for CSS Animations that are canceled
+Fail	getAnimations for CSS Animations follows animation-name order
+Fail	{ subtree: false } on a leaf element returns the element's animations and ignore pseudo-elements
+Pass	{ subtree: true } on a leaf element returns the element's animations and its pseudo-elements' animations
+Fail	{ subtree: false } on an element with a child returns only the element's animations
+Pass	{ subtree: true } on an element with a child returns animations from the element, its pseudo-elements, its child and its child pseudo-elements
+Pass	{ subtree: true } on an element with many descendants returns animations from all the descendants

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations.tentative.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 22 tests
 
-15 Pass
-7 Fail
+16 Pass
+6 Fail
 Pass	getAnimations for non-animated content
 Pass	getAnimations for CSS Animations
 Pass	getAnimations returns CSSAnimation objects for CSS Animations
@@ -20,7 +20,7 @@ Pass	getAnimations for CSS animations in delay phase
 Pass	getAnimations for zero-duration CSS Animations
 Pass	getAnimations returns objects with the same identity
 Pass	getAnimations for CSS Animations that are canceled
-Fail	getAnimations for CSS Animations follows animation-name order
+Pass	getAnimations for CSS Animations follows animation-name order
 Fail	{ subtree: false } on a leaf element returns the element's animations and ignore pseudo-elements
 Pass	{ subtree: true } on a leaf element returns the element's animations and its pseudo-elements' animations
 Fail	{ subtree: false } on an element with a child returns only the element's animations

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/Element-getAnimations.tentative.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 22 tests
 
-16 Pass
-6 Fail
+17 Pass
+5 Fail
 Pass	getAnimations for non-animated content
 Pass	getAnimations for CSS Animations
 Pass	getAnimations returns CSSAnimation objects for CSS Animations
@@ -14,7 +14,7 @@ Pass	getAnimations for CSS Animations that have finished but are forwards fillin
 Pass	getAnimations for CSS Animations with animation-name: none
 Fail	getAnimations for CSS Animations with animation-name: missing
 Fail	getAnimations for CSS Animations where the @keyframes rule is added later
-Fail	getAnimations for CSS Animations with duplicated animation-name
+Pass	getAnimations for CSS Animations with duplicated animation-name
 Pass	getAnimations for CSS Animations with empty keyframes rule
 Pass	getAnimations for CSS animations in delay phase
 Pass	getAnimations for zero-duration CSS Animations

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/event-dispatch.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/event-dispatch.tentative.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 32 tests
 
-26 Pass
-6 Fail
+27 Pass
+5 Fail
 Pass	Idle -> Active
 Fail	Idle -> After
 Pass	Before -> Active
@@ -35,4 +35,4 @@ Fail	Cancel the animation after clearing the target effect.
 Pass	Replacing a running animation should get animationcancel earlier than animationstart
 Pass	The cancel event should be fired before the new start event if both have the same position in the animation list
 Pass	The cancel event with an earlier position in animation list should be fired earlier
-Fail	The order of the cancel events follows the relative positions in the animation list at the point when they were cancelled
+Pass	The order of the cancel events follows the relative positions in the animation list at the point when they were cancelled

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/CSSAnimation-compositeOrder.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/CSSAnimation-compositeOrder.tentative.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Animation composite order</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-composite-order">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+@keyframes margin50 {
+  from {
+    margin-left: 50px;
+  }
+  to {
+    margin-left: 50px;
+  }
+}
+@keyframes margin100 {
+  from {
+    margin-left: 100px;
+  }
+  to {
+    margin-left: 100px;
+  }
+}
+</style>
+<div id="log"</div>
+<script>
+'use strict';
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'margin100 100s';
+  assert_equals(getComputedStyle(div).marginLeft, '100px');
+  div.style.animation = 'margin50 100s, margin100 100s';
+  // The margin should be unaffected by margin50 since it is named earlier
+  // in the animation list.
+  assert_equals(getComputedStyle(div).marginLeft, '100px');
+}, "Animations are composited by their order in the animation-name property.");
+
+promise_test(async t => {
+  const div = addDiv(t);
+  const animA = div.animate({margin: ["100px","100px"]}, 100000);
+  assert_equals(getComputedStyle(div).marginLeft, '100px');
+  div.style.animation = 'margin50 100s';
+  // Wait for animation starts
+  await animA.ready;
+  await waitForAnimationFrames(1);
+  assert_equals(getComputedStyle(div).marginLeft, '100px',
+                "A higher-priority animation is not overriden by a more recent"
+                + "one.");
+}, 'Web-animation replaces CSS animation');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/Document-getAnimations.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/Document-getAnimations.tentative.html
@@ -1,0 +1,444 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Document.getAnimations() for CSS animations</title>
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/#animation-composite-order">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+@keyframes animLeft {
+  to { left: 100px }
+}
+@keyframes animTop {
+  to { top: 100px }
+}
+@keyframes animBottom {
+  to { bottom: 100px }
+}
+@keyframes animRight {
+  to { right: 100px }
+}
+
+@keyframes anim1 {
+  to { left: 100px }
+}
+@keyframes anim2 {
+  to { top: 100px }
+}
+@keyframes anim3 {
+  to { bottom: 100px }
+}
+@keyframes anim4 {
+  to { right: 100px }
+}
+
+</style>
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  assert_equals(document.getAnimations().length, 0,
+    'getAnimations returns an empty sequence for a document'
+    + ' with no animations');
+}, 'getAnimations for non-animated content');
+
+test(t => {
+  const div = addDiv(t);
+
+  // Add an animation
+  div.style.animation = 'animLeft 100s';
+  assert_equals(document.getAnimations().length, 1,
+                'getAnimations returns a running CSS Animation');
+
+  // Add another animation
+  div.style.animation = 'animLeft 100s, animTop 100s';
+  assert_equals(document.getAnimations().length, 2,
+                'getAnimations returns two running CSS Animations');
+
+  // Remove both
+  div.style.animation = '';
+  assert_equals(document.getAnimations().length, 0,
+                'getAnimations returns no running CSS Animations');
+}, 'getAnimations for CSS Animations');
+
+test(t => {
+  const div = addDiv(t);
+  const animation1 = 'animLeft 100s'
+  const animation2 = 'animBottom 100s'
+  div.style.animation = animation1;
+  const animations1 = document.getAnimations();
+  assert_equals(animations1.length, 1,
+                'getAnimations returns all running CSS Animations');
+  div.style.animation = animation2 + ', ' + animation1;
+  const animations = document.getAnimations();
+  assert_equals(animations.length, 2,
+                'getAnimations returns all running CSS Animations');
+  assert_equals(animations[0].animationName, 'animBottom',
+                'Order of first animation returned');
+  assert_equals(animations[1].animationName, 'animLeft',
+                'Order of second animation returned');
+}, 'Order of CSS Animations - within an element unaffected by start time');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'animLeft 100s, animTop 100s, animRight 100s, ' +
+                        'animBottom 100s';
+
+  const animations = document.getAnimations();
+  assert_equals(animations.length, 4,
+                'getAnimations returns all running CSS Animations');
+  assert_equals(animations[0].animationName, 'animLeft',
+                'Order of first animation returned');
+  assert_equals(animations[1].animationName, 'animTop',
+                'Order of second animation returned');
+  assert_equals(animations[2].animationName, 'animRight',
+                'Order of third animation returned');
+  assert_equals(animations[3].animationName, 'animBottom',
+                'Order of fourth animation returned');
+}, 'Order of CSS Animations - within an element');
+
+test(t => {
+  const div1 = addDiv(t, { style: 'animation: animLeft 100s' });
+  const div2 = addDiv(t, { style: 'animation: animLeft 100s' });
+  const div3 = addDiv(t, { style: 'animation: animLeft 100s' });
+  const div4 = addDiv(t, { style: 'animation: animLeft 100s' });
+
+  let animations = document.getAnimations();
+  assert_equals(animations.length, 4,
+                'getAnimations returns all running CSS Animations');
+  assert_equals(animations[0].effect.target, div1,
+                'Order of first animation returned');
+  assert_equals(animations[1].effect.target, div2,
+                'Order of second animation returned');
+  assert_equals(animations[2].effect.target, div3,
+                'Order of third animation returned');
+  assert_equals(animations[3].effect.target, div4,
+                'Order of fourth animation returned');
+
+  // Order should be depth-first pre-order so add some depth as follows:
+  //
+  //      <parent>
+  //       /  |
+  //      2   3
+  //    /  \
+  //   1   4
+  //
+  // Which should give: 2, 1, 4, 3
+  div2.appendChild(div1);
+  div2.appendChild(div4);
+  animations = document.getAnimations();
+  assert_equals(animations[0].effect.target, div2,
+                'Order of first animation returned after tree surgery');
+  assert_equals(animations[1].effect.target, div1,
+                'Order of second animation returned after tree surgery');
+  assert_equals(animations[2].effect.target, div4,
+                'Order of third animation returned after tree surgery');
+  assert_equals(animations[3].effect.target, div3,
+                'Order of fourth animation returned after tree surgery');
+
+}, 'Order of CSS Animations - across elements');
+
+test(t => {
+  const div1 = addDiv(t, { style: 'animation: animLeft 100s, animTop 100s' });
+  const div2 = addDiv(t, { style: 'animation: animBottom 100s' });
+
+  let expectedResults = [ [ div1, 'animLeft' ],
+                            [ div1, 'animTop' ],
+                            [ div2, 'animBottom' ] ];
+  let animations = document.getAnimations();
+  assert_equals(animations.length, expectedResults.length,
+                'getAnimations returns all running CSS Animations');
+  animations.forEach((anim, i) => {
+    assert_equals(anim.effect.target, expectedResults[i][0],
+                  'Target of animation in position ' + i);
+    assert_equals(anim.animationName, expectedResults[i][1],
+                  'Name of animation in position ' + i);
+  });
+
+  // Modify tree structure and animation list
+  div2.appendChild(div1);
+  div1.style.animation = 'animLeft 100s, animRight 100s, animTop 100s';
+
+  expectedResults = [ [ div2, 'animBottom' ],
+                      [ div1, 'animLeft' ],
+                      [ div1, 'animRight' ],
+                      [ div1, 'animTop' ] ];
+  animations = document.getAnimations();
+  assert_equals(animations.length, expectedResults.length,
+                'getAnimations returns all running CSS Animations after ' +
+                'making changes');
+  animations.forEach((anim, i) => {
+    assert_equals(anim.effect.target, expectedResults[i][0],
+                  'Target of animation in position ' + i + ' after changes');
+    assert_equals(anim.animationName, expectedResults[i][1],
+                  'Name of animation in position ' + i + ' after changes');
+  });
+}, 'Order of CSS Animations - across and within elements');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s, animTop 100s' });
+  const animLeft = document.getAnimations()[0];
+  assert_equals(animLeft.animationName, 'animLeft',
+                'Originally, animLeft animation comes first');
+
+  // Pause: now we are ignoring animation-play-state.
+  animLeft.pause();
+
+  // Disassociate animLeft from markup and restart
+  div.style.animation = 'animTop 100s';
+
+  // The animation should be cancelled regardless of whether we are ignoring
+  // animation-play-state.
+  assert_equals(document.getAnimations().length, 1,
+      'one animation (animLeft) cancelled');
+  assert_equals(document.getAnimations()[0].animationName, 'animTop',
+      'only animTop remains');
+  animLeft.play();
+
+  const animations = document.getAnimations();
+  assert_equals(animations.length, 2,
+                'getAnimations returns markup-bound and free animations');
+  assert_equals(animations[0].animationName, 'animTop',
+                'Markup-bound animations come first');
+  assert_equals(animations[1].animationName, 'animLeft',
+      'Free animations come last');
+}, 'Order of CSS Animations - markup-bound vs free animations');
+
+test(t => {
+  // Add an animation first
+  const div = addDiv(t, { style: 'animation: animLeft 100s' });
+  const animLeft = document.getAnimations()[0];
+  // Disassociate animLeft from markup and restart
+  div.style.animation = '';
+  assert_equals(document.getAnimations().length, 0, "css animation cancelled");
+  animLeft.play();
+
+  div.style.top = '0px';
+  div.style.transition = 'all 100s';
+  flushComputedStyle(div);
+  // *Then* add a transition
+  div.style.top = '100px';
+  flushComputedStyle(div);
+
+  // Although the transition was added later, it should come first in the list
+  const animations = document.getAnimations();
+  assert_equals(animations.length, 2,
+                'Both CSS animations and transitions are returned');
+  assert_class_string(animations[0], 'CSSTransition', 'Transition comes first');
+  assert_equals(animations[1].animationName,
+      "animLeft", 'Free animations come last');
+}, 'Order of CSS Animations - free animation vs CSS Transitions');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s, animTop 100s' });
+  const animLeft = document.getAnimations()[0];
+  const animTop  = document.getAnimations()[1];
+
+  // Disassociate both animations from markup and restart in opposite order
+  div.style.animation = '';
+  assert_equals(document.getAnimations().length, 0, "animations are removed");
+  animTop.play();
+  animLeft.play();
+
+  const animations = document.getAnimations();
+  assert_equals(animations.length, 2,
+                'getAnimations returns free animations');
+  assert_equals(animations[0].animationName, "animTop",
+                'Free animations are returned in the order they are started');
+  assert_equals(animations[1].animationName, "animLeft",
+                'Animations started later are returned later');
+
+  // Restarting an animation should have no effect
+  animTop.cancel();
+  animTop.play();
+  assert_equals(document.getAnimations()[0], animTop,
+                'After restarting, the ordering of free animations' +
+                ' does not change');
+}, 'Order of CSS Animations - free animations');
+
+test(t => {
+  // Add an animation first
+  const div = addDiv(t, { style: 'animation: animLeft 100s' });
+  div.style.top = '0px';
+  div.style.transition = 'all 100s';
+  flushComputedStyle(div);
+
+  // *Then* add a transition
+  div.style.top = '100px';
+  flushComputedStyle(div);
+
+  // Although the transition was added later, it should come first in the list
+  const animations = document.getAnimations();
+  assert_equals(animations.length, 2,
+                'Both CSS animations and transitions are returned');
+  assert_class_string(animations[0], 'CSSTransition', 'Transition comes first');
+  assert_class_string(animations[1], 'CSSAnimation', 'Animation comes second');
+}, 'Order of CSS Animations and CSS Transitions');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s forwards' });
+  div.getAnimations()[0].finish();
+  assert_equals(document.getAnimations().length, 1,
+                'Forwards-filling CSS animations are returned');
+}, 'Finished but filling CSS Animations are returned');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s' });
+  div.getAnimations()[0].finish();
+  assert_equals(document.getAnimations().length, 0,
+                'Non-filling finished CSS animations are not returned');
+}, 'Finished but not filling CSS Animations are not returned');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s 100s' });
+  assert_equals(document.getAnimations().length, 1,
+                'Yet-to-start CSS animations are returned');
+}, 'Yet-to-start CSS Animations are returned');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s' });
+  div.getAnimations()[0].cancel();
+  assert_equals(document.getAnimations().length, 0,
+                'CSS animations canceled by the API are not returned');
+}, 'CSS Animations canceled via the API are not returned');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: animLeft 100s' });
+  const anim = div.getAnimations()[0];
+  anim.cancel();
+  anim.play();
+  assert_equals(document.getAnimations().length, 1,
+                'CSS animations canceled and restarted by the API are ' +
+                'returned');
+}, 'CSS Animations canceled and restarted via the API are returned');
+
+test(t => {
+  addStyle(t, {
+      '#parent::after': "content: ''; animation: anim1 100s ; ",
+      '#parent::before': "content: ''; animation: anim2 100s;",
+      '#child::after': "content: ''; animation: anim3 100s;",
+      '#child::before': "content: ''; animation: anim4 100s;",
+    });
+  const parent = addDiv(t, { id: 'parent' });
+  const child = addDiv(t, { id: 'child'});
+  parent.appendChild(child);
+  var animations = document.getAnimations();
+  var expectedAnimations = [
+      [parent, '::before', 'anim2'],
+      [parent, '::after', 'anim1'],
+      [child, '::before', 'anim4'],
+      [child, '::after', 'anim3'],
+    ];
+  pseudoAnimCompare(animations, expectedAnimations)
+
+  // Swap animation1 and aimation3's effect
+  var anim1 = animations[0];
+  var anim3 = animations[2];
+  const temp = anim1.effect;
+  anim1.effect = anim3.effect;
+  anim3.effect = temp;
+
+  animations = document.getAnimations();
+  expectedAnimations = [
+      [child, '::before', 'anim2'],
+      [parent, '::after', 'anim1'],
+      [parent, '::before', 'anim4'],
+      [child, '::after', 'anim3'],
+    ];
+  pseudoAnimCompare(animations, expectedAnimations)
+}, 'pseudo element with replaced target does not affect animation ordering');
+
+function pseudoAnimCompare(animations, expectedAnimations) {
+  assert_equals(
+      animations.length,
+      expectedAnimations.length,
+      'CSS animations on both pseudo-elements and elements are returned'
+    );
+  for (const [index, expected] of expectedAnimations.entries()) {
+      const [element, pseudo, name] = expected;
+      const actual = animations[index];
+      if (pseudo) {
+        assert_equals(
+          actual.effect.target,
+          element,
+          `Animation #${index + 1} has the expected target`
+        );
+        assert_equals(
+          actual.effect.pseudoElement,
+          pseudo,
+          `Animation #${index + 1} has the expected pseudo type`
+        );
+        if (name) {
+          assert_equals(
+            actual.animationName,
+            name,
+            `Animation #${index + 1} has the expected name`
+          );
+        }
+      } else {
+        assert_equals(
+          actual.effect.target,
+          element,
+          `Animation #${index + 1} has the expected target`
+        );
+        assert_equals(
+          actual.effect.pseudoElement,
+          null,
+          `Animation #${index + 1} has a null pseudo type`
+        );
+      }
+    }
+}
+
+function pseudoTest(description, testMarkerPseudos) {
+  test(t => {
+    // Create two divs with the following arrangement:
+    //
+    //       parent
+    //    (::marker,)  // Optionally
+    //     ::before,
+    //     ::after
+    //        |
+    //       child
+
+    addStyle(t, {
+      '#parent::after': "content: ''; animation: animLeft 100s;",
+      '#parent::before': "content: ''; animation: animRight 100s;",
+    });
+
+    if (testMarkerPseudos) {
+      addStyle(t, {
+        '#parent': 'display: list-item;',
+        '#parent::marker': "content: ''; animation: animLeft 100s;",
+      });
+    }
+
+    const parent = addDiv(t, { id: 'parent' });
+    const child = addDiv(t);
+    parent.appendChild(child);
+    for (const div of [parent, child]) {
+      div.setAttribute('style', 'animation: animBottom 100s');
+    }
+
+    const expectedAnimations = [
+      [parent, undefined],
+      [parent, '::marker'],
+      [parent, '::before'],
+      [parent, '::after'],
+      [child, undefined],
+    ];
+    if (!testMarkerPseudos) {
+      expectedAnimations.splice(1, 1);
+    }
+
+    const animations = document.getAnimations();
+    pseudoAnimCompare(animations, expectedAnimations)
+  }, description);
+}
+
+pseudoTest('CSS Animations targetting (pseudo-)elements should have correct '
+     + 'order after sorting', false);
+pseudoTest('CSS Animations targetting (pseudo-)elements should have correct '
+     + 'order after sorting (::marker)', true);
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/Element-getAnimations-dynamic-changes.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/Element-getAnimations-dynamic-changes.tentative.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>
+Element.getAnimations() - Dynamic changes to the list of CSS animations
+</title>
+<!-- TODO: Add a more specific link for this once it is specified. -->
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+@keyframes anim1 {
+  to { left: 100px }
+}
+@keyframes anim2 { }
+</style>
+<div id="log"></div>
+<script>
+'use strict';
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s';
+  const originalAnimation = div.getAnimations()[0];
+
+  // Wait a moment so we can confirm the startTime doesn't change (and doesn't
+  // simply reflect the current time).
+  await originalAnimation.ready;
+
+  const originalStartTime = originalAnimation.startTime;
+  const originalCurrentTime = originalAnimation.currentTime;
+
+  // Wait a moment so we can confirm the startTime doesn't change (and
+  // doesn't simply reflect the current time).
+  await waitForNextFrame();
+
+  div.style.animationDuration = '200s';
+  const animation = div.getAnimations()[0];
+  assert_equals(animation, originalAnimation,
+                'The same Animation is returned after updating'
+                + ' animation duration');
+  assert_equals(animation.startTime, originalStartTime,
+                'Animations returned by getAnimations preserve'
+                + ' their startTime even when they are updated');
+  // Sanity check
+  assert_not_equals(animation.currentTime, originalCurrentTime,
+                    'Animation.currentTime has updated in next'
+                    + ' requestAnimationFrame callback');
+}, 'Animations preserve their startTime when changed');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s, anim1 100s';
+
+  // Store original state
+  let animations = div.getAnimations();
+  const animation1 = animations[0];
+  const animation2 = animations[1];
+
+  // Update first in list
+  div.style.animationDuration = '200s, 100s';
+  animations = div.getAnimations();
+  assert_equals(animations[0], animation1,
+                'First Animation is in same position after update');
+  assert_equals(animations[1], animation2,
+                'Second Animation is in same position after update');
+}, 'Updated Animations maintain their order in the list');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 200s, anim1 100s';
+
+  // Store original state
+  let animations = div.getAnimations();
+  const animation1 = animations[0];
+  const animation2 = animations[1];
+
+  // Wait before continuing so we can compare start times (otherwise the
+  // new Animation objects and existing Animation objects will all have the same
+  // start time).
+  await waitForAllAnimations(animations);
+  await waitForFrame();
+
+  // Swap duration of first and second in list and prepend animation at the
+  // same time
+  div.style.animation = 'anim1 100s, anim1 100s, anim1 200s';
+  animations = div.getAnimations();
+  assert_true(animations[0] !== animation1 && animations[0] !== animation2,
+              'New Animation is prepended to start of list');
+  assert_equals(animations[1], animation1,
+                'First animation is in second position after update');
+  assert_equals(animations[2], animation2,
+                'Second animation is in third position after update');
+  assert_equals(animations[1].startTime, animations[2].startTime,
+                'Old animations have the same start time');
+  assert_equals(animations[0].startTime, null,
+                'New animation has a null start time');
+
+  await animations[0].ready;
+
+  assert_greater_than(animations[0].startTime, animations[1].startTime,
+                      'New animation has later start time');
+}, 'Only the startTimes of existing animations are preserved');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s, anim1 100s';
+  const secondAnimation = div.getAnimations()[1];
+
+  // Wait before continuing so we can compare start times
+  await secondAnimation.ready;
+  await waitForNextFrame();
+
+  // Trim list of animations
+  div.style.animationName = 'anim1';
+  const animations = div.getAnimations();
+  assert_equals(animations.length, 1, 'List of Animations was trimmed');
+  assert_equals(animations[0], secondAnimation,
+                'Remaining Animation is the second one in the list');
+  assert_equals(typeof(animations[0].startTime), 'number',
+                'Remaining Animation has resolved startTime');
+  assert_less_than(animations[0].startTime,
+                   animations[0].timeline.currentTime,
+                   'Remaining Animation preserves startTime');
+}, 'Animations are removed from the start of the list while preserving'
+   + ' the state of existing Animations');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s';
+  const firstAddedAnimation = div.getAnimations()[0];
+
+  // Wait and add second Animation
+  await firstAddedAnimation.ready;
+  await waitForFrame();
+
+  div.style.animation = 'anim1 100s, anim1 100s';
+  const secondAddedAnimation = div.getAnimations()[0];
+
+  // Wait again and add another Animation
+  await secondAddedAnimation.ready;
+  await waitForFrame();
+
+  div.style.animation = 'anim1 100s, anim2 100s, anim1 100s';
+  const animations = div.getAnimations();
+  assert_not_equals(firstAddedAnimation, secondAddedAnimation,
+                    'New Animations are added to start of the list');
+  assert_equals(animations[0], secondAddedAnimation,
+                'Second Animation remains in same position after'
+                + ' interleaving');
+  assert_equals(animations[2], firstAddedAnimation,
+                'First Animation remains in same position after'
+                + ' interleaving');
+  await animations[1].ready;
+
+  assert_greater_than(animations[1].startTime, animations[0].startTime,
+                      'Interleaved animation starts later than existing ' +
+                      'animations');
+  assert_greater_than(animations[0].startTime, animations[2].startTime,
+                      'Original animations retain their start time');
+}, 'Animation state is preserved when interleaving animations in list');
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/Element-getAnimations.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/Element-getAnimations.tentative.html
@@ -1,0 +1,453 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Element.getAnimations() for CSS animations</title>
+<!-- TODO: Add a more specific link for this once it is specified. -->
+<link rel="help" href="https://drafts.csswg.org/css-animations-2/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+@keyframes anim1 {
+  to { left: 100px }
+}
+@keyframes anim2 {
+  to { top: 100px }
+}
+@keyframes multiPropAnim {
+  to { background: green, opacity: 0.5, left: 100px, top: 100px }
+}
+::before {
+  content: ''
+}
+::after {
+  content: ''
+}
+@keyframes empty { }
+</style>
+<div id="log"></div>
+<script>
+'use strict';
+
+test(t => {
+  const div = addDiv(t);
+  assert_equals(div.getAnimations().length, 0,
+    'getAnimations returns an empty sequence for an element'
+    + ' with no animations');
+}, 'getAnimations for non-animated content');
+
+promise_test(async t => {
+  const div = addDiv(t);
+
+  // Add an animation
+  div.style.animation = 'anim1 100s';
+  let animations = div.getAnimations();
+  assert_equals(animations.length, 1,
+    'getAnimations returns an Animation running CSS Animations');
+  await animations[0].ready;
+
+  // Add a second animation
+  div.style.animation = 'anim1 100s, anim2 100s';
+  animations = div.getAnimations();
+  assert_equals(animations.length, 2,
+    'getAnimations returns one CSSAnimation for each value of animation-name');
+  // (We don't check the order of the Animations since that is covered by tests
+  //  later in this file.)
+}, 'getAnimations for CSS Animations');
+
+test(t => {
+  const div = addDiv(t, { style: 'animation: anim1 100s' });
+  assert_class_string(div.getAnimations()[0], 'CSSAnimation',
+                      'Interface of returned animation is CSSAnimation');
+}, 'getAnimations returns CSSAnimation objects for CSS Animations');
+
+test(t => {
+  const div = addDiv(t);
+
+  // Add an animation that targets multiple properties
+  div.style.animation = 'multiPropAnim 100s';
+  assert_equals(div.getAnimations().length, 1,
+    'getAnimations returns only one Animation for a CSS Animation'
+    + ' that targets multiple properties');
+}, 'getAnimations for multi-property animations');
+
+promise_test(async t => {
+  const div = addDiv(t);
+
+  // Add an animation
+  div.style.backgroundColor = 'red';
+  div.style.animation = 'anim1 100s';
+  getComputedStyle(div).backgroundColor;
+
+  // Wait until a frame after the animation starts, then add a transition
+  let animations = div.getAnimations();
+  await animations[0].ready;
+  await waitForFrame();
+
+  div.style.transition = 'all 100s';
+  div.style.backgroundColor = 'green';
+
+  animations = div.getAnimations();
+  assert_equals(animations.length, 2,
+    'getAnimations returns Animations for both animations and'
+    + ' transitions that run simultaneously');
+  assert_class_string(animations[0], 'CSSTransition',
+                      'First-returned animation is the CSS Transition');
+  assert_class_string(animations[1], 'CSSAnimation',
+                      'Second-returned animation is the CSS Animation');
+}, 'getAnimations for both CSS Animations and CSS Transitions at once');
+
+async_test(t => {
+  const div = addDiv(t);
+
+  // Set up event listener
+  div.addEventListener('animationend', t.step_func(() => {
+    assert_equals(div.getAnimations().length, 0,
+      'getAnimations does not return Animations for finished '
+      + ' (and non-forwards-filling) CSS Animations');
+    t.done();
+  }));
+
+  // Add a very short animation
+  div.style.animation = 'anim1 0.01s';
+}, 'getAnimations for CSS Animations that have finished');
+
+async_test(t => {
+  const div = addDiv(t);
+
+  // Set up event listener
+  div.addEventListener('animationend', t.step_func(() => {
+    assert_equals(div.getAnimations().length, 1,
+      'getAnimations returns Animations for CSS Animations that have'
+      + ' finished but are filling forwards');
+    t.done();
+  }));
+
+  // Add a very short animation
+  div.style.animation = 'anim1 0.01s forwards';
+}, 'getAnimations for CSS Animations that have finished but are'
+   + ' forwards filling');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'none 100s';
+
+  let animations = div.getAnimations();
+  assert_equals(animations.length, 0,
+    'getAnimations returns an empty sequence for an element'
+    + ' with animation-name: none');
+
+  div.style.animation = 'none 100s, anim1 100s';
+  animations = div.getAnimations();
+  assert_equals(animations.length, 1,
+    'getAnimations returns Animations only for those CSS Animations whose'
+    + ' animation-name is not none');
+}, 'getAnimations for CSS Animations with animation-name: none');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'missing 100s';
+  let animations = div.getAnimations();
+  assert_equals(animations.length, 0,
+    'getAnimations returns an empty sequence for an element'
+    + ' with animation-name: missing');
+
+  div.style.animation = 'anim1 100s, missing 100s';
+  animations = div.getAnimations();
+  assert_equals(animations.length, 1,
+    'getAnimations returns Animations only for those CSS Animations whose'
+    + ' animation-name is found');
+}, 'getAnimations for CSS Animations with animation-name: missing');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s, notyet 100s';
+  let animations = div.getAnimations();
+  assert_equals(animations.length, 1,
+    'getAnimations initally only returns Animations for CSS Animations whose'
+    + ' animation-name is found');
+
+  await animations[0].ready;
+  await waitForFrame();
+
+  const keyframes = '@keyframes notyet { to { left: 100px; } }';
+  document.styleSheets[0].insertRule(keyframes, 0);
+  animations = div.getAnimations();
+  assert_equals(animations.length, 2,
+    'getAnimations includes Animation when @keyframes rule is added'
+    + ' later');
+  await waitForAllAnimations(animations);
+
+  assert_true(animations[0].startTime < animations[1].startTime,
+    'Newly added animation has a later start time');
+  document.styleSheets[0].deleteRule(0);
+}, 'getAnimations for CSS Animations where the @keyframes rule is added'
+   + ' later');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s, anim1 100s';
+  assert_equals(div.getAnimations().length, 2,
+    'getAnimations returns one Animation for each CSS animation-name'
+    + ' even if the names are duplicated');
+}, 'getAnimations for CSS Animations with duplicated animation-name');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'empty 100s';
+  assert_equals(div.getAnimations().length, 1,
+    'getAnimations returns Animations for CSS animations with an'
+    + ' empty keyframes rule');
+}, 'getAnimations for CSS Animations with empty keyframes rule');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s 100s';
+  const animations = div.getAnimations();
+  assert_equals(animations.length, 1,
+    'getAnimations returns animations for CSS animations whose'
+    + ' delay makes them start later');
+  await animations[0].ready;
+  await waitForFrame();
+
+  assert_true(animations[0].startTime <= document.timeline.currentTime,
+    'For CSS Animations in delay phase, the start time of the Animation is'
+    + ' not in the future');
+}, 'getAnimations for CSS animations in delay phase');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 0s 100s';
+  assert_equals(div.getAnimations().length, 1,
+    'getAnimations returns animations for CSS animations whose'
+    + ' duration is zero');
+  div.remove();
+}, 'getAnimations for zero-duration CSS Animations');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s';
+  const originalAnimation = div.getAnimations()[0];
+
+  // Update pause state (an Animation change)
+  div.style.animationPlayState = 'paused';
+  const pendingAnimation = div.getAnimations()[0];
+  assert_equals(pendingAnimation.playState, 'paused',
+                'animation\'s play state is updated');
+  assert_equals(originalAnimation, pendingAnimation,
+                'getAnimations returns the same objects even when their'
+                + ' play state changes');
+
+  // Update duration (an Animation change)
+  div.style.animationDuration = '200s';
+  const extendedAnimation = div.getAnimations()[0];
+  assert_equals(
+    extendedAnimation.effect.getTiming().duration,
+    200 * MS_PER_SEC,
+    'animation\'s duration has been updated'
+  );
+  assert_equals(originalAnimation, extendedAnimation,
+                'getAnimations returns the same objects even when their'
+                + ' duration changes');
+}, 'getAnimations returns objects with the same identity');
+
+test(t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim1 100s';
+
+  assert_equals(div.getAnimations().length, 1,
+    'getAnimations returns an animation before canceling');
+
+  const animation = div.getAnimations()[0];
+
+  animation.cancel();
+  assert_equals(div.getAnimations().length, 0,
+    'getAnimations does not return canceled animations');
+
+  animation.play();
+  assert_equals(div.getAnimations().length, 1,
+    'getAnimations returns canceled animations that have been re-started');
+
+}, 'getAnimations for CSS Animations that are canceled');
+
+promise_test(async t => {
+  const div = addDiv(t);
+  div.style.animation = 'anim2 100s';
+
+  await div.getAnimations()[0].ready;
+
+  // Prepend to the list and test that even though anim1 was triggered
+  // *after* anim2, it should come first because it appears first
+  // in the animation-name property.
+  div.style.animation = 'anim1 100s, anim2 100s';
+  let anims = div.getAnimations();
+  assert_equals(anims[0].animationName, 'anim1',
+                'animation order after prepending to list');
+  assert_equals(anims[1].animationName, 'anim2',
+                'animation order after prepending to list');
+
+  // Normally calling cancel and play would this push anim1 to the top of
+  // the stack but it shouldn't for CSS animations that map an the
+  // animation-name property.
+  const anim1 = anims[0];
+  anim1.cancel();
+  anim1.play();
+  anims = div.getAnimations();
+  assert_equals(anims[0].animationName, 'anim1',
+                'animation order after canceling and restarting');
+  assert_equals(anims[1].animationName, 'anim2',
+                'animation order after canceling and restarting');
+}, 'getAnimations for CSS Animations follows animation-name order');
+
+test(t => {
+  addStyle(t, { '#target::after': 'animation: anim1 10s;',
+                '#target::before': 'animation: anim1 10s;' });
+  const target = addDiv(t, { 'id': 'target' });
+  target.style.animation = 'anim1 100s';
+  const animations = target.getAnimations({ subtree: false });
+
+  assert_equals(animations.length, 1,
+                'Should find only the element');
+  assert_equals(animations[0].effect.target, target,
+                'Effect target should be the element');
+}, '{ subtree: false } on a leaf element returns the element\'s animations'
+   + ' and ignore pseudo-elements');
+
+test(t => {
+  addStyle(t, { '#target::after': 'animation: anim1 10s;',
+                '#target::before': 'animation: anim1 10s;' });
+  const target = addDiv(t, { 'id': 'target' });
+  target.style.animation = 'anim1 100s';
+  const animations = target.getAnimations({ subtree: true });
+
+  assert_equals(animations.length, 3,
+                'getAnimations({ subtree: true }) ' +
+                'should return animations on pseudo-elements');
+  assert_equals(animations[0].effect.target, target,
+                'The animation targeting the parent element ' +
+                'should be returned first');
+  assert_equals(animations[0].effect.pseudoElement, null,
+                'The animation targeting the parent element ' +
+                'should be returned first')
+  assert_equals(animations[1].effect.pseudoElement, '::before',
+                'The animation targeting the ::before pseudo-element ' +
+                'should be returned second');
+  assert_equals(animations[2].effect.pseudoElement, '::after',
+                'The animation targeting the ::after pesudo-element ' +
+                'should be returned last');
+}, '{ subtree: true } on a leaf element returns the element\'s animations'
+   + ' and its pseudo-elements\' animations');
+
+test(t => {
+  addStyle(t, { '#parent::after': 'animation: anim1 10s;',
+                '#parent::before': 'animation: anim1 10s;',
+                '#child::after': 'animation: anim1 10s;',
+                '#child::before': 'animation: anim1 10s;' });
+  const parent = addDiv(t, { 'id': 'parent' });
+  parent.style.animation = 'anim1 100s';
+  const child = addDiv(t, { 'id': 'child' });
+  child.style.animation = 'anim1 100s';
+  parent.appendChild(child);
+
+  const animations = parent.getAnimations({ subtree: false });
+  assert_equals(animations.length, 1,
+                'Should find only the element even if it has a child');
+  assert_equals(animations[0].effect.target, parent,
+                'Effect target should be the element');
+}, '{ subtree: false } on an element with a child returns only the element\'s'
+   + ' animations');
+
+test(t => {
+  addStyle(t, { '#parent::after': 'animation: anim1 10s;',
+                '#parent::before': 'animation: anim1 10s;',
+                '#child::after': 'animation: anim1 10s;',
+                '#child::before': 'animation: anim1 10s;' });
+  const parent = addDiv(t, { 'id': 'parent' });
+  const child = addDiv(t, { 'id': 'child' });
+  parent.style.animation = 'anim1 100s';
+  child.style.animation = 'anim1 100s';
+  parent.appendChild(child);
+
+  const animations = parent.getAnimations({ subtree: true });
+  assert_equals(animations.length, 6,
+                'Should find all elements, pseudo-elements that parent has');
+
+  assert_equals(animations[0].effect.target, parent,
+                'The animation targeting the parent element ' +
+                'should be returned first');
+  assert_equals(animations[0].effect.pseudoElement, null,
+                'The animation targeting the parent element ' +
+                'should be returned first');
+  assert_equals(animations[1].effect.pseudoElement, '::before',
+                'The animation targeting the ::before pseudo-element ' +
+                'should be returned second');
+  assert_equals(animations[1].effect.target, parent,
+                'This ::before element should be child of parent element');
+  assert_equals(animations[2].effect.pseudoElement, '::after',
+                'The animation targeting the ::after pesudo-element ' +
+                'should be returned third');
+  assert_equals(animations[2].effect.target, parent,
+                'This ::after element should be child of parent element');
+
+  assert_equals(animations[3].effect.target, child,
+                'The animation targeting the child element ' +
+                'should be returned fourth');
+  assert_equals(animations[4].effect.pseudoElement, '::before',
+                'The animation targeting the ::before pseudo-element ' +
+                'should be returned fifth');
+  assert_equals(animations[4].effect.target, child,
+                'This ::before element should be child of child element');
+  assert_equals(animations[5].effect.pseudoElement, '::after',
+                'The animation targeting the ::after pesudo-element ' +
+                'should be returned last');
+  assert_equals(animations[5].effect.target, child,
+                'This ::after element should be child of child element');
+}, '{ subtree: true } on an element with a child returns animations from the'
+   + ' element, its pseudo-elements, its child and its child pseudo-elements');
+
+test(t => {
+  const parent = addDiv(t, { 'id': 'parent' });
+  const child1 = addDiv(t, { 'id': 'child1' });
+  const grandchild1 = addDiv(t, { 'id': 'grandchild1' });
+  const grandchild2 = addDiv(t, { 'id': 'grandchild2' });
+  const child2 = addDiv(t, { 'id': 'child2' });
+
+  parent.style.animation = 'anim1 100s';
+  child1.style.animation = 'anim1 100s';
+  grandchild1.style.animation = 'anim1 100s';
+  grandchild2.style.animation = 'anim1 100s';
+  child2.style.animation = 'anim1 100s';
+
+  parent.appendChild(child1);
+  child1.appendChild(grandchild1);
+  child1.appendChild(grandchild2);
+  parent.appendChild(child2);
+
+  const animations = parent.getAnimations({ subtree: true });
+  assert_equals(
+    parent.getAnimations({ subtree: true }).length, 5,
+                         'Should find all descendants of the element');
+
+  assert_equals(animations[0].effect.target, parent,
+                'The animation targeting the parent element ' +
+                'should be returned first');
+
+  assert_equals(animations[1].effect.target, child1,
+                'The animation targeting the child1 element ' +
+                'should be returned second');
+
+  assert_equals(animations[2].effect.target, grandchild1,
+                'The animation targeting the grandchild1 element ' +
+                'should be returned third');
+
+  assert_equals(animations[3].effect.target, grandchild2,
+                'The animation targeting the grandchild2 element ' +
+                'should be returned fourth');
+
+  assert_equals(animations[4].effect.target, child2,
+                'The animation targeting the child2 element ' +
+                'should be returned last');
+
+}, '{ subtree: true } on an element with many descendants returns animations'
+   + ' from all the descendants');
+
+</script>


### PR DESCRIPTION
Fixes #10635 (although the animation on https://futo.tech still doesn't play since we don't support animation of registered custom properties as mentioned in #2705).

Previously we stored CSS defined animations in a `HashSet` with the `animation-name` entry as the key, this doesn't work since multiple CSS defined animations can share the same `animation-name` entry value.

We now store the CSS defined animations in a `Vector` and implement the spec defined matching behavior.

This PR also implements some more of the composite order computation algorithm (to avoid a regression that would otherwise occur since we now create CSS defined animations in reverse order) and includes a couple of drive-by animation cleanups.

CC @AtkinsSJ 