### PR TITLE
Stream WebGL commands via shared memory

### DIFF
--- a/Libraries/LibWeb/WebGL/RemoteWebGLTransport.h
+++ b/Libraries/LibWeb/WebGL/RemoteWebGLTransport.h
@@ -34,6 +34,10 @@ public:
     virtual Optional<Painting::CanvasId> canvas_id() const = 0;
     virtual void destroy_context() = 0;
 
+    virtual void set_shared_command_buffer(Core::AnonymousBuffer const&) = 0;
+    virtual void send_commands_from_shared_buffer(u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> const& bitmaps) = 0;
+    virtual bool wait_until_published_commands_executed() = 0;
+
     virtual void send_commands(ByteBuffer const&, Vector<Gfx::DecodedImageFrame> const& bitmaps) = 0;
     virtual void present_canvas(bool preserve_drawing_buffer) = 0;
     virtual ByteBuffer sync_call(ByteBuffer request) = 0;

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextImpl.cpp
@@ -212,14 +212,15 @@ void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL
 {
     m_context->make_current();
 
-    ByteBuffer src_data_storage;
-    ReadonlyBytes src_data_span;
-    if (!src_data.has<Empty>()) {
-        src_data_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
-        src_data_span = src_data_storage;
+    if (src_data.has<Empty>()) {
+        m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, 0, nullptr);
+        return;
     }
 
-    m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes src_data_bytes) {
+        m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_bytes.size(), src_data_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -244,9 +245,10 @@ void WebGL2RenderingContextImpl::tex_image3d(WebIDL::UnsignedLong target, WebIDL
 {
     m_context->make_current();
 
-    auto src_data_span = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset), GL_INVALID_OPERATION);
-
-    m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_span.size(), src_data_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, /* src_length_override= */ 0, [&](ReadonlyBytes src_data_bytes) {
+        m_context->tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, format, type, src_data_bytes.size(), src_data_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextImpl::tex_sub_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long zoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -264,14 +266,15 @@ void WebGL2RenderingContextImpl::tex_sub_image3d(WebIDL::UnsignedLong target, We
 {
     m_context->make_current();
 
-    ByteBuffer src_data_storage;
-    ReadonlyBytes src_data_span;
-    if (!src_data.has<Empty>()) {
-        src_data_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data.downcast<WebIDL::ArrayBufferViewVariant>() }, src_offset), GL_INVALID_OPERATION);
-        src_data_span = src_data_storage;
+    if (src_data.has<Empty>()) {
+        m_context->tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, 0, nullptr);
+        return;
     }
 
-    m_context->tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, src_data_span.size(), src_data_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data.downcast<WebIDL::ArrayBufferViewVariant>() }, src_offset, /* src_length_override= */ 0, [&](ReadonlyBytes src_data_bytes) {
+        m_context->tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, src_data_bytes.size(), src_data_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextImpl::uniform1ui(GC::Ptr<WebGLUniformLocation> location, WebIDL::UnsignedLong v0)
@@ -1355,8 +1358,10 @@ void WebGL2RenderingContextImpl::compressed_tex_image3d(WebIDL::UnsignedLong tar
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
-    m_context->compressed_tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, pixels.size(), pixels.size(), pixels.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, src_length_override, [&](ReadonlyBytes pixels_bytes) {
+        m_context->compressed_tex_image3d_robust_angle(target, level, internalformat, width, height, depth, border, pixels_bytes.size(), pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextImpl::compressed_tex_sub_image3d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long zoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::Long depth, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override)
@@ -1368,8 +1373,10 @@ void WebGL2RenderingContextImpl::compressed_tex_sub_image3d(WebIDL::UnsignedLong
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
-    m_context->compressed_tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, pixels.size(), pixels.size(), pixels.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, src_length_override, [&](ReadonlyBytes pixels_bytes) {
+        m_context->compressed_tex_sub_image3d_robust_angle(target, level, xoffset, yoffset, zoffset, width, height, depth, format, pixels_bytes.size(), pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 }

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.cpp
@@ -46,46 +46,55 @@ void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, W
         return;
     }
 
-    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data.downcast<WebIDL::BufferSourceVariant>() }, /* src_offset= */ 0), GL_INVALID_VALUE);
-    m_context->buffer_data(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data.downcast<WebIDL::BufferSourceVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes data) {
+        m_context->buffer_data(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, WebIDL::BufferSource src_data)
 {
     m_context->make_current();
 
-    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(src_data, /* src_offset= */ 0), GL_INVALID_VALUE);
-    m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(src_data, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes data) {
+        m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLong usage, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length)
 {
     m_context->make_current();
 
-    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, length), GL_INVALID_VALUE);
-    m_context->buffer_data(target, data.size(), data.data(), usage);
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, length, [&](ReadonlyBytes data) {
+        m_context->buffer_data(target, data.size(), data.data(), usage);
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong dst_byte_offset, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong length)
 {
     m_context->make_current();
 
-    auto data = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, length), GL_INVALID_VALUE);
-    m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, length, [&](ReadonlyBytes data) {
+        m_context->buffer_sub_data(target, dst_byte_offset, data.size(), data.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
 {
     m_context->make_current();
 
-    ByteBuffer pixels_storage;
-    ReadonlyBytes pixels_span;
-    if (!pixels.has<Empty>()) {
-        pixels_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
-        pixels_span = pixels_storage;
+    if (pixels.has<Empty>()) {
+        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, 0, nullptr);
+        return;
     }
 
-    m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes pixels_bytes) {
+        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long internalformat, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -103,14 +112,15 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
 {
     m_context->make_current();
 
-    ByteBuffer pixels_storage;
-    ReadonlyBytes pixels_span;
-    if (!pixels.has<Empty>()) {
-        pixels_storage = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
-        pixels_span = pixels_storage;
+    if (pixels.has<Empty>()) {
+        m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, 0, nullptr);
+        return;
     }
 
-    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes pixels_bytes) {
+        m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -146,9 +156,10 @@ void WebGL2RenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, W
 {
     m_context->make_current();
 
-    auto pixels_span = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset), GL_INVALID_OPERATION);
-
-    m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_span.size(), pixels_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, /* src_length_override= */ 0, [&](ReadonlyBytes pixels_bytes) {
+        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)
@@ -166,9 +177,10 @@ void WebGL2RenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong targe
 {
     m_context->make_current();
 
-    auto pixels_span = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset), GL_INVALID_OPERATION);
-
-    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_span.size(), pixels_span.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, /* src_length_override= */ 0, [&](ReadonlyBytes pixels_bytes) {
+        m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGL2RenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override)
@@ -180,8 +192,10 @@ void WebGL2RenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLon
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
-    m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, pixels.size(), pixels.size(), pixels.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, src_length_override, [&](ReadonlyBytes pixels_bytes) {
+        m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, pixels_bytes.size(), pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override)
@@ -193,8 +207,10 @@ void WebGL2RenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::Unsigne
         return;
     }
 
-    auto pixels = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { src_data }, src_offset, src_length_override), GL_INVALID_VALUE);
-    m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, pixels.size(), pixels.size(), pixels.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { src_data }, src_offset, src_length_override, [&](ReadonlyBytes pixels_bytes) {
+        m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, pixels_bytes.size(), pixels_bytes.size(), pixels_bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGL2RenderingContextOverloads::uniform1fv(GC::Ptr<WebGLUniformLocation> location, Float32List values, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length)

--- a/Libraries/LibWeb/WebGL/WebGLCommandList.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLCommandList.cpp
@@ -34,13 +34,16 @@ static void write_payload(Bytes destination, ReadonlyBytes payload, ReadonlyByte
     __builtin_memset(destination.offset_pointer(cursor), 0, destination.size() - cursor);
 }
 
-void WebGLCommandList::append_bytes(WebGLCommandType type, ReadonlyBytes payload, ReadonlyBytes inline_data)
+size_t WebGLCommandList::padded_record_size(ReadonlyBytes payload, ReadonlyBytes inline_data)
 {
-    VERIFY(m_bytes.size() % command_alignment == 0);
+    return align_up_to(sizeof(WebGLCommandHeader) + payload_layout_size(payload, inline_data), command_alignment);
+}
 
-    auto record_size = sizeof(WebGLCommandHeader) + payload_layout_size(payload, inline_data);
-    auto padded_record_size = align_up_to(record_size, command_alignment);
-    auto padded_payload_size = padded_record_size - sizeof(WebGLCommandHeader);
+void WebGLCommandList::write_record(Bytes destination, WebGLCommandType type, ReadonlyBytes payload, ReadonlyBytes inline_data)
+{
+    VERIFY(destination.size() == padded_record_size(payload, inline_data));
+
+    auto padded_payload_size = destination.size() - sizeof(WebGLCommandHeader);
     VERIFY(padded_payload_size <= NumericLimits<u32>::max());
 
     WebGLCommandHeader header {
@@ -48,11 +51,18 @@ void WebGLCommandList::append_bytes(WebGLCommandType type, ReadonlyBytes payload
         .payload_size = static_cast<u32>(padded_payload_size),
     };
 
+    __builtin_memcpy(destination.data(), &header, sizeof(header));
+    write_payload(destination.slice(sizeof(header)), payload, inline_data);
+}
+
+void WebGLCommandList::append_bytes(WebGLCommandType type, ReadonlyBytes payload, ReadonlyBytes inline_data)
+{
+    VERIFY(m_bytes.size() % command_alignment == 0);
+
+    auto record_size = padded_record_size(payload, inline_data);
     auto record_offset = m_bytes.size();
-    m_bytes.resize(record_offset + padded_record_size);
-    auto record = m_bytes.bytes().slice(record_offset);
-    __builtin_memcpy(record.data(), &header, sizeof(header));
-    write_payload(record.slice(sizeof(header)), payload, inline_data);
+    m_bytes.resize(record_offset + record_size);
+    write_record(m_bytes.bytes().slice(record_offset), type, payload, inline_data);
 }
 
 ByteBuffer WebGLSyncCall::encode_request_bytes(WebGLSyncCallType type, ReadonlyBytes request, ReadonlyBytes inline_data)

--- a/Libraries/LibWeb/WebGL/WebGLCommandList.h
+++ b/Libraries/LibWeb/WebGL/WebGLCommandList.h
@@ -44,6 +44,9 @@ public:
 
     void append_bytes(WebGLCommandType, ReadonlyBytes payload, ReadonlyBytes inline_data);
 
+    static size_t padded_record_size(ReadonlyBytes payload, ReadonlyBytes inline_data);
+    static void write_record(Bytes destination, WebGLCommandType, ReadonlyBytes payload, ReadonlyBytes inline_data);
+
     template<typename Callback>
     static ErrorOr<void> for_each_command(ReadonlyBytes bytes, Callback&& callback)
     {

--- a/Libraries/LibWeb/WebGL/WebGLContextProxyBase.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLContextProxyBase.cpp
@@ -20,6 +20,7 @@ WebGLContextProxyBase::WebGLContextProxyBase(NonnullRefPtr<RemoteWebGLTransport>
     , m_webgl_version(webgl_version)
     , m_supported_extensions(move(supported_extensions))
 {
+    initialize_shared_command_buffer();
 }
 
 WebGLContextProxyBase::~WebGLContextProxyBase()
@@ -32,17 +33,111 @@ void WebGLContextProxyBase::restore(NonnullRefPtr<RemoteWebGLTransport> transpor
     m_transport = move(transport);
     m_supported_extensions = move(supported_extensions);
     m_lost = false;
-    m_commands.clear_with_capacity();
+    m_out_of_line_commands.clear_with_capacity();
     m_pending_bitmaps.clear_with_capacity();
     m_string_cache.clear();
+    initialize_shared_command_buffer();
+}
+
+void WebGLContextProxyBase::initialize_shared_command_buffer()
+{
+    m_shared_data_cursor = 0;
+    m_shared_data_flush_base = 0;
+    m_last_published_flush_sequence_number = 0;
+
+    auto shared_command_buffer_or_error = WebGLSharedCommandBuffer::create();
+    if (shared_command_buffer_or_error.is_error()) {
+        m_shared_command_buffer = {};
+        return;
+    }
+    m_shared_command_buffer = shared_command_buffer_or_error.release_value();
+    m_transport->set_shared_command_buffer(m_shared_command_buffer.buffer());
+}
+
+void WebGLContextProxyBase::record_bytes(WebGLCommandType type, ReadonlyBytes payload, ReadonlyBytes inline_data)
+{
+    if (m_lost)
+        return;
+
+    if (!m_shared_command_buffer.is_valid()) {
+        m_out_of_line_commands.append_bytes(type, payload, inline_data);
+        if (m_out_of_line_commands.size_in_bytes() >= max_pending_command_bytes)
+            flush_commands();
+        return;
+    }
+
+    auto data_region = m_shared_command_buffer.data_region();
+    auto record_size = WebGLCommandList::padded_record_size(payload, inline_data);
+
+    if (record_size > data_region.size()) {
+        flush_commands();
+        WebGLCommandList oversized_command_list;
+        oversized_command_list.append_bytes(type, payload, inline_data);
+        m_transport->send_commands(oversized_command_list.buffer(), {});
+        return;
+    }
+
+    rewind_shared_data_cursor_if_all_published_commands_executed();
+    ensure_shared_data_capacity(record_size);
+    if (m_lost)
+        return;
+
+    WebGLCommandList::write_record(data_region.slice(m_shared_data_cursor, record_size), type, payload, inline_data);
+    m_shared_data_cursor += record_size;
+    if (m_shared_data_cursor - m_shared_data_flush_base >= max_pending_command_bytes)
+        flush_commands();
+}
+
+void WebGLContextProxyBase::rewind_shared_data_cursor_if_all_published_commands_executed()
+{
+    if (m_shared_data_cursor == 0 || m_shared_data_cursor != m_shared_data_flush_base)
+        return;
+    if (m_shared_command_buffer.executed_flush_sequence_number() >= m_last_published_flush_sequence_number) {
+        m_shared_data_cursor = 0;
+        m_shared_data_flush_base = 0;
+    }
+}
+
+void WebGLContextProxyBase::ensure_shared_data_capacity(size_t record_size)
+{
+    auto data_region_capacity = m_shared_command_buffer.data_region().size();
+    VERIFY(record_size <= data_region_capacity);
+    if (record_size <= data_region_capacity - m_shared_data_cursor)
+        return;
+
+    flush_commands();
+    VERIFY(m_shared_data_cursor == m_shared_data_flush_base);
+    if (m_shared_command_buffer.executed_flush_sequence_number() < m_last_published_flush_sequence_number) {
+        if (!m_transport->wait_until_published_commands_executed()) {
+            set_lost();
+            return;
+        }
+        VERIFY(m_shared_command_buffer.executed_flush_sequence_number() >= m_last_published_flush_sequence_number);
+    }
+    m_shared_data_cursor = 0;
+    m_shared_data_flush_base = 0;
 }
 
 void WebGLContextProxyBase::flush_commands()
 {
-    if (m_commands.is_empty())
+    if (m_shared_command_buffer.is_valid()) {
+        if (m_shared_data_cursor == m_shared_data_flush_base)
+            return;
+        m_last_published_flush_sequence_number++;
+        m_transport->send_commands_from_shared_buffer(
+            m_shared_data_flush_base,
+            m_shared_data_cursor - m_shared_data_flush_base,
+            m_last_published_flush_sequence_number,
+            m_pending_bitmaps);
+        m_shared_data_flush_base = m_shared_data_cursor;
+        m_pending_bitmaps.clear_with_capacity();
         return;
-    m_transport->send_commands(m_commands.buffer(), m_pending_bitmaps);
-    m_commands.clear_with_capacity();
+    }
+
+    if (m_out_of_line_commands.is_empty())
+        return;
+    m_transport->send_commands(m_out_of_line_commands.buffer(), m_pending_bitmaps);
+    m_out_of_line_commands.clear_with_capacity();
     m_pending_bitmaps.clear_with_capacity();
 }
 
@@ -54,6 +149,16 @@ u32 WebGLContextProxyBase::append_pending_bitmap(Gfx::DecodedImageFrame frame)
 
     if (m_pending_bitmaps.size() >= max_bitmap_attachments_per_message)
         flush_commands();
+
+    // Reserve space for the upcoming bitmap-referencing command now: a capacity flush
+    // between this append and its record would publish the bitmap with the wrong batch.
+    static constexpr size_t reserved_record_size_for_bitmap_command = 256;
+    static_assert(sizeof(WebGLCommandHeader) + sizeof(Commands::TexImage2DFromBitmap) <= reserved_record_size_for_bitmap_command);
+    static_assert(sizeof(WebGLCommandHeader) + sizeof(Commands::TexSubImage2DFromBitmap) <= reserved_record_size_for_bitmap_command);
+    static_assert(sizeof(WebGLCommandHeader) + sizeof(Commands::TexImage3DFromBitmap) <= reserved_record_size_for_bitmap_command);
+    static_assert(sizeof(WebGLCommandHeader) + sizeof(Commands::TexSubImage3DFromBitmap) <= reserved_record_size_for_bitmap_command);
+    if (m_shared_command_buffer.is_valid())
+        ensure_shared_data_capacity(reserved_record_size_for_bitmap_command);
 
     auto bitmap_index = static_cast<u32>(m_pending_bitmaps.size());
     m_pending_bitmaps.append(move(frame));

--- a/Libraries/LibWeb/WebGL/WebGLContextProxyBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLContextProxyBase.h
@@ -23,6 +23,7 @@
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 #include <LibWeb/WebGL/RemoteWebGLTransport.h>
 #include <LibWeb/WebGL/WebGLCommandList.h>
+#include <LibWeb/WebGL/WebGLSharedCommandBuffer.h>
 
 namespace Web::WebGL {
 
@@ -82,12 +83,10 @@ protected:
     template<typename Command>
     void record(Command const& command, ReadonlyBytes inline_data = {})
     {
-        if (m_lost)
-            return;
-        m_commands.append(command, inline_data);
-        if (m_commands.size_in_bytes() >= max_pending_command_bytes)
-            flush_commands();
+        record_bytes(Command::command_type, { &command, sizeof(command) }, inline_data);
     }
+
+    void record_bytes(WebGLCommandType, ReadonlyBytes payload, ReadonlyBytes inline_data);
 
     ByteBuffer send_sync_call(ByteBuffer request);
     bool is_lost() const { return m_lost; }
@@ -96,11 +95,18 @@ protected:
 
 private:
     u32 append_pending_bitmap(Gfx::DecodedImageFrame);
+    void initialize_shared_command_buffer();
+    void rewind_shared_data_cursor_if_all_published_commands_executed();
+    void ensure_shared_data_capacity(size_t record_size);
 
     NonnullRefPtr<RemoteWebGLTransport> m_transport;
     WebGLVersion m_webgl_version { WebGLVersion::WebGL1 };
     Vector<String> m_supported_extensions;
-    WebGLCommandList m_commands;
+    WebGLSharedCommandBuffer m_shared_command_buffer;
+    size_t m_shared_data_cursor { 0 };
+    size_t m_shared_data_flush_base { 0 };
+    u64 m_last_published_flush_sequence_number { 0 };
+    WebGLCommandList m_out_of_line_commands;
     Vector<Gfx::DecodedImageFrame> m_pending_bitmaps;
     u32 m_next_object_id { 1 };
     bool m_lost { false };

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.h
@@ -111,7 +111,10 @@ protected:
         return src_span.slice(src_offset, src_length_override);
     }
 
-    static ErrorOr<ByteBuffer> copy_buffer_source_to_byte_buffer(WebIDL::BufferSource src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override = 0)
+    // The callback's view may point straight into the JS heap: it must not escape the
+    // callback, run script, or allocate on the JS heap while held.
+    template<typename Callback>
+    static ErrorOr<void> with_buffer_source_bytes(WebIDL::BufferSource src_data, WebIDL::UnsignedLongLong src_offset, WebIDL::UnsignedLong src_length_override, Callback&& callback)
     {
         auto array_buffer = src_data.viewed_array_buffer();
         if (!array_buffer || array_buffer->is_detached()) [[unlikely]]
@@ -120,7 +123,8 @@ protected:
         if (src_data.is_out_of_bounds()) {
             if (src_offset != 0 || src_length_override != 0) [[unlikely]]
                 return Error::from_errno(EINVAL);
-            return ByteBuffer::create_uninitialized(0);
+            callback(ReadonlyBytes {});
+            return {};
         }
 
         auto element_size = src_data.element_size();
@@ -148,7 +152,10 @@ protected:
         if (byte_length > array_buffer->byte_length() - byte_offset_in_buffer.value()) [[unlikely]]
             return Error::from_errno(EINVAL);
 
-        return array_buffer->copy_to_byte_buffer(byte_offset_in_buffer.value(), byte_length);
+        array_buffer->with_readonly_bytes(byte_offset_in_buffer.value(), byte_length, [&](ReadonlyBytes bytes) {
+            callback(bytes);
+        });
+        return {};
     }
 
     template<typename T>

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.cpp
@@ -44,16 +44,20 @@ void WebGLRenderingContextOverloads::buffer_data(WebIDL::UnsignedLong target, We
         return;
     }
 
-    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { data.downcast<WebIDL::BufferSourceVariant>() }, /* src_offset= */ 0), GL_INVALID_VALUE);
-    m_context->buffer_data(target, static_cast<GLsizeiptr>(bytes.size()), bytes.data(), usage);
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { data.downcast<WebIDL::BufferSourceVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes bytes) {
+        m_context->buffer_data(target, static_cast<GLsizeiptr>(bytes.size()), bytes.data(), usage);
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGLRenderingContextOverloads::buffer_sub_data(WebIDL::UnsignedLong target, WebIDL::LongLong offset, WebIDL::BufferSource data)
 {
     m_context->make_current();
 
-    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(data, /* src_offset= */ 0), GL_INVALID_VALUE);
-    m_context->buffer_sub_data(target, offset, bytes.size(), bytes.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(data, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes bytes) {
+        m_context->buffer_sub_data(target, offset, bytes.size(), bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGLRenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::UnsignedLong internalformat, WebIDL::Long width, WebIDL::Long height, WebIDL::Long border, WebIDL::ArrayBufferView data)
@@ -65,8 +69,10 @@ void WebGLRenderingContextOverloads::compressed_tex_image2d(WebIDL::UnsignedLong
         return;
     }
 
-    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { data }, /* src_offset= */ 0), GL_INVALID_VALUE);
-    m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, bytes.size(), bytes.size(), bytes.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { data }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes bytes) {
+        m_context->compressed_tex_image2d_robust_angle(target, level, internalformat, width, height, border, bytes.size(), bytes.size(), bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGLRenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::ArrayBufferView data)
@@ -78,8 +84,10 @@ void WebGLRenderingContextOverloads::compressed_tex_sub_image2d(WebIDL::Unsigned
         return;
     }
 
-    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { data }, /* src_offset= */ 0), GL_INVALID_VALUE);
-    m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, bytes.size(), bytes.size(), bytes.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { data }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes bytes) {
+        m_context->compressed_tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, bytes.size(), bytes.size(), bytes.data());
+    }),
+        GL_INVALID_VALUE);
 }
 
 void WebGLRenderingContextOverloads::read_pixels(WebIDL::Long x, WebIDL::Long y, WebIDL::Long width, WebIDL::Long height, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, WebIDL::NullableArrayBufferViewVariant pixels)
