### PR TITLE
LibWeb: Reduce accumulated visual context rebuild work

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -106,29 +106,21 @@ bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
     return false;
 }
 
-// https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block
-// Checks if the computed values of this node would establish an absolute positioning
-// containing block. This is separate from establishes_an_absolute_positioning_containing_block()
-// because that function also checks is<Box>, but we need these checks for inline elements too.
-bool Node::computed_values_establish_absolute_positioning_containing_block() const
+// https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block
+static bool computed_values_establish_fixed_positioning_containing_block(Node const& node)
 {
-    auto const& computed_values = this->computed_values();
+    auto const& computed_values = node.computed_values();
 
     // https://drafts.csswg.org/css-will-change/#will-change
-    // If any non-initial value of a property would cause the element to generate a containing block for absolutely
+    // If any non-initial value of a property would cause the element to generate a containing block for fixed
     // positioned elements, specifying that property in will-change must cause the element to generate a containing
-    // block for absolutely positioned elements.
+    // block for fixed positioned elements.
     auto will_change_property = [&](CSS::PropertyID property_id) {
         return computed_values.will_change().has_property(property_id);
     };
 
-    // https://drafts.csswg.org/css-position/#position-property
-    // Values other than 'static' make the box a positioned box, and cause it to establish an absolute positioning
-    // containing block for its descendants.
-    if (computed_values.position() != CSS::Positioning::Static || will_change_property(CSS::PropertyID::Position))
-        return true;
-
-    if (is_transformable()) {
+    auto is_transformable = node.is_transformable();
+    if (is_transformable) {
         // https://drafts.csswg.org/css-transforms-1/#propdef-transform
         // Any computed value other than none for the transform affects containing block and stacking context.
         if (!computed_values.transformations().is_empty() || will_change_property(CSS::PropertyID::Transform))
@@ -144,21 +136,21 @@ bool Node::computed_values_establish_absolute_positioning_containing_block() con
     // https://drafts.csswg.org/css-transforms-2/#propdef-perspective
     // The use of this property with any value other than 'none' establishes a stacking context. It also establishes
     // a containing block for all descendants, just like the 'transform' property does.
-    if (is_transformable() && (computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective)))
+    if (is_transformable && (computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective)))
         return true;
 
     // https://drafts.csswg.org/filter-effects-1/#FilterProperty
     // A value other than none for the filter property results in the creation of a containing block for absolute and
     // fixed positioned descendants, unless the element it applies to is a document root element in the current
     // browsing context.
-    if ((computed_values.filter().has_filters() || will_change_property(CSS::PropertyID::Filter)) && !is_root_element())
+    if ((computed_values.filter().has_filters() || will_change_property(CSS::PropertyID::Filter)) && !node.is_root_element())
         return true;
 
     // https://drafts.csswg.org/filter-effects-2/#BackdropFilterProperty
     // A computed value of other than none results in the creation of both a stacking context and a containing block
     // for absolute and fixed position descendants, unless the element it applies to is a document root element in the
     // current browsing context.
-    if ((computed_values.backdrop_filter().has_filters() || will_change_property(CSS::PropertyID::BackdropFilter)) && !is_root_element())
+    if ((computed_values.backdrop_filter().has_filters() || will_change_property(CSS::PropertyID::BackdropFilter)) && !node.is_root_element())
         return true;
 
     // https://drafts.csswg.org/css-contain-2/#containment-types
@@ -166,13 +158,13 @@ bool Node::computed_values_establish_absolute_positioning_containing_block() con
     //    containing block.
     // 4. The paint containment box establishes an absolute positioning containing block and a fixed positioning
     //    containing block.
-    if (has_layout_containment() || has_paint_containment() || will_change_property(CSS::PropertyID::Contain))
+    if (node.has_layout_containment() || node.has_paint_containment() || will_change_property(CSS::PropertyID::Contain))
         return true;
 
     // https://drafts.csswg.org/css-transforms-2/#transform-style-property
     // A computed value of 'preserve-3d' for 'transform-style' on a transformable element establishes both a
     // stacking context and a containing block for all descendants.
-    if (is_transformable() && (computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)))
+    if (is_transformable && (computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)))
         return true;
 
     // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block-concept
@@ -180,6 +172,23 @@ bool Node::computed_values_establish_absolute_positioning_containing_block() con
     //        positioning containing block for ::view-transition and its descendants.
 
     return false;
