### PR TITLE
Revert "LibWebView: Add last_access_time to WebStorage tables that lack it"

### DIFF
--- a/Libraries/LibDatabase/Database.cpp
+++ b/Libraries/LibDatabase/Database.cpp
@@ -361,16 +361,6 @@ ErrorOr<bool> Database::table_exists(StringView table)
     return exists;
 }
 
-ErrorOr<bool> Database::column_exists(StringView table, StringView column)
-{
-    if (!m_column_exists_statement.has_value())
-        m_column_exists_statement = TRY(prepare_statement("SELECT 1 FROM pragma_table_info(?) WHERE name = ?;"sv));
-
-    bool exists = false;
-    TRY(try_execute_statement(*m_column_exists_statement, [&](auto) { exists = true; }, TRY(String::from_utf8(table)), TRY(String::from_utf8(column))));
-    return exists;
-}
-
 ErrorOr<Optional<u32>> Database::schema_version(StringView store)
 {
     if (!TRY(table_exists("SchemaVersions"sv)))

--- a/Libraries/LibDatabase/Database.h
+++ b/Libraries/LibDatabase/Database.h
@@ -123,8 +123,6 @@ public:
 
     ErrorOr<bool> table_exists(StringView table);
 
-    ErrorOr<bool> column_exists(StringView table, StringView column);
-
     // The version recorded for the store in SchemaVersions, or empty if it has none yet.
     ErrorOr<Optional<u32>> schema_version(StringView store);
 
@@ -198,7 +196,6 @@ private:
     sqlite3* m_database { nullptr };
     Vector<sqlite3_stmt*> m_prepared_statements;
     Optional<StatementID> m_table_exists_statement;
-    Optional<StatementID> m_column_exists_statement;
     Optional<StatementID> m_schema_version_statement;
 };
 

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -15,12 +15,11 @@ namespace WebView {
 // Quota size is specified in https://storage.spec.whatwg.org/#registered-storage-endpoints
 static constexpr size_t LOCAL_STORAGE_QUOTA = 5 * MiB;
 
-static constexpr u32 WEB_STORAGE_SCHEMA_BASELINE_VERSION = 1u;
-static constexpr u32 WEB_STORAGE_SCHEMA_LAST_ACCESS_TIME_VERSION = 2u;
+static constexpr u32 WEB_STORAGE_SCHEMA_BASELINE_VERSION = 2u;
 
 ErrorOr<Database::MigrationOutcome> StorageJar::migrate_schema(Database::Database& database, Database::MigrationMode mode)
 {
-    Array<Database::Migration, 2> migrations { {
+    Array<Database::Migration, 1> migrations { {
         { .version = WEB_STORAGE_SCHEMA_BASELINE_VERSION, .sql = R"#(
             CREATE TABLE IF NOT EXISTS WebStorage (
                 storage_endpoint INTEGER,
@@ -31,13 +30,6 @@ ErrorOr<Database::MigrationOutcome> StorageJar::migrate_schema(Database::Databas
                 PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
             );
         )#"sv },
-        // A WebStorage table created before last_access_time existed is adopted as-is by the
-        // baseline CREATE ... IF NOT EXISTS above, so add the column to databases that lack it.
-        { .version = WEB_STORAGE_SCHEMA_LAST_ACCESS_TIME_VERSION, .backfill = [](Database::Database& database) -> ErrorOr<void> {
-             if (!TRY(database.column_exists("WebStorage"sv, "last_access_time"sv)))
-                 TRY(database.execute_raw("ALTER TABLE WebStorage ADD COLUMN last_access_time INTEGER;"));
-             return {};
-         } },
     } };
 
     return database.migrate("WebStorage"sv, migrations, mode);

--- a/Tests/LibWebView/TestStorageJar.cpp
+++ b/Tests/LibWebView/TestStorageJar.cpp
@@ -34,34 +34,11 @@ TEST_CASE(newer_storage_schema_reports_database_too_new)
     EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database, Database::MigrationMode::CheckOnly)), Database::MigrationOutcome::DatabaseTooNew);
 }
 
-TEST_CASE(migrates_web_storage_table_created_before_last_access_time)
+TEST_CASE(storage_schema_version_2_database_migrates_cleanly)
 {
     auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
 
-    TRY_OR_FAIL(database->execute_raw(R"#(
-        CREATE TABLE WebStorage (
-            storage_endpoint INTEGER,
-            storage_key TEXT,
-            bottle_key TEXT,
-            bottle_value TEXT,
-            PRIMARY KEY(storage_endpoint, storage_key, bottle_key)
-        );
-    )#"));
-
-    EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
-
-    auto jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
-
-    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16, "bar"_utf16);
-    EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16), Optional<Utf16String> { "bar"_utf16 });
-
-    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 2u });
-}
-
-TEST_CASE(migration_to_add_last_access_time_is_idempotent)
-{
-    auto database = TRY_OR_FAIL(Database::Database::create_memory_backed());
-
+    // Databases written while schema version 2 shipped must still migrate, not be rejected as too new.
     TRY_OR_FAIL(database->execute_raw(R"#(
         CREATE TABLE WebStorage (
             storage_endpoint INTEGER,
@@ -73,13 +50,11 @@ TEST_CASE(migration_to_add_last_access_time_is_idempotent)
         );
     )#"));
     TRY_OR_FAIL(database->execute_raw("CREATE TABLE SchemaVersions (store TEXT PRIMARY KEY, version INTEGER NOT NULL);"));
-    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('WebStorage', 1);"));
+    TRY_OR_FAIL(database->execute_raw("INSERT INTO SchemaVersions (store, version) VALUES ('WebStorage', 2);"));
 
     EXPECT_EQ(TRY_OR_FAIL(WebView::StorageJar::migrate_schema(*database)), Database::MigrationOutcome::Success);
 
     auto jar = TRY_OR_FAIL(WebView::StorageJar::create(*database));
     jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16, "bar"_utf16);
     EXPECT_EQ(jar->get_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "foo"_utf16), Optional<Utf16String> { "bar"_utf16 });
-
-    EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 2u });
 }


### PR DESCRIPTION
This reverts commit 09ed299 — but the baseline schema stays at v2 rather than going back to 1. See https://github.com/LadybirdBrowser/ladybird/pull/10709#issuecomment-4990748161.
