### PR TITLE
DevTools: Fill in some data about network requests

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -504,6 +504,8 @@ void FrameActor::on_network_request_started(DevToolsDelegate::NetworkRequestData
     actor.set_request_info(move(data.url), move(data.method), data.start_time, move(data.request_headers), move(data.request_body), move(data.initiator_type));
     if (auto tab = m_tab.strong_ref())
         actor.set_browsing_context_ids(tab->description().id, tab->inner_window_id());
+    actor.set_referrer_policy(move(data.referrer_policy));
+    actor.set_is_navigation_request(data.is_navigation_request);
     m_network_events.set(data.request_id, actor);
 
     JsonArray events;

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -502,6 +502,8 @@ void FrameActor::on_network_request_started(DevToolsDelegate::NetworkRequestData
 {
     auto& actor = devtools().register_actor<NetworkEventActor>(data.request_id);
     actor.set_request_info(move(data.url), move(data.method), data.start_time, move(data.request_headers), move(data.request_body), move(data.initiator_type));
+    if (auto tab = m_tab.strong_ref())
+        actor.set_browsing_context_ids(tab->description().id, tab->inner_window_id());
     m_network_events.set(data.request_id, actor);
 
     JsonArray events;
@@ -563,8 +565,8 @@ void FrameActor::on_network_response_headers_received(DevToolsDelegate::NetworkR
     update_entry.set("resourceId"sv, static_cast<i64>(data.request_id));
     update_entry.set("resourceType"sv, "network-event"sv);
     update_entry.set("resourceUpdates"sv, move(resource_updates));
-    update_entry.set("browsingContextID"sv, 1);
-    update_entry.set("innerWindowId"sv, 1);
+    update_entry.set("browsingContextID"sv, actor.browsing_context_id());
+    update_entry.set("innerWindowId"sv, actor.inner_window_id());
 
     JsonArray updates;
     updates.must_append(move(update_entry));
@@ -616,8 +618,8 @@ void FrameActor::on_network_request_finished(DevToolsDelegate::NetworkRequestCom
     update_entry.set("resourceId"sv, static_cast<i64>(data.request_id));
     update_entry.set("resourceType"sv, "network-event"sv);
     update_entry.set("resourceUpdates"sv, move(resource_updates));
-    update_entry.set("browsingContextID"sv, 1);
-    update_entry.set("innerWindowId"sv, 1);
+    update_entry.set("browsingContextID"sv, actor.browsing_context_id());
+    update_entry.set("innerWindowId"sv, actor.inner_window_id());
 
     JsonArray updates;
     updates.must_append(move(update_entry));

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -528,6 +528,8 @@ void FrameActor::on_network_response_headers_received(DevToolsDelegate::NetworkR
 
     auto& actor = *it->value;
     actor.set_response_start(data.status_code, data.reason_phrase);
+    auto loaded_from_cache = data.came_from_cache == Requests::CameFromCache::Yes;
+    actor.set_loaded_from_cache(loaded_from_cache);
 
     // Extract Content-Type before moving headers
     String mime_type;
@@ -546,6 +548,7 @@ void FrameActor::on_network_response_headers_received(DevToolsDelegate::NetworkR
     resource_updates.set("statusText"sv, data.reason_phrase.value_or(String {}));
     resource_updates.set("headersSize"sv, headers_size);
     resource_updates.set("mimeType"sv, mime_type);
+    resource_updates.set("fromCache"sv, loaded_from_cache);
     // FIXME: Get actual HTTP version from response
     resource_updates.set("httpVersion"sv, "HTTP/1.1"sv);
     // FIXME: Get actual remote address and port from connection

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -506,6 +506,7 @@ void FrameActor::on_network_request_started(DevToolsDelegate::NetworkRequestData
         actor.set_browsing_context_ids(tab->description().id, tab->inner_window_id());
     actor.set_referrer_policy(move(data.referrer_policy));
     actor.set_is_navigation_request(data.is_navigation_request);
+    actor.set_priority(data.priority);
     m_network_events.set(data.request_id, actor);
 
     JsonArray events;

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
@@ -46,6 +46,11 @@ void NetworkEventActor::set_response_headers(Vector<HTTP::Header> response_heade
     m_response_headers = move(response_headers);
 }
 
+void NetworkEventActor::set_loaded_from_cache(bool loaded_from_cache)
+{
+    m_loaded_from_cache = loaded_from_cache;
+}
+
 void NetworkEventActor::append_response_body(ByteBuffer data)
 {
     // Limit response body size to prevent memory issues
@@ -101,8 +106,7 @@ JsonObject NetworkEventActor::serialize_initial_event() const
     event.set("isXHR"sv, is_xhr);
     event.set("cause"sv, move(cause));
     event.set("private"sv, false);
-    // FIXME: Detect if response is from cache
-    event.set("fromCache"sv, false);
+    event.set("fromCache"sv, m_loaded_from_cache);
     event.set("fromServiceWorker"sv, false);
     event.set("isThirdPartyTrackingResource"sv, false);
     // FIXME: Get actual referrer policy from request

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
@@ -12,6 +12,19 @@
 
 namespace DevTools {
 
+static i32 to_firefox_request_priority(Web::Fetch::Infrastructure::Request::Priority priority)
+{
+    switch (priority) {
+    case Web::Fetch::Infrastructure::Request::Priority::High:
+        return -10;
+    case Web::Fetch::Infrastructure::Request::Priority::Low:
+        return 10;
+    case Web::Fetch::Infrastructure::Request::Priority::Auto:
+        return 0;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 NonnullRefPtr<NetworkEventActor> NetworkEventActor::create(DevToolsServer& devtools, String name, u64 request_id)
 {
     return adopt_ref(*new NetworkEventActor(devtools, move(name), request_id));
@@ -65,6 +78,11 @@ void NetworkEventActor::set_referrer_policy(String referrer_policy)
 void NetworkEventActor::set_is_navigation_request(bool is_navigation_request)
 {
     m_is_navigation_request = is_navigation_request;
+}
+
+void NetworkEventActor::set_priority(Web::Fetch::Infrastructure::Request::Priority priority)
+{
+    m_priority = priority;
 }
 
 void NetworkEventActor::append_response_body(ByteBuffer data)
@@ -134,8 +152,7 @@ JsonObject NetworkEventActor::serialize_initial_event() const
     event.set("channelId"sv, static_cast<i64>(m_request_id));
     event.set("browsingContextID"sv, m_browsing_context_id);
     event.set("innerWindowId"sv, m_inner_window_id);
-    // FIXME: Get request priority
-    event.set("priority"sv, 0);
+    event.set("priority"sv, to_firefox_request_priority(m_priority));
     event.set("isNavigationRequest"sv, m_is_navigation_request);
     event.set("chromeContext"sv, false);
 

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
@@ -57,6 +57,16 @@ void NetworkEventActor::set_browsing_context_ids(u64 browsing_context_id, u64 in
     m_inner_window_id = inner_window_id;
 }
 
+void NetworkEventActor::set_referrer_policy(String referrer_policy)
+{
+    m_referrer_policy = move(referrer_policy);
+}
+
+void NetworkEventActor::set_is_navigation_request(bool is_navigation_request)
+{
+    m_is_navigation_request = is_navigation_request;
+}
+
 void NetworkEventActor::append_response_body(ByteBuffer data)
 {
     // Limit response body size to prevent memory issues
@@ -115,8 +125,10 @@ JsonObject NetworkEventActor::serialize_initial_event() const
     event.set("fromCache"sv, m_loaded_from_cache);
     event.set("fromServiceWorker"sv, false);
     event.set("isThirdPartyTrackingResource"sv, false);
-    // FIXME: Get actual referrer policy from request
-    event.set("referrerPolicy"sv, "strict-origin-when-cross-origin"sv);
+    if (m_referrer_policy.is_empty())
+        event.set("referrerPolicy"sv, "strict-origin-when-cross-origin"sv);
+    else
+        event.set("referrerPolicy"sv, m_referrer_policy);
     event.set("blockedReason"sv, 0);
     event.set("blockingExtension"sv, JsonValue {});
     event.set("channelId"sv, static_cast<i64>(m_request_id));
@@ -124,8 +136,7 @@ JsonObject NetworkEventActor::serialize_initial_event() const
     event.set("innerWindowId"sv, m_inner_window_id);
     // FIXME: Get request priority
     event.set("priority"sv, 0);
-    // FIXME: Detect if this is a navigation request
-    event.set("isNavigationRequest"sv, false);
+    event.set("isNavigationRequest"sv, m_is_navigation_request);
     event.set("chromeContext"sv, false);
 
     return event;

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.cpp
@@ -51,6 +51,12 @@ void NetworkEventActor::set_loaded_from_cache(bool loaded_from_cache)
     m_loaded_from_cache = loaded_from_cache;
 }
 
+void NetworkEventActor::set_browsing_context_ids(u64 browsing_context_id, u64 inner_window_id)
+{
+    m_browsing_context_id = browsing_context_id;
+    m_inner_window_id = inner_window_id;
+}
+
 void NetworkEventActor::append_response_body(ByteBuffer data)
 {
     // Limit response body size to prevent memory issues
@@ -114,10 +120,8 @@ JsonObject NetworkEventActor::serialize_initial_event() const
     event.set("blockedReason"sv, 0);
     event.set("blockingExtension"sv, JsonValue {});
     event.set("channelId"sv, static_cast<i64>(m_request_id));
-    // FIXME: Get actual browsing context ID from the page
-    event.set("browsingContextID"sv, 1);
-    // FIXME: Get actual inner window ID
-    event.set("innerWindowId"sv, 1);
+    event.set("browsingContextID"sv, m_browsing_context_id);
+    event.set("innerWindowId"sv, m_inner_window_id);
     // FIXME: Get request priority
     event.set("priority"sv, 0);
     // FIXME: Detect if this is a navigation request

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.h
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.h
@@ -24,8 +24,11 @@ public:
     virtual ~NetworkEventActor() override;
 
     u64 request_id() const { return m_request_id; }
+    u64 browsing_context_id() const { return m_browsing_context_id; }
+    u64 inner_window_id() const { return m_inner_window_id; }
 
     void set_request_info(String url, String method, UnixDateTime start_time, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type);
+    void set_browsing_context_ids(u64 browsing_context_id, u64 inner_window_id);
     void set_response_start(u32 status_code, Optional<String> reason_phrase);
     void set_response_headers(Vector<HTTP::Header> response_headers);
     void set_loaded_from_cache(bool);
@@ -60,6 +63,8 @@ private:
     Optional<String> m_reason_phrase;
     Vector<HTTP::Header> m_response_headers;
     bool m_loaded_from_cache { false };
+    u64 m_browsing_context_id { 1 };
+    u64 m_inner_window_id { 1 };
 
     ByteBuffer m_response_body;
     u64 m_body_size { 0 };

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.h
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.h
@@ -13,6 +13,7 @@
 #include <LibHTTP/Header.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 
 namespace DevTools {
 
@@ -31,6 +32,7 @@ public:
     void set_browsing_context_ids(u64 browsing_context_id, u64 inner_window_id);
     void set_referrer_policy(String);
     void set_is_navigation_request(bool);
+    void set_priority(Web::Fetch::Infrastructure::Request::Priority);
     void set_response_start(u32 status_code, Optional<String> reason_phrase);
     void set_response_headers(Vector<HTTP::Header> response_headers);
     void set_loaded_from_cache(bool);
@@ -69,6 +71,7 @@ private:
     u64 m_inner_window_id { 1 };
     String m_referrer_policy;
     bool m_is_navigation_request { false };
+    Web::Fetch::Infrastructure::Request::Priority m_priority { Web::Fetch::Infrastructure::Request::Priority::Auto };
 
     ByteBuffer m_response_body;
     u64 m_body_size { 0 };

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.h
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.h
@@ -29,6 +29,8 @@ public:
 
     void set_request_info(String url, String method, UnixDateTime start_time, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type);
     void set_browsing_context_ids(u64 browsing_context_id, u64 inner_window_id);
+    void set_referrer_policy(String);
+    void set_is_navigation_request(bool);
     void set_response_start(u32 status_code, Optional<String> reason_phrase);
     void set_response_headers(Vector<HTTP::Header> response_headers);
     void set_loaded_from_cache(bool);
@@ -65,6 +67,8 @@ private:
     bool m_loaded_from_cache { false };
     u64 m_browsing_context_id { 1 };
     u64 m_inner_window_id { 1 };
+    String m_referrer_policy;
+    bool m_is_navigation_request { false };
 
     ByteBuffer m_response_body;
     u64 m_body_size { 0 };

--- a/Libraries/LibDevTools/Actors/NetworkEventActor.h
+++ b/Libraries/LibDevTools/Actors/NetworkEventActor.h
@@ -28,6 +28,7 @@ public:
     void set_request_info(String url, String method, UnixDateTime start_time, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type);
     void set_response_start(u32 status_code, Optional<String> reason_phrase);
     void set_response_headers(Vector<HTTP::Header> response_headers);
+    void set_loaded_from_cache(bool);
     void append_response_body(ByteBuffer data);
     void set_request_complete(u64 body_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error);
 
@@ -58,6 +59,7 @@ private:
     Optional<u32> m_status_code;
     Optional<String> m_reason_phrase;
     Vector<HTTP::Header> m_response_headers;
+    bool m_loaded_from_cache { false };
 
     ByteBuffer m_response_body;
     u64 m_body_size { 0 };

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -181,6 +181,8 @@ public:
         Vector<HTTP::Header> request_headers;
         ByteBuffer request_body;
         Optional<String> initiator_type;
+        String referrer_policy;
+        bool is_navigation_request { false };
     };
 
     struct NetworkResponseData {

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -19,6 +19,7 @@
 #include <LibDevTools/Forward.h>
 #include <LibHTTP/Cookie/Cookie.h>
 #include <LibHTTP/Header.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibWeb/CSS/Selector.h>
@@ -187,6 +188,7 @@ public:
         u32 status_code { 0 };
         Optional<String> reason_phrase;
         Vector<HTTP::Header> response_headers;
+        Requests::CameFromCache came_from_cache { Requests::CameFromCache::No };
     };
 
     struct NetworkRequestCompleteData {

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -24,6 +24,7 @@
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/StorageAPI/StorageEndpoint.h>
@@ -183,6 +184,7 @@ public:
         Optional<String> initiator_type;
         String referrer_policy;
         bool is_navigation_request { false };
+        Web::Fetch::Infrastructure::Request::Priority priority { Web::Fetch::Infrastructure::Request::Priority::Auto };
     };
 
     struct NetworkResponseData {

--- a/Libraries/LibRequests/CameFromCache.h
+++ b/Libraries/LibRequests/CameFromCache.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Requests {
+
+enum class CameFromCache : u8 {
+    No,
+    Yes,
+};
+
+}

--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -190,12 +190,13 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
 
     m_internal_buffered_data = make<InternalBufferedData>();
 
-    on_headers_received = [this](auto headers, auto response_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key) {
+    on_headers_received = [this](auto headers, auto response_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key, auto came_from_cache) {
         m_internal_buffered_data->response_headers = move(headers);
         m_internal_buffered_data->response_code = move(response_code);
         m_internal_buffered_data->reason_phrase = reason_phrase;
         m_internal_buffered_data->javascript_bytecode = move(javascript_bytecode);
         m_internal_buffered_data->javascript_bytecode_cache_vary_key = javascript_bytecode_cache_vary_key;
+        m_internal_buffered_data->came_from_cache = came_from_cache;
     };
 
     on_finish = [this, on_buffered_request_finished = move(on_buffered_request_finished)](auto total_size, auto& timing_info, auto network_error) {
@@ -217,6 +218,7 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
             m_internal_buffered_data->reason_phrase,
             move(m_internal_buffered_data->javascript_bytecode),
             m_internal_buffered_data->javascript_bytecode_cache_vary_key,
+            m_internal_buffered_data->came_from_cache,
             move(payload));
     };
 
@@ -250,10 +252,10 @@ void Request::did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo
         on_finish(total_size, timing_info, effective_network_error);
 }
 
-void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)
+void Request::did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache)
 {
     if (on_headers_received)
-        on_headers_received(move(response_headers), response_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
+        on_headers_received(move(response_headers), response_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key, came_from_cache);
 }
 
 void Request::did_request_certificates(Badge<RequestClient>)

--- a/Libraries/LibRequests/Request.h
+++ b/Libraries/LibRequests/Request.h
@@ -16,6 +16,7 @@
 #include <LibCore/ImmutableBytes.h>
 #include <LibCore/Notifier.h>
 #include <LibHTTP/HeaderList.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 
@@ -97,13 +98,13 @@ public:
     void release_for_transfer();
     [[nodiscard]] bool has_file_backed_response_body() const;
 
-    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Core::ImmutableBytes payload)>;
+    using BufferedRequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache, Core::ImmutableBytes payload)>;
 
     // Configure the request such that the entirety of the response data is buffered. The callback receives that data and
     // the response headers all at once. Using this method is mutually exclusive with `set_unbuffered_data_received_callback`.
     void set_buffered_request_finished_callback(BufferedRequestFinished);
 
-    using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
+    using HeadersReceived = Function<void(NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache)>;
     using DataReceived = Function<void(ResponseData data)>;
     using CachedBodyAvailable = Function<void(Core::ImmutableBytes data)>;
     using RequestFinished = Function<void(u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> network_error)>;
@@ -117,7 +118,7 @@ public:
     Function<CertificateAndKey()> on_certificate_requested;
 
     void did_finish(Badge<RequestClient>, u64 total_size, RequestTimingInfo const& timing_info, Optional<NetworkError> const& network_error);
-    void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key);
+    void did_receive_headers(Badge<RequestClient>, NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache);
     void did_request_certificates(Badge<RequestClient>);
     void did_transfer(Badge<RequestClient>);
 
@@ -159,6 +160,7 @@ private:
         Optional<String> reason_phrase;
         Optional<Core::ImmutableBytes> javascript_bytecode;
         Optional<u64> javascript_bytecode_cache_vary_key;
+        CameFromCache came_from_cache { CameFromCache::No };
         Optional<Core::ImmutableBytes> payload;
     };
 

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -208,14 +208,14 @@ void RequestClient::request_finished(u64 request_id, u64 total_size, RequestTimi
     }
 }
 
-void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode_file, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key)
+void RequestClient::headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode_file, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key, CameFromCache came_from_cache)
 {
     Optional<Core::ImmutableBytes> javascript_bytecode;
     if (javascript_bytecode_file.has_value())
         javascript_bytecode = map_javascript_bytecode_file(javascript_bytecode_file->take_fd(), javascript_bytecode_size);
 
     if (auto request = m_requests.get(request_id); request.has_value())
-        (*request)->did_receive_headers({}, HTTP::HeaderList::create(move(response_headers)), status_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
+        (*request)->did_receive_headers({}, HTTP::HeaderList::create(move(response_headers)), status_code, reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key, came_from_cache);
     else
         warnln("Received headers for non-existent request {}", request_id);
 }

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -14,6 +14,7 @@
 #include <LibHTTP/HeaderList.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibRequests/CacheSizes.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibRequests/WebSocket.h>
 #include <LibWebSocket/WebSocket.h>
@@ -67,7 +68,7 @@ private:
     virtual void request_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_cached_body_file_available(u64 request_id, IPC::File, u64 offset, u64 size) override;
     virtual void request_finished(u64 request_id, u64, RequestTimingInfo, Optional<NetworkError>) override;
-    virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<IPC::File>, u64 javascript_bytecode_size, Optional<u64>) override;
+    virtual void headers_became_available(u64 request_id, Vector<HTTP::Header>, Optional<u32>, Optional<String>, Optional<IPC::File>, u64 javascript_bytecode_size, Optional<u64>, CameFromCache) override;
     virtual void request_transferred(u64 request_id) override;
 
     virtual void retrieve_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, URL::URL url, RequestServer::IsPrivate) override;

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2248,7 +2248,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
     // 13. Set up stream with byte reading support with pullAlgorithm set to pullAlgorithm, cancelAlgorithm set to cancelAlgorithm.
     stream->set_up_with_byte_reading_support(pull_algorithm, cancel_algorithm);
 
-    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](Requests::Request* request_server_request, HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key) {
+    auto on_headers_received = GC::create_function(vm.heap(), [&vm, pending_response, stream, request, fetched_data_receiver](Requests::Request* request_server_request, HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Requests::CameFromCache) {
         if (pending_response->is_resolved()) {
             // RequestServer will send us the response headers twice, the second time being for HTTP trailers. This
             // fetch algorithm is not interested in trailers, so just drop them here.

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2194,6 +2194,7 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
     load_request.set_request_mode(request->mode());
     load_request.set_referrer_policy(request->referrer_policy());
     load_request.set_is_navigation_request(request->is_navigation_request());
+    load_request.set_priority(request->priority());
     load_request.set_source_url(content_blocker_source_url_for_request(*request));
 
     if (auto const* body = request->body().get_pointer<GC::Ref<Infrastructure::Body>>()) {

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2192,6 +2192,8 @@ GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(
     load_request.set_initiator_type(request->initiator_type());
     load_request.set_destination(request->destination());
     load_request.set_request_mode(request->mode());
+    load_request.set_referrer_policy(request->referrer_policy());
+    load_request.set_is_navigation_request(request->is_navigation_request());
     load_request.set_source_url(content_blocker_source_url_for_request(*request));
 
     if (auto const* body = request->body().get_pointer<GC::Ref<Infrastructure::Body>>()) {

--- a/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Libraries/LibWeb/Loader/LoadRequest.h
@@ -17,6 +17,7 @@
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 
 namespace Web {
 
@@ -51,6 +52,12 @@ public:
     Fetch::Infrastructure::Request::Mode request_mode() const { return m_request_mode; }
     void set_request_mode(Fetch::Infrastructure::Request::Mode request_mode) { m_request_mode = request_mode; }
 
+    ReferrerPolicy::ReferrerPolicy referrer_policy() const { return m_referrer_policy; }
+    void set_referrer_policy(ReferrerPolicy::ReferrerPolicy referrer_policy) { m_referrer_policy = referrer_policy; }
+
+    bool is_navigation_request() const { return m_is_navigation_request; }
+    void set_is_navigation_request(bool is_navigation_request) { m_is_navigation_request = is_navigation_request; }
+
     Optional<URL::URL> const& source_url() const { return m_source_url; }
     void set_source_url(URL::URL source_url) { m_source_url = move(source_url); }
 
@@ -74,6 +81,8 @@ private:
     Optional<Fetch::Infrastructure::Request::InitiatorType> m_initiator_type;
     Optional<Fetch::Infrastructure::Request::Destination> m_destination;
     Fetch::Infrastructure::Request::Mode m_request_mode { Fetch::Infrastructure::Request::Mode::NoCORS };
+    ReferrerPolicy::ReferrerPolicy m_referrer_policy { ReferrerPolicy::DEFAULT_REFERRER_POLICY };
+    bool m_is_navigation_request { false };
     Optional<URL::URL> m_source_url;
 };
 

--- a/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Libraries/LibWeb/Loader/LoadRequest.h
@@ -58,6 +58,9 @@ public:
     bool is_navigation_request() const { return m_is_navigation_request; }
     void set_is_navigation_request(bool is_navigation_request) { m_is_navigation_request = is_navigation_request; }
 
+    Fetch::Infrastructure::Request::Priority priority() const { return m_priority; }
+    void set_priority(Fetch::Infrastructure::Request::Priority priority) { m_priority = priority; }
+
     Optional<URL::URL> const& source_url() const { return m_source_url; }
     void set_source_url(URL::URL source_url) { m_source_url = move(source_url); }
 
@@ -83,6 +86,7 @@ private:
     Fetch::Infrastructure::Request::Mode m_request_mode { Fetch::Infrastructure::Request::Mode::NoCORS };
     ReferrerPolicy::ReferrerPolicy m_referrer_policy { ReferrerPolicy::DEFAULT_REFERRER_POLICY };
     bool m_is_navigation_request { false };
+    Fetch::Infrastructure::Request::Priority m_priority { Fetch::Infrastructure::Request::Priority::Auto };
     Optional<URL::URL> m_source_url;
 };
 

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -400,7 +400,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete = move(on_complete), request](ReadonlyBytes data, Requests::RequestTimingInfo const& timing_info, HTTP::HeaderList const& response_headers) {
                 log_success(request);
-                on_headers_received->function()(nullptr, response_headers, {}, {}, {}, {});
+                on_headers_received->function()(nullptr, response_headers, {}, {}, {}, {}, Requests::CameFromCache::No);
                 on_data_received->function()(Requests::ResponseData::from_bytes(data));
                 on_complete->function()(true, timing_info, {});
             });
@@ -411,7 +411,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         handle_resource_load_request(
             request,
             [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
-                on_headers_received->function()(nullptr, load_result.response_headers, {}, {}, {}, {});
+                on_headers_received->function()(nullptr, load_result.response_headers, {}, {}, {}, {}, Requests::CameFromCache::No);
                 on_data_received->function()(Requests::ResponseData::from_bytes(load_result.data));
                 on_complete->function()(true, load_result.timing_info, {});
             },
@@ -427,7 +427,7 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
             request,
             [request, on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete](FileLoadResult const& load_result) {
                 log_success(request);
-                on_headers_received->function()(nullptr, load_result.response_headers, {}, {}, {}, {});
+                on_headers_received->function()(nullptr, load_result.response_headers, {}, {}, {}, {}, Requests::CameFromCache::No);
                 on_data_received->function()(Requests::ResponseData::from_bytes(load_result.data));
                 on_complete->function()(true, load_result.timing_info, {});
             },
@@ -452,13 +452,13 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
         return nullptr;
     }
 
-    auto protocol_headers_received = [this, on_headers_received = move(on_headers_received), request, &protocol_request = *protocol_request](auto const& response_headers, auto status_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key) {
+    auto protocol_headers_received = [this, on_headers_received = move(on_headers_received), request, &protocol_request = *protocol_request](auto const& response_headers, auto status_code, auto const& reason_phrase, auto javascript_bytecode, auto javascript_bytecode_cache_vary_key, auto came_from_cache) {
         handle_network_response_headers(request, response_headers);
 
         if (auto page = request.page())
-            page->client().page_did_receive_network_response_headers(protocol_request.id(), status_code.value_or(0), reason_phrase, response_headers->headers());
+            page->client().page_did_receive_network_response_headers(protocol_request.id(), status_code.value_or(0), reason_phrase, response_headers->headers(), came_from_cache);
 
-        on_headers_received->function()(&protocol_request, response_headers, move(status_code), reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key);
+        on_headers_received->function()(&protocol_request, response_headers, move(status_code), reason_phrase, move(javascript_bytecode), javascript_bytecode_cache_vary_key, came_from_cache);
     };
 
     auto protocol_data_received = [on_data_received = move(on_data_received), request, request_id = protocol_request->id()](auto data) {

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -520,7 +520,8 @@ RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest cons
         Optional<String> initiator_type_string;
         if (request.initiator_type().has_value())
             initiator_type_string = MUST(Fetch::Infrastructure::initiator_type_to_string(request.initiator_type().value()).view().to_utf8());
-        page->client().page_did_start_network_request(protocol_request->id(), request.url().value(), request.method(), request.headers().headers(), request.body(), move(initiator_type_string));
+        auto referrer_policy = MUST(String::from_utf8(ReferrerPolicy::to_string(request.referrer_policy())));
+        page->client().page_did_start_network_request(protocol_request->id(), request.url().value(), request.method(), request.headers().headers(), request.body(), move(initiator_type_string), referrer_policy, request.is_navigation_request());
     }
 
     ++m_pending_loads;

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -521,7 +521,7 @@ RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest cons
         if (request.initiator_type().has_value())
             initiator_type_string = MUST(Fetch::Infrastructure::initiator_type_to_string(request.initiator_type().value()).view().to_utf8());
         auto referrer_policy = MUST(String::from_utf8(ReferrerPolicy::to_string(request.referrer_policy())));
-        page->client().page_did_start_network_request(protocol_request->id(), request.url().value(), request.method(), request.headers().headers(), request.body(), move(initiator_type_string), referrer_policy, request.is_navigation_request());
+        page->client().page_did_start_network_request(protocol_request->id(), request.url().value(), request.method(), request.headers().headers(), request.body(), move(initiator_type_string), referrer_policy, request.is_navigation_request(), request.priority());
     }
 
     ++m_pending_loads;

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -14,6 +14,7 @@
 #include <LibCore/ImmutableBytes.h>
 #include <LibGC/Function.h>
 #include <LibHTTP/HeaderList.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/Forward.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
@@ -34,7 +35,7 @@ public:
 
     void set_client(NonnullRefPtr<Requests::RequestClient>);
 
-    using OnHeadersReceived = GC::Function<void(Requests::Request*, HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key)>;
+    using OnHeadersReceived = GC::Function<void(Requests::Request*, HTTP::HeaderList const& response_headers, Optional<u32> status_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes> javascript_bytecode, Optional<u64> javascript_bytecode_cache_vary_key, Requests::CameFromCache came_from_cache)>;
     using OnDataReceived = GC::Function<void(Requests::ResponseData data)>;
     using OnCachedBodyAvailable = GC::Function<void(Core::ImmutableBytes data)>;
     using OnComplete = GC::Function<void(bool success, Requests::RequestTimingInfo const& timing_info, Optional<StringView> error_message)>;

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -614,7 +614,7 @@ public:
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
     virtual void page_did_change_screen_wake_lock_state(ScreenWakeLockState) { }
 
-    virtual void page_did_start_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] URL::URL const& url, [[maybe_unused]] ByteString const& method, [[maybe_unused]] Vector<HTTP::Header> const& request_headers, [[maybe_unused]] ReadonlyBytes request_body, [[maybe_unused]] Optional<String> initiator_type) { }
+    virtual void page_did_start_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] URL::URL const& url, [[maybe_unused]] ByteString const& method, [[maybe_unused]] Vector<HTTP::Header> const& request_headers, [[maybe_unused]] ReadonlyBytes request_body, [[maybe_unused]] Optional<String> initiator_type, [[maybe_unused]] String const& referrer_policy, [[maybe_unused]] bool is_navigation_request) { }
     virtual void page_did_receive_network_response_headers([[maybe_unused]] u64 request_id, [[maybe_unused]] u32 status_code, [[maybe_unused]] Optional<String> reason_phrase, [[maybe_unused]] Vector<HTTP::Header> const& response_headers, [[maybe_unused]] Requests::CameFromCache came_from_cache) { }
     virtual void page_did_receive_network_response_body([[maybe_unused]] u64 request_id, [[maybe_unused]] ReadonlyBytes data) { }
     virtual void page_did_finish_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] u64 body_size, [[maybe_unused]] Requests::RequestTimingInfo const& timing_info, [[maybe_unused]] Optional<Requests::NetworkError> const& network_error) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -614,7 +614,7 @@ public:
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
     virtual void page_did_change_screen_wake_lock_state(ScreenWakeLockState) { }
 
-    virtual void page_did_start_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] URL::URL const& url, [[maybe_unused]] ByteString const& method, [[maybe_unused]] Vector<HTTP::Header> const& request_headers, [[maybe_unused]] ReadonlyBytes request_body, [[maybe_unused]] Optional<String> initiator_type, [[maybe_unused]] String const& referrer_policy, [[maybe_unused]] bool is_navigation_request) { }
+    virtual void page_did_start_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] URL::URL const& url, [[maybe_unused]] ByteString const& method, [[maybe_unused]] Vector<HTTP::Header> const& request_headers, [[maybe_unused]] ReadonlyBytes request_body, [[maybe_unused]] Optional<String> initiator_type, [[maybe_unused]] String const& referrer_policy, [[maybe_unused]] bool is_navigation_request, [[maybe_unused]] Fetch::Infrastructure::Request::Priority priority) { }
     virtual void page_did_receive_network_response_headers([[maybe_unused]] u64 request_id, [[maybe_unused]] u32 status_code, [[maybe_unused]] Optional<String> reason_phrase, [[maybe_unused]] Vector<HTTP::Header> const& response_headers, [[maybe_unused]] Requests::CameFromCache came_from_cache) { }
     virtual void page_did_receive_network_response_body([[maybe_unused]] u64 request_id, [[maybe_unused]] ReadonlyBytes data) { }
     virtual void page_did_finish_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] u64 body_size, [[maybe_unused]] Requests::RequestTimingInfo const& timing_info, [[maybe_unused]] Optional<Requests::NetworkError> const& network_error) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -30,6 +30,7 @@
 #include <LibHTTP/Header.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/TransportHandle.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