+}
+
+// https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block
+// Checks if the computed values of this node would establish an absolute positioning
+// containing block. This is separate from establishes_an_absolute_positioning_containing_block()
+// because that function also checks is<Box>, but we need these checks for inline elements too.
+bool Node::computed_values_establish_absolute_positioning_containing_block() const
+{
+    auto const& computed_values = this->computed_values();
+
+    // https://drafts.csswg.org/css-position/#position-property
+    // Values other than 'static' make the box a positioned box, and cause it to establish an absolute positioning
+    // containing block for its descendants.
+    if (computed_values.position() != CSS::Positioning::Static || computed_values.will_change().has_property(CSS::PropertyID::Position))
+        return true;
+
+    return computed_values_establish_fixed_positioning_containing_block(*this);
 }
 
 // https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block
@@ -210,68 +219,30 @@ bool Node::establishes_a_fixed_positioning_containing_block() const
     if (is_svg_foreign_object_box())
         return true;
 
+    return computed_values_establish_fixed_positioning_containing_block(*this);
+}
+
+Node::PositioningContainingBlockEstablishment Node::establishes_positioning_containing_blocks() const
+{
+    if (!is<Box>(*this))
+        return {};
+
+    // https://github.com/w3c/fxtf-drafts/issues/307#issuecomment-499612420
+    // foreignObject establishes a containing block for absolutely and fixed positioned elements.
+    if (is_svg_foreign_object_box())
+        return { true, true };
+
+    auto establishes_fixed_positioning_containing_block = computed_values_establish_fixed_positioning_containing_block(*this);
+    if (establishes_fixed_positioning_containing_block)
+        return { true, true };
+
+    if (is<Viewport>(*this))
+        return { true, false };
+
     auto const& computed_values = this->computed_values();
-
-    // https://drafts.csswg.org/css-will-change/#will-change
-    // If any non-initial value of a property would cause the element to generate a containing block for fixed
-    // positioned elements, specifying that property in will-change must cause the element to generate a containing
-    // block for fixed positioned elements.
-    auto will_change_property = [&](CSS::PropertyID property_id) {
-        return computed_values.will_change().has_property(property_id);
-    };
-
-    if (is_transformable()) {
-        // https://drafts.csswg.org/css-transforms-1/#propdef-transform
-        // Any computed value other than none for the transform affects containing block and stacking context.
-        if (!computed_values.transformations().is_empty() || will_change_property(CSS::PropertyID::Transform))
-            return true;
-        if (computed_values.translate() || will_change_property(CSS::PropertyID::Translate))
-            return true;
-        if (computed_values.rotate() || will_change_property(CSS::PropertyID::Rotate))
-            return true;
-        if (computed_values.scale() || will_change_property(CSS::PropertyID::Scale))
-            return true;
-    }
-
-    // https://drafts.csswg.org/css-transforms-2/#propdef-perspective
-    // The use of this property with any value other than 'none' establishes a stacking context. It also establishes
-    // a containing block for all descendants, just like the 'transform' property does.
-    if (is_transformable() && (computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective)))
-        return true;
-
-    // https://drafts.csswg.org/filter-effects-1/#FilterProperty
-    // A value other than none for the filter property results in the creation of a containing block for absolute and
-    // fixed positioned descendants, unless the element it applies to is a document root element in the current
-    // browsing context.
-    if ((computed_values.filter().has_filters() || will_change_property(CSS::PropertyID::Filter)) && !is_root_element())
-        return true;
-
-    // https://drafts.csswg.org/filter-effects-2/#BackdropFilterProperty
-    // A computed value of other than none results in the creation of both a stacking context and a containing block
-    // for absolute and fixed position descendants, unless the element it applies to is a document root element in the
-    // current browsing context.
-    if ((computed_values.backdrop_filter().has_filters() || will_change_property(CSS::PropertyID::BackdropFilter)) && !is_root_element())
-        return true;
-
-    // https://drafts.csswg.org/css-contain-2/#containment-types
-    // 4. The layout containment box establishes an absolute positioning containing block and a fixed positioning
-    //    containing block.
-    // 4. The paint containment box establishes an absolute positioning containing block and a fixed positioning
-    //    containing block.
-    if (has_layout_containment() || has_paint_containment() || will_change_property(CSS::PropertyID::Contain))
-        return true;
-
-    // https://drafts.csswg.org/css-transforms-2/#transform-style-property
-    // A computed value of 'preserve-3d' for 'transform-style' on a transformable element establishes both a
-    // stacking context and a containing block for all descendants.
-    if (is_transformable() && (computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)))
-        return true;
-
-    // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block-concept
-    // FIXME: The snapshot containing block is considered to be an absolute positioning containing block and a fixed
-    //        positioning containing block for ::view-transition and its descendants.
-
-    return false;
+    auto establishes_absolute_positioning_containing_block = computed_values.position() != CSS::Positioning::Static
+        || computed_values.will_change().has_property(CSS::PropertyID::Position);
+    return { establishes_absolute_positioning_containing_block, false };
 }
 
 static Box* nearest_ancestor_capable_of_forming_a_containing_block(Node& node)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -116,8 +116,9 @@ static bool computed_values_establish_fixed_positioning_containing_block(Node co
     // positioned elements, specifying that property in will-change must cause the element to generate a containing
     // block for fixed positioned elements.
     auto const& will_change = computed_values.will_change();
+    auto has_will_change = !will_change.is_auto();
     auto will_change_property = [&](CSS::PropertyID property_id) {
-        return !will_change.is_auto() && will_change.has_property(property_id);
+        return has_will_change && will_change.has_property(property_id);
     };
 
     Optional<bool> is_transformable;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -115,28 +115,33 @@ static bool computed_values_establish_fixed_positioning_containing_block(Node co
     // If any non-initial value of a property would cause the element to generate a containing block for fixed
     // positioned elements, specifying that property in will-change must cause the element to generate a containing
     // block for fixed positioned elements.
+    auto const& will_change = computed_values.will_change();
     auto will_change_property = [&](CSS::PropertyID property_id) {
-        return computed_values.will_change().has_property(property_id);
+        return !will_change.is_auto() && will_change.has_property(property_id);
     };
 
-    auto is_transformable = node.is_transformable();
-    if (is_transformable) {
-        // https://drafts.csswg.org/css-transforms-1/#propdef-transform
-        // Any computed value other than none for the transform affects containing block and stacking context.
-        if (!computed_values.transformations().is_empty() || will_change_property(CSS::PropertyID::Transform))
-            return true;
-        if (computed_values.translate() || will_change_property(CSS::PropertyID::Translate))
-            return true;
-        if (computed_values.rotate() || will_change_property(CSS::PropertyID::Rotate))
-            return true;
-        if (computed_values.scale() || will_change_property(CSS::PropertyID::Scale))
-            return true;
-    }
+    Optional<bool> is_transformable;
+    auto node_is_transformable = [&] {
+        if (!is_transformable.has_value())
+            is_transformable = node.is_transformable();
+        return *is_transformable;
+    };
+
+    // https://drafts.csswg.org/css-transforms-1/#propdef-transform
+    // Any computed value other than none for the transform affects containing block and stacking context.
+    if ((!computed_values.transformations().is_empty() || will_change_property(CSS::PropertyID::Transform)) && node_is_transformable())
+        return true;
+    if ((computed_values.translate() || will_change_property(CSS::PropertyID::Translate)) && node_is_transformable())
+        return true;
+    if ((computed_values.rotate() || will_change_property(CSS::PropertyID::Rotate)) && node_is_transformable())
+        return true;
+    if ((computed_values.scale() || will_change_property(CSS::PropertyID::Scale)) && node_is_transformable())
+        return true;
 
     // https://drafts.csswg.org/css-transforms-2/#propdef-perspective
     // The use of this property with any value other than 'none' establishes a stacking context. It also establishes
     // a containing block for all descendants, just like the 'transform' property does.
-    if (is_transformable && (computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective)))
+    if ((computed_values.perspective().has_value() || will_change_property(CSS::PropertyID::Perspective)) && node_is_transformable())
         return true;
 
     // https://drafts.csswg.org/filter-effects-1/#FilterProperty
@@ -158,13 +163,18 @@ static bool computed_values_establish_fixed_positioning_containing_block(Node co
     //    containing block.
     // 4. The paint containment box establishes an absolute positioning containing block and a fixed positioning
     //    containing block.
-    if (node.has_layout_containment() || node.has_paint_containment() || will_change_property(CSS::PropertyID::Contain))
+    if (will_change_property(CSS::PropertyID::Contain))
+        return true;
+    auto content_visibility_adds_containment = computed_values.content_visibility() == CSS::ContentVisibility::Auto;
+    if ((computed_values.contain().layout_containment || content_visibility_adds_containment) && node.has_layout_containment())
+        return true;
+    if ((computed_values.contain().paint_containment || content_visibility_adds_containment) && node.has_paint_containment())
         return true;
 
     // https://drafts.csswg.org/css-transforms-2/#transform-style-property
     // A computed value of 'preserve-3d' for 'transform-style' on a transformable element establishes both a
     // stacking context and a containing block for all descendants.
-    if (is_transformable && (computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)))
+    if ((computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)) && node_is_transformable())
         return true;
 
     // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block-concept
