### PR TITLE
LibWeb: Stop inspector overlays growing the visual context tree

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8815,6 +8815,10 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     update_paint_and_hit_testing_properties_if_needed();
     VERIFY(paintable());
 
+    // Drop the inspector-overlay context nodes appended by the previous recording; this appends its own. Safe because
+    // the pruned tree only reaches the compositor together with (or after) the display list recorded against it here.
+    paintable()->prune_inspector_overlay_visual_contexts();
+
     auto display_list = Painting::DisplayList::create(paintable()->visual_context_tree());
     Painting::DisplayListRecorder display_list_recorder(display_list, paintable()->visual_context_tree(), resource_storage);
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -110,6 +110,15 @@ void Internals::force_incompatible_visual_context_tree_rebuild()
     document.set_needs_accumulated_visual_contexts_update(true);
 }
 
+u64 Internals::visual_context_tree_node_count()
+{
+    auto& document = window().associated_document();
+    auto paintable = document.paintable();
+    if (!paintable || !paintable->has_visual_context_tree())
+        return 0;
+    return paintable->visual_context_tree().nodes().size();
+}
+
 // https://web-platform-tests.org/writing-tests/reftests.html#components-of-a-reftest
 WebIDL::ExceptionOr<void> Internals::load_reference_test_metadata()
 {

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -38,6 +38,7 @@ public:
     void signal_test_is_done(Utf16String const& text);
     void set_test_timeout(double milliseconds);
     void force_incompatible_visual_context_tree_rebuild();
+    u64 visual_context_tree_node_count();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 
     WebIDL::ExceptionOr<Utf16String> set_time_zone(Utf16String const& time_zone);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -4,6 +4,7 @@ interface Internals {
     undefined signalTestIsDone(Utf16DOMString text);
     undefined setTestTimeout(double milliseconds);
     undefined forceIncompatibleVisualContextTreeRebuild();
+    unsigned long long visualContextTreeNodeCount();
     undefined loadReferenceTestMetadata();
 
     Utf16DOMString setTimeZone(Utf16DOMString timeZone);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -648,6 +648,14 @@ VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, 
     return index;
 }
 
+void AccumulatedVisualContextTree::shrink(size_t node_count)
+{
+    // The visual viewport root node must always remain.
+    VERIFY(node_count >= 1);
+    VERIFY(node_count <= m_nodes.size());
+    m_nodes.shrink(node_count, true);
+}
+
 void AccumulatedVisualContextTree::set_visual_viewport_transform(TransformData transform)
 {
     VERIFY(!m_nodes.is_empty());

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -137,6 +137,7 @@ public:
     u64 version() const { return m_version; }
 
     WEB_API VisualContextIndex append(VisualContextData data, VisualContextIndex parent_index);
+    WEB_API void shrink(size_t node_count);
     WEB_API void set_visual_viewport_transform(TransformData);
     WEB_API bool is_compatible_with(AccumulatedVisualContextTree const&) const;
     WEB_API void reuse_version_from(AccumulatedVisualContextTree const&);

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -206,6 +206,8 @@ void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext
                 relevant_indices.append(i);
         }
 
+        // NB: These nodes are transient: they're only referenced by the display list being recorded right now — and the
+        //     next recording prunes them again (see ViewportPaintable::prune_inspector_overlay_visual_contexts).
         auto overlay_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
         for (auto const& source_visual_context_index : relevant_indices.in_reverse())
             overlay_visual_context_index = visual_context_tree.append(visual_context_tree.node_at(source_visual_context_index).data, overlay_visual_context_index);

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -114,6 +114,7 @@ void ViewportPaintable::reset_for_relayout()
     clear_scroll_state();
     m_paintable_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree.clear();
+    m_visual_context_tree_node_count_without_inspector_overlays = 0;
     m_visual_context_tree_needs_compositor_update = false;
 }
 
@@ -278,6 +279,7 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         document().set_needs_to_record_display_list();
     }
     m_visual_context_tree = move(visual_context_tree);
+    m_visual_context_tree_node_count_without_inspector_overlays = m_visual_context_tree->nodes().size();
     m_visual_context_tree_needs_compositor_update = true;
 }
 
@@ -301,6 +303,17 @@ void ViewportPaintable::update_visual_viewport_accumulated_visual_context()
     }
     Painting::update_visual_viewport_accumulated_visual_context(*this);
     m_visual_context_tree_needs_compositor_update = true;
+}
+
+// Painting inspector overlays appends the highlighted elements' transform/scroll ancestor contexts onto the visual
+// context tree (see Paintable::paint_with_inspector_overlay_context). Those nodes are only referenced by the display
+// list recorded alongside them — so each new recording prunes the ones appended by the previous recording before
+// appending its own; otherwise they would accumulate without bound.
+void ViewportPaintable::prune_inspector_overlay_visual_contexts()
+{
+    if (!m_visual_context_tree.has_value())
+        return;
+    m_visual_context_tree->shrink(m_visual_context_tree_node_count_without_inspector_overlays);
 }
 
 void ViewportPaintable::invalidate_all_cached_paint()

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -35,6 +35,7 @@ public:
     void assign_accumulated_visual_contexts();
     bool update_accumulated_visual_context_values(Paintable&);
     void update_visual_viewport_accumulated_visual_context();
