### PR TITLE
AK+Meta: Update simdutf to 9.0.0

### DIFF
--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -56,7 +56,7 @@
         {
           "type": "git",
           "url": "https://github.com/simdutf/simdutf.git",
-          "tag": "v7.4.0"
+          "tag": "v9.0.0"
         }
       ],
       "config-opts": [

--- a/Meta/CMake/vcpkg/overlay-ports/simdutf/portfile.cmake
+++ b/Meta/CMake/vcpkg/overlay-ports/simdutf/portfile.cmake
@@ -1,0 +1,30 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO simdutf/simdutf
+    REF "v${VERSION}"
+    SHA512 0c74226247cbe95368efa87ab84f5217485f16bcdf7a9def8741c6086cb86e6c378f0c437030d2be0934726e3ea9c28b5df2e593d0c654c78291c455a8d1e103
+    HEAD_REF master
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+    "tools" SIMDUTF_TOOLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS ${FEATURE_OPTIONS}
+        -DSIMDUTF_TESTS=OFF
+        -DSIMDUTF_BENCHMARKS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+vcpkg_fixup_pkgconfig()
+if ("tools" IN_LIST FEATURES)
+    vcpkg_copy_tools(TOOL_NAMES fastbase64 sutf AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE-APACHE")

--- a/Meta/CMake/vcpkg/overlay-ports/simdutf/vcpkg.json
+++ b/Meta/CMake/vcpkg/overlay-ports/simdutf/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "simdutf",
+  "version-semver": "9.0.0",
+  "description": "Unicode validation and transcoding at billions of characters per second",
+  "homepage": "https://github.com/simdutf/simdutf",
+  "license": "Apache-2.0 OR MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tools": {
+      "description": "Build the fastbase64 and simdutf command line tools for transcoding strings"
+    }
+  }
+}

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/Array.h>
 #include <AK/ByteString.h>
 #include <AK/Vector.h>
 
@@ -157,6 +158,24 @@ TEST_CASE(find)
     EXPECT_EQ(test_string_view.find('b'), 2U);
     EXPECT_EQ(test_string_view.find('_'), 6U);
     EXPECT_EQ(test_string_view.find('n').has_value(), false);
+}
+
+TEST_CASE(find_nul_at_any_alignment)
+{
+    // The AVX-512 implementation of simdutf versions before 9.0.0 reported false positives
+    // for a NUL needle when the searched range straddled a 64-byte boundary.
+    alignas(64) Array<char, 192> buffer;
+    buffer.fill('A');
+
+    for (size_t start_offset = 0; start_offset < 64; ++start_offset) {
+        StringView view { buffer.data() + start_offset, 6 };
+        EXPECT(!view.find('\0').has_value());
+        EXPECT(!view.contains('\0'));
+    }
+
+    buffer[65] = '\0';
+    StringView view { buffer.data() + 62, 6 };
+    EXPECT_EQ(view.find('\0'), 3U);
 }
 
 TEST_CASE(find_last)

--- a/Tests/AK/TestUtf16View.cpp
+++ b/Tests/AK/TestUtf16View.cpp
@@ -854,6 +854,29 @@ TEST_CASE(find_code_unit_offset)
     EXPECT(!view.find_code_unit_offset(u"baz"sv).has_value());
 }
 
+TEST_CASE(find_code_unit_offset_nul_at_any_alignment)
+{
+    // The AVX-512 implementation of simdutf versions before 9.0.0 reported false positives
+    // for a NUL needle when the searched range straddled a 64-byte boundary.
+    alignas(64) Array<char, 96> ascii_buffer;
+    ascii_buffer.fill('A');
+
+    for (size_t start_offset = 0; start_offset < 64; ++start_offset) {
+        Utf16View view { StringView { ascii_buffer.data() + start_offset, 6 } };
+        EXPECT(!view.find_code_unit_offset(u'\0').has_value());
+        EXPECT(!view.contains(u'\0'));
+    }
+
+    alignas(64) Array<char16_t, 96> utf16_buffer;
+    utf16_buffer.fill(u'A');
+
+    for (size_t start_offset = 0; start_offset < 32; ++start_offset) {
+        Utf16View view { utf16_buffer.data() + start_offset, 6 };
+        EXPECT(!view.find_code_unit_offset(u'\0').has_value());
+        EXPECT(!view.contains(u'\0'));
+    }
+}
+
 TEST_CASE(find_code_unit_offset_ignoring_case)
 {
     auto conversion_result = Utf16String::from_utf8("😀Foo😀Bar"sv);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -385,7 +385,7 @@
     },
     {
       "name": "simdutf",
-      "version": "7.4.0#0"
+      "version": "9.0.0#0"
     },
     {
       "name": "skia",


### PR DESCRIPTION
simdutf versions before 9.0.0 return false positives when searching for a NUL character in a range that straddles a 64-byte boundary. The AVX-512 kernel loads the head of the range with a masked load that zero-fills the lanes past the end of the range, but compares all 64 lanes against the needle, so every zero-filled lane matches a NUL needle. This made `trim_ascii_whitespace()` strip trailing NUL characters, which allowed script elements whose type attribute ends in a NUL character to execute.

Version 9.0.0 is the first release that contains the fix. The newest simdutf version known to the pinned vcpkg baseline is 8.2.0, so an overlay port is required.