### PR TITLE
LibDevTools: Support launching Firefox devtools directly from Ladybird

### DIFF
--- a/Documentation/DevTools.md
+++ b/Documentation/DevTools.md
@@ -10,9 +10,12 @@ command line flag. A banner will be displayed in Ladybird with the port on which
 port may be changed by providing a port to the command line flag, e.g. `--devtools=6001`. To disable DevTools, use the
 menu item (which will now be titled "Disable DevTools"), or close the banner.
 
-Once DevTools is enabled, in Firefox, navigate to `about:debugging` and select the "Setup" tab. In the "Network Location"
-form, enter the DevTools server address. In the above example, this will be `localhost:6000`. You will only have to
-enter this information once:
+Once DevTools is enabled, you may use the "Open Client" button on the banner to open a Firefox DevTools client window to
+inspect the current tab. Only one such window may be open at a time.
+
+Alternatively, in Firefox, navigate to `about:debugging` and select the "Setup" tab. In the "Network Location" form,
+enter the DevTools server address. In the above example with `--devtools=6001`, this will be `localhost:6001`. You will
+only have to enter this information once:
 
 <img src="Images/devtools_setup.png" alt="DevTools setup" width="675px" />
 

--- a/Libraries/LibCore/File.h
+++ b/Libraries/LibCore/File.h
@@ -41,6 +41,7 @@ public:
         KeepOnExec = 32,
         Nonblocking = 64,
         DontCreate = 128,
+        NoFollow = 256,
     };
 
     enum class ShouldCloseFileDescriptor {

--- a/Libraries/LibCore/FilePosix.cpp
+++ b/Libraries/LibCore/FilePosix.cpp
@@ -36,6 +36,8 @@ int File::open_mode_to_options(OpenMode mode)
         flags |= O_CLOEXEC;
     if (has_flag(mode, OpenMode::Nonblocking))
         flags |= O_NONBLOCK;
+    if (has_flag(mode, OpenMode::NoFollow))
+        flags |= O_NOFOLLOW;
 
     // Some open modes, like `ReadWrite` imply the ability to create the file if it doesn't exist.
     // Certain applications may not want this privilege, and for compatibility reasons, this is

--- a/Libraries/LibCore/FileWindows.cpp
+++ b/Libraries/LibCore/FileWindows.cpp
@@ -69,14 +69,17 @@ ErrorOr<void> File::open_path(StringView filename, mode_t)
     bool should_truncate = has_flag(m_mode, OpenMode::Truncate);
     if (!has_flag(m_mode, OpenMode::ReadWrite) && has_flag(m_mode, OpenMode::Write) && !has_any_flag(m_mode, OpenMode::Append | OpenMode::MustBeNew))
         should_truncate = true;
+    bool const no_follow = has_flag(m_mode, OpenMode::NoFollow);
 
+    // When NoFollow is requested, defer truncation until after checking whether the
+    // opened handle refers to a reparse point.
     DWORD creation_disposition;
     if (has_flag(m_mode, OpenMode::MustBeNew) && may_create)
         creation_disposition = CREATE_NEW;
     else if (may_create)
-        creation_disposition = should_truncate ? CREATE_ALWAYS : OPEN_ALWAYS;
+        creation_disposition = should_truncate && !no_follow ? CREATE_ALWAYS : OPEN_ALWAYS;
     else
-        creation_disposition = should_truncate ? TRUNCATE_EXISTING : OPEN_EXISTING;
+        creation_disposition = should_truncate && !no_follow ? TRUNCATE_EXISTING : OPEN_EXISTING;
 
     SECURITY_ATTRIBUTES security_attributes = {};
     security_attributes.nLength = sizeof(security_attributes);
@@ -86,18 +89,39 @@ ErrorOr<void> File::open_path(StringView filename, mode_t)
 
     // Share as permissively as POSIX opens do. FILE_FLAG_BACKUP_SEMANTICS allows opening
     // directories, which Core::Directory and the file:// directory listing depend on.
+    DWORD flags_and_attributes = FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS;
+    if (no_follow)
+        flags_and_attributes |= FILE_FLAG_OPEN_REPARSE_POINT;
+
     HANDLE handle = CreateFileW(
         wide_filename.data(),
         desired_access,
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         &security_attributes,
         creation_disposition,
-        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+        flags_and_attributes,
         nullptr);
     if (handle == INVALID_HANDLE_VALUE)
         return open_error_from_windows_error();
 
     m_fd = to_fd(handle);
+
+    if (no_follow) {
+        BY_HANDLE_FILE_INFORMATION file_information = {};
+        if (!GetFileInformationByHandle(handle, &file_information)) {
+            auto error = Error::from_windows_error();
+            close();
+            return error;
+        }
+        if (file_information.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+            close();
+            return Error::from_string_literal("Core::File: Refusing to follow a symbolic link");
+        }
+
+        if (should_truncate)
+            TRY(truncate(0));
+    }
+
     return {};
 }
 

