### PR TITLE
LibWeb/CSS: Fix remaining `@namespace` WPT failures

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -654,7 +654,7 @@ void CSSStyleSheet::recalculate_rule_caches()
         }
         case CSSRule::Type::Namespace: {
             auto& namespace_rule = as<CSSNamespaceRule>(*rule);
-            if (!namespace_rule.namespace_uri().is_empty() && namespace_rule.prefix().is_empty())
+            if (namespace_rule.prefix().is_empty())
                 m_default_namespace_rule = namespace_rule;
 
             m_namespace_rules.set(namespace_rule.prefix(), namespace_rule);

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -1579,6 +1579,11 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     return false;
 }
 
+static bool is_in_null_namespace(DOM::Element const& element)
+{
+    return !element.namespace_uri().has_value() || element.namespace_uri()->is_empty();
+}
+
 static ALWAYS_INLINE bool matches_namespace(
     CSS::Selector::SimpleSelector::QualifiedName const& qualified_name,
     DOM::Element const& element,
@@ -1590,11 +1595,14 @@ static ALWAYS_INLINE bool matches_namespace(
         if (!style_sheet_for_rule || !style_sheet_for_rule->default_namespace_rule())
             return true;
         // "Otherwise it is equivalent to ns|E where ns is the default namespace."
+        if (style_sheet_for_rule->default_namespace_rule()->namespace_uri().is_empty())
+            return is_in_null_namespace(element);
+
         return element.namespace_uri().has_value()
             && fly_string_equals_utf16(style_sheet_for_rule->default_namespace_rule()->namespace_uri(), element.namespace_uri()->view());
     case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::None:
         // "elements with name E without a namespace"
-        return !element.namespace_uri().has_value();
+        return is_in_null_namespace(element);
     case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Any:
         // "elements with name E in any namespace, including those without a namespace"
         return true;
@@ -1612,7 +1620,7 @@ static ALWAYS_INLINE bool matches_namespace(
         // In CSS Namespaces a namespace name consisting of the empty string is taken to represent the null namespace
         // or lack of a namespace.
         if (selector_namespace.has_value() && selector_namespace.value().is_empty())
-            return !element.namespace_uri().has_value();
+            return is_in_null_namespace(element);
 
         return selector_namespace.has_value()
             && element.namespace_uri().has_value()

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -231,12 +231,14 @@ RuleCache const* StyleComputer::rule_cache_for_cascade_origin(CascadeOrigin casc
 
 [[nodiscard]] static bool filter_namespace_rule(Optional<Utf16FlyString> const& element_namespace_uri, MatchingRule const& rule)
 {
-    // FIXME: Filter out non-default namespace using prefixes
-    if (rule.default_namespace.has_value()) {
-        if (!element_namespace_uri.has_value() || element_namespace_uri->view() != rule.default_namespace->view())
-            return false;
-    }
-    return true;
+    if (!rule.element_namespace_filter.has_value())
+        return true;
+
+    if (rule.element_namespace_filter->is_empty())
+        return !element_namespace_uri.has_value() || element_namespace_uri->is_empty();
+
+    return element_namespace_uri.has_value()
+        && element_namespace_uri->view() == rule.element_namespace_filter->view();
 }
 
 NonnullRefPtr<InvalidationPlan> StyleComputer::invalidation_plan_for_properties(Vector<InvalidationSet::Property> const& properties, StyleScope const& style_scope) const

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -85,6 +85,51 @@ void MatchingRule::visit_edges(GC::Cell::Visitor& visitor) const
     visitor.visit(scope_rule);
 }
 
+static Optional<Utf16FlyString> namespace_filter_for_qualified_name(Selector::SimpleSelector::QualifiedName const& qualified_name, CSSStyleSheet const& style_sheet)
+{
+    switch (qualified_name.namespace_type) {
+    case Selector::SimpleSelector::QualifiedName::NamespaceType::Default:
+        return style_sheet.default_namespace();
+    case Selector::SimpleSelector::QualifiedName::NamespaceType::None:
+        return Utf16FlyString {};
+    case Selector::SimpleSelector::QualifiedName::NamespaceType::Any:
+        return {};
+    case Selector::SimpleSelector::QualifiedName::NamespaceType::Named:
+        return style_sheet.namespace_uri(qualified_name.namespace_);
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static Selector::CompoundSelector const& target_compound_selector_for_namespace_filter(Selector const& selector)
+{
+    auto const& compound_selectors = selector.compound_selectors();
+    VERIFY(!compound_selectors.is_empty());
+
+    if (auto compound_selector = compound_selectors.last_matching([](auto const& compound_selector) {
+            return compound_selector.combinator != Selector::Combinator::PseudoElement;
+        });
+        compound_selector.has_value())
+        return compound_selector.value();
+
+    return compound_selectors.first();
+}
+
+static Optional<Utf16FlyString> element_namespace_filter_for_rule(Selector const& selector, CSSStyleSheet const& style_sheet)
+{
+    if (selector.is_slotted() || selector.has_part_pseudo_element())
+        return {};
+
+    auto const& compound_selector = target_compound_selector_for_namespace_filter(selector);
+    for (auto const& simple_selector : compound_selector.simple_selectors) {
+        if (simple_selector.type == Selector::SimpleSelector::Type::TagName
+            || simple_selector.type == Selector::SimpleSelector::Type::Universal) {
+            return namespace_filter_for_qualified_name(simple_selector.qualified_name(), style_sheet);
+        }
+    }
+
+    return style_sheet.default_namespace();
+}
+
 void RuleCache::visit_edges(GC::Cell::Visitor& visitor)
 {
     auto visit_vector = [&](auto& vector) {
@@ -610,7 +655,7 @@ void StyleScope::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin
                     .sheet = current_style_sheet,
                     .container_rule = container_rule,
                     .scope_rule = scope_rule,
-                    .default_namespace = current_style_sheet.default_namespace(),
+                    .element_namespace_filter = element_namespace_filter_for_rule(selector, current_style_sheet),
                     .selector = selector,
                     .selector_index = selector_index,
                     .style_sheet_index = style_sheet_index,

--- a/Libraries/LibWeb/CSS/StyleScope.h
+++ b/Libraries/LibWeb/CSS/StyleScope.h
@@ -35,7 +35,7 @@ struct MatchingRule {
     GC::Ptr<CSSStyleSheet const> sheet;
     GC::Ptr<CSSContainerRule const> container_rule;
     GC::Ptr<CSSRule const> scope_rule; // Either CSSScopeRule or CSSImportRule
-    Optional<Utf16FlyString> default_namespace;
+    Optional<Utf16FlyString> element_namespace_filter;
     Selector const& selector;
     size_t selector_index { 0 };
     size_t style_sheet_index { 0 };

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-1-block.xml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-1-block.xml
@@ -1,0 +1,10 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/"/>
+  <link rel="author" title="Mozilla" href="http://mozilla.org/"/>
+  <title>CSS Namespaces Test Suite reference</title>
+ </head>
+ <body>
+  <p style="background: lime">This sentence should have a green background.</p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-2-generic.xml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-2-generic.xml
@@ -1,0 +1,13 @@
+<root>
+ <head xmlns="http://www.w3.org/1999/xhtml">
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/"/>
+  <link rel="author" title="Mozilla" href="http://mozilla.org/"/>
+  <title>CSS Namespaces Test Suite reference</title>
+  <style>
+   t, root { display:block }
+   t { background:lime }
+  </style>
+ </head>
+ <t>This sentence should have a green background.</t>
+ <t>This sentence should have a green background.</t>
+</root>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-2.xml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-2.xml
@@ -1,0 +1,11 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/"/>
+  <link rel="author" title="Mozilla" href="http://mozilla.org/"/>
+  <title>CSS Namespaces Test Suite reference</title>
+ </head>
+ <body>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-3.xml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-3.xml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/"/>
+  <link rel="author" title="Mozilla" href="http://mozilla.org/"/>
+  <title>CSS Namespaces Test Suite reference</title>
+ </head>
+ <body>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-6.xml
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-namespaces/reference/ref-lime-6.xml
@@ -1,0 +1,15 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="L. David Baron" href="https://dbaron.org/"/>
+  <link rel="author" title="Mozilla" href="http://mozilla.org/"/>
+  <title>CSS Namespaces Test Suite reference</title>
+ </head>
+ <body>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+  <p><test style="background: lime">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-001.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-001.xml
@@ -1,0 +1,20 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#prefixes"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <title>CSS Namespaces Test Suite: prefix case-sensitivity</title>
+  <style>
+   @namespace Foo "y";
+   @namespace foo "x";
+   test { background:red }
+   Foo|test { background:lime }
+   foo|test { background:red }
+   FOO|test { background:red }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="y">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-004.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-004.xml
@@ -1,0 +1,18 @@
+<root>
+ <head xmlns="http://www.w3.org/1999/xhtml">
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#prefixes"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-2-generic.xml"/>
+  <title>CSS Namespaces Test Suite: empty string default namespace</title>
+  <style>
+   @namespace "";
+   @namespace x "test";
+   *|t, *|root { display:block }
+   *|t, t[x] { background:lime }
+   t { background:red }
+  </style>
+ </head>
+ <t x="">This sentence should have a green background.</t>
+ <t xmlns="test">This sentence should have a green background.</t>
+</root>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-005.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-005.xml
@@ -1,0 +1,18 @@
+<root>
+ <head xmlns="http://www.w3.org/1999/xhtml">
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="author" title="Boris Zbarsky" href="https://bugzilla.mozilla.org/show_bug.cgi?id=458381#c4"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#prefixes"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-2-generic.xml"/>
+  <title>CSS Namespaces Test Suite: no default namespace</title>
+  <style>
+   @namespace x "test";
+   root *|* { background:red; display:block }
+   head { display:none }
+   t { background: lime }
+  </style>
+ </head>
+ <t>This sentence should have a green background.</t>
+ <t xmlns="test">This sentence should have a green background.</t>
+</root>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-006.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/prefix-006.xml
@@ -1,0 +1,23 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#prefixes"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-2.xml"/>
+  <title>CSS Namespaces Test Suite: no prefix</title>
+  <style>
+   @namespace "test";
+   |t { background:lime }
+   t { background:red }
+  </style>
+  <style>
+   @namespace "test";
+   t2 { background:lime }
+   |t2 { background:red }
+  </style>
+ </head>
+ <body>
+  <p><t xmlns="">This sentence should have a green background.</t></p>
+  <p><t2 xmlns="test">This sentence should have a green background.</t2></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/scope-001.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/scope-001.xml
@@ -1,0 +1,20 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#scope"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <meta name="flags" content="invalid"/>
+  <title>CSS Namespaces Test Suite: scope &lt;style></title>
+  <style>
+   @namespace x url("test");
+   test { background:lime }
+  </style>
+  <style>
+   x|test { background:red }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/support/fail.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/support/fail.css
@@ -1,0 +1,1 @@
+* { background:red ! important }

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/support/syntax-007.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/support/syntax-007.css
@@ -1,0 +1,5 @@
+@charset "UTF-8";
+@namespace url("test");
+@namespace url("test2");
+*|test { background:lime }
+test { background:red }

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-001.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-001.xml
@@ -1,0 +1,16 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1-block.xml"/>
+  <title>CSS Namespaces Test Suite: @namespace case-insensitivity</title>
+  <style>
+   @NAmespace x "http://www.w3.org/1999/xhtml";
+   x|p { background: lime }
+  </style>
+ </head>
+ <body>
+  <p>This sentence should have a green background.</p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-002.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-002.xml
@@ -1,0 +1,16 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1-block.xml"/>
+  <title>CSS Namespaces Test Suite: @namespace syntax with escapes</title>
+  <style>
+   @\N\000041 mes\pac\65  x "http://www.w3.org/1999/xhtml";
+   x|p { background: lime }
+  </style>
+ </head>
+ <body>
+  <p>This sentence should have a green background.</p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-003.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-003.xml
@@ -1,0 +1,39 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-5.xml"/>
+  <title>CSS Namespaces Test Suite: @namespace default namespace syntax</title>
+  <style>
+   *|test { background:red }
+  </style>
+  <style>
+   @namespace url(test-a);
+   test { background:lime }
+  </style>
+  <style>
+   @namespace url('test-b');
+   test { background:lime }
+  </style>
+  <style>
+   @namespace url("test-c");
+   test { background:lime }
+  </style>
+  <style>
+   @namespace 'test-d';
+   test { background:lime }
+  </style>
+  <style>
+   @namespace "test-e";
+   test { background:lime }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test-a">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-b">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-c">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-d">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-e">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-004.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-004.xml
@@ -1,0 +1,17 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <title>CSS Namespaces Test Suite: @namespace url() with escape</title>
+  <style>
+   @namespace u\00072l("test");
+   *|test { background:red }
+   test { background: lime }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-005.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-005.xml
@@ -1,0 +1,27 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-5.xml"/>
+  <title>CSS Namespaces Test Suite: @namespace string and url() syntax</title>
+  <style>
+   test { background:red }
+  </style>
+  <style>
+   @namespace a url(test-a);
+   @namespace b url('test-b');
+   @namespace c url("test-c");
+   @namespace d 'test-d';
+   @namespace e "test-e";
+   a|test, b|test, c|test, d|test, e|test { background:lime }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test-a">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-b">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-c">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-d">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-e">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-006.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-006.xml
@@ -1,0 +1,20 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <meta name="flags" content="invalid"/>
+  <title>CSS Namespaces Test Suite: invalid ordering of @namespace and @import</title>
+  <style>
+   @namespace x u\00072l("test");
+   @import url("support/fail.css");
+   @namespace url("test2");
+   x|test { background:lime }
+   test { background:red }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-007.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-007.xml
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <title>CSS Namespaces Test Suite: @namespace and @charset</title>
+  <link rel="stylesheet" href="support/syntax-007.css"/>
+ </head>
+ <body>
+  <p><test xmlns="test">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-008.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-008.xml
@@ -1,0 +1,23 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-2.xml"/>
+  <title>CSS Namespaces Test Suite: escapes in prefix</title>
+  <style>
+   @namespace \72x url("test");
+   t { background:red }
+   r\78|t { background:lime }
+  </style>
+  <style>
+   @namespace \032  url("test"); /* two spaces, see CSS 2.1, 4.1.3 */
+   t2 { background:red }
+   \32|t2 { background:lime }
+  </style>
+ </head>
+ <body>
+  <p><t xmlns="test">This sentence should have a green background.</t></p>
+  <p><t2 xmlns="test">This sentence should have a green background.</t2></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-009.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-009.xml
@@ -1,0 +1,18 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <title>CSS Namespaces Test Suite: escaped vertical bar in qualified name</title>
+  <style>
+   @namespace x "test";
+   test { background:red }
+   x|test { background:lime }
+   x\00007Ctest { background:red }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-010.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-010.xml
@@ -1,0 +1,36 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-3.xml"/>
+  <meta name="flags" content="invalid"/>
+  <title>CSS Namespaces Test Suite: duplicate @namespace declarations</title>
+  <style>
+   @namespace "1";
+   @namespace dummy "yummy";
+   @namespace "2";
+   *|t { background:lime }
+   t { background:red }
+  </style>
+  <style>
+   @namespace "1";
+   @namespace dummy "yummy";
+   @namespace "2";
+   *|t2 { background:red }
+   t2 { background:lime }
+  </style>
+  <style>
+   @namespace x "1";
+   @namespace dummy "yummy";
+   @namespace x "2";
+   *|t3 { background:red }
+   x|t3 { background:lime }
+  </style>
+ </head>
+ <body>
+  <p><t xmlns="1">This sentence should have a green background.</t></p>
+  <p><t2 xmlns="2">This sentence should have a green background.</t2></p>
+  <p><t3 xmlns="2">This sentence should have a green background.</t3></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-011.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-011.xml
@@ -1,0 +1,47 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-6.xml"/>
+  <title>CSS Namespaces Test Suite: string comparison (no URI resolving)</title>
+  <style>
+   @namespace url("http://example.com/");
+   *|t { background:lime }
+   t { background:red }
+  </style>
+  <style>
+   @namespace url("http://example.com/");
+   *|t2 { background:lime }
+   t2 { background:red }
+  </style>
+  <style>
+   @namespace url("HTTP://example.com/");
+   *|t3 { background:lime }
+   t3 { background:red }
+  </style>
+  <style>
+   @namespace url("http://example.COM/");
+   *|t4 { background:lime }
+   t4 { background:red }
+  </style>
+  <style>
+   @namespace url("%41");
+   *|t5 { background:lime }
+   t5 { background:red }
+  </style>
+  <style>
+   @namespace url("A");
+   *|t6 { background:lime }
+   t6 { background:red }
+  </style>
+ </head>
+ <body>
+  <p><t xmlns="HTTP://example.com/">This sentence should have a green background.</t></p>
+  <p><t2 xmlns="http://example.COM/">This sentence should have a green background.</t2></p>
+  <p><t3 xmlns="http://example.com/">This sentence should have a green background.</t3></p>
+  <p><t4 xmlns="http://example.com/">This sentence should have a green background.</t4></p>
+  <p><t5 xmlns="A">This sentence should have a green background.</t5></p>
+  <p><t6 xmlns="%41">This sentence should have a green background.</t6></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-012.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-012.xml
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-3.xml"/>
+  <title>CSS Namespaces Test Suite: whitespace and comment handling</title>
+  <style>
+   test { background:red }
+  </style>
+  <style>
+   @namespace/* test */
+   a
+   url(
+test-a );
+
+   @namespace/**/b/**/url(	'test-b'
+);
+
+   @namespace	c	url("test-c"
+);
+
+   a|test, b|test, c|test { background:lime }
+  </style>
+ </head>
+ <body>
+  <p><test xmlns="test-a">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-b">This sentence should have a green background.</test></p>
+  <p><test xmlns="test-c">This sentence should have a green background.</test></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-014.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-014.xml
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-3.xml"/>
+  <meta name="flags" content="invalid"/>
+  <title>CSS Namespaces Test Suite: @namespace and invalid at-rules</title>
+  <style>
+   t, t2, t3 { background:red }
+  </style>
+  <style>
+   @import x {}
+   @namespace x "test";
+   x|t { background:lime }
+  </style>
+  <style>
+   @namespace x "test-top";
+   @foobar this is funny { not:sure }
+   @namespace "test";
+   @foobar this is funner;
+   t2 { background:lime }
+   x|t3 { background:lime }
+   </style>
+ </head>
+ <body>
+  <p><t xmlns="test">This sentence should have a green background.</t></p>
+  <p><t2 xmlns="test">This sentence should have a green background.</t2></p>
+  <p><t3 xmlns="test-top">This sentence should have a green background.</t3></p>
+ </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-015.xml
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-namespaces/syntax-015.xml
@@ -1,0 +1,18 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <link rel="author" title="Anne van Kesteren" href="http://annevankesteren.nl/"/>
+  <link rel="author" title="Opera Software ASA" href="http://opera.com/"/>
+  <link rel="help" href="http://www.w3.org/TR/css-namespaces-3/#syntax"/>
+  <link rel="match" href="../../../../expected/wpt-import/css/css-namespaces/reference/ref-lime-1.xml"/>
+  <title>CSS Namespaces Test Suite: invalid URI</title>
+  <style>
+   @namespace x url("test");
+   @namespace x url("}x&lt; >x{");
+   t { background:lime }
+   x|t { background:red }
+  </style>
+ </head>
+ <body>
+  <p><t xmlns="test">This sentence should have a green background.</t></p>
+ </body>
+</html>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -502,3 +502,6 @@ Text/input/wpt-import/html/semantics/embedded-content/the-img-element/sizes/pars
 
 ; This test isn't reliable yet with GCC.
 Text/input/indexeddb-gc-closes-unreachable-connection.html
+
+; Times out for unknown reasons.
+Text/input/wpt-import/domxpath/xml_xpath_tests.xml

--- a/Tests/LibWeb/Text/expected/css/namespace-filter.txt
+++ b/Tests/LibWeb/Text/expected/css/namespace-filter.txt
@@ -1,0 +1,4 @@
+HTML element with class selector using SVG default namespace: rgba(0, 0, 0, 0)
+HTML element with any-namespace universal selector: rgb(0, 128, 0)
+SVG element with class selector using SVG default namespace: rgb(0, 128, 0)
+Null-namespace element with no-namespace universal selector: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/css/namespace-filter.html
+++ b/Tests/LibWeb/Text/input/css/namespace-filter.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<script src="../include.js"></script>
+<style>
+    @namespace svg "http://www.w3.org/2000/svg";
+    @namespace "http://www.w3.org/2000/svg";
+
+    .html-class {
+        background-color: red;
+    }
+
+    *|*.html-any {
+        background-color: green;
+    }
+
+    .svg-class {
+        background-color: green;
+    }
+
+    |*.null-class {
+        background-color: green;
+    }
+</style>
+<body>
+<script>
+    test(() => {
+        const html = document.createElement("div");
+        html.className = "html-class";
+        document.body.appendChild(html);
+        println(`HTML element with class selector using SVG default namespace: ${getComputedStyle(html).backgroundColor}`);
+
+        const htmlAny = document.createElement("div");
+        htmlAny.className = "html-any";
+        document.body.appendChild(htmlAny);
+        println(`HTML element with any-namespace universal selector: ${getComputedStyle(htmlAny).backgroundColor}`);
+
+        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svg.setAttribute("class", "svg-class");
+        document.body.appendChild(svg);
+        println(`SVG element with class selector using SVG default namespace: ${getComputedStyle(svg).backgroundColor}`);
+
+        const nullElement = document.createElementNS("", "test");
+        nullElement.setAttribute("class", "null-class");
+        document.body.appendChild(nullElement);
+        println(`Null-namespace element with no-namespace universal selector: ${getComputedStyle(nullElement).backgroundColor}`);
+    });
+</script>

--- a/Tests/LibWeb/test-web/Collection.cpp
+++ b/Tests/LibWeb/test-web/Collection.cpp
@@ -18,7 +18,7 @@ namespace TestWeb {
 
 bool is_valid_test_name(StringView test_name)
 {
-    auto valid_test_file_suffixes = { ".htm"sv, ".html"sv, ".svg"sv, ".xhtml"sv, ".xht"sv, ".pdf"sv };
+    auto valid_test_file_suffixes = { ".htm"sv, ".html"sv, ".svg"sv, ".xhtml"sv, ".xht"sv, ".xml"sv, ".pdf"sv };
     return any_of(valid_test_file_suffixes, [&](auto suffix) { return test_name.ends_with(suffix); });
 }
 


### PR DESCRIPTION
Also includes a fix for us completely ignoring WPT tests with a `.xml` extension - we already had one imported, and it times out, so I've disabled it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS namespace selector matching for elements with missing or empty namespace values.
  * Corrected handling of default, named, and explicitly null namespaces.
  * Improved namespace filtering for selectors across HTML, XML, and SVG content.

* **Tests**
  * Added comprehensive CSS namespace syntax, prefix, scope, and filtering coverage.
  * Added support for discovering XML-based tests.
  * Skipped a timing-out XPath test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->