### PR TITLE
Stop rebuilding the whole layout tree on top layer changes

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -805,6 +805,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_top_layer_elements);
     visitor.visit(m_top_layer_pending_removals);
+    visitor.visit(m_elements_with_pending_top_layer_membership_change);
     visitor.visit(m_showing_auto_popover_list);
     visitor.visit(m_showing_hint_popover_list);
     visitor.visit(m_popover_pointerdown_target);
@@ -2080,6 +2081,7 @@ void Document::update_layout(UpdateLayoutReason reason)
     constexpr size_t max_container_query_layout_passes = 8;
     for (size_t layout_pass = 0; layout_pass < max_container_query_layout_passes; ++layout_pass) {
         update_style();
+        process_pending_top_layer_layout_changes();
 
         auto const should_collect_devtools_layout_data = page().client().has_active_devtools_client();
         auto const force_devtools_layout_data_collection = should_collect_devtools_layout_data
@@ -2226,6 +2228,10 @@ void Document::update_layout(UpdateLayoutReason reason)
         }
 
         if (needs_style_update_after_layout())
+            continue;
+
+        // A zone rebuild requested during layout tree construction runs as another pass.
+        if (m_top_layer_needs_layout_zone_rebuild || !m_elements_with_pending_top_layer_membership_change.is_empty())
             continue;
 
         // The pass cap above bounds repeated container query style/layout cycles.
@@ -7948,7 +7954,7 @@ void Document::add_an_element_to_the_top_layer(GC::Ref<Element> element)
     // FIXME: 4. At the UA !important cascade origin, add a rule targeting el containing an overlay: auto declaration.
     element->set_rendered_in_top_layer(true);
     element->set_needs_style_update(true);
-    invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentAddAnElementToTheTopLayer);
+    m_elements_with_pending_top_layer_membership_change.append(element);
 }
 
 // https://drafts.csswg.org/css-position-4/#request-an-element-to-be-removed-from-the-top-layer
@@ -7963,7 +7969,7 @@ void Document::request_an_element_to_be_remove_from_the_top_layer(GC::Ref<Elemen
     // FIXME: 3. Remove the UA !important overlay: auto rule targeting el.
     element->set_rendered_in_top_layer(false);
     element->set_needs_style_update(true);
-    invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentRequestAnElementToBeRemovedFromTheTopLayer);
+    m_elements_with_pending_top_layer_membership_change.append(element);
 
     // 4. Append el to doc’s pending top layer removals.
     m_top_layer_pending_removals.set(element);
@@ -7983,7 +7989,7 @@ void Document::remove_an_element_from_the_top_layer_immediately(GC::Ref<Element>
     element->set_rendered_in_top_layer(false);
     element->set_needs_style_update(true);
 
-    invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentImmediatelyRemoveElementFromTheTopLayer);
+    m_elements_with_pending_top_layer_membership_change.append(element);
 }
 
 // https://drafts.csswg.org/css-position-4/#process-top-layer-removals
@@ -8004,9 +8010,66 @@ void Document::process_top_layer_removals()
         m_top_layer_elements.remove(element);
         m_top_layer_pending_removals.remove(element);
     }
+}
 
