### PR TITLE
LibWeb: Build accumulated visual contexts lazily

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1804,7 +1804,6 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed)
     unsafe_paintable()->reassign_scroll_frames();
 
     set_needs_accumulated_visual_contexts_update(true);
-    update_paint_and_hit_testing_properties_if_needed();
 
     // Selection state lives on paintable fragments, which the commit has rebuilt.
     if (auto range = get_selection()->range())
@@ -2873,7 +2872,7 @@ static CSSPixelPoint compute_mouse_event_offset(CSSPixelPoint position, Painting
 {
     auto inverse_transform_point = [](Painting::Paintable const& paintable_box, CSSPixelPoint position) -> Optional<CSSPixelPoint> {
         auto viewport_paintable = paintable_box.document().unsafe_paintable();
-        if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
+        if (!viewport_paintable)
             return {};
         auto pixel_ratio = static_cast<float>(paintable_box.document().page().client().device_pixels_per_css_pixel());
         auto const& visual_context_tree = viewport_paintable->visual_context_tree();

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -574,6 +574,14 @@ WebIDL::UnsignedLongLong Internals::full_layout_count()
     return window().associated_document().full_layout_count();
 }
 
+WebIDL::UnsignedLongLong Internals::accumulated_visual_context_tree_build_count()
+{
+    auto paintable = window().associated_document().unsafe_paintable();
+    if (!paintable)
+        return 0;
+    return paintable->accumulated_visual_context_tree_build_count();
+}
+
 void Internals::set_autoplay_policy(Utf16String const& policy)
 {
     if (auto parsed = HTML::autoplay_policy_from_string(policy.utf16_view()); parsed.has_value())

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -92,6 +92,7 @@ public:
     void set_content_blocking_enabled(bool enabled);
     WebIDL::UnsignedLongLong partial_layout_count();
     WebIDL::UnsignedLongLong full_layout_count();
+    WebIDL::UnsignedLongLong accumulated_visual_context_tree_build_count();
     void set_autoplay_policy(Utf16String const& policy);
 
     Utf16String get_computed_role(DOM::Element& element);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -82,6 +82,7 @@ interface Internals {
     undefined setContentBlockingEnabled(boolean enabled);
     unsigned long long partialLayoutCount();
     unsigned long long fullLayoutCount();
+    unsigned long long accumulatedVisualContextTreeBuildCount();
     undefined setAutoplayPolicy(Utf16DOMString policy);
 
     Utf16DOMString getComputedRole(Element element);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -625,7 +625,8 @@ bool update_accumulated_visual_context_values(ViewportPaintable& viewport_painta
 
 void update_visual_viewport_accumulated_visual_context(ViewportPaintable& viewport_paintable)
 {
-    viewport_paintable.visual_context_tree().set_visual_viewport_transform(visual_viewport_transform_data(viewport_paintable.document()));
+    VERIFY(viewport_paintable.m_visual_context_tree.has_value());
+    viewport_paintable.m_visual_context_tree->set_visual_viewport_transform(visual_viewport_transform_data(viewport_paintable.document()));
 }
 
 VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, VisualContextIndex parent_index)

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -2578,7 +2578,7 @@ BorderRadiiData Paintable::normalized_border_radii_data(ShrinkRadiiForBorders sh
 Optional<CSSPixelPoint> Paintable::transform_point_to_local(CSSPixelPoint screen_position) const
 {
     auto viewport_paintable = document().paintable();
-    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
+    if (!viewport_paintable)
         return screen_position;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
     auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
@@ -2592,7 +2592,7 @@ Optional<CSSPixelPoint> Paintable::transform_point_to_local(CSSPixelPoint screen
 Optional<CSSPixelPoint> Paintable::transform_point_to_local_for_descendants(CSSPixelPoint screen_position) const
 {
     auto viewport_paintable = document().paintable();
-    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
+    if (!viewport_paintable)
         return screen_position;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
     auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
@@ -2606,7 +2606,7 @@ Optional<CSSPixelPoint> Paintable::transform_point_to_local_for_descendants(CSSP
 CSSPixelRect Paintable::transform_rect_to_viewport(CSSPixelRect const& rect, AccumulatedVisualContextTree::IncludeVisualViewportTransform include_visual_viewport_transform) const
 {
     auto viewport_paintable = document().paintable();
-    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
+    if (!viewport_paintable)
         return rect;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
     auto const& scroll_state = viewport_paintable->scroll_state_snapshot();
@@ -2618,7 +2618,7 @@ CSSPixelRect Paintable::transform_rect_to_viewport(CSSPixelRect const& rect, Acc
 CSSPixelPoint Paintable::inverse_transform_point(CSSPixelPoint screen_position) const
 {
     auto viewport_paintable = document().paintable();
-    if (!viewport_paintable || !viewport_paintable->has_visual_context_tree())
+    if (!viewport_paintable)
         return screen_position;
     auto pixel_ratio = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
     auto const& visual_context_tree = viewport_paintable->visual_context_tree();

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -42,6 +42,25 @@ ViewportPaintable::ViewportPaintable(Layout::Viewport const& layout_viewport)
 
 ViewportPaintable::~ViewportPaintable() = default;
 
+void ViewportPaintable::ensure_visual_context_tree() const
+{
+    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
+}
+
+AccumulatedVisualContextTree const& ViewportPaintable::visual_context_tree() const
+{
+    ensure_visual_context_tree();
+    VERIFY(m_visual_context_tree.has_value());
+    return *m_visual_context_tree;
+}
+
+AccumulatedVisualContextTree& ViewportPaintable::visual_context_tree()
+{
+    ensure_visual_context_tree();
+    VERIFY(m_visual_context_tree.has_value());
+    return *m_visual_context_tree;
+}
+
 struct BlockingWheelEventRegionState {
     bool has_blocking_wheel_event_listeners { false };
     bool has_blocking_wheel_event_region_covering_viewport { false };
@@ -247,6 +266,7 @@ void ViewportPaintable::assign_scroll_frames()
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
     auto visual_context_tree = build_accumulated_visual_context_tree(*this);
+    ++m_accumulated_visual_context_tree_build_count;
     auto is_compatible = m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree);
     if (m_force_incompatible_visual_context_tree_rebuild_for_testing) {
         m_force_incompatible_visual_context_tree_rebuild_for_testing = false;

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -39,6 +39,7 @@ public:
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
     void set_force_incompatible_visual_context_tree_rebuild_for_testing() { m_force_incompatible_visual_context_tree_rebuild_for_testing = true; }
     bool has_visual_context_tree() const { return m_visual_context_tree.has_value(); }
+    u64 accumulated_visual_context_tree_build_count() const { return m_accumulated_visual_context_tree_build_count; }
 
     GC::Ptr<Selection::Selection> selection() const;
     void recompute_selection_states(DOM::Range&);
@@ -58,20 +59,15 @@ public:
     void set_paintable_boxes_with_auto_content_visibility(Vector<WeakPtr<Paintable>> paintable_boxes) { m_paintable_boxes_with_auto_content_visibility = move(paintable_boxes); }
     Vector<WeakPtr<Paintable>> const& paintable_boxes_with_auto_content_visibility() const { return m_paintable_boxes_with_auto_content_visibility; }
 
-    AccumulatedVisualContextTree const& visual_context_tree() const
-    {
-        VERIFY(m_visual_context_tree.has_value());
-        return *m_visual_context_tree;
-    }
-    AccumulatedVisualContextTree& visual_context_tree()
-    {
-        VERIFY(m_visual_context_tree.has_value());
-        return *m_visual_context_tree;
-    }
+    AccumulatedVisualContextTree const& visual_context_tree() const;
+    AccumulatedVisualContextTree& visual_context_tree();
 
 private:
+    friend void update_visual_viewport_accumulated_visual_context(ViewportPaintable&);
+
     virtual bool is_viewport_paintable() const override { return true; }
 
+    void ensure_visual_context_tree() const;
     void build_stacking_context_tree();
     void clear_scroll_state();
     void precompute_sticky_constraints(ScrollFrameIndex, Paintable const&);
@@ -85,6 +81,7 @@ private:
     Vector<WeakPtr<Paintable>> m_paintable_boxes_with_auto_content_visibility;
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
+    u64 m_accumulated_visual_context_tree_build_count { 0 };
     bool m_visual_context_tree_needs_compositor_update { false };
     bool m_force_incompatible_visual_context_tree_rebuild_for_testing { false };
 };

--- a/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
+++ b/Tests/LibWeb/Text/expected/lazy-accumulated-visual-context-rebuild.txt
@@ -1,0 +1,6 @@
+offset width: 110
+offset width: 120
+offset width: 130
+builds after layout-only reads: 0
+bounding rect width: 130
+builds after transform-sensitive read: 1

--- a/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
+++ b/Tests/LibWeb/Text/input/lazy-accumulated-visual-context-rebuild.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="target" style="width: 100px; height: 100px"></div>
+<script>
+    test(() => {
+        const target = document.getElementById('target');
+
+        target.getBoundingClientRect();
+        const initialBuildCount = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+
+        for (const width of [110, 120, 130]) {
+            target.style.width = `${width}px`;
+            lines.push(`offset width: ${target.offsetWidth}`);
+        }
+
+        lines.push(`builds after layout-only reads: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+
+        lines.push(`bounding rect width: ${target.getBoundingClientRect().width}`);
+        lines.push(`builds after transform-sensitive read: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
Layout commits rebuilt the accumulated visual context tree immediately, even when callers requested transform-independent metrics such as offsetWidth. Repeated mutation and forced-layout cycles therefore walked the full paint tree after every layout.

Keep the tree dirty after layout and resolve it through the viewport paintable accessor when transforms, painting, or hit testing consume it. Preserve non-mutating presence checks for lifecycle-sensitive visual viewport updates.

Add an internals counter and regression test showing that layout-only metric reads perform no builds. The first transform-aware read coalesces the pending work into one build.

This avoids a full AVC rebuild on every single frame while scrubbing YouTube videos. (And in many many other cases :)