### PR TITLE
UI/Qt: Clear pressed tab when opening a tab context menu

### DIFF
--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -809,6 +809,7 @@ void TabBar::contextMenuEvent(QContextMenuEvent* event)
     if (tab_index < 0)
         return;
 
+    m_pressed_tab = nullptr;
     if (auto* tab = m_tab_widget->tab(tab_index))
         tab->context_menu()->exec(event->globalPos());
 }


### PR DESCRIPTION
`TabBar::mousePressEvent()` sets `m_pressed_tab` before `TabBar::contextMenuEvent()` is called. If we don't clear it to nullptr, we continue to think that a mouse button is pressed on a tab, which suppresses the tab preview-on-hover. Clearing it to nullptr makes that work again.

Fixes #10544