@@ -185,7 +195,8 @@ bool Node::computed_values_establish_absolute_positioning_containing_block() con
     // https://drafts.csswg.org/css-position/#position-property
     // Values other than 'static' make the box a positioned box, and cause it to establish an absolute positioning
     // containing block for its descendants.
-    if (computed_values.position() != CSS::Positioning::Static || computed_values.will_change().has_property(CSS::PropertyID::Position))
+    if (computed_values.position() != CSS::Positioning::Static
+        || (!computed_values.will_change().is_auto() && computed_values.will_change().has_property(CSS::PropertyID::Position)))
         return true;
 
     return computed_values_establish_fixed_positioning_containing_block(*this);
@@ -236,13 +247,16 @@ Node::PositioningContainingBlockEstablishment Node::establishes_positioning_cont
     if (establishes_fixed_positioning_containing_block)
         return { true, true };
 
+    auto const& computed_values = this->computed_values();
+    auto establishes_absolute_positioning_containing_block = computed_values.position() != CSS::Positioning::Static
+        || (!computed_values.will_change().is_auto() && computed_values.will_change().has_property(CSS::PropertyID::Position));
+    if (establishes_absolute_positioning_containing_block)
+        return { true, false };
+
     if (is<Viewport>(*this))
         return { true, false };
 