--- a/Libraries/LibDevTools/Actors/DeviceActor.cpp
+++ b/Libraries/LibDevTools/Actors/DeviceActor.cpp
@@ -42,7 +42,7 @@ void DeviceActor::handle_message(Message const& message)
         value.set("version"sv, browser_version);
         value.set("appbuildid"sv, build_id);
         value.set("platformbuildid"sv, build_id);
-        value.set("platformversion"sv, "139.0"sv);
+        value.set("platformversion"sv, "152.0"sv);
         value.set("useragent"sv, Web::default_user_agent);
         value.set("os"sv, platform_name);
         value.set("arch"sv, arch);

--- a/Libraries/LibDevTools/Actors/RootActor.cpp
+++ b/Libraries/LibDevTools/Actors/RootActor.cpp
@@ -92,16 +92,30 @@ void RootActor::handle_message(Message const& message)
         if (!browser_id.has_value())
             return;
 
-        for (auto const& actor : devtools().actor_registry()) {
-            auto const* tab_actor = as_if<TabActor>(*actor.value);
-            if (!tab_actor)
-                continue;
-            if (tab_actor->description().id != *browser_id)
-                continue;
+        TabActor const* tab_actor = nullptr;
 
-            response.set("tab"sv, tab_actor->serialize_description());
-            break;
+        for (auto const& actor : devtools().actor_registry()) {
+            auto const* candidate = as_if<TabActor>(*actor.value);
+
+            if (candidate && candidate->description().id == *browser_id) {
+                tab_actor = candidate;
+                break;
+            }
         }
+
+        // The tab might not have been registered yet if the client did not request the tab list on this connection,
+        // e.g. when a toolbox connects directly to a tab known from a previous connection.
+        if (!tab_actor) {
+            for (auto& tab_description : devtools().delegate().tab_list()) {
+                if (tab_description.id == *browser_id) {
+                    tab_actor = &devtools().register_actor<TabActor>(move(tab_description));
+                    break;
+                }
+            }
+        }
+
+        if (tab_actor)
+            response.set("tab"sv, tab_actor->serialize_description());
 
         send_response(message, move(response));
         return;

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -32,9 +32,10 @@ set(SOURCES
     Actors/WatcherActor.cpp
     Connection.cpp
     DevToolsServer.cpp
+    FirefoxClient.cpp
     IndexedDBSerialization.cpp
     StorageHelpers.cpp
 )
 
 ladybird_lib(LibDevTools devtools EXPLICIT_SYMBOL_EXPORT)
-target_link_libraries(LibDevTools PRIVATE LibCore LibHTTP LibWeb LibURL)
+target_link_libraries(LibDevTools PRIVATE LibCore LibFileSystem LibHTTP LibWeb LibURL)

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -216,6 +216,7 @@ public:
 
     virtual void did_connect_devtools_client(TabDescription const&) const { }
     virtual void did_disconnect_devtools_client(TabDescription const&) const { }
+    virtual void did_close_devtools_connection() { }
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsServer.cpp
+++ b/Libraries/LibDevTools/DevToolsServer.cpp
@@ -87,10 +87,13 @@ void DevToolsServer::unregister_actor(String const& name)
 
 ErrorOr<void> DevToolsServer::on_new_client()
 {
+    // The client must be accepted even when one is already active; a pending connection left in the listen backlog
+    // would cause the accept notifier to fire in a busy loop.
+    auto client = TRY(m_server->accept());
+
     if (m_connection)
         return Error::from_string_literal("Only one active DevTools connection is currently allowed");
 
-    auto client = TRY(m_server->accept());
     auto buffered_socket = TRY(Core::BufferedTCPSocket::create(move(client)));
 
     m_connection = Connection::create(move(buffered_socket));

--- a/Libraries/LibDevTools/DevToolsServer.cpp
+++ b/Libraries/LibDevTools/DevToolsServer.cpp
@@ -16,6 +16,7 @@
 #include <LibDevTools/Actors/ProcessActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Connection.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
 
 namespace DevTools {
@@ -155,6 +156,8 @@ void DevToolsServer::close_connection()
         weak_self->m_connection = nullptr;
         weak_self->m_actor_registry.clear();
         weak_self->m_root_actor = nullptr;
+
+        weak_self->m_delegate.did_close_devtools_connection();
     });
 }
 

