### PR TITLE
LibUnicode: Gate Rust IDNA bindings behind a feature

### DIFF
--- a/Libraries/LibURL/Rust/Cargo.toml
+++ b/Libraries/LibURL/Rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["staticlib"]
 [dependencies]
 encoding_rs = "0.8.35"
 libregex_rust = { path = "../../LibRegex/Rust" }
-libunicode_rust = { path = "../../LibUnicode/Rust" }
+libunicode_rust = { path = "../../LibUnicode/Rust", features = ["idna"] }
 
 [features]
 default = []

--- a/Libraries/LibUnicode/Rust/Cargo.toml
+++ b/Libraries/LibUnicode/Rust/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 default = []
 allocator = []
+idna = []
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/Libraries/LibUnicode/Rust/src/lib.rs
+++ b/Libraries/LibUnicode/Rust/src/lib.rs
@@ -10,4 +10,5 @@ mod rust_allocator;
 
 pub mod calendar;
 pub mod character_types;
+#[cfg(feature = "idna")]
 pub mod idna;


### PR DESCRIPTION
Distribution builds use static libraries, and release Rust codegen can place IDNA bindings in the same object as used character type functions. This leaves JS and Regex archives with a callback reference that cannot be resolved from LibUnicode due to static archive ordering.

Make IDNA opt-in and enable it only for LibURL, its sole consumer. This keeps the callback out of unrelated Rust archives while retaining URL IDNA support.