-    auto const& computed_values = this->computed_values();
-    auto establishes_absolute_positioning_containing_block = computed_values.position() != CSS::Positioning::Static
-        || computed_values.will_change().has_property(CSS::PropertyID::Position);
-    return { establishes_absolute_positioning_containing_block, false };
+    return {};
 }
 
 static Box* nearest_ancestor_capable_of_forming_a_containing_block(Node& node)
@@ -1546,6 +1560,16 @@ bool Node::has_inline_size_containment() const
 // https://drafts.csswg.org/css-contain-2/#containment-layout
 bool Node::has_layout_containment() const
 {
+    auto const& computed_values = this->computed_values();
+    auto has_layout_containment = computed_values.contain().layout_containment;
+
+    // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
+    // Changes the used value of the 'contain' property so as to turn on layout containment, style containment, and
+    // paint containment for the element.
+    has_layout_containment = has_layout_containment || computed_values.content_visibility() == CSS::ContentVisibility::Auto;
+    if (!has_layout_containment)
+        return false;
+
     // However, giving an element layout containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
@@ -1560,16 +1584,7 @@ bool Node::has_layout_containment() const
     if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
         return false;
 
-    if (computed_values().contain().layout_containment)
-        return true;
-
-    // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
-    // Changes the used value of the 'contain' property so as to turn on layout containment, style containment, and
-    // paint containment for the element.
-    if (computed_values().content_visibility() == CSS::ContentVisibility::Auto)
-        return true;
-
-    return false;
+    return true;
 }
 // https://drafts.csswg.org/css-contain-2/#containment-style
 bool Node::has_style_containment() const
@@ -1596,6 +1611,16 @@ bool Node::has_style_containment() const
 // https://drafts.csswg.org/css-contain-2/#containment-paint
 bool Node::has_paint_containment() const
 {
+    auto const& computed_values = this->computed_values();
+    auto has_paint_containment = computed_values.contain().paint_containment;
+
+    // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
+    // Changes the used value of the 'contain' property so as to turn on layout containment, style containment, and
+    // paint containment for the element.
+    has_paint_containment = has_paint_containment || computed_values.content_visibility() == CSS::ContentVisibility::Auto;
+    if (!has_paint_containment)
+        return false;
+
     // However, giving an element paint containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
@@ -1610,16 +1635,7 @@ bool Node::has_paint_containment() const
     if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
         return false;
 
-    if (computed_values().contain().paint_containment)
-        return true;
-
-    // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
-    // Changes the used value of the 'contain' property so as to turn on layout containment, style containment, and
-    // paint containment for the element.
-    if (computed_values().content_visibility() == CSS::ContentVisibility::Auto)
-        return true;
-
-    return false;
+    return true;
 }
 
 bool NodeWithStyleAndBoxModelMetrics::is_inline_flow_interrupting_block() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -216,9 +216,15 @@ public:
 
     bool establishes_stacking_context() const;
 
+    struct PositioningContainingBlockEstablishment {
+        bool absolute;
+        bool fixed;
+    };
+
     bool computed_values_establish_absolute_positioning_containing_block() const;
     bool establishes_an_absolute_positioning_containing_block() const;
     bool establishes_a_fixed_positioning_containing_block() const;