-    if (!elements_to_remove.is_empty())
-        invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentPendingTopLayerRemovalsProcessed);
+// The top layer is treated as a single rebuild zone: any membership change detaches the box
+// subtree of every rendered member and re-marks the members, after which the top layer pass of
+// the tree builder recreates all their boxes in top layer order. Runs after style update so
+// that elements that left the top layer are classified by their up-to-date computed display.
+void Document::process_pending_top_layer_layout_changes()
+{
+    if (m_elements_with_pending_top_layer_membership_change.is_empty() && !m_top_layer_needs_layout_zone_rebuild)
+        return;
+
+    auto elements_with_membership_change = move(m_elements_with_pending_top_layer_membership_change);
+    m_top_layer_needs_layout_zone_rebuild = false;
+
+    // An already pending full build recreates every box anyway.
+    if (!m_layout_root || needs_full_layout_tree_update())
+        return;
+
+    // Marks are applied only after every detach has run: detaching clears the flags across the
+    // detached subtree and would wipe the fresh mark of a member nested inside another member.
+    GC::RootVector<GC::Ref<Element>> elements_to_mark_for_layout_tree_update;
+
+    for (auto const& element : elements_with_membership_change) {
+        // NB: Elements that changed membership more than once are processed by their final state.
+        if (element->rendered_in_top_layer()) {
+            // An entering element whose box is still attached at its normal position leaves
+            // anonymous wrappers and inline fragments behind; the parent subtree rebuild heals
+            // that structure, while the top layer pass rebuilds the element itself.
+            // NB: Called during top layer processing, outside layout tree construction.
+            auto* element_layout_node = element->unsafe_layout_node();
+            bool element_has_box_at_normal_position = element_layout_node && element_layout_node->parent() && !element_layout_node->topmost_layout_node_of_top_layer_placement();
+            if (element_has_box_at_normal_position) {
+                if (auto* flat_tree_parent = element->flat_tree_parent(); flat_tree_parent && !flat_tree_parent->is_document())
+                    flat_tree_parent->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::TopLayerMembershipChange);
+            }
+        } else {
+            // A leaving element that is still rendered (fullscreen exit, mostly) needs a box
+            // back among already-built sibling boxes, which only a full rebuild can order.
+            bool element_is_still_rendered = element->is_connected()
+                && element->computed_properties()
+                && !element->computed_properties()->display().is_none();
+            if (element_is_still_rendered) {
+                invalidate_layout_tree(InvalidateLayoutTreeReason::TopLayerElementStillRenderedAfterRemoval);
+                return;
+            }
+            Layout::TreeBuilder::detach_top_layer_element_layout_subtree(element);
+            if (element->is_connected())
+                elements_to_mark_for_layout_tree_update.append(element);
+        }
+    }
+
+    for (auto const& member : m_top_layer_elements) {
+        if (!member->rendered_in_top_layer())
+            continue;
+        Layout::TreeBuilder::detach_top_layer_element_layout_subtree(member);
+        elements_to_mark_for_layout_tree_update.append(member);
+    }
+
+    for (auto const& element : elements_to_mark_for_layout_tree_update)
+        element->set_needs_layout_tree_update(true, SetNeedsLayoutTreeUpdateReason::TopLayerMembershipChange);
 }
 
 // https://html.spec.whatwg.org/multipage/popover.html#topmost-auto-popover

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -77,11 +77,8 @@ enum class QuirksMode {
     Yes
 };
 