@@ -614,7 +615,7 @@ public:
     virtual void page_did_change_screen_wake_lock_state(ScreenWakeLockState) { }
 
     virtual void page_did_start_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] URL::URL const& url, [[maybe_unused]] ByteString const& method, [[maybe_unused]] Vector<HTTP::Header> const& request_headers, [[maybe_unused]] ReadonlyBytes request_body, [[maybe_unused]] Optional<String> initiator_type) { }
-    virtual void page_did_receive_network_response_headers([[maybe_unused]] u64 request_id, [[maybe_unused]] u32 status_code, [[maybe_unused]] Optional<String> reason_phrase, [[maybe_unused]] Vector<HTTP::Header> const& response_headers) { }
+    virtual void page_did_receive_network_response_headers([[maybe_unused]] u64 request_id, [[maybe_unused]] u32 status_code, [[maybe_unused]] Optional<String> reason_phrase, [[maybe_unused]] Vector<HTTP::Header> const& response_headers, [[maybe_unused]] Requests::CameFromCache came_from_cache) { }
     virtual void page_did_receive_network_response_body([[maybe_unused]] u64 request_id, [[maybe_unused]] ReadonlyBytes data) { }
     virtual void page_did_finish_network_request([[maybe_unused]] u64 request_id, [[maybe_unused]] u64 body_size, [[maybe_unused]] Requests::RequestTimingInfo const& timing_info, [[maybe_unused]] Optional<Requests::NetworkError> const& network_error) { }
     virtual void page_did_report_worker_exception([[maybe_unused]] Utf16String const& message, [[maybe_unused]] Utf16String const& filename, [[maybe_unused]] u32 lineno, [[maybe_unused]] u32 colno) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2899,8 +2899,8 @@ void Application::listen_for_network_events(DevTools::TabDescription const& desc
         on_request_started({ request_id, url.to_string(), MUST(String::from_byte_string(method)), UnixDateTime::now(), headers, move(request_body), move(initiator_type) });
     };
 