--- a/Libraries/LibDevTools/DevToolsServer.h
+++ b/Libraries/LibDevTools/DevToolsServer.h
@@ -27,6 +27,7 @@ public:
     ~DevToolsServer();
 
     RefPtr<Connection>& connection() { return m_connection; }
+    bool has_active_connection() const { return m_connection; }
     DevToolsDelegate const& delegate() const { return m_delegate; }
     ActorRegistry const& actor_registry() const { return m_actor_registry; }
     Optional<u16> local_port() const;

--- a/Libraries/LibDevTools/FirefoxClient.cpp
+++ b/Libraries/LibDevTools/FirefoxClient.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/ByteString.h>
+#include <AK/LexicalPath.h>
+#include <AK/NeverDestroyed.h>
+#include <LibCore/ConfigFile.h>
+#include <LibCore/Directory.h>
+#include <LibCore/Environment.h>
+#include <LibCore/File.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibDevTools/FirefoxClient.h>
+#include <LibFileSystem/FileSystem.h>
+
+#if !defined(AK_OS_WINDOWS)
+#    include <unistd.h>
+#endif
+
+namespace DevTools {
+
+#if defined(AK_OS_LINUX)
+static constexpr auto PROFILE_NAME = "LadybirdDevTools"sv;
+#endif
+
+static constexpr auto PROFILE_PREFS = R"~~~(
+user_pref("app.update.auto", false);
+user_pref("browser.aboutwelcome.enabled", false);
+user_pref("browser.sessionstore.resume_from_crash", false);
+user_pref("browser.shell.checkDefaultBrowser", false);
+user_pref("browser.startup.couldRestoreSession.count", -1);
+user_pref("browser.startup.homepage_override.mstone", "ignore");
+user_pref("browser.tabs.inTitlebar", 0);
+user_pref("browser.warnOnQuit", false);
+user_pref("datareporting.policy.dataSubmissionEnabled", false);
+user_pref("devtools.aboutdebugging.network-locations", "[]");
+user_pref("devtools.chrome.enabled", true);
+user_pref("devtools.debugger.prompt-connection", false);
+user_pref("devtools.debugger.remote-enabled", true);
+user_pref("termsofuse.bypassNotification", true);
+user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
+user_pref("toolkit.startup.max_resumed_crashes", -1);
+)~~~"sv;
+
+static constexpr auto USER_CHROME_CSS = R"~~~(
+#nav-bar,
+#PersonalToolbar,
+#TabsToolbar {
+    visibility: collapse !important;
+}
+)~~~"sv;
+
+static LexicalPath const& profile_directory()
+{
+    static NeverDestroyed<LexicalPath> path = LexicalPath::join(Core::StandardPaths::user_data_directory(), "Ladybird"sv, "DevTools"sv, "firefox-profile"sv);
+    return *path;
+}
+
+static ErrorOr<void> prepare_firefox_profile(LexicalPath const& profile)
+{
+    auto open_regular_file = [](Core::Directory const& directory, StringView filename) -> ErrorOr<NonnullOwnPtr<Core::File>> {
+        auto file = TRY(directory.open(filename, Core::File::OpenMode::ReadWrite | Core::File::OpenMode::NoFollow));
+        if (!S_ISREG(TRY(file->stat()).st_mode))
+            return Error::from_errno(EINVAL);
+
+        TRY(file->truncate(0));
+        return file;
+    };
+
+    // Below we go out of our way to avoid following symbolic links in any existing profile. So entries such as
+    // "user.js" cannot redirect writes outside the profile.
+    auto profile_directory = TRY(Core::Directory::create(profile, Core::Directory::CreateDirectories::Yes));
+
+    auto prefs = TRY(open_regular_file(profile_directory, "user.js"sv));
+    TRY(prefs->write_until_depleted(PROFILE_PREFS.bytes()));
+
+    auto chrome = profile.append("chrome"sv);
+    TRY(Core::Directory::create(chrome, Core::Directory::CreateDirectories::Yes));
+
+    auto chrome_file = TRY(profile_directory.open("chrome"sv, Core::File::OpenMode::Read | Core::File::OpenMode::NoFollow));
+    if (!S_ISDIR(TRY(chrome_file->stat()).st_mode))
+        return Error::from_errno(ENOTDIR);
+    auto chrome_directory = TRY(Core::Directory::adopt_fd(chrome_file->leak_fd(), move(chrome)));
+
+    auto user_chrome = TRY(open_regular_file(chrome_directory, "userChrome.css"sv));
+    TRY(user_chrome->write_until_depleted(USER_CHROME_CSS.bytes()));
+
+    return {};
+}
+
+struct FirefoxInstallation {
+    LexicalPath executable;
+    Vector<ByteString> arguments;
+    Optional<LexicalPath> profiles_ini;
+};
+
+#if defined(AK_OS_LINUX)
+static bool flatpak_firefox_is_installed(LexicalPath const& flatpak)
+{
+    auto process = Core::Process::spawn({
+        .name = "find-firefox-flatpak"sv,
+        .executable = flatpak.string(),
+        .die_with_parent = true,
+        .arguments = {
+            "info"sv,
+            "org.mozilla.firefox"sv,
+        },
+        .file_actions = {
+            Core::FileAction::OpenFile { "/dev/null", Core::File::OpenMode::Write, STDOUT_FILENO },
+            Core::FileAction::OpenFile { "/dev/null", Core::File::OpenMode::Write, STDERR_FILENO },
+        },
+    });
+    if (process.is_error())
+        return false;
+
+    auto exit_code = process.value().wait_for_termination();
+    return !exit_code.is_error() && exit_code.value() == 0;
+}
+
+static ErrorOr<Optional<LexicalPath>> find_firefox_profile(LexicalPath const& profiles_ini, StringView profile_name)
+{
+    auto profiles = TRY(Core::ConfigFile::open(profiles_ini.string()));
+
+    for (auto const& group : profiles->groups()) {
+        if (!group.starts_with("Profile"sv) || profiles->read_entry(group, "Name"sv) != profile_name)
+            continue;
+
+        auto path = profiles->read_entry(group, "Path"sv);
+        if (path.is_empty())
+            continue;
+
+        if (!profiles->read_bool_entry(group, "IsRelative"sv))
+            return LexicalPath { move(path) };
+
+        return LexicalPath::join(profiles_ini.dirname(), path);
+    }
+
+    return OptionalNone {};
+}
+
+static ErrorOr<LexicalPath> ensure_confined_firefox_profile(FirefoxInstallation const& installation)
+{
+    VERIFY(installation.profiles_ini.has_value());
+
+    auto profile = TRY(find_firefox_profile(*installation.profiles_ini, PROFILE_NAME));
+    if (!profile.has_value()) {
+        auto arguments = installation.arguments;
+        arguments.append("--createprofile"sv);
+        arguments.append(PROFILE_NAME);
+
+        auto process = TRY(Core::Process::spawn({
+            .name = "create-devtools-profile"sv,
+            .executable = installation.executable.string(),
+            .die_with_parent = true,
+            .arguments = arguments,
+        }));
+        if (TRY(process.wait_for_termination()) != 0)
+            return Error::from_string_literal("Firefox failed to create the Ladybird DevTools profile");
+
+        profile = TRY(find_firefox_profile(*installation.profiles_ini, PROFILE_NAME));
+        if (!profile.has_value())
+            return Error::from_string_literal("Firefox did not register the Ladybird DevTools profile");
+    }
+
+    auto profiles_directory = LexicalPath { installation.profiles_ini->dirname() };
+    if (!profile->is_child_of(profiles_directory))
+        return Error::from_string_literal("The Ladybird DevTools profile is outside the Firefox sandbox");
+
+    return profile.release_value();
+}
+#endif
+
+static Optional<FirefoxInstallation> firefox_installation_from_binary(StringView candidate)
+{
+    if (!FileSystem::is_regular_file(candidate))
+        return {};
+#if !defined(AK_OS_WINDOWS)
+    if (Core::System::access(candidate, X_OK).is_error())
+        return {};
+#endif
+
+    auto canonical_path = FileSystem::real_path(candidate);
+    if (canonical_path.is_error())
+        return {};
+
+#if defined(AK_OS_LINUX)
+    auto executable = LexicalPath { canonical_path.value() };
+    if (executable.basename() == "flatpak"sv) {
+        if (!flatpak_firefox_is_installed(executable))
+            return {};
+
+        return FirefoxInstallation {
+            .executable = move(executable),
+            .arguments = {
+                "run"sv,
+                "--env=MOZ_GTK_TITLEBAR_DECORATION=system"sv,
+                "org.mozilla.firefox"sv,
+            },
+            .profiles_ini = LexicalPath::join(Core::StandardPaths::home_directory(), ".var"sv, "app"sv, "org.mozilla.firefox"sv, ".mozilla"sv, "firefox"sv, "profiles.ini"sv),
+        };
+    }
+
+    if (canonical_path.value() == "/usr/bin/snap"sv) {
+        return FirefoxInstallation {
+            .executable = LexicalPath { candidate },
+            .arguments = {},
+            .profiles_ini = LexicalPath::join(Core::StandardPaths::home_directory(), "snap"sv, "firefox"sv, "common"sv, ".mozilla"sv, "firefox"sv, "profiles.ini"sv),
+        };
+    }
+
+    if (candidate.starts_with("/snap/"sv) || canonical_path.value().starts_with("/snap/"sv))
+        return {};
+    if (candidate.starts_with("/var/lib/flatpak/"sv) || canonical_path.value().starts_with("/var/lib/flatpak/"sv))
+        return {};
+    if (candidate.contains("/.var/app/org.mozilla.firefox/"sv) || canonical_path.value().contains("/.var/app/org.mozilla.firefox/"sv))
+        return {};
+#endif
+
+    return FirefoxInstallation {
+        .executable = LexicalPath { canonical_path.release_value() },
+        .arguments = {},
+        .profiles_ini = {},
+    };
+}
+
+static Optional<FirefoxInstallation> find_firefox_in_path()
+{
+    static constexpr auto EXECUTABLE_NAMES = to_array<StringView>({
+        "firefox"sv,
+#if defined(AK_OS_LINUX)
+        "flatpak"sv,
+#endif
+    });
+
+    auto search_path = Core::Environment::get("PATH"sv).value_or(DEFAULT_PATH_SV);
+
+    for (auto executable_name : EXECUTABLE_NAMES) {
+        for (auto directory : search_path.split_view(':')) {
+            auto candidate = LexicalPath::join(directory, executable_name);
+
+            if (auto installation = firefox_installation_from_binary(candidate.string()); installation.has_value())
+                return installation;
+        }
+    }
+
+    return {};
+}
+
+static Optional<FirefoxInstallation> find_firefox_installation()
+{
+#if defined(AK_OS_MACOS)
+    static constexpr auto APPLICATION_NAME = "Firefox.app"sv;
+
+    auto candidate = LexicalPath::join("/Applications"sv, APPLICATION_NAME, "Contents"sv, "MacOS"sv, "firefox"sv);
+    if (auto installation = firefox_installation_from_binary(candidate.string()); installation.has_value())
+        return installation;
+
+    return find_firefox_in_path();
+#else
+    return find_firefox_in_path();
+#endif
+}
+
+NonnullOwnPtr<FirefoxClient> FirefoxClient::create()
+{
+    return adopt_own(*new FirefoxClient());
+}
+
+FirefoxClient::~FirefoxClient()
+{
+    if (is_running())
+        (void)Core::Process::terminate_process(m_process->pid(), Core::Process::TerminationMode::Graceful);
+}
+
+bool FirefoxClient::is_running() const
+{
+#if defined(AK_OS_WINDOWS)
+    // FIXME: Implement actual live-process detection for this PID on Windows.
+    return m_process.has_value();
+#else
+    return m_process.has_value() && !Core::System::kill(m_process->pid(), 0).is_error();
+#endif
+}
+
+ErrorOr<void> FirefoxClient::ensure_running(u16 port, u64 tab_id)
+{
+    if (is_running())
+        return {};
+
+    auto installation = find_firefox_installation();
+    if (!installation.has_value())
+        return Error::from_string_literal("No Firefox installation was found");
+
+    auto arguments = installation->arguments;
+    arguments.append("-no-remote"sv);
+#if defined(AK_OS_MACOS)
+    arguments.append("-foreground"sv);
+#endif
+
+#if defined(AK_OS_LINUX)
+    if (installation->profiles_ini.has_value()) {
+        auto profile = TRY(ensure_confined_firefox_profile(*installation));
+        TRY(prepare_firefox_profile(profile));
+
+        arguments.append("-P"sv);
+        arguments.append(PROFILE_NAME);
+    } else
+#endif
+    {
+        TRY(prepare_firefox_profile(profile_directory()));
+
+        arguments.append("-profile"sv);
+        arguments.append(profile_directory().string());
+    }
+
+    arguments.extend({
+        "--width"sv,
+        "1280"sv,
+        "--height"sv,
+        "850"sv,
+        ByteString::formatted("about:devtools-toolbox?type=tab&id={}&host=localhost&port={}", tab_id, port),
+    });
+
+    auto executable = installation->executable.string();
+    bool search_for_executable_in_path = false;
+
+#if defined(AK_OS_LINUX)
+    if (installation->executable.basename() != "flatpak"sv) {
+        arguments.prepend({
+            "MOZ_GTK_TITLEBAR_DECORATION=system"sv,
+            move(executable),
+        });
+        executable = "env";
+        search_for_executable_in_path = true;
+    }
+#endif
+
+    m_process = TRY(Core::Process::spawn({
+        .name = "devtools-client"sv,
+        .executable = move(executable),
+        .search_for_executable_in_path = search_for_executable_in_path,
+        .die_with_parent = true,
+        .arguments = arguments,
+    }));
+
+    return {};
+}
+
+}