+    void prune_inspector_overlay_visual_contexts();
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
     void set_force_incompatible_visual_context_tree_rebuild_for_testing() { m_force_incompatible_visual_context_tree_rebuild_for_testing = true; }
@@ -82,6 +83,7 @@ private:
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
     u64 m_accumulated_visual_context_tree_build_count { 0 };
+    size_t m_visual_context_tree_node_count_without_inspector_overlays { 0 };
     bool m_visual_context_tree_needs_compositor_update { false };
     bool m_force_incompatible_visual_context_tree_rebuild_for_testing { false };
 };

--- a/Tests/LibWeb/Text/expected/inspector-overlay-visual-context-tree-growth.txt
+++ b/Tests/LibWeb/Text/expected/inspector-overlay-visual-context-tree-growth.txt
@@ -1,0 +1,3 @@
+PASS: recording with an inspector highlight appends overlay context nodes
+PASS: repeated recordings while highlighted do not grow the visual context tree
+PASS: overlay context nodes are pruned once the highlight is cleared

--- a/Tests/LibWeb/Text/input/inspector-overlay-visual-context-tree-growth.html
+++ b/Tests/LibWeb/Text/input/inspector-overlay-visual-context-tree-growth.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!-- Each display-list recording that paints an inspector overlay appends the highlighted element's transform/scroll
+     contexts onto the accumulated visual context tree. Those nodes are transient: the next recording must prune them
+     before appending its own — rather than letting them accumulate (and get shipped to the compositor) for the lifetime
+     of the tree. See #10368.
+
+     NB: The tree is only rebuilt from scratch when layout is invalidated. Mutating the DOM between measurements (e.g.,
+     via println) would dirty layout and force a rebuild — masking the growth. So, as in
+     visual-context-value-only-updates.html, all measurements are taken first, and printed at the end. -->
+<style>
+    #box {
+        width: 100px;
+        height: 100px;
+        transform: rotate(10deg);
+        background: orange;
+    }
+</style>
+<script src="include.js"></script>
+<div id="box"></div>
+<script>
+    test(() => {
+        const box = document.getElementById("box");
+
+        // dumpDisplayList() records a fresh display list; the count that follows is the resulting live visual context
+        // tree size (base nodes plus any inspector-overlay nodes appended).
+        const recordAndCount = () => {
+            internals.dumpDisplayList();
+            return internals.visualContextTreeNodeCount();
+        };
+
+        const baseCount = recordAndCount();
+
+        internals.setHighlightedNode(box);
+        const highlightedCounts = [];
+        for (let i = 0; i < 6; i++)
+            highlightedCounts.push(recordAndCount());
+
+        internals.setHighlightedNode(null);
+        const clearedCount = recordAndCount();
+
+        const overlayAppended = highlightedCounts[0] > baseCount;
+        const stayedFlat = highlightedCounts.every(c => c === highlightedCounts[0]);
+        const returnedToBase = clearedCount === baseCount;
+
+        println(overlayAppended
+            ? "PASS: recording with an inspector highlight appends overlay context nodes"
+            : `FAIL: expected overlay nodes to be appended (base ${baseCount}, highlighted ${highlightedCounts[0]})`);
+        println(stayedFlat
+            ? "PASS: repeated recordings while highlighted do not grow the visual context tree"
+            : `FAIL: visual context tree grew across repeated recordings: ${highlightedCounts.join(", ")}`);
+        println(returnedToBase
+            ? "PASS: overlay context nodes are pruned once the highlight is cleared"
+            : `FAIL: expected ${baseCount} nodes after clearing the highlight, got ${clearedCount}`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** While a node was highlighted in the devtools inspector, every display-list recording appended the highlighted element’s transform and scroll contexts onto the document’s accumulated visual context tree — *and nothing ever removed them*. Repeatedly toggling the highlight grew the tree without bound (thousands of nodes within a minute, over an animated element) — every one of them re-shipped to the Compositor in each tree update. And since a freshly-rebuilt tree never matched the polluted one, every rebuild while (or after) highlighting minted a new tree version — and forced a full display-list re-record.

**Cause:** `Paintable::paint_with_inspector_overlay_context` const_cast’ed the live tree owned by the `ViewportPaintable`, and appended the overlay’s context chain to it on every recording. The appended nodes were only referenced by the display list recorded alongside them — but they stayed in the tree for the tree’s whole lifetime.

**Fix:** Track the tree’s node count as of the last rebuild, and prune any nodes beyond it at the start of each display-list recording — so each recording appends its own overlay chain in place of the previous one, and the tree returns to its built size once nothing is highlighted. Pruning at recording time preserves the producer/Compositor shape expectations: A tree with pruned or re-appended overlay nodes only reaches the Compositor together with — or in value-only updates after — the display list that was recorded against exactly that shape.

This also adds a new `internals.visualContextTreeNodeCount()` method — so the regression test can observe the tree size deterministically.

Discovered this while looking into https://github.com/LadybirdBrowser/ladybird/issues/10368.
