### PR TITLE
LibWebView: Learn exact omnibox navigation after one choice

### DIFF
--- a/Documentation/Omnibox.md
+++ b/Documentation/Omnibox.md
@@ -86,7 +86,7 @@ Match classes, from strongest to weakest, include:
 
 - Exact URL.
 - URL prefix.
-- Exact bookmark title.
+- Exact history or bookmark title.
 - Title word prefix.
 - URL substring.
 - Title substring.
@@ -94,6 +94,10 @@ Match classes, from strongest to weakest, include:
 
 Title matching uses Unicode case folding. URL completion uses ASCII case-insensitive comparison
 because serialized non-ASCII URL components are already encoded.
+
+History titles participate after three input code points. Exact history titles outrank title-prefix
+matches, allowing a page named `Wikimedia Commons` to rank ahead of pages whose titles merely end
+in `Wikimedia Commons`. They remain ineligible for automatic selection and inline completion.
 
 Bookmark titles and folders normally participate after three input code points. An exact bookmark
 title participates at any non-empty length, so a bookmark named `GH` is retrieved by `GH`, `gh`, or
@@ -140,7 +144,10 @@ explicit use before they can become automatic:
 
 - A one-character deep destination requires three explicit uses.
 - A two-character deep destination requires two explicit uses.
-- Search-like adaptive URL inputs require two explicit uses.
+
+An exact input-to-URL association of at least two characters becomes automatic after one explicit
+choice, including search-like input containing whitespace. This allows the omnibox to learn a
+deliberate navigation without allowing passive title matches to replace the search action.
 
 Adaptive scores decay with time. Prefix evidence is scaled by the square root of the typed-prefix
 length divided by the learned-input length, so very short prefixes receive less credit.

--- a/Libraries/LibWebView/AutocompleteRanker.cpp
+++ b/Libraries/LibWebView/AutocompleteRanker.cpp
@@ -240,6 +240,8 @@ Vector<AutocompleteSuggestion> rank_history_suggestions(StringView query, Vector
             folded_query,
             folded_url,
             folded_title.map([](auto const& title) { return title.bytes_as_string_view(); }));
+        if (folded_title == folded_query && match_relevance(AutocompleteMatchClass::ExactTitle) > match_relevance(match_class))
+            match_class = AutocompleteMatchClass::ExactTitle;
         if (match_class == AutocompleteMatchClass::None)
             continue;
 
@@ -402,11 +404,6 @@ Vector<AutocompleteSuggestion> rank_bookmark_suggestions(StringView query, Vecto
     return suggestions;
 }
 
