### PR TITLE
LibWeb: Fix crash and load-time jank exposed by rituals.com

### DIFF
--- a/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -51,11 +51,12 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const = 0;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const = 0;
 
+    bool has_clients() const { return !m_clients.is_empty(); }
+
 protected:
     DecodedImageData();
 
     void notify_clients_did_update();
-    bool has_clients() const { return !m_clients.is_empty(); }
     virtual void on_client_registered() { }
 
 private:

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -420,6 +420,13 @@ void EventLoop::update_the_rendering()
             // NOTE: Recalculation of styles is handled by update_layout()
             document->update_layout(DOM::UpdateLayoutReason::HTMLEventLoopRenderingUpdate);
 
+            // AD-HOC: Script that ran earlier in this rendering update may have spun the event loop (e.g. with a
+            //         synchronous XHR) and run tasks that stopped document from being actively rendered, for example
+            //         by detaching it from its navigable after its iframe was removed. update_layout() is a no-op for
+            //         such documents, which can leave them without a paint tree, so skip the rest of this step.
+            if (!document->navigable() || document->navigable()->active_document() != document)
+                break;
+
             // Clamp viewport scroll offset to valid range after layout, in case the
             // scrollable overflow area has shrunk (e.g. after a viewport size change).
             if (auto navigable = document->navigable())
@@ -533,7 +540,9 @@ void EventLoop::update_the_rendering()
     // 22. For each doc of docs, update the rendering or user interface of doc and its node navigable to reflect the current state.
     for (auto& doc : docs.in_reverse()) {
         auto navigable = doc->navigable();
-        if (!navigable->needs_repaint())
+        // AD-HOC: Script that ran earlier in this rendering update may have spun the event loop and run tasks that
+        //         detached doc from its navigable (e.g. after its iframe was removed).
+        if (!navigable || !navigable->needs_repaint())
             continue;
         // OPTIMIZATION: Don't paint navigables hidden by an ancestor iframe with visibility: hidden.
         //               needs_repaint() stays true — so, once the navigable becomes visible, it's painted.

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -792,6 +792,10 @@ after_step_7:
             abort_the_image_request(realm(), m_pending_request);
             m_pending_request = nullptr;
 
+            // AD-HOC: The element may have been rendering as blank space while a load was pending;
+            //         now that the current request is broken it renders its alt text instead.
+            set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
+
             // 2. Queue an element task on the DOM manipulation task source given the img element and the following steps:
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this, maybe_omit_events, previous_url] {
                 // AD-HOC: Bail out if the document became inactive (e.g. iframe removed or navigated)
@@ -833,6 +837,10 @@ after_step_7:
 
             // 3. Set the pending request to null.
             m_pending_request = nullptr;
+
+            // AD-HOC: The element may have been rendering as blank space while a load was pending;
+            //         now that the current request is broken it renders its alt text instead.
+            set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
 
             // 4. Queue an element task on the DOM manipulation task source given the img element and the following steps:
             queue_an_element_task(HTML::Task::Source::DOMManipulation, [this, selected_source, maybe_omit_events, previous_url] {
@@ -1045,6 +1053,10 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
             // upgrade the pending request to the current request if image request is the pending request,
             if (image_request == m_pending_request)
                 upgrade_pending_request_to_current_request();
+
+            // AD-HOC: The element may have been rendering as blank space while the load was pending;
+            //         now that the current request is broken it renders its alt text instead.
+            set_needs_layout_update_or_repaint_after_image_data_change(*this, DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
 
             // and then, if maybe omit events is not set or previousURL is not equal to urlString,
             // queue an element task on the DOM manipulation task source given the img element
@@ -1438,6 +1450,18 @@ GC::Ptr<DecodedImageData> HTMLImageElement::decoded_image_data() const
     if (!m_current_request)
         return nullptr;
     return m_current_request->image_data();
+}
+
+bool HTMLImageElement::is_image_pending() const
+{
+    // INTEROP: Modeled on Blink's ImageIsPotentiallyAvailable: an image whose fetch is still in
+    //          progress, or whose lazy load is deferred, is expected to produce image data later,
+    //          so the element renders as blank space instead of its alt text while waiting.
+    if (!m_current_request || m_current_request->state() == ImageRequest::State::Broken)
+        return false;
+    if (m_current_request->is_fetching() || m_pending_request)
+        return true;
+    return has_lazy_load_resumption_steps();
 }
 
 Optional<CSSPixels> HTMLImageElement::intrinsic_width() const

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -108,6 +108,7 @@ public:
     bool allows_auto_sizes() const;
 
     // ^Layout::ImageProvider
+    virtual bool is_image_pending() const override;
     virtual GC::Ptr<DecodedImageData> decoded_image_data() const override;
     virtual Optional<CSSPixels> intrinsic_width() const override;
     virtual Optional<CSSPixels> intrinsic_height() const override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1774,6 +1774,10 @@ WebIDL::ExceptionOr<void> HTMLInputElement::handle_src_attribute(Utf16View value
             });
 
             m_load_event_delayer.clear();
+
+            // NB: The element may have been rendering as blank space while the load was pending;
+            //     now that the load failed it renders its alt text instead.
+            set_needs_layout_tree_update(true, DOM::SetNeedsLayoutTreeUpdateReason::HTMLInputElementSrcAttribute);
         });
 
     if (m_resource_request->needs_fetching()) {
@@ -2300,6 +2304,11 @@ GC::Ptr<DecodedImageData> HTMLInputElement::image_data() const
     if (m_resource_request)
         return m_resource_request->image_data();
     return nullptr;
+}
+
+bool HTMLInputElement::is_image_pending() const
+{
+    return m_resource_request && m_resource_request->is_fetching();
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -286,6 +286,7 @@ private:
     virtual bool supports_dimension_attributes() const override { return type_state() == TypeAttributeState::ImageButton; }
 
     // ^Layout::ImageProvider
+    virtual bool is_image_pending() const override;
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const override { return image_data(); }
 
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/HTML/LazyLoadingElement.h
+++ b/Libraries/LibWeb/HTML/LazyLoadingElement.h
@@ -59,6 +59,8 @@ public:
         return lazy_loading_attribute() == LazyLoading::Lazy;
     }
 
