### PR TITLE
LibWebView: Add last_access_time to WebStorage tables that lack it

### DIFF
--- a/Libraries/LibDatabase/Database.cpp
+++ b/Libraries/LibDatabase/Database.cpp
@@ -361,6 +361,16 @@ ErrorOr<bool> Database::table_exists(StringView table)
     return exists;
 }
 
+ErrorOr<bool> Database::column_exists(StringView table, StringView column)
+{
+    if (!m_column_exists_statement.has_value())
+        m_column_exists_statement = TRY(prepare_statement("SELECT 1 FROM pragma_table_info(?) WHERE name = ?;"sv));
+
+    bool exists = false;
+    TRY(try_execute_statement(*m_column_exists_statement, [&](auto) { exists = true; }, TRY(String::from_utf8(table)), TRY(String::from_utf8(column))));
+    return exists;
+}
+
 ErrorOr<Optional<u32>> Database::schema_version(StringView store)
 {
     if (!TRY(table_exists("SchemaVersions"sv)))

--- a/Libraries/LibDatabase/Database.h
+++ b/Libraries/LibDatabase/Database.h
@@ -123,6 +123,8 @@ public:
 
     ErrorOr<bool> table_exists(StringView table);
 
+    ErrorOr<bool> column_exists(StringView table, StringView column);
+
     // The version recorded for the store in SchemaVersions, or empty if it has none yet.
     ErrorOr<Optional<u32>> schema_version(StringView store);
 
@@ -196,6 +198,7 @@ private:
     sqlite3* m_database { nullptr };
     Vector<sqlite3_stmt*> m_prepared_statements;
     Optional<StatementID> m_table_exists_statement;
+    Optional<StatementID> m_column_exists_statement;
     Optional<StatementID> m_schema_version_statement;
 };
 

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -16,10 +16,11 @@ namespace WebView {
 static constexpr size_t LOCAL_STORAGE_QUOTA = 5 * MiB;
 
 static constexpr u32 WEB_STORAGE_SCHEMA_BASELINE_VERSION = 1u;
+static constexpr u32 WEB_STORAGE_SCHEMA_LAST_ACCESS_TIME_VERSION = 2u;
 
 ErrorOr<Database::MigrationOutcome> StorageJar::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 1> migrations { {
+    Array<Database::Migration, 2> migrations { {
         { .version = WEB_STORAGE_SCHEMA_BASELINE_VERSION, .sql = R"#(
             CREATE TABLE IF NOT EXISTS WebStorage (
                 storage_endpoint INTEGER,
@@ -30,6 +31,13 @@ ErrorOr<Database::MigrationOutcome> StorageJar::migrate_schema(Database::Databas
                 PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
             );
         )#"sv },
+        // A WebStorage table created before last_access_time existed is adopted as-is by the
+        // baseline CREATE ... IF NOT EXISTS above, so add the column to databases that lack it.
+        { .version = WEB_STORAGE_SCHEMA_LAST_ACCESS_TIME_VERSION, .backfill = [](Database::Database& database) -> ErrorOr<void> {
+             if (!TRY(database.column_exists("WebStorage"sv, "last_access_time"sv)))
+                 TRY(database.execute_raw("ALTER TABLE WebStorage ADD COLUMN last_access_time INTEGER;"));
+             return {};
+         } },
     } };
 
     return database.migrate("WebStorage"sv, migrations, mode);

--- a/Tests/LibWebView/TestStorageJar.cpp
+++ b/Tests/LibWebView/TestStorageJar.cpp
@@ -20,7 +20,7 @@ TEST_CASE(storage_round_trips_on_fresh_database)
     jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16, "bar"_utf16);
     EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16), Optional<Utf16String> { "bar"_utf16 });
 
-    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 1u });
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 2u });
 }
 
 TEST_CASE(newer_storage_schema_reports_database_too_new)
@@ -32,4 +32,54 @@ TEST_CASE(newer_storage_schema_reports_database_too_new)
 
     EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::DatabaseTooNew);
     EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
+}
+
+TEST_CASE(migrates_web_storage_table_created_before_last_access_time)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw(R"#(
+        CREATE TABLE WebStorage (
+            storage_endpoint INTEGER,
+            storage_key TEXT,
+            bottle_key TEXT,
+            bottle_value TEXT,
+            PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
+        );
+    )#"));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+    auto jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
+
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16, "bar"_utf16);
+    EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16), Optional<Utf16String> { "bar"_utf16 });
+
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 2u });
+}
+
+TEST_CASE(migration_to_add_last_access_time_is_idempotent)
+{
+    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
+
+    TRY_OR_FAIL(database->execute_raw(R"#(
+        CREATE TABLE WebStorage (
+            storage_endpoint INTEGER,
+            storage_key TEXT,
+            bottle_key TEXT,
+            bottle_value TEXT,
+            last_access_time INTEGER,
+            PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
+        );
+    )#"));
+    TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('WebStorage', 1);"));
+
+    EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
+
+    auto jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16, "bar"_utf16);
+    EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16), Optional<Utf16String> { "bar"_utf16 });
+
+    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 2u });
 }


### PR DESCRIPTION
**Problem:** Crash at launch with a fatal “SQL logic error”. Deleting `ladybird.db` “fixes” it (while discarding the user’s local storage).

**Cause:** When `StorageJar` adopted the schema-migration framework, it put `last_access_time` only in the version 1 baseline `CREATE TABLE IF NOT EXISTS` and dropped the earlier `ALTER TABLE ... ADD COLUMN` retrofit. For a DB whose `WebStorage` table predates the column, that baseline create is a no-op — so the column is never added. For users whose `ladybird.db` has a `WebStorage` table created before the `last_access_time` column was added, every `StorageJar` statement that references `last_access_time` then fails to prepare, so the storage layer can’t start.

**Fix:** Append a version 2 migration whose backfill adds `last_access_time` when it’s missing. A new `Database::column_exists()` helper makes the add idempotent — so DBs that already have the column are left untouched, rather than hitting a duplicate-column error. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10606.