--- a/Libraries/LibDevTools/FirefoxClient.h
+++ b/Libraries/LibDevTools/FirefoxClient.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Optional.h>
+#include <LibCore/Process.h>
+#include <LibDevTools/Forward.h>
+
+namespace DevTools {
+
+class DEVTOOLS_API FirefoxClient {
+public:
+    static NonnullOwnPtr<FirefoxClient> create();
+    ~FirefoxClient();
+
+    ErrorOr<void> ensure_running(u16 port, u64 tab_id);
+    bool is_running() const;
+
+private:
+    FirefoxClient() = default;
+
+    Optional<Core::Process> m_process;
+};
+
+}

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -10,10 +10,10 @@
 
 namespace DevTools {
 
-class Actor;
 class AccessibilityActor;
 class AccessibilityNodeActor;
 class AccessibilityWalkerActor;
+class Actor;
 class Connection;
 class ConsoleActor;
 class CookiesActor;
@@ -21,6 +21,7 @@ class CSSPropertiesActor;
 class DeviceActor;
 class DevToolsDelegate;
 class DevToolsServer;
+class FirefoxClient;
 class FrameActor;
 class HighlighterActor;
 class IndexedDBActor;
@@ -35,9 +36,9 @@ class PreferenceActor;
 class ProcessActor;
 class RootActor;
 class SourceActor;
+class StorageActor;
 class StyleRuleActor;
 class StyleSheetsActor;
-class StorageActor;
 class TabActor;
 class TargetConfigurationActor;
 class ThreadActor;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -21,6 +21,7 @@
 #include <LibCore/TimeZoneWatcher.h>
 #include <LibDatabase/Database.h>
 #include <LibDevTools/DevToolsServer.h>
+#include <LibDevTools/FirefoxClient.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibIPC/TransportHandle.h>
 #include <LibImageDecoderClient/Client.h>
@@ -1350,6 +1351,24 @@ ErrorOr<void> Application::launch_devtools_server()
     return {};
 }
 