-#define ENUMERATE_INVALIDATE_LAYOUT_TREE_REASONS(X)       \
-    X(DocumentAddAnElementToTheTopLayer)                  \
-    X(DocumentRequestAnElementToBeRemovedFromTheTopLayer) \
-    X(DocumentImmediatelyRemoveElementFromTheTopLayer)    \
-    X(DocumentPendingTopLayerRemovalsProcessed)
+#define ENUMERATE_INVALIDATE_LAYOUT_TREE_REASONS(X) \
+    X(TopLayerElementStillRenderedAfterRemoval)
 
 enum class InvalidateLayoutTreeReason {
 #define ENUMERATE_INVALIDATE_LAYOUT_TREE_REASON(e) e,
@@ -1091,6 +1088,8 @@ public:
     void remove_an_element_from_the_top_layer_immediately(GC::Ref<Element>);
     void process_top_layer_removals();
 
+    void set_top_layer_needs_layout_zone_rebuild() { m_top_layer_needs_layout_zone_rebuild = true; }
+
     OrderedHashTable<GC::Ref<Element>> const& top_layer_elements() const { return m_top_layer_elements; }
 
     // AD-HOC: These lists are managed dynamically instead of being generated as needed.
@@ -1328,6 +1327,7 @@ private:
 
     void clear_layout_and_paintable_nodes_for_inactive_document();
     void tear_down_layout_tree();
+    void process_pending_top_layer_layout_changes();
 
     void update_active_element();
     void collect_paintable_boxes_with_auto_content_visibility();
@@ -1733,6 +1733,8 @@ private:
     // instead they generate boxes as if they were siblings of the root element.
     OrderedHashTable<GC::Ref<Element>> m_top_layer_elements;
     OrderedHashTable<GC::Ref<Element>> m_top_layer_pending_removals;
+    Vector<GC::Ref<Element>> m_elements_with_pending_top_layer_membership_change;
+    bool m_top_layer_needs_layout_zone_rebuild { false };
 
     Vector<GC::Ref<HTML::HTMLElement>> m_showing_auto_popover_list;
     Vector<GC::Ref<HTML::HTMLElement>> m_showing_hint_popover_list;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1091,6 +1091,7 @@ public:
     void set_top_layer_needs_layout_zone_rebuild() { m_top_layer_needs_layout_zone_rebuild = true; }
 
     OrderedHashTable<GC::Ref<Element>> const& top_layer_elements() const { return m_top_layer_elements; }
+    bool top_layer_pending_removals_contains(GC::Ref<Element> element) const { return m_top_layer_pending_removals.contains(element); }
 
     // AD-HOC: These lists are managed dynamically instead of being generated as needed.
     // Spec issue: https://github.com/whatwg/html/issues/11007

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1115,7 +1115,20 @@ void Element::set_needs_layout_tree_rebuild(SetNeedsLayoutTreeUpdateReason reaso
     //     boxes based on the element's own needs-layout-tree-update flag; the DOM parent's subtree rebuild skips them
     //     entirely. Mark the element itself in that case. This still propagates child-needs-layout-tree-update up to
     //     the document, which is what makes the top layer pass run.
-    if (auto parent = parent_element(); parent && !rendered_in_top_layer())
+    // NB: Called outside layout tree construction.
+    auto* layout_node = unsafe_layout_node();
+    // An element that just left the top layer keeps its box as a viewport child until the
+    // pending membership change is processed, so the parent must not be rebuilt for it either.
+    bool element_box_is_placed_in_top_layer = layout_node && layout_node->topmost_layout_node_of_top_layer_placement();
+    if (rendered_in_top_layer() || element_box_is_placed_in_top_layer) {
+        // An attached box is replaced in its viewport slot, keeping top layer order; a fresh
+        // insert of a detached member appends out of order, so it needs a zone rebuild.
+        if (!layout_node || !layout_node->parent())
+            document().set_top_layer_needs_layout_zone_rebuild();
+        set_needs_layout_tree_update(true, reason);
+        return;
+    }
+    if (auto parent = parent_element())
         parent->set_needs_layout_tree_update(true, reason);
     else
         set_needs_layout_tree_update(true, reason);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1795,6 +1795,9 @@ static bool is_structural_boundary_self_rebuild_reason(SetNeedsLayoutTreeUpdateR
     case SetNeedsLayoutTreeUpdateReason::CharacterDataReplaceData:
     case SetNeedsLayoutTreeUpdateReason::ElementSetInnerHTML:
     case SetNeedsLayoutTreeUpdateReason::ShadowRootSetInnerHTML:
+    // The box of an element that entered the top layer leaves the parent's subtree,
+    // which is a child-list change.
+    case SetNeedsLayoutTreeUpdateReason::TopLayerMembershipChange:
         return true;
     default:
         return false;
@@ -1934,6 +1937,14 @@ void Node::removed_from(IsSubtreeRoot, Node*, Node&)
     m_in_editable_subtree = false;
     m_inside_blocking_wheel_event_handler = false;
     clear_layout_node_paintable();
+    // A top layer element's box is a viewport child rather than part of the parent's box
+    // subtree, so the parent rebuild triggered by this removal can never detach it.
+    if (m_layout_node) {
+        if (auto* top_layer_placement = m_layout_node->topmost_layout_node_of_top_layer_placement()) {
+            top_layer_placement->prepare_subtree_for_detach_from_layout_tree();
+            top_layer_placement->remove();
+        }
+    }
     m_layout_node = nullptr;
     m_paintable = nullptr;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -106,7 +106,8 @@ enum class SetNeedsLayoutReason {
     X(NodeSetTextContent)                                 \
     X(None)                                               \
     X(ShadowRootSetInnerHTML)                             \
-    X(StyleChange)
+    X(StyleChange)                                        \
+    X(TopLayerMembershipChange)
 
 enum class SetNeedsLayoutTreeUpdateReason {
 #define ENUMERATE_SET_NEEDS_LAYOUT_TREE_UPDATE_REASON(e) e,

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -239,7 +239,10 @@ WebIDL::ExceptionOr<void> HTMLDialogElement::show_a_modal_dialog(HTMLDialogEleme
 
     // 15. If subject's node document's top layer does not already contain subject, then add an element to the top
     //     layer given subject.
-    if (!subject.document().top_layer_elements().contains(subject))
+    // AD-HOC: A dialog closed and re-shown before removals were processed is contained only as
+    //         a pending removal; adding again cancels that pending removal.
+    if (!subject.document().top_layer_elements().contains(subject)
+        || subject.document().top_layer_pending_removals_contains(subject))
         subject.document().add_an_element_to_the_top_layer(subject);
 
     // FIXME: 16. Set subject's previously focused element to the focused element.

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -90,6 +90,16 @@ void Node::prepare_subtree_for_detach_from_layout_tree()
     });
 }
 
+Node* Node::topmost_layout_node_of_top_layer_placement()
+{
+    auto* direct_viewport_child_candidate = this;
+    while (direct_viewport_child_candidate->parent() && direct_viewport_child_candidate->parent()->is_anonymous())
+        direct_viewport_child_candidate = direct_viewport_child_candidate->parent();
+    if (!direct_viewport_child_candidate->parent() || !direct_viewport_child_candidate->parent()->is_viewport())
+        return nullptr;
+    return direct_viewport_child_candidate;
+}
+
 // https://www.w3.org/TR/css-display-3/#out-of-flow
 bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
 {

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -99,6 +99,10 @@ public:
     void prepare_for_detach_from_layout_tree();
     void prepare_subtree_for_detach_from_layout_tree();
 
+    // Returns the direct viewport child above this node (the node itself or its outermost
+    // anonymous table-fixup wrapper), or null when the node is not placed as a top layer box.
+    Node* topmost_layout_node_of_top_layer_placement();
+
     virtual RefPtr<Painting::Paintable> create_paintable() const;
 
     DOM::Document& document();

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -756,7 +756,7 @@ static bool display_contents_text_needs_style_wrapper(DOM::Text& text_node, DOM:
     return !first_is_one_of(style_parent.computed_properties()->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse);
 }
 
-TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* content_visibility_hidden_root)
+TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* cleared_subtree_root)
 {
     node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
     node.set_child_needs_layout_tree_update(false);
@@ -766,9 +766,9 @@ TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node
     // SVGPatternBox, SVGMaskBox, and SVGClipBox are created on behalf of a referencing
     // element and attached to that element's layout subtree. Skip them so they survive
     // cleanup of their DOM ancestor, unless their layout attachment is inside the
-    // subtree being hidden too.
+    // subtree being cleared too.
     if (layout_node && is_svg_resource_box(*layout_node)
-        && (!content_visibility_hidden_root || !layout_node_is_attached_to_dom_subtree(*layout_node, *content_visibility_hidden_root))) {
+        && (!cleared_subtree_root || !layout_node_is_attached_to_dom_subtree(*layout_node, *cleared_subtree_root))) {
         return TraversalDecision::SkipChildrenAndContinue;
     }
 
@@ -782,6 +782,34 @@ TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node
         static_cast<DOM::Element&>(node).clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
 
     return TraversalDecision::Continue;
+}
+
+void TreeBuilder::detach_top_layer_element_layout_subtree(DOM::Element& element)
+{
+    // NB: Called at DOM mutation processing time, outside layout tree construction.
+    if (auto element_layout_node = RefPtr { element.unsafe_layout_node() }) {
+        // Take along any anonymous wrapper table fixup created around the box; an emptied
+        // table wrapper left behind as a viewport child asserts during layout.
+        RefPtr<Layout::Node> layout_node_to_detach = element_layout_node;
+        if (auto* top_layer_placement = element_layout_node->topmost_layout_node_of_top_layer_placement())
+            layout_node_to_detach = top_layer_placement;
+        layout_node_to_detach->prepare_subtree_for_detach_from_layout_tree();
+        if (layout_node_to_detach->parent())
+            layout_node_to_detach->remove();
+    }
+    element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+        return clear_stale_layout_and_paint_node(node, &element);
+    });
+    // Assigned slottables are flat tree children of a slot, not DOM descendants.
+    if (auto* slot_element = as_if<HTML::HTMLSlotElement>(element)) {
+        for (auto const& slottable : slot_element->assigned_nodes_internal()) {
+            slottable.visit([&](DOM::Node& slottable_root) {
+                slottable_root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                    return clear_stale_layout_and_paint_node(node, &slottable_root);
+                });
+            });
+        }
+    }
 }
 
 static bool element_has_an_unrendered_flat_tree_ancestor(DOM::Element const& element)
