### PR TITLE
LibWeb: Correct generated image and ratio-only replaced sizing

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1451,7 +1451,10 @@ void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
                     - item.borders.cross_before - item.borders.cross_after;
 
                 auto const& computed_min_size = computed_cross_min_size(item.box);
-                auto cross_min_size = (!computed_min_size.is_auto() && !computed_min_size.contains_percentage()) ? specified_cross_min_size(item) : 0;
+                // https://drafts.csswg.org/css-flexbox-1/#definite-sizes
+                // Once the cross size of a flex line has been determined, the cross sizes of items in auto-sized flex
+                // containers are also considered definite for the purpose of layout.
+                auto cross_min_size = !computed_min_size.is_auto() ? specified_cross_min_size(item) : 0;
                 auto cross_max_size = !should_treat_cross_max_size_as_none(item.box) ? specified_cross_max_size(item) : CSSPixels::max();
 
                 item.cross_size = css_clamp(unclamped_cross_size, cross_min_size, cross_max_size);

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2858,6 +2858,14 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
     if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
         return transferred_width.value();
     if (!auto_size.has_width()) {
+        // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
+        // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
+        // replaced element with a natural aspect ratio and no natural size in that axis.
+        auto const& computed_width = box.computed_values().width();
+        auto const& computed_height = box.computed_values().height();
+        if (box.is_replaced_box() && auto_size.has_aspect_ratio() && !auto_size.has_height() && computed_width.is_length() && computed_height.is_intrinsic_sizing_constraint())
+            return calculate_inner_width(box, AvailableSize::make_definite(0), computed_width, containing_block_constraints);
+
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         // "If the box is non-replaced, then the entire value of any max size property or preferred size property
         // ('width'/'max-width'/'height'/'max-height') specified as an expression containing a percentage [...] that is

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -41,6 +41,8 @@ enum class SizeDimension {
     Height,
 };
 
+// NB: Intrinsic grid sizing can transfer an aspect ratio before block-axis border metrics are copied into the layout
+//     state. Border widths are already definite at computed-value time, while padding remains resolved in the state.
 static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_width)
 {
     VERIFY(box.has_preferred_aspect_ratio());
@@ -50,9 +52,14 @@ static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::U
         return 0;
 
     if (box.computed_values().box_sizing_for_aspect_ratio() == CSS::BoxSizing::BorderBox) {
-        auto border_box_width = content_width + box_state.border_box_left() + box_state.border_box_right();
+        auto const& computed_values = box.computed_values();
+        auto border_box_left = computed_values.border_left().width + box_state.padding_left;
+        auto border_box_right = computed_values.border_right().width + box_state.padding_right;
+        auto border_box_top = computed_values.border_top().width + box_state.padding_top;
+        auto border_box_bottom = computed_values.border_bottom().width + box_state.padding_bottom;
+        auto border_box_width = content_width + border_box_left + border_box_right;
         auto border_box_height = border_box_width / aspect_ratio;
-        return max(border_box_height - box_state.border_box_top() - box_state.border_box_bottom(), 0);
+        return max(border_box_height - border_box_top - border_box_bottom, 0);
     }
 
     return content_width / aspect_ratio;
@@ -72,16 +79,27 @@ static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::Us
         return 0;
 
     if (box.computed_values().box_sizing_for_aspect_ratio() == CSS::BoxSizing::BorderBox) {
-        auto border_box_height = content_height + box_state.border_box_top() + box_state.border_box_bottom();
+        auto const& computed_values = box.computed_values();
+        auto border_box_left = computed_values.border_left().width + box_state.padding_left;
+        auto border_box_right = computed_values.border_right().width + box_state.padding_right;
+        auto border_box_top = computed_values.border_top().width + box_state.padding_top;
+        auto border_box_bottom = computed_values.border_bottom().width + box_state.padding_bottom;
+        auto border_box_height = content_height + border_box_top + border_box_bottom;
         auto border_box_width = border_box_height * aspect_ratio;
-        return max(border_box_width - box_state.border_box_left() - box_state.border_box_right(), 0);
+        return max(border_box_width - border_box_left - border_box_right, 0);
     }
 
     return content_height * aspect_ratio;
 }
 
+struct ReplacedMaxContentSizeConstraints {
+    Optional<CSSPixels> definite_size_in_ratio_determining_axis;
+    Optional<CSSPixels> minimum_width;
+    Optional<CSSPixels> minimum_height;
+};
+
 // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
-static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural_size(Box const& box, CSS::SizeWithAspectRatio const& natural_size, SizeDimension dimension, Optional<CSSPixels> definite_opposite_size = {})
+static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural_size(Box const& box, CSS::SizeWithAspectRatio const& natural_size, LayoutState::UsedValues const& box_state, SizeDimension dimension, ReplacedMaxContentSizeConstraints const& constraints = {})
 {
     // the intrinsic sizes of replaced elements without natural sizes are defined below:
     auto is_width = dimension == SizeDimension::Width;
@@ -109,18 +127,16 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
 
     // For the max-content size:
     // If it has a preferred aspect ratio:
-    if (natural_size.has_aspect_ratio()) {
-        auto aspect_ratio = natural_size.aspect_ratio.value();
-
+    if (box.has_preferred_aspect_ratio()) {
         // If the available space is definite in the inline axis, use the stretch fit into that size for the inline size
         // and calculate the block size using the aspect ratio.
         //
         // NB: This helper is only for the max-content size, which has no definite available inline size. Callers may
         //     still know a definite used size in the opposite axis when the box lacks a natural size in that axis.
-        if (definite_opposite_size.has_value()) {
-            auto opposite_size = definite_opposite_size.value();
-            return is_width ? opposite_size * aspect_ratio : opposite_size / aspect_ratio;
-        }
+        if (constraints.definite_size_in_ratio_determining_axis.has_value())
+            return is_width
+                ? content_width_from_aspect_ratio(box, box_state, constraints.definite_size_in_ratio_determining_axis.value())
+                : content_height_from_aspect_ratio(box, box_state, constraints.definite_size_in_ratio_determining_axis.value());
 
         // Otherwise if the box has a <length> as its computed value for min-width or min-height, use that size and
         // calculate the other dimension using the aspect ratio; if both dimensions have a <length> minimum, choose the
@@ -130,17 +146,27 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         //       believed to be a better behavior, and likely to be Web-compatible, but please send feedback to the CSSWG
         //       if there are any problems.
         Optional<CSSPixels> size_from_min_width;
-        auto const& min_width = box.computed_values().min_width();
-        if (min_width.is_length()) {
-            auto inline_size = min_width.to_px(0);
-            size_from_min_width = is_width ? inline_size : inline_size / aspect_ratio;
+        if (constraints.minimum_width.has_value()) {
+            auto inline_size = constraints.minimum_width.value();
+            size_from_min_width = is_width ? inline_size : content_height_from_aspect_ratio(box, box_state, inline_size);
+        } else {
+            auto const& min_width = box.computed_values().min_width();
+            if (min_width.is_length_percentage() && !min_width.contains_percentage()) {
+                auto inline_size = min_width.to_px(0);
+                size_from_min_width = is_width ? inline_size : content_height_from_aspect_ratio(box, box_state, inline_size);
+            }
         }
 
         Optional<CSSPixels> size_from_min_height;
-        auto const& min_height = box.computed_values().min_height();
-        if (min_height.is_length()) {
-            auto block_size = min_height.to_px(0);
-            size_from_min_height = is_width ? block_size * aspect_ratio : block_size;
+        if (constraints.minimum_height.has_value()) {
+            auto block_size = constraints.minimum_height.value();
+            size_from_min_height = is_width ? content_width_from_aspect_ratio(box, box_state, block_size) : block_size;
+        } else {
+            auto const& min_height = box.computed_values().min_height();
+            if (min_height.is_length_percentage() && !min_height.contains_percentage()) {
+                auto block_size = min_height.to_px(0);
+                size_from_min_height = is_width ? content_width_from_aspect_ratio(box, box_state, block_size) : block_size;
+            }
         }
 
         if (size_from_min_width.has_value() && size_from_min_height.has_value())
@@ -156,15 +182,17 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         // NOTE: This author-controllable behavior is made possible by the new auto value for the min size properties.
         //       This is believed to be a better behavior, but it is not yet clear if it is Web-compatible, so please
         //       send feedback to the CSSWG if there are any problems.
-        auto inline_size = box.document().viewport_rect().width();
-        return is_width ? inline_size : inline_size / aspect_ratio;
+        auto initial_containing_block_inline_size = box.document().viewport_rect().width();
+        return is_width ? initial_containing_block_inline_size : content_height_from_aspect_ratio(box, box_state, initial_containing_block_inline_size);
     }
 
     // If it has no preferred aspect ratio:
     // For both the min-content size and max-content size:
     // If the box has a <length> as its computed minimum size (min-width/min-height) in that dimension, use that size.
+    if (is_width && constraints.minimum_width.has_value())
+        return constraints.minimum_width.value();
     auto const& min_size = is_width ? box.computed_values().min_width() : box.computed_values().min_height();
-    if (min_size.is_length())
+    if (min_size.is_length_percentage() && !min_size.contains_percentage())
         return min_size.to_px(0);
 
     // Otherwise, use 300px for the width and/or 150px for the height as needed.
@@ -2858,14 +2886,6 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
     if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
         return transferred_width.value();
     if (!auto_size.has_width()) {
-        // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
-        // When a box has a preferred aspect ratio, its automatic sizes are calculated the same as for a
-        // replaced element with a natural aspect ratio and no natural size in that axis.
-        auto const& computed_width = box.computed_values().width();
-        auto const& computed_height = box.computed_values().height();
-        if (box.is_replaced_box() && auto_size.has_aspect_ratio() && !auto_size.has_height() && computed_width.is_length() && computed_height.is_intrinsic_sizing_constraint())
-            return calculate_inner_width(box, AvailableSize::make_definite(0), computed_width, containing_block_constraints);
-
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         // "If the box is non-replaced, then the entire value of any max size property or preferred size property
         // ('width'/'max-width'/'height'/'max-height') specified as an expression containing a percentage [...] that is
@@ -2890,8 +2910,94 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
             definite_height = box_state.content_height();
     }
 
-    if (auto max_content_width = max_content_size_for_replaced_element_without_natural_size(box, auto_size, SizeDimension::Width, definite_height); max_content_width.has_value())
+    auto max_content_available_width = AvailableSize::make_max_content();
+    auto intrinsic_available_space = AvailableSpace(max_content_available_width, AvailableSize::make_indefinite());
+
+    auto resolve_destination_width = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
+        if (!size.is_length_percentage())
+            return {};
+
+        switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_width, size_property)) {
+        case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
+            return {};
+        case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
+            auto zero_percentage_basis_constraints = containing_block_constraints;
+            zero_percentage_basis_constraints.percentage_basis_width = 0;
+            return calculate_inner_width(box, max_content_available_width, size, zero_percentage_basis_constraints);
+        }
+        case CyclicPercentageIntrinsicContribution::NotCyclic:
+            if (size.contains_percentage() && !containing_block_constraints.percentage_basis_width.has_value())
+                return {};
+            return calculate_inner_width(box, max_content_available_width, size, containing_block_constraints);
+        }
+        VERIFY_NOT_REACHED();
+    };
+
+    auto resolve_size_in_origin_axis = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
+        if (!size.is_length_percentage())
+            return {};
+        if (!size.contains_percentage() || containing_block_constraints.percentage_basis_height.has_value())
+            return calculate_inner_height(box, intrinsic_available_space, size, containing_block_constraints);
+
+        switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_width, size_property)) {
+        case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
+            return {};
+        case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
+            auto zero_percentage_basis_constraints = containing_block_constraints;
+            zero_percentage_basis_constraints.percentage_basis_height = 0;
+            return calculate_inner_height(box, intrinsic_available_space, size, zero_percentage_basis_constraints);
+        }
+        case CyclicPercentageIntrinsicContribution::NotCyclic:
+            return {};
+        }
+        VERIFY_NOT_REACHED();
+    };
+
+    auto definite_minimum_size_in_destination_axis = resolve_destination_width(box.computed_values().min_width(), CyclicPercentageSizeProperty::MinSize);
+    auto definite_minimum_size_in_origin_axis = resolve_size_in_origin_axis(box.computed_values().min_height(), CyclicPercentageSizeProperty::MinSize);
+    ReplacedMaxContentSizeConstraints constraints {
+        .definite_size_in_ratio_determining_axis = definite_height,
+        .minimum_width = definite_minimum_size_in_destination_axis,
+        .minimum_height = definite_minimum_size_in_origin_axis,
+    };
+
+    if (auto max_content_width = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Width, constraints); max_content_width.has_value()) {
+        if (!definite_height.has_value() && box.has_preferred_aspect_ratio()) {
+            if (auto definite_maximum_size_in_origin_axis = resolve_size_in_origin_axis(box.computed_values().max_height(), CyclicPercentageSizeProperty::PreferredOrMaxSize); definite_maximum_size_in_origin_axis.has_value()) {
+                // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers
+                // First, any definite minimum size is converted and transferred from the origin to destination axis.
+                // This transferred minimum is capped by any definite preferred or maximum size in the destination axis.
+                Optional<CSSPixels> transferred_minimum;
+                if (definite_minimum_size_in_origin_axis.has_value()) {
+                    transferred_minimum = content_width_from_aspect_ratio(box, m_state.get(box), definite_minimum_size_in_origin_axis.value());
+
+                    auto cap_transferred_minimum = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) {
+                        if (auto resolved_size = resolve_destination_width(size, size_property); resolved_size.has_value())
+                            transferred_minimum = min(transferred_minimum.value(), resolved_size.value());
+                    };
+                    cap_transferred_minimum(box.computed_values().width(), CyclicPercentageSizeProperty::PreferredOrMaxSize);
+                    cap_transferred_minimum(box.computed_values().max_width(), CyclicPercentageSizeProperty::PreferredOrMaxSize);
+                }
+
+                // Then, any definite maximum size is converted and transferred from the origin to destination.
+                // This transferred maximum is floored by any definite preferred or minimum size in the destination axis
+                // as well as by the transferred minimum, if any.
+                auto transferred_maximum = content_width_from_aspect_ratio(box, m_state.get(box), definite_maximum_size_in_origin_axis.value());
+
+                auto floor_transferred_maximum = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) {
+                    if (auto resolved_size = resolve_destination_width(size, size_property); resolved_size.has_value())
+                        transferred_maximum = max(transferred_maximum, resolved_size.value());
+                };
+                floor_transferred_maximum(box.computed_values().width(), CyclicPercentageSizeProperty::PreferredOrMaxSize);
+                floor_transferred_maximum(box.computed_values().min_width(), CyclicPercentageSizeProperty::MinSize);
+                if (transferred_minimum.has_value())
+                    transferred_maximum = max(transferred_maximum, transferred_minimum.value());
+
+                return min(max_content_width.value(), transferred_maximum);
+            }
+        }
         return max_content_width.value();