-    view->on_network_response_headers_received = [on_response_headers = move(on_response_headers)](u64 request_id, u32 status_code, Optional<String> const& reason_phrase, Vector<HTTP::Header> const& headers) {
-        on_response_headers({ request_id, status_code, reason_phrase, headers });
+    view->on_network_response_headers_received = [on_response_headers = move(on_response_headers)](u64 request_id, u32 status_code, Optional<String> const& reason_phrase, Vector<HTTP::Header> const& headers, Requests::CameFromCache came_from_cache) {
+        on_response_headers({ request_id, status_code, reason_phrase, headers, came_from_cache });
     };
 
     view->on_network_response_body_received = [on_response_body = move(on_response_body)](u64 request_id, ByteBuffer data) {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2895,8 +2895,18 @@ void Application::listen_for_network_events(DevTools::TabDescription const& desc
     if (!view.has_value())
         return;
 
-    view->on_network_request_started = [on_request_started = move(on_request_started)](u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& headers, ByteBuffer request_body, Optional<String> initiator_type) {
-        on_request_started({ request_id, url.to_string(), MUST(String::from_byte_string(method)), UnixDateTime::now(), headers, move(request_body), move(initiator_type) });
+    view->on_network_request_started = [on_request_started = move(on_request_started)](u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request) {
+        on_request_started({
+            .request_id = request_id,
+            .url = url.to_string(),
+            .method = MUST(String::from_byte_string(method)),
+            .start_time = UnixDateTime::now(),
+            .request_headers = headers,
+            .request_body = move(request_body),
+            .initiator_type = move(initiator_type),
+            .referrer_policy = move(referrer_policy),
+            .is_navigation_request = is_navigation_request,
+        });
     };
 
     view->on_network_response_headers_received = [on_response_headers = move(on_response_headers)](u64 request_id, u32 status_code, Optional<String> const& reason_phrase, Vector<HTTP::Header> const& headers, Requests::CameFromCache came_from_cache) {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -2895,7 +2895,7 @@ void Application::listen_for_network_events(DevTools::TabDescription const& desc
     if (!view.has_value())
         return;
 
-    view->on_network_request_started = [on_request_started = move(on_request_started)](u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request) {
+    view->on_network_request_started = [on_request_started = move(on_request_started)](u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority priority) {
         on_request_started({
             .request_id = request_id,
             .url = url.to_string(),
@@ -2906,6 +2906,7 @@ void Application::listen_for_network_events(DevTools::TabDescription const& desc
             .initiator_type = move(initiator_type),
             .referrer_policy = move(referrer_policy),
             .is_navigation_request = is_navigation_request,
+            .priority = priority,
         });
     };
 

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -310,7 +310,7 @@ void Autocomplete::start_remote_query(AutocompleteQueryID query_id, Autocomplete
     m_request = Application::request_server_client(m_is_private).start_request("GET"sv, *url);
 
     m_request->set_buffered_request_finished_callback(
-        [this, query_id, engine, query = move(query)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Core::ImmutableBytes payload) {
+        [this, query_id, engine, query = move(query)](u64, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const& network_error, HTTP::HeaderList const& response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Requests::CameFromCache, Core::ImmutableBytes payload) {
             Core::deferred_invoke([this]() { m_request.clear(); });
 
             if (m_query_id != query_id) {

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -124,7 +124,7 @@ void FileDownloader::attach_request_to_download(u64 download_id, NonnullRefPtr<R
     active->request = request;
 
     request->set_unbuffered_request_callbacks(
-        [this, download_id](NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>) {
+        [this, download_id](NonnullRefPtr<HTTP::HeaderList> response_headers, Optional<u32> response_code, Optional<String> const& reason_phrase, Optional<Core::ImmutableBytes>, Optional<u64>, Requests::CameFromCache) {
             auto* download = mutable_download_or_null(download_id);
             if (!download)
                 return;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -29,6 +29,7 @@
 #include <LibGfx/SharedImage.h>
 #include <LibGfx/SharedImageBuffer.h>
 #include <LibHTTP/Header.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/Forward.h>
 #include <LibRequests/NetworkError.h>
 #include <LibWeb/Bindings/Navigation.h>
@@ -351,7 +352,7 @@ public:
     Function<void(JsonValue)> on_received_js_console_result;
     Function<void(ConsoleOutput)> on_console_message;
     Function<void(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ByteBuffer, Optional<String>)> on_network_request_started;
-    Function<void(u64 request_id, u32 status_code, Optional<String> const&, Vector<HTTP::Header> const&)> on_network_response_headers_received;
+    Function<void(u64 request_id, u32 status_code, Optional<String> const&, Vector<HTTP::Header> const&, Requests::CameFromCache)> on_network_response_headers_received;
     Function<void(u64 request_id, ByteBuffer)> on_network_response_body_received;
     Function<void(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&)> on_network_request_finished;
     Function<void(i32 count_waiting)> on_resource_status_change;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -33,6 +33,7 @@
 #include <LibRequests/Forward.h>
 #include <LibRequests/NetworkError.h>
 #include <LibWeb/Bindings/Navigation.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
@@ -351,7 +352,7 @@ public:
     Function<void(Web::HTML::ScriptRegistry::Description)> on_devtools_source_available;
     Function<void(JsonValue)> on_received_js_console_result;
     Function<void(ConsoleOutput)> on_console_message;
-    Function<void(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ByteBuffer, Optional<String>, String, bool)> on_network_request_started;
+    Function<void(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ByteBuffer, Optional<String>, String, bool, Web::Fetch::Infrastructure::Request::Priority)> on_network_request_started;
     Function<void(u64 request_id, u32 status_code, Optional<String> const&, Vector<HTTP::Header> const&, Requests::CameFromCache)> on_network_response_headers_received;
     Function<void(u64 request_id, ByteBuffer)> on_network_response_body_received;
     Function<void(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&)> on_network_request_finished;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -351,7 +351,7 @@ public:
     Function<void(Web::HTML::ScriptRegistry::Description)> on_devtools_source_available;
     Function<void(JsonValue)> on_received_js_console_result;
     Function<void(ConsoleOutput)> on_console_message;
-    Function<void(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ByteBuffer, Optional<String>)> on_network_request_started;
+    Function<void(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ByteBuffer, Optional<String>, String, bool)> on_network_request_started;
     Function<void(u64 request_id, u32 status_code, Optional<String> const&, Vector<HTTP::Header> const&, Requests::CameFromCache)> on_network_response_headers_received;
     Function<void(u64 request_id, ByteBuffer)> on_network_response_body_received;
     Function<void(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&)> on_network_request_finished;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1205,11 +1205,11 @@ void WebContentClient::did_start_network_request(u64 page_id, u64 request_id, UR
     }
 }
 
-void WebContentClient::did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> response_headers)
+void WebContentClient::did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> response_headers, Requests::CameFromCache came_from_cache)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_network_response_headers_received)
-            view->on_network_response_headers_received(request_id, status_code, reason_phrase, response_headers);
+            view->on_network_response_headers_received(request_id, status_code, reason_phrase, response_headers, came_from_cache);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1197,11 +1197,11 @@ void WebContentClient::did_output_js_console_message(u64 page_id, ConsoleOutput 
     }
 }
 
-void WebContentClient::did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request)
+void WebContentClient::did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority priority)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_network_request_started)
-            view->on_network_request_started(request_id, url, method, request_headers, move(request_body), move(initiator_type), move(referrer_policy), is_navigation_request);
+            view->on_network_request_started(request_id, url, method, request_headers, move(request_body), move(initiator_type), move(referrer_policy), is_navigation_request, priority);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1197,11 +1197,11 @@ void WebContentClient::did_output_js_console_message(u64 page_id, ConsoleOutput 
     }
 }
 
-void WebContentClient::did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type)
+void WebContentClient::did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_network_request_started)
-            view->on_network_request_started(request_id, url, method, request_headers, move(request_body), move(initiator_type));
+            view->on_network_request_started(request_id, url, method, request_headers, move(request_body), move(initiator_type), move(referrer_policy), is_navigation_request);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -178,7 +178,7 @@ private:
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, Optional<Core::AnonymousBuffer>) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;
     virtual void did_output_js_console_message(u64 page_id, ConsoleOutput) override;
-    virtual void did_start_network_request(u64 page_id, u64 request_id, URL::URL, ByteString method, Vector<HTTP::Header>, ByteBuffer request_body, Optional<String> initiator_type) override;
+    virtual void did_start_network_request(u64 page_id, u64 request_id, URL::URL, ByteString method, Vector<HTTP::Header>, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request) override;
     virtual void did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header>, Requests::CameFromCache) override;
     virtual void did_receive_network_response_body(u64 page_id, u64 request_id, ByteBuffer data) override;
     virtual void did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo, Optional<Requests::NetworkError>) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -20,6 +20,7 @@
 #include <LibHTTP/Header.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibIPC/Transport.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -178,7 +179,7 @@ private:
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;
     virtual void did_output_js_console_message(u64 page_id, ConsoleOutput) override;
     virtual void did_start_network_request(u64 page_id, u64 request_id, URL::URL, ByteString method, Vector<HTTP::Header>, ByteBuffer request_body, Optional<String> initiator_type) override;
-    virtual void did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header>) override;
+    virtual void did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header>, Requests::CameFromCache) override;
     virtual void did_receive_network_response_body(u64 page_id, u64 request_id, ByteBuffer data) override;
     virtual void did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo, Optional<Requests::NetworkError>) override;
     virtual void did_change_favicon(u64 page_id, Gfx::ShareableBitmap) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -27,6 +27,7 @@
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/Compositor/Types.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/CrossProcessId.h>
@@ -178,7 +179,7 @@ private:
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, Optional<Core::AnonymousBuffer>) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue) override;
     virtual void did_output_js_console_message(u64 page_id, ConsoleOutput) override;
