### PR TITLE
Compositor: Drop version-mismatched updates instead of crashing

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -119,6 +119,27 @@ u64 Internals::visual_context_tree_node_count()
     return paintable->visual_context_tree().nodes().size();
 }
 
+void Internals::send_mismatched_visual_context_tree_update_to_compositor()
+{
+    auto& document = window().associated_document();
+    auto navigable = document.navigable();
+    if (!navigable || !navigable->has_compositor_context())
+        return;
+    auto paintable = document.paintable();
+    if (!paintable || !paintable->has_visual_context_tree())
+        return;
+
+    // Force a fresh, incompatible rebuild — so the tree is minted with a new version that the Compositor's installed
+    // display list was never recorded against.
+    paintable->set_force_incompatible_visual_context_tree_rebuild_for_testing();
+    document.set_needs_accumulated_visual_contexts_update(true);
+    document.update_paint_and_hit_testing_properties_if_needed();
+
+    // Send a bare visual-context-tree update carrying that new version *without* re-recording the display list —
+    // deliberately reproducing the peer inconsistency behind issue #10368.
+    navigable->compositor_context().update_visual_context_tree(paintable->visual_context_tree());
+}
+
 // https://web-platform-tests.org/writing-tests/reftests.html#components-of-a-reftest
 WebIDL::ExceptionOr<void> Internals::load_reference_test_metadata()
 {

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -39,6 +39,7 @@ public:
     void set_test_timeout(double milliseconds);
     void force_incompatible_visual_context_tree_rebuild();
     u64 visual_context_tree_node_count();
+    void send_mismatched_visual_context_tree_update_to_compositor();
     WebIDL::ExceptionOr<void> load_reference_test_metadata();
 
     WebIDL::ExceptionOr<Utf16String> set_time_zone(Utf16String const& time_zone);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -5,6 +5,7 @@ interface Internals {
     undefined setTestTimeout(double milliseconds);
     undefined forceIncompatibleVisualContextTreeRebuild();
     unsigned long long visualContextTreeNodeCount();
+    undefined sendMismatchedVisualContextTreeUpdateToCompositor();
     undefined loadReferenceTestMetadata();
 
     Utf16DOMString setTimeZone(Utf16DOMString timeZone);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1151,6 +1151,9 @@ void Application::handle_compositor_process_death()
         m_compositor_recovery_state = CompositorRecoveryState::Idle;
         recover_compositor_process();
     });
+
+    if (on_compositor_process_death)
+        on_compositor_process_death();
 }
 
 void Application::recover_compositor_process()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -150,6 +150,8 @@ public:
     bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     void notify_compositor_presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
 