+    }
 
     // Boxes with no children have zero intrinsic width.
     if (!box.has_children())
@@ -2970,7 +3076,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_height())
         return auto_size.height.value();
-    if (auto max_content_height = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), SizeDimension::Height); max_content_height.has_value())
+    if (auto max_content_height = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), m_state.get(box), SizeDimension::Height); max_content_height.has_value())
         return max_content_height.value();
 
     // Boxes with no children have zero intrinsic height.
@@ -3521,14 +3627,30 @@ FormattingContext::CyclicPercentageIntrinsicContribution FormattingContext::cycl
         return CyclicPercentageIntrinsicContribution::NotCyclic;
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
+    // For the min size properties, as well as for margins and paddings (and gutters), a cyclic percentage is resolved
+    // against zero for determining intrinsic size contributions.
+    if (size_property == CyclicPercentageSizeProperty::MinSize && available_size.is_intrinsic_sizing_constraint())
+        return CyclicPercentageIntrinsicContribution::ResolveAsZero;
+
+    // If the box is non-replaced, then the entire value of any max size property or preferred size property
+    // ('width'/'max-width'/'height'/'max-height') specified as an expression containing a percentage (such as '10%' or
+    // 'calc(10px + 0%)') that is cyclic is treated for the purpose of calculating the box's intrinsic size contributions
+    // only as that property's initial value.
     if (available_size.is_min_content()) {
-        if (size_property == CyclicPercentageSizeProperty::PreferredOrMaxSize && box.is_replaced_box())
+        // If the box is replaced, a cyclic percentage in the value of any max size property or preferred size property
+        // ('width'/'max-width'/'height'/'max-height'), is resolved against zero when calculating the min-content
+        // contribution in the corresponding axis.
+        if (box.is_replaced_box())
             return CyclicPercentageIntrinsicContribution::ResolveAsZero;
         return CyclicPercentageIntrinsicContribution::TreatAsInitialValue;
     }
 
-    if (available_size.is_max_content())
+    if (available_size.is_max_content()) {
+        // Likewise, if the box is replaced, then the entire value of any max size property or preferred size property
+        // specified as an expression containing a percentage that is cyclic is treated for the purpose of calculating
+        // the box's max-content contributions only as that property's initial value.
         return CyclicPercentageIntrinsicContribution::TreatAsInitialValue;
+    }
 
     return CyclicPercentageIntrinsicContribution::NotCyclic;
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -189,8 +189,6 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
     // If it has no preferred aspect ratio:
     // For both the min-content size and max-content size:
     // If the box has a <length> as its computed minimum size (min-width/min-height) in that dimension, use that size.
-    if (is_width && constraints.minimum_width.has_value())
-        return constraints.minimum_width.value();
     auto const& min_size = is_width ? box.computed_values().min_width() : box.computed_values().min_height();
     if (min_size.is_length_percentage() && !min_size.contains_percentage())
         return min_size.to_px(0);
@@ -2814,15 +2812,26 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
         // FIXME: If the box also has a preferred aspect ratio, then this min-content contribution is
         //        floored by any <length-percentage> minimum size from the opposite axis—resolving any
         //        such percentage against zero—transferred through the preferred aspect ratio.
-        if (auto const& width = box.computed_values().width(); width.is_percentage())
-            return width.to_px(0);
-        if (auto const& max_width = box.computed_values().max_width(); max_width.is_percentage())
-            return max_width.to_px(0);
+        // Note: The min-content contribution is, as always, also floored by the minimum size in its own axis.
+        if (box.computed_values().width().contains_percentage() || box.computed_values().max_width().contains_percentage()) {
+            auto const& min_width = box.computed_values().min_width();
+            if (!min_width.is_length_percentage())
+                return 0;
+
+            auto zero_percentage_basis_constraints = containing_block_constraints;
+            zero_percentage_basis_constraints.percentage_basis_width = 0;
+            return calculate_inner_width(box, AvailableSize::make_min_content(), min_width, zero_percentage_basis_constraints);
+        }
     }
     if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
         return transferred_width.value();
-    if (auto auto_size = box.auto_content_box_size(); auto_size.has_width())
+    auto auto_size = box.auto_content_box_size();
+    if (auto_size.has_width())
         return auto_size.width.value();
+    if (box.is_replaced_box() && !box.has_preferred_aspect_ratio()) {
+        if (auto fallback_width = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Width); fallback_width.has_value())
+            return fallback_width.value();
+    }
 
     // Boxes with no children have zero intrinsic width.
     if (!box.has_children())

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -196,9 +196,8 @@ protected:
         ResolveAsZero,
         TreatAsInitialValue,
     };
-    // CSS Sizing resolves cyclic percentages differently for minimum sizes than for preferred/max sizes.
-    // In particular, replaced boxes resolve cyclic preferred/max sizes against zero for min-content
-    // contributions, while cyclic min sizes are treated as their initial value.
+    // NB: Selects the applicable cyclic-percentage intrinsic size contribution rule for minimum versus preferred and
+    //     maximum size properties.
     enum class CyclicPercentageSizeProperty {
         PreferredOrMaxSize,
         MinSize,

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2244,6 +2244,12 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
         CSSPixels containing_block_size = containing_block_size_for_item(item, dimension);
         Alignment alignment = alignment_for_item(item.box, dimension);
 
+        // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+        // A grid item is sized within the containing block defined by its grid area.
+        auto grid_area_constraints = grid_area_constraints_for_item(item);
+        if (dimension == GridDimension::Row)
+            grid_area_constraints.percentage_basis_height = containing_block_size;
+
         auto const& preferred_size = item.preferred_size(dimension);
 
         struct ItemAlignment {
@@ -2315,28 +2321,38 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)))
         };
 
-        auto calculate_inner_size = [this, &item, dimension, available_space](CSS::Size const& size) {
+        auto calculate_inner_size = [this, &item, dimension, available_space, grid_area_constraints](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return calculate_inner_width(item.box, available_space.width, size, grid_area_constraints_for_item(item));
-            return calculate_inner_height(item.box, available_space, size, grid_area_constraints_for_item(item));
+                return calculate_inner_width(item.box, available_space.width, size, grid_area_constraints);
+            return calculate_inner_height(item.box, available_space, size, grid_area_constraints);
         };
 
-        auto tentative_size_for_replaced_element = [this, &item, dimension, available_space](CSS::Size const& size) {
+        auto tentative_size_for_replaced_element = [this, &item, dimension, available_space, grid_area_constraints](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return tentative_width_for_replaced_element(item.box, size, available_space, grid_area_constraints_for_item(item));
-            return tentative_height_for_replaced_element(item.box, size, available_space, grid_area_constraints_for_item(item));
+                return tentative_width_for_replaced_element(item.box, size, available_space, grid_area_constraints);
+            return tentative_height_for_replaced_element(item.box, size, available_space, grid_area_constraints);
         };
 
         ItemAlignment used_alignment;
-        auto hint = item.box.auto_content_box_size();
-        bool has_replaced_size_hint_in_this_axis = false;
+        auto natural_size = item.box.auto_content_box_size();
+        bool has_natural_size_in_relevant_axis = false;
         if (dimension == GridDimension::Column) {
-            has_replaced_size_hint_in_this_axis = hint.has_width() || (hint.has_height() && item.box.has_preferred_aspect_ratio());
+            has_natural_size_in_relevant_axis = natural_size.has_width() || (natural_size.has_height() && item.box.has_preferred_aspect_ratio());
         } else {
-            has_replaced_size_hint_in_this_axis = hint.has_height() || (hint.has_width() && item.box.has_preferred_aspect_ratio());
+            has_natural_size_in_relevant_axis = natural_size.has_height() || (natural_size.has_width() && item.box.has_preferred_aspect_ratio());
         }
 
-        if (item.box.is_replaced_box() && has_replaced_size_hint_in_this_axis) {
+        auto use_replaced_sizing = item.box.is_replaced_box() && has_natural_size_in_relevant_axis;
+
+        // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+        // If the grid item has no preferred aspect ratio, and no natural size in the relevant axis (if it is a replaced
+        // element), the grid item is sized as for 'align-self: stretch'.
+        // INTEROP: Blink, WebKit, and Gecko instead use replaced sizing for normal-aligned replaced items. Match that
+        //          behavior for leaf replaced boxes, while retaining our existing behavior for controls with children.
+        if (item.box.is_replaced_box() && alignment == Alignment::Normal && !item.box.is_replaced_box_with_children())
+            use_replaced_sizing = true;
+
+        if (use_replaced_sizing) {
             auto tentative_size = tentative_size_for_replaced_element(preferred_size);
             used_alignment = try_compute_size(tentative_size, item.preferred_size(dimension));
         } else {
@@ -2372,14 +2388,14 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             } else if (preferred_size.is_auto() || preferred_size.is_fit_content()) {
                 CSSPixels fit_content_size;
                 if (dimension == GridDimension::Column) {
-                    fit_content_size = calculate_fit_content_width(item.box, available_space, grid_area_constraints_for_item(item));
+                    fit_content_size = calculate_fit_content_width(item.box, available_space, grid_area_constraints);
                 } else if (preferred_size.is_auto() && item.box.has_preferred_aspect_ratio() && *item.box.preferred_aspect_ratio() != 0 && item.used_values.has_definite_width()) {
                     // NB: When the item has a preferred aspect ratio and a definite width, resolve the
                     //     height through the aspect ratio instead of using fit-content sizing, which would
                     //     incorrectly use the available width (grid area width) instead of the item's width.
-                    fit_content_size = item.used_values.content_width() / *item.box.preferred_aspect_ratio();
+                    fit_content_size = calculate_inner_height(item.box, available_space, CSS::Size::make_auto(), grid_area_constraints);
                 } else {
-                    fit_content_size = calculate_fit_content_height(item.box, available_space, grid_area_constraints_for_item(item));
+                    fit_content_size = calculate_fit_content_height(item.box, available_space, grid_area_constraints);
                 }
                 used_alignment = try_compute_size(fit_content_size, preferred_size);
             } else {
@@ -2388,7 +2404,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             }
         }
 
-        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)) : should_treat_max_height_as_none(item.box, available_space.height, grid_area_constraints_for_item(item));
+        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints) : should_treat_max_height_as_none(item.box, available_space.height, grid_area_constraints);
         if (!should_treat_maximum_size_as_none) {
             auto const& maximum_size = item.maximum_size(dimension);
             auto max_size_px = calculate_inner_size(maximum_size);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -96,14 +96,17 @@ static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithSt
 
 static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::Display display)
 {
-    // https://drafts.csswg.org/css-tables-3/#table-structure
-    // Replaced elements with a table-root display behave as block or inline depending on their
-    // outer display type. Replaced elements with a table-internal display behave as inline.
+    // https://drafts.csswg.org/css-display-3/#outer-role
+    // Note: Outer display types do affect replaced elements.
     if (display.is_table_inside()) {
         if (display.is_block_outside())
             return CSS::Display::from_short(CSS::Display::Short::Block);
         return CSS::Display::from_short(CSS::Display::Short::Inline);
     }
+
+    // https://drafts.csswg.org/css-display-3/#layout-specific-display
+    // When the 'display' property of a replaced element computes to one of the layout-internal values, it is handled
+    // as having a used value of 'display: inline'.
     if (display.is_internal_table() || display.is_table_caption())
         return CSS::Display::from_short(CSS::Display::Short::Inline);
     return {};
@@ -348,6 +351,17 @@ static NonnullRefPtr<ImageBox> create_content_image_box(DOM::Document& document,
     return image_box;
 }
 
+static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::ComputedContentData const& content)
+{
+    if (content.type != CSS::ComputedContentData::Type::List
+        || content.items.size() != 1
+        || !content.items.first().has<NonnullRefPtr<CSS::AbstractImageStyleValue const>>()) {
+        return nullptr;
+    }
+
+    return content.items.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue const>>().ptr();
+}
+
 struct FirstLetterTarget {
     TextNode* text_node { nullptr };
     size_t letter_start { 0 };
@@ -572,23 +586,27 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
     if (!pseudo_element_values)
         return {};
 
+    auto pseudo_element_display = pseudo_element_values->display();
+
+    // https://drafts.csswg.org/css-display-3/#box-generation
+    // The element and its descendants generate no boxes or text sequences.
+    if (pseudo_element_display.is_none())
+        return {};
+
     auto initial_quote_nesting_level = m_quote_nesting_level;
     DOM::AbstractElement element_reference { element, pseudo_element };
     auto [pseudo_element_content, final_quote_nesting_level] = pseudo_element_values->resolved_content(element_reference, initial_quote_nesting_level);
     m_quote_nesting_level = final_quote_nesting_level;
-    auto pseudo_element_display = pseudo_element_values->display();
 
     // ::before and ::after only exist if they have content. `content: normal` computes to `none` for them.
-    // We also don't create them if they are `display: none`.
     if (first_is_one_of(pseudo_element, CSS::PseudoElement::Before, CSS::PseudoElement::After)
-        && (pseudo_element_display.is_none()
-            || pseudo_element_content.type == CSS::ContentData::Type::Normal
+        && (pseudo_element_content.type == CSS::ContentData::Type::Normal
             || pseudo_element_content.type == CSS::ContentData::Type::None))
         return {};
 
-    // For ::marker with content or display 'none' -- do nothing.
+    // For ::marker with content 'none' -- do nothing.
     if (pseudo_element == CSS::PseudoElement::Marker
-        && (pseudo_element_display.is_none() || pseudo_element_content.type == CSS::ContentData::Type::None))
+        && pseudo_element_content.type == CSS::ContentData::Type::None)
         return {};
 
     // For ::marker with content 'normal', create the marker pseudo-element from a ListItemMarkerBox
@@ -620,7 +638,30 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
         }
 
     RefPtr<NodeWithStyle> pseudo_element_node;