+ErrorOr<void> Application::launch_devtools_client()
+{
+    if (!m_devtools || !m_browser_options.devtools_port.has_value())
+        return Error::from_string_literal("DevTools is not currently enabled");
+
+    if (m_devtools->has_active_connection())
+        return Error::from_string_literal("A DevTools client is already connected");
+
+    auto view = active_web_view();
+    if (!view.has_value())
+        return Error::from_string_literal("No active tab is available for DevTools");
+
+    if (!m_devtools_client)
+        m_devtools_client = DevTools::FirefoxClient::create();
+
+    return m_devtools_client->ensure_running(*m_browser_options.devtools_port, view->view_id());
+}
+
 static NonnullRefPtr<Core::Timer> load_page_for_screenshot_and_exit(Core::EventLoop& event_loop, HeadlessWebView& view, URL::URL const& url, u32 screenshot_timeout)
 {
     outln("Taking screenshot after {} seconds", screenshot_timeout);
@@ -2228,6 +2247,7 @@ NonnullRefPtr<Application::BookmarkFolderPromise> Application::display_edit_book
 ErrorOr<void> Application::toggle_devtools_enabled()
 {
     if (m_devtools) {
+        m_devtools_client.clear();
         m_devtools.clear();
         on_devtools_disabled();
     } else {
@@ -3082,6 +3102,11 @@ void Application::did_disconnect_devtools_client(DevTools::TabDescription const&
         return;
 
     view->did_disconnect_devtools_client();
+}
+
+void Application::did_close_devtools_connection()
+{
+    m_devtools_client.clear();
 }
 
 }

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -272,6 +272,7 @@ public:
     void apply_view_options(Badge<ViewImplementation>, ViewImplementation&);
 
     ErrorOr<void> toggle_devtools_enabled();
+    ErrorOr<void> launch_devtools_client();
     void refresh_tab_list();
 
     Optional<Core::TimeZoneWatcher&> time_zone_watcher();
@@ -405,6 +406,7 @@ private:
     virtual void stop_listening_for_navigation_events(DevTools::TabDescription const&) const override;
     virtual void did_connect_devtools_client(DevTools::TabDescription const&) const override;
     virtual void did_disconnect_devtools_client(DevTools::TabDescription const&) const override;
+    virtual void did_close_devtools_connection() override;
 
     static Application* s_the;
 
@@ -516,6 +518,7 @@ private:
 #endif
 
     OwnPtr<DevTools::DevToolsServer> m_devtools;
+    OwnPtr<DevTools::FirefoxClient> m_devtools_client;
 
     mutable HashMap<u64, u64> m_navigation_listener_ids;
 };

--- a/Tests/LibCore/TestLibCoreDirectory.cpp
+++ b/Tests/LibCore/TestLibCoreDirectory.cpp
@@ -47,6 +47,16 @@ TEST_CASE(directory_open_and_stat)
 
         EXPECT(directory.stat("nonexistent-file.txt"sv).is_error());
         EXPECT(directory.open("nonexistent-file.txt"sv, Core::File::OpenMode::Read).is_error());
+
+#ifndef AK_OS_WINDOWS
+        auto link_path = directory.path().append("test-file-link.txt"sv);
+        TRY_OR_FAIL(Core::System::symlink("test-file.txt"sv, link_path.string()));
+        EXPECT(directory.open("test-file-link.txt"sv, Core::File::OpenMode::Write | Core::File::OpenMode::NoFollow).is_error());
+
+        auto file = TRY_OR_FAIL(directory.open("test-file.txt"sv, Core::File::OpenMode::ReadWrite | Core::File::OpenMode::NoFollow));
+        auto contents = TRY_OR_FAIL(file->read_until_eof());
+        EXPECT_EQ(StringView { contents.bytes() }, text);
+#endif
     }
 
     TRY_OR_FAIL(FileSystem::remove(directory_path, FileSystem::RecursionMode::Allowed));

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -1734,6 +1734,20 @@ static size_t source_actor_count(DevTools::DevToolsServer const& server)
     return count;
 }
 