-    virtual void did_start_network_request(u64 page_id, u64 request_id, URL::URL, ByteString method, Vector<HTTP::Header>, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request) override;
+    virtual void did_start_network_request(u64 page_id, u64 request_id, URL::URL, ByteString method, Vector<HTTP::Header>, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority) override;
     virtual void did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header>, Requests::CameFromCache) override;
     virtual void did_receive_network_response_body(u64 page_id, u64 request_id, ByteBuffer data) override;
     virtual void did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo, Optional<Requests::NetworkError>) override;

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -1315,7 +1315,10 @@ void Request::transfer_headers_to_client_if_needed()
 
 void Request::send_headers_to_client(Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key)
 {
-    m_client->async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_size, javascript_bytecode_cache_vary_key);
+    auto came_from_cache = m_cache_status == CacheStatus::ReadFromCache
+        ? Requests::CameFromCache::Yes
+        : Requests::CameFromCache::No;
+    m_client->async_headers_became_available(m_request_id, m_response_headers->headers(), m_status_code, m_reason_phrase, move(javascript_bytecode), javascript_bytecode_size, javascript_bytecode_cache_vary_key, came_from_cache);
 }
 
 ErrorOr<void> Request::write_queued_bytes_without_blocking()

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -1,6 +1,7 @@
 #include <LibHTTP/Header.h>
 #include <LibRequests/CacheSizes.h>
 #include <LibRequests/NetworkError.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
 #include <RequestServer/IsPrivate.h>