@@ -119,8 +127,10 @@ void WebGLRenderingContextOverloads::tex_image2d(WebIDL::UnsignedLong target, We
     m_context->make_current();
 
     if (!pixels.has<Empty>()) {
-        auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
-        m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, bytes.size(), bytes.data());
+        SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes bytes) {
+            m_context->tex_image2d_robust_angle(target, level, internalformat, width, height, border, format, type, bytes.size(), bytes.data());
+        }),
+            GL_INVALID_OPERATION);
         return;
     }
 
@@ -202,8 +212,10 @@ void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target
         return;
     }
 
-    auto bytes = SET_ERROR_VALUE_IF_ERROR(copy_buffer_source_to_byte_buffer(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0), GL_INVALID_OPERATION);
-    m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, bytes.size(), bytes.data());
+    SET_ERROR_VALUE_IF_ERROR(with_buffer_source_bytes(WebIDL::BufferSource { pixels.downcast<WebIDL::ArrayBufferViewVariant>() }, /* src_offset= */ 0, /* src_length_override= */ 0, [&](ReadonlyBytes bytes) {
+        m_context->tex_sub_image2d_robust_angle(target, level, xoffset, yoffset, width, height, format, type, bytes.size(), bytes.data());
+    }),
+        GL_INVALID_OPERATION);
 }
 
 void WebGLRenderingContextOverloads::tex_sub_image2d(WebIDL::UnsignedLong target, WebIDL::Long level, WebIDL::Long xoffset, WebIDL::Long yoffset, WebIDL::UnsignedLong format, WebIDL::UnsignedLong type, TexImageSource source)