@@ -808,8 +836,20 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
     if (dom_node.is_element()) {
         auto& element = static_cast<DOM::Element&>(dom_node);
-        if (element.rendered_in_top_layer() && !context.layout_top_layer)
+        if (element.rendered_in_top_layer() && !context.layout_top_layer) {
+            // A member found here without an attached box was cleared together with a hidden
+            // ancestor subtree, and nothing is scheduled to rebuild it: request a top layer
+            // zone rebuild, which runs as another update_layout pass and re-marks every member
+            // itself. Marking the member here instead would strand dirty flags under ancestors
+            // whose walks already finished, and a later update_layout would then treat the
+            // detached member boxes as up to date.
+            // NB: Called during layout tree construction.
+            auto* element_layout_node = element.unsafe_layout_node();
+            bool element_box_is_missing_or_detached = !element_layout_node || !element_layout_node->parent();
+            if (element_box_is_missing_or_detached && !element.needs_layout_tree_update())
+                element.document().set_top_layer_needs_layout_zone_rebuild();
             return;
+        }
     }
     if (dom_node.is_element())
         dom_node.document().style_computer().push_ancestor(static_cast<DOM::Element const&>(dom_node));

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -784,6 +784,20 @@ TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node
     return TraversalDecision::Continue;
 }
 
