### PR TITLE
LibWeb: Keep nested sticky offsets separate from scrolling

### DIFF
--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -114,31 +114,15 @@ Optional<AsyncScrollNodeID> AsyncScrollTree::scrollable_ancestor_for_node(AsyncS
     return {};
 }
 
-Optional<Painting::ScrollFrameIndex> AsyncScrollTree::parent_scroll_frame_index(Painting::ScrollFrameIndex scroll_frame_index) const
-{
-    for (auto const& node : m_scroll_nodes) {
-        if (node.node_id.scroll_frame_index != scroll_frame_index)
-            continue;
-        if (!node.parent_node_id.has_value())
-            return {};
-        return node.parent_node_id->scroll_frame_index;
-    }
-
-    if (auto const* sticky_area = sticky_area_for_scroll_frame_index(scroll_frame_index))
-        return sticky_area->parent_scroll_frame_index;
-
-    return {};
-}
-
-Gfx::FloatPoint AsyncScrollTree::cumulative_device_offset_for_frame(Painting::ScrollFrameIndex scroll_frame_index, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
+Gfx::FloatPoint AsyncScrollTree::cumulative_device_sticky_offset_for_frame(Painting::ScrollFrameIndex scroll_frame_index, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
 {
     Gfx::FloatPoint offset;
     for (auto index = scroll_frame_index; index.value();) {
-        offset.translate_by(scroll_state_snapshot.device_offset_for_index(index));
-        auto parent_index = parent_scroll_frame_index(index);
-        if (!parent_index.has_value())
+        auto const* sticky_area = sticky_area_for_scroll_frame_index(index);
+        if (!sticky_area)
             break;
-        index = *parent_index;
+        offset.translate_by(scroll_state_snapshot.device_offset_for_index(index));
+        index = sticky_area->parent_scroll_frame_index;
     }
     return offset;
 }
@@ -183,9 +167,7 @@ void AsyncScrollTree::update_sticky_offsets(Painting::ScrollStateSnapshot& scrol
         if (!sticky_area.nearest_scrolling_ancestor_index.value())
             continue;
 
-        Gfx::FloatPoint parent_sticky_offset;
-        if (sticky_area.parent_scroll_frame_index.value() && sticky_area_for_scroll_frame_index(sticky_area.parent_scroll_frame_index))
-            parent_sticky_offset = cumulative_device_offset_for_frame(sticky_area.parent_scroll_frame_index, scroll_state_snapshot);
+        auto parent_sticky_offset = cumulative_device_sticky_offset_for_frame(sticky_area.parent_scroll_frame_index, scroll_state_snapshot);
 
         auto sticky_position_in_ancestor = sticky_area.position_relative_to_scroll_ancestor.translated(parent_sticky_offset);
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -75,8 +75,7 @@ private:
     AsyncScrollNode const* scroll_node_for_stable_id(AsyncScrollNodeStableID) const;
     AsyncStickyArea const* sticky_area_for_scroll_frame_index(Painting::ScrollFrameIndex) const;
     Optional<AsyncScrollNodeID> scrollable_ancestor_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint delta) const;
-    Optional<Painting::ScrollFrameIndex> parent_scroll_frame_index(Painting::ScrollFrameIndex) const;
-    Gfx::FloatPoint cumulative_device_offset_for_frame(Painting::ScrollFrameIndex, Painting::ScrollStateSnapshot const&) const;
+    Gfx::FloatPoint cumulative_device_sticky_offset_for_frame(Painting::ScrollFrameIndex, Painting::ScrollStateSnapshot const&) const;
     Gfx::FloatPoint apply_scroll_delta_to_node(AsyncScrollNode const&, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
     void update_sticky_offsets(Painting::ScrollStateSnapshot&) const;
 

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -75,6 +75,16 @@ public:
         return offset;
     }
 
+    CSSPixelPoint cumulative_sticky_offset(ScrollFrameIndex index) const
+    {
+        CSSPixelPoint offset;
+        while (index.value() && frame_at(index).is_sticky()) {
+            offset += frame_at(index).own_offset();
+            index = frame_at(index).parent_index();
+        }
+        return offset;
+    }
+
     ScrollFrameIndex nearest_scrolling_ancestor(ScrollFrameIndex index) const
     {
         auto ancestor = frame_at(index).parent_index();

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -298,6 +298,9 @@ void ViewportPaintable::refresh_scroll_state()
         return;
     m_needs_to_refresh_scroll_state = false;
 
+    // https://drafts.csswg.org/css-position/#sticky-pos
+    // Sticky positioning is similar to relative positioning except the offsets are automatically calculated
+    // in reference to the nearest scrollport.
     m_scroll_state.for_each_sticky_frame([&](auto idx, auto& frame) {
         auto nearest_scrolling_ancestor_index = m_scroll_state.nearest_scrolling_ancestor(idx);
         if (!nearest_scrolling_ancestor_index.value() || !frame.has_sticky_constraints())
@@ -307,12 +310,10 @@ void ViewportPaintable::refresh_scroll_state()
         auto const& sticky_insets = sticky_data.insets;
         auto const& scroll_ancestor_paintable = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box();
 
-        // For nested sticky elements, the parent sticky's offset is applied via cumulative_offset.
-        // We need to adjust all position calculations to account for this, so we work in the
-        // coordinate space where the parent sticky is at its current (offset) position.
-        CSSPixelPoint parent_sticky_offset;
-        if (auto parent_idx = frame.parent_index(); parent_idx.value() && m_scroll_state.frame_at(parent_idx).is_sticky())
-            parent_sticky_offset = m_scroll_state.cumulative_offset(parent_idx);
+        // NB: For nested sticky elements, work in the coordinate space where the sticky ancestors are
+        //     at their current positions. The scrolling ancestor's offset is already represented by
+        //     scrollport_rect and must not be applied to the sticky position a second time.
+        auto parent_sticky_offset = m_scroll_state.cumulative_sticky_offset(frame.parent_index());
 
         auto sticky_position_in_ancestor = sticky_data.position_relative_to_scroll_ancestor + parent_sticky_offset;
 

--- a/Tests/LibWeb/Ref/expected/position-sticky-nested-after-repeated-scroll-ref.html
+++ b/Tests/LibWeb/Ref/expected/position-sticky-nested-after-repeated-scroll-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<script src="../input/wpt-import/common/reftest-wait.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .parent {
+        position: relative;
+        width: 200px;
+        height: 900px;
+    }
+
+    .first,
+    .second {
+        position: absolute;
+        width: 200px;
+        height: 50px;
+    }
+
+    .first {
+        top: 151px;
+        background: red;
+    }
+
+    .second {
+        top: 201px;
+        background: blue;
+    }
+</style>
+<div class="parent">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>
+<script>
+    scrollTo(0, 101);
+    requestAnimationFrame(takeScreenshot);
+</script>

--- a/Tests/LibWeb/Ref/input/position-sticky-nested-after-repeated-scroll.html
+++ b/Tests/LibWeb/Ref/input/position-sticky-nested-after-repeated-scroll.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/position-sticky-nested-after-repeated-scroll-ref.html">
+<script src="wpt-import/common/reftest-wait.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .parent {
+        position: sticky;
+        width: 200px;
+        height: 900px;
+    }
+
+    .first,
+    .second {
+        position: sticky;
+        width: 200px;
+        height: 50px;
+    }
+
+    .first {
+        top: 50px;
+        background: red;
+    }
+
+    .second {
+        top: 100px;
+        background: blue;
+    }
+</style>
+<div class="parent">
+    <div class="first"></div>
+    <div class="second"></div>
+</div>
+<script>
+    requestAnimationFrame(() => {
+        scrollTo(0, 100);
+        requestAnimationFrame(() => {
+            scrollTo(0, 101);
+            requestAnimationFrame(takeScreenshot);
+        });
+    });
+</script>


### PR DESCRIPTION
Accumulate only visual offsets from sticky ancestors when positioning a nested sticky box. Do not include the nearest scrolling ancestor because its offset is already represented by the scrollport rectangle; including it applies the prior scroll position twice on subsequent updates.

Mirror the calculation in the compositor and cover consecutive viewport scroll updates with a reference test.

Before:

<img width="1624" height="994" alt="Screenshot 2026-07-14 at 21 39 19" src="https://github.com/user-attachments/assets/c828b6dd-f40e-4544-b4a6-9c0753fe45a8" />

After:

<img width="1624" height="994" alt="Screenshot 2026-07-14 at 22 33 44" src="https://github.com/user-attachments/assets/0fe932f1-1549-452c-ba7e-1f5d7ade56f3" />