--- a/Libraries/LibWeb/WebGL/WebGLSharedCommandBuffer.h
+++ b/Libraries/LibWeb/WebGL/WebGLSharedCommandBuffer.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/Optional.h>
+#include <LibCore/AnonymousBuffer.h>
+
+namespace Web::WebGL {
+
+// WebContent records commands into the data region and publishes ranges via async IPC;
+// the Compositor stores each executed range's flush sequence number into the header.
+// The write cursor may rewind to the start only once that counter covers everything
+// published, so published bytes are never overwritten while still being read.
+class WebGLSharedCommandBuffer {
+public:
+    static constexpr size_t data_region_offset = 128;
+    static constexpr size_t default_data_region_capacity = 32 * MiB;
+
+    WebGLSharedCommandBuffer() = default;
+
+    static ErrorOr<WebGLSharedCommandBuffer> create(size_t data_region_capacity = default_data_region_capacity)
+    {
+        auto buffer = TRY(Core::AnonymousBuffer::create_with_size(data_region_offset + data_region_capacity));
+        return WebGLSharedCommandBuffer { move(buffer) };
+    }
+
+    static Optional<WebGLSharedCommandBuffer> adopt_received_buffer(Core::AnonymousBuffer buffer)
+    {
+        if (!buffer.is_valid() || buffer.size() <= data_region_offset)
+            return {};
+        return WebGLSharedCommandBuffer { move(buffer) };
+    }
+
+    bool is_valid() const { return m_buffer.is_valid(); }
+    Core::AnonymousBuffer const& buffer() const { return m_buffer; }
+
+    u64 executed_flush_sequence_number() const
+    {
+        return reinterpret_cast<Atomic<u64> const*>(m_buffer.data<u8>())->load(AK::MemoryOrder::memory_order_acquire);
+    }
+
+    void store_executed_flush_sequence_number(u64 flush_sequence_number)
+    {
+        reinterpret_cast<Atomic<u64>*>(m_buffer.data<u8>())->store(flush_sequence_number, AK::MemoryOrder::memory_order_release);
+    }
+
+    Bytes data_region()
+    {
+        return { m_buffer.data<u8>() + data_region_offset, m_buffer.size() - data_region_offset };
+    }
+
+    ReadonlyBytes data_region() const
+    {
+        return { m_buffer.data<u8>() + data_region_offset, m_buffer.size() - data_region_offset };
+    }
+
+private:
+    explicit WebGLSharedCommandBuffer(Core::AnonymousBuffer buffer)
+        : m_buffer(move(buffer))
+    {
+    }
+
+    Core::AnonymousBuffer m_buffer;
+};
+
+}

