### PR TITLE
Improve handling of `about:` URLs

### DIFF
--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -304,8 +304,8 @@ void ResourceLoader::handle_file_load_request(LoadRequest& request, FileHandler 
         on_load_counter_change();
 }
 
-template<typename Callback>
-void ResourceLoader::handle_about_load_request(LoadRequest const& request, Callback callback)
+template<typename ResourceHandler, typename ErrorHandler>
+void ResourceLoader::handle_about_load_request(LoadRequest const& request, ResourceHandler on_resource, ErrorHandler on_error)
 {
     auto const& url = request.url().value();
 
@@ -327,16 +327,15 @@ void ResourceLoader::handle_about_load_request(LoadRequest const& request, Callb
         if (!resource.is_error()) {
             auto const& buffer = resource.value()->data();
             ReadonlyBytes data(buffer.data(), buffer.size());
-            callback(data, timing_info, response_headers);
+            on_resource(data, timing_info, response_headers);
             return;
         }
     }
 
     Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(
         m_heap,
-        [callback, timing_info, response_headers = move(response_headers)]() mutable {
-            auto buffer = ByteString::empty().to_byte_buffer();
-            callback(buffer.bytes(), timing_info, response_headers);
+        [on_error, error_message = ByteString::formatted("No such about page: {}", serialized_path)]() {
+            on_error(error_message);
         }));
 }
 