-    if (pseudo_element_display.is_contents()) {
+
+    // https://drafts.csswg.org/css-content-3/#content-property
+    // Note: If the value of <content-list> is a single <image>, it must instead be interpreted as a
+    // <content-replacement>.
+    // Makes the element or pseudo-element a replaced element, filled with the specified <image>.
+    auto const* replacement_image = content_replacement_image(pseudo_element_values->computed_content());
+    auto is_content_replacement = replacement_image != nullptr;
+
+    // INTEROP: Blink, WebKit, and Gecko keep generated images as children of pseudo-element boxes. Preserve that
+    //          behavior for list items because our marker layout currently requires a ListItemBox.
+    if (pseudo_element_display.is_list_item())
+        is_content_replacement = false;
+
+    // https://drafts.csswg.org/css-display-3/#box-generation
+    // This value computes to 'display: none' on replaced elements.
+    // INTEROP: Blink, WebKit, and Gecko preserve image content on 'display: contents' pseudo-elements instead.
+    if (pseudo_element_display.is_contents())
+        is_content_replacement = false;
+
+    if (is_content_replacement) {
+        pseudo_element_node = create_content_image_box(document, nullptr, NonnullRefPtr { *pseudo_element_values }, const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
+        if (auto adjusted_display = adjusted_table_display_for_replaced_element(pseudo_element_display); adjusted_display.has_value())
+            pseudo_element_node->modify_computed_values([&](auto& values) { values.set_display(*adjusted_display); });
+    } else if (pseudo_element_display.is_contents()) {
         pseudo_element_node = make_ref_counted<InlineNode>(document, nullptr, NonnullRefPtr { *pseudo_element_values });
         pseudo_element_node->modify_computed_values([](auto& values) {
             values.set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
@@ -671,21 +712,29 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
 
         // FIXME: Handle images, and multiple values
         if (new_content.type == CSS::ContentData::Type::List) {
-            push_parent(*pseudo_element_node);
-            for (auto& item : new_content.data) {
-                RefPtr<Layout::Node> layout_node;
-                if (auto const* string = item.get_pointer<Utf16String>()) {
-                    layout_node = make_ref_counted<GeneratedTextNode>(document, *string);
-                } else {
-                    auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
-                    layout_node = create_content_image_box(document, nullptr, NonnullRefPtr { pseudo_element_node->computed_values() }, image);
-                    static_cast<NodeWithStyle&>(*layout_node).attach_style_resources();
+            if (!is_content_replacement) {
+                push_parent(*pseudo_element_node);
+                for (auto& item : new_content.data) {
+                    RefPtr<Layout::Node> layout_node;
+                    if (auto const* string = item.get_pointer<Utf16String>()) {
+                        layout_node = make_ref_counted<GeneratedTextNode>(document, *string);
+                    } else {
+                        auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
+                        auto image_box = create_content_image_box(document, nullptr, NonnullRefPtr { pseudo_element_node->computed_values() }, image);
+                        // https://drafts.csswg.org/css-content-3/#content-property
+                        // For <image>, this is an inline anonymous replaced element.
+                        image_box->modify_computed_values([](auto& values) {
+                            values.set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+                        });
+                        image_box->attach_style_resources();
+                        layout_node = move(image_box);
+                    }
+                    layout_node->set_generated_for(pseudo_element, element);
+                    auto display = layout_node->is_text_node() ? CSS::Display::from_short(CSS::Display::Short::Inline) : as<NodeWithStyle>(*layout_node).display();
+                    insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
                 }
-                layout_node->set_generated_for(pseudo_element, element);
-                auto display = layout_node->is_text_node() ? CSS::Display::from_short(CSS::Display::Short::Inline) : as<NodeWithStyle>(*layout_node).display();
-                insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
+                pop_parent();
             }
-            pop_parent();
         } else {
             TODO();
         }
@@ -696,15 +745,11 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
 
 RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Element& element, NonnullRefPtr<CSS::ComputedValues const> computed_values) const
 {
-    auto const& content = computed_values->computed_content();
-    if (content.type != CSS::ComputedContentData::Type::List
-        || content.items.size() != 1
-        || !content.items.first().has<NonnullRefPtr<CSS::AbstractImageStyleValue const>>()) {
+    auto const* replacement_image = content_replacement_image(computed_values->computed_content());
+    if (!replacement_image)
         return {};
-    }
 
-    auto& image = const_cast<CSS::AbstractImageStyleValue&>(*content.items.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue const>>());
-    return create_content_image_box(element.document(), element, move(computed_values), image);
+    return create_content_image_box(element.document(), element, move(computed_values), const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
 }
 
 static bool is_ignorable_whitespace(Layout::Node const& node)

--- a/Tests/LibWeb/Layout/expected/content-image-set.txt
+++ b/Tests/LibWeb/Layout/expected/content-image-set.txt
@@ -2,9 +2,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 216 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 200 0+0+8] children: not-inline
       BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 200 0+0+0] children: inline
-        InlineNode <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0]
-          frag 0 from ImageBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
-          ImageBox <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0] children: not-inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
+        ImageBox <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 200 0+0+0] children: not-inline
       BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
@@ -12,8 +11,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x200]
-        InlinePaintable (InlineNode(anonymous)) [8,8 200x200]
-          ImagePaintable (ImageBox(anonymous)) [8,8 200x200]
+        ImagePaintable (ImageBox(anonymous)) [8,8 200x200]
       PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/stretched-item-percentage-min-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretched-item-percentage-min-cross-size.txt
@@ -1,0 +1,52 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] children: not-inline
+      Box <div.row> at [0,0] flex-container(row) [0+0+0 800 0+0+0] [0+0+0 32 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.column> at [20,4] flex-container(column) flex-item [0+0+20 100 20+0+0] [0+0+4 24 4+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.indicator> at [0,4] positioned flex-item [0+0+0 100 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.label> at [20,8] flex-item [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,32] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.row> at [0,32] flex-container(row) [0+0+0 800 0+0+0] [0+0+0 32 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.column> at [20,36] flex-container(column) flex-item [0+0+20 100 20+0+0] [0+0+4 24 4+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.indicator.percentage-only> at [0,36] positioned flex-item [0+0+0 100 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.label> at [20,40] flex-item [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,64] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x64]
+      Paintable (Box<DIV>.row) [0,0 800x32]
+        Paintable (Box<DIV>.column) [0,0 140x32]
+          PaintableWithLines (BlockContainer<DIV>.indicator) [0,4 100x4]
+          PaintableWithLines (BlockContainer<DIV>.label) [20,8 100x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,32 800x0]
+      Paintable (Box<DIV>.row) [0,32 800x32]
+        Paintable (Box<DIV>.column) [0,32 140x32]
+          PaintableWithLines (BlockContainer<DIV>.indicator.percentage-only) [0,36 100x4]
+          PaintableWithLines (BlockContainer<DIV>.label) [20,40 100x20]
+      PaintableWithLines (BlockContainer(anonymous)) [0,64 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x64] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/stretched-item-percentage-min-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretched-item-percentage-min-cross-size.txt
@@ -7,7 +7,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         Box <div.column> at [20,4] flex-container(column) flex-item [0+0+20 100 20+0+0] [0+0+4 24 4+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          BlockContainer <div.indicator> at [0,4] positioned flex-item [0+0+0 100 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.indicator> at [0,4] positioned flex-item [0+0+0 140 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
           BlockContainer <div.label> at [20,8] flex-item [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
@@ -23,7 +23,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         Box <div.column> at [20,36] flex-container(column) flex-item [0+0+20 100 20+0+0] [0+0+4 24 4+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
-          BlockContainer <div.indicator.percentage-only> at [0,36] positioned flex-item [0+0+0 100 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
+          BlockContainer <div.indicator.percentage-only> at [0,36] positioned flex-item [0+0+0 150 0+0+0] [0+0+0 4 0+0+0] [BFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
           BlockContainer <div.label> at [20,40] flex-item [0+0+0 100 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
@@ -39,12 +39,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [0,0 800x64]
       Paintable (Box<DIV>.row) [0,0 800x32]
         Paintable (Box<DIV>.column) [0,0 140x32]
-          PaintableWithLines (BlockContainer<DIV>.indicator) [0,4 100x4]
+          PaintableWithLines (BlockContainer<DIV>.indicator) [0,4 140x4]
           PaintableWithLines (BlockContainer<DIV>.label) [20,8 100x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,32 800x0]
       Paintable (Box<DIV>.row) [0,32 800x32]
         Paintable (Box<DIV>.column) [0,32 140x32]
-          PaintableWithLines (BlockContainer<DIV>.indicator.percentage-only) [0,36 100x4]
+          PaintableWithLines (BlockContainer<DIV>.indicator.percentage-only) [0,36 150x4]
           PaintableWithLines (BlockContainer<DIV>.label) [20,40 100x20]
       PaintableWithLines (BlockContainer(anonymous)) [0,64 800x0]
 

--- a/Tests/LibWeb/Layout/expected/grid/ratio-only-replaced-item-conflicting-height-constraints.txt
+++ b/Tests/LibWeb/Layout/expected/grid/ratio-only-replaced-item-conflicting-height-constraints.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 32 0+0+8] children: not-inline
+      Box <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img> at [8,8] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,40] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x32]
+      Paintable (Box<DIV>) [8,8 784x32]
+        ImagePaintable (ImageBox<IMG>) [8,8 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,40 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x48] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/ratio-only-replaced-item-size-transfer-matrix.txt
+++ b/Tests/LibWeb/Layout/expected/grid/ratio-only-replaced-item-size-transfer-matrix.txt
@@ -1,0 +1,207 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 657 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 641 0+0+8] children: not-inline
+      Box <div> at [8,8] [0+0+0 64 0+0+720] [0+0+0 16 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-preferred> at [8,8] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,24] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,24] [0+0+0 64 0+0+720] [0+0+0 21 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-calculated-preferred> at [8,24] [0+0+0 42 0+0+0] [0+0+0 21 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 42 0+0+0] [0+0+0 21 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 42 0+0+0] [0+0+0 21 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 42 0+0+0] [0+0+0 21 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,45] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,45] [0+0+0 80 0+0+704] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.fixed-preferred> at [8,45] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [8,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,77] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,77] [0+0+0 80 0+0+704] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.calculated-preferred> at [8,77] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [8,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,109] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,109] [0+0+0 200 0+0+584] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.transferred-minimum> at [8,109] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,141] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,141] [0+0+0 20 0+0+764] [0+0+0 10 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-calculated-transferred-minimum> at [8,141] [0+0+0 20 0+0+0] [0+0+0 15 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 20 0+0+0] [0+0+0 15 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 20 0+0+0] [0+0+0 15 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,2.5] [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,151] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,151] [0+0+0 150 0+0+634] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.capped-transferred-minimum> at [8,151] [0+0+0 150 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 150 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 150 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,12.5] [0+0+0 150 0+0+0] [0+0+0 75 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,183] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,183] [0+0+0 150 0+0+634] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.calculated-capped-transferred-minimum> at [8,183] [0+0+0 150 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 150 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 150 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,12.5] [0+0+0 150 0+0+0] [0+0+0 75 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,215] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,215] [0+0+0 200 0+0+584] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-maximum> at [8,215] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,25] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,247] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,247] [0+0+0 10 0+0+774] [0+0+0 2 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-minimum> at [8,247] [0+0+0 15 0+0+0] [0+0+0 2 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 15 0+0+0] [0+0+0 2 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 15 0+0+0] [0+0+0 2 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [5.5,0] [0+0+0 4 0+0+0] [0+0+0 2 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,249] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,249] [0+0+0 0 0+0+784] [0+0+0 0 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-zero-minimum> at [8,249] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,249] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,249] [0+0+0 0 0+0+784] [0+0+0 0 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-zero-calculated-minimum> at [8,249] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,249] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,249] [0+0+0 80 0+0+704] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.calculated-minimum> at [8,249] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 80 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [8,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,281] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,281] [0+0+0 200 0+0+584] [0+0+0 100 0+0+0] [GFC] children: not-inline
+        ImageBox <img.fixed-minimum-only> at [8,281] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,381] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,381] [0+0+0 200 0+0+584] [0+0+0 100 0+0+0] [GFC] children: not-inline
+        ImageBox <img.calculated-minimum-only> at [8,381] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,481] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,481] [0+0+0 84 0+0+700] [0+0+0 52 0+0+0] [GFC] children: not-inline
+        ImageBox <img.border-box-maximum> at [18,491] [0+10+0 64 0+10+0] [0+10+0 32 0+10+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,533] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.definite-height> at [8,533] [0+0+0 100 0+0+684] [0+0+0 100 0+0+0] [GFC] children: not-inline
+        ImageBox <img.percentage-maximum> at [8,533] [0+0+0 100 0+0+0] [0+0+0 50 0+0+50] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 100 0+0+0] [0+0+0 50 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,633] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.available-width> at [8,633] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-preferred> at [8,633] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,649] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.available-width> at [8,649] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-zero-minimum> at [8,649] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,649] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x657]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x657]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x641]
+      Paintable (Box<DIV>) [8,8 64x16]
+        ImagePaintable (ImageBox<IMG>.cyclic-preferred) [8,8 32x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,24 784x0]
+      Paintable (Box<DIV>) [8,24 64x21]
+        ImagePaintable (ImageBox<IMG>.cyclic-calculated-preferred) [8,24 42x21]
+      PaintableWithLines (BlockContainer(anonymous)) [8,45 784x0]
+      Paintable (Box<DIV>) [8,45 80x32]
+        ImagePaintable (ImageBox<IMG>.fixed-preferred) [8,45 80x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,77 784x0]
+      Paintable (Box<DIV>) [8,77 80x32]
+        ImagePaintable (ImageBox<IMG>.calculated-preferred) [8,77 80x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,109 784x0]
+      Paintable (Box<DIV>) [8,109 200x32]
+        ImagePaintable (ImageBox<IMG>.transferred-minimum) [8,109 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,141 784x0]
+      Paintable (Box<DIV>) [8,141 20x10]
+        ImagePaintable (ImageBox<IMG>.cyclic-calculated-transferred-minimum) [8,141 20x15]
+      PaintableWithLines (BlockContainer(anonymous)) [8,151 784x0]
+      Paintable (Box<DIV>) [8,151 150x32]
+        ImagePaintable (ImageBox<IMG>.capped-transferred-minimum) [8,151 150x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,183 784x0]
+      Paintable (Box<DIV>) [8,183 150x32]
+        ImagePaintable (ImageBox<IMG>.calculated-capped-transferred-minimum) [8,183 150x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,215 784x0]
+      Paintable (Box<DIV>) [8,215 200x32]
+        ImagePaintable (ImageBox<IMG>.cyclic-maximum) [8,215 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,247 784x0]
+      Paintable (Box<DIV>) [8,247 10x2]
+        ImagePaintable (ImageBox<IMG>.cyclic-minimum) [8,247 15x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,249 784x0]
+      Paintable (Box<DIV>) [8,249 0x0]
+        ImagePaintable (ImageBox<IMG>.cyclic-zero-minimum) [8,249 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,249 784x0]
+      Paintable (Box<DIV>) [8,249 0x0]
+        ImagePaintable (ImageBox<IMG>.cyclic-zero-calculated-minimum) [8,249 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,249 784x0]
+      Paintable (Box<DIV>) [8,249 80x32]
+        ImagePaintable (ImageBox<IMG>.calculated-minimum) [8,249 80x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,281 784x0]
+      Paintable (Box<DIV>) [8,281 200x100]
+        ImagePaintable (ImageBox<IMG>.fixed-minimum-only) [8,281 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,381 784x0]
+      Paintable (Box<DIV>) [8,381 200x100]
+        ImagePaintable (ImageBox<IMG>.calculated-minimum-only) [8,381 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,481 784x0]
+      Paintable (Box<DIV>) [8,481 84x52]
+        ImagePaintable (ImageBox<IMG>.border-box-maximum) [8,481 84x52]
+      PaintableWithLines (BlockContainer(anonymous)) [8,533 784x0]
+      Paintable (Box<DIV>.definite-height) [8,533 100x100]
+        ImagePaintable (ImageBox<IMG>.percentage-maximum) [8,533 100x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,633 784x0]
+      Paintable (Box<DIV>.available-width) [8,633 784x16]
+        ImagePaintable (ImageBox<IMG>.cyclic-preferred) [8,633 32x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,649 784x0]
+      Paintable (Box<DIV>.available-width) [8,649 784x0]
+        ImagePaintable (ImageBox<IMG>.cyclic-zero-minimum) [8,649 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,649 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x657] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/replaced-item-preferred-ratio-source-matrix.txt
+++ b/Tests/LibWeb/Layout/expected/grid/replaced-item-preferred-ratio-source-matrix.txt
@@ -1,0 +1,230 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 1884 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 1868 0+0+8] children: not-inline
+      Box <div> at [8,8] [0+0+0 64 0+0+720] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img> at [8,8] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,40] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,40] [0+0+0 64 0+0+720] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio> at [8,40] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,72] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,72] [0+0+0 64 0+0+720] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.calculated-maximum> at [8,72] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,104] [0+0+0 800 0+0+-16] [0+0+0 400 0+0+0] [GFC] children: not-inline
+        ImageBox <img.unconstrained> at [8,104] [0+0+0 800 0+0+0] [0+0+0 400 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,504] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,504] [0+0+0 800 0+0+-16] [0+0+0 400 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.unconstrained> at [8,504] [0+0+0 800 0+0+0] [0+0+0 400 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,904] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,904] [0+0+0 200 0+0+584] [0+0+0 100 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.minimum-only> at [8,904] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1004] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1004] [0+0+0 220 0+0+564] [0+0+0 120 0+0+0] [GFC] children: not-inline
+        ImageBox <img.border-box-minimum-only> at [18,1014] [0+10+0 200 0+10+0] [0+10+0 100 0+10+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1124] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1124] [0+0+0 240 0+0+544] [0+0+0 120 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.border-box-minimum-only> at [18,1134] [0+10+0 220 0+10+0] [0+10+0 100 0+10+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1244] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.definite-height> at [8,1244] [0+0+0 200 0+0+584] [0+0+0 200 0+0+0] [GFC] children: not-inline
+        ImageBox <img.percentage-minimum-only> at [8,1244] [0+0+0 200 0+0+0] [0+0+0 100 0+0+100] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1444] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.definite-height> at [8,1444] [0+0+0 200 0+0+584] [0+0+0 200 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.percentage-minimum-only> at [8,1444] [0+0+0 200 0+0+0] [0+0+0 100 0+0+100] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1644] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1644] [0+0+0 200 0+0+584] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.conflicting-heights> at [8,1644] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1676] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1676] [0+0+0 0 0+0+784] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-zero-minimum> at [8,1676] [0+0+0 0 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1708] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1708] [0+0+0 10 0+0+774] [0+0+0 2 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-calculated-minimum> at [8,1708] [0+0+0 15 0+0+0] [0+0+0 2 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1710] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1710] [0+0+0 0 0+0+784] [0+0+0 0 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.cyclic-zero-minimum> at [8,1710] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1710] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1710] [0+0+0 0 0+0+784] [0+0+0 0 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.cyclic-zero-minimum.unconstrained> at [8,1710] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1710] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1710] [0+0+0 10 0+0+774] [0+0+0 2 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.cyclic-calculated-minimum> at [8,1710] [0+0+0 15 0+0+0] [0+0+0 2 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1712] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1712] [0+0+0 64 0+0+720] [0+0+0 16 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.cyclic-preferred> at [8,1712] [0+0+0 32 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1728] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1728] [0+0+0 200 0+0+584] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.cyclic-maximum> at [8,1728] [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1760] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1760] [0+0+0 20 0+0+764] [0+0+0 20 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-ratio.border-box-cyclic-minimum> at [18,1770] [0+10+0 0 0+10+0] [0+10+0 0 0+10+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1780] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1780] [0+0+0 32 0+0+752] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-override> at [8,1780] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1812] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1812] [0+0+0 64 0+0+720] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-auto-with-ratio> at [8,1812] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1844] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,1844] [0+0+0 32 0+0+752] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.css-auto-with-ratio> at [8,1844] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+      BlockContainer <(anonymous)> at [8,1876] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x1884]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1884]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x1868]
+      Paintable (Box<DIV>) [8,8 64x32]
+        ImagePaintable (ImageBox<IMG>) [8,8 64x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,40 784x0]
+      Paintable (Box<DIV>) [8,40 64x32]
+        ImagePaintable (ImageBox<IMG>.css-ratio) [8,40 64x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,72 784x0]
+      Paintable (Box<DIV>) [8,72 64x32]
+        ImagePaintable (ImageBox<IMG>.css-ratio.calculated-maximum) [8,72 64x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,104 784x0]
+      Paintable (Box<DIV>) [8,104 800x400]
+        ImagePaintable (ImageBox<IMG>.unconstrained) [8,104 800x400]
+      PaintableWithLines (BlockContainer(anonymous)) [8,504 784x0]
+      Paintable (Box<DIV>) [8,504 800x400]
+        ImagePaintable (ImageBox<IMG>.css-ratio.unconstrained) [8,504 800x400]
+      PaintableWithLines (BlockContainer(anonymous)) [8,904 784x0]
+      Paintable (Box<DIV>) [8,904 200x100]
+        ImagePaintable (ImageBox<IMG>.css-ratio.minimum-only) [8,904 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1004 784x0]
+      Paintable (Box<DIV>) [8,1004 220x120]
+        ImagePaintable (ImageBox<IMG>.border-box-minimum-only) [8,1004 220x120]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1124 784x0]
+      Paintable (Box<DIV>) [8,1124 240x120]
+        ImagePaintable (ImageBox<IMG>.css-ratio.border-box-minimum-only) [8,1124 240x120]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1244 784x0]
+      Paintable (Box<DIV>.definite-height) [8,1244 200x200]
+        ImagePaintable (ImageBox<IMG>.percentage-minimum-only) [8,1244 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1444 784x0]
+      Paintable (Box<DIV>.definite-height) [8,1444 200x200]
+        ImagePaintable (ImageBox<IMG>.css-ratio.percentage-minimum-only) [8,1444 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1644 784x0]
+      Paintable (Box<DIV>) [8,1644 200x32]
+        ImagePaintable (ImageBox<IMG>.css-ratio.conflicting-heights) [8,1644 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1676 784x0]
+      Paintable (Box<DIV>) [8,1676 0x32]
+        ImagePaintable (ImageBox<IMG>.cyclic-zero-minimum) [8,1676 0x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1708 784x0]
+      Paintable (Box<DIV>) [8,1708 10x2]
+        ImagePaintable (ImageBox<IMG>.cyclic-calculated-minimum) [8,1708 15x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1710 784x0]
+      Paintable (Box<DIV>) [8,1710 0x0]
+        ImagePaintable (ImageBox<IMG>.css-ratio.cyclic-zero-minimum) [8,1710 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1710 784x0]
+      Paintable (Box<DIV>) [8,1710 0x0]
+        ImagePaintable (ImageBox<IMG>.css-ratio.cyclic-zero-minimum.unconstrained) [8,1710 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1710 784x0]
+      Paintable (Box<DIV>) [8,1710 10x2]
+        ImagePaintable (ImageBox<IMG>.css-ratio.cyclic-calculated-minimum) [8,1710 15x2]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1712 784x0]
+      Paintable (Box<DIV>) [8,1712 64x16]
+        ImagePaintable (ImageBox<IMG>.css-ratio.cyclic-preferred) [8,1712 32x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1728 784x0]
+      Paintable (Box<DIV>) [8,1728 200x32]
+        ImagePaintable (ImageBox<IMG>.css-ratio.cyclic-maximum) [8,1728 100x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1760 784x0]
+      Paintable (Box<DIV>) [8,1760 20x20]
+        ImagePaintable (ImageBox<IMG>.css-ratio.border-box-cyclic-minimum) [8,1760 20x20]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1780 784x0]
+      Paintable (Box<DIV>) [8,1780 32x32]
+        ImagePaintable (ImageBox<IMG>.css-override) [8,1780 32x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1812 784x0]
+      Paintable (Box<DIV>) [8,1812 64x32]
+        ImagePaintable (ImageBox<IMG>.css-auto-with-ratio) [8,1812 64x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1844 784x0]
+      Paintable (Box<DIV>) [8,1844 32x32]
+        ImagePaintable (ImageBox<IMG>.css-auto-with-ratio) [8,1844 32x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,1876 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x1884] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/replaced-item-preferred-ratio-source-matrix.txt
+++ b/Tests/LibWeb/Layout/expected/grid/replaced-item-preferred-ratio-source-matrix.txt
@@ -78,15 +78,15 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
       BlockContainer <(anonymous)> at [8,1676] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      Box <div> at [8,1676] [0+0+0 0 0+0+784] [0+0+0 32 0+0+0] [GFC] children: not-inline
