### PR TITLE
WebDriver: Keep the session alive while close() removes it

### DIFF
--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -175,6 +175,10 @@ void Session::close_all()
 // https://w3c.github.io/webdriver/#dfn-close-the-session
 void Session::close()
 {
+    // NB: Step 2 removes this session from the active-sessions map — usually dropping the last reference to it. So hold
+    //     a strong reference across close() — so removal can't destroy the session while the steps below still use it.
+    auto protector = NonnullRefPtr { *this };
+
     // 1. If session's HTTP flag is set, remove session from active HTTP sessions.
     if (has_flag(session_flags(), Web::WebDriver::SessionFlags::Http))
         s_http_sessions.remove(m_session_id);


### PR DESCRIPTION
**Problem:** WebDriver intermittently crashes with a heap-use-after-free when the last WebDriver window is removed during a process swap — such as when a UI-initiated navigation replaces the WebContent process and the outgoing renderer’s connection closes. AddressSanitizer reports both the free and the read inside `Session::close()`.

**Cause:** `web_content_connection_closed` removes the window whose connection closed; when that was the last window, `remove_window` calls `close()`. `close()` removes the session from the active-sessions map — which drops what’s often the last reference to the session — and destroys it mid-method. `close()` then keeps iterating the freed session’s windows and pending connections — reading freed memory.

**Fix:** Hold a strong reference to the session `close()` start — so removing it from the active-sessions map can’t destroy it before `close()` returns.

Came across this while investigating https://github.com/LadybirdBrowser/ladybird/issues/10711.