@@ -12,7 +13,7 @@ endpoint RequestClient
     request_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_cached_body_file_available(u64 request_id, IPC::File fd, u64 offset, u64 size) =|
     request_finished(u64 request_id, u64 total_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
-    headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key) =|
+    headers_became_available(u64 request_id, Vector<HTTP::Header> response_headers, Optional<u32> status_code, Optional<String> reason_phrase, Optional<IPC::File> javascript_bytecode, u64 javascript_bytecode_size, Optional<u64> javascript_bytecode_cache_vary_key, Requests::CameFromCache came_from_cache) =|
     request_transferred(u64 request_id) =|
 
     retrieve_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, URL::URL url, ::RequestServer::IsPrivate is_private) =|

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1328,9 +1328,9 @@ void PageClient::received_message_from_web_ui(Utf16String const& name, JS::Value
         m_web_ui->received_message_from_web_ui(name, data);
 }
 
-void PageClient::page_did_start_network_request(u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& request_headers, ReadonlyBytes request_body, Optional<String> initiator_type, String const& referrer_policy, bool is_navigation_request)
+void PageClient::page_did_start_network_request(u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& request_headers, ReadonlyBytes request_body, Optional<String> initiator_type, String const& referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority priority)
 {
-    client().async_did_start_network_request(m_id, request_id, url, method, request_headers, request_body, move(initiator_type), referrer_policy, is_navigation_request);
+    client().async_did_start_network_request(m_id, request_id, url, method, request_headers, request_body, move(initiator_type), referrer_policy, is_navigation_request, priority);
 }
 
 void PageClient::page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> const& response_headers, Requests::CameFromCache came_from_cache)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1328,9 +1328,9 @@ void PageClient::received_message_from_web_ui(Utf16String const& name, JS::Value
         m_web_ui->received_message_from_web_ui(name, data);
 }
 