-        ImageBox <img.cyclic-zero-minimum> at [8,1676] [0+0+0 0 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      Box <div> at [8,1676] [0+0+0 300 0+0+484] [0+0+0 32 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-zero-minimum> at [8,1676] [0+0+0 300 0+0+0] [0+0+0 32 0+0+0] children: not-inline
           (SVG-as-image isolated context)
           Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
             SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
       BlockContainer <(anonymous)> at [8,1708] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      Box <div> at [8,1708] [0+0+0 10 0+0+774] [0+0+0 2 0+0+0] [GFC] children: not-inline
-        ImageBox <img.cyclic-calculated-minimum> at [8,1708] [0+0+0 15 0+0+0] [0+0+0 2 0+0+0] children: not-inline
+      Box <div> at [8,1708] [0+0+0 300 0+0+484] [0+0+0 2 0+0+0] [GFC] children: not-inline
+        ImageBox <img.cyclic-calculated-minimum> at [8,1708] [0+0+0 300 0+0+0] [0+0+0 2 0+0+0] children: not-inline
           (SVG-as-image isolated context)
           Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
             SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
@@ -192,11 +192,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 808x1884]
       Paintable (Box<DIV>) [8,1644 200x32]
         ImagePaintable (ImageBox<IMG>.css-ratio.conflicting-heights) [8,1644 200x100]
       PaintableWithLines (BlockContainer(anonymous)) [8,1676 784x0]
-      Paintable (Box<DIV>) [8,1676 0x32]
-        ImagePaintable (ImageBox<IMG>.cyclic-zero-minimum) [8,1676 0x32]
+      Paintable (Box<DIV>) [8,1676 300x32]
+        ImagePaintable (ImageBox<IMG>.cyclic-zero-minimum) [8,1676 300x32]
       PaintableWithLines (BlockContainer(anonymous)) [8,1708 784x0]
-      Paintable (Box<DIV>) [8,1708 10x2]
-        ImagePaintable (ImageBox<IMG>.cyclic-calculated-minimum) [8,1708 15x2]
+      Paintable (Box<DIV>) [8,1708 300x2]
+        ImagePaintable (ImageBox<IMG>.cyclic-calculated-minimum) [8,1708 300x2]
       PaintableWithLines (BlockContainer(anonymous)) [8,1710 784x0]
       Paintable (Box<DIV>) [8,1710 0x0]
         ImagePaintable (ImageBox<IMG>.css-ratio.cyclic-zero-minimum) [8,1710 0x0]

--- a/Tests/LibWeb/Layout/expected/pseudo-element-content-list-with-quote-control.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-content-list-with-quote-control.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+        Box <(anonymous)> at [8,8] flex-container(row) [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] [FFC] children: not-inline
+          BlockContainer <(anonymous)> at [395,8] flex-item [0+0+0 10 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
+            frag 0 from ImageBox start: 0, length: 0, rect: [395,10 10x10] baseline: 10
+            ImageBox <(anonymous)> at [395,10] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,24] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x32]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x16]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x16]
+        Paintable (Box(anonymous)) [8,8 784x16]
+          PaintableWithLines (BlockContainer(anonymous)) [395,8 10x16]
+            ImagePaintable (ImageBox(anonymous)) [395,10 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,24 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x32] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement-display-none.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement-display-none.txt
@@ -1,0 +1,66 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 32 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.hidden-open> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.visible-pair> at [8,8] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,8] [0+0+0 58.703125 0+0+0] [0+0+0 16 0+0+0]
+          frag 0 from GeneratedTextNode start: 0, length: 7, rect: [8,8 58.703125x16] baseline: 12.796875
+              "[outer]"
+          GeneratedTextNode <(anonymous)> (not painted)
+        InlineNode <(anonymous)> at [66.703125,8] [0+0+0 66.078125 0+0+0] [0+0+0 16 0+0+0]
+          frag 0 from GeneratedTextNode start: 0, length: 8, rect: [66.703125,8 66.078125x16] baseline: 12.796875
+              "[/outer]"
+          GeneratedTextNode <(anonymous)> (not painted)
+      BlockContainer <(anonymous)> at [8,24] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.outer> at [8,24] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,24] [0+0+0 58.703125 0+0+0] [0+0+0 16 0+0+0]
+          frag 0 from GeneratedTextNode start: 0, length: 7, rect: [8,24 58.703125x16] baseline: 12.796875
+              "[outer]"
+          GeneratedTextNode <(anonymous)> (not painted)
+        InlineNode <span.hidden-close> at [8,24] [0+0+0 0 0+0+0] [0+0+0 16 0+0+0]
+        InlineNode <span.visible-inner> at [66.703125,24] [0+0+0 118.375 0+0+0] [0+0+0 16 0+0+0]
+          InlineNode <(anonymous)> at [66.703125,24] [0+0+0 55.5 0+0+0] [0+0+0 16 0+0+0]
+            frag 0 from GeneratedTextNode start: 0, length: 7, rect: [66.703125,24 55.5x16] baseline: 12.796875
+                "[inner]"
+            GeneratedTextNode <(anonymous)> (not painted)
+          InlineNode <(anonymous)> at [122.203125,24] [0+0+0 62.875 0+0+0] [0+0+0 16 0+0+0]
+            frag 0 from GeneratedTextNode start: 0, length: 8, rect: [122.203125,24 62.875x16] baseline: 12.796875
+                "[/inner]"
+            GeneratedTextNode <(anonymous)> (not painted)
+        InlineNode <(anonymous)> at [185.078125,24] [0+0+0 66.078125 0+0+0] [0+0+0 16 0+0+0]
+          frag 0 from GeneratedTextNode start: 0, length: 8, rect: [185.078125,24 66.078125x16] baseline: 12.796875
+              "[/outer]"
+          GeneratedTextNode <(anonymous)> (not painted)
+      BlockContainer <(anonymous)> at [8,40] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+  BlockContainer <dialog> at [400,300] positioned [381+3+16 0 16+3+381] [281+3+16 0 16+3+281] [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.hidden-open) [8,8 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>.visible-pair) [8,8 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,8 58.703125x16]
+        InlinePaintable (InlineNode(anonymous)) [66.703125,8 66.078125x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,24 784x0]
+      PaintableWithLines (BlockContainer<DIV>.outer) [8,24 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,24 58.703125x16]
+        InlinePaintable (InlineNode<SPAN>.hidden-close) [8,24 0x16]
+        InlinePaintable (InlineNode<SPAN>.visible-inner) [66.703125,24 118.375x16]
+          InlinePaintable (InlineNode(anonymous)) [66.703125,24 55.5x16]
+          InlinePaintable (InlineNode(anonymous)) [122.203125,24 62.875x16]
+        InlinePaintable (InlineNode(anonymous)) [185.078125,24 66.078125x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,40 784x0]
+  PaintableWithLines (BlockContainer<DIALOG>) [381,281 38x38]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x48] (z-index: auto)
+ SC for BlockContainer<DIALOG> [400,300 0x0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement-display-types.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement-display-types.txt
@@ -1,0 +1,203 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 280 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 264 0+0+8] children: not-inline
+      BlockContainer <div.inline.single> at [8,8] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,10 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 6, rect: [18,8 41.296875x16] baseline: 12.796875
+            "inline"
+        ImageBox <(anonymous)> at [8,10] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,24] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.block.single> at [8,24] [0+0+0 784 0+0+0] [0+0+0 26 0+0+0] children: not-inline
+        ImageBox <(anonymous)> at [8,24] [0+0+0 10 0+0+774] [0+0+0 10 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,34] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [8,34 40.671875x16] baseline: 12.796875
+              "block"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,50] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.flex.single> at [8,50] [0+0+0 784 0+0+0] [0+0+0 26 0+0+0] children: not-inline
+        ImageBox <(anonymous)> at [8,50] flex-container(row) [0+0+0 10 0+0+774] [0+0+0 10 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,60] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,60 29.09375x16] baseline: 12.796875
+              "flex"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,76] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.contents> at [8,76] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 8, rect: [18,76 70.25x16] baseline: 12.796875
+            "contents"
+        InlineNode <(anonymous)> at [8,78] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0]
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,78 10x10] baseline: 10
+          ImageBox <(anonymous)> at [8,78] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        InlineNode <(anonymous)> at [88.25,78] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0]
+          frag 0 from ImageBox start: 0, length: 0, rect: [88.25,78 10x10] baseline: 10
+          ImageBox <(anonymous)> at [88.25,78] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,92] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table> at [8,92] [0+0+0 784 0+0+0] [0+0+0 36 0+0+0] children: not-inline
+        ImageBox <(anonymous)> at [8,92] [0+0+0 10 0+0+774] [0+0+0 10 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [8,102] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [8,102 38.625x16] baseline: 12.796875
+              "table"
+          TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [8,118] [0+0+0 10 0+0+774] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,128] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.inline-table> at [8,128] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,130 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 12, rect: [18,128 86.40625x16] baseline: 12.796875
+            "inline-table"
+        frag 2 from ImageBox start: 0, length: 0, rect: [104.40625,130 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,130] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [104.40625,130] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,144] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-row-group> at [8,144] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,146 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 15, rect: [18,144 127.9375x16] baseline: 12.796875
+            "table-row-group"
+        frag 2 from ImageBox start: 0, length: 0, rect: [145.9375,146 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,146] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [145.9375,146] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,160] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-header-group> at [8,160] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,162 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 18, rect: [18,160 150.296875x16] baseline: 12.796875
+            "table-header-group"
+        frag 2 from ImageBox start: 0, length: 0, rect: [168.296875,162 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,162] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [168.296875,162] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,176] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-footer-group> at [8,176] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,178 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 18, rect: [18,176 149.09375x16] baseline: 12.796875
+            "table-footer-group"
+        frag 2 from ImageBox start: 0, length: 0, rect: [167.09375,178 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,178] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [167.09375,178] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,192] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-row> at [8,192] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,194 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 9, rect: [18,192 75.515625x16] baseline: 12.796875
+            "table-row"
+        frag 2 from ImageBox start: 0, length: 0, rect: [93.515625,194 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,194] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [93.515625,194] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-cell> at [8,208] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,210 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 10, rect: [18,208 71.1875x16] baseline: 12.796875
+            "table-cell"
+        frag 2 from ImageBox start: 0, length: 0, rect: [89.1875,210 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,210] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [89.1875,210] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,224] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-column-group> at [8,224] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,226 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 18, rect: [18,224 152.59375x16] baseline: 12.796875
+            "table-column-group"
+        frag 2 from ImageBox start: 0, length: 0, rect: [170.59375,226 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,226] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [170.59375,226] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,240] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-column> at [8,240] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,242 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 12, rect: [18,240 100.171875x16] baseline: 12.796875
+            "table-column"
+        frag 2 from ImageBox start: 0, length: 0, rect: [118.171875,242 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,242] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [118.171875,242] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,256] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.table-caption> at [8,256] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        frag 0 from ImageBox start: 0, length: 0, rect: [8,258 10x10] baseline: 10
+        frag 1 from TextNode start: 0, length: 13, rect: [18,256 104.15625x16] baseline: 12.796875
+            "table-caption"
+        frag 2 from ImageBox start: 0, length: 0, rect: [122.15625,258 10x10] baseline: 10
+        ImageBox <(anonymous)> at [8,258] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        TextNode <#text> (not painted)
+        ImageBox <(anonymous)> at [122.15625,258] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,272] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x280]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x264]
+      PaintableWithLines (BlockContainer<DIV>.inline.single) [8,8 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,10 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,24 784x0]
+      PaintableWithLines (BlockContainer<DIV>.block.single) [8,24 784x26]
+        ImagePaintable (ImageBox(anonymous)) [8,24 10x10]
+        PaintableWithLines (BlockContainer(anonymous)) [8,34 784x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]
+      PaintableWithLines (BlockContainer<DIV>.flex.single) [8,50 784x26]
+        ImagePaintable (ImageBox(anonymous)) [8,50 10x10]
+        PaintableWithLines (BlockContainer(anonymous)) [8,60 784x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,76 784x0]
+      PaintableWithLines (BlockContainer<DIV>.contents) [8,76 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,78 10x10]
+          ImagePaintable (ImageBox(anonymous)) [8,78 10x10]
+        InlinePaintable (InlineNode(anonymous)) [88.25,78 10x10]
+          ImagePaintable (ImageBox(anonymous)) [88.25,78 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,92 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table) [8,92 784x36]
+        ImagePaintable (ImageBox(anonymous)) [8,92 10x10]
+        PaintableWithLines (BlockContainer(anonymous)) [8,102 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,118 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,128 784x0]
+      PaintableWithLines (BlockContainer<DIV>.inline-table) [8,128 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,130 10x10]
+        ImagePaintable (ImageBox(anonymous)) [104.40625,130 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,144 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-row-group) [8,144 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,146 10x10]
+        ImagePaintable (ImageBox(anonymous)) [145.9375,146 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,160 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-header-group) [8,160 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,162 10x10]
+        ImagePaintable (ImageBox(anonymous)) [168.296875,162 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,176 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-footer-group) [8,176 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,178 10x10]
+        ImagePaintable (ImageBox(anonymous)) [167.09375,178 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,192 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-row) [8,192 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,194 10x10]
+        ImagePaintable (ImageBox(anonymous)) [93.515625,194 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-cell) [8,208 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,210 10x10]
+        ImagePaintable (ImageBox(anonymous)) [89.1875,210 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,224 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-column-group) [8,224 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,226 10x10]
+        ImagePaintable (ImageBox(anonymous)) [170.59375,226 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,240 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-column) [8,240 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,242 10x10]
+        ImagePaintable (ImageBox(anonymous)) [118.171875,242 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,256 784x0]
+      PaintableWithLines (BlockContainer<DIV>.table-caption) [8,256 784x16]
+        ImagePaintable (ImageBox(anonymous)) [8,258 10x10]
+        ImagePaintable (ImageBox(anonymous)) [122.15625,258 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,272 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x280] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement-list-item.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 32 0+0+8] children: not-inline
+      BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        ListItemBox <(anonymous)> at [22,8] [0+0+0 770 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [22,8 16x16] baseline: 16
+          ListItemMarkerBox <(anonymous)> at [8,13] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] children: not-inline
+          ImageBox <(anonymous)> at [22,8] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+        ListItemBox <(anonymous)> at [22,24] [0+0+0 770 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from ImageBox start: 0, length: 0, rect: [22,24 16x16] baseline: 16
+          ListItemMarkerBox <(anonymous)> at [8,29] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] children: not-inline
+          ImageBox <(anonymous)> at [22,24] [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,40] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x48]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x32]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x32]
+        PaintableWithLines (ListItemBox(anonymous)) [22,8 770x16]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [8,13 6x6]
+          ImagePaintable (ImageBox(anonymous)) [22,8 16x16]
+        PaintableWithLines (ListItemBox(anonymous)) [22,24 770x16]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [8,29 6x6]
+          ImagePaintable (ImageBox(anonymous)) [22,24 16x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,40 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x48] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement.txt
@@ -1,0 +1,118 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 288 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 272 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <button.flex-container.single-image> at [13,10] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [13,10] flex-item [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+          ImageBox <(anonymous)> at [13,10] [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [211,10] flex-item [0+0+0 51.296875 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 6, rect: [211,10 51.296875x16] baseline: 12.796875
+              "Ratio-"
+          frag 1 from TextNode start: 6, length: 4, rect: [220.953125,26 31.375x16] baseline: 12.796875
+              "only"
+          frag 2 from TextNode start: 11, length: 3, rect: [218.046875,42 37.1875x16] baseline: 12.796875
+              "SVG"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,56] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <button.flex-container.single-image.intrinsic-size> at [13,58] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [13,58] flex-item [0+0+0 40 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+          ImageBox <(anonymous)> at [13,58] [0+0+0 40 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [61,58] flex-item [0+0+0 142 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 14, rect: [79.8125,58 104.359375x16] baseline: 12.796875
+              "Intrinsic-size"
+          frag 1 from TextNode start: 15, length: 3, rect: [113.40625,74 37.1875x16] baseline: 12.796875
+              "SVG"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <button.flex-container.single-image.with-alt-text> at [13,106] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [13,106] flex-item [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+          ImageBox <(anonymous)> at [13,106] [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [211,106] flex-item [0+0+0 32.140625 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [214.390625,106 25.359375x16] baseline: 12.796875
+              "Alt"
+          frag 1 from TextNode start: 4, length: 4, rect: [211,122 32.140625x16] baseline: 12.796875
+              "text"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,152] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <button.flex-container.after-only> at [13,154] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> at [13,154] flex-item [0+0+0 45.109375 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [13,154 45.109375x16] baseline: 12.796875
+              "After"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [66.109375,154] flex-item [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+          ImageBox <(anonymous)> at [66.109375,154] [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,200] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.flex-container> at [8,200] flex-container(row) [0+0+0 200 0+0+584] [0+0+0 48 0+0+0] [FFC] children: not-inline
+        ImageBox <div.ordinary-replacement> at [8,200] flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [48,200] flex-item [0+0+0 134.75 0+0+0] [0+0+0 48 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 16, rect: [48,200 134.75x16] baseline: 12.796875
+              "Ordinary element"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,248] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.mixed-content> at [8,248] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,248] [0+0+0 102.71875 0+0+0] [0+0+0 16 0+0+0]
+          frag 0 from GeneratedTextNode start: 0, length: 6, rect: [8,248 52.53125x16] baseline: 12.796875
+              "before"
+          frag 1 from ImageBox start: 0, length: 0, rect: [60.53125,250 10x10] baseline: 10
+          frag 2 from GeneratedTextNode start: 0, length: 5, rect: [70.53125,248 40.1875x16] baseline: 12.796875
+              "after"
+          GeneratedTextNode <(anonymous)> (not painted)
+          ImageBox <(anonymous)> at [60.53125,250] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+          GeneratedTextNode <(anonymous)> (not painted)
+      BlockContainer <(anonymous)> at [8,264] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.multiple-images> at [8,264] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,266] [0+0+0 20 0+0+0] [0+0+0 10 0+0+0]
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,266 10x10] baseline: 10
+          frag 1 from ImageBox start: 0, length: 0, rect: [18,266 10x10] baseline: 10
+          ImageBox <(anonymous)> at [8,266] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+          ImageBox <(anonymous)> at [18,266] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,280] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x288]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x272]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      Paintable (Box<BUTTON>.flex-container.single-image) [8,8 200x48]
+        PaintableWithLines (BlockContainer(anonymous)) [13,10 190x32]
+          ImagePaintable (ImageBox(anonymous)) [13,10 190x32]
+        PaintableWithLines (BlockContainer(anonymous)) [211,10 51.296875x44]
+      PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]
+      Paintable (Box<BUTTON>.flex-container.single-image.intrinsic-size) [8,56 200x48]
+        PaintableWithLines (BlockContainer(anonymous)) [13,58 40x32]
+          ImagePaintable (ImageBox(anonymous)) [13,58 40x32]
+        PaintableWithLines (BlockContainer(anonymous)) [61,58 142x44]
+      PaintableWithLines (BlockContainer(anonymous)) [8,104 784x0]
+      Paintable (Box<BUTTON>.flex-container.single-image.with-alt-text) [8,104 200x48]
+        PaintableWithLines (BlockContainer(anonymous)) [13,106 190x32]
+          ImagePaintable (ImageBox(anonymous)) [13,106 190x32]
+        PaintableWithLines (BlockContainer(anonymous)) [211,106 32.140625x44]
+      PaintableWithLines (BlockContainer(anonymous)) [8,152 784x0]
+      Paintable (Box<BUTTON>.flex-container.after-only) [8,152 200x48]
+        PaintableWithLines (BlockContainer(anonymous)) [13,154 45.109375x44]
+        PaintableWithLines (BlockContainer(anonymous)) [66.109375,154 190x32]
+          ImagePaintable (ImageBox(anonymous)) [66.109375,154 190x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,200 784x0]
+      Paintable (Box<DIV>.flex-container) [8,200 200x48]
+        ImagePaintable (ImageBox<DIV>.ordinary-replacement) [8,200 32x32]
+        PaintableWithLines (BlockContainer(anonymous)) [48,200 134.75x48]
+      PaintableWithLines (BlockContainer(anonymous)) [8,248 784x0]
+      PaintableWithLines (BlockContainer<DIV>.mixed-content) [8,248 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,248 102.71875x16]
+          ImagePaintable (ImageBox(anonymous)) [60.53125,250 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,264 784x0]
+      PaintableWithLines (BlockContainer<DIV>.multiple-images) [8,264 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,266 20x10]
+          ImagePaintable (ImageBox(anonymous)) [8,266 10x10]
+          ImagePaintable (ImageBox(anonymous)) [18,266 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,280 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x288] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-content-replacement.txt
@@ -1,24 +1,18 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 288 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 272 0+0+8] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 336 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 320 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       Box <button.flex-container.single-image> at [13,10] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
-        BlockContainer <(anonymous)> at [13,10] flex-item [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
-          ImageBox <(anonymous)> at [13,10] [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [211,10] flex-item [0+0+0 51.296875 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 6, rect: [211,10 51.296875x16] baseline: 12.796875
-              "Ratio-"
-          frag 1 from TextNode start: 6, length: 4, rect: [220.953125,26 31.375x16] baseline: 12.796875
-              "only"
-          frag 2 from TextNode start: 11, length: 3, rect: [218.046875,42 37.1875x16] baseline: 12.796875
-              "SVG"
+        ImageBox <(anonymous)> at [13,10] flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [53,10] flex-item [0+0+0 127.859375 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 14, rect: [53,10 127.859375x16] baseline: 12.796875
+              "Ratio-only SVG"
           TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,56] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       Box <button.flex-container.single-image.intrinsic-size> at [13,58] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
-        BlockContainer <(anonymous)> at [13,58] flex-item [0+0+0 40 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
-          ImageBox <(anonymous)> at [13,58] [0+0+0 40 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        ImageBox <(anonymous)> at [13,58] flex-item [0+0+0 40 0+0+0] [0+0+0 32 0+0+0] children: not-inline
         BlockContainer <(anonymous)> at [61,58] flex-item [0+0+0 142 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 14, rect: [79.8125,58 104.359375x16] baseline: 12.796875
               "Intrinsic-size"
@@ -28,13 +22,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       Box <button.flex-container.single-image.with-alt-text> at [13,106] flex-container(row) [0+1+4 190 4+1+584] [0+1+1 44 1+1+0] [FFC] children: not-inline
-        BlockContainer <(anonymous)> at [13,106] flex-item [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
-          ImageBox <(anonymous)> at [13,106] [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [211,106] flex-item [0+0+0 32.140625 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [214.390625,106 25.359375x16] baseline: 12.796875
-              "Alt"
-          frag 1 from TextNode start: 4, length: 4, rect: [211,122 32.140625x16] baseline: 12.796875
-              "text"
+        ImageBox <(anonymous)> at [13,106] flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [53,106] flex-item [0+0+0 65.5 0+0+0] [0+0+0 44 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 8, rect: [53,106 65.5x16] baseline: 12.796875
+              "Alt text"
           TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,152] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
@@ -43,8 +34,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           frag 0 from TextNode start: 0, length: 5, rect: [13,154 45.109375x16] baseline: 12.796875
               "After"
           TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [66.109375,154] flex-item [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
-          ImageBox <(anonymous)> at [66.109375,154] [0+0+0 190 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        ImageBox <(anonymous)> at [66.109375,154] flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
       BlockContainer <(anonymous)> at [8,200] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       Box <div.flex-container> at [8,200] flex-container(row) [0+0+0 200 0+0+584] [0+0+0 48 0+0+0] [FFC] children: not-inline
@@ -55,64 +45,76 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,248] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      BlockContainer <div.mixed-content> at [8,248] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
-        InlineNode <(anonymous)> at [8,248] [0+0+0 102.71875 0+0+0] [0+0+0 16 0+0+0]
-          frag 0 from GeneratedTextNode start: 0, length: 6, rect: [8,248 52.53125x16] baseline: 12.796875
+      Box <div.flex-container> at [8,248] flex-container(row) [0+0+0 200 0+0+584] [0+0+0 48 0+0+0] [FFC] children: not-inline
+        ImageBox <img.direct-image> at [8,248] flex-item [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 32 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [48,248] flex-item [0+0+0 99.390625 0+0+0] [0+0+0 48 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 12, rect: [48,248 99.390625x16] baseline: 12.796875
+              "Direct image"
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,296] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.mixed-content> at [8,296] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,296] [0+0+0 102.71875 0+0+0] [0+0+0 16 0+0+0]
+          frag 0 from GeneratedTextNode start: 0, length: 6, rect: [8,296 52.53125x16] baseline: 12.796875
               "before"
-          frag 1 from ImageBox start: 0, length: 0, rect: [60.53125,250 10x10] baseline: 10
-          frag 2 from GeneratedTextNode start: 0, length: 5, rect: [70.53125,248 40.1875x16] baseline: 12.796875
+          frag 1 from ImageBox start: 0, length: 0, rect: [60.53125,298 10x10] baseline: 10
+          frag 2 from GeneratedTextNode start: 0, length: 5, rect: [70.53125,296 40.1875x16] baseline: 12.796875
               "after"
           GeneratedTextNode <(anonymous)> (not painted)
-          ImageBox <(anonymous)> at [60.53125,250] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+          ImageBox <(anonymous)> at [60.53125,298] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
           GeneratedTextNode <(anonymous)> (not painted)
-      BlockContainer <(anonymous)> at [8,264] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,312] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      BlockContainer <div.multiple-images> at [8,264] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
-        InlineNode <(anonymous)> at [8,266] [0+0+0 20 0+0+0] [0+0+0 10 0+0+0]
-          frag 0 from ImageBox start: 0, length: 0, rect: [8,266 10x10] baseline: 10
-          frag 1 from ImageBox start: 0, length: 0, rect: [18,266 10x10] baseline: 10
-          ImageBox <(anonymous)> at [8,266] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
-          ImageBox <(anonymous)> at [18,266] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
-      BlockContainer <(anonymous)> at [8,280] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <div.multiple-images> at [8,312] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
+        InlineNode <(anonymous)> at [8,314] [0+0+0 20 0+0+0] [0+0+0 10 0+0+0]
+          frag 0 from ImageBox start: 0, length: 0, rect: [8,314 10x10] baseline: 10
+          frag 1 from ImageBox start: 0, length: 0, rect: [18,314 10x10] baseline: 10
+          ImageBox <(anonymous)> at [8,314] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+          ImageBox <(anonymous)> at [18,314] [0+0+0 10 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,328] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x288]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x272]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x336]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x320]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       Paintable (Box<BUTTON>.flex-container.single-image) [8,8 200x48]
-        PaintableWithLines (BlockContainer(anonymous)) [13,10 190x32]
-          ImagePaintable (ImageBox(anonymous)) [13,10 190x32]
-        PaintableWithLines (BlockContainer(anonymous)) [211,10 51.296875x44]
+        ImagePaintable (ImageBox(anonymous)) [13,10 32x32]
+        PaintableWithLines (BlockContainer(anonymous)) [53,10 127.859375x44]
       PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]
       Paintable (Box<BUTTON>.flex-container.single-image.intrinsic-size) [8,56 200x48]
-        PaintableWithLines (BlockContainer(anonymous)) [13,58 40x32]
-          ImagePaintable (ImageBox(anonymous)) [13,58 40x32]
+        ImagePaintable (ImageBox(anonymous)) [13,58 40x32]
         PaintableWithLines (BlockContainer(anonymous)) [61,58 142x44]
       PaintableWithLines (BlockContainer(anonymous)) [8,104 784x0]
       Paintable (Box<BUTTON>.flex-container.single-image.with-alt-text) [8,104 200x48]
-        PaintableWithLines (BlockContainer(anonymous)) [13,106 190x32]
-          ImagePaintable (ImageBox(anonymous)) [13,106 190x32]
-        PaintableWithLines (BlockContainer(anonymous)) [211,106 32.140625x44]
+        ImagePaintable (ImageBox(anonymous)) [13,106 32x32]
+        PaintableWithLines (BlockContainer(anonymous)) [53,106 65.5x44]
       PaintableWithLines (BlockContainer(anonymous)) [8,152 784x0]
       Paintable (Box<BUTTON>.flex-container.after-only) [8,152 200x48]
         PaintableWithLines (BlockContainer(anonymous)) [13,154 45.109375x44]
-        PaintableWithLines (BlockContainer(anonymous)) [66.109375,154 190x32]
-          ImagePaintable (ImageBox(anonymous)) [66.109375,154 190x32]
+        ImagePaintable (ImageBox(anonymous)) [66.109375,154 32x32]
       PaintableWithLines (BlockContainer(anonymous)) [8,200 784x0]
       Paintable (Box<DIV>.flex-container) [8,200 200x48]
         ImagePaintable (ImageBox<DIV>.ordinary-replacement) [8,200 32x32]
         PaintableWithLines (BlockContainer(anonymous)) [48,200 134.75x48]
       PaintableWithLines (BlockContainer(anonymous)) [8,248 784x0]
-      PaintableWithLines (BlockContainer<DIV>.mixed-content) [8,248 784x16]
-        InlinePaintable (InlineNode(anonymous)) [8,248 102.71875x16]
-          ImagePaintable (ImageBox(anonymous)) [60.53125,250 10x10]
-      PaintableWithLines (BlockContainer(anonymous)) [8,264 784x0]
-      PaintableWithLines (BlockContainer<DIV>.multiple-images) [8,264 784x16]
-        InlinePaintable (InlineNode(anonymous)) [8,266 20x10]
-          ImagePaintable (ImageBox(anonymous)) [8,266 10x10]
-          ImagePaintable (ImageBox(anonymous)) [18,266 10x10]
-      PaintableWithLines (BlockContainer(anonymous)) [8,280 784x0]
+      Paintable (Box<DIV>.flex-container) [8,248 200x48]
+        ImagePaintable (ImageBox<IMG>.direct-image) [8,248 32x32]
+        PaintableWithLines (BlockContainer(anonymous)) [48,248 99.390625x48]
+      PaintableWithLines (BlockContainer(anonymous)) [8,296 784x0]
+      PaintableWithLines (BlockContainer<DIV>.mixed-content) [8,296 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,296 102.71875x16]
+          ImagePaintable (ImageBox(anonymous)) [60.53125,298 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,312 784x0]
+      PaintableWithLines (BlockContainer<DIV>.multiple-images) [8,312 784x16]
+        InlinePaintable (InlineNode(anonymous)) [8,314 20x10]
+          ImagePaintable (ImageBox(anonymous)) [8,314 10x10]
+          ImagePaintable (ImageBox(anonymous)) [18,314 10x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,328 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x288] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x336] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/ratio-only-replaced-image-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/ratio-only-replaced-image-fit-content.txt
@@ -1,0 +1,32 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 148 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 132 0+0+8] children: not-inline
+      Box <div> at [8,8] flex-container(row) [0+0+0 200 0+0+584] [0+0+0 100 0+0+0] [FFC] children: not-inline
+        ImageBox <img> at [8,8] flex-item [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,108] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div> at [8,108] flex-container(row) [0+0+0 200 0+0+584] [0+0+0 32 0+0+0] [FFC] children: not-inline
+        ImageBox <img.calculated-max-height> at [8,108] flex-item [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+          (SVG-as-image isolated context)
+          Viewport <#document> at [0,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] [BFC] children: not-inline
+            SVGSVGBox <svg> at [0,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] [SVG] children: not-inline
+              SVGGeometryBox <rect> at [0,0] [0+0+0 64 0+0+0] [0+0+0 32 0+0+0] children: not-inline
+      BlockContainer <(anonymous)> at [8,140] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x148]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x132]
+      Paintable (Box<DIV>) [8,8 200x100]
+        ImagePaintable (ImageBox<IMG>) [8,8 200x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
+      Paintable (Box<DIV>) [8,108 200x32]
+        ImagePaintable (ImageBox<IMG>.calculated-max-height) [8,108 64x32]
+      PaintableWithLines (BlockContainer(anonymous)) [8,140 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x148] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/flex/stretched-item-percentage-min-cross-size.html
+++ b/Tests/LibWeb/Layout/input/flex/stretched-item-percentage-min-cross-size.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .row {
+        display: flex;
+    }
+
+    .column {
+        display: flex;
+        flex-direction: column;
+        padding: 4px 20px;
+    }
+
+    .label {
+        width: 100px;
+        height: 20px;
+    }
+
+    .indicator {
+        position: relative;
+        left: -20px;
+        min-width: calc(100% + 40px);
+        height: 4px;
+        background: green;
+    }
+
+    .percentage-only {
+        min-width: 150%;
+    }
+</style>
+<div class="row">
+    <div class="column">
+        <div class="indicator"></div>
+        <div class="label"></div>
+    </div>
+</div>
+<div class="row">
+    <div class="column">
+        <div class="indicator percentage-only"></div>
+        <div class="label"></div>
+    </div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/ratio-only-replaced-item-conflicting-height-constraints.html
+++ b/Tests/LibWeb/Layout/input/grid/ratio-only-replaced-item-conflicting-height-constraints.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+    div {
+        display: grid;
+        grid-template-columns: max-content;
+    }
+
+    img {
+        min-height: 100px;
+        max-height: 32px;
+    }
+</style>
+<div><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='green'/%3E%3C/svg%3E"></div>

--- a/Tests/LibWeb/Layout/input/grid/ratio-only-replaced-item-size-transfer-matrix.html
+++ b/Tests/LibWeb/Layout/input/grid/ratio-only-replaced-item-size-transfer-matrix.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<style>
+    div {
+        display: grid;
+        grid-template-columns: max-content;
+        width: max-content;
+    }
+
+    img {
+        max-height: 32px;
+    }
+
+    .cyclic-preferred {
+        width: 50%;
+    }
+
+    .cyclic-calculated-preferred {
+        width: calc(10px + 50%);
+    }
+
+    .fixed-preferred {
+        width: 80px;
+    }
+
+    .calculated-preferred {
+        width: calc(80px);
+    }
+
+    .transferred-minimum {
+        min-height: 100px;
+    }
+
+    .cyclic-calculated-transferred-minimum {
+        min-height: calc(10px + 50%);
+    }
+
+    .capped-transferred-minimum {
+        min-height: 100px;
+        max-width: 150px;
+    }
+
+    .calculated-capped-transferred-minimum {
+        min-height: 100px;
+        max-width: calc(150px);
+    }
+
+    .cyclic-maximum {
+        min-height: 100px;
+        max-width: 50%;
+    }
+
+    .cyclic-minimum {
+        min-width: calc(10px + 50%);
+        max-height: 2px;
+    }
+
+    .cyclic-zero-minimum {
+        min-width: 50%;
+    }
+
+    .cyclic-zero-calculated-minimum {
+        min-width: calc(0px + 50%);
+    }
+
+    .calculated-minimum {
+        min-width: calc(80px);
+    }
+
+    .fixed-minimum-only,
+    .calculated-minimum-only {
+        max-height: none;
+        min-height: 100px;
+    }
+
+    .calculated-minimum-only {
+        min-height: calc(100px);
+    }
+
+    .border-box-maximum {
+        box-sizing: border-box;
+        border: 10px solid black;
+        max-height: calc(52px);
+    }
+
+    .definite-height {
+        align-items: start;
+        height: 100px;
+    }
+
+    .percentage-maximum {
+        max-height: 50%;
+    }
+
+    .available-width {
+        width: auto;
+    }
+</style>
+<div><img class="cyclic-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='red'/%3E%3C/svg%3E"></div>
+<div><img class="cyclic-calculated-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='green'/%3E%3C/svg%3E"></div>
+<div><img class="fixed-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='blue'/%3E%3C/svg%3E"></div>
+<div><img class="calculated-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='orange'/%3E%3C/svg%3E"></div>
+<div><img class="transferred-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='purple'/%3E%3C/svg%3E"></div>
+<div><img class="cyclic-calculated-transferred-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='pink'/%3E%3C/svg%3E"></div>
+<div><img class="capped-transferred-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='teal'/%3E%3C/svg%3E"></div>
+<div><img class="calculated-capped-transferred-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='gold'/%3E%3C/svg%3E"></div>
+<div><img class="cyclic-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='navy'/%3E%3C/svg%3E"></div>
+<div><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='maroon'/%3E%3C/svg%3E"></div>
+<div><img class="cyclic-zero-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='indigo'/%3E%3C/svg%3E"></div>
+<div><img class="cyclic-zero-calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='violet'/%3E%3C/svg%3E"></div>
+<div><img class="calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='coral'/%3E%3C/svg%3E"></div>
+<div><img class="fixed-minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='lime'/%3E%3C/svg%3E"></div>
+<div><img class="calculated-minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='aqua'/%3E%3C/svg%3E"></div>
+<div><img class="border-box-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='fuchsia'/%3E%3C/svg%3E"></div>
+<div class="definite-height"><img class="percentage-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='silver'/%3E%3C/svg%3E"></div>
+<div class="available-width"><img class="cyclic-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='olive'/%3E%3C/svg%3E"></div>
+<div class="available-width"><img class="cyclic-zero-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='crimson'/%3E%3C/svg%3E"></div>

--- a/Tests/LibWeb/Layout/input/grid/replaced-item-preferred-ratio-source-matrix.html
+++ b/Tests/LibWeb/Layout/input/grid/replaced-item-preferred-ratio-source-matrix.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<style>
+    div {
+        display: grid;
+        grid-template-columns: max-content;
+        width: max-content;
+    }
+
+    img {
+        max-height: 32px;
+    }
+
+    .css-ratio {
+        aspect-ratio: 2 / 1;
+    }
+
+    .calculated-maximum {
+        max-height: calc(32px);
+    }
+
+    .unconstrained {
+        max-height: none;
+    }
+
+    .minimum-only {
+        max-height: none;
+        min-height: 100px;
+    }
+
+    .border-box-minimum-only {
+        box-sizing: border-box;
+        border: 10px solid black;
+        max-height: none;
+        min-height: 120px;
+    }
+
+    .definite-height {
+        align-items: start;
+        height: 200px;
+    }
+
+    .percentage-minimum-only {
+        max-height: none;
+        min-height: 50%;
+    }
+
+    .conflicting-heights {
+        min-height: 100px;
+        max-height: 32px;
+    }
+
+    .cyclic-zero-minimum {
+        min-width: 50%;
+    }
+
+    .cyclic-calculated-minimum {
+        min-width: calc(10px + 50%);
+        max-height: 2px;
+    }
+
+    .cyclic-preferred {
+        width: 50%;
+    }
+
+    .cyclic-maximum {
+        min-height: 100px;
+        max-width: 50%;
+    }
+
+    .border-box-cyclic-minimum {
+        box-sizing: border-box;
+        border: 10px solid black;
+        min-width: 50%;
+    }
+
+    .css-override {
+        aspect-ratio: 1 / 1;
+    }
+
+    .css-auto-with-ratio {
+        aspect-ratio: auto 1 / 1;
+    }
+</style>
+<div><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio calculated-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="unconstrained" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio unconstrained" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="border-box-minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio border-box-minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="definite-height"><img class="percentage-minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3C/svg%3E"></div>
+<div class="definite-height"><img class="css-ratio percentage-minimum-only" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio conflicting-heights" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="cyclic-zero-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="cyclic-calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio cyclic-zero-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio cyclic-zero-minimum unconstrained" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio cyclic-calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio cyclic-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio cyclic-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-ratio border-box-cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div><img class="css-override" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3C/svg%3E"></div>
+<div><img class="css-auto-with-ratio" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3C/svg%3E"></div>
+<div><img class="css-auto-with-ratio" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>

--- a/Tests/LibWeb/Layout/input/pseudo-element-content-list-with-quote-control.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-content-list-with-quote-control.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    div::before {
+        content: no-open-quote url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='green'/%3E%3C/svg%3E");
+        display: flex;
+        justify-content: center;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Layout/input/pseudo-element-content-replacement-display-none.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-content-replacement-display-none.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        quotes: "[outer]" "[/outer]" "[inner]" "[/inner]";
+    }
+
+    dialog::backdrop {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' fill='green'/%3E%3C/svg%3E");
+        display: none;
+    }
+
+    .hidden-open::before {
+        content: open-quote;
+        display: none;
+    }
+
+    .visible-pair::before,
+    .outer::before,
+    .visible-inner::before {
+        content: open-quote;
+    }
+
+    .visible-pair::after,
+    .outer::after,
+    .visible-inner::after {
+        content: close-quote;
+    }
+
+    .hidden-close::before {
+        content: close-quote;
+        display: none;
+    }
+</style>
+<dialog></dialog>
+<div class="hidden-open"></div>
+<div class="visible-pair"></div>
+<div class="outer"><span class="hidden-close"></span><span class="visible-inner"></span></div>
+<script>
+    document.querySelector("dialog").showModal();
+</script>

--- a/Tests/LibWeb/Layout/input/pseudo-element-content-replacement-display-types.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-content-replacement-display-types.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<style>
+    div::before,
+    div::after {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='green'/%3E%3C/svg%3E");
+    }
+
+    .inline::before {
+        display: inline;
+    }
+
+    .block::before {
+        display: block;
+    }
+
+    .flex::before {
+        display: flex;
+    }
+
+    .contents::before,
+    .contents::after {
+        display: contents;
+    }
+
+    .single::after {
+        content: none;
+    }
+
+    .table::before,
+    .table::after {
+        display: table;
+    }
+
+    .inline-table::before,
+    .inline-table::after {
+        display: inline-table;
+    }
+
+    .table-row-group::before,
+    .table-row-group::after {
+        display: table-row-group;
+    }
+
+    .table-header-group::before,
+    .table-header-group::after {
+        display: table-header-group;
+    }
+
+    .table-footer-group::before,
+    .table-footer-group::after {
+        display: table-footer-group;
+    }
+
+    .table-row::before,
+    .table-row::after {
+        display: table-row;
+    }
+
+    .table-cell::before,
+    .table-cell::after {
+        display: table-cell;
+    }
+
+    .table-column-group::before,
+    .table-column-group::after {
+        display: table-column-group;
+    }
+
+    .table-column::before,
+    .table-column::after {
+        display: table-column;
+    }
+
+    .table-caption::before,
+    .table-caption::after {
+        display: table-caption;
+    }
+</style>
+<div class="inline single">inline</div>
+<div class="block single">block</div>
+<div class="flex single">flex</div>
+<div class="contents">contents</div>
+<div class="table">table</div>
+<div class="inline-table">inline-table</div>
+<div class="table-row-group">table-row-group</div>
+<div class="table-header-group">table-header-group</div>
+<div class="table-footer-group">table-footer-group</div>
+<div class="table-row">table-row</div>
+<div class="table-cell">table-cell</div>
+<div class="table-column-group">table-column-group</div>
+<div class="table-column">table-column</div>
+<div class="table-caption">table-caption</div>

--- a/Tests/LibWeb/Layout/input/pseudo-element-content-replacement-list-item.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-content-replacement-list-item.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+    div::before,
+    div::after {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' fill='green'/%3E%3C/svg%3E");
+        display: list-item;
+        list-style-position: inside;
+        list-style-type: square;
+    }
+</style>
+<div></div>

--- a/Tests/LibWeb/Layout/input/pseudo-element-content-replacement.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-content-replacement.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<style>
+    .flex-container {
+        display: flex;
+        width: 200px;
+        height: 48px;
+        gap: 8px;
+    }
+
+    .single-image::before,
+    .after-only::after,
+    .ordinary-replacement {
+        width: 32px;
+        min-width: fit-content;
+        max-height: 32px;
+    }
+
+    .single-image::before,
+    .after-only::after,
+    .ordinary-replacement {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'%3E%3Crect width='40' height='40' fill='green'/%3E%3C/svg%3E");
+    }
+
+    .single-image.intrinsic-size::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='0 0 40 40'%3E%3Crect width='40' height='40' fill='green'/%3E%3C/svg%3E");
+    }
+
+    .single-image.with-alt-text::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'%3E%3Crect width='40' height='40' fill='green'/%3E%3C/svg%3E") / "Green square";
+    }
+
+    .mixed-content::before {
+        content: "before" url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='green'/%3E%3C/svg%3E") "after";
+    }
+
+    .multiple-images::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='green'/%3E%3C/svg%3E") url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Crect width='10' height='10' fill='blue'/%3E%3C/svg%3E");
+    }
+</style>
+<body>
+    <button class="flex-container single-image">Ratio-only SVG</button>
+    <button class="flex-container single-image intrinsic-size">Intrinsic-size SVG</button>
+    <button class="flex-container single-image with-alt-text">Alt text</button>
+    <button class="flex-container after-only">After</button>
+    <div class="flex-container"><div class="ordinary-replacement"></div>Ordinary element</div>
+    <div class="mixed-content"></div>
+    <div class="multiple-images"></div>

