### PR TITLE
Implement "restore previous session" setting

### DIFF
--- a/Base/res/ladybird/about-pages/settings.html
+++ b/Base/res/ladybird/about-pages/settings.html
@@ -369,6 +369,18 @@
                         </div>
                     </div>
 
+                    <div class="card-group card-separator">
+                        <div class="inline-container">
+                            <label for="restore-previous-session">
+                                Restore previous session
+                                <p class="description">
+                                    Reopen windows and tabs from the previous session when Ladybird starts.
+                                </p>
+                            </label>
+                            <input id="restore-previous-session" type="checkbox" switch />
+                        </div>
+                    </div>
+
                     <div class="card-group inline-container">
                         <label for="default-zoom-level">Default Zoom Level</label>
                         <select id="default-zoom-level"></select>

--- a/Base/res/ladybird/about-pages/settings/browsing-behavior.js
+++ b/Base/res/ladybird/about-pages/settings/browsing-behavior.js
@@ -1,6 +1,7 @@
 const enableAutoscroll = document.querySelector("#enable-autoscroll");
 const enablePrimaryPaste = document.querySelector("#enable-primary-paste");
 const enablePrimaryPasteGroup = document.querySelector("#enable-primary-paste-group");
+const restorePreviousSession = document.querySelector("#restore-previous-session");
 
 let BROWSING_BEHAVIOR = {};
 
