### PR TITLE
LibWeb: Rebuild only referencing subtrees on SVG resource removal

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -107,6 +107,7 @@ enum class SetNeedsLayoutReason {
     X(None)                                               \
     X(ShadowRootSetInnerHTML)                             \
     X(StyleChange)                                        \
+    X(SVGResourceElementRemoved)                          \
     X(TopLayerMembershipChange)
 
 enum class SetNeedsLayoutTreeUpdateReason {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1360,6 +1360,7 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, Layout:
                 }
             }
             update_layout_tree(const_cast<SVG::SVGElement&>(*mask_or_clip_path), context, MustCreateSubtree::Yes);
+            const_cast<SVG::SVGElement&>(*mask_or_clip_path).register_resource_box_referencing_element({}, graphics_element);
             pop_parent();
         };
         if (auto mask = graphics_element.mask())
@@ -1385,6 +1386,11 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, Layout:
                 }
             }
             update_layout_tree(const_cast<SVG::SVGPatternElement&>(*content_element), context, MustCreateSubtree::Yes);
+            // NB: The referenced pattern may inherit its content from another pattern via href. Removing either
+            //     element invalidates the attached resource box, so register the referencer with both.
+            const_cast<SVG::SVGPatternElement&>(*content_element).register_resource_box_referencing_element({}, graphics_element);
+            if (pattern != content_element)
+                const_cast<SVG::SVGPatternElement&>(*pattern).register_resource_box_referencing_element({}, graphics_element);
             pop_parent();
         };
         if (auto fill = graphics_element.fill_pattern())

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -273,10 +273,33 @@ void SVGElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor,
     remove_from_use_element_that_reference_this();
 
     // A <mask>, <clipPath>, or <pattern> referenced via url(#id) is laid out as a resource box attached to the
-    // referencing element's layout subtree. So it outlives this element's own DOM node. Rebuild the layout tree
-    // while this element is still alive — so those stale resource boxes are dropped before this node is collected.
+    // referencing element's layout subtree. So it outlives this element's own DOM node. Rebuild those referencing
+    // subtrees while this element is still alive — so the stale resource boxes are dropped before this node is
+    // collected.
+    mark_resource_box_referencing_elements_for_layout_tree_update();
+
+    // References that resolve during display list recording (e.g. gradient or filter url(#id) references) don't
+    // build resource boxes, so there may be no layout invalidation to trigger re-recording. Request it explicitly
+    // to drop the visual effects of the removed element.
     if (id().has_value())
-        document().set_needs_full_layout_tree_update(true);
+        document().set_needs_repaint(Badge<SVGElement> {}, InvalidateDisplayList::Yes);
+}
+
+void SVGElement::register_resource_box_referencing_element(Badge<Layout::TreeBuilder>, DOM::Element& referencing_element)
+{
+    m_resource_box_referencing_elements.remove_all_matching([&](auto& weak_element) {
+        return !weak_element || weak_element == &referencing_element;
+    });
+    m_resource_box_referencing_elements.append(referencing_element);
+}
+
+void SVGElement::mark_resource_box_referencing_elements_for_layout_tree_update()
+{
+    for (auto& weak_referencing_element : m_resource_box_referencing_elements) {
+        if (auto referencing_element = weak_referencing_element.ptr())
+            referencing_element->set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::SVGResourceElementRemoved);
+    }
+    m_resource_box_referencing_elements.clear();
 }
 
 void SVGElement::remove_from_use_element_that_reference_this()

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGC/Weak.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
@@ -37,6 +38,8 @@ public:
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
+    void register_resource_box_referencing_element(Badge<Layout::TreeBuilder>, DOM::Element&);
+
 protected:
     SVGElement(DOM::Document&, DOM::QualifiedName);
 
@@ -52,6 +55,7 @@ protected:
 
     void update_use_elements_that_reference_this();
     void remove_from_use_element_that_reference_this();
+    void mark_resource_box_referencing_elements_for_layout_tree_update();
 
 private:
     // ^HTML::GlobalEventHandlers
@@ -60,6 +64,11 @@ private:
     virtual bool is_svg_element() const final { return true; }
 
     GC::Ptr<SVGAnimatedString> m_class_name_animated_string;
+
+    // Elements whose layout subtrees contain a <mask>, <clipPath>, or <pattern> resource box built
+    // from this element. Their subtrees must be rebuilt when this element is removed, since resource
+    // boxes are not attached under this element's own layout position.
+    Vector<GC::Weak<DOM::Element>> m_resource_box_referencing_elements;
 };
 
 }

