### PR TITLE
LibWebView+LibWeb: Cache each stored item’s quota size

### DIFF
--- a/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.cpp
@@ -153,8 +153,8 @@ Vector<Utf16String> SessionStorageBottle::keys() const
 
 Optional<Utf16String> SessionStorageBottle::get(Utf16View key) const
 {
-    if (auto value = m_map.get(key); value.has_value())
-        return value.value();
+    if (auto entry = m_map.get(key); entry.has_value())
+        return entry->value;
     return OptionalNone {};
 }
 
@@ -162,20 +162,19 @@ StorageSetResult SessionStorageBottle::set(Utf16View key, Utf16View value)
 {
     auto old_value = get(key);
 
+    auto new_size = storage_quota_size(key) + storage_quota_size(value);
+
     if (m_quota.has_value()) {
         size_t current_size = 0;
-        for (auto const& [existing_key, existing_value] : m_map) {
-            if (existing_key.utf16_view() != key) {
-                current_size += storage_quota_size(existing_key.utf16_view());
-                current_size += storage_quota_size(existing_value.utf16_view());
-            }
+        for (auto const& [existing_key, existing_entry] : m_map) {
+            if (existing_key.utf16_view() != key)
+                current_size += existing_entry.quota_size;
         }
-        size_t new_size = storage_quota_size(key) + storage_quota_size(value);
         if (current_size + new_size > m_quota.value())
             return WebView::StorageOperationError::QuotaExceededError;
     }
 
-    m_map.set(Utf16String::from_utf16(key), Utf16String::from_utf16(value));
+    m_map.set(Utf16String::from_utf16(key), { Utf16String::from_utf16(value), new_size });
     return old_value;
 }
 

--- a/Libraries/LibWeb/StorageAPI/StorageBottle.h
+++ b/Libraries/LibWeb/StorageAPI/StorageBottle.h
@@ -111,8 +111,14 @@ private:
     {
     }
 
+    struct Entry {
+        Utf16String value;
+        // Bytes this entry contributes toward the bottle's quota: Its key plus its value.
+        size_t quota_size { 0 };
+    };
+
     // A storage bottle has a map, which is initially an empty map
-    OrderedHashMap<Utf16String, Utf16String> m_map;
+    OrderedHashMap<Utf16String, Entry> m_map;
 };
 
 using BottleMap = Array<GC::Ptr<StorageBottle>, to_underlying(StorageEndpointType::Count)>;

--- a/Libraries/LibWebView/StorageJar.cpp
+++ b/Libraries/LibWebView/StorageJar.cpp
@@ -171,17 +171,15 @@ StorageSetResult StorageJar::TransientStorage::set_item(StorageLocation const& k
     u64 current_size = 0;
 
     for (auto const& [existing_key, existing_entry] : m_storage_items) {
-        if (existing_key.storage_endpoint == key.storage_endpoint && existing_key.storage_key == key.storage_key && existing_key.bottle_key != key.bottle_key) {
-            current_size += storage_quota_size(existing_key.bottle_key);
-            current_size += storage_quota_size(existing_entry.value);
-        }
+        if (existing_key.storage_endpoint == key.storage_endpoint && existing_key.storage_key == key.storage_key && existing_key.bottle_key != key.bottle_key)
+            current_size += existing_entry.quota_size;
     }
 
     auto new_size = storage_quota_size(key.bottle_key) + storage_quota_size(value);
     if (current_size + new_size > LOCAL_STORAGE_QUOTA)
         return StorageOperationError::QuotaExceededError;
 
-    m_storage_items.set(key, { value, UnixDateTime::now() });
+    m_storage_items.set(key, { value, UnixDateTime::now(), new_size });
     return old_value;
 }
 