@@ -398,11 +397,16 @@ RefPtr<Requests::Request> ResourceLoader::load(LoadRequest& request, GC::Root<On
     if (url.scheme() == "about"sv) {
         handle_about_load_request(
             request,
-            [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete = move(on_complete), request](ReadonlyBytes data, Requests::RequestTimingInfo const& timing_info, HTTP::HeaderList const& response_headers) {
+            [on_headers_received = move(on_headers_received), on_data_received = move(on_data_received), on_complete, request](ReadonlyBytes data, Requests::RequestTimingInfo const& timing_info, HTTP::HeaderList const& response_headers) {
                 log_success(request);
                 on_headers_received->function()(nullptr, response_headers, {}, {}, {}, {}, Requests::CameFromCache::No);
                 on_data_received->function()(Requests::ResponseData::from_bytes(data));
                 on_complete->function()(true, timing_info, {});
+            },
+            [on_complete, request](ByteString const& message) {
+                log_failure(request, message);
+                Requests::RequestTimingInfo fixme_implement_timing_info {};
+                on_complete->function()(false, fixme_implement_timing_info, StringView(message));
             });
         return nullptr;
     }

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -83,8 +83,8 @@ private:
     };
     template<typename FileHandler, typename ErrorHandler>
     void handle_file_load_request(LoadRequest& request, FileHandler on_file, ErrorHandler on_error);
-    template<typename Callback>
-    void handle_about_load_request(LoadRequest const& request, Callback callback);
+    template<typename ResourceHandler, typename ErrorHandler>
+    void handle_about_load_request(LoadRequest const& request, ResourceHandler on_resource, ErrorHandler on_error);
     template<typename ResourceHandler, typename ErrorHandler>
     void handle_resource_load_request(LoadRequest const& request, ResourceHandler on_resource, ErrorHandler on_error);
 

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -24,10 +24,12 @@
 #include <LibWebView/HistoryDebug.h>
 #include <LibWebView/HistoryStore.h>
 #include <LibWebView/URL.h>
+#include <LibWebView/WebUI.h>
 
 namespace WebView {
 
 static constexpr auto file_url_prefix = "file://"sv;
+static constexpr auto about_url_prefix = "about:"sv;
 
 static constexpr auto builtin_autocomplete_engines = to_array<AutocompleteEngine>({
     { "DuckDuckGo"sv, "https://duckduckgo.com/ac/?q={}"sv },
@@ -147,6 +149,37 @@ Vector<String> filter_remote_autocomplete_suggestions(StringView input, Vector<S
     suggestions.remove_all_matching([input](auto const& suggestion) {
         return !suggestion.bytes_as_string_view().starts_with(input, CaseSensitivity::CaseInsensitive);
     });
+    return suggestions;
+}
+
+Vector<AutocompleteSuggestion> web_ui_autocomplete_suggestions(StringView input)
+{
+    if (!input.starts_with(about_url_prefix, CaseSensitivity::CaseInsensitive))
+        return {};
+
+    Vector<AutocompleteSuggestion> suggestions;
+    suggestions.ensure_capacity(WebUI::pages().size());
+
+    for (auto const& page : WebUI::pages()) {
+        auto url = MUST(String::formatted("about:{}", page.host));
+        if (!url.bytes_as_string_view().starts_with(input, CaseSensitivity::CaseInsensitive))
+            continue;
+
+        suggestions.unchecked_append({
+            .source = AutocompleteSuggestionSource::WebUI,
+            .text = move(url),
+            .title = MUST(String::from_utf8(page.title)),
+            .subtitle = {},
+            .favicon_base64_png = {},
+            .highlight_input = {},
+            .match_class = AutocompleteMatchClass::URLPrefix,
+            .relevance = 1100,
+            .is_verbatim = false,
+            .can_be_automatically_selected = true,
+            .can_be_inline_completed = true,
+        });
+    }
+
     return suggestions;
 }
 
@@ -275,6 +308,13 @@ void Autocomplete::query_autocomplete_engine(AutocompleteQueryID query_id, Strin
         return;
     }
 
+    if (m_trimmed_query.bytes_as_string_view().starts_with(about_url_prefix, CaseSensitivity::CaseInsensitive)) {
+        m_remote_suggestions.clear();
+        m_remote_query_complete = true;
+        dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Skipping remote autocomplete for about URL query '{}'", m_trimmed_query);
+        return;
+    }
+
     auto engine = Application::settings().autocomplete_engine();
     if (!engine.has_value()) {
         m_remote_suggestions.clear();
@@ -362,13 +402,15 @@ void Autocomplete::deliver_current_result()
     if (!m_query_id.has_value())
         return;
 
-    auto verbatim_suggestion = literal_url_suggestion(m_query);
-    if (!verbatim_suggestion.has_value())
+    auto web_ui_suggestions = web_ui_autocomplete_suggestions(m_trimmed_query);
+    auto verbatim_suggestion = web_ui_suggestions.is_empty() ? literal_url_suggestion(m_query) : Optional<AutocompleteSuggestion> {};
+    if (web_ui_suggestions.is_empty() && !verbatim_suggestion.has_value())
         verbatim_suggestion = search_for_query_suggestion(m_query);
+    web_ui_suggestions.extend(m_local_suggestions);
     auto merged_suggestions = mux_autocomplete_suggestions(
         m_trimmed_query,
         move(verbatim_suggestion),
-        m_local_suggestions,
+        move(web_ui_suggestions),
         make_remote_suggestions(m_remote_suggestions),
         m_max_suggestions);
     for (auto& suggestion : merged_suggestions)

--- a/Libraries/LibWebView/Autocomplete.h
+++ b/Libraries/LibWebView/Autocomplete.h
@@ -38,6 +38,7 @@ static constexpr auto default_autocomplete_suggestion_limit = 8uz;
 
 enum class AutocompleteSuggestionSource {
     LiteralURL,
+    WebUI,
     History,
     Bookmark,
     Adaptive,
@@ -91,6 +92,7 @@ WEBVIEW_API Optional<AutocompleteEngine const&> find_autocomplete_engine_by_name
 WEBVIEW_API String autocomplete_suggestion_display_text(AutocompleteSuggestion const&);
 WEBVIEW_API Vector<AutocompleteMatchRange> autocomplete_match_ranges(StringView input, StringView text);
 WEBVIEW_API Vector<String> filter_remote_autocomplete_suggestions(StringView input, Vector<String> suggestions);
+WEBVIEW_API Vector<AutocompleteSuggestion> web_ui_autocomplete_suggestions(StringView input);
 WEBVIEW_API bool autocomplete_urls_match(StringView left, StringView right);
 WEBVIEW_API bool autocomplete_url_can_complete(StringView query, StringView suggestion);
 

--- a/Libraries/LibWebView/WebUI.cpp
+++ b/Libraries/LibWebView/WebUI.cpp
@@ -17,6 +17,31 @@
 
 namespace WebView {
 
+static constexpr auto s_pages = to_array<WebUI::Page>({
+    { "about"sv, "About URLs"sv, WebUI::PageType::Static },
+    { "bookmarks"sv, "Bookmarks"sv, WebUI::PageType::Dynamic },
+    { "downloads"sv, "Downloads"sv, WebUI::PageType::Dynamic },
+    { "history"sv, "History"sv, WebUI::PageType::Dynamic },
+    { "newtab"sv, "New Tab"sv, WebUI::PageType::Static },
+    { "processes"sv, "Task Manager"sv, WebUI::PageType::Dynamic },
+    { "settings"sv, "Settings"sv, WebUI::PageType::Dynamic },
+    { "version"sv, "Version"sv, WebUI::PageType::Dynamic },
+});
+
+ReadonlySpan<WebUI::Page> WebUI::pages()
+{
+    return s_pages;
+}
+
+Optional<WebUI::Page const&> WebUI::page_for_host(StringView host)
+{
+    for (auto const& page : s_pages) {
+        if (page.host == host)
+            return page;
+    }
+    return {};
+}
+
 template<typename WebUIType>
 static ErrorOr<NonnullRefPtr<WebUIType>> create_web_ui(WebContentClient& client, u64 page_id, String host)
 {
@@ -33,23 +58,27 @@ static ErrorOr<NonnullRefPtr<WebUIType>> create_web_ui(WebContentClient& client,
 
 ErrorOr<RefPtr<WebUI>> WebUI::create(WebContentClient& client, u64 page_id, String host)
 {
+    auto page = page_for_host(host);
+    if (!page.has_value() || page->type == PageType::Static)
+        return nullptr;
+
     RefPtr<WebUI> web_ui;
 
-    if (host == "bookmarks"sv)
+    if (page->host == "bookmarks"sv)
         web_ui = TRY(create_web_ui<BookmarksUI>(client, page_id, move(host)));
-    else if (host == "downloads"sv)
+    else if (page->host == "downloads"sv)
         web_ui = TRY(create_web_ui<DownloadsUI>(client, page_id, move(host)));
-    else if (host == "history"sv)
+    else if (page->host == "history"sv)
         web_ui = TRY(create_web_ui<HistoryUI>(client, page_id, move(host)));
-    else if (host == "processes"sv)
+    else if (page->host == "processes"sv)
         web_ui = TRY(create_web_ui<ProcessesUI>(client, page_id, move(host)));
-    else if (host == "settings"sv)
+    else if (page->host == "settings"sv)
         web_ui = TRY(create_web_ui<SettingsUI>(client, page_id, move(host)));
-    else if (host == "version"sv)
+    else if (page->host == "version"sv)
         web_ui = TRY(create_web_ui<VersionUI>(client, page_id, move(host)));
 
-    if (web_ui)
-        web_ui->register_interfaces();
+    VERIFY(web_ui);
+    web_ui->register_interfaces();
 
     return web_ui;
 }

--- a/Libraries/LibWebView/WebUI.h
+++ b/Libraries/LibWebView/WebUI.h
@@ -10,8 +10,11 @@
 #include <AK/HashMap.h>
 #include <AK/JsonValue.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <AK/RefPtr.h>
+#include <AK/Span.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibIPC/Transport.h>
@@ -25,6 +28,19 @@ class WEBVIEW_API WebUI
     : public IPC::ConnectionToServer<WebUIClientEndpoint, WebUIServerEndpoint>
     , public WebUIClientEndpoint {
 public:
+    enum class PageType {
+        Static,
+        Dynamic,
+    };
+
+    struct Page {
+        StringView host;
+        StringView title;
+        PageType type;
+    };
+
+    static ReadonlySpan<Page> pages();
+    static Optional<Page const&> page_for_host(StringView);
     static ErrorOr<RefPtr<WebUI>> create(WebContentClient&, u64 page_id, String host);
     virtual ~WebUI();
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -316,6 +316,9 @@ Text/input/wpt-import/html/canvas/element/drawing-images-to-the-canvas/2d.drawIm
 ; Requires cross origin frames.
 Text/input/wpt-import/web-locks/query.https.any.html
 
+; Requires reaching into the contentWindow of an <object>, which fails for file:// origins.
+Text/input/HTML/HTMLObjectElement-contentWindow.html
+
 [Skipped]
 ; Test seems broken
 Text/input/window-scrollTo.html

--- a/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-contentWindow.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLObjectElement-contentWindow.html
@@ -6,8 +6,7 @@
         println(`object.contentWindow initial value should be null: ${objectElement.contentWindow === null}`);
         objectElement.type = "text/html";
         objectElement.name = "PASS"
-        // FIXME: about:srcdoc is being used here as a convenient way to load a blank document. This isn't cross browser compatible.
-        objectElement.data = "about:srcdoc";
+        objectElement.data = "../../data/blank.html";
         objectElement.onload = () => {
             println(`contentWindow.name should be the same as object.name ${objectElement.contentWindow.name}`);
             document.body.removeChild(objectElement);

--- a/Tests/LibWeb/Text/input/HTML/focus-navigable-container.html
+++ b/Tests/LibWeb/Text/input/HTML/focus-navigable-container.html
@@ -23,7 +23,7 @@
         return new Promise(resolve => {
             const object = document.createElement("object");
             object.type = "text/html";
-            object.data = "about:srcdoc";
+            object.data = "../../data/blank.html";
             object.onload = () => resolve(object);
             document.body.appendChild(object);
         });

--- a/Tests/LibWebView/TestAutocomplete.cpp
+++ b/Tests/LibWebView/TestAutocomplete.cpp
@@ -217,6 +217,26 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         Core::EventLoop::current().spin_until([&]() { return whitespace_query_completed; });
     }
 
+    auto about_query_completed = false;
+    {
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.on_autocomplete_query_complete = [&](auto, auto const& suggestions, WebView::AutocompleteResultKind kind) {
+            if (kind != WebView::AutocompleteResultKind::Final)
+                return;
+            VERIFY(!suggestions.contains([](auto const& suggestion) {
+                return suggestion.source == WebView::AutocompleteSuggestionSource::Search;
+            }));
+            VERIFY(suggestions.contains([](auto const& suggestion) {
+                return suggestion.source == WebView::AutocompleteSuggestionSource::WebUI
+                    && suggestion.text == "about:settings"sv;
+            }));
+            autocomplete.cancel_pending_query();
+            about_query_completed = true;
+        };
+        autocomplete.query_autocomplete_engine(100, "about:set"_string);
+        Core::EventLoop::current().spin_until([&]() { return about_query_completed; });
+    }
+
     // A closed loopback port makes the request fail fast and deterministically, with no real network.
     // Its on_finish synchronously delivers the final result. A data: URL cannot be used because the request
     // server's DNS path requires a host.

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 #include <LibWebView/Omnibox.h>
+#include <LibWebView/WebUI.h>
 
 namespace {
 
@@ -23,7 +24,7 @@ AutocompleteSuggestion row(AutocompleteSuggestionSource source, StringView text)
         .favicon_base64_png = {},
         .highlight_input = {},
         .can_be_automatically_selected = true,
-        .can_be_inline_completed = source == AutocompleteSuggestionSource::History,
+        .can_be_inline_completed = source == AutocompleteSuggestionSource::History || source == AutocompleteSuggestionSource::WebUI,
     };
 }
 
@@ -62,6 +63,11 @@ AutocompleteSuggestion search_row(StringView query)
 AutocompleteSuggestion literal_row(StringView url)
 {
     return row(AutocompleteSuggestionSource::LiteralURL, url);
+}
+
+AutocompleteSuggestion web_ui_row(StringView url)
+{
+    return row(AutocompleteSuggestionSource::WebUI, url);
 }
 
 class ScriptedProvider final : public WebView::OmniboxSuggestionProvider {
@@ -186,6 +192,46 @@ struct Harness {
     Optional<size_t> visible_selection;
 };
 
+}
+
+TEST_CASE(all_web_ui_pages_are_suggested)
+{
+    static constexpr Array expected_urls {
+        "about:about"sv,
+        "about:bookmarks"sv,
+        "about:downloads"sv,
+        "about:history"sv,
+        "about:newtab"sv,
+        "about:processes"sv,
+        "about:settings"sv,
+        "about:version"sv,
+    };
+
+    auto suggestions = WebView::web_ui_autocomplete_suggestions("about:"sv);
+
+    EXPECT_EQ(WebView::WebUI::pages().size(), expected_urls.size());
+    EXPECT_EQ(suggestions.size(), expected_urls.size());
+    for (size_t index = 0; index < expected_urls.size(); ++index) {
+        EXPECT_EQ(suggestions[index].source, WebView::AutocompleteSuggestionSource::WebUI);
+        EXPECT_EQ(suggestions[index].text, expected_urls[index]);
+    }
+}
+
+TEST_CASE(web_ui_pages_are_matched_by_case_insensitive_url_prefix)
+{
+    auto suggestions = WebView::web_ui_autocomplete_suggestions("ABOUT:SET"sv);
+
+    EXPECT_EQ(suggestions.size(), 1u);
+    EXPECT_EQ(suggestions[0].text, "about:settings"sv);
+    EXPECT_EQ(suggestions[0].title, "Settings"sv);
+    EXPECT(suggestions[0].can_be_automatically_selected);
+    EXPECT(suggestions[0].can_be_inline_completed);
+}
+
+TEST_CASE(web_ui_pages_are_not_suggested_for_unrelated_input)
+{
+    EXPECT(WebView::web_ui_autocomplete_suggestions("settings"sv).is_empty());
+    EXPECT(WebView::web_ui_autocomplete_suggestions("about:foo"sv).is_empty());
 }
 
 TEST_CASE(fast_typing_publishes_each_local_generation)
@@ -607,6 +653,23 @@ TEST_CASE(a_literal_url_suggestion_never_completes)
 
     harness.omnibox.return_pressed();
     EXPECT_EQ(harness.commits.last(), "t.example/path"sv);
+}
+
+TEST_CASE(a_web_ui_suggestion_completes_and_commits_as_a_url)
+{
+    Harness harness;
+    harness.begin_editing();
+    harness.display_text = "about:set"_string;
+    harness.omnibox.text_edited(harness.display_text, true);
+
+    harness.provider->deliver({ web_ui_row("about:settings"sv) });
+    EXPECT_EQ(harness.display_text, "about:settings"sv);
+    EXPECT_EQ(harness.selection_start, 9u);
+    EXPECT_EQ(harness.omnibox.selected_suggestion(), 0u);
+
+    harness.omnibox.return_pressed();
+    EXPECT_EQ(harness.commits.last(), "about:settings"sv);
+    EXPECT_EQ(harness.provider->engagements.last().destination_kind, WebView::OmniboxDestinationKind::URL);
 }
 
 TEST_CASE(an_automatic_default_does_not_imply_inline_completion)


### PR DESCRIPTION
Firstly, fix the error reporting for invalid `about:foo` URLs. We had code to detect and report these, but weren't actually hitting it, and instead just produced a blank white page. Now we get an error.

<img width="742" height="546" alt="Screenshot_20260716_171315" src="https://github.com/user-attachments/assets/05c82dbc-a9a0-4835-bf1d-27b9e18eba0f" />

And then, show `about:` URLs in the autocomplete suggestions. When the input starts with `about:`, other suggestions are disabled.

<img width="1118" height="456" alt="image" src="https://github.com/user-attachments/assets/1528c9e1-bb4c-488d-928e-156cd1d235ab" />