--- a/Services/Compositor/CanvasHost.cpp
+++ b/Services/Compositor/CanvasHost.cpp
@@ -161,6 +161,34 @@ void CanvasHost::execute_webgl_commands(Web::Painting::CanvasId canvas_id, Reado
         m_canvas_surface_registry.set_canvas_surface(canvas_id, surface.release_nonnull());
 }
 
+void CanvasHost::set_webgl_shared_command_buffer(Web::Painting::CanvasId canvas_id, Web::WebGL::WebGLSharedCommandBuffer shared_command_buffer)
+{
+    auto* context = this->context(canvas_id);
+    VERIFY(context);
+    as_webgl(*context).set_shared_command_buffer(move(shared_command_buffer));
+}
+
+bool CanvasHost::execute_webgl_commands_from_shared_buffer(Web::Painting::CanvasId canvas_id, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> const& bitmaps)
+{
+    auto* context = this->context(canvas_id);
+    VERIFY(context);
+    auto& webgl_context = as_webgl(*context);
+
+    auto commands = webgl_context.shared_command_buffer_range(offset, size_in_bytes);
+    if (!commands.has_value())
+        return false;
+
+    // WebContent can rewrite shared bytes while they execute, so a malformed stream is
+    // a misbehaving peer rather than a Compositor bug; report instead of crashing.
+    if (webgl_context.execute_commands(*commands, bitmaps).is_error())
+        return false;
+    webgl_context.store_executed_flush_sequence_number(flush_sequence_number);
+
+    if (auto surface = webgl_context.surface())
+        m_canvas_surface_registry.set_canvas_surface(canvas_id, surface.release_nonnull());
+    return true;
+}
+
 ErrorOr<ByteBuffer> CanvasHost::execute_webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request)
 {
     auto* context = this->context(canvas_id);

--- a/Services/Compositor/CanvasHost.h
+++ b/Services/Compositor/CanvasHost.h
@@ -24,6 +24,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 #include <LibWeb/WebGL/Types.h>
+#include <LibWeb/WebGL/WebGLSharedCommandBuffer.h>
 
 namespace Web::Painting {
 
@@ -53,6 +54,8 @@ public:
 
     void execute_canvas_2d_stream(Vector<Web::Painting::Canvas2DCommandStreamSegment> const&);
     void execute_webgl_commands(Web::Painting::CanvasId, ReadonlyBytes, Vector<Gfx::DecodedImageFrame> const&);
+    void set_webgl_shared_command_buffer(Web::Painting::CanvasId, Web::WebGL::WebGLSharedCommandBuffer);
+    [[nodiscard]] bool execute_webgl_commands_from_shared_buffer(Web::Painting::CanvasId, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> const&);
     ErrorOr<ByteBuffer> execute_webgl_sync_call(Web::Painting::CanvasId, ByteBuffer request);
     Web::WebGL::ReadPixelsResult webgl_read_pixels_robust_angle(Web::Painting::CanvasId, Web::WebGL::GLint x, Web::WebGL::GLint y, Web::WebGL::GLsizei width, Web::WebGL::GLsizei height, Web::WebGL::GLenum format, Web::WebGL::GLenum type, Web::WebGL::GLsizei buf_size, Core::AnonymousBuffer pixels);
     bool webgl_read_buffer_sub_data(Web::Painting::CanvasId, Web::WebGL::GLenum target, Web::WebGL::GLintptr offset, Web::WebGL::GLintptr size, Core::AnonymousBuffer data);

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -39,6 +39,9 @@ endpoint CompositorWebContentServer
     get_canvas_pixels(Web::Painting::CanvasId canvas_id, Gfx::IntRect rect) => (Gfx::ShareableBitmap pixels)
 
     create_webgl_context(Web::WebGL::WebGLVersion webgl_version, Gfx::IntSize size, bool depth, bool stencil, bool antialias) => (bool success, Web::Painting::CanvasId canvas_id, Vector<String> supported_extensions)
+    webgl_set_command_buffer(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer command_buffer) =|
+    webgl_commands_from_shared_buffer(Web::Painting::CanvasId canvas_id, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> bitmaps) =|
+    webgl_drain_command_buffer(Web::Painting::CanvasId canvas_id) => ()
     webgl_commands(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps) =|
     webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer) =|
     webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request) => (ByteBuffer reply)

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -7,6 +7,7 @@
 #include <Compositor/ConnectionFromWebContent.h>
 #include <LibCore/System.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWeb/WebGL/WebGLSharedCommandBuffer.h>
 
 namespace Compositor {
 
@@ -154,6 +155,29 @@ Messages::CompositorWebContentServer::CreateWebglContextResponse ConnectionFromW
 {
     auto result = m_canvas_host.create_webgl_context(webgl_version, size, depth, stencil, antialias);
     return { result.success, result.canvas_id, move(result.supported_extensions) };
+}
+
+void ConnectionFromWebContent::webgl_set_command_buffer(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer command_buffer)
+{
+    auto shared_command_buffer = Web::WebGL::WebGLSharedCommandBuffer::adopt_received_buffer(move(command_buffer));
+    if (!shared_command_buffer.has_value()) {
+        did_misbehave("WebContent sent an invalid WebGL shared command buffer");
+        return;
+    }
+
+    m_canvas_host.set_webgl_shared_command_buffer(canvas_id, shared_command_buffer.release_value());
+}
+
+void ConnectionFromWebContent::webgl_commands_from_shared_buffer(Web::Painting::CanvasId canvas_id, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> bitmaps)
+{
+    if (!m_canvas_host.execute_webgl_commands_from_shared_buffer(canvas_id, offset, size_in_bytes, flush_sequence_number, bitmaps))
+        did_misbehave("WebContent published an invalid WebGL shared command buffer range");
+}
+
+void ConnectionFromWebContent::webgl_drain_command_buffer(Web::Painting::CanvasId)
+{
+    // The empty reply is the point: it proves every earlier message on this connection,
+    // including all published command ranges, has already been processed.
 }
 
 void ConnectionFromWebContent::webgl_commands(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps)

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -52,6 +52,9 @@ private:
     virtual Messages::CompositorWebContentServer::GetCanvasPixelsResponse get_canvas_pixels(Web::Painting::CanvasId, Gfx::IntRect) override;
 
     virtual Messages::CompositorWebContentServer::CreateWebglContextResponse create_webgl_context(Web::WebGL::WebGLVersion webgl_version, Gfx::IntSize size, bool depth, bool stencil, bool antialias) override;
+    virtual void webgl_set_command_buffer(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer command_buffer) override;
+    virtual void webgl_commands_from_shared_buffer(Web::Painting::CanvasId canvas_id, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> bitmaps) override;
+    virtual void webgl_drain_command_buffer(Web::Painting::CanvasId canvas_id) override;
     virtual void webgl_commands(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer commands, Vector<Gfx::DecodedImageFrame> bitmaps) override;
     virtual void webgl_present_canvas(Web::Painting::CanvasId canvas_id, bool preserve_drawing_buffer) override;
     virtual Messages::CompositorWebContentServer::WebglSyncCallResponse webgl_sync_call(Web::Painting::CanvasId canvas_id, ByteBuffer request) override;

--- a/Services/Compositor/HostWebGLContext.cpp
+++ b/Services/Compositor/HostWebGLContext.cpp
@@ -39,6 +39,18 @@ OwnPtr<HostWebGLContext> HostWebGLContext::create(RefPtr<Gfx::SkiaBackendContext
     return adopt_own(*new HostWebGLContext(gl_context.release_nonnull()));
 }
 
+Optional<ReadonlyBytes> HostWebGLContext::shared_command_buffer_range(u64 offset, u64 size_in_bytes) const
+{
+    if (!m_shared_command_buffer.is_valid())
+        return {};
+    auto data_region = m_shared_command_buffer.data_region();
+    if (offset % WebGLCommandList::command_alignment != 0)
+        return {};
+    if (offset > data_region.size() || size_in_bytes > data_region.size() - offset)
+        return {};
+    return data_region.slice(offset, size_in_bytes);
+}
+
 ErrorOr<void> HostWebGLContext::execute_commands(ReadonlyBytes bytes, Vector<Gfx::DecodedImageFrame> const& bitmaps)
 {
     m_gl_context->make_current();

--- a/Services/Compositor/HostWebGLContext.h
+++ b/Services/Compositor/HostWebGLContext.h
@@ -18,6 +18,7 @@
 #include <LibGfx/Size.h>
 #include <LibWeb/Painting/DisplayListResourceIds.h>
 #include <LibWeb/WebGL/Types.h>
+#include <LibWeb/WebGL/WebGLSharedCommandBuffer.h>
 
 namespace Web::WebGL::Commands {
 
@@ -35,6 +36,10 @@ public:
     static OwnPtr<HostWebGLContext> create(RefPtr<Gfx::SkiaBackendContext>, OpenGLContext::WebGLVersion, OpenGLContext::DrawingBufferOptions, Gfx::IntSize initial_size);
 
     ErrorOr<void> execute_commands(ReadonlyBytes, Vector<Gfx::DecodedImageFrame> const& bitmaps);
+
+    void set_shared_command_buffer(Web::WebGL::WebGLSharedCommandBuffer shared_command_buffer) { m_shared_command_buffer = move(shared_command_buffer); }
+    Optional<ReadonlyBytes> shared_command_buffer_range(u64 offset, u64 size_in_bytes) const;
+    void store_executed_flush_sequence_number(u64 flush_sequence_number) { m_shared_command_buffer.store_executed_flush_sequence_number(flush_sequence_number); }
     ErrorOr<ByteBuffer> execute_sync_call(ReadonlyBytes request);
     Gfx::ShareableBitmap read_back_drawing_buffer(Gfx::IntRect);
     Web::WebGL::ReadPixelsResult read_pixels_robust_angle(Web::WebGL::GLint x, Web::WebGL::GLint y, Web::WebGL::GLsizei width, Web::WebGL::GLsizei height, Web::WebGL::GLenum format, Web::WebGL::GLenum type, Web::WebGL::GLsizei buf_size, Core::AnonymousBuffer pixels);
@@ -55,6 +60,7 @@ private:
 
     NonnullOwnPtr<OpenGLContext> m_gl_context;
     WebGLObjectMap m_objects;
+    Web::WebGL::WebGLSharedCommandBuffer m_shared_command_buffer;
     bool m_needs_clear_before_next_frame { false };
 };
 

--- a/Services/WebContent/CompositorConnection.cpp
+++ b/Services/WebContent/CompositorConnection.cpp
@@ -202,6 +202,39 @@ Optional<Web::Painting::CanvasId> CompositorConnection::create_webgl_context(Web
     return response->canvas_id();
 }
 
+void CompositorConnection::set_webgl_command_buffer(Web::Painting::CanvasId canvas_id, Core::AnonymousBuffer const& command_buffer)
+{
+    if (!can_send_message_to_compositor())
+        return;
+
+    auto encoded_message = MUST(Messages::CompositorWebContentServer::WebglSetCommandBuffer::static_encode(canvas_id, command_buffer));
+    if (post_message(encoded_message).is_error())
+        did_lose_compositor();
+}
+
+void CompositorConnection::send_webgl_commands_from_shared_buffer(Web::Painting::CanvasId canvas_id, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> const& bitmaps)
+{
+    if (!can_send_message_to_compositor())
+        return;
+
+    auto encoded_message = MUST(Messages::CompositorWebContentServer::WebglCommandsFromSharedBuffer::static_encode(canvas_id, offset, size_in_bytes, flush_sequence_number, bitmaps));
+    if (post_message(encoded_message).is_error())
+        did_lose_compositor();
+}
+
+bool CompositorConnection::drain_webgl_command_buffer(Web::Painting::CanvasId canvas_id)
+{
+    if (!can_send_message_to_compositor())
+        return false;
+
+    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::WebglDrainCommandBuffer>(canvas_id);
+    if (!response) {
+        did_lose_compositor();
+        return false;
+    }
+    return true;
+}
+
 void CompositorConnection::send_webgl_commands(Web::Painting::CanvasId canvas_id, ByteBuffer const& commands, Vector<Gfx::DecodedImageFrame> const& bitmaps)
 {
     if (!can_send_message_to_compositor())

--- a/Services/WebContent/CompositorConnection.h
+++ b/Services/WebContent/CompositorConnection.h
@@ -58,6 +58,9 @@ public:
     void request_screenshot(Web::Compositor::CompositorContextId, NonnullRefPtr<Gfx::PaintingSurface>, Function<void()>&&);
 
     Optional<Web::Painting::CanvasId> create_webgl_context(Web::WebGL::WebGLVersion, Gfx::IntSize, bool depth, bool stencil, bool antialias, Vector<String>& out_supported_extensions);
+    void set_webgl_command_buffer(Web::Painting::CanvasId, Core::AnonymousBuffer const&);
+    void send_webgl_commands_from_shared_buffer(Web::Painting::CanvasId, u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> const& bitmaps);
+    bool drain_webgl_command_buffer(Web::Painting::CanvasId);
     void send_webgl_commands(Web::Painting::CanvasId, ByteBuffer const&, Vector<Gfx::DecodedImageFrame> const& bitmaps);
     void present_webgl_canvas(Web::Painting::CanvasId, bool preserve_drawing_buffer);
     ByteBuffer webgl_sync_call(Web::Painting::CanvasId, ByteBuffer request);

--- a/Services/WebContent/WebContentCompositorHost.cpp
+++ b/Services/WebContent/WebContentCompositorHost.cpp
@@ -52,6 +52,27 @@ private:
         m_canvas_id.clear();
     }
 
+    virtual void set_shared_command_buffer(Core::AnonymousBuffer const& command_buffer) override
+    {
+        if (!m_canvas_id.has_value())
+            return;
+        m_connection->set_webgl_command_buffer(*m_canvas_id, command_buffer);
+    }
+
+    virtual void send_commands_from_shared_buffer(u64 offset, u64 size_in_bytes, u64 flush_sequence_number, Vector<Gfx::DecodedImageFrame> const& bitmaps) override
+    {
+        if (!m_canvas_id.has_value())
+            return;
+        m_connection->send_webgl_commands_from_shared_buffer(*m_canvas_id, offset, size_in_bytes, flush_sequence_number, bitmaps);
+    }
+
+    virtual bool wait_until_published_commands_executed() override
+    {
+        if (!m_canvas_id.has_value())
+            return false;
+        return m_connection->drain_webgl_command_buffer(*m_canvas_id);
+    }
+
     virtual void send_commands(ByteBuffer const& commands, Vector<Gfx::DecodedImageFrame> const& bitmaps) override
     {
         if (!m_canvas_id.has_value())

--- a/Tests/LibWeb/TestWebIDLBuffers.cpp
+++ b/Tests/LibWeb/TestWebIDLBuffers.cpp
@@ -34,8 +34,17 @@ struct TestVM {
 struct ExposedWebGLRenderingContextBase : Web::WebGL::WebGLRenderingContextBase {
     WEB_NON_IDL_PLATFORM_OBJECT(ExposedWebGLRenderingContextBase, Web::WebGL::WebGLRenderingContextBase);
 
-    using Web::WebGL::WebGLRenderingContextBase::copy_buffer_source_to_byte_buffer;
+    using Web::WebGL::WebGLRenderingContextBase::with_buffer_source_bytes;
 };
+
+ErrorOr<ByteBuffer> buffer_source_bytes(Web::WebIDL::BufferSource source, u64 src_offset, u32 src_length_override = 0)
+{
+    ByteBuffer bytes;
+    TRY(ExposedWebGLRenderingContextBase::with_buffer_source_bytes(source, src_offset, src_length_override, [&](ReadonlyBytes view) {
+        bytes = MUST(ByteBuffer::copy(view));
+    }));
+    return bytes;
+}
 
 GC::Ref<JS::ArrayBuffer> create_shrunken_resizable_array_buffer(JS::VM& vm)
 {
@@ -129,11 +138,11 @@ TEST_CASE(buffer_source_copy_and_checked_write_handle_in_bounds_views)
     Web::WebIDL::BufferSource typed_array_source { typed_array_view };
     EXPECT_EQ(typed_array_source.byte_length(), 4u);
 
-    auto typed_array_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 1));
+    auto typed_array_bytes = MUST(buffer_source_bytes(typed_array_source, 1));
     EXPECT_EQ(typed_array_bytes.size(), 2uz);
     EXPECT_EQ(typed_array_bytes[0], 0x16);
     EXPECT_EQ(typed_array_bytes[1], 0x17);
-    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 3).is_error());
+    EXPECT(buffer_source_bytes(typed_array_source, 3).is_error());
 
     u8 one_byte = 0xaa;
     EXPECT(typed_array_view.write_checked({ &one_byte, 1 }).is_error());
@@ -149,7 +158,7 @@ TEST_CASE(buffer_source_copy_and_checked_write_handle_in_bounds_views)
     Web::WebIDL::BufferSource data_view_source { data_view_view };
     EXPECT_EQ(data_view_source.byte_length(), 4u);
 
-    auto data_view_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 2, 2));
+    auto data_view_bytes = MUST(buffer_source_bytes(data_view_source, 2, 2));
     EXPECT_EQ(data_view_bytes.size(), 2uz);
     EXPECT_EQ(data_view_bytes[0], 0x1a);
     EXPECT_EQ(data_view_bytes[1], 0x1b);