@@ -226,7 +224,7 @@ Requests::CacheSizes StorageJar::TransientStorage::estimate_storage_size_accesse
     Requests::CacheSizes sizes;
 
     for (auto const& [key, entry] : m_storage_items) {
-        auto size = key.storage_key.byte_count() + storage_quota_size(key.bottle_key) + storage_quota_size(entry.value);
+        auto size = key.storage_key.byte_count() + entry.quota_size;
         sizes.total += size;
 
         if (entry.last_access_time >= since)
@@ -369,10 +367,8 @@ u64 StorageJar::TransientStorage::usage(String const& storage_key)
 {
     u64 current_size_in_bytes = 0;
     for (auto const& [key, entry] : m_storage_items) {
-        if (key.storage_key == storage_key) {
-            current_size_in_bytes += storage_quota_size(key.bottle_key);
-            current_size_in_bytes += storage_quota_size(entry.value);
-        }
+        if (key.storage_key == storage_key)
+            current_size_in_bytes += entry.quota_size;
     }
     return current_size_in_bytes;
 }

--- a/Libraries/LibWebView/StorageJar.h
+++ b/Libraries/LibWebView/StorageJar.h
@@ -79,6 +79,8 @@ private:
         struct Entry {
             Utf16String value;
             UnixDateTime last_access_time;
+            // Bytes this entry contributes toward its storage key's quota: Its bottle key plus its value.
+            u64 quota_size { 0 };
         };
 
         HashMap<StorageLocation, Entry> m_storage_items;

--- a/Tests/LibWebView/TestStorageJar.cpp
+++ b/Tests/LibWebView/TestStorageJar.cpp
@@ -83,3 +83,44 @@ TEST_CASE(migration_to_add_last_access_time_is_idempotent)
 
     EXPECT_EQ(TRY_OR_FAIL(database->schema_version("WebStorage"sv)), Optional<u32> { 2u });
 }
+
+TEST_CASE(storage_usage_tracks_item_sizes)
+{
+    auto jar = WebView::StorageJar::create();
+
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "key"_utf16, "value"_utf16);
+    EXPECT_EQ(jar->usage("https://example.com"_string), 8u);
+
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "key"_utf16, "v"_utf16);
+    EXPECT_EQ(jar->usage("https://example.com"_string), 4u);
+
+    jar->remove_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "key"_utf16);
+    EXPECT_EQ(jar->usage("https://example.com"_string), 0u);
+}
+
+TEST_CASE(storage_usage_counts_utf8_bytes_not_code_units)
+{
+    auto jar = WebView::StorageJar::create();
+
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "k"_utf16, "\u00e9"_utf16);
+    EXPECT_EQ(jar->usage("https://example.com"_string), 3u);
+
+    jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "k"_utf16, "\U0001f600"_utf16);
+    EXPECT_EQ(jar->usage("https://example.com"_string), 5u);
+}
+
+TEST_CASE(storage_quota_is_enforced_per_storage_key)
+{
+    auto jar = WebView::StorageJar::create();
+
+    auto large_value = Utf16String::repeated('x', Web::StorageAPI::StorageEndpoint::LOCAL_STORAGE_QUOTA / 2 - 16);
+
+    EXPECT(jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "a"_utf16, large_value).has<Optional<Utf16String>>());
+    EXPECT(jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "b"_utf16, large_value).has<Optional<Utf16String>>());
+
+    // A third value exceeds the quota for this storage key.
+    EXPECT(jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://example.com"_string, "c"_utf16, large_value).has<WebView::StorageOperationError>());
+
+    // A different storage key has its own quota.
+    EXPECT(jar->set_item(WebView::StorageEndpointType::LocalStorage, "https://other.example"_string, "a"_utf16, large_value).has<Optional<Utf16String>>());
+}


### PR DESCRIPTION
**Problem:** A WPT test that fills the local-storage quota frequently timed out on the Sanitizer CI runners. And a WPT test that fills the session-storage quota was burning up 5.8s of the 30s per-test timeout on those same runners.

**Cause:** Quadratic string allocation: `storage_quota_size()` counted a string’s UTF-8 bytes by building a whole UTF-8 copy of it and discarding the copy. And `set_item()` for local storage, and `set()` for session storage, called it once per existing entry on every write, while totalling up the bytes already held — even though a stored entry’s size never changes. Filling the 5 MiB quota with 1 KiB items allocated and freed roughly 25 million strings.

**Fix:** Record an entry’s quota cost when it’s written, and sum the recorded costs — instead of recomputing them. The size travels with the value it describes — so removals need no bookkeeping and the cached size can’t drift. The local-storage WPT test drops from taking 5.8s under ASan to just 0.9s — and the session-storage one to just 0.4s.