+TEST_CASE(devtools_server_reports_connection_state)
+{
+    TestSession session;
+    session.server = MUST(DevTools::DevToolsServer::create(session.delegate, 0));
+    EXPECT(!session.server->has_active_connection());
+
+    session.client = ProtocolClient::connect(session.loop, *session.server);
+    EXPECT(session.server->has_active_connection());
+
+    session.client.clear();
+    spin_until(session.loop, [&] { return !session.server->has_active_connection(); });
+    EXPECT(!session.server->has_active_connection());
+}
+
 static JsonObject get_frame_target(ProtocolClient& client, StringView tab_actor)
 {
     auto watcher_actor = actor_from(client.request(tab_actor, "getWatcher"sv), "actor"sv);

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -182,11 +182,16 @@
     auto message = MUST(String::formatted("DevTools is enabled on port {}", WebView::Application::browser_options().devtools_port));
 
     [self.info_bar showWithMessage:Ladybird::string_to_ns_string(message)
-                dismissButtonTitle:@"Disable"
-              dismissButtonClicked:^{
-                  MUST(WebView::Application::the().toggle_devtools_enabled());
-              }
-                         activeTab:self.active_tab];
+        actionButtonTitle:@"Open Client"
+        actionButtonClicked:^{
+            if (auto result = WebView::Application::the().launch_devtools_client(); result.is_error())
+                WebView::Application::the().display_error_dialog(MUST(String::formatted("Unable to launch the DevTools client: {}", result.error())));
+        }
+        dismissButtonTitle:@"Disable"
+        dismissButtonClicked:^{
+            MUST(WebView::Application::the().toggle_devtools_enabled());
+        }
+        activeTab:self.active_tab];
 }
 
 - (void)onDevtoolsDisabled