--- a/Tests/LibWeb/Crash/SVG/mask-reference-id-removed-then-element-removed-and-gced.html
+++ b/Tests/LibWeb/Crash/SVG/mask-reference-id-removed-then-element-removed-and-gced.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<svg width="200" height="200">
+    <rect width="100" height="100" mask="url(#m)"/>
+</svg>
+<svg width="0" height="0">
+    <mask id="m"><rect width="100" height="100"/></mask>
+</svg>
+<script>
+    internals.dumpDisplayList();
+    const mask = document.getElementById("m");
+    mask.removeAttribute("id");
+    mask.remove();
+    internals.gc();
+    internals.dumpDisplayList();
+</script>

--- a/Tests/LibWeb/Crash/SVG/mask-reference-removed-and-gced-before-layout-update.html
+++ b/Tests/LibWeb/Crash/SVG/mask-reference-removed-and-gced-before-layout-update.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<svg width="200" height="200">
+    <rect width="100" height="100" mask="url(#m)"/>
+</svg>
+<svg width="0" height="0">
+    <mask id="m"><rect width="100" height="100"/></mask>
+</svg>
+<script>
+    internals.dumpDisplayList();
+    document.getElementById("m").remove();
+    internals.gc();
+    internals.dumpDisplayList();
+</script>

--- a/Tests/LibWeb/Layout/expected/svg/mask-reference-removed-resource-box-dropped.txt
+++ b/Tests/LibWeb/Layout/expected/svg/mask-reference-removed-resource-box-dropped.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 219 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 203 0+0+8] children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
+      frag 1 from TextNode start: 0, length: 1, rect: [208,195 8x16] baseline: 12.796875
+          " "
+      frag 2 from SVGSVGBox start: 0, length: 0, rect: [216,208 0x0] baseline: 0
+      SVGSVGBox <svg> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0] [SVG] children: inline
+        TextNode <#text> (not painted)
+        SVGGeometryBox <rect> at [8,8] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      SVGSVGBox <svg> at [216,208] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [SVG] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x219]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x203]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 200x200]
+        SVGPathPaintable (SVGGeometryBox<rect>) [8,8 100x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [216,208 0x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x219] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/svg/mask-reference-removed-resource-box-dropped.html
+++ b/Tests/LibWeb/Layout/input/svg/mask-reference-removed-resource-box-dropped.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<svg width="200" height="200">
+    <rect width="100" height="100" mask="url(#m)"/>
+</svg>
+<svg width="0" height="0">
+    <mask id="m"><rect width="50" height="50"/></mask>
+</svg>
+<script>
+    // Force a layout so the SVGMaskBox resource box is attached under the referencing <rect>
+    // before the <mask> is removed.
+    document.body.offsetWidth;
+    document.getElementById("m").remove();
+</script>

--- a/Tests/LibWeb/Ref/expected/svg-gradient-in-defs-removed-repaint-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-gradient-in-defs-removed-repaint-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+    <rect width="100" height="100" fill="url(#g)"/>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg-gradient-in-defs-removed-repaint.html
+++ b/Tests/LibWeb/Ref/input/svg-gradient-in-defs-removed-repaint.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/svg-gradient-in-defs-removed-repaint-ref.html">
+<svg width="100" height="100">
+    <defs>
+        <linearGradient id="g">
+            <stop offset="0" stop-color="red"/>
+            <stop offset="1" stop-color="red"/>
+        </linearGradient>
+    </defs>
+    <rect width="100" height="100" fill="url(#g)"/>
+</svg>
+<script>
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            document.getElementById("g").remove();
+            requestAnimationFrame(() => {
+                if (window.internals)
+                    internals.signalTestIsDone("PASS");
+                else
+                    document.documentElement.classList.remove("reftest-wait");
+            });
+        });
+    });
+</script>
+</html>


### PR DESCRIPTION
Removing any SVG element with an id requested a full layout tree rebuild. The rebuild was there to drop stale <mask>, <clipPath>, and <pattern> resource boxes, which are attached to each referencing element's layout subtree and so outlive the removed resource element — painting would otherwise dereference their weak DOM pointers after the element was garbage collected.

Now TreeBuilder registers the referencing element with the resource element when it attaches a resource box, and removal marks only those subtrees for layout tree update. Registration is keyed on actual attachment rather than the id present at removal time, which also fixes a crash when the id attribute was removed before the element. Gradient and filter references resolve during display list recording and build no boxes, so removal still requests a re-record to drop their effects.