### PR TITLE
LibHTTP+LibWebView+RequestServer: Remove the partitioned disk cache mode

### DIFF
--- a/Libraries/LibHTTP/Cache/DiskCache.cpp
+++ b/Libraries/LibHTTP/Cache/DiskCache.cpp
@@ -44,20 +44,20 @@ static constexpr StringView cache_directory_for_mode(DiskCache::Mode mode)
     switch (mode) {
     case DiskCache::Mode::Normal:
         return "Cache"sv;
-    case DiskCache::Mode::Partitioned:
-        // FIXME: Ideally, we could support multiple RequestServer processes using the same database by setting a
-        //        reasonable busy timeout. We would also have to prevent multiple processes writing to the same cache
-        //        entry file at the same time with some interprocess locking mechanism.
-        return "PartitionedCache"sv;
     case DiskCache::Mode::Testing:
         return "TestCache"sv;
     }
     VERIFY_NOT_REACHED();
 }
 
-ErrorOr<DiskCache> DiskCache::create(Mode mode, LexicalPath cache_root)
+ErrorOr<Optional<DiskCache>> DiskCache::create(Mode mode, LexicalPath const& cache_root)
 {
     auto cache_directory = cache_root.append(cache_directory_for_mode(mode));
+
+    // Start with a clean slate in test mode. The index is in-memory, but the cache files themselves are leftover.
+    if (mode == Mode::Testing)
+        (void)FileSystem::remove(cache_directory.string(), FileSystem::RecursionMode::Allowed);
+
     TRY(Core::Directory::create(cache_directory, Core::Directory::CreateDirectories::Yes));
 
     auto database = mode == DiskCache::Mode::Normal
@@ -65,16 +65,14 @@ ErrorOr<DiskCache> DiskCache::create(Mode mode, LexicalPath cache_root)
         : TRY(Database::Database::create_memory_backed());
 
     if (TRY(CacheIndex::migrate_schema(*database)) == Database::MigrationOutcome::DatabaseTooNew) {
-        // Entry file names are derived from the cache key, so writing into the existing cache
-        // directory without its index would corrupt entries the newer build's index refers to.
-        // Partitioned mode is already a per-process transient cache in its own directory.
-        // (A fresh memory-backed database always migrates, so this is necessarily Mode::Normal.)
-        dbgln("Disk cache index was created by a newer Ladybird version; using a transient cache this session");
-        return create(Mode::Partitioned, move(cache_root));
+        // Entry file names are derived from the cache key, so writing into the existing cache directory without its
+        // index would corrupt entries the newer build's index refers to. (A fresh memory-backed database always
+        // migrates, so this is necessarily Mode::Normal.)
+        dbgln("Disk cache index was created by a newer Ladybird version; disabling disk cache for this session");
+        return OptionalNone {};
     }
 
     auto index = TRY(CacheIndex::create(database, cache_directory));
-
     return DiskCache { mode, move(database), move(cache_directory), move(index) };
 }
 