-static bool query_contains_whitespace(StringView query)
-{
-    return any_of(query, [](auto code_unit) { return is_ascii_space(code_unit); });
-}
-
 Vector<AutocompleteSuggestion> rank_engagement_suggestions(StringView query, Vector<StoredOmniboxEngagement> engagements, size_t limit, UnixDateTime now)
 {
     if (query.is_empty())
@@ -466,8 +463,7 @@ Vector<AutocompleteSuggestion> rank_engagement_suggestions(StringView query, Vec
                 && !exact_association && !short_deep_prefix_has_evidence)
                 adjusted_match_relevance -= 200;
             auto syntactic_url_prefix = autocomplete_url_can_complete(query, engagement.destination);
-            auto explicit_threshold = query_length == 1 ? 3u : query_contains_whitespace(query) ? 2u
-                                                                                                : 1u;
+            auto explicit_threshold = query_length == 1 ? 3u : 1u;
             if (exact_association) {
                 can_be_automatically_selected = engagement.explicit_use_count >= explicit_threshold
                     || (query_length >= 2 && weighted_uses >= 3.0);

--- a/Libraries/LibWebView/AutocompleteRanker.cpp
+++ b/Libraries/LibWebView/AutocompleteRanker.cpp
@@ -236,11 +236,15 @@ Vector<AutocompleteSuggestion> rank_history_suggestions(StringView query, Vector
         if (entry.title.has_value())
             folded_title = MUST(entry.title->to_casefold());
 
+        Optional<StringView> folded_title_for_matching;
+        if (query_length >= 3 && folded_title.has_value())
+            folded_title_for_matching = folded_title->bytes_as_string_view();
+
         auto match_class = classify_match(
             folded_query,
             folded_url,
-            folded_title.map([](auto const& title) { return title.bytes_as_string_view(); }));
-        if (folded_title == folded_query && match_relevance(AutocompleteMatchClass::ExactTitle) > match_relevance(match_class))
+            folded_title_for_matching);
+        if (query_length >= 3 && folded_title == folded_query && match_relevance(AutocompleteMatchClass::ExactTitle) > match_relevance(match_class))
             match_class = AutocompleteMatchClass::ExactTitle;
         if (match_class == AutocompleteMatchClass::None)
             continue;

--- a/Tests/LibWebView/TestAutocompleteRanker.cpp
+++ b/Tests/LibWebView/TestAutocompleteRanker.cpp
@@ -84,6 +84,19 @@ TEST_CASE(title_match_never_becomes_default_or_completion)
     EXPECT(!suggestions[0].can_be_inline_completed);
 }
 
+TEST_CASE(history_title_matches_require_three_characters)
+{
+    auto one_character_suggestions = rank("w"sv, {
+                                                     entry("https://example.com/"sv, "Wikimedia Commons"sv, 2),
+                                                 });
+    auto two_character_suggestions = rank("GH"sv, {
+                                                      entry("https://example.com/"sv, "GH"sv, 2),
+                                                  });
+
+    EXPECT(one_character_suggestions.is_empty());
+    EXPECT(two_character_suggestions.is_empty());
+}
+
 TEST_CASE(exact_history_title_outranks_title_suffix)
 {
     auto suggestions = rank("Wikimedia Commons"sv, {

--- a/Tests/LibWebView/TestAutocompleteRanker.cpp
+++ b/Tests/LibWebView/TestAutocompleteRanker.cpp
@@ -84,6 +84,21 @@ TEST_CASE(title_match_never_becomes_default_or_completion)
     EXPECT(!suggestions[0].can_be_inline_completed);
 }
 
+TEST_CASE(exact_history_title_outranks_title_suffix)
+{
+    auto suggestions = rank("Wikimedia Commons"sv, {
+                                                       entry("https://commons.wikimedia.org/wiki/Category:Electricity"sv, "Category:Electricity - Wikimedia Commons"sv, 100),
+                                                       entry("https://commons.wikimedia.org/wiki/Main_Page"sv, "Wikimedia Commons"sv, 1),
+                                                   });
+
+    EXPECT_EQ(suggestions.size(), 2u);
+    EXPECT_EQ(suggestions[0].text, "https://commons.wikimedia.org/wiki/Main_Page"sv);
+    EXPECT_EQ(suggestions[0].match_class, WebView::AutocompleteMatchClass::ExactTitle);
+    EXPECT(!suggestions[0].can_be_automatically_selected);
+    EXPECT(!suggestions[0].can_be_inline_completed);
+    EXPECT_EQ(suggestions[1].match_class, WebView::AutocompleteMatchClass::TitlePrefix);
+}
+
 TEST_CASE(passive_visit_frequency_does_not_become_navigation_intent)
 {
     auto suggestions = rank("example"sv, {
@@ -346,22 +361,16 @@ TEST_CASE(short_adaptive_prefixes_require_explicit_evidence)
     EXPECT(strong_suggestions[0].can_be_inline_completed);
 }
 
-TEST_CASE(search_like_adaptive_url_requires_two_explicit_uses)
+TEST_CASE(exact_search_like_adaptive_url_requires_one_explicit_use)
 {
-    auto weak = WebView::rank_engagement_suggestions("lady docs"sv, {
-                                                                        engagement("lady docs"sv, WebView::OmniboxDestinationKind::URL, "https://ladybird.org/docs/"sv, 1),
-                                                                    },
-        8, UnixDateTime::from_seconds_since_epoch(now_seconds));
-    auto strong = WebView::rank_engagement_suggestions("lady docs"sv, {
-                                                                          engagement("lady docs"sv, WebView::OmniboxDestinationKind::URL, "https://ladybird.org/docs/"sv, 2),
-                                                                      },
+    auto suggestions = WebView::rank_engagement_suggestions("lady docs"sv, {
+                                                                               engagement("lady docs"sv, WebView::OmniboxDestinationKind::URL, "https://ladybird.org/docs/"sv, 1),
+                                                                           },
         8, UnixDateTime::from_seconds_since_epoch(now_seconds));
 
-    EXPECT_EQ(weak.size(), 1u);
-    EXPECT(!weak[0].can_be_automatically_selected);
-    EXPECT_EQ(strong.size(), 1u);
-    EXPECT(strong[0].can_be_automatically_selected);
-    EXPECT(!strong[0].can_be_inline_completed);
+    EXPECT_EQ(suggestions.size(), 1u);
+    EXPECT(suggestions[0].can_be_automatically_selected);
+    EXPECT(!suggestions[0].can_be_inline_completed);
 }
 
 TEST_CASE(previous_searches_never_become_automatic_completions)


### PR DESCRIPTION
Treat exact history titles as stronger evidence than generic title prefixes. Keep title-only results ineligible for automatic selection.

Allow exact input-to-URL associations with at least two characters to become the default after one explicit choice.  This includes input containing whitespace. Keep stricter thresholds for one-character and non-exact prefixes. Add ranker coverage and document the behavior.