+    PositioningContainingBlockEstablishment establishes_positioning_containing_blocks() const;
 
     Gfx::Font const& first_available_font() const;
     Gfx::Font const& font(DisplayListRecordingContext&) const;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -255,14 +255,12 @@ public:
 
     [[nodiscard]] bool has_css_transform() const
     {
-        if (!is_transformable())
-            return false;
-
         auto const& computed_values = this->computed_values();
-        return !computed_values.transformations().is_empty()
+        auto has_transform = !computed_values.transformations().is_empty()
             || computed_values.rotate()
             || computed_values.translate()
             || computed_values.scale();
+        return has_transform && is_transformable();
     }
 
     // https://drafts.csswg.org/css-ui/#propdef-user-select

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -315,10 +315,12 @@ static Optional<EffectsData> compute_effects_data(Paintable& box, double pixel_r
     auto const& computed_values = box.computed_values();
     if (computed_values.filter().has_filters())
         box.set_filter(resolve_css_filter(computed_values.filter(), box));
-    else
+    else if (box.filter().has_filters() || box.filter().svg_filter_bounds.has_value())
         box.set_filter({});
 
-    auto gfx_filter = to_gfx_filter(box.filter(), pixel_ratio);
+    Optional<Gfx::Filter> gfx_filter;
+    if (box.filter().has_filters())
+        gfx_filter = to_gfx_filter(box.filter(), pixel_ratio);
     EffectsData effects {
         computed_values.opacity(),
         mix_blend_mode_to_compositing_and_blending_operator(computed_values.mix_blend_mode()),

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -505,9 +505,10 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
         paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
-        if (paintable_box.layout_node().establishes_an_absolute_positioning_containing_block())
+        auto positioning_containing_blocks = paintable_box.layout_node().establishes_positioning_containing_blocks();
+        if (positioning_containing_blocks.absolute)
             state_for_absolute_position_descendants = state_for_descendants;
-        if (paintable_box.layout_node().establishes_a_fixed_positioning_containing_block())
+        if (positioning_containing_blocks.fixed)
             state_for_fixed_position_descendants = state_for_descendants;
 
         return DescendantVisualContexts {

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -122,7 +122,11 @@ static Optional<Gfx::AffineTransform> svg_to_css_pixels_transform(Paintable cons
 // https://drafts.csswg.org/css-transforms-2/#ctm
 Optional<TransformData> compute_transform(Paintable const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
 {
-    if (!paintable_box.has_css_transform())
+    auto has_transform = !computed_values.transformations().is_empty()
+        || computed_values.rotate()
+        || computed_values.translate()
+        || computed_values.scale();
+    if (!has_transform || !paintable_box.layout_node().is_transformable())
         return {};
 
     // The transformation matrix is computed from the transform, transform-origin, translate, rotate, scale, and
@@ -174,11 +178,8 @@ Optional<TransformData> compute_transform(Paintable const& paintable_box, CSS::C
 // https://drafts.csswg.org/css-transforms-2/#perspective-matrix
 static Optional<Gfx::FloatMatrix4x4> compute_perspective_matrix(Paintable const& paintable_box, CSS::ComputedValues const& computed_values)
 {
-    if (!paintable_box.layout_node().is_transformable())
-        return {};
-
     auto perspective = computed_values.perspective();
-    if (!perspective.has_value())
+    if (!perspective.has_value() || !paintable_box.layout_node().is_transformable())
         return {};
 
     // The perspective matrix is computed as follows:
@@ -216,7 +217,9 @@ static Optional<ClipData> compute_clip_data(Paintable const& paintable_box, CSS:
     //    any such mechanism through other properties, such as overflow, resize, or text-overflow.
     //    NOTE: This clipping shape respects overflow-clip-margin, allowing an element with paint containment
     //          to still slightly overflow its normal bounds.
-    if (paintable_box.layout_node().has_paint_containment()) {
+    auto has_paint_containment = computed_values.contain().paint_containment
+        || computed_values.content_visibility() == CSS::ContentVisibility::Auto;
+    if (has_paint_containment && paintable_box.layout_node().has_paint_containment()) {
         // NOTE: Note: The behavior is described in this paragraph is equivalent to changing 'overflow-x: visible' into
         //       'overflow-x: clip' and 'overflow-y: visible' into 'overflow-y: clip' at used value time, while leaving other
         //       values of 'overflow-x' and 'overflow-y' unchanged.
@@ -266,8 +269,10 @@ static Optional<ClipData> compute_clip_data(Paintable const& paintable_box, CSS:
     return {};
 }
 
-static Optional<ClipData> compute_css_clip_data(Paintable const& paintable_box, DevicePixelConverter const& converter)
+static Optional<ClipData> compute_css_clip_data(Paintable const& paintable_box, CSS::ComputedValues const& computed_values, DevicePixelConverter const& converter)
 {
+    if (!computed_values.clip().is_rect())
+        return {};
     if (auto css_clip = paintable_box.get_clip_rect(); css_clip.has_value()) {
         auto effective_rect = effective_css_clip_rect(*css_clip);
         return ClipData { converter.rounded_device_rect(effective_rect), {} };
@@ -433,7 +438,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             paintable_box.set_has_non_invertible_css_transform(false);
         }
 
-        if (auto css_clip = compute_css_clip_data(paintable_box, converter); css_clip.has_value())
+        if (auto css_clip = compute_css_clip_data(paintable_box, computed_values, converter); css_clip.has_value())
             append_to_own_and_positioned_descendant_contexts(css_clip.value());
 
         if (auto clip_path_data = compute_basic_shape_clip_path_data(paintable_box, computed_values, converter, scale); clip_path_data.has_value())

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -119,14 +119,18 @@ static Optional<Gfx::AffineTransform> svg_to_css_pixels_transform(Paintable cons
     return {};
 }
 
+static bool computed_values_have_transform(CSS::ComputedValues const& computed_values)
+{
+    return !computed_values.transformations().is_empty()
+        || !computed_values.rotate().is_null()
+        || !computed_values.translate().is_null()
+        || !computed_values.scale().is_null();
+}
+
 // https://drafts.csswg.org/css-transforms-2/#ctm
 Optional<TransformData> compute_transform(Paintable const& paintable_box, CSS::ComputedValues const& computed_values, double pixel_ratio)
 {
-    auto has_transform = !computed_values.transformations().is_empty()
-        || computed_values.rotate()
-        || computed_values.translate()
-        || computed_values.scale();
-    if (!has_transform || !paintable_box.layout_node().is_transformable())
+    if (!computed_values_have_transform(computed_values) || !paintable_box.layout_node().is_transformable())
         return {};
 
     // The transformation matrix is computed from the transform, transform-origin, translate, rotate, scale, and
@@ -436,15 +440,21 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         if (auto effects = compute_effects_data(paintable_box, computed_values, pixel_ratio); effects.has_value())
             append_to_own_and_positioned_descendant_contexts(effects.value());
 
-        if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
-            paintable_box.set_has_non_invertible_css_transform(!transform_data->matrix.is_invertible());
-            own_state = append_node(own_state, *transform_data);
+        if (computed_values_have_transform(computed_values)) {
+            if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
+                paintable_box.set_has_non_invertible_css_transform(!transform_data->matrix.is_invertible());
+                own_state = append_node(own_state, *transform_data);
+            } else {
+                paintable_box.set_has_non_invertible_css_transform(false);
+            }
         } else {
             paintable_box.set_has_non_invertible_css_transform(false);
         }
 
-        if (auto css_clip = compute_css_clip_data(paintable_box, computed_values, converter); css_clip.has_value())
-            append_to_own_and_positioned_descendant_contexts(css_clip.value());
+        if (computed_values.clip().is_rect()) {
+            if (auto css_clip = compute_css_clip_data(paintable_box, computed_values, converter); css_clip.has_value())
+                append_to_own_and_positioned_descendant_contexts(css_clip.value());
+        }
 
         if (auto clip_path_data = compute_basic_shape_clip_path_data(paintable_box, computed_values, converter, scale); clip_path_data.has_value())
             append_to_own_and_positioned_descendant_contexts(clip_path_data.value());
@@ -502,11 +512,19 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         // Build state for descendants: own state + perspective + clip + scroll.
         VisualContextIndex state_for_descendants = own_state;
 
-        if (auto perspective_data = compute_perspective_data(paintable_box, computed_values, scale); perspective_data.has_value())
-            state_for_descendants = append_node(state_for_descendants, *perspective_data);
+        if (computed_values.perspective().has_value()) {
+            if (auto perspective_data = compute_perspective_data(paintable_box, computed_values, scale); perspective_data.has_value())
+                state_for_descendants = append_node(state_for_descendants, *perspective_data);
+        }
 
-        if (auto clip_data = compute_clip_data(paintable_box, computed_values, converter); clip_data.has_value())
-            state_for_descendants = append_node(state_for_descendants, clip_data.value());
+        auto may_have_clip = computed_values.overflow_x() != CSS::Overflow::Visible
+            || computed_values.overflow_y() != CSS::Overflow::Visible
+            || computed_values.contain().paint_containment
+            || computed_values.content_visibility() == CSS::ContentVisibility::Auto;
+        if (may_have_clip) {
+            if (auto clip_data = compute_clip_data(paintable_box, computed_values, converter); clip_data.has_value())
+                state_for_descendants = append_node(state_for_descendants, clip_data.value());
+        }
 
         if (paintable_box.own_scroll_frame_index().value()) {
             auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame_index() == paintable_box.own_scroll_frame_index();

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -310,13 +310,15 @@ static Optional<PerspectiveData> compute_perspective_data(Paintable const& paint
 }
 
 // NB: Resolves the box's filter as a side effect, since the effects data embeds the resolved gfx filter.
-static Optional<EffectsData> compute_effects_data(Paintable& box, double pixel_ratio)
+static Optional<EffectsData> compute_effects_data(Paintable& box, CSS::ComputedValues const& computed_values, double pixel_ratio)
 {
-    auto const& computed_values = box.computed_values();
     if (computed_values.filter().has_filters())
         box.set_filter(resolve_css_filter(computed_values.filter(), box));
     else if (box.filter().has_filters() || box.filter().svg_filter_bounds.has_value())
         box.set_filter({});
+
+    if (!box.filter().has_filters() && computed_values.opacity() == 1 && computed_values.mix_blend_mode() == CSS::MixBlendMode::Normal)
+        return {};
 
     Optional<Gfx::Filter> gfx_filter;
     if (box.filter().has_filters())
@@ -357,8 +359,9 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         VisualContextIndex fixed_position;
     };
 
-    auto build_paintable_box = [&](Paintable& paintable_box, DescendantVisualContexts inherited_contexts) -> DescendantVisualContexts {
+    auto build_paintable_box = [&](Paintable& paintable_box, DescendantVisualContexts inherited_contexts, bool may_be_root_element) -> DescendantVisualContexts {
         auto first_visual_context_node_index = visual_context_tree.nodes().size();
+        auto& layout_node = paintable_box.layout_node();
 
         VisualContextIndex inherited_state;
 
@@ -381,7 +384,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         //     box. When the anchor is itself an anchor-positioned box, its layout position does not include its own
         //     paint-time shift, so each chained anchor's shift is emitted as well, masked to the axes that every link
         //     below it compensates in. The visited set and depth cap guard against malformed anchor chains.
-        if (auto const* box = as_if<Layout::Box>(&paintable_box.layout_node())) {
+        if (auto const* box = as_if<Layout::Box>(&layout_node)) {
             auto const& scroll_state = viewport_paintable.scroll_state();
             bool compensate_x = true;
             bool compensate_y = true;
@@ -428,9 +431,9 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 own_state = append_node(own_state, ScrollData { sticky_idx, true });
         }
 
-        auto const& computed_values = paintable_box.computed_values();
+        auto const& computed_values = layout_node.computed_values();
 
-        if (auto effects = compute_effects_data(paintable_box, pixel_ratio); effects.has_value())
+        if (auto effects = compute_effects_data(paintable_box, computed_values, pixel_ratio); effects.has_value())
             append_to_own_and_positioned_descendant_contexts(effects.value());
 
         if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
@@ -449,7 +452,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         paintable_box.set_accumulated_visual_context(own_state);
 
         Vector<CSS::BackgroundLayerData> const* background_layers = &computed_values.background_layers();
-        if (paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
+        auto is_root_element = may_be_root_element && layout_node.is_root_element();
+        if (is_root_element) {
             if (auto* html_element = as_if<HTML::HTMLHtmlElement>(paintable_box.dom_node().ptr())) {
                 if (html_element->should_use_body_background_properties())
                     background_layers = paintable_box.document().background_layers();
@@ -471,8 +475,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 // their ancestor elements) and do not have their background propagated to the canvas, a value of fixed
                 // for the background-attachment property is treated as if it had a value of scroll.
                 auto has_transform_ancestor = false;
-                if (!paintable_box.layout_node_with_style_and_box_metrics().is_root_element()) {
-                    for (auto const* node = &paintable_box.layout_node(); node && !node->is_viewport(); node = node->parent()) {
+                if (!is_root_element) {
+                    for (auto const* node = &layout_node; node && !node->is_viewport(); node = node->parent()) {
                         if (node->has_css_transform()) {
                             has_transform_ancestor = true;
                             break;
@@ -512,7 +516,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
         paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
-        auto positioning_containing_blocks = paintable_box.layout_node().establishes_positioning_containing_blocks();
+        auto positioning_containing_blocks = layout_node.establishes_positioning_containing_blocks();
         if (positioning_containing_blocks.absolute)
             state_for_absolute_position_descendants = state_for_descendants;
         if (positioning_containing_blocks.fixed)
@@ -534,16 +538,17 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
     struct PendingPaintable {
         Paintable* paintable;
         DescendantVisualContexts inherited_contexts;
+        bool may_be_root_element;
     };
     Vector<PendingPaintable, 64> pending_paintables;
     for (auto* child = viewport_paintable.last_child_ptr(); child; child = child->previous_sibling_ptr())
-        pending_paintables.append({ child, viewport_contexts });
+        pending_paintables.append({ child, viewport_contexts, true });
 
     while (!pending_paintables.is_empty()) {
         auto pending = pending_paintables.take_last();
-        auto child_contexts = build_paintable_box(*pending.paintable, pending.inherited_contexts);
+        auto child_contexts = build_paintable_box(*pending.paintable, pending.inherited_contexts, pending.may_be_root_element);
         for (auto* child = pending.paintable->last_child_ptr(); child; child = child->previous_sibling_ptr())
-            pending_paintables.append({ child, child_contexts });
+            pending_paintables.append({ child, child_contexts, false });
     }
 
     return visual_context_tree;
@@ -562,7 +567,7 @@ bool update_accumulated_visual_context_values(ViewportPaintable& viewport_painta
     auto pixel_ratio = viewport_paintable.document().page().client().device_pixels_per_css_pixel();
     auto const& computed_values = paintable_box.computed_values();
 
-    auto effects = compute_effects_data(paintable_box, pixel_ratio);
+    auto effects = compute_effects_data(paintable_box, computed_values, pixel_ratio);
     auto transform = compute_transform(paintable_box, computed_values, pixel_ratio);
     auto perspective = compute_perspective_data(paintable_box, computed_values, static_cast<float>(pixel_ratio));
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -350,7 +350,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         VisualContextIndex fixed_position;
     };
 
-    auto build_paintable_box = [&](auto& self, Paintable& paintable_box, DescendantVisualContexts inherited_contexts) -> void {
+    auto build_paintable_box = [&](Paintable& paintable_box, DescendantVisualContexts inherited_contexts) -> DescendantVisualContexts {
         auto first_visual_context_node_index = visual_context_tree.nodes().size();
 
         VisualContextIndex inherited_state;
@@ -510,15 +510,11 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         if (paintable_box.layout_node().establishes_a_fixed_positioning_containing_block())
             state_for_fixed_position_descendants = state_for_descendants;
 
-        DescendantVisualContexts child_contexts {
+        return DescendantVisualContexts {
             state_for_descendants,
             state_for_absolute_position_descendants,
             state_for_fixed_position_descendants,
         };
-        paintable_box.for_each_child_of_type<Paintable>([&](Paintable& child) {
-            self(self, child, child_contexts);
-            return IterationDecision::Continue;
-        });
     };
 
     DescendantVisualContexts viewport_contexts {
@@ -526,10 +522,21 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         viewport_state_for_descendants,
         visual_viewport_context_index,
     };
-    viewport_paintable.for_each_child_of_type<Paintable>([&](Paintable& child) {
-        build_paintable_box(build_paintable_box, child, viewport_contexts);
-        return IterationDecision::Continue;
-    });
+
+    struct PendingPaintable {
+        Paintable* paintable;
+        DescendantVisualContexts inherited_contexts;
+    };
+    Vector<PendingPaintable, 64> pending_paintables;
+    for (auto* child = viewport_paintable.last_child_ptr(); child; child = child->previous_sibling_ptr())
+        pending_paintables.append({ child, viewport_contexts });
+
+    while (!pending_paintables.is_empty()) {
+        auto pending = pending_paintables.take_last();
+        auto child_contexts = build_paintable_box(*pending.paintable, pending.inherited_contexts);
+        for (auto* child = pending.paintable->last_child_ptr(); child; child = child->previous_sibling_ptr())
+            pending_paintables.append({ child, child_contexts });
+    }
 
     return visual_context_tree;
 }


### PR DESCRIPTION
Build the accumulated visual context tree iteratively, preserving preorder traversal while avoiding recursive typed traversal and its reference-count traffic.

Share absolute and fixed positioning containing-block checks, reuse layout nodes and computed values, and check inexpensive CSS values before evaluating their applicability. Skip inactive transform, perspective, clipping, effects, and filter work.

On https://nyan.cat, this reduced the sampled weight of accumulated visual context rebuilding from 15.3% to 7.5%.