### PR TITLE
LibWeb+LibWebView: Report targeted history entry updates

### DIFF
--- a/Libraries/LibWeb/HTML/History.cpp
+++ b/Libraries/LibWeb/HTML/History.cpp
@@ -269,6 +269,11 @@ WebIDL::ExceptionOr<void> History::set_scroll_restoration(Bindings::ScrollRestor
         break;
     }
 
+    if (this_relevant_global_object.associated_document().page().client().should_report_session_history_updates()) {
+        auto navigable = this_relevant_global_object.navigable();
+        this_relevant_global_object.associated_document().page().client().page_did_update_session_history_entry_scroll_restoration_mode(navigable->id(), active_session_history_entry->navigation_api_key(), active_session_history_entry->scroll_restoration_mode());
+    }
+
     return {};
 }
 

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -38,7 +38,7 @@ GC_DEFINE_ALLOCATOR(NavigationAPIMethodTracker);
 
 static Bindings::NavigationResult navigation_api_method_tracker_derived_result(GC::Ref<NavigationAPIMethodTracker> api_method_tracker);
 
-static void report_session_history_update_for_navigation_api_state_change(DOM::Document& document)
+static void report_navigation_api_state_update(DOM::Document& document, SessionHistoryEntry const& entry)
 {
     auto navigable = document.navigable();
     if (!navigable)
@@ -48,8 +48,7 @@ static void report_session_history_update_for_navigation_api_state_change(DOM::D
     if (!traversable->page().client().should_report_session_history_updates())
         return;
 
-    auto session_history_snapshot = traversable->create_session_history_snapshot();
-    traversable->page().client().page_did_update_session_history(session_history_snapshot.top_level_session_history_entries, session_history_snapshot.used_session_history_steps, session_history_snapshot.current_used_step_index);
+    traversable->page().client().page_did_update_session_history_entry_navigation_api_state(navigable->id(), entry.navigation_api_key(), entry.navigation_api_state());
 }
 
 NavigationAPIMethodTracker::NavigationAPIMethodTracker(GC::Ref<Navigation> navigation,
@@ -161,7 +160,7 @@ WebIDL::ExceptionOr<void> Navigation::update_current_entry(Bindings::NavigationU
     // NB: The UI-process session history mirror needs to observe updateCurrentEntry() state changes so restored
     //     WebContent processes can reconstruct Navigation API state from the authoritative UI-owned history.
     auto& document = as<HTML::Window>(relevant_global_object(*this)).associated_document();
-    report_session_history_update_for_navigation_api_state_change(document);
+    report_navigation_api_state_update(document, current->session_history_entry());
 
     // 5. Fire an event named currententrychange at this using NavigationCurrentEntryChangeEvent,
     //    with its navigationType attribute initialized to null and its from initialized to current.

--- a/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
+++ b/Libraries/LibWeb/HTML/Parser/Rust/src/parser.rs
@@ -4468,30 +4468,6 @@ unsafe fn utf16_namespace_uri_from_ffi(
     Some(unsafe { utf16_string_from_ffi(ptr, len) })
 }
 
-unsafe fn owned_attributes_from_ffi(
-    attributes: *const RustFfiHtmlParserAttribute,
-    attribute_count: usize,
-) -> Vec<OwnedAttribute> {
-    if attributes.is_null() || attribute_count == 0 {
-        return Vec::new();
-    }
-
-    let attributes = unsafe { std::slice::from_raw_parts(attributes, attribute_count) };
-    attributes
-        .iter()
-        .map(|attribute| OwnedAttribute {
-            local_name: unsafe { utf16_string_from_ffi(attribute.local_name_ptr, attribute.local_name_len) },
-            prefix: if attribute.prefix_len == 0 {
-                None
-            } else {
-                Some(unsafe { utf16_string_from_ffi(attribute.prefix_ptr, attribute.prefix_len) })
-            },
-            namespace_: attribute.namespace_,
-            value: unsafe { utf16_string_from_ffi(attribute.value_ptr, attribute.value_len) },
-        })
-        .collect()
-}
-
 unsafe fn owned_context_attributes_from_ffi(
     attributes: *const RustFfiHtmlParserContextAttribute,
     attribute_count: usize,

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -583,6 +583,8 @@ public:
     virtual void page_did_close_top_level_traversable() { }
     virtual bool should_report_session_history_updates() const { return true; }
     virtual void page_did_update_session_history([[maybe_unused]] Vector<HTML::SessionHistoryEntryDescriptor> const& entries, [[maybe_unused]] Vector<i32> const& used_steps, [[maybe_unused]] size_t current_used_step_index) { }
+    virtual void page_did_update_session_history_entry_navigation_api_state([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] HTML::StorageSerializationRecord const& navigation_api_state) { }
+    virtual void page_did_update_session_history_entry_scroll_restoration_mode([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] HTML::ScrollRestorationMode scroll_restoration_mode) { }
     virtual String page_did_request_ui_process_session_history_for_testing() { return "{}"_string; }
     virtual String page_did_update_session_history_and_request_ui_process_session_history_for_testing([[maybe_unused]] Vector<HTML::SessionHistoryEntryDescriptor> const& entries, [[maybe_unused]] Vector<i32> const& used_steps, [[maybe_unused]] size_t current_used_step_index) { return "{}"_string; }
     virtual bool page_did_request_traverse_the_history_by_delta([[maybe_unused]] int delta, [[maybe_unused]] HistoryTraversalPrecheck history_traversal_precheck) { return false; }

--- a/Libraries/LibWebView/CanonicalNavigable.cpp
+++ b/Libraries/LibWebView/CanonicalNavigable.cpp
@@ -28,6 +28,13 @@ WebContentClient& CanonicalNavigable::reporting_client() const
     return *m_reporting_client;
 }
 
+bool CanonicalNavigable::is_hosted_by(WebContentClient const& client, u64 page_id) const
+{
+    if (m_host_locality == HostLocality::Remote)
+        return m_remote_client.ptr() == &client && m_remote_page_id == page_id;
+    return m_reporting_client.ptr() == &client && m_reporting_page_id == page_id;
+}
+
 // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-top
 CanonicalTraversable& CanonicalNavigable::top_level_traversable()
 {

--- a/Libraries/LibWebView/CanonicalNavigable.h
+++ b/Libraries/LibWebView/CanonicalNavigable.h
@@ -68,6 +68,7 @@ public:
     IterationDecision for_each_in_subtree(Function<IterationDecision(CanonicalNavigable const&)> const&) const;
 
     bool has_remote_host() const { return m_host_locality == HostLocality::Remote && m_remote_client && m_remote_page_id != 0; }
+    bool is_hosted_by(WebContentClient const&, u64 page_id) const;
     WebContentClient& remote_host_client() const;
     u64 remote_host_page_id() const { return m_remote_page_id; }
 

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -264,6 +264,24 @@ WebContentSessionHistoryUpdateDecision CanonicalTraversable::did_receive_web_con
     };
 }
 
+bool CanonicalTraversable::update_session_history_entry_navigation_api_state(CanonicalNavigable const& navigable, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state)
+{
+    VERIFY(&navigable.top_level_traversable() == this);
+
+    if (&navigable == this)
+        return m_session_history.update_top_level_navigation_api_state(navigation_api_key, move(navigation_api_state));
+    return m_session_history.update_nested_navigation_api_state(navigable.id(), navigation_api_key, move(navigation_api_state));
+}
+
+bool CanonicalTraversable::update_session_history_entry_scroll_restoration_mode(CanonicalNavigable const& navigable, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode)
+{
+    VERIFY(&navigable.top_level_traversable() == this);
+
+    if (&navigable == this)
+        return m_session_history.update_top_level_scroll_restoration_mode(navigation_api_key, scroll_restoration_mode);
+    return m_session_history.update_nested_scroll_restoration_mode(navigable.id(), navigation_api_key, scroll_restoration_mode);
+}
+
 WebContentSessionHistoryUpdateResult CanonicalTraversable::update_session_history_from_web_content(Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index, bool pending_step_after_fallback_load_was_restored, bool seed_web_content_on_invalid_snapshot, URL::URL const& current_url)
 {
     auto update_result = m_session_history.update_from_web_content(move(entries), move(used_steps), current_used_step_index);

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -40,18 +40,24 @@ CanonicalNavigable& CanonicalTraversable::insert(WebContentClient& reporting_cli
     return navigable_ref;
 }
 
-Optional<CanonicalNavigable&> CanonicalTraversable::find(Web::HTML::CrossProcessId frame_id)
+Optional<CanonicalNavigable&> CanonicalTraversable::find(Web::HTML::CrossProcessId navigable_id)
 {
-    auto navigable = m_navigable_index.get(frame_id);
+    if (id() == navigable_id)
+        return *this;
+
+    auto navigable = m_navigable_index.get(navigable_id);
     if (!navigable.has_value() || !navigable.value())
         return {};
 
     return *navigable.value();
 }
 
-Optional<CanonicalNavigable const&> CanonicalTraversable::find(Web::HTML::CrossProcessId frame_id) const
+Optional<CanonicalNavigable const&> CanonicalTraversable::find(Web::HTML::CrossProcessId navigable_id) const
 {
-    auto navigable = m_navigable_index.get(frame_id);
+    if (id() == navigable_id)
+        return *this;
+
+    auto navigable = m_navigable_index.get(navigable_id);
     if (!navigable.has_value() || !navigable.value())
         return {};
 

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -235,6 +235,8 @@ public:
     void prepare_to_seed_web_content_session_history_from_ui_process();
     WebContentSessionHistoryUpdateDecision did_receive_web_content_session_history_update(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
     WebContentSessionHistoryUpdateDecision did_receive_web_content_session_history_update_for_testing(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
+    bool update_session_history_entry_navigation_api_state(CanonicalNavigable const&, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state);
+    bool update_session_history_entry_scroll_restoration_mode(CanonicalNavigable const&, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode);
     WebContentSessionHistorySeedAckResult did_receive_web_content_session_history_seed_ack(bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
     NavigationStartResult did_start_navigation(URL::URL const&, Web::HTML::DocumentResource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior, bool is_showing_crash_page);
     NavigationCancelResult did_cancel_navigation(URL::URL const&, bool has_webdriver_pending_navigation);

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -211,8 +211,8 @@ public:
     virtual bool is_top_level_traversable() const override { return true; }
 
     CanonicalNavigable& insert(WebContentClient& reporting_client, u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, CanonicalNavigable& fallback_parent);
-    Optional<CanonicalNavigable&> find(Web::HTML::CrossProcessId frame_id);
-    Optional<CanonicalNavigable const&> find(Web::HTML::CrossProcessId frame_id) const;
+    Optional<CanonicalNavigable&> find(Web::HTML::CrossProcessId navigable_id);
+    Optional<CanonicalNavigable const&> find(Web::HTML::CrossProcessId navigable_id) const;
     void remove(CanonicalNavigable&);
 
     TraversableSessionHistory const& session_history() const { return m_session_history; }

--- a/Libraries/LibWebView/SessionHistory.cpp
+++ b/Libraries/LibWebView/SessionHistory.cpp
@@ -484,6 +484,85 @@ void TraversableSessionHistory::clear_current_entry_reload_pending()
     m_entries[*current_top_level_entry_index].document_state.reload_pending = false;
 }
 
+template<typename UpdateEntry>
+static bool update_session_history_entry_by_navigation_api_key(Vector<TraversableSessionHistory::Entry>& entries, Utf16String const& navigation_api_key, UpdateEntry const& update_entry)
+{
+    auto did_update = false;
+    for (auto& entry : entries) {
+        if (entry.navigation_api_key == navigation_api_key) {
+            update_entry(entry);
+            did_update = true;
+        }
+    }
+    return did_update;
+}
+
+template<typename UpdateEntry>
+static bool update_nested_session_history_entries_by_navigation_api_key(Vector<TraversableSessionHistory::Entry>& entries, Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, UpdateEntry const& update_entry)
+{
+    auto did_update = false;
+    for (auto& entry : entries) {
+        for (auto& nested_history : entry.document_state.nested_histories) {
+            if (nested_history.id == navigable_id)
+                did_update |= update_session_history_entry_by_navigation_api_key(nested_history.entries, navigation_api_key, update_entry);
+            did_update |= update_nested_session_history_entries_by_navigation_api_key(nested_history.entries, navigable_id, navigation_api_key, update_entry);
+        }
+    }
+    return did_update;
+}
+
+template<typename UpdateEntry>
+static bool update_top_level_session_history_entries_by_navigation_api_key(Vector<TraversableSessionHistory::Entry>& entries, Vector<TraversableSessionHistory::Entry>& web_content_known_entries, Utf16String const& navigation_api_key, UpdateEntry const& update_entry)
+{
+    auto did_update = update_session_history_entry_by_navigation_api_key(entries, navigation_api_key, update_entry);
+    if (!did_update)
+        return false;
+
+    update_session_history_entry_by_navigation_api_key(web_content_known_entries, navigation_api_key, update_entry);
+
+    return true;
+}
+
+template<typename UpdateEntry>
+static bool update_nested_session_history_entries_by_navigation_api_key(Vector<TraversableSessionHistory::Entry>& entries, Vector<TraversableSessionHistory::Entry>& web_content_known_entries, Web::HTML::CrossProcessId nested_history_id, Utf16String const& navigation_api_key, UpdateEntry const& update_entry)
+{
+    auto did_update = update_nested_session_history_entries_by_navigation_api_key(entries, nested_history_id, navigation_api_key, update_entry);
+    if (!did_update)
+        return false;
+
+    update_nested_session_history_entries_by_navigation_api_key(web_content_known_entries, nested_history_id, navigation_api_key, update_entry);
+
+    return true;
+}
+
+bool TraversableSessionHistory::update_top_level_navigation_api_state(Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state)
+{
+    return update_top_level_session_history_entries_by_navigation_api_key(m_entries, m_web_content_known_entries, navigation_api_key, [&](Entry& entry) {
+        entry.navigation_api_state = navigation_api_state;
+    });
+}
+
+bool TraversableSessionHistory::update_nested_navigation_api_state(Web::HTML::CrossProcessId nested_history_id, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state)
+{
+    return update_nested_session_history_entries_by_navigation_api_key(m_entries, m_web_content_known_entries, nested_history_id, navigation_api_key, [&](Entry& entry) {
+        entry.navigation_api_state = navigation_api_state;
+    });
+}
+
+bool TraversableSessionHistory::update_top_level_scroll_restoration_mode(Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode)
+{
+    return update_top_level_session_history_entries_by_navigation_api_key(m_entries, m_web_content_known_entries, navigation_api_key, [&](Entry& entry) {
+        entry.scroll_restoration_mode = scroll_restoration_mode;
+    });
+}
+
+bool TraversableSessionHistory::update_nested_scroll_restoration_mode(Web::HTML::CrossProcessId nested_history_id, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode)
+{
+    return update_nested_session_history_entries_by_navigation_api_key(m_entries, m_web_content_known_entries, nested_history_id, navigation_api_key, [&](Entry& entry) {
+        entry.scroll_restoration_mode = scroll_restoration_mode;
+    });
+}
+
 Optional<size_t> TraversableSessionHistory::current_top_level_entry_index() const
 {
     if (!m_current_used_step_index.has_value())

--- a/Libraries/LibWebView/SessionHistory.h
+++ b/Libraries/LibWebView/SessionHistory.h
@@ -59,6 +59,10 @@ public:
     void replace_current_entry(URL::URL, Web::HTML::CrossProcessId document_state_id, Web::HTML::DocumentResource);
     void mark_current_entry_reload_pending();
     void clear_current_entry_reload_pending();
+    bool update_top_level_navigation_api_state(Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state);
+    bool update_nested_navigation_api_state(Web::HTML::CrossProcessId nested_history_id, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state);
+    bool update_top_level_scroll_restoration_mode(Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode);
+    bool update_nested_scroll_restoration_mode(Web::HTML::CrossProcessId nested_history_id, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode);
     UpdateResult update_from_web_content(Vector<Entry> entries, Vector<i32> used_steps, size_t current_used_step_index);
     [[nodiscard]] bool did_seed_web_content_from_ui_process(Vector<Entry> entries, Vector<i32> used_steps, size_t current_used_step_index);
     void did_seed_web_content_from_ui_process(size_t current_top_level_entry_index);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -276,6 +276,22 @@ CanonicalNavigable* WebContentClient::navigable_for_page(u64 page_id)
     return nullptr;
 }
 
+Optional<CanonicalNavigable&> WebContentClient::hosted_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id)
+{
+    auto* page_host = navigable_for_page(page_id);
+    if (!page_host)
+        return {};
+
+    auto navigable = page_host->top_level_traversable().find(navigable_id);
+    if (!navigable.has_value())
+        return {};
+
+    if (&*navigable == page_host || navigable->is_hosted_by(*this, page_id))
+        return *navigable;
+
+    return {};
+}
+
 Optional<CanonicalNavigable&> WebContentClient::child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id)
 {
     auto* host = navigable_for_page(page_id);
@@ -1801,6 +1817,22 @@ void WebContentClient::did_update_session_history(u64 page_id, Vector<Web::HTML:
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
         view->did_update_session_history({}, move(entries), move(used_steps), current_used_step_index);
+}
+
+void WebContentClient::did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state)
+{
+    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    if (!navigable.has_value())
+        return;
+    navigable->top_level_traversable().update_session_history_entry_navigation_api_state(*navigable, navigation_api_key, move(navigation_api_state));
+}
+
+void WebContentClient::did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode)
+{
+    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    if (!navigable.has_value())
+        return;
+    navigable->top_level_traversable().update_session_history_entry_scroll_restoration_mode(*navigable, navigation_api_key, scroll_restoration_mode);
 }
 
 Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse WebContentClient::did_request_ui_process_session_history_for_testing(u64 page_id)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -85,6 +85,7 @@ public:
 
     CanonicalNavigable* embedded_page_host(u64 page_id);
     CanonicalNavigable* navigable_for_page(u64 page_id);
+    Optional<CanonicalNavigable&> hosted_navigable_for_page(u64 page_id, Web::HTML::CrossProcessId navigable_id);
 
     Optional<CanonicalNavigable&> child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id);
 
@@ -247,6 +248,8 @@ private:
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState) override;
     virtual void did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index) override;
