### PR TITLE
Meta/WPT.sh: Prevent venv setup failure because of missing test behavior

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -551,7 +551,7 @@ run_wpt_chunked() {
 
     echo "Preparing the venv setup..."
     base_venv="${BUILD_DIR}/wpt-prep/_venv"
-    ./wpt --venv "$base_venv" run "${WPT_ARGS[@]}" ladybird THIS_TEST_CANNOT_POSSIBLY_EXIST "${WPT_TEST_TYPE_ARGS[@]}"
+    ./wpt --venv "$base_venv" run "${WPT_ARGS[@]}" --list-tests ladybird THIS_TEST_CANNOT_POSSIBLY_EXIST "${WPT_TEST_TYPE_ARGS[@]}"
 
     echo "Launching $procs chunked instances (concurrency=$concurrency each)"
     local logs=()
@@ -567,10 +567,10 @@ run_wpt_chunked() {
         touch "$logpath"
         logs+=("$logpath")
 
+        rm -rf "${runpath}/_venv"
         cp -r "$base_venv" "${runpath}/_venv"
 
         command=(./wpt --venv "${runpath}/_venv" \
-            --skip-venv-setup \
             run \
             --this-chunk="$((i + 1))" \
             --total-chunks="$procs" \


### PR DESCRIPTION
The old behavior was to fail `wpt` by providing it with the name of a test that does not exist, which necessitated `|| true`. This hid venv setup failures though, so that was less than ideal.

This new approach uses `--list-tests` which does not cause `wpt` to exit with a non-zero status code, but still sets up the venv and allows setup failures to propagate.

Remove `--skip-venv-setup` from the individual chunk runners since that is still required to _activate_ the venv.