-void PageClient::page_did_start_network_request(u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& request_headers, ReadonlyBytes request_body, Optional<String> initiator_type)
+void PageClient::page_did_start_network_request(u64 request_id, URL::URL const& url, ByteString const& method, Vector<HTTP::Header> const& request_headers, ReadonlyBytes request_body, Optional<String> initiator_type, String const& referrer_policy, bool is_navigation_request)
 {
-    client().async_did_start_network_request(m_id, request_id, url, method, request_headers, request_body, move(initiator_type));
+    client().async_did_start_network_request(m_id, request_id, url, method, request_headers, request_body, move(initiator_type), referrer_policy, is_navigation_request);
 }
 
 void PageClient::page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> const& response_headers, Requests::CameFromCache came_from_cache)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1333,9 +1333,9 @@ void PageClient::page_did_start_network_request(u64 request_id, URL::URL const& 
     client().async_did_start_network_request(m_id, request_id, url, method, request_headers, request_body, move(initiator_type));
 }
 
-void PageClient::page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> const& response_headers)
+void PageClient::page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> const& response_headers, Requests::CameFromCache came_from_cache)
 {
-    client().async_did_receive_network_response_headers(m_id, request_id, status_code, move(reason_phrase), response_headers);
+    client().async_did_receive_network_response_headers(m_id, request_id, status_code, move(reason_phrase), response_headers, came_from_cache);
 }
 
 void PageClient::page_did_receive_network_response_body(u64 request_id, ReadonlyBytes data)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -269,7 +269,7 @@ private:
     virtual void flush_pending_dom_mutations() override;
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot) override;
     virtual void received_message_from_web_ui(Utf16String const& name, JS::Value data) override;