+static bool element_has_an_unrendered_flat_tree_ancestor(DOM::Element const& element)
+{
+    for (auto const* ancestor = element.flat_tree_parent(); ancestor; ancestor = ancestor->flat_tree_parent()) {
+        auto const* ancestor_element = as_if<DOM::Element>(*ancestor);
+        if (!ancestor_element)
+            continue;
+        // Null style means the style update pass skipped a display:none subtree.
+        auto ancestor_style = ancestor_element->computed_properties();
+        if (!ancestor_style || ancestor_style->display().is_none())
+            return true;
+    }
+    return false;
+}
+
 void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree)
 {
     // NB: Called during layout tree construction.
@@ -1063,8 +1077,15 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                 // generate boxes as if they were siblings of the root element.
                 TemporaryChange<bool> layout_mask(context.layout_top_layer, true);
                 for (auto const& top_layer_element : document.top_layer_elements()) {
-                    if (top_layer_element->rendered_in_top_layer())
-                        update_layout_tree(top_layer_element, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
+                    if (!top_layer_element->rendered_in_top_layer())
+                        continue;
+                    if (element_has_an_unrendered_flat_tree_ancestor(top_layer_element)) {
+                        top_layer_element->for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                            return clear_stale_layout_and_paint_node(node, top_layer_element.ptr());
+                        });
+                        continue;
+                    }
+                    update_layout_tree(top_layer_element, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
                 }
             }
             pop_parent();

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -970,6 +970,12 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         }
     }
 
