### PR TITLE
WebDriver: Use one browser profile per WebDriver process

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -462,8 +462,11 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
     m_profile = TRY(Profile::create(profile_selection, profile_roots));
 #endif
 
+    // Browsers launched by WebDriver are driven directly and must never join an existing browser process.
+    bool coordinate_browser_process = !headless_mode.has_value() && !webdriver_endpoint.has_value() && should_coordinate_browser_process();
+
     // Synchronous IPC used to forward URLs to an existing browser process requires an event loop.
-    if (!headless_mode.has_value() && should_coordinate_browser_process()) {
+    if (coordinate_browser_process) {
         m_browser_options.headless_mode = headless_mode;
         m_event_loop = &create_platform_event_loop();
     }
@@ -495,7 +498,7 @@ ErrorOr<void> Application::initialize(Main::Arguments const& arguments)
 #endif
 
     m_browser_process = make<BrowserProcess>();
-    if (!headless_mode.has_value() && should_coordinate_browser_process()) {
+    if (coordinate_browser_process) {
         auto disposition = TRY(m_browser_process->connect(raw_urls, new_window ? NewWindow::Yes : NewWindow::No, profile().paths().runtime, profile_identity));
         if (disposition == BrowserProcess::ProcessDisposition::ExitProcess) {
             m_should_exit_after_profile_coordination = true;

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -369,6 +369,28 @@ cleanup_run_dirs() {
     sudo_and_ask "" rm -fr "${BUILD_DIR}/wpt"
 }
 
+WPT_PROFILES_PARENT="${BUILD_DIR}/wpt-profiles"
+WPT_PROFILES_ROOT="${WPT_PROFILES_PARENT}/run-$$"
+
+# Each WebDriver instance creates its browser profile under this run's profile root. The root is
+# removed when this script exits; roots leaked by previous unclean exits are swept before running.
+ensure_profiles_root() {
+    local stale pid
+    for stale in "${WPT_PROFILES_PARENT}"/run-*; do
+        [ -d "$stale" ] || continue
+        pid="${stale##*/run-}"
+        if ! kill -0 "$pid" 2>/dev/null; then
+            rm -rf "$stale"
+        fi
+    done
+    mkdir -p "${WPT_PROFILES_ROOT}"
+    WPT_ARGS+=( "--webdriver-arg=--profiles-directory=${WPT_PROFILES_ROOT}" )
+}
+
+cleanup_profiles_root() {
+    rm -rf "${WPT_PROFILES_ROOT}"
+}
+
 cleanup_merge_dirs_and_infra() {
     # Cleanup is only needed on Linux
     if [[ $OSTYPE == 'linux'* ]]; then
@@ -376,7 +398,7 @@ cleanup_merge_dirs_and_infra() {
         cleanup_run_infra
     fi
 }
-trap cleanup_merge_dirs_and_infra EXIT INT TERM
+trap 'cleanup_merge_dirs_and_infra; cleanup_profiles_root' EXIT INT TERM
 
 make_instances() {
     if [ "${PARALLEL_INSTANCES}" = 1 ]; then
@@ -607,6 +629,8 @@ update_hosts_file_if_needed() {
 execute_wpt() {
     local procs
 
+    ensure_profiles_root
+
     procs=$(make_instances)
     if [[ "$procs" -le 1 ]]; then
         absolutize_log_args
@@ -822,11 +846,10 @@ if [[ "$CMD" =~ ^(update|clean|run|serve|bisect|compare|import|list-tests)$ ]]; 
             run_wpt "${@}"
             ;;
         clean)
+            rm -rf "${WPT_PROFILES_PARENT}"
             if [[ $OSTYPE == 'linux'* ]]; then
                 cleanup_run_infra
                 cleanup_run_dirs true
-            else
-                echo "Cleanup is only needed on Linux"
             fi
             ;;
         serve)

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <AK/Platform.h>
+#include <AK/Random.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Directory.h>
 #include <LibCore/Environment.h>
@@ -13,6 +15,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibCore/TCPServer.h>
+#include <LibFileSystem/FileSystem.h>
 #include <LibMain/Main.h>
 #include <LibWeb/WebDriver/Capabilities.h>
 #include <LibWebView/Utilities.h>
@@ -35,7 +38,7 @@ static ErrorOr<Core::Process> launch_process(StringView application, ReadonlySpa
     return result;
 }
 
-static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, bool headless, bool expose_experimental_interfaces, bool expose_internals_object, bool force_cpu_painting, bool disable_sandbox, Optional<StringView> debug_process, Optional<StringView> default_time_zone, Optional<StringView> resource_substitution_map_path)
+static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint, ByteString const& profile_path, bool headless, bool expose_experimental_interfaces, bool expose_internals_object, bool force_cpu_painting, bool disable_sandbox, Optional<StringView> debug_process, Optional<StringView> default_time_zone, Optional<StringView> resource_substitution_map_path)
 {
     Vector<ByteString> arguments;
 #if defined(AK_OS_MACOS)
@@ -55,7 +58,7 @@ static Vector<ByteString> create_arguments(ByteString const& webdriver_endpoint,
         arguments.append("--headless"sv);
 
     arguments.append("--allow-popups"sv);
-    arguments.append("--force-new-process"sv);
+    arguments.append(ByteString::formatted("--profile-path={}", profile_path));
     arguments.append("--enable-autoplay"sv);
     arguments.append("--disable-scrollbar-painting"sv);
     if (expose_experimental_interfaces)
@@ -137,6 +140,9 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto webdriver_socket_path = ByteString::formatted("{}/webdriver", TRY(Core::StandardPaths::runtime_directory()));
     TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
 
+    // Every browser instance launched by this WebDriver process shares one profile, which is removed on clean exit.
+    auto profile_path = LexicalPath::join(Core::StandardPaths::tempfile_directory(), ByteString::formatted("ladybird-webdriver-profile-{:016x}-{:016x}", get_random<u64>(), get_random<u64>())).string();
+
     auto& loop = Core::EventLoop::initialize_for_current_thread();
     Core::EventLoop::register_signal(SIGINT, handle_signal);
     Core::EventLoop::register_signal(SIGTERM, handle_signal);
@@ -159,7 +165,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         }
 
         auto launch_browser_callback = [&](ByteString const& webdriver_endpoint, bool headless) {
-            auto arguments = create_arguments(webdriver_endpoint, headless, expose_experimental_interfaces, expose_internals_object, force_cpu_painting, disable_sandbox, debug_process, default_time_zone, resource_substitution_map_path);
+            auto arguments = create_arguments(webdriver_endpoint, profile_path, headless, expose_experimental_interfaces, expose_internals_object, force_cpu_painting, disable_sandbox, debug_process, default_time_zone, resource_substitution_map_path);
             return launch_process("Ladybird"sv, arguments.span());
         };
 
@@ -183,5 +189,11 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     auto result = loop.exec();
     WebDriver::Session::close_all();
+
+    if (FileSystem::exists(profile_path)) {
+        if (auto removal_result = FileSystem::remove(profile_path, FileSystem::RecursionMode::Allowed); removal_result.is_error())
+            warnln("Unable to remove WebDriver profile '{}': {}", profile_path, removal_result.error());
+    }
+
     return result;
 }

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -106,6 +106,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     bool headless = false;
     Optional<StringView> debug_process;
     Optional<StringView> default_time_zone;
+    Optional<StringView> profiles_directory;
     Optional<StringView> resource_substitution_map_path;
 
     Core::ArgsParser args_parser;
@@ -119,6 +120,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     args_parser.add_option(debug_process, "Wait for a debugger to attach to the given process name (WebContent, RequestServer, etc.)", "debug-process", 0, "process-name");
     args_parser.add_option(headless, "Launch browser without a graphical interface", "headless");
     args_parser.add_option(default_time_zone, "Default time zone", "default-time-zone", 0, "time-zone-id");
+    args_parser.add_option(profiles_directory, "Directory in which to create the browser profile", "profiles-directory", 0, "path");
     args_parser.add_option(resource_substitution_map_path, "Path to JSON file mapping URLs to local files", "resource-map", 0, "path");
     args_parser.parse(arguments);
 
@@ -141,7 +143,8 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     TRY(Core::Directory::create(webdriver_socket_path, Core::Directory::CreateDirectories::Yes));
 
     // Every browser instance launched by this WebDriver process shares one profile, which is removed on clean exit.
-    auto profile_path = LexicalPath::join(Core::StandardPaths::tempfile_directory(), ByteString::formatted("ladybird-webdriver-profile-{:016x}-{:016x}", get_random<u64>(), get_random<u64>())).string();
+    auto profile_parent_directory = profiles_directory.has_value() ? ByteString { *profiles_directory } : Core::StandardPaths::tempfile_directory();
+    auto profile_path = LexicalPath::join(profile_parent_directory, ByteString::formatted("ladybird-webdriver-profile-{:016x}-{:016x}", get_random<u64>(), get_random<u64>())).string();
 
     auto& loop = Core::EventLoop::initialize_for_current_thread();
     Core::EventLoop::register_signal(SIGINT, handle_signal);


### PR DESCRIPTION
Previously, each browser instance launched by WebDriver used its own temporary profile. These profiles were leaked whenever a browser did not exit cleanly. 

Browsers launched by the same WebDriver process now share a single profile, which is removed when the WebDriver process exits.

WPT.sh now places creates separate profiles for each concurrent WPT test and places them in a known directory, which is cleaned as part of `WPT.sh clean`.