-    virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>) override;
+    virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>, String const& referrer_policy, bool is_navigation_request) override;
     virtual void page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String>, Vector<HTTP::Header> const&, Requests::CameFromCache) override;
     virtual void page_did_receive_network_response_body(u64 request_id, ReadonlyBytes) override;
     virtual void page_did_finish_network_request(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -270,7 +270,7 @@ private:
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot) override;
     virtual void received_message_from_web_ui(Utf16String const& name, JS::Value data) override;
     virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>) override;
-    virtual void page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String>, Vector<HTTP::Header> const&) override;
+    virtual void page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String>, Vector<HTTP::Header> const&, Requests::CameFromCache) override;
     virtual void page_did_receive_network_response_body(u64 request_id, ReadonlyBytes) override;
     virtual void page_did_finish_network_request(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&) override;
     virtual void page_did_register_javascript_source(Web::DOM::Document&, Web::HTML::ScriptRegistry::Description const&) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -269,7 +269,7 @@ private:
     virtual void flush_pending_dom_mutations() override;
     virtual void page_did_take_screenshot(Gfx::ShareableBitmap const& screenshot) override;
     virtual void received_message_from_web_ui(Utf16String const& name, JS::Value data) override;
-    virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>, String const& referrer_policy, bool is_navigation_request) override;
+    virtual void page_did_start_network_request(u64 request_id, URL::URL const&, ByteString const&, Vector<HTTP::Header> const&, ReadonlyBytes, Optional<String>, String const& referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority) override;
     virtual void page_did_receive_network_response_headers(u64 request_id, u32 status_code, Optional<String>, Vector<HTTP::Header> const&, Requests::CameFromCache) override;
     virtual void page_did_receive_network_response_body(u64 request_id, ReadonlyBytes) override;
     virtual void page_did_finish_network_request(u64 request_id, u64 body_size, Requests::RequestTimingInfo const&, Optional<Requests::NetworkError> const&) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -17,6 +17,7 @@
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
@@ -187,7 +188,7 @@ endpoint WebContentClient
     did_execute_js_console_input(u64 page_id, JsonValue result) =|
     did_output_js_console_message(u64 page_id, WebView::ConsoleOutput console_output) =|
 
-    did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request) =|
+    did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request, Web::Fetch::Infrastructure::Request::Priority priority) =|
     did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> response_headers, Requests::CameFromCache came_from_cache) =|
     did_receive_network_response_body(u64 page_id, u64 request_id, ByteBuffer data) =|
     did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -8,6 +8,7 @@
 #include <LibHTTP/HSTS/ParsedHSTSPolicy.h>
 #include <LibHTTP/Header.h>
 #include <LibRequests/NetworkError.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/Navigation.h>
@@ -187,7 +188,7 @@ endpoint WebContentClient
     did_output_js_console_message(u64 page_id, WebView::ConsoleOutput console_output) =|
 
     did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type) =|
-    did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> response_headers) =|
+    did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> response_headers, Requests::CameFromCache came_from_cache) =|
     did_receive_network_response_body(u64 page_id, u64 request_id, ByteBuffer data) =|
     did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -187,7 +187,7 @@ endpoint WebContentClient
     did_execute_js_console_input(u64 page_id, JsonValue result) =|
     did_output_js_console_message(u64 page_id, WebView::ConsoleOutput console_output) =|
 
-    did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type) =|
+    did_start_network_request(u64 page_id, u64 request_id, URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, ByteBuffer request_body, Optional<String> initiator_type, String referrer_policy, bool is_navigation_request) =|
     did_receive_network_response_headers(u64 page_id, u64 request_id, u32 status_code, Optional<String> reason_phrase, Vector<HTTP::Header> response_headers, Requests::CameFromCache came_from_cache) =|
     did_receive_network_response_body(u64 page_id, u64 request_id, ByteBuffer data) =|
     did_finish_network_request(u64 page_id, u64 request_id, u64 body_size, Requests::RequestTimingInfo timing_info, Optional<Requests::NetworkError> network_error) =|

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1262,7 +1262,9 @@ public:
             .start_time = UnixDateTime::from_seconds_since_epoch(20),
             .request_headers = move(request_headers),
             .request_body = move(request_body),
-            .initiator_type = "fetch"_string });
+            .initiator_type = "fetch"_string,
+            .referrer_policy = "strict-origin-when-cross-origin"_string,
+            .is_navigation_request = false });
 
         Vector<HTTP::Header> response_headers;
         response_headers.append({ ByteString::formatted("Content-Type"), ByteString::formatted("application/json") });

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1264,7 +1264,8 @@ public:
             .request_body = move(request_body),
             .initiator_type = "fetch"_string,
             .referrer_policy = move(referrer_policy),
-            .is_navigation_request = is_navigation_request });
+            .is_navigation_request = is_navigation_request,
+            .priority = Web::Fetch::Infrastructure::Request::Priority::Auto });
 
         Vector<HTTP::Header> response_headers;
         response_headers.append({ ByteString::formatted("Content-Type"), ByteString::formatted("application/json") });

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1243,7 +1243,7 @@ public:
         on_console_message({ UnixDateTime::from_seconds_since_epoch(12), WebView::ConsoleError { "TypeError"_string, "bad things"_string, move(stack), true } });
     }
 
-    void emit_network_lifecycle(String referrer_policy = "strict-origin-when-cross-origin"_string, bool is_navigation_request = false) const
+    void emit_network_lifecycle(String referrer_policy = "strict-origin-when-cross-origin"_string, bool is_navigation_request = false, Web::Fetch::Infrastructure::Request::Priority priority = Web::Fetch::Infrastructure::Request::Priority::Auto) const
     {
         VERIFY(on_network_request_started);
         VERIFY(on_network_response_headers_received);
@@ -1265,7 +1265,7 @@ public:
             .initiator_type = "fetch"_string,
             .referrer_policy = move(referrer_policy),
             .is_navigation_request = is_navigation_request,
-            .priority = Web::Fetch::Infrastructure::Request::Priority::Auto });
+            .priority = priority });
 
         Vector<HTTP::Header> response_headers;
         response_headers.append({ ByteString::formatted("Content-Type"), ByteString::formatted("application/json") });
@@ -4141,12 +4141,13 @@ TEST_CASE(network_event_reports_request_metadata)
     auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
     auto inner_window_id = target.get_integer<u64>("innerWindowId"sv).value();
 
-    session->delegate.emit_network_lifecycle("no-referrer"_string, true);
+    session->delegate.emit_network_lifecycle("no-referrer"_string, true, Web::Fetch::Infrastructure::Request::Priority::High);
     auto network_event = read_resource(client, "network-event"sv);
     EXPECT_EQ(network_event.get_integer<u64>("browsingContextID"sv).value(), 42u);
     EXPECT_EQ(network_event.get_integer<u64>("innerWindowId"sv).value(), inner_window_id);
     EXPECT_EQ(network_event.get_string("referrerPolicy"sv).value(), "no-referrer"sv);
     EXPECT(network_event.get_bool("isNavigationRequest"sv).value());
