### PR TITLE
Meta/WPT.sh: Do not run venv preparation inside namespaces

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -551,7 +551,7 @@ run_wpt_chunked() {
 
     echo "Preparing the venv setup..."
     base_venv="${BUILD_DIR}/wpt-prep/_venv"
-    ./wpt --venv "$base_venv" run "${WPT_ARGS[@]}" ladybird THIS_TEST_CANNOT_POSSIBLY_EXIST "${WPT_TEST_TYPE_ARGS[@]}" || true
+    ./wpt --venv "$base_venv" run "${WPT_ARGS[@]}" ladybird THIS_TEST_CANNOT_POSSIBLY_EXIST "${WPT_TEST_TYPE_ARGS[@]}"
 
     echo "Launching $procs chunked instances (concurrency=$concurrency each)"
     local logs=()
@@ -570,6 +570,7 @@ run_wpt_chunked() {
         cp -r "$base_venv" "${runpath}/_venv"
 
         command=(./wpt --venv "${runpath}/_venv" \
+            --skip-venv-setup \
             run \
             --this-chunk="$((i + 1))" \
             --total-chunks="$procs" \


### PR DESCRIPTION
Previously, if our initial venv preparation would fail, WPT.sh would happily continue with starting the chunk runners. These would then check their venv and try to install any missing pieces, causing issues since we're running inside a netns.

We now prepare the venv and fail early; the individual runners explicitly skip venv setup.