--- a/UI/AppKit/Interface/InfoBar.h
+++ b/UI/AppKit/Interface/InfoBar.h
@@ -10,13 +10,15 @@
 
 @class Tab;
 
-using InfoBarDismissed = void (^)(void);
+using InfoBarButtonClicked = void (^)(void);
 
 @interface InfoBar : NSStackView
 
 - (void)showWithMessage:(NSString*)message
+       actionButtonTitle:(NSString*)action_title
+     actionButtonClicked:(InfoBarButtonClicked)on_action
       dismissButtonTitle:(NSString*)title
-    dismissButtonClicked:(InfoBarDismissed)on_dismissed
+    dismissButtonClicked:(InfoBarButtonClicked)on_dismissed
                activeTab:(Tab*)tab;
 - (void)hide;
 

--- a/UI/AppKit/Interface/InfoBar.mm
+++ b/UI/AppKit/Interface/InfoBar.mm
@@ -16,8 +16,10 @@ static constexpr CGFloat const INFO_BAR_HEIGHT = 40;
 @interface InfoBar ()
 
 @property (nonatomic, strong) NSTextField* text_label;
+@property (nonatomic, strong) NSButton* action_button;
 @property (nonatomic, strong) NSButton* dismiss_button;
-@property (nonatomic, copy) InfoBarDismissed on_dismissed;
+@property (nonatomic, copy) InfoBarButtonClicked on_action;
+@property (nonatomic, copy) InfoBarButtonClicked on_dismissed;
 
 @end
 