+    virtual void did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state) override;
+    virtual void did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestSiteIsolationProcessTreeForTestingResponse did_request_site_isolation_process_tree_for_testing(u64 page_id) override;
     virtual Messages::WebContentClient::DidUpdateSessionHistoryAndRequestUiProcessSessionHistoryForTestingResponse did_update_session_history_and_request_ui_process_session_history_for_testing(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1093,6 +1093,16 @@ void PageClient::page_did_update_session_history(Vector<Web::HTML::SessionHistor
     client().async_did_update_session_history(m_id, entries, used_steps, current_used_step_index);
 }
 
+void PageClient::page_did_update_session_history_entry_navigation_api_state(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord const& navigation_api_state)
+{
+    client().async_did_update_session_history_entry_navigation_api_state(m_id, navigable_id, navigation_api_key, navigation_api_state);
+}
+
+void PageClient::page_did_update_session_history_entry_scroll_restoration_mode(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode)
+{
+    client().async_did_update_session_history_entry_scroll_restoration_mode(m_id, navigable_id, navigation_api_key, scroll_restoration_mode);
+}
+
 String PageClient::page_did_request_ui_process_session_history_for_testing()
 {
     return client().did_request_ui_process_session_history_for_testing(m_id);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -243,6 +243,8 @@ private:
     virtual void page_did_change_needs_beforeunload_check(bool needs_beforeunload_check) override;
     virtual bool should_report_session_history_updates() const override;
     virtual void page_did_update_session_history(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Vector<i32> const& used_steps, size_t current_used_step_index) override;
+    virtual void page_did_update_session_history_entry_navigation_api_state(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord const& navigation_api_state) override;
+    virtual void page_did_update_session_history_entry_scroll_restoration_mode(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual String page_did_request_ui_process_session_history_for_testing() override;
     virtual String page_did_update_session_history_and_request_ui_process_session_history_for_testing(Vector<Web::HTML::SessionHistoryEntryDescriptor> const&, Vector<i32> const& used_steps, size_t current_used_step_index) override;
     virtual bool page_did_request_traverse_the_history_by_delta(int delta, Web::HistoryTraversalPrecheck) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -172,6 +172,8 @@ endpoint WebContentClient
     did_update_primary_selection(u64 page_id, String text) =|
 
     did_update_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) =|
+    did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state) =|
+    did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode) =|
     did_request_ui_process_session_history_for_testing(u64 page_id) => (String session_history)
     did_request_site_isolation_process_tree_for_testing(u64 page_id) => (String process_tree)
     did_update_session_history_and_request_ui_process_session_history_for_testing(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries, Vector<i32> used_steps, size_t current_used_step_index) => (String session_history)

