### PR TITLE
LibWeb: Reduce baseline layout and paint tree overhead

### DIFF
--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -32,6 +32,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/Layout/Node.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/Paintable.h>
 

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -299,9 +299,9 @@ Length::ResolutionContext Length::ResolutionContext::for_document(DOM::Document 
     };
 }
 
-Length::ResolutionContext Length::ResolutionContext::for_layout_node(Layout::Node const& node)
+Length::ResolutionContext Length::ResolutionContext::for_layout_node(Layout::NodeWithStyle const& node)
 {
-    Layout::Node const* root_layout_node;
+    Layout::NodeWithStyle const* root_layout_node;
     DOM::Element const* subject_element = nullptr;
 
     if (is<DOM::Document>(node.dom_node())) {
@@ -331,7 +331,7 @@ CSSPixels Length::to_px(ResolutionContext const& context) const
     return CSSPixels::nearest_value_for(to_px_without_rounding(context));
 }
 
-CSSPixels Length::to_px_slow_case(Layout::Node const& layout_node) const
+CSSPixels Length::to_px_slow_case(Layout::NodeWithStyle const& layout_node) const
 {
     if (!layout_node.document().browsing_context())
         return 0;

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -63,7 +63,7 @@ public:
     struct ResolutionContext {
         [[nodiscard]] static ResolutionContext for_document(DOM::Document const&);
         [[nodiscard]] static ResolutionContext for_element(DOM::AbstractElement const&);
-        [[nodiscard]] static ResolutionContext for_layout_node(Layout::Node const&);
+        [[nodiscard]] static ResolutionContext for_layout_node(Layout::NodeWithStyle const&);
 
         CSSPixelRect viewport_rect;
         FontMetrics font_metrics;
@@ -133,7 +133,7 @@ public:
 
     [[nodiscard]] CSSPixels to_px(ResolutionContext const&) const;
 
-    [[nodiscard]] ALWAYS_INLINE CSSPixels to_px(Layout::Node const& node) const
+    [[nodiscard]] ALWAYS_INLINE CSSPixels to_px(Layout::NodeWithStyle const& node) const
     {
         if (is_absolute())
             return absolute_length_to_px();
@@ -209,7 +209,7 @@ public:
     static Length from_style_value(NonnullRefPtr<StyleValue const> const&, Optional<Length> percentage_basis);
 
 private:
-    [[nodiscard]] CSSPixels to_px_slow_case(Layout::Node const&) const;
+    [[nodiscard]] CSSPixels to_px_slow_case(Layout::NodeWithStyle const&) const;
 
     LengthUnit m_unit;
     double m_value { 0 };

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6241,7 +6241,7 @@ static CSSPixelRect compute_intersection(GC::Ref<Element> target, CSSPixelRect t
 
                 // Apply scroll margin to expand the scrollport for scroll containers.
                 auto& scroll_margin = observer.scroll_margin_values();
-                auto const& layout_node = container->layout_node_with_style_and_box_metrics();
+                auto const& layout_node = container->layout_node();
                 if (layout_node.is_scroll_container() && !scroll_margin.is_empty()) {
                     clip_rect.inflate(
                         scroll_margin[0].to_px(clip_rect.height()),

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2538,7 +2538,7 @@ void Element::set_scroll_left(double x)
     if (!paintable_box())
         return;
 
-    if (!paintable_box()->layout_node_with_style_and_box_metrics().is_scroll_container())
+    if (!paintable_box()->layout_node().is_scroll_container())
         return;
 
     // FIXME: or the element has no overflow.
@@ -2595,7 +2595,7 @@ void Element::set_scroll_top(double y)
     if (!paintable_box())
         return;
 
-    if (!paintable_box()->layout_node_with_style_and_box_metrics().is_scroll_container())
+    if (!paintable_box()->layout_node().is_scroll_container())
         return;
 
     // FIXME: or the element has no overflow.

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -3469,8 +3469,8 @@ ErrorOr<Utf16String> Node::name_or_description(NameOrDescription target, Documen
                 const_cast<DOM::Document&>(document).update_layout(DOM::UpdateLayoutReason::NodeNameOrDescription);
                 auto const* layout_node = child_node->layout_node();
                 if (layout_node) {
-                    auto display = layout_node->display();
-                    if (display.is_inline_outside() && display.is_flow_inside()) {
+                    auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(*layout_node);
+                    if (!layout_node_with_style || (layout_node_with_style->display().is_inline_outside() && layout_node_with_style->display().is_flow_inside())) {
                         should_add_space = false;
                     }
                 }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -326,7 +326,8 @@ static Vector<Variant<Utf16String, RequiredLineBreakCount>> rendered_text_collec
     if (!layout_node->has_style_or_parent_with_style())
         return items;
 
-    auto const& computed_values = layout_node->computed_values();
+    auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(*layout_node);
+    auto const& computed_values = layout_node_with_style ? layout_node_with_style->computed_values() : layout_node->parent()->computed_values();
 
     // 2. If node's computed value of 'visibility' is not 'visible', then return items.
     if (computed_values.visibility() != CSS::Visibility::Visible)

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3961,7 +3961,7 @@ void collect_clipboard_text(DOM::Node const& node, DOM::Range const& range, Vect
         return;
     }
 
-    auto display = layout_node->computed_values().display();
+    auto display = as<Layout::NodeWithStyle>(*layout_node).display();
     if (display.is_table_cell() && node.next_sibling())
         items.append("\t"_utf16);
     if (display.is_table_row() && node.next_sibling())

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -311,7 +311,7 @@ CSSPixelRect IntersectionObserver::root_intersection_rectangle() const
         //    it’s the result of getting the bounding box for the intersection root.
         rect = element->bounding_client_rect_assuming_layout_clean();
         if (auto paintable_box = element->paintable_box())
-            intersection_root_is_scrollable = paintable_box->layout_node_with_style_and_box_metrics().is_scroll_container();
+            intersection_root_is_scrollable = paintable_box->layout_node().is_scroll_container();
     }
 
     // When calculating the root intersection rectangle for a same-origin-domain target, the rectangle is then

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1472,7 +1472,7 @@ void BlockFormattingContext::resolve_horizontal_box_model_metrics(Box const& box
     box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
 }
 
-BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root)
+BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floating_boxes(NodeWithStyle const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root)
 {
     auto const& computed_values = child_box.computed_values();
     auto result = DidIntroduceClearance::No;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -81,7 +81,7 @@ public:
         No,
     };
 
-    [[nodiscard]] DidIntroduceClearance clear_floating_boxes(Node const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root);
+    [[nodiscard]] DidIntroduceClearance clear_floating_boxes(NodeWithStyle const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root);
 
     void reset_margin_state() { m_margin_state.reset(); }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1767,7 +1767,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
             : child_used_values->border_box_height();
         auto const block_axis_line_height = inline_node.computed_values().line_height();
         auto const block_axis_start = [&] {
-            if (fragment.layout_node().computed_values().block_axis_is_reverse())
+            if (fragment.style_source().computed_values().block_axis_is_reverse())
                 return fragment.block_offset() + child_used_values->border_box_right() - block_axis_line_height;
             return fragment.block_offset() - (is_horizontal ? child_used_values->border_box_top() : child_used_values->border_box_left());
         }();

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1802,7 +1802,8 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
         }
 
         for (auto child = node.first_child(); child; child = child->next_sibling()) {
-            if (child->is_absolutely_positioned() || child->is_floating())
+            auto const* child_with_style = as_if<NodeWithStyle>(*child);
+            if (child_with_style && (child_with_style->is_absolutely_positioned() || child_with_style->is_floating()))
                 continue;
             auto const* child_used_values = state.try_get(*child);
             auto child_offset = child_used_values ? offset + child_used_values->content_offset() : offset;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -199,7 +199,7 @@ void InlineFormattingContext::compute_inline_box_pieces()
                 continue;
             auto fragment_index = committed_fragment_index++;
             auto const& fragment_node = fragment.layout_node();
-            bool is_interrupting_block_fragment = fragment_node.display().is_block_outside();
+            bool is_interrupting_block_fragment = fragment.style_source().display().is_block_outside();
 
             auto fragment_position = fragment.offset();
             auto fragment_size = fragment.size();
@@ -724,7 +724,7 @@ void InlineFormattingContext::generate_line_boxes()
 
         // Ignore collapsible whitespace chunks at the start of line, and if the last fragment already ends in whitespace.
         if (item.is_collapsible_whitespace && (line_boxes.is_empty() || line_boxes.last().is_empty_or_ends_in_whitespace() || line_boxes.last().has_block_level_box())) {
-            if (item.node->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
+            if (item.style_source().computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 auto next_width = iterator.next_non_whitespace_sequence_width();
                 if (next_width > 0) {
                     line_builder.prepare_to_append_inline_content();
@@ -748,7 +748,7 @@ void InlineFormattingContext::generate_line_boxes()
         case InlineLevelIterator::Item::Type::ForcedBreak: {
             line_builder.break_line(LineBuilder::ForcedBreak::Yes);
             if (item.node) {
-                auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this, m_layout_input->content_box_position_in_bfc_root.value());
+                auto introduce_clearance = parent().clear_floating_boxes(as<NodeWithStyle>(*item.node), *this, m_layout_input->content_box_position_in_bfc_root.value());
                 if (introduce_clearance == BlockFormattingContext::DidIntroduceClearance::Yes) {
                     line_builder.did_introduce_clearance(vertical_float_clearance());
                     parent().reset_margin_state();
@@ -800,7 +800,7 @@ void InlineFormattingContext::generate_line_boxes()
                 line_builder.commit_pending_margin_before_float();
                 if (!is<ListItemMarkerBox>(*box))
                     m_state.create(*box, m_layout_input->containing_block_constraints.percentage_basis_width, m_layout_input->containing_block_constraints.percentage_basis_height);
-                (void)parent().clear_floating_boxes(*item.node, *this, m_layout_input->content_box_position_in_bfc_root.value());
+                (void)parent().clear_floating_boxes(as<NodeWithStyle>(*item.node), *this, m_layout_input->content_box_position_in_bfc_root.value());
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
                 line_builder.set_unbreakable_run_width_interrupted_by_float(iterator.next_non_whitespace_sequence_width());
@@ -812,7 +812,7 @@ void InlineFormattingContext::generate_line_boxes()
             auto& text_node = as<Layout::TextNode>(*item.node);
             line_builder.prepare_to_append_inline_content();
 
-            if (text_node.computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
+            if (text_node.parent()->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 bool is_whitespace = false;
                 CSSPixels next_width = 0;
                 // If we're in a whitespace-collapsing context, we can simply check the flag.
@@ -849,7 +849,7 @@ void InlineFormattingContext::generate_line_boxes()
                 item.margin_start,
                 item.margin_end,
                 item.width,
-                text_node.computed_values().line_height(),
+                text_node.parent()->computed_values().line_height(),
                 move(item.glyph_run));
             break;
         }

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -117,10 +117,10 @@ void InlineLevelIterator::exit_node_with_box_model_metrics()
 Layout::Node const* InlineLevelIterator::next_inline_node_in_pre_order(Layout::Node const& current, Layout::Node const* stay_within)
 {
     if (current.first_child()
-        && (current.first_child()->display().is_inline_outside()
+        && (current.first_child()->is_inline()
             || is_inline_flow_interrupting_block(*current.first_child())
             || current.first_child()->is_out_of_flow(m_inline_formatting_context))
-        && current.display().is_flow_inside()
+        && as<NodeWithStyle>(current).display().is_flow_inside()
         && !is_inline_flow_interrupting_block(current)
         && !current.is_atomic_inline()) {
         if (!current.is_box() || !static_cast<Box const&>(current).is_out_of_flow(m_inline_formatting_context))
@@ -169,7 +169,7 @@ void InlineLevelIterator::skip_to_next()
     if (m_next_node
         && is<Layout::NodeWithStyleAndBoxModelMetrics>(*m_next_node)
         && m_next_node->is_inline()
-        && m_next_node->display().is_flow_inside()
+        && static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(*m_next_node).display().is_flow_inside()
         && !m_next_node->is_out_of_flow(m_inline_formatting_context)
         && !m_next_node->is_atomic_inline())
         enter_node_with_box_model_metrics(static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(*m_next_node));
@@ -192,7 +192,7 @@ CSSPixels InlineLevelIterator::next_non_whitespace_sequence_width()
         auto const& next_item = m_items[i];
         if (next_item.type == InlineLevelIterator::Item::Type::ForcedBreak || next_item.type == InlineLevelIterator::Item::Type::BlockLevelBox)
             break;
-        if (next_item.node->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
+        if (next_item.style_source().computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
             if (next_item.type != InlineLevelIterator::Item::Type::Text)
                 break;
             if (next_item.is_collapsible_whitespace)
@@ -279,7 +279,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
                 // Create an empty chunk for editable empty text fields
                 chunk_opt = TextNode::Chunk {
                     .view = {},
-                    .font = text_node->computed_values().font_list().first(),
+                    .font = text_node->parent()->computed_values().font_list().first(),
                     .is_all_whitespace = true,
                     .text_type = Gfx::GlyphRun::TextType::Common,
                 };
@@ -312,9 +312,9 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         if (do_respect_linebreak && chunk.has_breaking_newline)
             return Item { .type = Item::Type::ForcedBreak };
 
-        auto letter_spacing = text_node->computed_values().letter_spacing();
+        auto letter_spacing = text_node->parent()->computed_values().letter_spacing();
         // FIXME: We should apply word spacing to all word-separator characters not just breaking tabs
-        auto word_spacing = text_node->computed_values().word_spacing();
+        auto word_spacing = text_node->parent()->computed_values().word_spacing();
 
         auto x = 0.0f;
         if (chunk.has_breaking_tab) {
@@ -323,7 +323,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
             CSSPixels accumulated_width = m_accumulated_width_for_tabs;
 
             // https://drafts.csswg.org/css-text/#tab-size-property
-            auto tab_width = text_node->computed_values().tab_size().visit(
+            auto tab_width = text_node->parent()->computed_values().tab_size().visit(
                 [&](CSSPixels const& css_pixels) -> CSSPixels {
                     return css_pixels;
                 },
@@ -464,8 +464,8 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
 
 void InlineLevelIterator::enter_text_node(Layout::TextNode const& text_node)
 {
-    auto white_space_collapse = text_node.computed_values().white_space_collapse();
-    auto text_wrap_mode = text_node.computed_values().text_wrap_mode();
+    auto white_space_collapse = text_node.parent()->computed_values().white_space_collapse();
+    auto text_wrap_mode = text_node.parent()->computed_values().text_wrap_mode();
 
     // https://drafts.csswg.org/css-text-4/#collapse
     bool do_wrap_lines = text_wrap_mode == CSS::TextWrapMode::Wrap;

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -379,7 +379,8 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         return item;
     }
 
-    if (m_current_node->is_absolutely_positioned()) {
+    auto const& current_node_with_style = as<NodeWithStyle>(*m_current_node);
+    if (current_node_with_style.is_absolutely_positioned()) {
         auto const& node = *m_current_node;
         auto has_unattached_inline_start_edges = m_extra_leading_metrics.has_value()
             && (m_extra_leading_metrics->margin != 0 || m_extra_leading_metrics->border != 0 || m_extra_leading_metrics->padding != 0);
@@ -391,7 +392,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         };
     }
 
-    if (m_current_node->is_floating()) {
+    if (current_node_with_style.is_floating()) {
         auto const& node = *m_current_node;
         skip_to_next();
         return Item {

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -53,6 +53,14 @@ public:
         {
             return border_start + padding_start + width + padding_end + border_end;
         }
+
+        NodeWithStyle const& style_source() const
+        {
+            VERIFY(node);
+            if (auto const* node_with_style = as_if<NodeWithStyle>(*node))
+                return *node_with_style;
+            return *node->parent();
+        }
     };
 
     InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutInput const&, LayoutMode);

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -167,10 +167,11 @@ static InlineAncestorChainRelativeOffset accumulated_relative_insets_from_inline
     for (auto const* ancestor = first_ancestor; ancestor && ancestor != stop_at; ancestor = ancestor->parent()) {
         if (!is<Layout::NodeWithStyleAndBoxModelMetrics>(*ancestor))
             break;
-        if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
+        auto const& ancestor_with_style = static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(*ancestor);
+        if (!ancestor_with_style.display().is_inline_outside() || !ancestor_with_style.display().is_flow_inside())
             break;
         result.found_fragmented_inline_node |= ancestor->is_fragmented_inline();
-        if (ancestor->computed_values().position() == CSS::Positioning::Relative) {
+        if (ancestor_with_style.computed_values().position() == CSS::Positioning::Relative) {
             VERIFY(ancestor->paintable());
             auto const& ancestor_paintable_box = *ancestor->paintable();
             auto const& inset = ancestor_paintable_box.box_model().inset;

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -252,6 +252,19 @@ static void build_paint_tree(Node& node, Painting::Paintable* parent_paintable =
         build_paint_tree(*child, paintable_for_children);
 }
 
+void LayoutState::resolve_paintable_containing_blocks(Node& root)
+{
+    root.for_each_in_inclusive_subtree([](Node& node) {
+        auto* paintable = node.paintable_ptr();
+        if (!paintable)
+            return TraversalDecision::Continue;
+
+        auto* containing_block = node.containing_block();
+        paintable->set_containing_block(containing_block ? containing_block->paintable_ptr() : nullptr);
+        return TraversalDecision::Continue;
+    });
+}
+
 void LayoutState::commit(Box& root)
 {
     if (!root.is_viewport()) {
@@ -469,6 +482,7 @@ void LayoutState::commit_used_values_and_build_paint_tree(Box& root, RefPtr<Pain
     });
 
     build_paint_tree(root, parent_paintable.ptr(), insert_before_paintable.ptr());
+    resolve_paintable_containing_blocks(root);
 
     resolve_relative_positions();
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -403,6 +403,7 @@ struct LayoutState {
     [[nodiscard]] Optional<ContainedAbsposChild> take_next_contained_abspos_child(Box const& target);
 
 private:
+    void resolve_paintable_containing_blocks(Node& root);
     void resolve_relative_positions();
 
     PagedStore<UsedValues> m_used_values_store;

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -41,7 +41,9 @@ void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length,
     CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width,
     CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run)
 {
-    bool text_align_is_justify = layout_node.computed_values().text_align() == CSS::TextAlign::Justify;
+    auto const* layout_node_with_style = as_if<NodeWithStyle>(layout_node);
+    auto const& style_source = layout_node_with_style ? *layout_node_with_style : *layout_node.parent();
+    bool text_align_is_justify = style_source.computed_values().text_align() == CSS::TextAlign::Justify;
     if (glyph_run && !text_align_is_justify && !m_fragments.is_empty()
         && &m_fragments.last().layout_node() == &layout_node
         && &m_fragments.last().m_glyph_run->font() == &glyph_run->font()
@@ -85,7 +87,7 @@ void LineBox::clamp_static_position_markers_to_inline_length()
 CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespace should_remove)
 {
     auto should_trim = [](LineBoxFragment* fragment) {
-        auto white_space_collapse = fragment->layout_node().computed_values().white_space_collapse();
+        auto white_space_collapse = fragment->style_source().computed_values().white_space_collapse();
 
         return white_space_collapse == CSS::WhiteSpaceCollapse::Collapse || white_space_collapse == CSS::WhiteSpaceCollapse::PreserveBreaks;
     };
@@ -134,7 +136,7 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
             break;
 
         auto const& font = last_fragment->glyph_run() ? last_fragment->glyph_run()->font() : last_fragment->layout_node().first_available_font();
-        CSSPixels last_character_width = CSSPixels(font.glyph_width(last_character)) + last_fragment->layout_node().computed_values().letter_spacing();
+        CSSPixels last_character_width = CSSPixels(font.glyph_width(last_character)) + last_fragment->style_source().computed_values().letter_spacing();
         whitespace_width += last_character_width;
         trailing_whitespace_width += last_character_width;
         if (should_remove == RemoveTrailingWhitespace::Yes) {

--- a/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -34,6 +34,13 @@ LineBoxFragment::LineBoxFragment(Node const& layout_node, size_t start, size_t l
     }
 }
 
+NodeWithStyle const& LineBoxFragment::style_source() const
+{
+    if (auto const* node_with_style = as_if<NodeWithStyle>(layout_node()))
+        return *node_with_style;
+    return *layout_node().parent();
+}
+
 CSSPixelPoint LineBoxFragment::offset() const
 {
     if (m_writing_mode != CSS::WritingMode::HorizontalTb)

--- a/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -27,6 +27,7 @@ public:
         VERIFY(m_layout_node);
         return *m_layout_node;
     }
+    NodeWithStyle const& style_source() const;
     size_t start() const { return m_start; }
     size_t length_in_code_units() const { return m_length_in_code_units; }
 

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -350,7 +350,7 @@ void LineBuilder::update_last_line()
     auto line_box_baseline = [&] {
         CSSPixels line_box_baseline = strut_baseline;
         for (auto& fragment : line_box.fragments()) {
-            auto const line_height = fragment.layout_node().computed_values().line_height();
+            auto const line_height = fragment.style_source().computed_values().line_height();
 
             CSSPixels fragment_baseline = 0;
             if (fragment.layout_node().is_text_node()) {
@@ -365,14 +365,14 @@ void LineBuilder::update_last_line()
 
             // NOTE: For fragments with a <length-percentage> vertical-align, shift the line box baseline down by the resolved amount.
             //       This ensures that we make enough vertical space on the line for any manually-aligned fragments.
-            if (auto const* length_percentage = fragment.layout_node().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
+            if (auto const* length_percentage = fragment.style_source().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
                 fragment_baseline += length_percentage->to_px(line_height);
             }
 
             if (fragment_baseline > line_box_baseline) {
                 if (!fragment.layout_node().is_text_node()) {
                     auto const& box = as<Layout::Box>(fragment.layout_node());
-                    auto const& vertical_align = fragment.layout_node().computed_values().vertical_align();
+                    auto const& vertical_align = fragment.style_source().computed_values().vertical_align();
                     should_align_strut_to_line_box_baseline |= box.display().is_inline_outside()
                         && box.display().is_flex_inside()
                         && vertical_align.has<CSS::VerticalAlign>()
@@ -461,7 +461,7 @@ void LineBuilder::update_last_line()
             .height = fragment.height(),
             .effective_box_top_offset = fragment.border_box_top(),
             .effective_box_bottom_offset = fragment.border_box_top(),
-            .line_height = fragment.layout_node().computed_values().line_height(),
+            .line_height = fragment.style_source().computed_values().line_height(),
         };
         if (fragment.is_atomic_inline()) {
             auto const& fragment_box_state = m_layout_state.get(static_cast<Box const&>(fragment.layout_node()));
@@ -470,7 +470,7 @@ void LineBuilder::update_last_line()
         }
 
         // Position the fragment according to the vertical-align of its own styled inline element.
-        auto const& own_vertical_align = fragment.layout_node().computed_values().vertical_align();
+        auto const& own_vertical_align = fragment.style_source().computed_values().vertical_align();
         CSSPixels new_fragment_block_offset = block_offset_value_for_alignment(own_vertical_align, fragment_metrics);
 
         // A 'top'- or 'bottom'-aligned box forms the root of its own aligned subtree and is positioned relative to the
@@ -478,9 +478,7 @@ void LineBuilder::update_last_line()
         auto* own_alignment = own_vertical_align.get_pointer<CSS::VerticalAlign>();
         bool own_alignment_is_line_relative = own_alignment && first_is_one_of(*own_alignment, CSS::VerticalAlign::Top, CSS::VerticalAlign::Bottom);
 
-        auto const& node = fragment.layout_node().has_style()
-            ? static_cast<NodeWithStyle const&>(fragment.layout_node())
-            : *fragment.layout_node().parent();
+        auto const& node = fragment.style_source();
         auto const* containing_block = &m_context.containing_block();
         auto const* first_ancestor = &node == containing_block ? nullptr : node.parent();
         for (auto const* ancestor = first_ancestor;
@@ -514,13 +512,13 @@ void LineBuilder::update_last_line()
             } else {
                 auto font_metrics = fragment.layout_node().first_available_font().pixel_metrics();
                 auto typographic_height = CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent);
-                auto leading = fragment.layout_node().computed_values().line_height() - typographic_height;
+                auto leading = fragment.style_source().computed_values().line_height() - typographic_height;
                 auto half_leading = leading / 2;
                 top_of_inline_box = (fragment.block_offset() + fragment.baseline() - CSSPixels::nearest_value_for(font_metrics.ascent) - half_leading);
                 bottom_of_inline_box = (fragment.block_offset() + fragment.baseline() + CSSPixels::nearest_value_for(font_metrics.descent) + half_leading);
             }
-            if (auto const* length_percentage = fragment.layout_node().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-                bottom_of_inline_box += length_percentage->to_px(fragment.layout_node().computed_values().line_height());
+            if (auto const* length_percentage = fragment.style_source().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
+                bottom_of_inline_box += length_percentage->to_px(fragment.style_source().computed_values().line_height());
             }
         }
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -103,6 +103,18 @@ Node* Node::topmost_layout_node_of_top_layer_placement()
 // https://www.w3.org/TR/css-display-3/#out-of-flow
 bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
 {
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    return node_with_style && node_with_style->is_out_of_flow(formatting_context);
+}
+
+bool Node::is_out_of_flow() const
+{
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    return node_with_style && node_with_style->is_out_of_flow();
+}
+
+bool NodeWithStyle::is_out_of_flow(FormattingContext const& formatting_context) const
+{
     // A layout node is out of flow if either:
 
     // 1. It is floated (which requires that floating is not inhibited).
@@ -199,9 +211,9 @@ static bool computed_values_establish_fixed_positioning_containing_block(NodeWit
 // Checks if the computed values of this node would establish an absolute positioning
 // containing block. This is separate from establishes_an_absolute_positioning_containing_block()
 // because that function also checks is<Box>, but we need these checks for inline elements too.
-bool Node::computed_values_establish_absolute_positioning_containing_block() const
+bool NodeWithStyle::computed_values_establish_absolute_positioning_containing_block() const
 {
-    auto const& computed_values = as<NodeWithStyle>(*this).computed_values();
+    auto const& computed_values = this->computed_values();
 
     // https://drafts.csswg.org/css-position/#position-property
     // Values other than 'static' make the box a positioned box, and cause it to establish an absolute positioning
@@ -210,11 +222,11 @@ bool Node::computed_values_establish_absolute_positioning_containing_block() con
         || (!computed_values.will_change().is_auto() && computed_values.will_change().has_property(CSS::PropertyID::Position)))
         return true;
 
-    return computed_values_establish_fixed_positioning_containing_block(as<NodeWithStyle>(*this));
+    return computed_values_establish_fixed_positioning_containing_block(*this);
 }
 
 // https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block
-bool Node::establishes_an_absolute_positioning_containing_block() const
+bool NodeWithStyle::establishes_an_absolute_positioning_containing_block() const
 {
     if (!is<Box>(*this))
         return false;
@@ -231,7 +243,7 @@ bool Node::establishes_an_absolute_positioning_containing_block() const
 }
 
 // https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block
-bool Node::establishes_a_fixed_positioning_containing_block() const
+bool NodeWithStyle::establishes_a_fixed_positioning_containing_block() const
 {
     if (!is<Box>(*this))
         return false;
@@ -241,10 +253,10 @@ bool Node::establishes_a_fixed_positioning_containing_block() const
     if (is_svg_foreign_object_box())
         return true;
 
-    return computed_values_establish_fixed_positioning_containing_block(as<NodeWithStyle>(*this));
+    return computed_values_establish_fixed_positioning_containing_block(*this);
 }
 
-Node::PositioningContainingBlockEstablishment Node::establishes_positioning_containing_blocks() const
+NodeWithStyle::PositioningContainingBlockEstablishment NodeWithStyle::establishes_positioning_containing_blocks() const
 {
     if (!is<Box>(*this))
         return {};
@@ -254,11 +266,11 @@ Node::PositioningContainingBlockEstablishment Node::establishes_positioning_cont
     if (is_svg_foreign_object_box())
         return { true, true };
 
-    auto establishes_fixed_positioning_containing_block = computed_values_establish_fixed_positioning_containing_block(as<NodeWithStyle>(*this));
+    auto establishes_fixed_positioning_containing_block = computed_values_establish_fixed_positioning_containing_block(*this);
     if (establishes_fixed_positioning_containing_block)
         return { true, true };
 
-    auto const& computed_values = as<NodeWithStyle>(*this).computed_values();
+    auto const& computed_values = this->computed_values();
     auto establishes_absolute_positioning_containing_block = computed_values.position() != CSS::Positioning::Static
         || (!computed_values.will_change().is_auto() && computed_values.will_change().has_property(CSS::PropertyID::Position));
     if (establishes_absolute_positioning_containing_block)
@@ -410,14 +422,11 @@ Box const* Node::non_anonymous_containing_block() const
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-bool Node::establishes_stacking_context() const
+bool NodeWithStyle::establishes_stacking_context() const
 {
     // NOTE: While MDN is not authoritative, there isn't a single convenient location
     //       in the CSS specifications where the rules for stacking contexts is described.
     //       That's why the "spec link" here points to MDN.
-
-    if (!has_style())
-        return false;
 
     if (is_svg_box())
         return false;
@@ -430,7 +439,7 @@ bool Node::establishes_stacking_context() const
     if (is_root_element())
         return true;
 
-    auto const& computed_values = as<NodeWithStyle>(*this).computed_values();
+    auto const& computed_values = this->computed_values();
 
     auto position = computed_values.position();
 
@@ -563,47 +572,34 @@ Viewport& Node::root()
     return *document().unsafe_layout_node();
 }
 
-bool Node::is_floating() const
+bool NodeWithStyle::is_floating() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
     // flex-items don't float.
     if (is_flex_item())
         return false;
-    return node_with_style->computed_values().float_() != CSS::Float::None;
+    return computed_values().float_() != CSS::Float::None;
 }
 
-bool Node::is_positioned() const
+bool NodeWithStyle::is_positioned() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    return node_with_style && node_with_style->computed_values().position() != CSS::Positioning::Static;
+    return computed_values().position() != CSS::Positioning::Static;
 }
 
-bool Node::is_absolutely_positioned() const
+bool NodeWithStyle::is_absolutely_positioned() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto position = node_with_style->computed_values().position();
+    auto position = computed_values().position();
     return position == CSS::Positioning::Absolute || position == CSS::Positioning::Fixed;
 }
 
-bool Node::is_fixed_position() const
+bool NodeWithStyle::is_fixed_position() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto position = node_with_style->computed_values().position();
+    auto position = computed_values().position();
     return position == CSS::Positioning::Fixed;
 }
 
-bool Node::is_sticky_position() const
+bool NodeWithStyle::is_sticky_position() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto position = node_with_style->computed_values().position();
+    auto position = computed_values().position();
     return position == CSS::Positioning::Sticky;
 }
 
@@ -1203,21 +1199,15 @@ bool Node::is_inline() const
     return as<NodeWithStyle>(*this).display().is_inline_outside();
 }
 
-bool Node::is_inline_block() const
+bool NodeWithStyle::is_inline_block() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto display = node_with_style->display();
+    auto display = this->display();
     return display.is_inline_outside() && display.is_flow_root_inside();
 }
 
-bool Node::is_inline_table() const
+bool NodeWithStyle::is_inline_table() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto display = node_with_style->display();
+    auto display = this->display();
     return display.is_inline_outside() && display.is_table_inside();
 }
 
@@ -1228,11 +1218,11 @@ bool Node::is_replaced_element() const
     return is_replaced_box() || is<HTML::HTMLInputElement>(dom_node());
 }
 
-bool Node::has_replaced_element_table_display_adjustment() const
+bool NodeWithStyle::has_replaced_element_table_display_adjustment() const
 {
     if (!is_replaced_element())
         return false;
-    auto display = as<NodeWithStyle>(*this).display_before_box_type_transformation();
+    auto display = display_before_box_type_transformation();
     return display.is_table_inside() || display.is_internal_table() || display.is_table_caption();
 }
 
@@ -1265,7 +1255,7 @@ NodeWithStyleAndBoxModelMetrics const* Node::nearest_fragmented_inline_ancestor(
 }
 
 // https://drafts.csswg.org/css-transforms-1/#transformable-element
-bool Node::is_transformable() const
+bool NodeWithStyle::is_transformable() const
 {
     // A transformable element is an element in one of these categories:
     auto const* dom_node = this->dom_node();
@@ -1291,7 +1281,7 @@ bool Node::is_transformable() const
     //   table-column boxes, and table-column-group boxes [CSS2].
     bool is_element_or_pseudo_element = is<DOM::Element>(dom_node) || is_generated_for_pseudo_element();
     if (is_element_or_pseudo_element && is_box()) {
-        auto display = as<NodeWithStyle>(*this).display();
+        auto display = this->display();
         if (display.is_table_column() || display.is_table_column_group())
             return false;
 
@@ -1514,74 +1504,63 @@ CSS::UserSelect Node::user_select_used_value() const
 }
 
 // https://drafts.csswg.org/css-contain-2/#containment-size
-bool Node::has_size_containment() const
+bool NodeWithStyle::has_size_containment() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-
     // However, giving an element size containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
     // Note: This is the principal box
 
     // - if its inner display type is 'table'
-    if (node_with_style->display().is_table_inside())
+    if (display().is_table_inside())
         return false;
 
     // - if its principal box is an internal table box
-    if (node_with_style->display().is_internal_table())
+    if (display().is_internal_table())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Implement this.
 
-    if (node_with_style->computed_values().contain().size_containment)
+    if (computed_values().contain().size_containment)
         return true;
 
-    if (node_with_style->computed_values().container_type().is_size_container)
+    if (computed_values().container_type().is_size_container)
         return true;
 
     return false;
 }
 // https://drafts.csswg.org/css-contain-2/#containment-inline-size
-bool Node::has_inline_size_containment() const
+bool NodeWithStyle::has_inline_size_containment() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-
     // Giving an element inline-size containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
     // Note: This is the principal box
 
     // - if its inner display type is 'table'
-    if (node_with_style->display().is_table_inside())
+    if (display().is_table_inside())
         return false;
 
     // - if its principal box is an internal table box
-    if (node_with_style->display().is_internal_table())
+    if (display().is_internal_table())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Implement this.
 
-    if (node_with_style->computed_values().contain().inline_size_containment)
+    if (computed_values().contain().inline_size_containment)
         return true;
 
-    if (node_with_style->computed_values().container_type().is_inline_size_container)
+    if (computed_values().container_type().is_inline_size_container)
         return true;
 
     return false;
 }
 // https://drafts.csswg.org/css-contain-2/#containment-layout
-bool Node::has_layout_containment() const
+bool NodeWithStyle::has_layout_containment() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto const& computed_values = node_with_style->computed_values();
+    auto const& computed_values = this->computed_values();
     auto has_layout_containment = computed_values.contain().layout_containment;
 
     // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
@@ -1597,49 +1576,42 @@ bool Node::has_layout_containment() const
     // Note: This is the principal box
 
     // - if its principal box is an internal table box other than 'table-cell'
-    if (node_with_style->display().is_internal_table() && !node_with_style->display().is_table_cell())
+    if (display().is_internal_table() && !display().is_table_cell())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Also check for internal ruby boxes.
-    if (node_with_style->display().is_inline_outside() && node_with_style->display().is_flow_inside() && !is_replaced_box())
+    if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
         return false;
 
     return true;
 }
 // https://drafts.csswg.org/css-contain-2/#containment-style
-bool Node::has_style_containment() const
+bool NodeWithStyle::has_style_containment() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-
     // However, giving an element style containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
     // Note: This is the principal box
 
-    if (node_with_style->computed_values().contain().style_containment)
+    if (computed_values().contain().style_containment)
         return true;
 
-    if (node_with_style->computed_values().container_type().is_size_container || node_with_style->computed_values().container_type().is_inline_size_container)
+    if (computed_values().container_type().is_size_container || computed_values().container_type().is_inline_size_container)
         return true;
 
     // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
     // Changes the used value of the 'contain' property so as to turn on layout containment, style containment, and
     // paint containment for the element.
-    if (node_with_style->computed_values().content_visibility() == CSS::ContentVisibility::Auto)
+    if (computed_values().content_visibility() == CSS::ContentVisibility::Auto)
         return true;
 
     return false;
 }
 // https://drafts.csswg.org/css-contain-2/#containment-paint
-bool Node::has_paint_containment() const
+bool NodeWithStyle::has_paint_containment() const
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(*this);
-    if (!node_with_style)
-        return false;
-    auto const& computed_values = node_with_style->computed_values();
+    auto const& computed_values = this->computed_values();
     auto has_paint_containment = computed_values.contain().paint_containment;
 
     // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
@@ -1655,12 +1627,12 @@ bool Node::has_paint_containment() const
     // Note: This is the principal box
 
     // - if its principal box is an internal table box other than 'table-cell'
-    if (node_with_style->display().is_internal_table() && !node_with_style->display().is_table_cell())
+    if (display().is_internal_table() && !display().is_table_cell())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Also check for internal ruby boxes.
-    if (node_with_style->display().is_inline_outside() && node_with_style->display().is_flow_inside() && !is_replaced_box())
+    if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
         return false;
 
     return true;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -106,7 +106,7 @@ bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
     // A layout node is out of flow if either:
 
     // 1. It is floated (which requires that floating is not inhibited).
-    if (!formatting_context.inhibits_floating() && computed_values().float_() != CSS::Float::None)
+    if (!formatting_context.inhibits_floating() && is_floating())
         return true;
 
     // 2. It is "absolutely positioned".
@@ -117,7 +117,7 @@ bool Node::is_out_of_flow(FormattingContext const& formatting_context) const
 }
 
 // https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block
-static bool computed_values_establish_fixed_positioning_containing_block(Node const& node)
+static bool computed_values_establish_fixed_positioning_containing_block(NodeWithStyle const& node)
 {
     auto const& computed_values = node.computed_values();
 
@@ -201,7 +201,7 @@ static bool computed_values_establish_fixed_positioning_containing_block(Node co
 // because that function also checks is<Box>, but we need these checks for inline elements too.
 bool Node::computed_values_establish_absolute_positioning_containing_block() const
 {
-    auto const& computed_values = this->computed_values();
+    auto const& computed_values = as<NodeWithStyle>(*this).computed_values();
 
     // https://drafts.csswg.org/css-position/#position-property
     // Values other than 'static' make the box a positioned box, and cause it to establish an absolute positioning
@@ -210,7 +210,7 @@ bool Node::computed_values_establish_absolute_positioning_containing_block() con
         || (!computed_values.will_change().is_auto() && computed_values.will_change().has_property(CSS::PropertyID::Position)))
         return true;
 
-    return computed_values_establish_fixed_positioning_containing_block(*this);
+    return computed_values_establish_fixed_positioning_containing_block(as<NodeWithStyle>(*this));
 }
 
 // https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block
@@ -241,7 +241,7 @@ bool Node::establishes_a_fixed_positioning_containing_block() const
     if (is_svg_foreign_object_box())
         return true;
 
-    return computed_values_establish_fixed_positioning_containing_block(*this);
+    return computed_values_establish_fixed_positioning_containing_block(as<NodeWithStyle>(*this));
 }
 
 Node::PositioningContainingBlockEstablishment Node::establishes_positioning_containing_blocks() const
@@ -254,11 +254,11 @@ Node::PositioningContainingBlockEstablishment Node::establishes_positioning_cont
     if (is_svg_foreign_object_box())
         return { true, true };
 
-    auto establishes_fixed_positioning_containing_block = computed_values_establish_fixed_positioning_containing_block(*this);
+    auto establishes_fixed_positioning_containing_block = computed_values_establish_fixed_positioning_containing_block(as<NodeWithStyle>(*this));
     if (establishes_fixed_positioning_containing_block)
         return { true, true };
 
-    auto const& computed_values = this->computed_values();
+    auto const& computed_values = as<NodeWithStyle>(*this).computed_values();
     auto establishes_absolute_positioning_containing_block = computed_values.position() != CSS::Positioning::Static
         || (!computed_values.will_change().is_auto() && computed_values.will_change().has_property(CSS::PropertyID::Position));
     if (establishes_absolute_positioning_containing_block)
@@ -293,7 +293,7 @@ void Node::recompute_containing_block(Badge<DOM::Document>)
         return;
     }
 
-    auto position = computed_values().position();
+    auto position = as<NodeWithStyle>(*this).computed_values().position();
 
     // https://drafts.csswg.org/css-position-3/#absolute-cb
     if (position == CSS::Positioning::Absolute) {
@@ -430,7 +430,7 @@ bool Node::establishes_stacking_context() const
     if (is_root_element())
         return true;
 
-    auto const& computed_values = this->computed_values();
+    auto const& computed_values = as<NodeWithStyle>(*this).computed_values();
 
     auto position = computed_values.position();
 
@@ -565,40 +565,45 @@ Viewport& Node::root()
 
 bool Node::is_floating() const
 {
-    if (!has_style())
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
         return false;
     // flex-items don't float.
     if (is_flex_item())
         return false;
-    return computed_values().float_() != CSS::Float::None;
+    return node_with_style->computed_values().float_() != CSS::Float::None;
 }
 
 bool Node::is_positioned() const
 {
-    return has_style() && computed_values().position() != CSS::Positioning::Static;
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    return node_with_style && node_with_style->computed_values().position() != CSS::Positioning::Static;
 }
 
 bool Node::is_absolutely_positioned() const
 {
-    if (!has_style())
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
         return false;
-    auto position = computed_values().position();
+    auto position = node_with_style->computed_values().position();
     return position == CSS::Positioning::Absolute || position == CSS::Positioning::Fixed;
 }
 
 bool Node::is_fixed_position() const
 {
-    if (!has_style())
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
         return false;
-    auto position = computed_values().position();
+    auto position = node_with_style->computed_values().position();
     return position == CSS::Positioning::Fixed;
 }
 
 bool Node::is_sticky_position() const
 {
-    if (!has_style())
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
         return false;
-    auto position = computed_values().position();
+    auto position = node_with_style->computed_values().position();
     return position == CSS::Positioning::Sticky;
 }
 
@@ -1191,39 +1196,28 @@ String Node::debug_description() const
     return MUST(builder.to_string());
 }
 
-CSS::Display Node::display() const
-{
-    if (!has_style()) {
-        // NOTE: No style means this is dumb text content.
-        return CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow);
-    }
-
-    return computed_values().display();
-}
-
-CSS::Display Node::display_before_box_type_transformation() const
-{
-    if (!has_style()) {
-        return CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow);
-    }
-
-    return computed_values().display_before_box_type_transformation();
-}
-
 bool Node::is_inline() const
 {
-    return display().is_inline_outside();
+    if (is<TextNode>(*this))
+        return true;
+    return as<NodeWithStyle>(*this).display().is_inline_outside();
 }
 
 bool Node::is_inline_block() const
 {
-    auto display = this->display();
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+    auto display = node_with_style->display();
     return display.is_inline_outside() && display.is_flow_root_inside();
 }
 
 bool Node::is_inline_table() const
 {
-    auto display = this->display();
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+    auto display = node_with_style->display();
     return display.is_inline_outside() && display.is_table_inside();
 }
 
@@ -1238,7 +1232,7 @@ bool Node::has_replaced_element_table_display_adjustment() const
 {
     if (!is_replaced_element())
         return false;
-    auto display = display_before_box_type_transformation();
+    auto display = as<NodeWithStyle>(*this).display_before_box_type_transformation();
     return display.is_table_inside() || display.is_internal_table() || display.is_table_caption();
 }
 
@@ -1246,14 +1240,17 @@ bool Node::is_atomic_inline() const
 {
     if (is_replaced_element() || is_list_item_marker_box())
         return true;
-    auto display = this->display();
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+    auto display = node_with_style->display();
     return display.is_inline_outside() && !display.is_flow_inside();
 }
 
 bool Node::is_fragmented_inline() const
 {
     return is_inline_node()
-        || (is_list_item_box() && display().is_inline_outside() && display().is_flow_inside());
+        || (is_list_item_box() && as<NodeWithStyle>(*this).display().is_inline_outside() && as<NodeWithStyle>(*this).display().is_flow_inside());
 }
 
 NodeWithStyleAndBoxModelMetrics const* Node::nearest_fragmented_inline_ancestor() const
@@ -1294,7 +1291,7 @@ bool Node::is_transformable() const
     //   table-column boxes, and table-column-group boxes [CSS2].
     bool is_element_or_pseudo_element = is<DOM::Element>(dom_node) || is_generated_for_pseudo_element();
     if (is_element_or_pseudo_element && is_box()) {
-        auto display = this->display();
+        auto display = as<NodeWithStyle>(*this).display();
         if (display.is_table_column() || display.is_table_column_group())
             return false;
 
@@ -1501,7 +1498,9 @@ CSS::UserSelect Node::user_select_used_value() const
             return node->user_select_used_value();
     }
 
-    auto computed_value = computed_values().user_select();
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    auto const& computed_values = node_with_style ? node_with_style->computed_values() : parent()->computed_values();
+    auto computed_value = computed_values.user_select();
     if (computed_value != CSS::UserSelect::Auto)
         return computed_value;
 
@@ -1517,26 +1516,30 @@ CSS::UserSelect Node::user_select_used_value() const
 // https://drafts.csswg.org/css-contain-2/#containment-size
 bool Node::has_size_containment() const
 {
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+
     // However, giving an element size containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
     // Note: This is the principal box
 
     // - if its inner display type is 'table'
-    if (display().is_table_inside())
+    if (node_with_style->display().is_table_inside())
         return false;
 
     // - if its principal box is an internal table box
-    if (display().is_internal_table())
+    if (node_with_style->display().is_internal_table())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Implement this.
 
-    if (computed_values().contain().size_containment)
+    if (node_with_style->computed_values().contain().size_containment)
         return true;
 
-    if (computed_values().container_type().is_size_container)
+    if (node_with_style->computed_values().container_type().is_size_container)
         return true;
 
     return false;
@@ -1544,26 +1547,30 @@ bool Node::has_size_containment() const
 // https://drafts.csswg.org/css-contain-2/#containment-inline-size
 bool Node::has_inline_size_containment() const
 {
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+
     // Giving an element inline-size containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
     // Note: This is the principal box
 
     // - if its inner display type is 'table'
-    if (display().is_table_inside())
+    if (node_with_style->display().is_table_inside())
         return false;
 
     // - if its principal box is an internal table box
-    if (display().is_internal_table())
+    if (node_with_style->display().is_internal_table())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Implement this.
 
-    if (computed_values().contain().inline_size_containment)
+    if (node_with_style->computed_values().contain().inline_size_containment)
         return true;
 
-    if (computed_values().container_type().is_inline_size_container)
+    if (node_with_style->computed_values().container_type().is_inline_size_container)
         return true;
 
     return false;
@@ -1571,7 +1578,10 @@ bool Node::has_inline_size_containment() const
 // https://drafts.csswg.org/css-contain-2/#containment-layout
 bool Node::has_layout_containment() const
 {
-    auto const& computed_values = this->computed_values();
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+    auto const& computed_values = node_with_style->computed_values();
     auto has_layout_containment = computed_values.contain().layout_containment;
 
     // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
@@ -1587,12 +1597,12 @@ bool Node::has_layout_containment() const
     // Note: This is the principal box
 
     // - if its principal box is an internal table box other than 'table-cell'
-    if (display().is_internal_table() && !display().is_table_cell())
+    if (node_with_style->display().is_internal_table() && !node_with_style->display().is_table_cell())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Also check for internal ruby boxes.
-    if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
+    if (node_with_style->display().is_inline_outside() && node_with_style->display().is_flow_inside() && !is_replaced_box())
         return false;
 
     return true;
@@ -1600,21 +1610,25 @@ bool Node::has_layout_containment() const
 // https://drafts.csswg.org/css-contain-2/#containment-style
 bool Node::has_style_containment() const
 {
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+
     // However, giving an element style containment has no effect if any of the following are true:
 
     // - if the element does not generate a principal box (as is the case with 'display: contents' or 'display: none')
     // Note: This is the principal box
 
-    if (computed_values().contain().style_containment)
+    if (node_with_style->computed_values().contain().style_containment)
         return true;
 
-    if (computed_values().container_type().is_size_container || computed_values().container_type().is_inline_size_container)
+    if (node_with_style->computed_values().container_type().is_size_container || node_with_style->computed_values().container_type().is_inline_size_container)
         return true;
 
     // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
     // Changes the used value of the 'contain' property so as to turn on layout containment, style containment, and
     // paint containment for the element.
-    if (computed_values().content_visibility() == CSS::ContentVisibility::Auto)
+    if (node_with_style->computed_values().content_visibility() == CSS::ContentVisibility::Auto)
         return true;
 
     return false;
@@ -1622,7 +1636,10 @@ bool Node::has_style_containment() const
 // https://drafts.csswg.org/css-contain-2/#containment-paint
 bool Node::has_paint_containment() const
 {
-    auto const& computed_values = this->computed_values();
+    auto const* node_with_style = as_if<NodeWithStyle>(*this);
+    if (!node_with_style)
+        return false;
+    auto const& computed_values = node_with_style->computed_values();
     auto has_paint_containment = computed_values.contain().paint_containment;
 
     // https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-auto
@@ -1638,12 +1655,12 @@ bool Node::has_paint_containment() const
     // Note: This is the principal box
 
     // - if its principal box is an internal table box other than 'table-cell'
-    if (display().is_internal_table() && !display().is_table_cell())
+    if (node_with_style->display().is_internal_table() && !node_with_style->display().is_table_cell())
         return false;
 
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Also check for internal ruby boxes.
-    if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
+    if (node_with_style->display().is_inline_outside() && node_with_style->display().is_flow_inside() && !is_replaced_box())
         return false;
 
     return true;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -444,12 +444,12 @@ inline CSS::ImmutableComputedValues const& Node::computed_values() const
 
 inline NodeWithStyle const* Node::parent() const
 {
-    return static_cast<NodeWithStyle const*>(Base::parent().ptr());
+    return static_cast<NodeWithStyle const*>(Base::parent_ptr());
 }
 
 inline NodeWithStyle* Node::parent()
 {
-    return static_cast<NodeWithStyle*>(Base::parent().ptr());
+    return static_cast<NodeWithStyle*>(Base::parent_ptr());
 }
 
 inline Gfx::Font const& NodeWithStyle::first_available_font() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -124,9 +124,6 @@ public:
 
     virtual bool can_have_children() const { return true; }
 
-    CSS::Display display() const;
-    CSS::Display display_before_box_type_transformation() const;
-
     bool is_inline() const;
     bool is_inline_block() const;
     bool is_inline_table() const;
@@ -236,8 +233,6 @@ public:
     Gfx::Font const& font(DisplayListRecordingContext&) const;
     Gfx::Font const& font(float scale_factor) const;
 
-    CSS::ImmutableComputedValues const& computed_values() const;
-
     NodeWithStyle* parent();
     NodeWithStyle const* parent() const;
 
@@ -258,16 +253,6 @@ public:
     // An element is called in-flow if it is not out-of-flow.
     // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
     bool is_in_flow() const { return !is_out_of_flow(); }
-
-    [[nodiscard]] bool has_css_transform() const
-    {
-        auto const& computed_values = this->computed_values();
-        auto has_transform = !computed_values.transformations().is_empty()
-            || computed_values.rotate()
-            || computed_values.translate()
-            || computed_values.scale();
-        return has_transform && is_transformable();
-    }
 
     // https://drafts.csswg.org/css-ui/#propdef-user-select
     CSS::UserSelect user_select_used_value() const;
@@ -345,6 +330,17 @@ public:
 
     CSS::ImmutableComputedValues const& computed_values() const { return static_cast<CSS::ImmutableComputedValues const&>(*m_computed_values); }
     CSS::MutableComputedValues& mutable_computed_values() { return static_cast<CSS::MutableComputedValues&>(*m_computed_values); }
+    CSS::Display display() const { return computed_values().display(); }
+    CSS::Display display_before_box_type_transformation() const { return computed_values().display_before_box_type_transformation(); }
+    [[nodiscard]] bool has_css_transform() const
+    {
+        auto const& computed_values = this->computed_values();
+        auto has_transform = !computed_values.transformations().is_empty()
+            || computed_values.rotate()
+            || computed_values.translate()
+            || computed_values.scale();
+        return has_transform && is_transformable();
+    }
 
     void clear_image_observers();
     void apply_style(CSS::ComputedProperties const&);
@@ -431,15 +427,6 @@ inline Gfx::Font const& Node::font(float scale_factor) const
 {
     auto const& font = first_available_font();
     return font.with_size(font.point_size() * scale_factor);
-}
-
-inline CSS::ImmutableComputedValues const& Node::computed_values() const
-{
-    VERIFY(has_style_or_parent_with_style());
-
-    if (m_has_style)
-        return static_cast<NodeWithStyle const*>(this)->computed_values();
-    return parent()->computed_values();
 }
 
 inline NodeWithStyle const* Node::parent() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -94,6 +94,8 @@ public:
 
     RefPtr<Painting::Paintable> paintable() { return m_paintable; }
     RefPtr<Painting::Paintable const> paintable() const { return m_paintable; }
+    Painting::Paintable* paintable_ptr() { return m_paintable.ptr(); }
+    Painting::Paintable const* paintable_ptr() const { return m_paintable.ptr(); }
     void set_paintable(RefPtr<Painting::Paintable>);
     void clear_paintable();
     void prepare_for_detach_from_layout_tree();

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -125,17 +125,21 @@ public:
     virtual bool can_have_children() const { return true; }
 
     bool is_inline() const;
-    bool is_inline_block() const;
-    bool is_inline_table() const;
 
     bool is_replaced_element() const;
-    bool has_replaced_element_table_display_adjustment() const;
     bool is_atomic_inline() const;
     bool is_fragmented_inline() const;
     NodeWithStyleAndBoxModelMetrics const* nearest_fragmented_inline_ancestor() const;
-    bool is_transformable() const;
 
     bool is_out_of_flow(FormattingContext const&) const;
+
+    // An element is called out of flow if it is floated, absolutely positioned, or is the root element.
+    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
+    bool is_out_of_flow() const;
+
+    // An element is called in-flow if it is not out-of-flow.
+    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
+    bool is_in_flow() const { return !is_out_of_flow(); }
 
     // These are used to optimize hot is<T> variants for some classes where dynamic_cast is too slow.
     virtual bool is_box() const { return false; }
@@ -168,12 +172,6 @@ public:
 
     template<typename T>
     bool fast_is() const = delete;
-
-    bool is_floating() const;
-    bool is_positioned() const;
-    bool is_absolutely_positioned() const;
-    bool is_fixed_position() const;
-    bool is_sticky_position() const;
 
     bool is_flex_item() const { return m_is_flex_item; }
     void set_flex_item(bool b) { m_is_flex_item = b; }
@@ -217,18 +215,6 @@ public:
     // https://www.w3.org/TR/CSS22/visuren.html#anonymous-block-level
     Box const* non_anonymous_containing_block() const;
 
-    bool establishes_stacking_context() const;
-
-    struct PositioningContainingBlockEstablishment {
-        bool absolute;
-        bool fixed;
-    };
-
-    bool computed_values_establish_absolute_positioning_containing_block() const;
-    bool establishes_an_absolute_positioning_containing_block() const;
-    bool establishes_a_fixed_positioning_containing_block() const;
-    PositioningContainingBlockEstablishment establishes_positioning_containing_blocks() const;
-
     Gfx::Font const& first_available_font() const;
     Gfx::Font const& font(DisplayListRecordingContext&) const;
     Gfx::Font const& font(float scale_factor) const;
@@ -246,23 +232,8 @@ public:
     u32 initial_quote_nesting_level() const { return m_initial_quote_nesting_level; }
     void set_initial_quote_nesting_level(u32 value) { m_initial_quote_nesting_level = value; }
 
-    // An element is called out of flow if it is floated, absolutely positioned, or is the root element.
-    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
-    bool is_out_of_flow() const { return is_floating() || is_absolutely_positioned(); }
-
-    // An element is called in-flow if it is not out-of-flow.
-    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
-    bool is_in_flow() const { return !is_out_of_flow(); }
-
     // https://drafts.csswg.org/css-ui/#propdef-user-select
     CSS::UserSelect user_select_used_value() const;
-
-    // https://drafts.csswg.org/css-contain-2/#containment-types
-    bool has_size_containment() const;
-    bool has_inline_size_containment() const;
-    bool has_layout_containment() const;
-    bool has_style_containment() const;
-    bool has_paint_containment() const;
 
     [[nodiscard]] bool has_been_wrapped_in_table_wrapper() const { return m_has_been_wrapped_in_table_wrapper; }
     void set_has_been_wrapped_in_table_wrapper(bool value) { m_has_been_wrapped_in_table_wrapper = value; }
@@ -332,6 +303,46 @@ public:
     CSS::MutableComputedValues& mutable_computed_values() { return static_cast<CSS::MutableComputedValues&>(*m_computed_values); }
     CSS::Display display() const { return computed_values().display(); }
     CSS::Display display_before_box_type_transformation() const { return computed_values().display_before_box_type_transformation(); }
+    bool is_inline_block() const;
+    bool is_inline_table() const;
+    bool has_replaced_element_table_display_adjustment() const;
+    bool is_transformable() const;
+
+    bool is_floating() const;
+    bool is_positioned() const;
+    bool is_absolutely_positioned() const;
+    bool is_fixed_position() const;
+    bool is_sticky_position() const;
+
+    // https://www.w3.org/TR/css-display-3/#out-of-flow
+    bool is_out_of_flow(FormattingContext const&) const;
+
+    // An element is called out of flow if it is floated, absolutely positioned, or is the root element.
+    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
+    bool is_out_of_flow() const { return is_floating() || is_absolutely_positioned(); }
+
+    // An element is called in-flow if it is not out-of-flow.
+    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
+    bool is_in_flow() const { return !is_out_of_flow(); }
+
+    bool establishes_stacking_context() const;
+    bool computed_values_establish_absolute_positioning_containing_block() const;
+    bool establishes_an_absolute_positioning_containing_block() const;
+    bool establishes_a_fixed_positioning_containing_block() const;
+
+    struct PositioningContainingBlockEstablishment {
+        bool absolute;
+        bool fixed;
+    };
+    PositioningContainingBlockEstablishment establishes_positioning_containing_blocks() const;
+
+    // https://drafts.csswg.org/css-contain-2/#containment-types
+    bool has_size_containment() const;
+    bool has_inline_size_containment() const;
+    bool has_layout_containment() const;
+    bool has_style_containment() const;
+    bool has_paint_containment() const;
+
     [[nodiscard]] bool has_css_transform() const
     {
         auto const& computed_values = this->computed_values();

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -187,7 +187,7 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
                 // NB: Reserve one pixel of reachable inline-axis overflow for an end-of-line caret. This keeps the
                 //     caret at its insertion position while allowing a text control to scroll the painted bar fully
                 //     into view, matching the caret overflow accounted for by other engines.
-                auto const& computed_values = fragment.layout_node().computed_values();
+                auto const& computed_values = fragment.style_source().computed_values();
                 if (inline_axis_is_horizontal(computed_values.writing_mode())) {
                     if (computed_values.inline_axis_is_reverse())
                         fragment_rect.set_left(fragment_rect.left() - 1);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -37,10 +37,11 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
 {
     CSSPixels caption_height = 0;
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
-        if (!child->display().is_table_caption() || child->computed_values().caption_side() != phase) {
+        auto const* child_box_ptr = as_if<Box>(*child);
+        if (!child_box_ptr || !child_box_ptr->display().is_table_caption() || child_box_ptr->computed_values().caption_side() != phase) {
             continue;
         }
-        auto const& child_box = as<Box>(*child);
+        auto const& child_box = *child_box_ptr;
         // Captions live inside the table wrapper, so their quirks percentage height basis derives
         // from the wrapper, not from anything the table box inherited.
         auto const& caption_constraints = m_participant_constraints;
@@ -493,12 +494,11 @@ CSSPixels TableFormattingContext::compute_capmin()
     CSSPixels capmin = 0;
     auto width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_width.value_or(0);
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
-        if (!child->display().is_table_caption()) {
+        auto const* child_box = as_if<Box>(*child);
+        if (!child_box || !child_box->display().is_table_caption()) {
             continue;
         }
-        VERIFY(child->is_box());
-        auto const& child_box = static_cast<Box const&>(*child);
-        auto const& computed_values = child_box.computed_values();
+        auto const& computed_values = child_box->computed_values();
 
         auto margin_left = computed_values.margin().left().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero();
         auto margin_right = computed_values.margin().right().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero();
@@ -514,9 +514,9 @@ CSSPixels TableFormattingContext::compute_capmin()
                 + margin_right;
         };
 
-        auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_width(child_box, m_participant_constraints));
+        auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_width(*child_box, m_participant_constraints));
         if (!computed_values.width().is_auto() && !computed_values.width().contains_percentage()) {
-            auto preferred_inner_width = calculate_inner_width(child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width(), m_participant_constraints);
+            auto preferred_inner_width = calculate_inner_width(*child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width(), m_participant_constraints);
             caption_min_content_contribution = max(caption_min_content_contribution, outer_size_for_inner_size(preferred_inner_width));
         }
 
@@ -1344,7 +1344,10 @@ void TableFormattingContext::position_cell_boxes()
         auto child = cell.box.first_child();
         if (!child || child->next_sibling())
             return false;
-        auto const& display = child->computed_values().display();
+        auto const* child_with_style = as_if<NodeWithStyle>(*child);
+        if (!child_with_style)
+            return false;
+        auto const& display = child_with_style->display();
         return display.is_flex_inside() || display.is_grid_inside();
     };
 
@@ -1467,7 +1470,7 @@ bool TableFormattingContext::border_is_less_specific(CSS::BorderData const& a, C
 
 CSS::BorderData const& TableFormattingContext::border_data_conflicting_edge(TableFormattingContext::ConflictingEdge const& conflicting_edge)
 {
-    auto const& style = conflicting_edge.element->computed_values();
+    auto const& style = as<NodeWithStyle>(*conflicting_edge.element).computed_values();
     switch (conflicting_edge.side) {
     case ConflictingSide::Top: {
         return style.border_top();
@@ -1644,11 +1647,12 @@ void TableFormattingContext::BorderConflictFinder::collect_conflicting_col_eleme
     m_col_elements_by_index.resize(m_context->m_columns.size());
     size_t column_index = 0;
     for (auto child = m_context->table_box().first_child(); child; child = child->next_sibling()) {
-        if (!child->display().is_table_column_group()) {
+        auto const* child_with_style = as_if<NodeWithStyle>(*child);
+        if (!child_with_style || !child_with_style->display().is_table_column_group()) {
             continue;
         }
         for (auto child_of_column_group = child->first_child(); child_of_column_group; child_of_column_group = child_of_column_group->next_sibling()) {
-            VERIFY(child_of_column_group->display().is_table_column());
+            VERIFY(as<NodeWithStyle>(*child_of_column_group).display().is_table_column());
             auto const& col_node = static_cast<HTML::HTMLElement const&>(*child_of_column_group->dom_node());
             unsigned span = col_node.get_attribute_value(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             m_col_elements_by_index.resize(column_index + span);

--- a/Libraries/LibWeb/Layout/TableGrid.cpp
+++ b/Libraries/LibWeb/Layout/TableGrid.cpp
@@ -39,10 +39,11 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
         // 5. Let current cell be the first td or th element child in the tr element being processed.
         for (auto child = row.first_child(); child; child = child->next_sibling()) {
             // NB: This actually applies to children with `display: table-cell`, not just td/th elements.
-            if (!child->display().is_table_cell())
+            auto const* child_box = as_if<Box>(*child);
+            if (!child_box || !child_box->display().is_table_cell())
                 continue;
 
-            auto& current_cell = as<Box>(*child);
+            auto& current_cell = const_cast<Box&>(*child_box);
 
             // 6. Cells: While x_current is less than x_width and the slot with coordinate (x_current, y_current)
             //    already has a cell assigned to it, increase x_current by 1.

--- a/Libraries/LibWeb/Layout/TableGrid.h
+++ b/Libraries/LibWeb/Layout/TableGrid.h
@@ -57,18 +57,23 @@ public:
 
     static bool is_table_row_group(Node const& node)
     {
-        auto const& display = node.display();
+        auto const* node_with_style = as_if<NodeWithStyle>(node);
+        if (!node_with_style)
+            return false;
+        auto const& display = node_with_style->display();
         return display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group();
     }
 
     static bool is_table_row(Node const& node)
     {
-        return node.display().is_table_row();
+        auto const* node_with_style = as_if<NodeWithStyle>(node);
+        return node_with_style && node_with_style->display().is_table_row();
     }
 
     static bool is_table_column_group(Node const& node)
     {
-        return node.display().is_table_column_group();
+        auto const* node_with_style = as_if<NodeWithStyle>(node);
+        return node_with_style && node_with_style->display().is_table_column_group();
     }
 
     template<typename Matcher, typename Callback>

--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -341,7 +341,7 @@ static Utf16String apply_text_transform(Utf16String const& string, CSS::TextTran
 
 TextNode::TextForRenderingCacheKey TextNode::create_text_for_rendering_cache_key() const
 {
-    auto text_transform = computed_values().text_transform();
+    auto text_transform = parent()->computed_values().text_transform();
     Optional<Utf16String> lang;
     if (first_is_one_of(text_transform, CSS::TextTransform::Uppercase, CSS::TextTransform::Lowercase, CSS::TextTransform::Capitalize)) {
         if (auto parent_element = parent_element_for_text_transform())
@@ -350,7 +350,7 @@ TextNode::TextForRenderingCacheKey TextNode::create_text_for_rendering_cache_key
 
     return {
         .text_transform = text_transform,
-        .white_space_collapse = computed_values().white_space_collapse(),
+        .white_space_collapse = parent()->computed_values().white_space_collapse(),
         .lang = move(lang),
         .is_password_input = is_password_input(),
         .dom_start_offset = dom_start_offset(),
@@ -508,7 +508,7 @@ TextNode::ChunkList const& TextNode::chunks_for_layout(bool should_wrap_lines, b
 {
     auto const& cache = ensure_text_dependent_cache();
 
-    auto const& computed_values = this->computed_values();
+    auto const& computed_values = parent()->computed_values();
     ChunkCacheKey key {
         .should_wrap_lines = should_wrap_lines,
         .should_respect_linebreaks = should_respect_linebreaks,
@@ -546,7 +546,7 @@ static bool is_interword_space(u32 code_point)
 }
 
 TextNode::ChunkIterator::ChunkIterator(TextNode const& text_node, bool should_wrap_lines, bool should_respect_linebreaks)
-    : ChunkIterator(text_node, text_node.text_for_rendering(), text_node.grapheme_segmenter(), text_node.line_segmenter(), text_node.computed_values().word_break(), should_wrap_lines, should_respect_linebreaks)
+    : ChunkIterator(text_node, text_node.text_for_rendering(), text_node.grapheme_segmenter(), text_node.line_segmenter(), text_node.parent()->computed_values().word_break(), should_wrap_lines, should_respect_linebreaks)
 {
 }
 
@@ -556,13 +556,13 @@ TextNode::ChunkIterator::ChunkIterator(TextNode const& text_node, Utf16View cons
     : m_should_wrap_lines(should_wrap_lines)
     , m_should_respect_linebreaks(should_respect_linebreaks)
     , m_view(text)
-    , m_font_cascade_list(text_node.computed_values().font_list())
+    , m_font_cascade_list(text_node.parent()->computed_values().font_list())
     , m_grapheme_segmenter(grapheme_segmenter)
     , m_line_segmenter(line_segmenter)
     , m_word_break(word_break)
-    , m_font_variant_emoji(text_node.computed_values().font_variant_emoji())
+    , m_font_variant_emoji(text_node.parent()->computed_values().font_variant_emoji())
 {
-    m_should_collapse_whitespace = first_is_one_of(text_node.computed_values().white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse, CSS::WhiteSpaceCollapse::PreserveBreaks);
+    m_should_collapse_whitespace = first_is_one_of(text_node.parent()->computed_values().white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse, CSS::WhiteSpaceCollapse::PreserveBreaks);
 }
 
 static Gfx::GlyphRun::TextType text_type_for_code_point(u32 code_point)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -89,8 +89,8 @@ static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithSt
     return parent.display().is_table_inside()
         && child_with_style
         && !child.is_anonymous()
-        && child.is_out_of_flow()
-        && !child.has_replaced_element_table_display_adjustment()
+        && child_with_style->is_out_of_flow()
+        && !child_with_style->has_replaced_element_table_display_adjustment()
         && child_with_style->display_before_box_type_transformation().is_internal_table();
 }
 
@@ -1179,7 +1179,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     // Giving an element style containment has the following effects:
     // 2. The effects of the 'content' property’s 'open-quote', 'close-quote', 'no-open-quote' and 'no-close-quote' must
     //    be scoped to the element’s sub-tree.
-    if (layout_node->has_style_or_parent_with_style() && layout_node->has_style_containment()) {
+    if (auto const* node_with_style = as_if<NodeWithStyle>(*layout_node); node_with_style && node_with_style->has_style_containment()) {
         m_quote_nesting_level = prior_quote_nesting_level;
     }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -85,11 +85,13 @@ static bool has_in_flow_block_children(Layout::Node const& layout_node)
 
 static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithStyle const& parent, Layout::Node const& child)
 {
+    auto const* child_with_style = as_if<Layout::NodeWithStyle>(child);
     return parent.display().is_table_inside()
+        && child_with_style
         && !child.is_anonymous()
         && child.is_out_of_flow()
         && !child.has_replaced_element_table_display_adjustment()
-        && child.display_before_box_type_transformation().is_internal_table();
+        && child_with_style->display_before_box_type_transformation().is_internal_table();
 }
 
 static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::Display display)
@@ -228,7 +230,7 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
         insertion_point.set_children_are_inline(true);
     } else if (node.is_in_flow()) {
         // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
-        if (!insertion_point.display().is_inline_outside() || !insertion_point.display().is_flow_inside())
+        if (!as<NodeWithStyle>(insertion_point).display().is_inline_outside() || !as<NodeWithStyle>(insertion_point).display().is_flow_inside())
             insertion_point.set_children_are_inline(false);
     }
 }
@@ -398,7 +400,7 @@ static Optional<FirstLetterTarget> find_first_letter_in_text(TextNode& text_node
 
     // When white-space preserves segment breaks, a newline before any letter puts the letter on a later line, so the
     // first formatted line is empty and ::first-letter must not match.
-    auto const white_space_collapse = text_node.computed_values().white_space_collapse();
+    auto const white_space_collapse = text_node.parent()->computed_values().white_space_collapse();
     auto const preserves_segment_breaks = first_is_one_of(white_space_collapse,
         CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces);
 
@@ -667,7 +669,8 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
                     layout_node = create_content_image_box(document, nullptr, *pseudo_element_style, image);
                 }
                 layout_node->set_generated_for(pseudo_element, element);
-                insert_node_into_inline_or_block_ancestor(*layout_node, layout_node->display(), AppendOrPrepend::Append);
+                auto display = layout_node->is_text_node() ? CSS::Display::from_short(CSS::Display::Short::Inline) : as<NodeWithStyle>(*layout_node).display();
+                insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
             }
             pop_parent();
         } else {
@@ -1291,7 +1294,7 @@ void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, Layo
     // If the element is an input element, or if it is a button element and its computed value for 'display' is not
     // 'inline-grid', 'grid', 'inline-flex', or 'flex', then the element's box has a child anonymous button content box
     // with the following behaviors:
-    auto display = layout_node.display();
+    auto display = as<NodeWithStyle>(layout_node).display();
     if (!display.is_grid_inside() && !display.is_flex_inside()) {
         auto& parent = as<NodeWithStyle>(layout_node);
 
@@ -1503,7 +1506,10 @@ void TreeBuilder::fixup_tables(NodeWithStyle& root)
 static bool is_first_or_last_child_with_table_non_root_sibling_if_any(Node const& node)
 {
     auto is_table_non_root_box = [](Node const& node) {
-        auto const display = node.display();
+        auto const* node_with_style = as_if<NodeWithStyle>(node);
+        if (!node_with_style)
+            return false;
+        auto const display = node_with_style->display();
         return display.is_table_row()
             || display.is_table_column()
             || display.is_table_row_group()
@@ -1531,7 +1537,10 @@ static bool is_first_or_last_child_with_table_non_root_sibling_if_any(Node const
 // https://drafts.csswg.org/css-tables-3/#tabular-container
 static bool is_tabular_container(Node const& node)
 {
-    auto const& display = node.display();
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    if (!node_with_style)
+        return false;
+    auto const& display = node_with_style->display();
     return display.is_table_inside()
         || display.is_table_row()
         || display.is_table_row_group()
@@ -1558,7 +1567,8 @@ void TreeBuilder::remove_irrelevant_boxes(NodeWithStyle& root)
     // 2. Children of a table-column-group which are not a table-column.
     for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableColumnGroup>(root, [&](Box& table_column_group) {
         table_column_group.for_each_child([&](auto& child) {
-            if (!child.display().is_table_column())
+            auto const* child_with_style = as_if<NodeWithStyle>(child);
+            if (!child_with_style || !child_with_style->display().is_table_column())
                 to_remove.append(child);
             return IterationDecision::Continue;
         });
@@ -1605,7 +1615,7 @@ static bool is_table_track_group(CSS::Display display)
         || display.is_table_column_group();
 }
 
-static CSS::Display display_for_table_fixup(Node const& node)
+static CSS::Display display_for_table_fixup(NodeWithStyle const& node)
 {
     // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
     // For the purposes of these rules, out-of-flow elements are represented as inline elements of zero width and
@@ -1620,7 +1630,7 @@ static CSS::Display display_for_table_fixup(Node const& node)
     return node.display();
 }
 
-static bool is_proper_table_child(Node const& node)
+static bool is_proper_table_child(NodeWithStyle const& node)
 {
     auto const display = display_for_table_fixup(node);
     return is_table_track_group(display) || is_table_track(display) || display.is_table_caption();
@@ -1628,26 +1638,30 @@ static bool is_proper_table_child(Node const& node)
 
 static bool is_not_proper_table_child(Node const& node)
 {
-    if (!node.has_style())
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    if (!node_with_style)
         return true;
-    return !is_proper_table_child(node);
+    return !is_proper_table_child(*node_with_style);
 }
 
 static bool is_not_table_row(Node const& node)
 {
-    if (!node.has_style())
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    if (!node_with_style)
         return true;
-    return !TableGrid::is_table_row(node);
+    return !TableGrid::is_table_row(*node_with_style);
 }
 
 static bool is_table_column(Node const& node)
 {
-    return node.display().is_table_column();
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    return node_with_style && node_with_style->display().is_table_column();
 }
 
 static bool is_table_cell(Node const& node)
 {
-    return node.display().is_table_cell();
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    return node_with_style && node_with_style->display().is_table_cell();
 }
 
 static bool is_not_table_cell(Node const& node)
@@ -1659,7 +1673,10 @@ static bool is_not_table_cell(Node const& node)
 
 static bool is_table_row_group_column_group_or_caption(Node const& node)
 {
-    auto const display = display_for_table_fixup(node);
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    if (!node_with_style)
+        return false;
+    auto const display = display_for_table_fixup(*node_with_style);
     return is_table_track_group(display) || display.is_table_caption();
 }
 

--- a/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Libraries/LibWeb/Layout/Viewport.cpp
@@ -74,7 +74,7 @@ void Viewport::update_text_blocks()
     };
 
     for_each_in_inclusive_subtree([&](auto const& layout_node) {
-        if (layout_node.display().is_none())
+        if (auto const* layout_node_with_style = as_if<NodeWithStyle>(layout_node); layout_node_with_style && layout_node_with_style->display().is_none())
             return TraversalDecision::Continue;
 
         auto const pseudo = layout_node.generated_for_pseudo_element();
@@ -86,7 +86,7 @@ void Viewport::update_text_blocks()
         }
 
         if (auto* text_node = as_if<Layout::TextNode>(layout_node)) {
-            auto const& computed_values = text_node->computed_values();
+            auto const& computed_values = text_node->parent()->computed_values();
             if (computed_values.visibility() != CSS::Visibility::Visible || computed_values.opacity() == 0)
                 return TraversalDecision::Continue;
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -3261,7 +3261,7 @@ void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<
             auto* host_layout_node = host_element ? host_element->layout_node() : nullptr;
             auto const* cursor_data = &paintable->computed_values().cursor();
             if (hit_text_node && host_layout_node)
-                cursor_data = &host_layout_node->computed_values().cursor();
+                cursor_data = &as<Layout::NodeWithStyle>(*host_layout_node).computed_values().cursor();
 
             auto* host_node_with_style = host_layout_node ? as_if<Layout::NodeWithStyle>(*host_layout_node) : nullptr;
             auto is_selectable_text_node = hit_text_node

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -486,7 +486,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 // for the background-attachment property is treated as if it had a value of scroll.
                 auto has_transform_ancestor = false;
                 if (!is_root_element) {
-                    for (auto const* node = &layout_node; node && !node->is_viewport(); node = node->parent()) {
+                    for (Layout::NodeWithStyle const* node = &layout_node; node && !node->is_viewport(); node = node->parent()) {
                         if (node->has_css_transform()) {
                             has_transform_ancestor = true;
                             break;

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -294,7 +294,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
         CSSPixels initial_image_x = image_rect.x();
         CSSPixels image_y = image_rect.y();
 
-        image.resolve_for_size(paintable_box.layout_node_with_style_and_box_metrics(), image_rect.size());
+        image.resolve_for_size(paintable_box.layout_node(), image_rect.size());
 
         auto for_each_image_device_rect = [&](auto callback) {
             while (image_y < css_clip_rect.bottom()) {

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -247,7 +247,7 @@ static bool text_fragment_is_hit_testable(PaintableFragment const& fragment)
     if (!text_node)
         return false;
 
-    auto const& computed_values = text_node->computed_values();
+    auto const& computed_values = text_node->parent()->computed_values();
     if (computed_values.visibility() != CSS::Visibility::Visible || computed_values.opacity() == 0)
         return false;
     if (auto const* node = text_node->dom_text(); node && node->is_inert())

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -124,7 +124,7 @@ void InlinePaintable::paint(DisplayListRecordingContext& context, PaintPhase pha
 
     if (phase == PaintPhase::Background && is_visible()) {
         paint_backdrop_filter(context);
-        bool background_is_propagated_to_root = body_background_is_propagated_to_root(layout_node_with_style_and_box_metrics());
+        bool background_is_propagated_to_root = body_background_is_propagated_to_root(layout_node());
         auto has_borders = has_css_borders();
         for_each_piece([&](auto const& piece) {
             if (piece.is_geometry_only_placeholder)

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -84,27 +84,15 @@ DOM::Document& Paintable::document()
 
 RefPtr<Paintable> Paintable::containing_block() const
 {
-    return const_cast<Paintable*>(containing_block_ptr());
+    return m_containing_block;
 }
 
-Paintable const* Paintable::containing_block_ptr() const
+void Paintable::set_containing_block(Paintable* containing_block)
 {
-    if (m_containing_block.has_value()) {
-        if (auto* containing_block = m_containing_block->ptr())
-            return containing_block;
-    }
-
-    auto* containing_block = [&] -> Paintable const* {
-        auto containing_layout_box = layout_node().containing_block();
-        if (!containing_layout_box)
-            return nullptr;
-        auto* paintable_box = containing_layout_box->paintable_ptr();
-        if (!paintable_box)
-            return nullptr;
-        return paintable_box;
-    }();
+    if (m_containing_block == containing_block)
+        return;
     m_containing_block = containing_block;
-    return containing_block;
+    invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
 }
 
 CSS::ImmutableComputedValues const& Paintable::computed_values() const
@@ -979,7 +967,7 @@ Paintable::~Paintable()
 
 void Paintable::detach_from_layout_node(Badge<Layout::Node>)
 {
-    m_containing_block.clear();
+    m_containing_block = nullptr;
     m_layout_node.clear();
     detach_chrome_widgets();
 }
@@ -1064,7 +1052,7 @@ void Paintable::reset_for_relayout()
     while (first_child())
         first_child()->remove();
 
-    m_containing_block = {};
+    m_containing_block = nullptr;
 
     m_offset = {};
     m_content_size = {};

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -757,10 +757,8 @@ static Color effective_scrollbar_background_color(Paintable const& paintable_box
     auto background_color = paintable_box.document().canvas_background_color();
 
     Vector<Layout::NodeWithStyle const*> ancestors;
-    for (auto const* layout_node = &paintable_box.layout_node(); layout_node; layout_node = layout_node->parent()) {
-        if (auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(layout_node))
-            ancestors.append(layout_node_with_style);
-    }
+    for (Layout::NodeWithStyle const* layout_node = &paintable_box.layout_node(); layout_node; layout_node = layout_node->parent())
+        ancestors.append(layout_node);
 
     for (auto const* layout_node : ancestors.in_reverse()) {
         auto const& layout_node_with_style = *layout_node;
@@ -868,7 +866,7 @@ static void record_blocking_wheel_event_region(Paintable const& paintable_box, D
 ResolvedCSSFilter resolve_css_filter(CSS::Filter const& computed_filter, Paintable const& paintable_box)
 {
     auto const& computed_values = paintable_box.computed_values();
-    auto const& layout_node = paintable_box.layout_node_with_style_and_box_metrics();
+    auto const& layout_node = paintable_box.layout_node();
 
     ResolvedCSSFilter result;
     for (auto const& filter_operation : computed_filter.filters()) {
@@ -945,7 +943,7 @@ NonnullRefPtr<Paintable> Paintable::create(Layout::Box const& layout_box)
     return adopt_ref(*new Paintable(layout_box));
 }
 
-Paintable::Paintable(Layout::Node const& layout_node)
+Paintable::Paintable(Layout::NodeWithStyleAndBoxModelMetrics const& layout_node)
     : m_layout_node(layout_node)
 {
     auto& computed_values = layout_node.computed_values();
@@ -967,7 +965,7 @@ Paintable::Paintable(Layout::Node const& layout_node)
 }
 
 Paintable::Paintable(Layout::Box const& layout_box)
-    : Paintable(static_cast<Layout::Node const&>(layout_box))
+    : Paintable(static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(layout_box))
 {
 }
 
@@ -998,11 +996,6 @@ void Paintable::detach_chrome_widgets()
         m_resize_handle->detach_from_paintable({});
         m_resize_handle = nullptr;
     }
-}
-
-Layout::NodeWithStyleAndBoxModelMetrics const& Paintable::layout_node_with_style_and_box_metrics() const
-{
-    return as<Layout::NodeWithStyleAndBoxModelMetrics const>(layout_node());
 }
 
 bool Paintable::has_css_transform() const
@@ -1380,7 +1373,7 @@ CSSPixelRect Paintable::overflow_clip_edge_rect() const
 Optional<CSSPixelRect> Paintable::get_clip_rect() const
 {
     auto clip = computed_values().clip();
-    if (clip.is_rect() && layout_node_with_style_and_box_metrics().is_absolutely_positioned()) {
+    if (clip.is_rect() && layout_node().is_absolutely_positioned()) {
         auto border_box = absolute_border_box_rect();
         return clip.to_rect().resolved(border_box);
     }
@@ -2492,18 +2485,18 @@ bool Paintable::has_css_borders() const
 void Paintable::paint_background(DisplayListRecordingContext& context) const
 {
     // If the body's background properties were propagated to the root element, do not re-paint the body's background.
-    if (body_background_is_propagated_to_root(layout_node_with_style_and_box_metrics()))
+    if (body_background_is_propagated_to_root(layout_node()))
         return;
 
     auto const& computed_values = this->computed_values();
 
     // https://drafts.csswg.org/css-backgrounds/#root-background
-    if (layout_node_with_style_and_box_metrics().is_root_element()) {
+    if (layout_node().is_root_element()) {
         auto background_rect = absolute_border_box_rect();
         Color background_color = computed_values.background_color();
         auto const* background_layers = &computed_values.background_layers();
 
-        auto& html_element = as<HTML::HTMLHtmlElement>(*layout_node_with_style_and_box_metrics().dom_node());
+        auto& html_element = as<HTML::HTMLHtmlElement>(*layout_node().dom_node());
         if (html_element.should_use_body_background_properties()) {
             background_layers = document().background_layers();
             background_color = document().background_color();

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -84,19 +84,24 @@ DOM::Document& Paintable::document()
 
 RefPtr<Paintable> Paintable::containing_block() const
 {
+    return const_cast<Paintable*>(containing_block_ptr());
+}
+
+Paintable const* Paintable::containing_block_ptr() const
+{
     if (m_containing_block.has_value()) {
-        if (auto containing_block = m_containing_block->strong_ref())
+        if (auto* containing_block = m_containing_block->ptr())
             return containing_block;
     }
 
-    auto containing_block = [&] -> RefPtr<Paintable> {
+    auto* containing_block = [&] -> Paintable const* {
         auto containing_layout_box = layout_node().containing_block();
         if (!containing_layout_box)
             return nullptr;
-        auto paintable_box = containing_layout_box->paintable_box();
+        auto* paintable_box = containing_layout_box->paintable_ptr();
         if (!paintable_box)
             return nullptr;
-        return const_cast<Paintable&>(*paintable_box);
+        return paintable_box;
     }();
     m_containing_block = containing_block;
     return containing_block;
@@ -2807,7 +2812,7 @@ ScrollFrameIndex Paintable::nearest_scroll_frame_index() const
 {
     if (is_fixed_position())
         return {};
-    auto paintable = this->containing_block();
+    auto const* paintable = containing_block_ptr();
     while (paintable) {
         if (paintable->own_scroll_frame_index().value())
             return paintable->own_scroll_frame_index();
@@ -2815,7 +2820,7 @@ ScrollFrameIndex Paintable::nearest_scroll_frame_index() const
         // because they must reference a scrollport for their sticky offset computation.
         if (paintable->is_fixed_position() && !is_sticky_position())
             return {};
-        paintable = paintable->containing_block();
+        paintable = paintable->containing_block_ptr();
     }
     return {};
 }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -295,6 +295,8 @@ Paintable::SelectionStyle Paintable::selection_style_for_node(Layout::Node const
     // Selections render in a muted color while the window does not have focus.
     auto navigable = layout_node.document().navigable();
     auto window_is_active = navigable && navigable->is_focused();
+    auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(layout_node);
+    auto const& style_source = layout_node_with_style ? *layout_node_with_style : *layout_node.parent();
 
     auto default_style_for_color_scheme = [&](CSS::PreferredColorScheme color_scheme, bool use_palette_for_normal_color_scheme = true) {
         auto palette = layout_node.document().page().palette();
@@ -310,17 +312,17 @@ Paintable::SelectionStyle Paintable::selection_style_for_node(Layout::Node const
 
     // For text nodes, check the parent element since text nodes don't have computed properties.
     if (!node)
-        return default_style_for_color_scheme(layout_node.computed_values().color_scheme());
+        return default_style_for_color_scheme(style_source.computed_values().color_scheme());
 
     DOM::Element const* element = as_if<DOM::Element>(*node);
     if (!element)
         element = node->parent_element();
     if (!element)
-        return default_style_for_color_scheme(layout_node.computed_values().color_scheme());
+        return default_style_for_color_scheme(style_source.computed_values().color_scheme());
 
     auto color_scheme_is_normal = element->computed_properties()->property(CSS::PropertyID::ColorScheme).as_color_scheme().schemes().is_empty();
     auto use_palette_for_normal_color_scheme = color_scheme_is_normal && !layout_node.document().supported_color_schemes().has_value();
-    auto default_style = default_style_for_color_scheme(layout_node.computed_values().color_scheme(), use_palette_for_normal_color_scheme);
+    auto default_style = default_style_for_color_scheme(style_source.computed_values().color_scheme(), use_palette_for_normal_color_scheme);
 
     auto style_from_element = [&](DOM::Element const& element) -> Optional<SelectionStyle> {
         auto element_layout_node = element.layout_node();
@@ -423,7 +425,7 @@ void Paintable::scroll_text_offset_into_view(DOM::Text const& text, size_t offse
 {
     auto scroll_to_cursor = [&](PaintableFragment const& fragment) {
         auto cursor_rect = fragment.range_rect(SelectionState::StartAndEnd, offset, offset);
-        auto const& computed_values = fragment.layout_node().computed_values();
+        auto const& computed_values = fragment.style_source().computed_values();
         if (computed_values.writing_mode() == CSS::WritingMode::HorizontalTb) {
             if (computed_values.inline_axis_is_reverse())
                 cursor_rect.set_x(cursor_rect.x() - 1);

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -85,12 +85,12 @@ public:
     virtual bool forms_unconnected_subtree() const { return false; }
 
     bool has_layout_node() const { return m_layout_node; }
-    Layout::Node const& layout_node() const
+    Layout::NodeWithStyleAndBoxModelMetrics const& layout_node() const
     {
         VERIFY(m_layout_node);
         return *m_layout_node;
     }
-    Layout::Node& layout_node() { return const_cast<Layout::Node&>(const_cast<Paintable const&>(*this).layout_node()); }
+    Layout::NodeWithStyleAndBoxModelMetrics& layout_node() { return const_cast<Layout::NodeWithStyleAndBoxModelMetrics&>(const_cast<Paintable const&>(*this).layout_node()); }
 
     [[nodiscard]] GC::Ptr<DOM::Node> dom_node();
     [[nodiscard]] GC::Ptr<DOM::Node const> dom_node() const;
@@ -185,8 +185,6 @@ public:
 
     virtual Optional<CSSPixelRect> get_clip_area() const { return {}; }
     virtual Optional<DisplayListResource> calculate_clip(DisplayListRecordingContext&, CSSPixelRect const&) const { return {}; }
-
-    Layout::NodeWithStyleAndBoxModelMetrics const& layout_node_with_style_and_box_metrics() const;
 
     auto& box_model() { return m_box_model; }
     auto const& box_model() const { return m_box_model; }
@@ -434,7 +432,7 @@ public:
     [[nodiscard]] ScrollFrameIndex own_scroll_frame_index() const { return m_own_scroll_frame_index; }
 
 protected:
-    explicit Paintable(Layout::Node const&);
+    explicit Paintable(Layout::NodeWithStyleAndBoxModelMetrics const&);
     explicit Paintable(Layout::Box const&);
 
     void paint_with_inspector_overlay_context(DisplayListRecordingContext&, Function<void()> const&) const;
@@ -476,7 +474,7 @@ private:
     void invalidate_absolute_geometry_cache(InvalidateDescendantGeometry);
 
     GC::Weak<DOM::Node> m_dom_node;
-    WeakPtr<Layout::Node const> m_layout_node;
+    WeakPtr<Layout::NodeWithStyleAndBoxModelMetrics const> m_layout_node;
 
     SelectionState m_selection_state { SelectionState::None };
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -103,7 +103,7 @@ public:
     GC::Ptr<HTML::LocalNavigable> navigable() const;
 
     RefPtr<Paintable> containing_block() const;
-    Paintable const* containing_block_ptr() const;
+    Paintable const* containing_block_ptr() const { return m_containing_block; }
 
     template<typename T>
     bool fast_is() const = delete;
@@ -456,9 +456,9 @@ protected:
     CSSPixels available_scrollbar_length(ScrollDirection direction, ChromeMetrics const& chrome_metrics) const;
     Optional<CSSPixelRect> absolute_resizer_rect(ChromeMetrics const& chrome_metrics) const;
 
-    Optional<WeakPtr<Paintable>> mutable m_containing_block;
-
 private:
+    friend struct Layout::LayoutState;
+
     struct CachedPaintData;
     enum class InvalidateDescendantGeometry {
         No,
@@ -467,6 +467,7 @@ private:
 
     void detach_from_layout_node(Badge<Layout::Node>);
     void detach_chrome_widgets();
+    void set_containing_block(Paintable* containing_block);
 
     void paint_middle_button_scroll_indicator(DisplayListRecordingContext&) const;
     void acquire_cache_references_for_cached_commands(ReadonlyBytes) const;
@@ -475,6 +476,7 @@ private:
 
     GC::Weak<DOM::Node> m_dom_node;
     WeakPtr<Layout::NodeWithStyleAndBoxModelMetrics const> m_layout_node;
+    Paintable* m_containing_block { nullptr };
 
     SelectionState m_selection_state { SelectionState::None };
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -103,6 +103,7 @@ public:
     GC::Ptr<HTML::LocalNavigable> navigable() const;
 
     RefPtr<Paintable> containing_block() const;
+    Paintable const* containing_block_ptr() const;
 
     template<typename T>
     bool fast_is() const = delete;

--- a/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -69,6 +69,19 @@ PaintableFragment::PaintableFragment(PaintableWithLines const& paintable_with_li
     }
 }
 
+bool PaintableFragment::is_block_level_box() const
+{
+    auto const* layout_node_with_style = as_if<Layout::NodeWithStyle>(layout_node());
+    return layout_node_with_style && layout_node_with_style->display().is_block_outside();
+}
+
+Layout::NodeWithStyle const& PaintableFragment::style_source() const
+{
+    if (auto const* node_with_style = as_if<Layout::NodeWithStyle>(layout_node()))
+        return *node_with_style;
+    return *layout_node().parent();
+}
+
 void PaintableFragment::set_selection_state(Paintable::SelectionState state)
 {
     if (m_selection_state == state)

--- a/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -30,6 +30,7 @@ public:
         VERIFY(m_layout_node);
         return *m_layout_node;
     }
+    Layout::NodeWithStyle const& style_source() const;
     bool has_layout_node() const { return !!m_layout_node; }
     // For in-place layout tree updates that replace the referenced node.
     void set_layout_node(Layout::Node const& layout_node) { m_layout_node = layout_node; }
@@ -42,7 +43,7 @@ public:
 
     // Interrupting block-level boxes (block-in-inline) are recorded as phantom fragments; most
     // fragment consumers (hit testing, render spans, client rects) must skip them.
-    bool is_block_level_box() const { return layout_node().display().is_block_outside(); }
+    bool is_block_level_box() const;
 
     size_t start_offset() const { return m_start_offset; }
     size_t length_in_code_units() const { return m_length_in_code_units; }

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -35,7 +35,7 @@ static Gfx::Path build_triangle_wave_path(Gfx::IntPoint from, Gfx::IntPoint to, 
 static void compute_render_spans(PaintableFragment const&, Vector<PaintableFragment::FragmentSpan, 4>&);
 static void paint_text_fragment(DisplayListRecordingContext&, PaintableFragment::FragmentSpan const&);
 
-static bool layout_node_is_visible(Layout::Node const& layout_node)
+static bool layout_node_is_visible(Layout::NodeWithStyle const& layout_node)
 {
     auto const& computed_values = layout_node.computed_values();
     return computed_values.visibility() == CSS::Visibility::Visible && computed_values.opacity() != 0;
@@ -328,7 +328,7 @@ static void resolve_text_fragment_properties(PaintableWithLines const& paintable
         auto const& font = text_node->first_available_font();
         auto const glyph_height = CSSPixels::nearest_value_for(font.pixel_size());
         auto const line_thickness = [&] {
-            auto const& thickness = text_node->computed_values().text_decoration_thickness();
+            auto const& thickness = text_node->parent()->computed_values().text_decoration_thickness();
             return thickness.value.visit(
                 [glyph_height](CSS::TextDecorationThickness::Auto) {
                     // https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-thickness-auto
@@ -344,13 +344,13 @@ static void resolve_text_fragment_properties(PaintableWithLines const& paintable
                 },
                 [&](CSS::LengthPercentage const& length_percentage) {
                     // https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-thickness-length-percentage
-                    auto resolved_length = length_percentage.resolved(CSS::Length(1, CSS::LengthUnit::Em).to_px(*text_node)).to_px(*text_node);
+                    auto resolved_length = length_percentage.resolved(CSS::Length(1, CSS::LengthUnit::Em).to_px(*text_node->parent())).to_px(*text_node->parent());
                     return max(resolved_length, 1);
                 });
         }();
         fragment.set_text_decoration_thickness(line_thickness);
 
-        auto const& text_shadow = text_node->computed_values().text_shadow();
+        auto const& text_shadow = text_node->parent()->computed_values().text_shadow();
         Vector<ShadowData> resolved_shadow_data;
         if (!text_shadow.is_empty()) {
             resolved_shadow_data.ensure_capacity(text_shadow.size());
@@ -425,10 +425,10 @@ void compute_render_spans(PaintableFragment const& fragment, Vector<PaintableFra
         return;
     }
 
-    if (!layout_node_is_visible(*text_node))
+    if (!layout_node_is_visible(*text_node->parent()))
         return;
 
-    auto text_color = text_node->computed_values().webkit_text_fill_color();
+    auto text_color = text_node->parent()->computed_values().webkit_text_fill_color();
     auto selection_offsets = fragment.selection_offsets();
 
     // No selection: single span with base styling.
@@ -630,9 +630,9 @@ void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context, Inli
             return;
         // Like the glyphs around it, the caret follows the text's own visibility, which may
         // differ from this box's.
-        if (!layout_node_is_visible(fragment->layout_node()))
+        if (!layout_node_is_visible(fragment->style_source()))
             return;
-        caret_color = fragment->layout_node().computed_values().caret_color();
+        caret_color = fragment->style_source().computed_values().caret_color();
         cursor_rect = fragment->range_rect(SelectionState::StartAndEnd, cursor_position->offset(), cursor_position->offset());
     } else if (owner) {
         // Blank lines and empty editable elements are handled by the block / the box itself.
@@ -641,7 +641,7 @@ void PaintableWithLines::paint_cursor(DisplayListRecordingContext& context, Inli
         // Blank-line and empty-element carets belong to this block itself.
         return;
     } else if (auto empty_line_rect = empty_line_caret_rect(*cursor_position); empty_line_rect.has_value()) {
-        caret_color = m_fragments.first().layout_node().computed_values().caret_color();
+        caret_color = m_fragments.first().style_source().computed_values().caret_color();
         cursor_rect = { empty_line_rect->x(), empty_line_rect->y(), 1, empty_line_rect->height() };
     } else {
         // Empty editable elements have no fragments, but should still draw a cursor.
@@ -739,9 +739,9 @@ void paint_text_decoration(DisplayListRecordingContext& context, Layout::TextNod
         line_style = span.text_decoration->style;
         text_decoration_lines = span.text_decoration->line;
     } else {
-        line_color = text_node.computed_values().text_decoration_color();
-        line_style = text_node.computed_values().text_decoration_style();
-        text_decoration_lines = text_node.computed_values().text_decoration_line();
+        line_color = text_node.parent()->computed_values().text_decoration_color();
+        line_style = text_node.parent()->computed_values().text_decoration_style();
+        text_decoration_lines = text_node.parent()->computed_values().text_decoration_line();
     }
 
     // Compute the decoration box for this span.
@@ -753,8 +753,8 @@ void paint_text_decoration(DisplayListRecordingContext& context, Layout::TextNod
         fragment_box.set_x(span_rect.x());
         fragment_box.set_width(span_rect.width());
     }
-    auto text_underline_offset = text_node.computed_values().text_underline_offset();
-    auto text_underline_position = text_node.computed_values().text_underline_position();
+    auto text_underline_offset = text_node.parent()->computed_values().text_underline_offset();
+    auto text_underline_position = text_node.parent()->computed_values().text_underline_position();
     for (auto line : text_decoration_lines) {
         auto line_thickness = fragment.text_decoration_thickness();
 
@@ -847,7 +847,7 @@ void paint_text_decoration(DisplayListRecordingContext& context, Layout::TextNod
         // https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink-property
         // FIXME: For text-decoration-skip-ink: auto, skip CJK ideographs and symbols from the intercept
         //        computation, since their complex strokes would create too many gaps in the decoration line.
-        auto skip_ink = text_node.computed_values().text_decoration_skip_ink();
+        auto skip_ink = text_node.parent()->computed_values().text_decoration_skip_ink();
         bool should_skip_ink = skip_ink != CSS::TextDecorationSkipInk::None
             && first_is_one_of(line, CSS::TextDecorationLine::Underline, CSS::TextDecorationLine::Overline);
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -219,7 +219,7 @@ void ViewportPaintable::reassign_scroll_frames()
 
 void ViewportPaintable::assign_scroll_frames()
 {
-    for_each_in_inclusive_subtree_of_type<Paintable>([&](auto& paintable_box) {
+    for_each_in_inclusive_subtree([&](auto& paintable_box) {
         paintable_box.set_enclosing_scroll_frame_index({});
         paintable_box.set_own_scroll_frame_index({});
 
@@ -250,7 +250,7 @@ void ViewportPaintable::assign_scroll_frames()
         if (paintable.is_fixed_position() || paintable.is_sticky_position())
             return TraversalDecision::Continue;
 
-        for (auto block = paintable.containing_block(); block; block = block->containing_block()) {
+        for (auto const* block = paintable.containing_block_ptr(); block; block = block->containing_block_ptr()) {
             if (auto index = block->own_scroll_frame_index(); index.value()) {
                 paintable.set_enclosing_scroll_frame_index(index);
                 return TraversalDecision::Continue;

--- a/Libraries/LibWeb/RefCountedTreeNode.h
+++ b/Libraries/LibWeb/RefCountedTreeNode.h
@@ -17,35 +17,40 @@
 
 namespace Web {
 
+enum class IncludeRefCountedTreeRoot {
+    No,
+    Yes,
+};
+
 template<typename T, typename Callback>
-TraversalDecision traverse_ref_counted_preorder(RefPtr<T> root, Callback callback)
+TraversalDecision traverse_ref_counted_preorder(T& root, IncludeRefCountedTreeRoot include_root, Callback callback)
 {
-    auto current = root;
+    auto* current = include_root == IncludeRefCountedTreeRoot::Yes ? &root : root.first_child_ptr();
     while (current) {
         TraversalDecision decision = callback(*current);
         if (decision == TraversalDecision::Break)
             return TraversalDecision::Break;
 
         if (decision != TraversalDecision::SkipChildrenAndContinue) {
-            if (auto first_child = current->first_child()) {
-                current = move(first_child);
+            if (auto* first_child = current->first_child_ptr()) {
+                current = first_child;
                 continue;
             }
         }
-        if (current == root)
+        if (current == &root)
             break;
 
-        if (auto next_sibling = current->next_sibling()) {
-            current = move(next_sibling);
+        if (auto* next_sibling = current->next_sibling_ptr()) {
+            current = next_sibling;
             continue;
         }
 
-        while (current != root && !current->next_sibling())
-            current = current->parent();
-        if (current == root)
+        while (current != &root && !current->next_sibling_ptr())
+            current = current->parent_ptr();
+        if (current == &root)
             break;
 
-        current = current->next_sibling();
+        current = current->next_sibling_ptr();
     }
     return TraversalDecision::Continue;
 }
@@ -53,8 +58,13 @@ TraversalDecision traverse_ref_counted_preorder(RefPtr<T> root, Callback callbac
 template<typename T>
 class WEB_API RefCountedTreeNode {
 public:
+    // Traversal helpers do not retain visited nodes. Callbacks must not detach or reparent the current node or otherwise
+    // cause it to be destroyed.
     RefPtr<T> parent() { return m_parent.strong_ref(); }
     RefPtr<T const> parent() const { return m_parent.strong_ref(); }
+
+    T* parent_ptr() { return m_parent.ptr(); }
+    T const* parent_ptr() const { return m_parent.ptr(); }
 
     bool has_children() const { return m_first_child; }
 
@@ -300,13 +310,13 @@ public:
     template<typename Callback>
     TraversalDecision for_each_in_inclusive_subtree(Callback callback) const
     {
-        return traverse_ref_counted_preorder(RefPtr<T const> { static_cast<T const&>(*this) }, callback);
+        return traverse_ref_counted_preorder(static_cast<T const&>(*this), IncludeRefCountedTreeRoot::Yes, callback);
     }
 
     template<typename Callback>
     TraversalDecision for_each_in_inclusive_subtree(Callback callback)
     {
-        return traverse_ref_counted_preorder(RefPtr<T> { static_cast<T&>(*this) }, callback);
+        return traverse_ref_counted_preorder(static_cast<T&>(*this), IncludeRefCountedTreeRoot::Yes, callback);
     }
 
     template<typename U, typename Callback>
@@ -332,41 +342,33 @@ public:
     template<typename Callback>
     TraversalDecision for_each_in_subtree(Callback callback) const
     {
-        for (auto child = first_child(); child; child = child->next_sibling()) {
-            if (child->for_each_in_inclusive_subtree(callback) == TraversalDecision::Break)
-                return TraversalDecision::Break;
-        }
-        return TraversalDecision::Continue;
+        return traverse_ref_counted_preorder(static_cast<T const&>(*this), IncludeRefCountedTreeRoot::No, callback);
     }
 
     template<typename Callback>
     TraversalDecision for_each_in_subtree(Callback callback)
     {
-        for (auto child = first_child(); child; child = child->next_sibling()) {
-            if (child->for_each_in_inclusive_subtree(callback) == TraversalDecision::Break)
-                return TraversalDecision::Break;
-        }
-        return TraversalDecision::Continue;
+        return traverse_ref_counted_preorder(static_cast<T&>(*this), IncludeRefCountedTreeRoot::No, callback);
     }
 
     template<typename U, typename Callback>
     TraversalDecision for_each_in_subtree_of_type(Callback callback)
     {
-        for (auto child = first_child(); child; child = child->next_sibling()) {
-            if (child->template for_each_in_inclusive_subtree_of_type<U>(callback) == TraversalDecision::Break)
-                return TraversalDecision::Break;
-        }
-        return TraversalDecision::Continue;
+        return for_each_in_subtree([callback = move(callback)](T& node) {
+            if (auto* node_of_type = as_if<U>(node))
+                return callback(*node_of_type);
+            return TraversalDecision::Continue;
+        });
     }
 
     template<typename U, typename Callback>
     TraversalDecision for_each_in_subtree_of_type(Callback callback) const
     {
-        for (auto child = first_child(); child; child = child->next_sibling()) {
-            if (child->template for_each_in_inclusive_subtree_of_type<U>(callback) == TraversalDecision::Break)
-                return TraversalDecision::Break;
-        }
-        return TraversalDecision::Continue;
+        return for_each_in_subtree([callback = move(callback)](T const& node) {
+            if (auto const* node_of_type = as_if<U>(node))
+                return callback(*node_of_type);
+            return TraversalDecision::Continue;
+        });
     }
 
     template<typename Callback>
@@ -378,7 +380,7 @@ public:
     template<typename Callback>
     void for_each_child(Callback callback)
     {
-        for (auto node = first_child(); node; node = node->next_sibling()) {
+        for (auto* node = first_child_ptr(); node; node = node->next_sibling_ptr()) {
             if (callback(*node) == IterationDecision::Break)
                 return;
         }
@@ -387,7 +389,7 @@ public:
     template<typename U, typename Callback>
     void for_each_child_of_type(Callback callback)
     {
-        for (auto node = first_child(); node; node = node->next_sibling()) {
+        for (auto* node = first_child_ptr(); node; node = node->next_sibling_ptr()) {
             auto* node_of_type = as_if<U>(*node);
             if (!node_of_type)
                 continue;
@@ -491,7 +493,7 @@ public:
     template<typename Callback>
     void for_each_ancestor(Callback callback) const
     {
-        for (auto ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+        for (auto* ancestor = parent_ptr(); ancestor; ancestor = ancestor->parent_ptr()) {
             if (callback(*ancestor) == IterationDecision::Break)
                 return;
         }

--- a/Libraries/LibWeb/VisualLines.cpp
+++ b/Libraries/LibWeb/VisualLines.cpp
@@ -19,7 +19,7 @@ namespace Web {
 
 bool white_space_preserves_newlines(Layout::TextNode const& layout_node)
 {
-    return first_is_one_of(layout_node.computed_values().white_space_collapse(),
+    return first_is_one_of(layout_node.parent()->computed_values().white_space_collapse(),
         CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks);
 }
 

--- a/Tests/LibWeb/TestRefCountedTreeNode.cpp
+++ b/Tests/LibWeb/TestRefCountedTreeNode.cpp
@@ -186,3 +186,58 @@ TEST_CASE(preorder_traversal_uses_sibling_links)
     EXPECT_EQ(values[3], 4);
     EXPECT_EQ(values[4], 3);
 }
+
+TEST_CASE(tree_traversal_does_not_retain_nodes)
+{
+    auto root = TestNode::create(0);
+    auto first = TestNode::create(1);
+    auto second = TestNode::create(2);
+    auto second_child = TestNode::create(3);
+
+    root->append_child(first);
+    root->append_child(second);
+    second->append_child(second_child);
+
+    Vector<unsigned> ref_counts;
+    root->for_each_in_inclusive_subtree([&](TestNode& node) {
+        ref_counts.append(node.ref_count());
+        return Web::TraversalDecision::Continue;
+    });
+
+    EXPECT_EQ(ref_counts.size(), 4u);
+    EXPECT_EQ(ref_counts[0], root->ref_count());
+    EXPECT_EQ(ref_counts[1], first->ref_count());
+    EXPECT_EQ(ref_counts[2], second->ref_count());
+    EXPECT_EQ(ref_counts[3], second_child->ref_count());
+
+    ref_counts.clear();
+    root->for_each_in_subtree([&](TestNode& node) {
+        ref_counts.append(node.ref_count());
+        return Web::TraversalDecision::Continue;
+    });
+
+    EXPECT_EQ(ref_counts.size(), 3u);
+    EXPECT_EQ(ref_counts[0], first->ref_count());
+    EXPECT_EQ(ref_counts[1], second->ref_count());
+    EXPECT_EQ(ref_counts[2], second_child->ref_count());
+
+    ref_counts.clear();
+    root->for_each_child([&](TestNode& node) {
+        ref_counts.append(node.ref_count());
+        return IterationDecision::Continue;
+    });
+
+    EXPECT_EQ(ref_counts.size(), 2u);
+    EXPECT_EQ(ref_counts[0], first->ref_count());
+    EXPECT_EQ(ref_counts[1], second->ref_count());
+
+    ref_counts.clear();
+    second_child->for_each_ancestor([&](TestNode const& node) {
+        ref_counts.append(node.ref_count());
+        return IterationDecision::Continue;
+    });
+
+    EXPECT_EQ(ref_counts.size(), 2u);
+    EXPECT_EQ(ref_counts[0], second->ref_count());
+    EXPECT_EQ(ref_counts[1], root->ref_count());
+}


### PR DESCRIPTION
Reduce recurring overhead in layout and paint-tree processing by removing unnecessary ownership and style-resolution work from hot paths.

- Traverse ref-counted trees through raw links and avoid promoting layout node parent pointers.
- Encode that paintables are always backed by styled layout nodes, and move computed-value access and style-derived predicates off generic `Layout::Node`.
- Make text-specific callers identify their actual style source instead of implicitly borrowing parent styles.
- Resolve paintable containing blocks once during layout commit and store them as direct non-owning pointers instead of lazily promoting an `Optional<WeakPtr>`.

On a page that's constantly churning CPU through relayout such as https://nyan.cat, this removes about 10-15% overhead.