@@ -28,12 +30,18 @@ static constexpr CGFloat const INFO_BAR_HEIGHT = 40;
     if (self = [super init]) {
         self.text_label = [NSTextField labelWithString:@""];
 
+        self.action_button = [NSButton buttonWithTitle:@""
+                                                target:self
+                                                action:@selector(performAction:)];
+        [self.action_button setBezelStyle:NSBezelStyleAccessoryBarAction];
+
         self.dismiss_button = [NSButton buttonWithTitle:@""
                                                  target:self
                                                  action:@selector(dismiss:)];
         [self.dismiss_button setBezelStyle:NSBezelStyleAccessoryBarAction];
 
         [self addView:self.text_label inGravity:NSStackViewGravityLeading];
+        [self addView:self.action_button inGravity:NSStackViewGravityTrailing];
         [self addView:self.dismiss_button inGravity:NSStackViewGravityTrailing];
 
         [self setOrientation:NSUserInterfaceLayoutOrientationHorizontal];
@@ -46,12 +54,16 @@ static constexpr CGFloat const INFO_BAR_HEIGHT = 40;
 }
 
 - (void)showWithMessage:(NSString*)message
+       actionButtonTitle:(NSString*)action_title
+     actionButtonClicked:(InfoBarButtonClicked)on_action
       dismissButtonTitle:(NSString*)title
-    dismissButtonClicked:(InfoBarDismissed)on_dismissed
+    dismissButtonClicked:(InfoBarButtonClicked)on_dismissed
                activeTab:(Tab*)tab
 {
     [self.text_label setStringValue:message];
 
+    self.action_button.title = action_title;
+    self.on_action = on_action;
     self.dismiss_button.title = title;
     self.on_dismissed = on_dismissed;
 
@@ -60,6 +72,12 @@ static constexpr CGFloat const INFO_BAR_HEIGHT = 40;
     }
 
     [self setHidden:NO];
+}
+
+- (void)performAction:(id)sender
+{
+    if (self.on_action)
+        self.on_action();
 }
 
 - (void)dismiss:(id)sender

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -503,6 +503,10 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     main_layout->addWidget(m_tabs_container, 1);
 
     m_devtools_banner = new DevToolsBanner(main_widget);
+    connect(m_devtools_banner, &DevToolsBanner::launch_client_requested, this, [] {
+        if (auto result = WebView::Application::the().launch_devtools_client(); result.is_error())
+            WebView::Application::the().display_error_dialog(MUST(String::formatted("Unable to launch the DevTools client: {}", result.error())));
+    });
     connect(m_devtools_banner, &DevToolsBanner::disable_requested, this, [] {
         MUST(WebView::Application::the().toggle_devtools_enabled());
     });

--- a/UI/Qt/DevToolsBanner.cpp
+++ b/UI/Qt/DevToolsBanner.cpp
@@ -31,6 +31,10 @@ DevToolsBanner::DevToolsBanner(QWidget* parent)
     layout->addWidget(m_label);
     layout->addStretch();
 
+    auto* launch_client_button = new QPushButton("Open Client", this);
+    connect(launch_client_button, &QPushButton::clicked, this, &DevToolsBanner::launch_client_requested);
+    layout->addWidget(launch_client_button);
+
     auto* disable_button = new QPushButton("Disable", this);
     connect(disable_button, &QPushButton::clicked, this, &DevToolsBanner::disable_requested);
     layout->addWidget(disable_button);

--- a/UI/Qt/DevToolsBanner.h
+++ b/UI/Qt/DevToolsBanner.h
@@ -23,6 +23,7 @@ public:
     void set_port(u16 port);
 
 signals:
+    void launch_client_requested();
     void disable_requested();
 
 private:


### PR DESCRIPTION
We previously would have to start the devtools server in Ladybird and manually open `about:debugging` in Firefox to connect to the server, then pick which tab to inspect. We can now detect an already-installed Firefox instance and launch the devtools client directly through that. To do so, we create a Ladybird-owned Firefox profile with specific prefs and CSS to enable immediate communication with Ladybird.

[devtools.webm](https://github.com/user-attachments/assets/57ea0d94-cb60-44dd-a735-3d536f1a449f)
