### PR TITLE
UI/Qt: Shrink navigation toolbar buttons

### DIFF
--- a/UI/Qt/ChromeStyle.cpp
+++ b/UI/Qt/ChromeStyle.cpp
@@ -348,10 +348,10 @@ QWidget#LadybirdNavigationToolbar QToolButton {{
     color: {5};
     background: transparent;
     border: 1px solid transparent;
-    border-radius: 17px;
-    min-width: 34px;
-    min-height: 34px;
-    margin: 1px 0;
+    border-radius: 16px;
+    min-width: 32px;
+    min-height: 32px;
+    margin: 0 0 2px 0;
     padding: 0;
 }}
 
@@ -374,6 +374,10 @@ QWidget#LadybirdNavigationToolbar QToolButton:disabled {{
 
 QWidget#LadybirdNavigationToolbar QToolButton::menu-indicator {{
     image: none;
+}}
+
+QWidget#LadybirdNavigationToolbar QToolButton#LadybirdHamburgerButton {{
+    margin: 1px 0;
 }}
 
 QPushButton#LadybirdPrivateBadge {{

--- a/UI/Qt/Icon.cpp
+++ b/UI/Qt/Icon.cpp
@@ -263,9 +263,9 @@ static QPixmap create_chrome_icon_pixmap(ChromeIcon icon, QColor color, qreal de
         break;
     case ChromeIcon::Menu:
         painter.setPen(chrome_icon_pen(color, 1.55));
-        painter.drawLine(QPointF(4.1, 6.2), QPointF(15.9, 6.2));
-        painter.drawLine(QPointF(4.1, 10.0), QPointF(15.9, 10.0));
-        painter.drawLine(QPointF(4.1, 13.8), QPointF(15.9, 13.8));
+        painter.drawLine(QPointF(4.1, 5.7), QPointF(15.9, 5.7));
+        painter.drawLine(QPointF(4.1, 9.5), QPointF(15.9, 9.5));
+        painter.drawLine(QPointF(4.1, 13.3), QPointF(15.9, 13.3));
         break;
     case ChromeIcon::Star:
         draw_star_icon(painter, color, false);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -156,6 +156,8 @@ private:
     QIcon m_progress_icon;
 };
 
+static constexpr int TOOLBAR_BUTTON_SIZE = 34;
+
 static QToolButton* create_toolbar_button(QWidget& parent, QAction& action)
 {
     auto* button = new QToolButton(&parent);
@@ -163,7 +165,7 @@ static QToolButton* create_toolbar_button(QWidget& parent, QAction& action)
     button->setAutoRaise(true);
     button->setFocusPolicy(Qt::NoFocus);
     button->setIconSize({ 20, 20 });
-    button->setFixedSize(36, 36);
+    button->setFixedSize(TOOLBAR_BUTTON_SIZE, TOOLBAR_BUTTON_SIZE);
 
     // FIXME: In Menu.cpp, we set the initial visibility of the action before we've associated it with this QToolButton.
     //        It would be nicer if we didn't have to do this here.
@@ -599,7 +601,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_downloads_button->setAutoRaise(true);
     m_downloads_button->setFocusPolicy(Qt::NoFocus);
     m_downloads_button->setIconSize({ 20, 20 });
-    m_downloads_button->setFixedSize(36, 36);
+    m_downloads_button->setFixedSize(TOOLBAR_BUTTON_SIZE, TOOLBAR_BUTTON_SIZE);
     m_downloads_button->setVisible(m_open_downloads_page_action->isVisible());
     QObject::connect(m_downloads_button, &QToolButton::clicked, this, [this] {
         show_downloads_popover();
@@ -617,11 +619,12 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     });
 
     m_hamburger_button = new HamburgerButton(m_toolbar);
+    m_hamburger_button->setObjectName("LadybirdHamburgerButton");
     m_hamburger_button->setText("Show &Menu");
     m_hamburger_button->setToolTip("Show Menu");
     m_hamburger_button->setIcon(create_chrome_icon(ChromeIcon::Menu, palette()));
     m_hamburger_button->setIconSize({ 20, 20 });
-    m_hamburger_button->setFixedSize(36, 36);
+    m_hamburger_button->setFixedSize(TOOLBAR_BUTTON_SIZE, TOOLBAR_BUTTON_SIZE);
     m_hamburger_button->setAutoRaise(true);
     m_hamburger_button->setFocusPolicy(Qt::NoFocus);
     m_hamburger_button->setPopupMode(QToolButton::InstantPopup);


### PR DESCRIPTION
Reduce toolbar button height alongside the recently tightened browser chrome. Keep all standard toolbar controls aligned by applying the same size to navigation, sidebar, downloads, and menu buttons. Adjust the styled bounds and menu glyph position to preserve visual centering.