### PR TITLE
LibWeb: Release discarded navigation redirect requests

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1486,6 +1486,13 @@ GC::Ptr<PendingResponse> http_redirect_fetch(JS::Realm& realm, Infrastructure::F
     if (!location_url_or_error.is_error() && !location_url_or_error.value().has_value())
         return PendingResponse::create(vm, request, response);
 
+    // AD-HOC: Navigation responses are kept alive in RequestServer so they can be transferred to the UI process if
+    //         they become downloads. This response will be discarded in favor of either a network error or the
+    //         redirect response, so release that hold and stop the request if it is still active.
+    internal_response->release_request_for_transfer();
+    if (auto const& request_server_request = internal_response->request_server_request(); request_server_request.has_value() && request_server_request->request)
+        request_server_request->request->stop();
+
     // 5. If locationURL is failure, then return a network error.
     if (location_url_or_error.is_error())
         return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request redirect URL is invalid"_string));

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -50,7 +50,7 @@ void populate_request_from_client(JS::Realm const&, Infrastructure::Request&);
 void fetch_response_handover(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 GC::Ref<PendingResponse> scheme_fetch(JS::Realm&, Infrastructure::FetchParams const&);
 GC::Ref<PendingResponse> http_fetch(JS::Realm&, Infrastructure::FetchParams const&, MakeCORSPreflight make_cors_preflight = MakeCORSPreflight::No);
-GC::Ptr<PendingResponse> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
+WEB_API GC::Ptr<PendingResponse> http_redirect_fetch(JS::Realm&, Infrastructure::FetchParams const&, Infrastructure::Response&);
 GC::Ref<PendingResponse> http_network_or_cache_fetch(JS::Realm&, Infrastructure::FetchParams const&, IsAuthenticationFetch is_authentication_fetch = IsAuthenticationFetch::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No);
 GC::Ref<PendingResponse> nonstandard_resource_loader_file_or_http_network_fetch(JS::Realm&, Infrastructure::FetchParams const&, HTTP::Cookie::IncludeCredentials include_credentials = HTTP::Cookie::IncludeCredentials::No, IsNewConnectionFetch is_new_connection_fetch = IsNewConnectionFetch::No, RefPtr<HTTP::MemoryCache> = {});
 GC::Ref<PendingResponse> cors_preflight_fetch(JS::Realm&, Infrastructure::Request&);

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -40,7 +40,7 @@ ladybird_utility(css-tokenizer SOURCES css-tokenizer.cpp LIBS LibFileSystem LibM
 target_link_libraries(TestContentBlocker PRIVATE LibURL)
 target_link_libraries(TestControlMessageQueue PRIVATE LibSync)
 target_link_libraries(TestDisplayListDamage PRIVATE LibGfx)
-target_link_libraries(TestFetchResponse PRIVATE LibGC LibHTTP LibJS)
+target_link_libraries(TestFetchResponse PRIVATE LibGC LibHTTP LibJS LibRequests LibURL)
 target_link_libraries(TestFetchURL PRIVATE LibURL)
 target_link_libraries(TestAccumulatedVisualContext PRIVATE LibGfx)
 target_link_libraries(TestImageData PRIVATE LibGC LibJS)

--- a/Tests/LibWeb/TestFetchResponse.cpp
+++ b/Tests/LibWeb/TestFetchResponse.cpp
@@ -8,7 +8,40 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWeb/Fetch/Fetching/Fetching.h>
+#include <LibWeb/Fetch/Infrastructure/FetchParams.h>
+#include <LibWeb/Fetch/Infrastructure/FetchTimingInfo.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+
+namespace {
+
+class TransferTrackingResponse final : public Web::Fetch::Infrastructure::Response {
+    GC_CELL(TransferTrackingResponse, Web::Fetch::Infrastructure::Response);
+    GC_DECLARE_ALLOCATOR(TransferTrackingResponse);
+
+public:
+    static GC::Ref<TransferTrackingResponse> create(JS::VM& vm)
+    {
+        return vm.heap().allocate<TransferTrackingResponse>();
+    }
+
+    bool was_released_for_transfer() const { return m_was_released_for_transfer; }
+    virtual void release_request_for_transfer() const override { m_was_released_for_transfer = true; }
+
+private:
+    TransferTrackingResponse()
+        : Response(HTTP::HeaderList::create())
+    {
+    }
+
+    mutable bool m_was_released_for_transfer { false };
+};
+
+GC_DEFINE_ALLOCATOR(TransferTrackingResponse);
+
+}
 
 TEST_CASE(javascript_bytecode_cache_memory_cache_request_headers_are_cloned)
 {
@@ -28,4 +61,28 @@ TEST_CASE(javascript_bytecode_cache_memory_cache_request_headers_are_cloned)
 
     VERIFY(cloned_request_headers.has_value());
     EXPECT_EQ((*cloned_request_headers)->get("User-Agent"sv), Optional<ByteString> { "Ladybird" });
+}
+
+TEST_CASE(http_redirect_fetch_releases_intermediate_response_for_transfer)
+{
+    auto vm = JS::VM::create();
+    auto root_execution_context = JS::create_simple_execution_context<JS::GlobalObject>(*vm);
+    auto& realm = *root_execution_context->realm;
+
+    auto request_url = URL::Parser::basic_parse("https://example.test/start"sv);
+    VERIFY(request_url.has_value());
+
+    auto request = Web::Fetch::Infrastructure::Request::create(*vm);
+    request->set_url_list({ request_url.release_value() });
+    request->set_redirect_count(20);
+
+    auto fetch_params = Web::Fetch::Infrastructure::FetchParams::create(*vm, request, Web::Fetch::Infrastructure::FetchTimingInfo::create(*vm));
+    auto response = TransferTrackingResponse::create(*vm);
+    response->set_status(302);
+    response->set_header_list(HTTP::HeaderList::create({ { "Location"sv, "/redirected"sv } }));
+
+    auto pending_response = Web::Fetch::Fetching::http_redirect_fetch(realm, fetch_params, response);
+
+    VERIFY(pending_response);
+    EXPECT(response->was_released_for_transfer());
 }


### PR DESCRIPTION
Since f45451570e15, document navigation requests have been retained in RequestServer so they can be handed to the UI process if a response becomes a download. Intermediate redirect responses never reach download handling, however, and replacing FetchController's pending request left each retained response pipe open. Repeated redirects eventually exhausted RequestServer's file descriptors.

The Fetch specification does not account for this lifecycle. RequestServer transfer retention is a Ladybird implementation detail, not web-observable Fetch state. Release the transfer hold before discarding an intermediate redirect response, and stop its request when it is still active.

Cover this with a focused http_redirect_fetch() test that records the release of a synthetic intermediate response. An end-to-end regression would have to lower the process file limit and perform hundreds of navigations, making it slow and dependent on test-runner arguments and process timing. The unit test directly protects the missing ownership step.

This is one of the potential sources for FD leaks that we're seeing on our WPT runner.