+    EXPECT_EQ(network_event.get_integer<i64>("priority"sv).value(), -10);
 
     auto headers_update = read_resource(client, "network-event"sv, "resources-updated-array"sv);
     EXPECT_EQ(headers_update.get_integer<u64>("browsingContextID"sv).value(), 42u);

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -21,6 +21,7 @@
 #include <LibDevTools/IndexedDBSerialization.h>
 #include <LibHTTP/Cookie/ParsedCookie.h>
 #include <LibHTTP/Header.h>
+#include <LibRequests/CameFromCache.h>
 #include <LibRequests/RequestTimingInfo.h>
 #include <LibTest/TestCase.h>
 #include <LibThreading/Thread.h>
@@ -1268,7 +1269,8 @@ public:
         on_network_response_headers_received({ .request_id = 100,
             .status_code = 200,
             .reason_phrase = "OK"_string,
-            .response_headers = move(response_headers) });
+            .response_headers = move(response_headers),
+            .came_from_cache = Requests::CameFromCache::Yes });
 
         ByteBuffer response_body;
         response_body.append("{\"ok\":true}", 11);
@@ -4151,8 +4153,11 @@ TEST_CASE(console_network_navigation_and_accessibility)
     auto network_event = read_resource(client, "network-event"sv);
     EXPECT_EQ(network_event.get_string("method"sv).value(), "POST"sv);
     EXPECT(network_event.get_bool("isXHR"sv).value());
+    EXPECT(!network_event.get_bool("fromCache"sv).value());
     auto network_actor = network_event.get_string("actor"sv).release_value();
-    (void)read_resource(client, "network-event"sv, "resources-updated-array"sv);
+    auto headers_update = read_resource(client, "network-event"sv, "resources-updated-array"sv);
+    auto header_resource_updates = headers_update.get_object("resourceUpdates"sv).release_value();
+    EXPECT(header_resource_updates.get_bool("fromCache"sv).value());
     (void)read_resource(client, "network-event"sv, "resources-updated-array"sv);
 
     JsonObject content_request;

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -636,7 +636,7 @@ class TestDevToolsDelegate final : public DevTools::DevToolsDelegate {
 public:
     virtual Vector<DevTools::TabDescription> tab_list() const override
     {
-        return { { .id = 1, .title = "Fixture page"_string, .url = tab_url } };
+        return { { .id = tab_id, .title = "Fixture page"_string, .url = tab_url } };
     }
 
     virtual Vector<DevTools::CSSProperty> css_property_list() const override
@@ -1365,6 +1365,7 @@ public:
     mutable Function<void(Vector<HTTP::Cookie::Cookie>)> on_host_cookie_change;
     mutable HashMap<u64, Function<void(DevToolsDelegate::StorageChange)>> storage_change_listeners;
     String tab_url { "https://example.test/"_string };
+    u64 tab_id { 1 };
     mutable HashMap<u64, Function<void(JsonObject)>> indexed_database_change_listeners;
 
     struct NavigationListener {
@@ -1688,10 +1689,11 @@ struct TestSession {
     OwnPtr<ProtocolClient> client;
 };
 
-static NonnullOwnPtr<TestSession> create_session(StringView tab_url = "https://example.test/"sv)
+static NonnullOwnPtr<TestSession> create_session(StringView tab_url = "https://example.test/"sv, u64 tab_id = 1)
 {
     auto session = make<TestSession>();
     session->delegate.tab_url = MUST(String::from_utf8(tab_url));
+    session->delegate.tab_id = tab_id;
     session->server = MUST(DevTools::DevToolsServer::create(session->delegate, 0));
     session->client = ProtocolClient::connect(session->loop, *session->server);
     return session;
@@ -4125,6 +4127,29 @@ TEST_CASE(devtools_server_teardown_with_pending_actor_cleanup)
     session->server->connection()->on_connection_closed();
     session->server.clear();
     pump(session->loop);
+}
+
+TEST_CASE(network_event_reports_target_context_ids)
+{
+    auto session = create_session("https://example.test/"sv, 42);
+    auto& client = *session->client;
+    (void)client.read_message();
+
+    auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
+    auto inner_window_id = target.get_integer<u64>("innerWindowId"sv).value();
+
+    session->delegate.emit_network_lifecycle();
+    auto network_event = read_resource(client, "network-event"sv);
+    EXPECT_EQ(network_event.get_integer<u64>("browsingContextID"sv).value(), 42u);
+    EXPECT_EQ(network_event.get_integer<u64>("innerWindowId"sv).value(), inner_window_id);
+
+    auto headers_update = read_resource(client, "network-event"sv, "resources-updated-array"sv);
+    EXPECT_EQ(headers_update.get_integer<u64>("browsingContextID"sv).value(), 42u);
+    EXPECT_EQ(headers_update.get_integer<u64>("innerWindowId"sv).value(), inner_window_id);
+
+    auto completion_update = read_resource(client, "network-event"sv, "resources-updated-array"sv);
+    EXPECT_EQ(completion_update.get_integer<u64>("browsingContextID"sv).value(), 42u);
+    EXPECT_EQ(completion_update.get_integer<u64>("innerWindowId"sv).value(), inner_window_id);
 }
 
 TEST_CASE(console_network_navigation_and_accessibility)

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1243,7 +1243,7 @@ public:
         on_console_message({ UnixDateTime::from_seconds_since_epoch(12), WebView::ConsoleError { "TypeError"_string, "bad things"_string, move(stack), true } });
     }
 
-    void emit_network_lifecycle() const
+    void emit_network_lifecycle(String referrer_policy = "strict-origin-when-cross-origin"_string, bool is_navigation_request = false) const
     {
         VERIFY(on_network_request_started);
         VERIFY(on_network_response_headers_received);
@@ -1263,8 +1263,8 @@ public:
             .request_headers = move(request_headers),
             .request_body = move(request_body),
             .initiator_type = "fetch"_string,
-            .referrer_policy = "strict-origin-when-cross-origin"_string,
-            .is_navigation_request = false });
+            .referrer_policy = move(referrer_policy),
+            .is_navigation_request = is_navigation_request });
 
         Vector<HTTP::Header> response_headers;
         response_headers.append({ ByteString::formatted("Content-Type"), ByteString::formatted("application/json") });
@@ -4131,7 +4131,7 @@ TEST_CASE(devtools_server_teardown_with_pending_actor_cleanup)
     pump(session->loop);
 }
 
-TEST_CASE(network_event_reports_target_context_ids)
+TEST_CASE(network_event_reports_request_metadata)
 {
     auto session = create_session("https://example.test/"sv, 42);
     auto& client = *session->client;
@@ -4140,10 +4140,12 @@ TEST_CASE(network_event_reports_target_context_ids)
     auto target = get_frame_target(client, actor_from(get_tab(client), "actor"sv));
     auto inner_window_id = target.get_integer<u64>("innerWindowId"sv).value();
 
-    session->delegate.emit_network_lifecycle();
+    session->delegate.emit_network_lifecycle("no-referrer"_string, true);
     auto network_event = read_resource(client, "network-event"sv);
     EXPECT_EQ(network_event.get_integer<u64>("browsingContextID"sv).value(), 42u);
     EXPECT_EQ(network_event.get_integer<u64>("innerWindowId"sv).value(), inner_window_id);
+    EXPECT_EQ(network_event.get_string("referrerPolicy"sv).value(), "no-referrer"sv);
+    EXPECT(network_event.get_bool("isNavigationRequest"sv).value());
 
     auto headers_update = read_resource(client, "network-event"sv, "resources-updated-array"sv);
     EXPECT_EQ(headers_update.get_integer<u64>("browsingContextID"sv).value(), 42u);


### PR DESCRIPTION
We had a few FIXMEs with hard-coded values for network requests, so this PR fills those in with real values. Specifically:
- Whether it was cached
- Referrer policy
- Browsing context and window IDs
- Priority
- Whether it was a navigation request