+    // A top layer member nested inside this member must be skipped at its normal position
+    // like anywhere else in the walk, so its own turn of the pass builds its viewport box.
+    Optional<TemporaryChange<bool>> layout_top_layer_cleared_for_member_descendants;
+    if (auto* element = as_if<DOM::Element>(dom_node); element && element->rendered_in_top_layer() && context.layout_top_layer)
+        layout_top_layer_cleared_for_member_descendants.emplace(context.layout_top_layer, false);
+
     if (dom_node.is_document()) {
         m_layout_root = layout_node;
     } else if (should_create_layout_node) {
@@ -1140,6 +1146,12 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
 void TreeBuilder::update_layout_tree_for_display_contents(DOM::Element& element, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree, bool should_create_layout_node)
 {
+    // A display:contents member builds its children through this path, so the top layer flag
+    // is consumed here the same way update_layout_tree does for members with a box.
+    Optional<TemporaryChange<bool>> layout_top_layer_cleared_for_member_descendants;
+    if (element.rendered_in_top_layer() && context.layout_top_layer)
+        layout_top_layer_cleared_for_member_descendants.emplace(context.layout_top_layer, false);
+
     element.clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
 
     if (should_create_layout_node) {

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -31,6 +31,8 @@ public:
 
     void note_tree_restructuring_at(Layout::Node const&);
 
+    static void detach_top_layer_element_layout_subtree(DOM::Element&);
+
 private:
     struct Context {
         bool has_svg_root = false;
@@ -51,7 +53,7 @@ private:
     void update_layout_tree(DOM::Node&, Context&, MustCreateSubtree);
     void update_layout_tree_for_display_contents(DOM::Element&, Context&, MustCreateSubtree, bool should_create_layout_node);
     void update_layout_tree_for_svg_switch_children(SVG::SVGSwitchElement&, Context&, MustCreateSubtree);
-    TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* content_visibility_hidden_root = nullptr);
+    static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
     void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(&node); }
     void pop_parent() { m_ancestor_stack.take_last(); }

--- a/Tests/LibWeb/Ref/expected/top-layer-dialog-close-removes-boxes-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-dialog-close-removes-boxes-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-dialog-reshown-same-task-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-dialog-reshown-same-task-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    #backdrop {
+        position: fixed;
+        inset: 0;
+        background: red;
+    }
+    #dialog {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div id="backdrop"></div>
+<div id="dialog"></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-element-inside-display-none-subtree-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-element-inside-display-none-subtree-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-element-revealed-with-ancestor-keeps-paint-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-element-revealed-with-ancestor-keeps-paint-order-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    div {
+        position: fixed;
+        top: 0;
+        height: 100px;
+    }
+    #left {
+        left: 0;
+        width: 100px;
+        background: green;
+    }
+    #right {
+        left: 100px;
+        width: 100px;
+        background: blue;
+    }
+</style>
+<div id="left"></div>
+<div id="right"></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-nested-member-is-viewport-sibling-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-nested-member-is-viewport-sibling-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+    div {
+        position: fixed;
+        top: 0;
+        width: 100px;
+        height: 100px;
+    }
+    #outer-substitute {
+        left: 200px;
+        background: green;
+        opacity: 0.5;
+    }
+    #inner-substitute {
+        left: 0;
+        background: blue;
+    }
+</style>
+<div id="outer-substitute"></div>
+<div id="inner-substitute"></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-reshown-element-moves-to-top-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-reshown-element-moves-to-top-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    div {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-revealed-element-keeps-paint-order-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-revealed-element-keeps-paint-order-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+    div {
+        position: fixed;
+        left: 0;
+        top: 0;
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/top-layer-slot-popover-hidden-removes-slotted-boxes-ref.html
+++ b/Tests/LibWeb/Ref/expected/top-layer-slot-popover-hidden-removes-slotted-boxes-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/Tests/LibWeb/Ref/input/top-layer-dialog-close-removes-boxes.html
+++ b/Tests/LibWeb/Ref/input/top-layer-dialog-close-removes-boxes.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-dialog-close-removes-boxes-ref.html">
+<style>
+    #visible-marker {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+    dialog {
+        position: fixed;
+        left: 0;
+        top: 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    dialog::backdrop {
+        background: red;
+    }
+</style>
+<div id="visible-marker"></div>
+<dialog id="dialog"></dialog>
+<script>
+    dialog.showModal();
+    document.body.offsetHeight;
+    dialog.close();
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-dialog-reshown-same-task.html
+++ b/Tests/LibWeb/Ref/input/top-layer-dialog-reshown-same-task.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-dialog-reshown-same-task-ref.html">
+<style>
+    dialog {
+        position: fixed;
+        left: 0;
+        top: 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+    dialog::backdrop {
+        background: red;
+    }
+</style>
+<dialog id="dialog"></dialog>
+<script>
+    dialog.showModal();
+    document.body.offsetHeight;
+    // Closing leaves the dialog in the top layer as a pending removal until the event loop
+    // processes removals; re-showing in the same task must cancel that pending removal and
+    // render the dialog in the top layer again, ::backdrop included.
+    dialog.close();
+    dialog.showModal();
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-element-inside-display-none-subtree.html
+++ b/Tests/LibWeb/Ref/input/top-layer-element-inside-display-none-subtree.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-element-inside-display-none-subtree-ref.html">
+<style>
+    #visible-marker {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+    #hidden-container {
+        display: none;
+    }
+    dialog {
+        position: fixed;
+        left: 0;
+        top: 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    dialog::backdrop {
+        background: red;
+    }
+</style>
+<div id="visible-marker"></div>
+<div id="hidden-container">
+    <dialog id="dialog"></dialog>
+</div>
+<script>
+    dialog.showModal();
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-element-revealed-with-ancestor-keeps-paint-order.html
+++ b/Tests/LibWeb/Ref/input/top-layer-element-revealed-with-ancestor-keeps-paint-order.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-element-revealed-with-ancestor-keeps-paint-order-ref.html">
+<style>
+    dialog {
+        position: fixed;
+        inset: 0 auto auto 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        height: 100px;
+    }
+    dialog::backdrop {
+        background: transparent;
+    }
+    #a {
+        width: 200px;
+        background: blue;
+    }
+    #b {
+        width: 100px;
+        background: green;
+    }
+</style>
+<div id="container">
+    <dialog id="a"></dialog>
+</div>
+<dialog id="b"></dialog>
+<script>
+    a.showModal();
+    b.showModal();
+    document.body.offsetHeight;
+    // Revealing the container must bring back the box of a, which was torn down together with
+    // the container's subtree, at a's top layer position: below b, not appended above it.
+    container.style.display = "none";
+    document.body.offsetHeight;
+    container.style.display = "block";
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-nested-member-is-viewport-sibling.html
+++ b/Tests/LibWeb/Ref/input/top-layer-nested-member-is-viewport-sibling.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-nested-member-is-viewport-sibling-ref.html">
+<style>
+    dialog {
+        position: fixed;
+        inset: 0 auto auto 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        width: 100px;
+        height: 100px;
+    }
+    dialog::backdrop {
+        background: transparent;
+    }
+    #outer {
+        background: green;
+        opacity: 0.5;
+        transform: translateX(200px);
+    }
+    #inner {
+        background: blue;
+    }
+</style>
+<dialog id="outer"><dialog id="inner"></dialog></dialog>
+<script>
+    // The inner dialog's box must escape the outer's opacity and transform.
+    outer.showModal();
+    inner.showModal();
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-reshown-element-moves-to-top.html
+++ b/Tests/LibWeb/Ref/input/top-layer-reshown-element-moves-to-top.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-reshown-element-moves-to-top-ref.html">
+<style>
+    [popover] {
+        position: fixed;
+        left: 0;
+        top: 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        width: 100px;
+        height: 100px;
+    }
+    #a {
+        background: red;
+    }
+    #b {
+        background: green;
+    }
+</style>
+<div id="a" popover="manual"></div>
+<div id="b" popover="manual"></div>
+<script>
+    a.showPopover();
+    b.showPopover();
+    document.body.offsetHeight;
+    // Re-showing a moves it to the end of the top layer, so its box must move above b's.
+    a.hidePopover();
+    a.showPopover();
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-revealed-element-keeps-paint-order.html
+++ b/Tests/LibWeb/Ref/input/top-layer-revealed-element-keeps-paint-order.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-revealed-element-keeps-paint-order-ref.html">
+<style>
+    dialog {
+        position: fixed;
+        left: 0;
+        top: 0;
+        inset: 0 auto auto 0;
+        margin: 0;
+        border: 0;
+        padding: 0;
+        width: 100px;
+        height: 100px;
+    }
+    dialog::backdrop {
+        background: transparent;
+    }
+    #a {
+        background: red;
+    }
+    #b {
+        background: green;
+    }
+</style>
+<dialog id="a"></dialog>
+<dialog id="b"></dialog>
+<script>
+    a.showModal();
+    b.showModal();
+    // Hide a's box without leaving the top layer, then reveal it: the fresh box must return to
+    // a's top layer position (below b), not get appended above b.
+    a.style.display = "none";
+    document.body.offsetHeight;
+    a.style.display = "block";
+</script>