@@ -13,6 +14,7 @@ const loadSettings = settings => {
 
     enableAutoscroll.checked = !!BROWSING_BEHAVIOR.enableAutoscroll;
     enablePrimaryPaste.checked = !!BROWSING_BEHAVIOR.enablePrimaryPaste;
+    restorePreviousSession.checked = !!BROWSING_BEHAVIOR.restorePreviousSession;
 };
 
 function addChangeHandler(input, name) {
@@ -24,6 +26,7 @@ function addChangeHandler(input, name) {
 
 addChangeHandler(enableAutoscroll, "enableAutoscroll");
 addChangeHandler(enablePrimaryPaste, "enablePrimaryPaste");
+addChangeHandler(restorePreviousSession, "restorePreviousSession");
 
 document.addEventListener("WebUIMessage", event => {
     if (event.detail.name === "loadFeatures") {

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES
     Profile.cpp
     SearchEngine.cpp
     SessionHistory.cpp
+    SessionStore.cpp
     Settings.cpp
     SiteIsolation.cpp
     SiteIsolationManager.cpp

--- a/Libraries/LibWebView/SessionStore.cpp
+++ b/Libraries/LibWebView/SessionStore.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/LexicalPath.h>
+#include <LibCore/Directory.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/SessionStore.h>
+#include <LibWebView/Utilities.h>
+
+namespace WebView {
+
+static constexpr auto SESSION_STORE_FILENAME = "Session.json"sv;
+static constexpr auto SESSION_STORE_TEMPORARY_FILENAME = "Session.json.tmp"sv;
+static constexpr auto VERSION_KEY = "version"sv;
+static constexpr auto WINDOWS_KEY = "windows"sv;
+static constexpr auto TABS_KEY = "tabs"sv;
+static constexpr auto URL_KEY = "url"sv;
+static constexpr auto ACTIVE_TAB_INDEX_KEY = "activeTabIndex"sv;
+static constexpr auto ACTIVE_WINDOW_INDEX_KEY = "activeWindowIndex"sv;
+static constexpr auto X_KEY = "x"sv;
+static constexpr auto Y_KEY = "y"sv;
+static constexpr auto WIDTH_KEY = "width"sv;
+static constexpr auto HEIGHT_KEY = "height"sv;
+static constexpr auto MAXIMIZED_KEY = "maximized"sv;
+static constexpr u32 CURRENT_SESSION_STORE_VERSION = 2;
+
+ByteString session_store_path(Profile const& profile)
+{
+    return LexicalPath::join(profile.paths().data, SESSION_STORE_FILENAME).string();
+}
+
+static ByteString temporary_session_store_path(Profile const& profile)
+{
+    return LexicalPath::join(profile.paths().data, SESSION_STORE_TEMPORARY_FILENAME).string();
+}
+
+static Optional<SessionTab> parse_tab(JsonValue const& tab_value)
+{
+    if (!tab_value.is_object())
+        return {};
+
+    auto url = tab_value.as_object().get_string(URL_KEY);
+    if (!url.has_value())
+        return {};
+
+    auto parsed_url = URL::Parser::basic_parse(*url);
+    if (!parsed_url.has_value() || parsed_url->scheme().is_empty())
+        return {};
+
+    return SessionTab { .url = parsed_url.release_value() };
+}
+
+static Optional<SessionWindow> parse_window(JsonValue const& window_value)
+{
+    if (!window_value.is_object())
+        return {};
+
+    auto tabs = window_value.as_object().get_array(TABS_KEY);
+    if (!tabs.has_value())
+        return {};
+
+    SessionWindow window;
+    window.tabs.ensure_capacity(tabs->size());
+
+    tabs->for_each([&](JsonValue const& tab_value) {
+        if (auto tab = parse_tab(tab_value); tab.has_value())
+            window.tabs.append(tab.release_value());
+    });
+
+    if (window.tabs.is_empty())
+        return {};
+
+    if (auto active_tab_index = window_value.as_object().get_integer<size_t>(ACTIVE_TAB_INDEX_KEY); active_tab_index.has_value())
+        window.active_tab_index = min(*active_tab_index, window.tabs.size() - 1);
+    if (auto x = window_value.as_object().get_integer<i32>(X_KEY); x.has_value())
+        window.x = *x;
+    if (auto y = window_value.as_object().get_integer<i32>(Y_KEY); y.has_value())
+        window.y = *y;
+    if (auto width = window_value.as_object().get_integer<i32>(WIDTH_KEY); width.has_value())
+        window.width = *width;
+    if (auto height = window_value.as_object().get_integer<i32>(HEIGHT_KEY); height.has_value())
+        window.height = *height;
+    if (auto maximized = window_value.as_object().get_bool(MAXIMIZED_KEY); maximized.has_value())
+        window.maximized = *maximized;
+
+    return window;
+}
+
+ErrorOr<Optional<Session>> load_session(Profile const& profile)
+{
+    auto path = session_store_path(profile);
+    if (!FileSystem::exists(path))
+        return Optional<Session> {};
+
+    auto json = read_json_file(path);
+    if (json.is_error())
+        return Optional<Session> {};
+
+    auto version = json.value().get_integer<u32>(VERSION_KEY);
+    if (!version.has_value() || *version != CURRENT_SESSION_STORE_VERSION)
+        return Optional<Session> {};
+
+    auto windows = json.value().get_array(WINDOWS_KEY);
+    if (!windows.has_value())
+        return Optional<Session> {};
+
+    Session session;
+    session.windows.ensure_capacity(windows->size());
+
+    windows->for_each([&](JsonValue const& window_value) {
+        if (auto window = parse_window(window_value); window.has_value())
+            session.windows.append(window.release_value());
+    });
+
+    if (session.is_empty())
+        return Optional<Session> {};
+
+    if (auto active_window_index = json.value().get_integer<size_t>(ACTIVE_WINDOW_INDEX_KEY); active_window_index.has_value())
+        session.active_window_index = min(*active_window_index, session.windows.size() - 1);
+
+    return session;
+}
+
+static JsonValue serialize_session(Session const& session)
+{
+    JsonObject root;
+    root.set(VERSION_KEY, CURRENT_SESSION_STORE_VERSION);
+    root.set(ACTIVE_WINDOW_INDEX_KEY, session.active_window_index);
+
+    JsonArray windows;
+    windows.ensure_capacity(session.windows.size());
+
+    for (auto const& window : session.windows) {
+        JsonObject window_object;
+        window_object.set(ACTIVE_TAB_INDEX_KEY, window.active_tab_index);
+        if (window.x.has_value())
+            window_object.set(X_KEY, *window.x);
+        if (window.y.has_value())
+            window_object.set(Y_KEY, *window.y);
+        if (window.width.has_value())
+            window_object.set(WIDTH_KEY, *window.width);
+        if (window.height.has_value())
+            window_object.set(HEIGHT_KEY, *window.height);
+        window_object.set(MAXIMIZED_KEY, window.maximized);
+
+        JsonArray tabs;
+        tabs.ensure_capacity(window.tabs.size());
+
+        for (auto const& tab : window.tabs) {
+            JsonObject tab_object;
+            tab_object.set(URL_KEY, tab.url.serialize());
+            tabs.must_append(move(tab_object));
+        }
+
+        window_object.set(TABS_KEY, move(tabs));
+        windows.must_append(move(window_object));
+    }
+
+    root.set(WINDOWS_KEY, move(windows));
+    return root;
+}
+
+ErrorOr<void> save_session(Profile const& profile, Session const& session)
+{
+    if (session.is_empty())
+        return clear_session(profile);
+
+    auto path = session_store_path(profile);
+    auto temporary_path = temporary_session_store_path(profile);
+
+    TRY(Core::Directory::create(profile.paths().data, Core::Directory::CreateDirectories::Yes, 0700));
+
+    {
+        auto file = TRY(Core::File::open(temporary_path, Core::File::OpenMode::Write));
+        TRY(file->write_until_depleted(serialize_session(session).serialized()));
+    }
+
+    TRY(Core::System::rename(temporary_path, path));
+    return {};
+}
+
+ErrorOr<void> clear_session(Profile const& profile)
+{
+    auto path = session_store_path(profile);
+    if (!FileSystem::exists(path))
+        return {};
+    TRY(FileSystem::remove(path, FileSystem::RecursionMode::Disallowed));
+    return {};
+}
+
+}

--- a/Libraries/LibWebView/SessionStore.h
+++ b/Libraries/LibWebView/SessionStore.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <AK/Error.h>
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+#include <LibURL/URL.h>
+#include <LibWebView/Export.h>
+#include <LibWebView/Profile.h>
+
+namespace WebView {
+
+struct SessionTab {
+    URL::URL url;
+};
+
+struct SessionWindow {
+    Vector<SessionTab> tabs;
+    size_t active_tab_index { 0 };
+    Optional<i32> x;
+    Optional<i32> y;
+    Optional<i32> width;
+    Optional<i32> height;
+    bool maximized { false };
+};
+
+struct Session {
+    Vector<SessionWindow> windows;
+    size_t active_window_index { 0 };
+
+    bool is_empty() const
+    {
+        for (auto const& window : windows) {
+            if (!window.tabs.is_empty())
+                return false;
+        }
+        return true;
+    }
+};
+
+WEBVIEW_API ByteString session_store_path(Profile const&);
+WEBVIEW_API ErrorOr<Optional<Session>> load_session(Profile const&);
+WEBVIEW_API ErrorOr<void> save_session(Profile const&, Session const&);
+WEBVIEW_API ErrorOr<void> clear_session(Profile const&);
+
+}

--- a/Libraries/LibWebView/Settings.cpp
+++ b/Libraries/LibWebView/Settings.cpp
@@ -47,6 +47,7 @@ static auto DEFAULT_LANGUAGE = "en"_string;
 static constexpr auto BROWSING_BEHAVIOR_KEY = "browsingBehavior"sv;
 static constexpr auto ENABLE_AUTOSCROLL_KEY = "enableAutoscroll"sv;
 static constexpr auto ENABLE_PRIMARY_PASTE_KEY = "enablePrimaryPaste"sv;
+static constexpr auto RESTORE_PREVIOUS_SESSION_KEY = "restorePreviousSession"sv;
 
 static constexpr auto SEARCH_ENGINE_KEY = "searchEngine"sv;
 static constexpr auto SEARCH_ENGINE_CUSTOM_KEY = "custom"sv;
@@ -344,6 +345,7 @@ JsonValue Settings::serialize_json() const
     JsonObject browsing_behavior;
     browsing_behavior.set(ENABLE_AUTOSCROLL_KEY, m_browsing_behavior.enable_autoscroll);
     browsing_behavior.set(ENABLE_PRIMARY_PASTE_KEY, m_browsing_behavior.enable_primary_paste);
+    browsing_behavior.set(RESTORE_PREVIOUS_SESSION_KEY, m_browsing_behavior.restore_previous_session);
     settings.set(BROWSING_BEHAVIOR_KEY, move(browsing_behavior));
 
     JsonArray custom_search_engines;
@@ -565,6 +567,8 @@ BrowsingBehavior Settings::parse_browsing_behavior(JsonValue const& settings)
         browsing_behavior.enable_autoscroll = *enable_autoscroll;
     if (auto enable_primary_paste = settings.as_object().get_bool(ENABLE_PRIMARY_PASTE_KEY); enable_primary_paste.has_value())
         browsing_behavior.enable_primary_paste = *enable_primary_paste;
+    if (auto restore_previous_session = settings.as_object().get_bool(RESTORE_PREVIOUS_SESSION_KEY); restore_previous_session.has_value())
+        browsing_behavior.restore_previous_session = *restore_previous_session;
 
     return browsing_behavior;
 }
@@ -895,6 +899,7 @@ ErrorOr<void> encode(Encoder& encoder, WebView::BrowsingBehavior const& browsing
 {
     TRY(encoder.encode(browsing_behavior.enable_autoscroll));
     TRY(encoder.encode(browsing_behavior.enable_primary_paste));
+    TRY(encoder.encode(browsing_behavior.restore_previous_session));
 
     return {};
 }
@@ -904,8 +909,9 @@ ErrorOr<WebView::BrowsingBehavior> decode(Decoder& decoder)
 {
     auto enable_autoscroll = TRY(decoder.decode<bool>());
     auto enable_primary_paste = TRY(decoder.decode<bool>());
+    auto restore_previous_session = TRY(decoder.decode<bool>());
 
-    return WebView::BrowsingBehavior { enable_autoscroll, enable_primary_paste };
+    return WebView::BrowsingBehavior { enable_autoscroll, enable_primary_paste, restore_previous_session };
 }
 
 }

--- a/Libraries/LibWebView/Settings.h
+++ b/Libraries/LibWebView/Settings.h
@@ -38,6 +38,7 @@ struct TabSettings {
 struct BrowsingBehavior {
     bool enable_autoscroll { true };
     bool enable_primary_paste { true };
+    bool restore_previous_session { false };
 };
 
 struct SiteSetting {

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SOURCES
     TestOmnibox.cpp
     TestProfile.cpp
     TestSessionHistory.cpp
+    TestSessionStore.cpp
     TestStorageJar.cpp
     TestWebViewURL.cpp
 )

--- a/Tests/LibWebView/TestSessionStore.cpp
+++ b/Tests/LibWebView/TestSessionStore.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <LibCore/Directory.h>
+#include <LibCore/File.h>
+#include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/Profile.h>
+#include <LibWebView/SessionStore.h>
+
+static ByteString test_root()
+{
+    return LexicalPath::join(Core::StandardPaths::tempfile_directory(), ByteString::formatted("test-session-store-{}", Core::System::getpid())).string();
+}
+
+static WebView::ProfileRoots roots()
+{
+    auto root = test_root();
+    return {
+        .config = LexicalPath::join(root, "config-root"sv).string(),
+        .data = LexicalPath::join(root, "data-root"sv).string(),
+        .cache = LexicalPath::join(root, "cache-root"sv).string(),
+        .runtime = LexicalPath::join(root, "runtime-root"sv).string(),
+        .temporary = LexicalPath::join(root, "temporary-root"sv).string(),
+    };
+}
+
+static void remove_test_root()
+{
+    if (FileSystem::exists(test_root()))
+        MUST(FileSystem::remove(test_root(), FileSystem::RecursionMode::Allowed));
+}
+
+static URL::URL parse_url(StringView url)
+{
+    return URL::Parser::basic_parse(url).release_value();
+}
+
+TEST_CASE(missing_session_file_loads_as_empty)
+{
+    remove_test_root();
+    auto profile = MUST(WebView::Profile::create({ .name = "default" }, roots()));
+
+    auto session = TRY_OR_FAIL(WebView::load_session(profile));
+    EXPECT(!session.has_value());
+
+    remove_test_root();
+}
+
+TEST_CASE(save_and_load_round_trips_profile_session)
+{
+    remove_test_root();
+    auto profile = MUST(WebView::Profile::create({ .name = "default" }, roots()));
+
+    WebView::Session session;
+    session.active_window_index = 1;
+    session.windows.append({
+        .tabs = { { parse_url("https://example.com/"sv) }, { parse_url("about:settings"sv) } },
+        .active_tab_index = 1,
+        .x = 10,
+        .y = 20,
+        .width = 1024,
+        .height = 768,
+        .maximized = true,
+    });
+    session.windows.append({
+        .tabs = { { parse_url("https://ladybird.org/"sv) } },
+        .active_tab_index = 0,
+        .x = 30,
+        .y = 40,
+        .width = 800,
+        .height = 600,
+    });
+
+    TRY_OR_FAIL(WebView::save_session(profile, session));
+
+    auto loaded = TRY_OR_FAIL(WebView::load_session(profile));
+    VERIFY(loaded.has_value());
+    EXPECT_EQ(loaded->active_window_index, 1u);
+    EXPECT_EQ(loaded->windows.size(), 2u);
+    EXPECT_EQ(loaded->windows[0].active_tab_index, 1u);
+    EXPECT_EQ(loaded->windows[0].x, 10);
+    EXPECT_EQ(loaded->windows[0].y, 20);
+    EXPECT_EQ(loaded->windows[0].width, 1024);
+    EXPECT_EQ(loaded->windows[0].height, 768);
+    EXPECT(loaded->windows[0].maximized);
+    EXPECT_EQ(loaded->windows[0].tabs.size(), 2u);
+    EXPECT_EQ(loaded->windows[0].tabs[0].url.serialize(), "https://example.com/"sv);
+    EXPECT_EQ(loaded->windows[0].tabs[1].url.serialize(), "about:settings"sv);
+    EXPECT_EQ(loaded->windows[1].x, 30);
+    EXPECT_EQ(loaded->windows[1].y, 40);
+    EXPECT_EQ(loaded->windows[1].width, 800);
+    EXPECT_EQ(loaded->windows[1].height, 600);
+    EXPECT(!loaded->windows[1].maximized);
+    EXPECT_EQ(loaded->windows[1].tabs[0].url.serialize(), "https://ladybird.org/"sv);
+
+    remove_test_root();
+}
+
+TEST_CASE(negative_active_indices_default_to_zero)
+{
+    remove_test_root();
+    auto profile = MUST(WebView::Profile::create({ .name = "default" }, roots()));
+
+    MUST(Core::Directory::create(profile.paths().data, Core::Directory::CreateDirectories::Yes, 0700));
+    auto file = MUST(Core::File::open(WebView::session_store_path(profile), Core::File::OpenMode::Write));
+    MUST(file->write_until_depleted(R"json({
+        "version": 2,
+        "activeWindowIndex": -1,
+        "windows": [{
+            "activeTabIndex": -1,
+            "tabs": [{ "url": "https://example.com/" }]
+        }]
+    })json"sv));
+
+    auto session = TRY_OR_FAIL(WebView::load_session(profile));
+    VERIFY(session.has_value());
+    EXPECT_EQ(session->active_window_index, 0u);
+    EXPECT_EQ(session->windows[0].active_tab_index, 0u);
+
+    remove_test_root();
+}
+
+TEST_CASE(corrupt_session_file_loads_as_empty)
+{
+    remove_test_root();
+    auto profile = MUST(WebView::Profile::create({ .name = "default" }, roots()));
+
+    MUST(Core::Directory::create(profile.paths().data, Core::Directory::CreateDirectories::Yes, 0700));
+    auto file = MUST(Core::File::open(WebView::session_store_path(profile), Core::File::OpenMode::Write));
+    MUST(file->write_until_depleted("not json"sv.bytes()));
+
+    auto session = TRY_OR_FAIL(WebView::load_session(profile));
+    EXPECT(!session.has_value());
+
+    remove_test_root();
+}
+
+TEST_CASE(empty_session_is_cleared)
+{
+    remove_test_root();
+    auto profile = MUST(WebView::Profile::create({ .name = "default" }, roots()));
+
+    WebView::Session session;
+    session.windows.append({ .tabs = { { parse_url("https://example.com/"sv) } } });
+    TRY_OR_FAIL(WebView::save_session(profile, session));
+    EXPECT(FileSystem::exists(WebView::session_store_path(profile)));
+
+    TRY_OR_FAIL(WebView::save_session(profile, {}));
+    EXPECT(!FileSystem::exists(WebView::session_store_path(profile)));
+
+    remove_test_root();
+}
+
+TEST_CASE(session_files_are_profile_specific)
+{
+    remove_test_root();
+    auto first_profile = MUST(WebView::Profile::create({ .name = "first" }, roots()));
+    auto second_profile = MUST(WebView::Profile::create({ .name = "second" }, roots()));
+
+    WebView::Session session;
+    session.windows.append({ .tabs = { { parse_url("https://first.example/"sv) } } });
+    TRY_OR_FAIL(WebView::save_session(first_profile, session));
+
+    auto first_session = TRY_OR_FAIL(WebView::load_session(first_profile));
+    auto second_session = TRY_OR_FAIL(WebView::load_session(second_profile));
+    EXPECT(first_session.has_value());
+    EXPECT(!second_session.has_value());
+    EXPECT_NE(WebView::session_store_path(first_profile), WebView::session_store_path(second_profile));
+
+    remove_test_root();
+}

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -7,6 +7,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibURL/InternalURLs.h>
 #include <LibWebView/HistoryStore.h>
+#include <LibWebView/SessionStore.h>
 #include <LibWebView/URL.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/ChromeStyle.h>
@@ -454,6 +455,83 @@ BrowserWindow* Application::non_private_window_if_any() const
     return nullptr;
 }
 
+static bool is_restorable_window(BrowserWindow const& window)
+{
+    return window.isVisible()
+        && window.is_private() == WebView::IsPrivate::No
+        && !window.is_popup_window();
+}
+
+static WebView::SessionWindow session_window_from_browser_window(BrowserWindow const& window)
+{
+    WebView::SessionWindow session_window;
+    session_window.tabs.ensure_capacity(window.tab_count());
+
+    auto* current_tab = window.current_tab();
+    window.for_each_tab([&](Tab const& tab) {
+        auto const& url = tab.view().url();
+        if (url.scheme().is_empty())
+            return;
+        if (&tab == current_tab)
+            session_window.active_tab_index = session_window.tabs.size();
+        session_window.tabs.append({ .url = url });
+    });
+
+    session_window.x = window.pos().x();
+    session_window.y = window.pos().y();
+    session_window.width = window.width();
+    session_window.height = window.height();
+    session_window.maximized = window.isMaximized();
+
+    return session_window;
+}
+
+static WebView::Session collect_session(BrowserWindow const* closing_window = nullptr)
+{
+    WebView::Session session;
+
+    auto append_window = [&](BrowserWindow const& window) {
+        if (!is_restorable_window(window))
+            return;
+
+        auto session_window = session_window_from_browser_window(window);
+        if (session_window.tabs.is_empty())
+            return;
+
+        if (&window == Application::the().active_window_if_any())
+            session.active_window_index = session.windows.size();
+
+        session.windows.append(move(session_window));
+    };
+
+    if (closing_window)
+        append_window(*closing_window);
+
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        auto* window = as_if<BrowserWindow>(widget);
+        if (!window || window == closing_window)
+            continue;
+        append_window(*window);
+    }
+
+    if (session.active_window_index >= session.windows.size())
+        session.active_window_index = 0;
+
+    return session;
+}
+
+static bool has_other_restorable_window(BrowserWindow const& closing_window)
+{
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        auto* window = as_if<BrowserWindow>(widget);
+        if (!window || window == &closing_window)
+            continue;
+        if (is_restorable_window(*window))
+            return true;
+    }
+    return false;
+}
+
 WindowConfiguration Application::configuration_for_new_window() const
 {
     if (auto* previous_active_window = active_window_if_any(); previous_active_window && previous_active_window->isVisible()) {
@@ -555,14 +633,90 @@ void Application::quit()
     if (!confirm_cancel_active_downloads(active_window_if_any()))
         return;
 
+    if (WebView::Application::settings().browsing_behavior().restore_previous_session) {
+        auto session = collect_session();
+        if (auto result = WebView::save_session(profile(), session); result.is_error())
+            warnln("Unable to save session: {}", result.error());
+    }
+
+    m_is_quitting = true;
     QApplication::closeAllWindows();
 
     for (auto* widget : QApplication::topLevelWidgets()) {
-        if (as_if<BrowserWindow>(widget) && widget->isVisible())
+        if (as_if<BrowserWindow>(widget) && widget->isVisible()) {
+            m_is_quitting = false;
             return;
+        }
     }
 
     QApplication::quit();
+}
+
+bool Application::restore_previous_session()
+{
+    if (!WebView::Application::settings().browsing_behavior().restore_previous_session)
+        return false;
+
+    auto session = WebView::load_session(profile());
+    if (session.is_error()) {
+        warnln("Unable to load session: {}", session.error());
+        return false;
+    }
+    if (!session.value().has_value())
+        return false;
+
+    auto const& session_value = *session.value();
+    BrowserWindow* restored_active_window = nullptr;
+    for (size_t window_index = 0; window_index < session_value.windows.size(); ++window_index) {
+        auto const& session_window = session_value.windows[window_index];
+        Vector<URL::URL> urls;
+        urls.ensure_capacity(session_window.tabs.size());
+        for (auto const& tab : session_window.tabs)
+            urls.append(tab.url);
+
+        auto configuration = configuration_for_new_window();
+        if (session_window.x.has_value())
+            configuration.x = Web::DevicePixels { *session_window.x };
+        if (session_window.y.has_value())
+            configuration.y = Web::DevicePixels { *session_window.y };
+        if (session_window.width.has_value())
+            configuration.width = Web::DevicePixels { *session_window.width };
+        if (session_window.height.has_value())
+            configuration.height = Web::DevicePixels { *session_window.height };
+        configuration.maximized = session_window.maximized;
+
+        auto& window = new_window(urls, configuration);
+        window.activate_tab(static_cast<int>(session_window.active_tab_index));
+        if (window_index == session_value.active_window_index)
+            restored_active_window = &window;
+    }
+
+    if (restored_active_window) {
+        set_active_window(*restored_active_window);
+        restored_active_window->activateWindow();
+        restored_active_window->raise();
+    }
+
+    return true;
+}
+
+void Application::save_session_before_last_window_closes(BrowserWindow const& closing_window)
+{
+    if (m_is_quitting)
+        return;
+    if (!WebView::Application::settings().browsing_behavior().restore_previous_session)
+        return;
+    if (!is_restorable_window(closing_window))
+        return;
+    if (has_other_restorable_window(closing_window))
+        return;
+
+    auto session = collect_session(&closing_window);
+    if (session.is_empty())
+        return;
+
+    if (auto result = WebView::save_session(profile(), session); result.is_error())
+        warnln("Unable to save session: {}", result.error());
 }
 
 bool Application::confirm_cancel_active_downloads(QWidget* parent)

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -50,6 +50,8 @@ public:
     void reopen_recently_closed_tab();
     void open_file();
     void quit();
+    bool restore_previous_session();
+    void save_session_before_last_window_closes(BrowserWindow const&);
     bool confirm_cancel_active_downloads(QWidget* parent = nullptr);
     void initialize_macos_application_menu();
     QMenu* qt_bookmarks_menu() const;
@@ -121,6 +123,7 @@ private:
 
     OwnPtr<QApplication> m_application;
     BrowserWindow* m_active_window { nullptr };
+    bool m_is_quitting { false };
 };
 
 }

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -1584,6 +1584,8 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     size_t recently_closed_window_active_tab_index { 0 };
 
     if (m_is_private == WebView::IsPrivate::No) {
+        Application::the().save_session_before_last_window_closes(*this);
+
         if (m_should_record_closed_window_on_close && m_tabs_container->count() > 0) {
             recently_closed_window_urls = recently_closed_urls_for_window(*m_tabs_container);
             recently_closed_window_active_tab_index = static_cast<size_t>(m_tabs_container->current_index());

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -127,8 +127,9 @@ public:
 
     WebContentView& view() const { return m_current_tab->view(); }
     WebView::IsPrivate is_private() const { return m_is_private; }
+    bool is_popup_window() const { return m_is_popup_window == IsPopupWindow::Yes; }
 
-    int tab_count() { return m_tabs_container->count(); }
+    int tab_count() const { return m_tabs_container->count(); }
     int tab_index(Tab*);
 
     Tab& create_new_tab(Web::HTML::ActivateTab activate_tab, TabLocation);

--- a/UI/Qt/BrowserWindow.h
+++ b/UI/Qt/BrowserWindow.h
@@ -149,6 +149,13 @@ public:
             callback(*m_tabs_container->tab(i));
     }
 
+    template<typename Callback>
+    void for_each_tab(Callback&& callback) const
+    {
+        for (int i = 0; i < m_tabs_container->count(); ++i)
+            callback(const_cast<Tab const&>(*m_tabs_container->tab(i)));
+    }
+
     void update_tabs_display();
 
     void rebuild_bookmarks_menu();

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -112,8 +112,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
             configuration.x = last_position->x();
             configuration.y = last_position->y();
         }
-        auto& window = app->new_window(browser_options.urls, configuration);
-        window.setWindowTitle("Ladybird");
+        if (!browser_options.raw_urls.is_empty() || !app->restore_previous_session()) {
+            auto& window = app->new_window(browser_options.urls, configuration);
+            window.setWindowTitle("Ladybird");
+        }
     }
 
     return app->execute();


### PR DESCRIPTION
When this is enabled, exiting Ladybird saves the current browser windows and tabs to disk, as a JSON file local to the current profile. Reopening it restores that session, including active window/tabs, and window sizes and positions.

I've only implemented this for Qt for now, but most of the logic is in LibWebView.