+    [[nodiscard]] bool has_lazy_load_resumption_steps() const { return m_lazy_load_resumption_steps; }
+
     void set_lazy_load_resumption_steps(Function<void()> steps)
     {
         auto& element = static_cast<T&>(*this);

--- a/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
+++ b/Libraries/LibWeb/HTML/ListOfAvailableImages.cpp
@@ -58,11 +58,17 @@ void ListOfAvailableImages::prune_to_limits(size_t external_memory_limit, size_t
         size_t decoded_image_count { 0 };
     };
 
+    // NB: Entries whose image data still has clients (e.g. a live element displaying it) are not counted or pruned.
+    //     Pruning them frees no memory, since the clients keep the decoded data alive, but it forces a refetch if
+    //     script recreates an element with the same URL, e.g. when a framework re-renders the page.
     auto cache_size = [&] {
         CacheSize cache_size;
-        for (auto const& it : m_images)
+        for (auto const& it : m_images) {
+            if (it.value->image_data->has_clients())
+                continue;
             cache_size.decoded_image_size += it.value->image_data->external_memory_size();
-        cache_size.decoded_image_count = m_images.size();
+            ++cache_size.decoded_image_count;
+        }
         return cache_size;
     };
 
@@ -72,6 +78,8 @@ void ListOfAvailableImages::prune_to_limits(size_t external_memory_limit, size_t
         u64 least_recently_used_serial = NumericLimits<u64>::max();
 
         for (auto const& it : m_images) {
+            if (it.value->image_data->has_clients())
+                continue;
             if (it.value->cache_touch_serial >= least_recently_used_serial)
                 continue;
             least_recently_used_key = it.key;

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -91,6 +91,14 @@ GC::Ptr<DecodedImageData> SharedResourceRequest::image_data() const
     return m_image_data;
 }
 
+bool SharedResourceRequest::can_be_pruned_from_memory_cache() const
+{
+    // NB: Pruning an image that still has clients (e.g. a live element displaying it) frees no memory, since the
+    //     clients keep the decoded data alive, but it forces a refetch if script recreates an element with the
+    //     same URL, e.g. when a framework re-renders the page.
+    return m_image_data && !m_image_data->has_clients();
+}
+
 void SharedResourceRequest::touch_memory_cache_entry()
 {
     m_cache_touch_serial = ++s_next_memory_cache_touch_serial;

--- a/Libraries/LibWeb/HTML/SharedResourceRequest.h
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.h
@@ -29,7 +29,7 @@ public:
     URL::URL const& url() const { return m_url; }
 
     [[nodiscard]] GC::Ptr<DecodedImageData> image_data() const;
-    [[nodiscard]] bool can_be_pruned_from_memory_cache() const { return m_image_data; }
+    [[nodiscard]] bool can_be_pruned_from_memory_cache() const;
     [[nodiscard]] u64 cache_touch_serial() const { return m_cache_touch_serial; }
     void touch_memory_cache_entry();
 

--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -64,6 +64,10 @@ CSS::SizeWithAspectRatio ImageBox::natural_size() const
         };
     }
 
+    // While a load is still pending we render blank space, not the alt text.
+    if (image_provider.is_image_pending())
+        return { 0, 0, {} };
+
     Utf16String alt;
     if (auto element = dom_node())
         alt = element->get_attribute_value(HTML::AttributeNames::alt);
@@ -91,7 +95,7 @@ void ImageBox::dom_node_did_update_alt_text(Badge<ImageProvider>)
 
 bool ImageBox::renders_as_alt_text() const
 {
-    return !image_provider().is_image_available();
+    return image_provider().renders_as_alt_text();
 }
 
 RefPtr<Painting::Paintable> ImageBox::create_paintable() const

--- a/Libraries/LibWeb/Layout/ImageProvider.h
+++ b/Libraries/LibWeb/Layout/ImageProvider.h
@@ -22,6 +22,16 @@ public:
 
     bool is_image_available() const { return decoded_image_data() != nullptr; }
 
+    // Whether image data is expected to become available later, e.g. a fetch is still in progress
+    // or a lazy load is deferred.
+    virtual bool is_image_pending() const { return false; }
+
+    // https://html.spec.whatwg.org/multipage/rendering.html#images-3
+    // The alt text fallback is only for images that are known not to render (they failed, or there
+    // is nothing to load); while an image is still expected to arrive, the element renders as
+    // blank space, matching other engines.
+    bool renders_as_alt_text() const { return !is_image_available() && !is_image_pending(); }
+
     virtual GC::Ptr<HTML::DecodedImageData> decoded_image_data() const = 0;
 
     virtual Optional<CSSPixels> intrinsic_width() const;

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -87,7 +87,7 @@ void ImagePaintable::reset_for_relayout()
     Paintable::reset_for_relayout();
 
     if (!m_is_svg_image) {
-        m_renders_as_alt_text = !m_image_provider.is_image_available();
+        m_renders_as_alt_text = m_image_provider.renders_as_alt_text();
         if (auto const* image_box = as_if<Layout::ImageBox>(layout_node())) {
             if (auto element = image_box->dom_node())
                 m_alt_text = element->get_attribute_value(HTML::AttributeNames::alt);
@@ -105,7 +105,7 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
     if (phase == PaintPhase::Foreground) {
         auto image_rect = absolute_rect();
         auto image_rect_device_pixels = context.rounded_device_rect(image_rect);
-        auto renders_as_alt_text = m_is_svg_image ? m_renders_as_alt_text : !m_image_provider.is_image_available();
+        auto renders_as_alt_text = m_is_svg_image ? m_renders_as_alt_text : m_image_provider.renders_as_alt_text();
         if (renders_as_alt_text) {
             if (!m_alt_text.is_empty()) {
                 auto enclosing_rect = context.enclosing_device_rect(image_rect).to_type<int>();

--- a/Tests/LibWeb/Crash/HTML/display-none-iframe-detached-during-raf-sync-xhr.html
+++ b/Tests/LibWeb/Crash/HTML/display-none-iframe-detached-during-raf-sync-xhr.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!-- Test: Insert a display:none iframe (so its about:blank document is never laid out and never
+     gets a paint tree), then remove it from an animation frame callback and immediately perform a
+     synchronous XHR. Removing the iframe queues a deferred task that detaches the child document
+     from its navigable, and the sync XHR spins the event loop from inside the rendering update,
+     running that task before the update's style/layout step. That document is still in the
+     update's docs set, so the style/layout step processes a detached document with no paintable,
+     which the content-visibility step used to dereference. -->
+<html class="test-wait">
+<body>
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            const iframe = document.createElement("iframe");
+            iframe.style.display = "none";
+            document.body.appendChild(iframe);
+            requestAnimationFrame(() => {
+                iframe.remove();
+                try {
+                    // The fetch fails for file: URLs, but send() still spins the event loop long
+                    // enough to run the queued detach task, which is all this test needs.
+                    const xhr = new XMLHttpRequest();
+                    xhr.open("GET", "../../Assets/blank.html", false);
+                    xhr.send();
+                } catch {}
+                requestAnimationFrame(() => {
+                    document.documentElement.classList.remove("test-wait");
+                });
+            });
+        }, 0);
+    });
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/expected/HTML/displayed-image-survives-decoded-image-cache-pruning.txt
+++ b/Tests/LibWeb/Text/expected/HTML/displayed-image-survives-decoded-image-cache-pruning.txt
@@ -1,1 +1,1 @@
-recreated image is completely available: false
+recreated image is completely available: true

--- a/Tests/LibWeb/Text/expected/HTML/displayed-image-survives-decoded-image-cache-pruning.txt
+++ b/Tests/LibWeb/Text/expected/HTML/displayed-image-survives-decoded-image-cache-pruning.txt
@@ -1,0 +1,1 @@
+recreated image is completely available: false

--- a/Tests/LibWeb/Text/expected/HTML/img-pending-load-renders-blank-not-alt-text.txt
+++ b/Tests/LibWeb/Text/expected/HTML/img-pending-load-renders-blank-not-alt-text.txt
@@ -1,0 +1,5 @@
+pending image renders blank: false
+broken image renders alt text: true
+src-less image renders alt text: true
+deferred lazy image renders blank: false
+unblocked image loaded with natural width: 1

--- a/Tests/LibWeb/Text/expected/HTML/img-pending-load-renders-blank-not-alt-text.txt
+++ b/Tests/LibWeb/Text/expected/HTML/img-pending-load-renders-blank-not-alt-text.txt
@@ -1,5 +1,5 @@
-pending image renders blank: false
+pending image renders blank: true
 broken image renders alt text: true
 src-less image renders alt text: true
-deferred lazy image renders blank: false
+deferred lazy image renders blank: true
 unblocked image loaded with natural width: 1

--- a/Tests/LibWeb/Text/input/HTML/displayed-image-survives-decoded-image-cache-pruning.html
+++ b/Tests/LibWeb/Text/input/HTML/displayed-image-survives-decoded-image-cache-pruning.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // A document's decoded image caches (the shared resource requests and the list of available
+    // images) are pruned to fixed size/count limits as image loads complete. An image that is
+    // still displayed by a live element must survive that pruning: evicting it frees no memory
+    // (the displaying element keeps the decoded data alive), but it forces a refetch when script
+    // recreates an element with the same URL, e.g. when a framework re-renders the page.
+    asyncTest(async (done) => {
+        const keptImage = document.createElement("img");
+        keptImage.src = "../../../Assets/120.png";
+        document.body.appendChild(keptImage);
+        await new Promise((resolve, reject) => {
+            keptImage.onload = resolve;
+            keptImage.onerror = () => reject(new Error("Failed to load kept image"));
+        });
+
+        // Load enough other images to overflow the cache's count limit.
+        const canvas = document.createElement("canvas");
+        canvas.width = canvas.height = 1;
+        const context = canvas.getContext("2d");
+        const fillerLoads = [];
+        for (let i = 0; i < 100; ++i) {
+            context.fillStyle = `rgb(${i % 256}, ${Math.floor(i / 256)}, 0)`;
+            context.fillRect(0, 0, 1, 1);
+            const filler = document.createElement("img");
+            filler.src = canvas.toDataURL();
+            fillerLoads.push(new Promise((resolve, reject) => {
+                filler.onload = resolve;
+                filler.onerror = () => reject(new Error("Failed to load filler image"));
+            }));
+        }
+        await Promise.all(fillerLoads);
+
+        const recreated = document.createElement("img");
+        recreated.src = "../../../Assets/120.png";
+        println(`recreated image is completely available: ${recreated.complete && recreated.naturalWidth > 0}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/img-pending-load-renders-blank-not-alt-text.html
+++ b/Tests/LibWeb/Text/input/HTML/img-pending-load-renders-blank-not-alt-text.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    // While an img element's image is still loading (or its lazy load is deferred), the element
+    // must render as blank space, not as its alt text; the fallback text is only for images that
+    // failed or that have no source at all. This matches Chrome and Firefox, and avoids flashing
+    // alt text on pages that are still loading their images.
+    asyncTest(async (done) => {
+        const TINY_PNG_BASE64 =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+        const httpServer = httpTestServer();
+        const testID = crypto.randomUUID();
+        const unblockToken = `img-pending-alt-text-${testID}`;
+        const pendingURL = await httpServer.createEcho("GET", `/img-pending-alt-text-${testID}`, {
+            status: 200,
+            headers: { "Content-Type": "image/png" },
+            body: TINY_PNG_BASE64,
+            body_encoding: "base64",
+            wait_for_unblock: unblockToken,
+        });
+        const brokenURL = await httpServer.createEcho("GET", `/img-broken-alt-text-${testID}`, {
+            status: 404,
+            body: "not found",
+        });
+
+        const rendersBlank = (img) => img.getBoundingClientRect().width === 0;
+
+        const pendingImage = document.createElement("img");
+        pendingImage.alt = "some alt text";
+        pendingImage.src = pendingURL;
+        document.body.appendChild(pendingImage);
+        const pendingImageLoaded = new Promise((resolve) => (pendingImage.onload = resolve));
+
+        // Let the queued "update the image data" start the (stalled) fetch before looking.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        println(`pending image renders blank: ${rendersBlank(pendingImage)}`);
+
+        const brokenImage = document.createElement("img");
+        brokenImage.alt = "some alt text";
+        brokenImage.src = brokenURL;
+        document.body.appendChild(brokenImage);
+        await new Promise((resolve) => (brokenImage.onerror = resolve));
+        println(`broken image renders alt text: ${!rendersBlank(brokenImage)}`);
+
+        const sourcelessImage = document.createElement("img");
+        sourcelessImage.alt = "some alt text";
+        document.body.appendChild(sourcelessImage);
+        println(`src-less image renders alt text: ${!rendersBlank(sourcelessImage)}`);
+
+        const lazyImage = document.createElement("img");
+        lazyImage.alt = "some alt text";
+        lazyImage.loading = "lazy";
+        lazyImage.style.position = "absolute";
+        lazyImage.style.top = "100000px";
+        lazyImage.src = "/never-fetched.png";
+        document.body.appendChild(lazyImage);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        println(`deferred lazy image renders blank: ${rendersBlank(lazyImage)}`);
+
+        await fetch(new URL(`/unblock/${unblockToken}`, pendingURL));
+        await pendingImageLoaded;
+        println(`unblocked image loaded with natural width: ${pendingImage.naturalWidth}`);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Loading rituals.com product pages in Ladybird was extremely janky: alt
text and raw SKU numbers flashed while images loaded, the whole page
re-rendered midway through load, and the cookie consent dialog vanished
before it could be clicked. The trigger is a bug on the site itself: a
React hydration mismatch (error 418, reproducible in Chrome) makes it
throw away its entire server-rendered DOM and re-render client-side.
Other engines hide this recovery completely, so this branch fixes the
three things that made it visible (and fatal) in Ladybird.

First, WebContent could crash during the re-render. Script running
inside a rendering update can spin the event loop (e.g. with a
synchronous XHR) and run the deferred task that detaches a removed
iframe's document from its navigable. The style/layout step then
dereferenced the detached document's null paintable, and the painting
step its null navigable. Both spots now skip such documents, with a
deterministic crash test.

Second, the document's decoded image caches evicted entries for images
still displayed by live elements. That frees no memory, since the
displaying element keeps the decoded data alive, but it forces a
refetch and re-decode when script recreates an element with the same
URL, which is exactly what a framework re-render does. In-use entries
now survive pruning, so re-created images repaint instantly.

Third, img elements rendered their alt text whenever image data was
unavailable, including while a load was still in progress. Chrome and
Firefox render blank space for images they still expect to load and
reserve the alt text fallback for images that failed or have no source.
ImageProvider now has an is_image_pending() hook modeled on Blink's
ImageIsPotentiallyAvailable, and broken-state transitions invalidate
layout since blank to alt text is now a rendering change.

Each behavior change comes with a test committed ahead of the fix where
possible. With all three, the page loads cleanly: no alt text soup, the
re-render is imperceptible, and the consent dialog stays up.