### PR TITLE
LibWeb: Add a deterministic parser append-insertion regression test

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -2118,10 +2118,19 @@ struct NodeAndOffset {
     }
 };
 
+static u64 s_parser_non_append_insertions { 0 };
+
+u64 parser_non_append_insertions()
+{
+    return s_parser_non_append_insertions;
+}
+
 static NodeAndOffset node_and_offset_from_html_parser_ffi(size_t node, size_t offset)
 {
     auto& dom_node = node_from_html_parser_ffi(node);
     VERIFY(offset == NodeAndOffset::append_child_offset || offset <= dom_node.child_count());
+    if (offset != NodeAndOffset::append_child_offset)
+        ++s_parser_non_append_insertions;
     return { dom_node, offset };
 }
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -2100,10 +2100,19 @@ struct NodeAndOffset {
     }
 };
 
+static u64 s_parser_non_append_insertions { 0 };
+
+u64 parser_non_append_insertions()
+{
+    return s_parser_non_append_insertions;
+}
+
 static NodeAndOffset node_and_offset_from_html_parser_ffi(size_t node, size_t offset)
 {
     auto& dom_node = node_from_html_parser_ffi(node);
     VERIFY(offset == NodeAndOffset::append_child_offset || offset <= dom_node.child_count());
+    if (offset != NodeAndOffset::append_child_offset)
+        ++s_parser_non_append_insertions;
     return { dom_node, offset };
 }
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -208,4 +208,6 @@ RefPtr<CSS::StyleValue const> parse_nonzero_dimension_value(Utf16View);
 Optional<Color> parse_legacy_color_value(Utf16View);
 RefPtr<CSS::StyleValue const> parse_table_child_element_align_value(Utf16View);
 
+u64 parser_non_append_insertions();
+
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -205,4 +205,6 @@ RefPtr<CSS::StyleValue const> parse_nonzero_dimension_value(Utf16View);
 Optional<Color> parse_legacy_color_value(Utf16View);
 RefPtr<CSS::StyleValue const> parse_table_child_element_align_value(Utf16View);
 
+u64 parser_non_append_insertions();
+
 }

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/SharedResourceRequest.h>
@@ -926,6 +927,11 @@ void Internals::set_geolocation_emulated_position(double latitude, double longit
         .latitude = latitude,
         .longitude = longitude,
     });
+}
+
+u64 Internals::parser_non_append_insertions()
+{
+    return HTML::parser_non_append_insertions();
 }
 
 JS::Object* Internals::get_style_invalidation_counters()

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -65,6 +65,7 @@
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
 #include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -969,6 +970,11 @@ void Internals::set_geolocation_emulated_position(double latitude, double longit
         .latitude = latitude,
         .longitude = longitude,
     });
+}
+
+u64 Internals::parser_non_append_insertions()
+{
+    return HTML::parser_non_append_insertions();
 }
 
 bool Internals::media_element_is_fetching(HTML::HTMLMediaElement& element)

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -146,6 +146,7 @@ public:
     WebIDL::ExceptionOr<void> set_environments_top_level_url(Utf16String const& url);
     void set_geolocation_emulated_position(double latitude, double longitude, double accuracy);
 
+    u64 parser_non_append_insertions();
     JS::Object* get_style_invalidation_counters();
     void reset_style_invalidation_counters();
     JS::Object* layout_tree_build_stats();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -161,6 +161,7 @@ public:
     void set_environments_top_level_url(Utf16String const& url);
     void set_geolocation_emulated_position(double latitude, double longitude, double accuracy);
 