@@ -164,21 +173,21 @@ TEST_CASE(buffer_source_copy_and_checked_write_handle_in_bounds_views)
     EXPECT_EQ(final_bytes[10], 0xe1);
 }
 
-TEST_CASE(webgl_buffer_source_copy_treats_out_of_bounds_views_as_empty)
+TEST_CASE(webgl_buffer_source_bytes_treats_out_of_bounds_views_as_empty)
 {
     TestVM test_vm;
 
     Web::WebIDL::BufferSource typed_array_source { typed_array_view(*test_vm.vm) };
-    auto typed_array_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 0));
+    auto typed_array_bytes = MUST(buffer_source_bytes(typed_array_source, 0));
     EXPECT_EQ(typed_array_bytes.size(), 0uz);
-    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 1).is_error());
-    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(typed_array_source, 0, 1).is_error());
+    EXPECT(buffer_source_bytes(typed_array_source, 1).is_error());
+    EXPECT(buffer_source_bytes(typed_array_source, 0, 1).is_error());
 
     Web::WebIDL::BufferSource data_view_source { make_data_view(*test_vm.vm) };
-    auto data_view_bytes = MUST(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 0));
+    auto data_view_bytes = MUST(buffer_source_bytes(data_view_source, 0));
     EXPECT_EQ(data_view_bytes.size(), 0uz);
-    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 1).is_error());
-    EXPECT(ExposedWebGLRenderingContextBase::copy_buffer_source_to_byte_buffer(data_view_source, 0, 1).is_error());
+    EXPECT(buffer_source_bytes(data_view_source, 1).is_error());
+    EXPECT(buffer_source_bytes(data_view_source, 0, 1).is_error());
 }
 
 TEST_CASE(array_buffer_view_checked_write_handles_out_of_bounds_views)


### PR DESCRIPTION
The WebGL transport copied every recorded byte into a freshly allocated AnonymousBuffer on each flush, three copies per uploaded texel, up to ~40% of WebContent's saturated main thread on texture-upload-heavy content, and 6% of the Compositor's CPU spent just unmapping received batches. Each context now records commands in place into one persistent 32 MiB shared-memory buffer mapped by both processes: a flush publishes only (offset, size, seq), the Compositor executes straight from the mapping and acks by storing the executed sequence number into the buffer header, and the write cursor rewinds only once everything published has executed (a sync drain message provides backpressure; the old path remains for oversized commands and as a fallback). This cuts the transport to ~6% of the main thread on the same content.