--- a/Tests/LibWebView/TestSessionHistory.cpp
+++ b/Tests/LibWebView/TestSessionHistory.cpp
@@ -254,6 +254,47 @@ TEST_CASE(complete_web_content_update_replaces_mirror)
     expect_current_entry(history, 1, "https://b.example/"sv);
 }
 
+TEST_CASE(targeted_entry_updates_find_nested_history_entries_by_navigation_api_key)
+{
+    WebView::TraversableSessionHistory history;
+
+    Vector<Web::HTML::SessionHistoryEntryDescriptor> entries {
+        entry(0, "https://top.example/0"sv, 1, 1, "top-0"sv, "top-id-0"sv, Web::HTML::ScrollRestorationMode::Auto),
+        entry(1, "https://top.example/1"sv, 2, 2, "top-1"sv, "top-id-1"sv, Web::HTML::ScrollRestorationMode::Auto),
+    };
+
+    auto entries0 = {
+        entry(0, "https://child.example/0"sv, 3, 3, "child-0"sv, "child-id-0"sv, Web::HTML::ScrollRestorationMode::Auto),
+        entry(2, "https://child.example/1"sv, 4, 4, "child-1"sv, "child-id-1"sv, Web::HTML::ScrollRestorationMode::Auto),
+    };
+    entries[0].document_state.nested_histories.append(nested_history("frame-1"sv, entries0));
+    auto entries1 = {
+        entry(0, "https://child.example/0"sv, 3, 3, "child-0"sv, "child-id-0"sv, Web::HTML::ScrollRestorationMode::Auto),
+        entry(2, "https://child.example/1"sv, 4, 4, "child-1"sv, "child-id-1"sv, Web::HTML::ScrollRestorationMode::Auto),
+    };
+    entries[1].document_state.nested_histories.append(nested_history("frame-1"sv, entries1));
+
+    auto update_result = history.update_from_web_content(move(entries), { 0, 1, 2 }, 2);
+    EXPECT_EQ(update_result, WebView::TraversableSessionHistory::UpdateResult::CompleteSnapshot);
+
+    EXPECT(history.update_nested_navigation_api_state(navigable_id("frame-1"sv), Utf16String::from_utf8("child-1"sv), state_record(9)));
+    EXPECT(history.update_nested_scroll_restoration_mode(navigable_id("frame-1"sv), Utf16String::from_utf8("child-1"sv), Web::HTML::ScrollRestorationMode::Manual));
+
+    auto expect_copied_nested_histories_were_updated = [](Vector<Web::HTML::SessionHistoryEntryDescriptor> const& copied_entries) {
+        VERIFY(copied_entries.size() == 2);
+        for (auto const& top_level_entry : copied_entries) {
+            VERIFY(top_level_entry.document_state.nested_histories.size() == 1);
+            auto const& nested_entries = top_level_entry.document_state.nested_histories[0].entries;
+            VERIFY(nested_entries.size() == 2);
+            expect_entry_state(nested_entries[0], 3, 3, "child-0"sv, "child-id-0"sv, Web::HTML::ScrollRestorationMode::Auto);
+            expect_entry_state(nested_entries[1], 4, 9, "child-1"sv, "child-id-1"sv, Web::HTML::ScrollRestorationMode::Manual);
+        }
+    };
+
+    expect_copied_nested_histories_were_updated(history.entries());
+    expect_copied_nested_histories_were_updated(history.web_content_known_entries());
+}
+
 TEST_CASE(fresh_process_snapshot_does_not_drop_previous_entries)
 {
     WebView::TraversableSessionHistory history;


### PR DESCRIPTION
Avoid sending a complete session history snapshot when
Navigation.updateCurrentEntry() changes Navigation API state or when
History.scrollRestoration changes the current entry.

Instead, send two typed messages identifying the entry using its
navigable ID and existing Navigation API key. Apply the changes directly
to the UI process's canonical TraversableSessionHistory, including
copies stored in nested histories and the WebContent-known history.

This replaces full WebContent-produced snapshots for these two cases
with targeted UI-process entry updates, moving (in a very small step)
toward the UI-owned session history model required for site isolation.