+    u64 parser_non_append_insertions();
     DOM::Document::StyleInvalidationCounters const& style_invalidation_counters() const;
     GC::Ref<JS::Object> style_invalidation_counters_object() const;
     void reset_style_invalidation_counters();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -136,6 +136,9 @@ interface Internals {
 
     undefined clearElement(HTMLElement element);
 
+    // Returns the number of insertions that computed an explicit child offset instead of using the append sentinel.
+    unsigned long long parserNonAppendInsertions();
+
     // Returns a snapshot of the style-invalidation and recomputation counters for the current document.
     // Keys include hasAncestorWalkInvocations, hasInvalidationRuleCacheBuilds,
     // styleInvalidations, elementStyleRecomputations, and elementStyleNoopRecomputations.

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -140,6 +140,9 @@ interface Internals {
 
     undefined clearElement(HTMLElement element);
 
+    // Returns the number of insertions that computed an explicit child offset instead of using the append sentinel.
+    unsigned long long parserNonAppendInsertions();
+
     // Returns a snapshot of the style engine counters exposed to LibWeb tests.
     // Keys include styleEngineReactionBatchRuns, styleEnginePublishedReactions,
     // elementStyleRecomputations, and styleEnvironmentVersion.

--- a/Tests/LibWeb/Text/expected/html-parser-foster-parented-insertion-is-counted.txt
+++ b/Tests/LibWeb/Text/expected/html-parser-foster-parented-insertion-is-counted.txt
@@ -1,0 +1,1 @@
+a foster-parented insertion computed an explicit offset

--- a/Tests/LibWeb/Text/expected/html-parser-script-created-parser-many-flat-siblings.txt
+++ b/Tests/LibWeb/Text/expected/html-parser-script-created-parser-many-flat-siblings.txt
@@ -1,0 +1,2 @@
+PASS
+parser appended every sibling using the append sentinel

--- a/Tests/LibWeb/Text/input/html-parser-foster-parented-insertion-is-counted.html
+++ b/Tests/LibWeb/Text/input/html-parser-foster-parented-insertion-is-counted.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    // Liveness canary for internals.parserNonAppendInsertions().
+    const before = internals.parserNonAppendInsertions();
+    document.write("<table><b>fostered</b></table>");
+    const nonAppendInsertions = internals.parserNonAppendInsertions() - before;
+
+    test(() => {
+        if (nonAppendInsertions > 0)
+            println("a foster-parented insertion computed an explicit offset");
+        else
+            println(`FAIL: expected a foster-parented insertion to compute an explicit offset, got ${nonAppendInsertions}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/html-parser-script-created-parser-many-flat-siblings.html
+++ b/Tests/LibWeb/Text/input/html-parser-script-created-parser-many-flat-siblings.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    // Regression test for a problem where the parser computed every append-style insertion location by counting the
+    // parent’s children. That's an O(children) sibling-list walk, so inserting N flat siblings performed O(N^2) sibling
+    // hops overall. A previous test was racy due to trying to catch the regression through timing measurement. This
+    // test instead doesn't rely on timing at all. Appends now resolve to an append sentinel, not an explicit child
+    // index; internals.parserNonAppendInsertions() counts insertions that carried an explicit offset rather than the
+    // sentinel — so appending flat siblings must add zero.
+    const siblingCount = 5000;
+    const before = internals.parserNonAppendInsertions();
+    document.write("<span></span>".repeat(siblingCount) + "<span>PASS</span>");
+    const nonAppendInsertions = internals.parserNonAppendInsertions() - before;
+
+    test(() => {
+        println(document.getElementsByTagName("span").item(siblingCount).textContent);
+        if (nonAppendInsertions === 0)
+            println("parser appended every sibling using the append sentinel");
+        else
+            println(`parser computed an explicit insertion offset ${nonAppendInsertions} time(s) while appending ${siblingCount} flat siblings`);
+    });
+</script>


### PR DESCRIPTION
This test ensures parser append-insertion behavior has remained linear — rather than having regressed into going quadratic. The test directly asserts that appends resolve to an append sentinel instead of an explicit child index. A new internals method counts parser insertions that carried an explicit offset rather than the sentinel, incremented at the single FFI chokepoint every insertion flows through. Appending 5000 flat siblings must add 0. A companion test checks that a foster-parented (genuinely non-append) insertion does increment the counter — so an always-zero counter can’t let the regression test silently pass.

This replaces a test removed in 5b04398 that had tried to catch the regression by instead measuring timing; that timing-based test turned out in practice to be very flaky/racy under CI.
