### PR TITLE
LibJS: Avoid unnecessary bigint math in the `Date` constructor / `Date.now`

### DIFF
--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2020-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2020, Nico Weber <thakis@chromium.org>
  * Copyright (c) 2021, Petróczi Zoltán <petroczizoltan@tutanota.com>
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2022-2026, Tim Flynn <trflynn89@ladybird.org>
  * Copyright (c) 2025, Manuel Zahariev <manuel@duck.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -61,7 +61,7 @@ ThrowCompletionOr<Value> DateConstructor::call()
     auto& vm = this->vm();
 
     // 1. If NewTarget is undefined, return ToDateString(SystemUTCEpochMilliseconds()).
-    return PrimitiveString::create(vm, to_date_string(Temporal::system_utc_epoch_milliseconds(vm)));
+    return PrimitiveString::create(vm, to_date_string(Temporal::system_utc_epoch_milliseconds()));
 }
 
 // 21.4.2.1 Date ( ...values ), https://tc39.es/ecma262/#sec-date
@@ -76,7 +76,7 @@ ThrowCompletionOr<GC::Ref<Object>> DateConstructor::construct(FunctionObject& ne
     // 3. If numberOfArgs = 0, then
     if (vm.argument_count() == 0) {
         // a. Let dv be SystemUTCEpochMilliseconds().
-        date_value = Temporal::system_utc_epoch_milliseconds(vm);
+        date_value = Temporal::system_utc_epoch_milliseconds();
     }
     // 4. Else if numberOfArgs = 1, then
     else if (vm.argument_count() == 1) {
@@ -164,7 +164,7 @@ ThrowCompletionOr<GC::Ref<Object>> DateConstructor::construct(FunctionObject& ne
 JS_DEFINE_NATIVE_FUNCTION(DateConstructor::now)
 {
     // 1. Return SystemUTCEpochMilliseconds().
-    return Temporal::system_utc_epoch_milliseconds(vm);
+    return Temporal::system_utc_epoch_milliseconds();
 }
 
 // 21.4.3.2 Date.parse ( string ), https://tc39.es/ecma262/#sec-date.parse

--- a/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -1,10 +1,11 @@
 /*
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2024-2026, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Time.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/Temporal/Instant.h>
 #include <LibJS/Runtime/Temporal/Now.h>
@@ -121,16 +122,16 @@ JS_DEFINE_NATIVE_FUNCTION(Now::plain_time_iso)
 }
 
 // 2.3.2 SystemUTCEpochMilliseconds ( ), https://tc39.es/proposal-temporal/#sec-temporal-systemutcepochmilliseconds
-double system_utc_epoch_milliseconds(VM& vm)
+double system_utc_epoch_milliseconds()
 {
     // 1. Let global be GetGlobalObject().
-    auto const& global = vm.get_global_object();
-
     // 2. Let nowNs be HostSystemUTCEpochNanoseconds(global).
-    auto now_ns = vm.host_system_utc_epoch_nanoseconds(global);
+    // AD-HOC: Every caller of SystemUTCEpochMilliseconds is via Date.now and the Date constructor, which do not need
+    //         nanosecond precision. We can avoid unnecessary bigint math by returning milliseconds directly.
+    auto now_ns = AK::UnixDateTime::now().nanoseconds_since_epoch();
 
     // 3. Return 𝔽(floor(nowNs / 10**6)).
-    return big_floor(now_ns, NANOSECONDS_PER_MILLISECOND).to_double();
+    return floor(now_ns / 1'000'000);
 }
 
 // 2.3.3 SystemUTCEpochNanoseconds ( ), https://tc39.es/proposal-temporal/#sec-temporal-systemutcepochnanoseconds

--- a/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -32,7 +32,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(plain_time_iso);
 };
 
-double system_utc_epoch_milliseconds(VM&);
+double system_utc_epoch_milliseconds();
 Crypto::SignedBigInteger system_utc_epoch_nanoseconds(VM&);
 ThrowCompletionOr<ISODateTime> system_date_time(VM&, Value temporal_time_zone_like);
 


### PR DESCRIPTION
Temporal changed `Date` to acquire the current system time as nanoseconds, which are then converted to milliseconds via bigint division/flooring. We don't really need to jump through all those hoops; let's just return the time as milliseconds from the get-go.

This performs ~10x faster in a loop calling `Date.now` 10 million times.