--- a/Tests/LibWeb/Layout/input/pseudo-element-content-replacement.html
+++ b/Tests/LibWeb/Layout/input/pseudo-element-content-replacement.html
@@ -9,8 +9,10 @@
 
     .single-image::before,
     .after-only::after,
-    .ordinary-replacement {
+    .ordinary-replacement,
+    .direct-image {
         width: 32px;
+        height: fit-content;
         min-width: fit-content;
         max-height: 32px;
     }
@@ -43,5 +45,6 @@
     <button class="flex-container single-image with-alt-text">Alt text</button>
     <button class="flex-container after-only">After</button>
     <div class="flex-container"><div class="ordinary-replacement"></div>Ordinary element</div>
+    <div class="flex-container"><img class="direct-image" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'%3E%3Crect width='40' height='40' fill='green'/%3E%3C/svg%3E">Direct image</div>
     <div class="mixed-content"></div>
     <div class="multiple-images"></div>

--- a/Tests/LibWeb/Layout/input/ratio-only-replaced-image-fit-content.html
+++ b/Tests/LibWeb/Layout/input/ratio-only-replaced-image-fit-content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+    div {
+        display: flex;
+        width: 200px;
+    }
+
+    img {
+        width: 32px;
+        height: fit-content;
+        min-width: fit-content;
+    }
+
+    img.calculated-max-height {
+        max-height: calc(32px);
+    }
+</style>
+<div><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='green'/%3E%3C/svg%3E"></div>
+<div><img class="calculated-max-height" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 2 1'%3E%3Crect width='2' height='1' fill='blue'/%3E%3C/svg%3E"></div>

--- a/Tests/LibWeb/Text/expected/grid/replaced-element-fallback-size-matrix.txt
+++ b/Tests/LibWeb/Text/expected/grid/replaced-element-fallback-size-matrix.txt
@@ -1,0 +1,58 @@
+no intrinsic data: track 300, image 300x150
+cyclic minimum: track 300, image 300x150
+calculated cyclic minimum: track 300, image 300x150
+calculated cyclic minimum below fallback: track 300, image 350x150
+calculated cyclic minimum above fallback: track 400, image 600x150
+fixed minimum: track 400, image 400x150
+calculated minimum: track 400, image 400x150
+fixed maximum: track 100, image 100x150
+calculated maximum: track 100, image 100x150
+fixed preferred: track 100, image 100x150
+calculated preferred: track 100, image 100x150
+conflicting fixed min max: track 200, image 200x150
+cyclic maximum: track 300, image 150x150
+calculated cyclic maximum: track 300, image 170x150
+cyclic preferred: track 300, image 150x150
+calculated cyclic preferred: track 300, image 170x150
+conflicting cyclic min max: track 300, image 150x150
+opposite-axis minimum: track 300, image 300x200
+opposite-axis cyclic minimum: track 300, image 300x150
+border-box cyclic minimum: track 320, image 320x170
+natural width and cyclic minimum: track 120, image 120x150
+natural height and cyclic minimum: track 300, image 300x80
+natural dimensions and cyclic minimum: track 120, image 120x80
+CSS ratio and cyclic minimum: track 0, image 0x0
+auto CSS ratio and cyclic minimum: track 0, image 0x0
+min-content no intrinsic data: track 300, image 300x150
+min-content cyclic preferred: track 0, image 0x150
+min-content calculated cyclic preferred: track 0, image 20x150
+min-content cyclic maximum: track 0, image 0x150
+min-content calculated cyclic maximum: track 0, image 20x150
+min-content cyclic minimum: track 300, image 300x150
+min-content calculated cyclic minimum: track 300, image 300x150
+min-content calculated minimum above fallback: track 400, image 600x150
+min-content fixed minimum: track 400, image 400x150
+min-content fixed maximum: track 100, image 100x150
+min-content fixed preferred: track 100, image 100x150
+min-content conflicting fixed min max: track 200, image 200x150
+min-content natural width cyclic minimum: track 120, image 120x150
+min-content natural width calculated minimum: track 200, image 300x150
+min-content natural width calculated preferred: track 0, image 20x150
+min-content CSS ratio: track 0, image 0x0
+min-content CSS ratio cyclic preferred: track 0, image 0x0
+block no intrinsic data: track 150, image 300x150
+block cyclic minimum: track 150, image 300x150
+block calculated cyclic minimum: track 150, image 300x150
+block calculated minimum above fallback: track 200, image 300x300
+block fixed minimum: track 200, image 300x200
+block fixed maximum: track 100, image 300x100
+block calculated maximum: track 100, image 300x100
+block cyclic maximum: track 150, image 300x75
+block calculated cyclic maximum: track 150, image 300x95
+block cyclic preferred: track 150, image 300x75
+block calculated cyclic preferred: track 150, image 300x95
+block border-box cyclic minimum: track 170, image 320x170
+block border-box ratio from width: track 50, image 100x50
+block natural width: track 150, image 120x150
+block natural height: track 80, image 300x80
+block natural dimensions: track 80, image 120x80

--- a/Tests/LibWeb/Text/input/grid/replaced-element-fallback-size-matrix.html
+++ b/Tests/LibWeb/Text/input/grid/replaced-element-fallback-size-matrix.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    .case {
+        display: grid;
+        grid-template-columns: max-content;
+        width: max-content;
+    }
+
+    .min-content-case {
+        grid-template-columns: min-content;
+        width: min-content;
+    }
+
+    .row-case {
+        display: grid;
+        grid-template-columns: 100px;
+        grid-template-rows: max-content;
+        height: max-content;
+        width: 100px;
+    }
+
+    .cyclic-minimum {
+        min-width: 50%;
+    }
+
+    .cyclic-calculated-minimum {
+        min-width: calc(20px + 50%);
+    }
+
+    .cyclic-calculated-minimum-below-fallback {
+        min-width: calc(200px + 50%);
+    }
+
+    .cyclic-calculated-minimum-above-fallback {
+        min-width: calc(400px + 50%);
+    }
+
+    .fixed-minimum {
+        min-width: 400px;
+    }
+
+    .calculated-minimum {
+        min-width: calc(400px);
+    }
+
+    .fixed-maximum {
+        max-width: 100px;
+    }
+
+    .calculated-maximum {
+        max-width: calc(100px);
+    }
+
+    .fixed-preferred {
+        width: 100px;
+    }
+
+    .calculated-preferred {
+        width: calc(100px);
+    }
+
+    .conflicting-fixed-min-max {
+        min-width: 200px;
+        max-width: 100px;
+    }
+
+    .cyclic-maximum {
+        max-width: 50%;
+    }
+
+    .cyclic-calculated-maximum {
+        max-width: calc(20px + 50%);
+    }
+
+    .cyclic-preferred {
+        width: 50%;
+    }
+
+    .cyclic-calculated-preferred {
+        width: calc(20px + 50%);
+    }
+
+    .conflicting-cyclic-min-max {
+        min-width: 50%;
+        max-width: 25%;
+    }
+
+    .opposite-axis-minimum {
+        min-height: 200px;
+    }
+
+    .opposite-axis-cyclic-minimum {
+        min-height: 50%;
+    }
+
+    .border-box-cyclic-minimum {
+        box-sizing: border-box;
+        border: 10px solid;
+        min-width: 50%;
+    }
+
+    .css-ratio-cyclic-minimum {
+        aspect-ratio: 2 / 1;
+        min-width: 50%;
+    }
+
+    .css-ratio {
+        aspect-ratio: 2 / 1;
+    }
+
+    .css-auto-ratio-cyclic-minimum {
+        aspect-ratio: auto 2 / 1;
+        min-width: 50%;
+    }
+
+    .cyclic-block-minimum {
+        min-height: 50%;
+    }
+
+    .cyclic-calculated-block-minimum {
+        min-height: calc(20px + 50%);
+    }
+
+    .cyclic-calculated-block-minimum-above-fallback {
+        min-height: calc(200px + 50%);
+    }
+
+    .fixed-block-minimum {
+        min-height: 200px;
+    }
+
+    .fixed-block-maximum {
+        max-height: 100px;
+    }
+
+    .calculated-block-maximum {
+        max-height: calc(100px);
+    }
+
+    .cyclic-block-maximum {
+        max-height: 50%;
+    }
+
+    .cyclic-calculated-block-maximum {
+        max-height: calc(20px + 50%);
+    }
+
+    .cyclic-block-preferred {
+        height: 50%;
+    }
+
+    .cyclic-calculated-block-preferred {
+        height: calc(20px + 50%);
+    }
+
+    .border-box-cyclic-block-minimum {
+        box-sizing: border-box;
+        border: 10px solid;
+        min-height: 50%;
+    }
+
+    .border-box-ratio-from-width {
+        align-self: start;
+        aspect-ratio: 2 / 1;
+        box-sizing: border-box;
+        border: 10px solid;
+        width: 100px;
+    }
+</style>
+<div class="case" data-label="no intrinsic data"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="cyclic minimum"><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated cyclic minimum"><img class="cyclic-calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated cyclic minimum below fallback"><img class="cyclic-calculated-minimum-below-fallback" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated cyclic minimum above fallback"><img class="cyclic-calculated-minimum-above-fallback" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="fixed minimum"><img class="fixed-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated minimum"><img class="calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="fixed maximum"><img class="fixed-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated maximum"><img class="calculated-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="fixed preferred"><img class="fixed-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated preferred"><img class="calculated-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="conflicting fixed min max"><img class="conflicting-fixed-min-max" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="cyclic maximum"><img class="cyclic-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated cyclic maximum"><img class="cyclic-calculated-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="cyclic preferred"><img class="cyclic-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="calculated cyclic preferred"><img class="cyclic-calculated-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="conflicting cyclic min max"><img class="conflicting-cyclic-min-max" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="opposite-axis minimum"><img class="opposite-axis-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="opposite-axis cyclic minimum"><img class="opposite-axis-cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="border-box cyclic minimum"><img class="border-box-cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="natural width and cyclic minimum"><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120'%3E%3C/svg%3E"></div>
+<div class="case" data-label="natural height and cyclic minimum"><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='80'%3E%3C/svg%3E"></div>
+<div class="case" data-label="natural dimensions and cyclic minimum"><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='80'%3E%3C/svg%3E"></div>
+<div class="case" data-label="CSS ratio and cyclic minimum"><img class="css-ratio-cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case" data-label="auto CSS ratio and cyclic minimum"><img class="css-auto-ratio-cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content no intrinsic data"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content cyclic preferred"><img class="cyclic-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content calculated cyclic preferred"><img class="cyclic-calculated-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content cyclic maximum"><img class="cyclic-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content calculated cyclic maximum"><img class="cyclic-calculated-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content cyclic minimum"><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content calculated cyclic minimum"><img class="cyclic-calculated-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content calculated minimum above fallback"><img class="cyclic-calculated-minimum-above-fallback" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content fixed minimum"><img class="fixed-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content fixed maximum"><img class="fixed-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content fixed preferred"><img class="fixed-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content conflicting fixed min max"><img class="conflicting-fixed-min-max" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content natural width cyclic minimum"><img class="cyclic-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content natural width calculated minimum"><img class="cyclic-calculated-minimum-below-fallback" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content natural width calculated preferred"><img class="cyclic-calculated-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content CSS ratio"><img class="css-ratio" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="case min-content-case" data-label="min-content CSS ratio cyclic preferred"><img class="css-ratio cyclic-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block no intrinsic data"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block cyclic minimum"><img class="cyclic-block-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block calculated cyclic minimum"><img class="cyclic-calculated-block-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block calculated minimum above fallback"><img class="cyclic-calculated-block-minimum-above-fallback" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block fixed minimum"><img class="fixed-block-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block fixed maximum"><img class="fixed-block-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block calculated maximum"><img class="calculated-block-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block cyclic maximum"><img class="cyclic-block-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block calculated cyclic maximum"><img class="cyclic-calculated-block-maximum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block cyclic preferred"><img class="cyclic-block-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block calculated cyclic preferred"><img class="cyclic-calculated-block-preferred" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block border-box cyclic minimum"><img class="border-box-cyclic-block-minimum" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block border-box ratio from width"><img class="border-box-ratio-from-width" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block natural width"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block natural height"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='80'%3E%3C/svg%3E"></div>
+<div class="row-case" data-label="block natural dimensions"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='80'%3E%3C/svg%3E"></div>
+<script>
+    asyncTest(async done => {
+        await Promise.all(Array.from(document.images, image => image.decode()));
+        for (const container of document.querySelectorAll(".case, .row-case")) {
+            const image = container.firstElementChild;
+            const containerRect = container.getBoundingClientRect();
+            const imageRect = image.getBoundingClientRect();
+            const trackSize = container.classList.contains("row-case") ? containerRect.height : containerRect.width;
+            println(`${container.dataset.label}: track ${trackSize}, image ${imageRect.width}x${imageRect.height}`);
+        }
+        done();
+    });
+</script>


### PR DESCRIPTION
Treat a single image in generated content as the pseudo-element’s replacement content, including display normalization and intrinsic sizing. Preserve interoperable behavior for `display: contents` and list-item pseudo-elements.

Honor preferred aspect ratios when sizing replaced boxes without natural dimensions. Transfer definite preferred, minimum, and maximum constraints through the ratio, apply cyclic percentage rules, and resolve grid percentage constraints against the final grid area.

Also resolve percentage cross-axis minimums for stretched flex items once the flex line has a definite cross size.

Add coverage for generated images, ratio sources, constraint transfers, fallback sizing, box sizing, grid placement, and stretched flex items.

Visual progression on the https://skatteverket.se/ login page!

Before:

<img width="1234" height="864" alt="Screenshot 2026-07-17 at 17 49 35" src="https://github.com/user-attachments/assets/fd212296-b58d-4fa1-8c74-23d55efd4422" />

After:

<img width="1458" height="956" alt="Screenshot 2026-07-17 at 17 49 49" src="https://github.com/user-attachments/assets/7d084fce-d887-496f-b2ff-9674e8aedca4" />