--- a/Tests/LibWeb/Ref/input/top-layer-slot-popover-hidden-removes-slotted-boxes.html
+++ b/Tests/LibWeb/Ref/input/top-layer-slot-popover-hidden-removes-slotted-boxes.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/top-layer-slot-popover-hidden-removes-slotted-boxes-ref.html">
+<style>
+    #content {
+        width: 100px;
+        height: 100px;
+        background: red;
+    }
+    #marker {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<div id="host"><div id="content"></div></div>
+<div id="marker"></div>
+<script>
+    const shadow_root = host.attachShadow({ mode: "open" });
+    shadow_root.innerHTML = '<slot id="s" popover></slot>';
+    const slot = shadow_root.getElementById("s");
+    slot.showPopover();
+    document.body.offsetHeight;
+    slot.hidePopover();
+</script>

--- a/Tests/LibWeb/Text/expected/top-layer-nested-fullscreen-members-keep-painting.txt
+++ b/Tests/LibWeb/Text/expected/top-layer-nested-fullscreen-members-keep-painting.txt
@@ -1,0 +1,4 @@
+1: first
+2: last
+3: first
+painted

--- a/Tests/LibWeb/Text/input/top-layer-nested-fullscreen-members-keep-painting.html
+++ b/Tests/LibWeb/Text/input/top-layer-nested-fullscreen-members-keep-painting.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="first"><div id="last"></div></div>
+<script>
+    // Zone rebuilds over nested fullscreen members used to leave detached boxes behind and
+    // crash on the next paint; the trailing frames force paints after the last rebuild.
+    asyncTest(async (done) => {
+        const first = document.getElementById("first");
+        const last = document.getElementById("last");
+
+        const activate_by_click = () =>
+            new Promise((resolve) => {
+                document.addEventListener("click", resolve, { once: true });
+                internals.click(5, 5);
+            });
+        const fullscreen_change = () =>
+            new Promise((resolve) => (document.onfullscreenchange = resolve));
+        const next_frame = () =>
+            new Promise((resolve) => requestAnimationFrame(resolve));
+
+        await activate_by_click();
+        await Promise.all([first.requestFullscreen(), fullscreen_change()]);
+        println(`1: ${document.fullscreenElement?.id}`);
+
+        await activate_by_click();
+        await Promise.all([last.requestFullscreen(), fullscreen_change()]);
+        println(`2: ${document.fullscreenElement?.id}`);
+
+        await activate_by_click();
+        await Promise.all([first.requestFullscreen(), fullscreen_change()]);
+        println(`3: ${document.fullscreenElement?.id}`);
+
+        await next_frame();
+        await next_frame();
+        await next_frame();
+        println("painted");
+        done();
+    });
+</script>


### PR DESCRIPTION
Opening or closing a dialog, popover, or fullscreen element currently invalidates the entire layout tree. This PR treats the top layer as a single rebuild zone instead: a membership change detaches the box subtree of every rendered member and re-marks them, so the tree builder's top layer pass recreates just those boxes in top layer order while the rest of the document keeps its layout tree. Along the way it fixes nested top layer members (a modal opened from a modal, a popover inside a fullscreen element) being built inside the outer member's subtree instead of as viewport siblings, stops building boxes for members hidden by a display:none ancestor, and un-sticks dialogs that are closed and re-shown in the same task.