@@ -84,19 +82,12 @@ DiskCache::DiskCache(Mode mode, NonnullRefPtr<Database::Database> database, Lexi
     , m_cache_directory(move(cache_directory))
     , m_index(move(index))
 {
-    if (m_mode == Mode::Partitioned)
-        m_partitioned_cache_key = String::number(Core::System::getpid());
 }
 
 DiskCache::DiskCache(DiskCache&&) = default;
 DiskCache& DiskCache::operator=(DiskCache&&) = default;
 
-DiskCache::~DiskCache()
-{
-    // Clean up cache directories in testing modes to prevent endless growth of disk usage.
-    if (m_mode != Mode::Normal)
-        remove_entries_accessed_since(UnixDateTime::earliest());
-}
+DiskCache::~DiskCache() = default;
 
 Variant<Optional<CacheEntryWriter&>, DiskCache::CacheHasOpenEntry> DiskCache::create_entry(CacheRequest& request, URL::URL const& url, StringView method, HeaderList const& request_headers, UnixDateTime request_start_time)
 {
@@ -109,7 +100,7 @@ Variant<Optional<CacheEntryWriter&>, DiskCache::CacheHasOpenEntry> DiskCache::cr
     }
 
     auto serialized_url = serialize_url_for_cache_storage(url);
-    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto cache_key = create_cache_key(serialized_url, method);
 
     if (check_if_cache_has_open_entry(request, cache_key, url, CheckReaderEntries::Yes))
         return CacheHasOpenEntry {};
@@ -139,7 +130,7 @@ Variant<Optional<CacheEntryReader&>, DiskCache::CacheHasOpenEntry> DiskCache::op
         return Optional<CacheEntryReader&> {};
 
     auto serialized_url = serialize_url_for_cache_storage(url);
-    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto cache_key = create_cache_key(serialized_url, method);
 
     if (check_if_cache_has_open_entry(request, cache_key, url, open_mode == OpenMode::Read ? CheckReaderEntries::No : CheckReaderEntries::Yes))
         return CacheHasOpenEntry {};
@@ -238,7 +229,7 @@ ErrorOr<bool> DiskCache::create_synthetic_entry(URL::URL const& url, StringView 
         return false;
 
     auto serialized_url = serialize_url_for_cache_storage(url);
-    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto cache_key = create_cache_key(serialized_url, method);
     constexpr u64 synthetic_vary_key = 0;
 
     if (m_index.has_entry(cache_key, synthetic_vary_key))
@@ -256,7 +247,7 @@ ErrorOr<bool> DiskCache::store_associated_data(URL::URL const& url, StringView m
         return false;
 
     auto serialized_url = serialize_url_for_cache_storage(url);
-    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto cache_key = create_cache_key(serialized_url, method);
     if (!vary_key.has_value()) {
         auto index_entry = m_index.find_entry(cache_key, request_headers);
         if (!index_entry.has_value())
@@ -291,7 +282,7 @@ ErrorOr<Optional<ByteBuffer>> DiskCache::retrieve_associated_data(URL::URL const
         return Optional<ByteBuffer> {};
 
     auto serialized_url = serialize_url_for_cache_storage(url);
-    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto cache_key = create_cache_key(serialized_url, method);
     if (!vary_key.has_value()) {
         auto index_entry = m_index.find_entry(cache_key, request_headers);
         if (!index_entry.has_value())
@@ -319,7 +310,7 @@ ErrorOr<Optional<CacheEntryBodyFile>> DiskCache::retrieve_associated_data_file(U
         return Optional<CacheEntryBodyFile> {};
 
     auto serialized_url = serialize_url_for_cache_storage(url);
-    auto cache_key = create_cache_key(serialized_url, method, m_partitioned_cache_key);
+    auto cache_key = create_cache_key(serialized_url, method);
     if (!vary_key.has_value()) {
         auto index_entry = m_index.find_entry(cache_key, request_headers);
         if (!index_entry.has_value())

--- a/Libraries/LibHTTP/Cache/DiskCache.h
+++ b/Libraries/LibHTTP/Cache/DiskCache.h
@@ -28,15 +28,11 @@ public:
     enum class Mode {
         Normal,
 
-        // In partitioned mode, the cache is enabled as normal, but each RequestServer process operates with a unique
-        // disk cache database.
-        Partitioned,
-
         // In test mode, we only enable caching of responses on a per-request basis, signified by a request header. The
         // response headers will include some status on how the request was handled.
         Testing,
     };
-    static ErrorOr<DiskCache> create(Mode, LexicalPath cache_root);
+    static ErrorOr<Optional<DiskCache>> create(Mode, LexicalPath const& cache_root);
 
     DiskCache(DiskCache&&);
     DiskCache& operator=(DiskCache&&);
@@ -83,8 +79,6 @@ private:
     void delete_entry(u64 cache_key, u64 vary_key);
 
     Mode m_mode;
-    Optional<String> m_partitioned_cache_key;
-
     NonnullRefPtr<Database::Database> m_database;
 
     struct OpenCacheEntry {

--- a/Libraries/LibHTTP/Cache/Utilities.cpp
+++ b/Libraries/LibHTTP/Cache/Utilities.cpp
@@ -72,14 +72,11 @@ static u64 serialize_hash(Crypto::Hash::SHA1& hasher)
     return result;
 }
 
-u64 create_cache_key(StringView url, StringView method, Optional<String const&> extra_cache_key)
+u64 create_cache_key(StringView url, StringView method)
 {
     auto hasher = Crypto::Hash::SHA1::create();
     hasher->update(url);
     hasher->update(method);
-
-    if (extra_cache_key.has_value())
-        hasher->update(*extra_cache_key);
 
     return serialize_hash(*hasher);
 }

--- a/Libraries/LibHTTP/Cache/Utilities.h
+++ b/Libraries/LibHTTP/Cache/Utilities.h
@@ -37,7 +37,7 @@ u64 compute_maximum_disk_cache_size(u64 free_bytes, u64 limit_maximum_disk_cache
 u64 compute_maximum_disk_cache_entry_size(u64 maximum_disk_cache_size);
 
 String serialize_url_for_cache_storage(URL::URL const&);
-u64 create_cache_key(StringView url, StringView method, Optional<String const&> extra_cache_key = {});
+u64 create_cache_key(StringView url, StringView method);
 u64 create_vary_key(HeaderList const& request_headers, HeaderList const& response_headers);
 LexicalPath path_for_cache_entry(LexicalPath const& cache_directory, u64 cache_key, u64 vary_key);
 LexicalPath path_for_cache_entry_associated_data(LexicalPath const& cache_directory, u64 cache_key, u64 vary_key, CacheEntryAssociatedData);

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -268,9 +268,6 @@ ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process()
     case HTTPDiskCacheMode::Enabled:
         arguments.append("enabled"sv);
         break;
-    case HTTPDiskCacheMode::Partitioned:
-        arguments.append("partitioned"sv);
-        break;
     case HTTPDiskCacheMode::Testing:
         arguments.append("testing"sv);
         break;

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -100,7 +100,6 @@ struct BrowserOptions {
 enum class HTTPDiskCacheMode {
     Disabled,
     Enabled,
-    Partitioned,
     Testing,
 };
 

--- a/Services/RequestServer/main.cpp
+++ b/Services/RequestServer/main.cpp
@@ -90,8 +90,6 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         auto mode = TRY([&]() -> ErrorOr<HTTP::DiskCache::Mode> {
             if (http_disk_cache_mode == "enabled"sv)
                 return HTTP::DiskCache::Mode::Normal;
-            if (http_disk_cache_mode == "partitioned"sv)
-                return HTTP::DiskCache::Mode::Partitioned;
             if (http_disk_cache_mode == "testing"sv)
                 return HTTP::DiskCache::Mode::Testing;
             return Error::from_string_literal("Unrecognized disk cache mode");

--- a/Tests/LibHTTP/TestDiskCache.cpp
+++ b/Tests/LibHTTP/TestDiskCache.cpp
@@ -62,7 +62,7 @@ static HTTP::CacheEntryWriter& create_cache_entry(HTTP::DiskCache& disk_cache, T
 
 TEST_CASE(associated_data_round_trips_with_cache_entry)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root())).release_value();
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -94,7 +94,7 @@ TEST_CASE(associated_data_round_trips_with_cache_entry)
 
 TEST_CASE(replacing_cache_entry_removes_associated_data)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root())).release_value();
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -125,7 +125,7 @@ TEST_CASE(replacing_cache_entry_removes_associated_data)
 
 TEST_CASE(flush_returns_mappable_body_file)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root())).release_value();
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -143,7 +143,7 @@ TEST_CASE(flush_returns_mappable_body_file)
 
 TEST_CASE(replacing_cache_entry_keeps_existing_body_mapping_stable)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root())).release_value();
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -170,7 +170,7 @@ TEST_CASE(replacing_cache_entry_keeps_existing_body_mapping_stable)
 
 TEST_CASE(associated_data_round_trips_with_explicit_vary_key)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root())).release_value();
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);
@@ -201,7 +201,7 @@ TEST_CASE(associated_data_round_trips_with_explicit_vary_key)
 
 TEST_CASE(associated_data_participates_in_cache_eviction)
 {
-    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root()));
+    auto disk_cache = MUST(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Testing, test_cache_root())).release_value();
     TestCacheRequest request;
 
     auto url = parse_url("https://example.com/script.js"sv);

