### PR TITLE
Tests: Wait for reseed convergence after blocked-reload crash recovery

### DIFF
--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -5279,8 +5279,17 @@ return [Math.floor(rect.left + rect.width / 2), Math.floor(rect.top + rect.heigh
         page_server.release_blocked_reload.set()
         wait_for_event(page_server.reload_blocked_document_ran, "reload document after crash recovery")
         expect_url(webdriver_port, session_id, "after blocked reload crash recovery", url_reload_blocked, log)
-        expect_current_ui_entry_reload_pending(
-            webdriver_port, session_id, "after blocked reload crash recovery", False, log
+        wait_for_session_history(
+            webdriver_port,
+            session_id,
+            "reload pending clears after blocked reload crash recovery",
+            lambda snapshot: (
+                not history_current_entry(snapshot["ui"])["reloadPending"]
+                and not snapshot["ui"]["waitingToSeedWebContent"]
+                and not snapshot["ui"]["waitingForWebContentSeedAck"]
+                and not snapshot["ui"]["reseedAfterCurrentHistoryLoad"]
+            ),
+            log,
         )
 
         expect_cross_site_fragment_navigation_from_ui_loads_document(


### PR DESCRIPTION
**Problem:** `TestWebDriverSessionHistory` regularly failed in CI jobs, predominantly on (slow/loaded) Sanitizer builds.

**Cause:** After the crash recovery reloads the current entry, the test waited only for the WebContent-side `reload_blocked_document_ran` event, and then sampled `reloadPending` once. But `reloadPending` and the reseed flags clear on the UI only once WebContent’s load-complete IPC lands — which lags that event. On a slow or loaded build, the check ran before the IPC arrived — and failed while the reseed was still in flight.

**Fix:** Wait for the reseed to converge (`reloadPending` and the seed and reseed flags all cleared) instead of sampling once — matching the wait-for-convergence pattern used elsewhere in the test.