+    Function<void()> on_compositor_process_death;
+
     virtual Optional<ViewImplementation&> active_web_view() const { return {}; }
     virtual Vector<ViewImplementation&> active_window_web_views() const { return {}; }
     virtual bool activate_tab_with_url(URL::URL const&) const { return false; }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -135,6 +135,13 @@ void CompositorState::update_display_list(Web::Compositor::CompositorContextId c
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
+    if (display_list->compatible_visual_context_tree_version() != visual_context_tree.version()) {
+        dbgln("Compositor: Dropping inconsistent display list update (display list version {}, tree version {})",
+            display_list->compatible_visual_context_tree_version(),
+            visual_context_tree.version());
+        return;
+    }
+
     context->apply_display_list_resource_transaction(move(resource_transaction));
     context->install_display_list_update(move(display_list), move(visual_context_tree), move(scroll_state_snapshot));
 }

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -186,8 +186,12 @@ void ContextState::install_display_list_update(
 
 void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualContextTree visual_context_tree)
 {
-    VERIFY(m_display_list);
-    VERIFY(m_display_list->compatible_visual_context_tree_version() == visual_context_tree.version());
+    if (!m_display_list || m_display_list->compatible_visual_context_tree_version() != visual_context_tree.version()) {
+        dbgln("Compositor: Dropping stale visual context tree update (tree version {}, display list version {})",
+            visual_context_tree.version(),
+            m_display_list ? m_display_list->compatible_visual_context_tree_version() : 0);
+        return;
+    }
     m_visual_context_tree = move(visual_context_tree);
     m_visual_context_tree_for_compositing.clear();
     if (m_async_visual_viewport_transform.has_value() && visual_viewport_transforms_match(visual_viewport_transform(*m_visual_context_tree), *m_async_visual_viewport_transform))

--- a/Tests/LibWeb/Crash/HTML/compositor-drops-mismatched-visual-context-tree-update.html
+++ b/Tests/LibWeb/Crash/HTML/compositor-drops-mismatched-visual-context-tree-update.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!-- Regression test for the Compositor dropping (rather than crashing on) a visual-context-tree update whose
+     version its installed display list was never recorded against. See #10368.
+     internals.sendMismatchedVisualContextTreeUpdateToCompositor() reproduces the peer inconsistency directly. With the
+     defensive Compositor fix, the update is dropped and the process survives (this test renders and passes); without
+     it, the Compositor crashes. -->
+<html class="test-wait">
+<head><style>#box { width: 100px; height: 100px; transform: rotate(10deg); background: orange; }</style></head>
+<body>
+<div id="box"></div>
+<script>
+    // Let a display list get recorded and installed on the Compositor first.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        internals.sendMismatchedVisualContextTreeUpdateToCompositor();
+        // If the Compositor survived (dropped the update), we reach here and finish.
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+            document.documentElement.classList.remove("test-wait");
+        }));
+    }));
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -1158,6 +1158,19 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     Vector<TestCompletion> non_passing_tests;
     bool fail_fast_triggered = false;
 
+    // If the Compositor dies, it takes the rendering pipeline of every in-flight test with it. So, fail all those as
+    // Crashed, not Pass. WebView::Application restarts the Compositor afterwards, so subsequent tests still run.
+    app.on_compositor_process_death = [&]() {
+        warnln("test-web: Compositor process died; failing all in-flight tests as crashed");
+        for (auto& view : views) {
+            if (auto index = s_current_test_index_by_view.get(view.ptr()); index.has_value()) {
+                test_run_capture.write_test_output(*view);
+                view->on_test_complete({ *index, TestResult::Crashed });
+            }
+        }
+    };
+    ScopeGuard clear_compositor_death_hook = [&] { app.on_compositor_process_death = {}; };
+
     for (auto [view_id, view] : enumerate(views)) {
         set_ui_callbacks_for_tests(*view, test_run_capture);
         view->clear_content_blockers();


### PR DESCRIPTION
**Problem:** Crash when a bare visual-context-tree update arrived carrying a tree version its installed display list wasn’t recorded against; e.g., while hovering an animated element in devtools (see #10368). And since when a Compositor died during a test run, `WebView::Application` queued a restart and recovered, test-web never learnt of the death — so a test that crashed the Compositor still reported Pass. So Compositor crashes couldn’t be caught by the test suite.

**Cause:** A display list and the accumulated visual-context tree it was recorded against are tied together by a shared version. WebContent’s composited fast path sends bare update_visual_context_tree messages (new transform values, same version) between full display-list updates. If an incompatible tree rebuild mints a new version on a frame that doesn’t re-record the display list, the bare update carries a version the Compositor’s display list has never seen — and the Compositor treated that inconsistency as a hard assertion. The known producer-side race was closed in 5dd185f by forcing a re-record when an incompatible rebuild mints a version. But the Compositor must never hard-crash on inconsistent peer data — whatever future producer bug might produce it.

**Fix:** On a version mismatch, drop the stale update and keep the current consistent display-list/tree pair instead of VERIFY-crashing. So that a Compositor crash can no longer slip past the suite, give `WebView::Application` an `on_compositor_process_death` callback; test-web installs that, and marks every in-flight test Crashed.

Discovered this while looking into https://github.com/LadybirdBrowser/ladybird/issues/10368.