--- a/Tests/LibWebView/TestProfile.cpp
+++ b/Tests/LibWebView/TestProfile.cpp
@@ -262,18 +262,18 @@ TEST_CASE(profile_caches_are_isolated)
     auto bytecode = TRY_OR_FAIL(ByteBuffer::copy("first-profile-bytecode"sv.bytes()));
 
     {
-        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { first_profile.paths().cache }));
+        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { first_profile.paths().cache })).release_value();
         EXPECT(TRY_OR_FAIL(cache.create_synthetic_entry(url, "GET"sv)));
         EXPECT(TRY_OR_FAIL(cache.store_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode, bytecode.bytes())));
     }
 
     {
-        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { second_profile.paths().cache }));
+        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { second_profile.paths().cache })).release_value();
         EXPECT(!TRY_OR_FAIL(cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode)).has_value());
     }
 
     {
-        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { first_profile.paths().cache }));
+        auto cache = TRY_OR_FAIL(HTTP::DiskCache::create(HTTP::DiskCache::Mode::Normal, LexicalPath { first_profile.paths().cache })).release_value();
         auto retrieved_bytecode = TRY_OR_FAIL(cache.retrieve_associated_data(url, "GET"sv, *request_headers, {}, HTTP::CacheEntryAssociatedData::JavaScriptBytecode));
         VERIFY(retrieved_bytecode.has_value());
         EXPECT_EQ(retrieved_bytecode->bytes(), bytecode.bytes());


### PR DESCRIPTION
This was added specifically for WebDriver browsing sessions, but it is now effectively unused since profiles were added:
257d3557d0da2f9e2b99a239558ae3e2aa1234a3

We now instead create a unique profile for each browser process launched by WebDriver. The profiles provide the isolation we need for multiple RequestServer processes.