### PR TITLE
LibJS: Outline cold AsmInt interpreter paths

### DIFF
--- a/Libraries/LibJS/AsmIntGen/src/allocator.rs
+++ b/Libraries/LibJS/AsmIntGen/src/allocator.rs
@@ -188,6 +188,10 @@ fn uniquify_macro_locals(body: &[AsmInstruction], suffix: u32) -> Vec<AsmInstruc
                     temps_declared.insert(name.clone());
                 }
             }
+        } else if insn.mnemonic == "cold" {
+            // Temperature metadata does not make a label macro-local. The
+            // annotated block may be referenced by the invoking handler or
+            // another macro expanded beside this one.
         } else {
             for op in &insn.operands {
                 if let Operand::Label(name) = op {

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -499,11 +499,6 @@ fn generate_handler(
     program: &Program,
     pinned: &PinnedConstants,
 ) -> String {
-    emit_handler_alignment(out, program.object_format);
-    w!(out, "asm_handler_{}:", handler.name);
-    // x21 = pb + pc is set by the dispatch sequence that branches here.
-    // It is callee-saved, so it survives C++ calls within the handler.
-
     let mut state = HandlerState::new();
 
     let mut counter = state.unique_counter;
@@ -515,6 +510,26 @@ fn generate_handler(
             )
         });
     state.unique_counter = counter;
+
+    if handler.is_cold {
+        assert!(
+            matches!(instructions.as_slice(), [instruction] if instruction.mnemonic == "call_slow_path"),
+            "cold handler '{}' must consist solely of call_slow_path",
+            handler.name
+        );
+        let mut cold = String::new();
+        emit_handler_alignment(&mut cold, program.object_format);
+        w!(cold, "asm_handler_{}:", handler.name);
+        emit_instruction(&mut cold, &instructions[0], handler, program, &mut state, pinned);
+        cold.push_str(&state.cold_blocks);
+        w!(cold);
+        return cold;
+    }
+
+    emit_handler_alignment(out, program.object_format);
+    w!(out, "asm_handler_{}:", handler.name);
+    // x21 = pb + pc is set by the dispatch sequence that branches here.
+    // It is callee-saved, so it survives C++ calls within the handler.
 
     let (hot_instructions, cold_instructions) = outline_cold_blocks(&instructions)
         .unwrap_or_else(|error| panic!("invalid cold block in handler '{}': {error}", handler.name));
@@ -2978,6 +2993,7 @@ mod tests {
             handlers: vec![Handler {
                 name: "Call".into(),
                 size: Some(1),
+                is_cold: false,
                 instructions,
             }],
             op_layouts: HashMap::from([(
@@ -3026,5 +3042,18 @@ mod tests {
         assert!(output.contains("    blr x9"));
         assert!(output.contains("    ldr x1, [sp, #120]"));
         assert!(output.contains("    ldr x0, [sp, #112]"));
+    }
+
+    #[test]
+    fn emits_cold_handler_after_hot_region() {
+        let mut program = coff_program(vec![AsmInstruction {
+            mnemonic: "call_slow_path".into(),
+            operands: vec![Operand::Register("slow_path".into())],
+        }]);
+        program.handlers[0].is_cold = true;
+
+        let output = generate(&program);
+
+        assert!(output.find("asm_cold_handler_paths:").unwrap() < output.find("asm_handler_Call:").unwrap());
     }
 }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_aarch64.rs
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::allocator::{flatten_and_allocate, handler_uses_named_temps};
+use crate::allocator::flatten_and_allocate;
 use crate::parser::{AsmInstruction, Handler, ObjectFormat, Operand, Program};
 use crate::registers::{Arch, resolve_register};
 use crate::shared::{
     AdjacentMemoryPair, HandlerState, get_immediate_value, resolve_adjacent_memory_pair,
-    resolve_field_ref, resolve_label, substitute_macro, uniquify_macro_labels, w,
+    outline_cold_blocks, resolve_field_ref, resolve_label, substitute_macro, uniquify_macro_labels, w,
 };
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -149,9 +149,16 @@ pub fn generate(program: &Program) -> String {
     // Generate fallback handler
     generate_fallback_handler(&mut out, program, &pinned);
 
-    // Generate each handler
+    // Generate the hot blocks of each handler first, keeping the interpreter's
+    // working set dense. Explicitly cold blocks are emitted afterwards.
+    let mut cold_handlers = String::new();
     for handler in &program.handlers {
-        generate_handler(&mut out, handler, program, &pinned);
+        cold_handlers.push_str(&generate_handler(&mut out, handler, program, &pinned));
+    }
+    if !cold_handlers.is_empty() {
+        w!(out, "// Cold handler paths");
+        w!(out, "asm_cold_handler_paths:");
+        out.push_str(&cold_handlers);
     }
 
     generate_exit_point(&mut out, program.object_format);
@@ -491,7 +498,7 @@ fn generate_handler(
     handler: &Handler,
     program: &Program,
     pinned: &PinnedConstants,
-) {
+) -> String {
     emit_handler_alignment(out, program.object_format);
     w!(out, "asm_handler_{}:", handler.name);
     // x21 = pb + pc is set by the dispatch sequence that branches here.
@@ -499,35 +506,34 @@ fn generate_handler(
 
     let mut state = HandlerState::new();
 
-    if handler_uses_named_temps(handler, program) {
-        // The allocator pre-expands macros and rewrites named temps to
-        // physical registers. The shared unique_counter continues from
-        // the value the allocator left it at, so canonicalize_nan fixup
-        // labels emitted later don't collide with macro-id labels.
-        let mut counter = state.unique_counter;
-        let flat = flatten_and_allocate(handler, program, Arch::Aarch64, &mut counter)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "register allocation failed for handler '{}': {}",
-                    err.handler, err.message
-                )
-            });
-        state.unique_counter = counter;
-        for insn in &flat {
-            emit_instruction(out, insn, handler, program, &mut state, pinned);
-        }
-    } else {
-        for insn in &handler.instructions {
-            emit_instruction(out, insn, handler, program, &mut state, pinned);
-        }
-    }
+    let mut counter = state.unique_counter;
+    let instructions = flatten_and_allocate(handler, program, Arch::Aarch64, &mut counter)
+        .unwrap_or_else(|err| {
+            panic!(
+                "register allocation failed for handler '{}': {}",
+                err.handler, err.message
+            )
+        });
+    state.unique_counter = counter;
 
-    // Emit cold fixup blocks after the main handler body
-    if !state.cold_blocks.is_empty() {
-        out.push_str(&state.cold_blocks);
-    }
+    let (hot_instructions, cold_instructions) = outline_cold_blocks(&instructions)
+        .unwrap_or_else(|error| panic!("invalid cold block in handler '{}': {error}", handler.name));
 
+    for instruction in &hot_instructions {
+        emit_instruction(out, instruction, handler, program, &mut state, pinned);
+    }
     w!(out);
+
+    let mut cold = String::new();
+    if !cold_instructions.is_empty() {
+        w!(cold, "// Cold paths for {}", handler.name);
+        for instruction in &cold_instructions {
+            emit_instruction(&mut cold, instruction, handler, program, &mut state, pinned);
+        }
+    }
+    cold.push_str(&state.cold_blocks);
+
+    cold
 }
 
 fn resolve_op(op: &Operand, handler: &Handler, program: &Program) -> String {
@@ -2964,6 +2970,7 @@ mod tests {
                 ("BOOLEAN_TAG".into(), 0xfffbu64 as i64),
                 ("NAN_BASE_TAG".into(), 0xfff8u64 as i64),
                 ("EXECUTION_CONTEXT_EXECUTABLE".into(), 16),
+                ("EXECUTION_CONTEXT_PROGRAM_COUNTER".into(), 20),
                 ("EXECUTABLE_BYTECODE_DATA".into(), 24),
                 ("SIZEOF_EXECUTION_CONTEXT".into(), 32),
             ]),

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -435,9 +435,6 @@ fn handler_size(handler: &Handler, program: &Program) -> u32 {
 }
 
 fn generate_handler(out: &mut String, handler: &Handler, program: &Program, abi: X86_64Abi) -> String {
-    w!(out, ".p2align 4");
-    w!(out, "asm_handler_{}:", handler.name);
-
     let mut state = HandlerState::new();
 
     let mut counter = state.unique_counter;
@@ -449,6 +446,24 @@ fn generate_handler(out: &mut String, handler: &Handler, program: &Program, abi:
             )
         });
     state.unique_counter = counter;
+
+    if handler.is_cold {
+        assert!(
+            matches!(instructions.as_slice(), [instruction] if instruction.mnemonic == "call_slow_path"),
+            "cold handler '{}' must consist solely of call_slow_path",
+            handler.name
+        );
+        let mut cold = String::new();
+        w!(cold, ".p2align 4");
+        w!(cold, "asm_handler_{}:", handler.name);
+        emit_instruction(&mut cold, &instructions[0], handler, program, &mut state, abi);
+        cold.push_str(&state.cold_blocks);
+        w!(cold);
+        return cold;
+    }
+
+    w!(out, ".p2align 4");
+    w!(out, "asm_handler_{}:", handler.name);
 
     let (hot_instructions, cold_instructions) = outline_cold_blocks(&instructions)
         .unwrap_or_else(|error| panic!("invalid cold block in handler '{}': {error}", handler.name));
@@ -1831,6 +1846,7 @@ mod tests {
         Handler {
             name: "Call".into(),
             size: None,
+            is_cold: false,
             instructions: Vec::new(),
         }
     }

--- a/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
+++ b/Libraries/LibJS/AsmIntGen/src/codegen_x86_64.rs
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::allocator::{flatten_and_allocate, handler_uses_named_temps};
+use crate::allocator::flatten_and_allocate;
 use crate::parser::{AsmInstruction, Handler, ObjectFormat, Operand, Program};
 use crate::registers::{Arch, resolve_register};
 use crate::shared::{
     HandlerState, ResolvedMemoryIndex, get_immediate_value, resolve_adjacent_memory_pair,
     resolve_field_ref, resolve_label, resolve_memory_operand, substitute_macro,
-    uniquify_macro_labels, w,
+    outline_cold_blocks, uniquify_macro_labels, w,
 };
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -103,9 +103,16 @@ pub fn generate(program: &Program) -> String {
     // Generate fallback handler
     generate_fallback_handler(&mut out, program, abi);
 
-    // Generate each handler
+    // Generate the hot blocks of each handler first, keeping the interpreter's
+    // working set dense. Explicitly cold blocks are emitted afterwards.
+    let mut cold_handlers = String::new();
     for handler in &program.handlers {
-        generate_handler(&mut out, handler, program, abi);
+        cold_handlers.push_str(&generate_handler(&mut out, handler, program, abi));
+    }
+    if !cold_handlers.is_empty() {
+        w!(out, "# Cold handler paths");
+        w!(out, "asm_cold_handler_paths:");
+        out.push_str(&cold_handlers);
     }
 
     generate_exit_point(&mut out, program.object_format, abi);
@@ -427,43 +434,40 @@ fn handler_size(handler: &Handler, program: &Program) -> u32 {
     }) as u32
 }
 
-fn generate_handler(out: &mut String, handler: &Handler, program: &Program, abi: X86_64Abi) {
+fn generate_handler(out: &mut String, handler: &Handler, program: &Program, abi: X86_64Abi) -> String {
     w!(out, ".p2align 4");
     w!(out, "asm_handler_{}:", handler.name);
 
     let mut state = HandlerState::new();
 
-    if handler_uses_named_temps(handler, program) {
-        // The allocator pre-expands macros and rewrites named temps to
-        // physical registers, so emit_instruction iterates a flat list and
-        // never re-enters the macro-expansion arm. The shared
-        // unique_counter is consumed for canonicalize_nan fixup labels
-        // continuing after the macro-id range used by the allocator.
-        let mut counter = state.unique_counter;
-        let flat = flatten_and_allocate(handler, program, Arch::X86_64, &mut counter)
-            .unwrap_or_else(|err| {
-                panic!(
-                    "register allocation failed for handler '{}': {}",
-                    err.handler, err.message
-                )
-            });
-        state.unique_counter = counter;
-        for insn in &flat {
-            emit_instruction(out, insn, handler, program, &mut state, abi);
-        }
-    } else {
-        // Existing path: expand macros recursively in emit_instruction.
-        for insn in &handler.instructions {
-            emit_instruction(out, insn, handler, program, &mut state, abi);
-        }
-    }
+    let mut counter = state.unique_counter;
+    let instructions = flatten_and_allocate(handler, program, Arch::X86_64, &mut counter)
+        .unwrap_or_else(|err| {
+            panic!(
+                "register allocation failed for handler '{}': {}",
+                err.handler, err.message
+            )
+        });
+    state.unique_counter = counter;
 
-    // Emit cold fixup blocks after the main handler body
-    if !state.cold_blocks.is_empty() {
-        out.push_str(&state.cold_blocks);
-    }
+    let (hot_instructions, cold_instructions) = outline_cold_blocks(&instructions)
+        .unwrap_or_else(|error| panic!("invalid cold block in handler '{}': {error}", handler.name));
 
+    for instruction in &hot_instructions {
+        emit_instruction(out, instruction, handler, program, &mut state, abi);
+    }
     w!(out);
+
+    let mut cold = String::new();
+    if !cold_instructions.is_empty() {
+        w!(cold, "# Cold paths for {}", handler.name);
+        for instruction in &cold_instructions {
+            emit_instruction(&mut cold, instruction, handler, program, &mut state, abi);
+        }
+    }
+    cold.push_str(&state.cold_blocks);
+
+    cold
 }
 
 fn resolve_op(op: &Operand, handler: &Handler, program: &Program) -> String {

--- a/Libraries/LibJS/AsmIntGen/src/instructions.rs
+++ b/Libraries/LibJS/AsmIntGen/src/instructions.rs
@@ -852,6 +852,9 @@ pub const INSTRUCTIONS: &[InstructionInfo] = &[
     // constant, so no scratch.
     plain("canonicalize_nan", &[GprOut, FprIn]),
 
+    // Layout directive consumed after allocation and before code emission.
+    plain("cold", &[Label]),
+
     // ------------------------------------------------------------------
     // Branching
     // ------------------------------------------------------------------
@@ -1025,6 +1028,7 @@ mod tests {
     /// When you add a new DSL instruction, add it to `INSTRUCTIONS` and
     /// to this list.
     const CODEGEN_MNEMONICS: &[&str] = &[
+        "cold",
         "label",
         "jmp",
         "exit",

--- a/Libraries/LibJS/AsmIntGen/src/parser.rs
+++ b/Libraries/LibJS/AsmIntGen/src/parser.rs
@@ -38,6 +38,7 @@ pub struct AsmInstruction {
 pub struct Handler {
     pub name: String,
     pub size: Option<u32>,
+    pub is_cold: bool,
     pub instructions: Vec<AsmInstruction>,
 }
 
@@ -116,8 +117,8 @@ pub fn parse(input: &str) -> Program {
             macros.insert(name, Macro { params, body });
             i += 1;
         } else if let Some(rest) = line.strip_prefix("handler ") {
-            // handler Name, size=N
-            let (name, size) = parse_handler_header(rest);
+            // handler Name [@cold], size=N
+            let (name, size, is_cold) = parse_handler_header(rest);
             i += 1;
             let mut instructions = Vec::new();
             while i < lines.len() {
@@ -133,6 +134,7 @@ pub fn parse(input: &str) -> Program {
             handlers.push(Handler {
                 name,
                 size,
+                is_cold,
                 instructions,
             });
             i += 1;
@@ -185,9 +187,12 @@ fn parse_macro_signature(s: &str) -> (String, Vec<String>) {
     }
 }
 
-fn parse_handler_header(s: &str) -> (String, Option<u32>) {
+fn parse_handler_header(s: &str) -> (String, Option<u32>, bool) {
     let parts: Vec<&str> = s.split(',').collect();
-    let name = parts[0].trim().to_string();
+    let header = parts[0].trim();
+    let (name, is_cold) = header
+        .strip_suffix(" @cold")
+        .map_or((header, false), |name| (name, true));
     let mut size = None;
     for part in &parts[1..] {
         let part = part.trim();
@@ -195,7 +200,7 @@ fn parse_handler_header(s: &str) -> (String, Option<u32>) {
             size = Some(val.trim().parse().unwrap());
         }
     }
-    (name, size)
+    (name.to_string(), size, is_cold)
 }
 
 fn parse_asm_instructions(line: &str) -> Vec<AsmInstruction> {
@@ -376,5 +381,14 @@ mod tests {
         assert!(matches!(instructions[0].operands.as_slice(), [Operand::Label(label)] if label == ".slow"));
         assert_eq!(instructions[1].mnemonic, "label");
         assert!(matches!(instructions[1].operands.as_slice(), [Operand::Label(label)] if label == ".slow"));
+    }
+
+    #[test]
+    fn parses_cold_handler_annotation() {
+        let program = parse("handler Throw @cold\n    call_slow_path slow\nend\n");
+        let handler = &program.handlers[0];
+
+        assert_eq!(handler.name, "Throw");
+        assert!(handler.is_cold);
     }
 }

--- a/Libraries/LibJS/AsmIntGen/src/parser.rs
+++ b/Libraries/LibJS/AsmIntGen/src/parser.rs
@@ -109,7 +109,7 @@ pub fn parse(input: &str) -> Program {
                     break;
                 }
                 if !l.is_empty() && !l.starts_with('#') {
-                    body.push(parse_asm_instruction(l));
+                    body.extend(parse_asm_instructions(l));
                 }
                 i += 1;
             }
@@ -126,7 +126,7 @@ pub fn parse(input: &str) -> Program {
                     break;
                 }
                 if !l.is_empty() && !l.starts_with('#') {
-                    instructions.push(parse_asm_instruction(l));
+                    instructions.extend(parse_asm_instructions(l));
                 }
                 i += 1;
             }
@@ -198,9 +198,29 @@ fn parse_handler_header(s: &str) -> (String, Option<u32>) {
     (name, size)
 }
 
-fn parse_asm_instruction(line: &str) -> AsmInstruction {
+fn parse_asm_instructions(line: &str) -> Vec<AsmInstruction> {
     let line = line.trim();
 
+    // A temperature suffix annotates the basic block without becoming part
+    // of the assembler-visible label name.
+    if let Some(label) = line.strip_suffix(" @cold").and_then(|line| line.strip_suffix(':')) {
+        let label = label.to_string();
+        return vec![
+            AsmInstruction {
+                mnemonic: "cold".to_string(),
+                operands: vec![Operand::Label(label.clone())],
+            },
+            AsmInstruction {
+                mnemonic: "label".to_string(),
+                operands: vec![Operand::Label(label)],
+            },
+        ];
+    }
+
+    vec![parse_asm_instruction(line)]
+}
+
+fn parse_asm_instruction(line: &str) -> AsmInstruction {
     // Label definition (e.g. ".slow:")
     if let Some(label) = line.strip_suffix(':') {
         return AsmInstruction {
@@ -344,5 +364,17 @@ mod tests {
             Operand::Register(name) => assert_eq!(name, "baz"),
             other => panic!("expected Register, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parses_cold_label_annotation() {
+        let program = parse("handler Mov\n.slow: @cold\n    dispatch_next\nend\n");
+        let instructions = &program.handlers[0].instructions;
+
+        assert_eq!(instructions.len(), 3);
+        assert_eq!(instructions[0].mnemonic, "cold");
+        assert!(matches!(instructions[0].operands.as_slice(), [Operand::Label(label)] if label == ".slow"));
+        assert_eq!(instructions[1].mnemonic, "label");
+        assert!(matches!(instructions[1].operands.as_slice(), [Operand::Label(label)] if label == ".slow"));
     }
 }

--- a/Libraries/LibJS/AsmIntGen/src/shared.rs
+++ b/Libraries/LibJS/AsmIntGen/src/shared.rs
@@ -457,6 +457,7 @@ mod tests {
         Handler {
             name: "Call".into(),
             size: None,
+            is_cold: false,
             instructions: Vec::new(),
         }
     }

--- a/Libraries/LibJS/AsmIntGen/src/shared.rs
+++ b/Libraries/LibJS/AsmIntGen/src/shared.rs
@@ -6,7 +6,7 @@
 
 use crate::parser::{AsmInstruction, Handler, Operand, Program};
 use crate::registers::{Arch, resolve_register};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Like `writeln!`, but without the `.unwrap()` -- writing to a `String` is infallible.
 macro_rules! w {
@@ -88,7 +88,7 @@ pub fn uniquify_macro_labels(body: &[AsmInstruction], suffix: u32) -> Vec<AsmIns
                     definitions.insert(name.clone());
                 }
             }
-        } else {
+        } else if insn.mnemonic != "cold" {
             for op in &insn.operands {
                 if let Operand::Label(name) = op {
                     if name.starts_with('.') {
@@ -156,6 +156,67 @@ pub fn get_immediate_value(op: &Operand, program: &Program) -> Option<i64> {
         Operand::Constant(name) => program.constants.get(name).copied(),
         _ => None,
     }
+}
+
+/// Outline explicitly cold basic blocks while preserving source order within
+/// the hot and cold partitions. Annotated blocks must neither receive nor
+/// produce fallthrough control flow, so moving them cannot alter semantics.
+pub fn outline_cold_blocks(instructions: &[AsmInstruction]) -> Result<(Vec<AsmInstruction>, Vec<AsmInstruction>), String> {
+    let cold_labels: HashSet<&str> = instructions
+        .iter()
+        .filter(|instruction| instruction.mnemonic == "cold")
+        .map(|instruction| match instruction.operands.as_slice() {
+            [Operand::Label(label)] => Ok(label.as_str()),
+            _ => Err("cold annotation requires exactly one label".to_string()),
+        })
+        .collect::<Result<_, _>>()?;
+    if cold_labels.is_empty() {
+        return Ok((instructions.to_vec(), Vec::new()));
+    }
+
+    let instructions: Vec<_> = instructions
+        .iter()
+        .filter(|instruction| instruction.mnemonic != "cold")
+        .cloned()
+        .collect();
+    let mut is_cold = vec![false; instructions.len()];
+
+    for label in cold_labels {
+        let start = instructions
+            .iter()
+            .position(|instruction| {
+                instruction.mnemonic == "label"
+                    && matches!(instruction.operands.as_slice(), [Operand::Label(candidate)] if candidate == label)
+            })
+            .ok_or_else(|| format!("cold annotation references missing label '{label}'"))?;
+        if start == 0 {
+            return Err(format!("handler entry block '{label}' cannot be cold"));
+        }
+        if start > 0 && !crate::instructions::lookup(&instructions[start - 1].mnemonic).is_some_and(|info| info.terminal) {
+            return Err(format!("cold block '{label}' receives fallthrough control flow"));
+        }
+        let end = instructions[start + 1..]
+            .iter()
+            .position(|instruction| instruction.mnemonic == "label")
+            .map(|offset| start + 1 + offset)
+            .unwrap_or(instructions.len());
+        let Some(last) = instructions[start..end].last() else {
+            return Err(format!("cold block '{label}' is empty"));
+        };
+        if !crate::instructions::lookup(&last.mnemonic).is_some_and(|info| info.terminal) {
+            return Err(format!("cold block '{label}' produces fallthrough control flow"));
+        }
+        is_cold[start..end].fill(true);
+    }
+
+    let (cold, hot): (Vec<_>, Vec<_>) = instructions
+        .into_iter()
+        .zip(is_cold)
+        .partition(|(_, is_cold)| *is_cold);
+    Ok((
+        hot.into_iter().map(|(instruction, _)| instruction).collect(),
+        cold.into_iter().map(|(instruction, _)| instruction).collect(),
+    ))
 }
 
 /// Mutable state accumulated during handler code generation.
@@ -313,6 +374,55 @@ pub fn resolve_adjacent_memory_pair(
 mod tests {
     use super::*;
     use crate::parser::{Handler, ObjectFormat, Program};
+
+    #[test]
+    fn outlines_explicit_cold_block() {
+        let instructions = vec![
+            AsmInstruction { mnemonic: "dispatch_next".into(), operands: vec![] },
+            AsmInstruction { mnemonic: "cold".into(), operands: vec![Operand::Label(".slow".into())] },
+            AsmInstruction { mnemonic: "label".into(), operands: vec![Operand::Label(".slow".into())] },
+            AsmInstruction { mnemonic: "call_slow_path".into(), operands: vec![] },
+        ];
+
+        let (hot, cold) = outline_cold_blocks(&instructions).unwrap();
+
+        assert_eq!(hot.len(), 1);
+        assert_eq!(hot[0].mnemonic, "dispatch_next");
+        assert_eq!(cold.len(), 2);
+        assert_eq!(cold[0].mnemonic, "label");
+        assert_eq!(cold[1].mnemonic, "call_slow_path");
+    }
+
+    #[test]
+    fn rejects_cold_block_with_fallthrough() {
+        let instructions = vec![
+            AsmInstruction { mnemonic: "mov".into(), operands: vec![] },
+            AsmInstruction { mnemonic: "cold".into(), operands: vec![Operand::Label(".slow".into())] },
+            AsmInstruction { mnemonic: "label".into(), operands: vec![Operand::Label(".slow".into())] },
+            AsmInstruction { mnemonic: "call_slow_path".into(), operands: vec![] },
+        ];
+
+        let error = outline_cold_blocks(&instructions).unwrap_err();
+
+        assert!(error.contains("receives fallthrough"));
+    }
+
+    #[test]
+    fn uniquify_macro_labels_ignores_cold_annotations() {
+        let instructions = vec![
+            AsmInstruction { mnemonic: "cold".into(), operands: vec![Operand::Label(".slow".into())] },
+            AsmInstruction { mnemonic: "label".into(), operands: vec![Operand::Label(".slow".into())] },
+            AsmInstruction { mnemonic: "call_slow_path".into(), operands: vec![] },
+        ];
+
+        let uniquified = uniquify_macro_labels(&instructions, 1);
+
+        assert_eq!(uniquified[0].mnemonic, "cold");
+        assert!(matches!(&uniquified[0].operands[0], Operand::Label(label) if label == ".slow"));
+        assert_eq!(uniquified[1].mnemonic, "label");
+        assert!(matches!(&uniquified[1].operands[0], Operand::Label(label) if label == ".slow"));
+    }
+
     use bytecode_def::OpLayout;
 
     fn test_program() -> Program {

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -308,7 +308,7 @@ macro boolean_result_epilogue(slow_path_func)
     mov result, BOOLEAN_FALSE
     store_operand m_dst, result
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path slow_path_func
 end
 
@@ -316,7 +316,7 @@ end
 # Defines .take_true, .take_false, and .slow labels.
 macro jump_binary_epilogue(slow_path_func)
     temp target
-.slow:
+.slow: @cold
     call_slow_path slow_path_func
 .take_true:
     load_label target, m_true_target
@@ -364,7 +364,7 @@ macro bitwise_op(op_insn, slow_path_func)
     box_int32 dst, lhs_int
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path slow_path_func
 end
 
@@ -388,7 +388,7 @@ macro prefix_inc_dec(op32_overflow, fp_op, slow_path_func)
     fp_mov dst, result_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path slow_path_func
 end
 
@@ -413,7 +413,7 @@ macro postfix_inc_dec(op32_overflow, fp_op, slow_path_func)
     fp_mov dst, result_dbl
     store_operand m_src, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path slow_path_func
 end
 
@@ -432,7 +432,7 @@ macro int32_shift_op(op_insn, slow_path_func)
     box_int32 dst, lhs_int
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path slow_path_func
 end
 
@@ -698,7 +698,7 @@ handler Add
     fp_mov dst, lhs_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_add
 end
 
@@ -727,7 +727,7 @@ handler Sub
     fp_mov dst, lhs_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_sub
 end
 
@@ -767,7 +767,7 @@ handler Mul
     fp_mov dst, lhs_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_mul
 end
 
@@ -1187,7 +1187,7 @@ handler GetBinding
     check_binding_initialized env, idx, binding_values, value, empty, .slow
     store_operand m_dst, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_get_binding
 end
 
@@ -1197,7 +1197,7 @@ handler DynamicGetBinding
     check_binding_initialized env, idx, binding_values, value, empty, .slow
     store_operand m_dst, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_get_binding
 end
 
@@ -1208,7 +1208,7 @@ handler GetInitializedBinding
     load_binding_value env, idx, binding_values, value
     store_operand m_dst, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_get_initialized_binding
 end
 
@@ -1218,7 +1218,7 @@ handler DynamicGetInitializedBinding
     load_binding_value env, idx, binding_values, value
     store_operand m_dst, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_get_initialized_binding
 end
 
@@ -1229,7 +1229,7 @@ handler InitializeLexicalBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_initialize_lexical_binding
 end
 
@@ -1239,7 +1239,7 @@ handler InitializeVariableBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_initialize_variable_binding
 end
 
@@ -1249,7 +1249,7 @@ handler DynamicInitializeLexicalBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_initialize_lexical_binding
 end
 
@@ -1259,7 +1259,7 @@ handler DynamicInitializeVariableBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_initialize_variable_binding
 end
 
@@ -1275,7 +1275,7 @@ handler SetLexicalBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_set_lexical_binding
 end
 
@@ -1290,7 +1290,7 @@ handler SetVariableBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_set_variable_binding
 end
 
@@ -1305,7 +1305,7 @@ handler DynamicSetLexicalBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_set_lexical_binding
 end
 
@@ -1320,7 +1320,7 @@ handler DynamicSetVariableBinding
     load_operand value, m_src
     store_binding_value env, idx, binding_values, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_set_variable_binding
 end
 
@@ -1420,7 +1420,7 @@ handler Div
     canonicalize_nan dst, lhs_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_div
 end
 
@@ -1480,7 +1480,7 @@ handler UnaryPlus
 .done:
     store_operand m_dst, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_unary_plus
 end
 
@@ -1491,7 +1491,7 @@ handler ThrowIfTDZ
     mov empty, EMPTY_VALUE
     branch_eq value, empty, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_throw_if_tdz
 end
 
@@ -1502,7 +1502,7 @@ handler ThrowIfNotObject
     extract_tag tag, value
     branch_ne tag, OBJECT_TAG, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_throw_if_not_object
 end
 
@@ -1514,7 +1514,7 @@ handler ThrowIfNullish
     and tag, 0xFFFE
     branch_eq tag, UNDEFINED_TAG, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_throw_if_nullish
 end
 
@@ -1566,7 +1566,7 @@ handler BitwiseNot
     box_int32_clean dst, dst
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_bitwise_not
 end
 
@@ -1614,7 +1614,7 @@ handler UnsignedRightShift
     fp_mov dst, dst_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_unsigned_right_shift
 end
 
@@ -1638,7 +1638,7 @@ handler Mod
     box_int32 dst, rem
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_mod
 end
 
@@ -1675,7 +1675,7 @@ handler GetCalleeAndThisFromEnvironment
     mov value, UNDEFINED_SHIFTED
     store_operand m_this_value, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_get_callee_and_this
 end
 
@@ -1688,7 +1688,7 @@ handler DynamicGetCalleeAndThisFromEnvironment
     mov value, UNDEFINED_SHIFTED
     store_operand m_this_value, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_dynamic_get_callee_and_this
 end
 
@@ -1739,7 +1739,7 @@ handler UnaryMinus
     toggle_bit value, 63
     store_operand m_dst, value
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_unary_minus
 end
 
@@ -1778,7 +1778,7 @@ handler ToInt32
     box_int32_clean dst, value
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     # Slow path handles other types (string, object, nullish, etc) and uncommon cases.
     call_slow_path asm_slow_path_to_int32
 end
@@ -1918,7 +1918,7 @@ handler PutByValue
     call_interp asm_try_put_by_value_typed_array, result
     branch_nonzero result, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_put_by_value
 end
 
@@ -1968,11 +1968,10 @@ handler GetById
 .try_cache:
     # Try all cache entries via C++ helper
     call_interp asm_try_get_by_id_cache, result
-    branch_zero result, .done
-.slow:
-    call_slow_path asm_slow_path_get_by_id
-.done:
+    branch_nonzero result, .slow
     dispatch_next
+.slow: @cold
+    call_slow_path asm_slow_path_get_by_id
 end
 
 handler GetByIdWithThis
@@ -2009,11 +2008,10 @@ handler PutById
 .try_cache:
     # Try all cache entries via C++ helper (handles AddOwnProperty)
     call_interp asm_try_put_by_id_cache, result
-    branch_zero result, .done
-.slow:
-    call_slow_path asm_slow_path_put_by_id
-.done:
+    branch_nonzero result, .slow
     dispatch_next
+.slow: @cold
+    call_slow_path asm_slow_path_put_by_id
 end
 
 handler PutByIdWithThis
@@ -2153,7 +2151,7 @@ handler GetByValue
     call_interp asm_try_get_by_value_typed_array, result
     branch_nonzero result, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_get_by_value
 end
 
@@ -2214,7 +2212,7 @@ handler GetLength
     fp_mov dst, length_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_get_length
 end
 
@@ -2270,11 +2268,11 @@ handler GetGlobal
     check_binding_initialized env, idx, binding_values, value, empty, .slow
     store_operand m_dst, value
     dispatch_next
-.slow_env:
+.slow_env: @cold
     call_interp asm_try_get_global_env_binding, result
     branch_nonzero result, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_get_global
 end
 
@@ -2319,11 +2317,11 @@ handler SetGlobal
     load_operand src, m_src
     store_binding_value env, idx, binding_values, src
     dispatch_next
-.slow_env:
+.slow_env: @cold
     call_interp asm_try_set_global_env_binding, result
     branch_nonzero result, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_set_global
 end
 
@@ -2811,7 +2809,7 @@ handler CallBuiltinMathAbs
     fp_mov dst, arg_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_math_abs
 end
 
@@ -2826,7 +2824,7 @@ handler CallBuiltinMathFloor
     box_double_or_int32 dst, arg_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_math_floor
 end
 
@@ -2841,7 +2839,7 @@ handler CallBuiltinMathCeil
     box_double_or_int32 dst, arg_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_math_ceil
 end
 
@@ -2856,7 +2854,7 @@ handler CallBuiltinMathSqrt
     box_double_or_int32 dst, arg_dbl
     store_operand m_dst, dst
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_math_sqrt
 end
 
@@ -2870,7 +2868,7 @@ handler CallBuiltinMathExp
     call_helper asm_helper_math_exp, arg, result
     store_operand m_dst, result
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_math_exp
 end
 
@@ -2961,7 +2959,7 @@ handler CallBuiltinStringFromCharCode
     store_operand m_dst, result
     dispatch_next
 
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_string_from_char_code
 end
 
@@ -2990,7 +2988,7 @@ handler CallBuiltinStringPrototypeCharCodeAt
     store_operand m_dst, dst
     dispatch_next
 
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_string_prototype_char_code_at
 end
 
@@ -3025,7 +3023,7 @@ handler CallBuiltinStringPrototypeCharAt
     store_operand m_dst, result
     dispatch_next
 
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_call_builtin_string_prototype_char_at
 end
 
@@ -3134,7 +3132,7 @@ handler ObjectPropertyIteratorNext
     store_operand m_dst_done, scratch
     dispatch_next
 
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_object_property_iterator_next
 end
 
@@ -3331,7 +3329,7 @@ handler ResolveThisBinding
     mov empty, EMPTY_VALUE
     branch_eq this_value, empty, .slow
     dispatch_next
-.slow:
+.slow: @cold
     call_slow_path asm_slow_path_resolve_this_binding
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -379,7 +379,7 @@ macro prefix_inc_dec(op32_overflow, fp_op, slow_path_func)
     box_int32_clean dst, int_value
     store_operand m_dst, dst
     dispatch_next
-.overflow:
+.overflow: @cold
     unbox_int32 int_value, value
     int_to_double result_dbl, int_value
     mov dst, DOUBLE_ONE
@@ -404,7 +404,7 @@ macro postfix_inc_dec(op32_overflow, fp_op, slow_path_func)
     box_int32_clean dst, int_value
     store_operand m_src, dst
     dispatch_next
-.overflow_after_store:
+.overflow_after_store: @cold
     unbox_int32 int_value, value
     int_to_double result_dbl, int_value
     mov dst, DOUBLE_ONE
@@ -688,7 +688,7 @@ handler Add
     box_int32_clean dst, lhs_int
     store_operand m_dst, dst
     dispatch_next
-.overflow:
+.overflow: @cold
     # Int32 overflow: convert both to double and redo the operation
     unbox_int32 lhs_int, lhs
     unbox_int32 rhs_int, rhs
@@ -718,7 +718,7 @@ handler Sub
     box_int32_clean dst, lhs_int
     store_operand m_dst, dst
     dispatch_next
-.overflow:
+.overflow: @cold
     unbox_int32 lhs_int, lhs
     unbox_int32 rhs_int, rhs
     int_to_double lhs_dbl, lhs_int
@@ -754,11 +754,11 @@ handler Mul
     box_int32_clean dst, lhs_int
     store_operand m_dst, dst
     dispatch_next
-.negative_zero:
+.negative_zero: @cold
     mov dst, NEGATIVE_ZERO
     store_operand m_dst, dst
     dispatch_next
-.overflow:
+.overflow: @cold
     unbox_int32 lhs_int, lhs
     unbox_int32 rhs_int, rhs
     int_to_double lhs_dbl, lhs_int
@@ -1722,11 +1722,11 @@ handler UnaryMinus
     box_int32_clean dst, int_value
     store_operand m_dst, dst
     dispatch_next
-.negative_zero:
+.negative_zero: @cold
     mov dst, NEGATIVE_ZERO
     store_operand m_dst, dst
     dispatch_next
-.overflow:
+.overflow: @cold
     # INT32_MIN: -(-2147483648) = 2147483648.0
     int_to_double dst_dbl, int_value
     fp_mov dst, dst_dbl

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -1837,7 +1837,7 @@ handler PutByValue
     load_operand src, m_src
     store64 [elements, index, 8], src
     dispatch_next
-.try_holey_array_slow:
+.try_holey_array_slow: @cold
     call_interp asm_try_put_by_value_holey_array, result
     branch_nonzero result, .slow
     dispatch_next
@@ -1914,7 +1914,7 @@ handler PutByValue
     caged_primitive_storage_address addr, elements, cached_offset, index, 1
     store16 [addr, 0], src_int32
     dispatch_next
-.try_typed_array_slow:
+.try_typed_array_slow: @cold
     call_interp asm_try_put_by_value_typed_array, result
     branch_nonzero result, .slow
     dispatch_next
@@ -2147,7 +2147,7 @@ handler GetByValue
     box_int32_clean dst, raw
     store_operand m_dst, dst
     dispatch_next
-.try_typed_array_slow:
+.try_typed_array_slow: @cold
     call_interp asm_try_get_by_value_typed_array, result
     branch_nonzero result, .slow
     dispatch_next
@@ -2769,11 +2769,11 @@ handler Call
     load32 native_pc, [exec_ctx, EXECUTION_CONTEXT_PROGRAM_COUNTER]
     mov pc, native_pc
     goto_handler pc
-.call_exit_asm:
+.call_exit_asm: @cold
     # No JS handler caught the native exception; bail out of the asm
     # dispatch loop and let the C++ caller of run_asm() see the throw.
     exit
-.call_slow:
+.call_slow: @cold
     call_slow_path asm_slow_path_call
 end
 

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -2138,7 +2138,7 @@ handler GetByValue
     load32 raw, [addr, 0]
     branch_bit_set raw, 31, .ta_uint32_to_double
     jmp .ta_box_int32
-.ta_uint32_to_double:
+.ta_uint32_to_double: @cold
     int_to_double slot_dbl, raw
     fp_mov dst, slot_dbl
     store_operand m_dst, dst
@@ -2207,7 +2207,7 @@ handler GetLength
     box_int32 dst, length
     store_operand m_dst, dst
     dispatch_next
-.length_double:
+.length_double: @cold
     int_to_double length_dbl, length
     fp_mov dst, length_dbl
     store_operand m_dst, dst
@@ -2801,7 +2801,7 @@ handler CallBuiltinMathAbs
     box_int32_clean dst, int_value
     store_operand m_dst, dst
     dispatch_next
-.abs_overflow:
+.abs_overflow: @cold
     # INT32_MIN: abs(-2147483648) = 2147483648.0
     unbox_int32 int_value, arg
     neg int_value
@@ -2983,7 +2983,7 @@ handler CallBuiltinStringPrototypeCharCodeAt
     store_operand m_dst, dst
     dispatch_next
 
-.out_of_bounds:
+.out_of_bounds: @cold
     mov dst, CANON_NAN_BITS
     store_operand m_dst, dst
     dispatch_next

--- a/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
+++ b/Libraries/LibJS/Bytecode/AsmInterpreter/asmint.asm
@@ -771,23 +771,23 @@ handler Mul
     call_slow_path asm_slow_path_mul
 end
 
-handler Exp
+handler Exp @cold
     call_slow_path asm_slow_path_exp
 end
 
-handler ConcatString
+handler ConcatString @cold
     call_slow_path asm_slow_path_concat_string
 end
 
-handler CopyObjectExcludingProperties
+handler CopyObjectExcludingProperties @cold
     call_slow_path asm_slow_path_copy_object_excluding_properties
 end
 
-handler ImportCall
+handler ImportCall @cold
     call_slow_path asm_slow_path_import_call
 end
 
-handler NewClass
+handler NewClass @cold
     call_slow_path asm_slow_path_new_class
 end
 
@@ -1098,15 +1098,15 @@ handler GetLexicalEnvironment
     dispatch_next
 end
 
-handler GetImportMeta
+handler GetImportMeta @cold
     call_slow_path asm_slow_path_get_import_meta
 end
 
-handler GetNewTarget
+handler GetNewTarget @cold
     call_slow_path asm_slow_path_get_new_target
 end
 
-handler GetSuperConstructor
+handler GetSuperConstructor @cold
     call_slow_path asm_slow_path_get_super_constructor
 end
 
@@ -1324,47 +1324,47 @@ handler DynamicSetVariableBinding
     call_slow_path asm_slow_path_dynamic_set_variable_binding
 end
 
-handler ResolveBinding
+handler ResolveBinding @cold
     call_slow_path asm_slow_path_resolve_binding
 end
 
-handler ResolveSuperBase
+handler ResolveSuperBase @cold
     call_slow_path asm_slow_path_resolve_super_base
 end
 
-handler SetResolvedBinding
+handler SetResolvedBinding @cold
     call_slow_path asm_slow_path_set_resolved_binding
 end
 
-handler TypeofBinding
+handler TypeofBinding @cold
     call_slow_path asm_slow_path_typeof_binding
 end
 
-handler DynamicTypeofBinding
+handler DynamicTypeofBinding @cold
     call_slow_path asm_slow_path_dynamic_typeof_binding
 end
 
-handler HasPrivateId
+handler HasPrivateId @cold
     call_slow_path asm_slow_path_has_private_id
 end
 
-handler SetFunctionName
+handler SetFunctionName @cold
     call_slow_path asm_slow_path_set_function_name
 end
 
-handler NewArrayWithLength
+handler NewArrayWithLength @cold
     call_slow_path asm_slow_path_new_array_with_length
 end
 
-handler ArrayAppend
+handler ArrayAppend @cold
     call_slow_path asm_slow_path_array_append
 end
 
-handler CreateVariable
+handler CreateVariable @cold
     call_slow_path asm_slow_path_create_variable
 end
 
-handler EnterObjectEnvironment
+handler EnterObjectEnvironment @cold
     call_slow_path asm_slow_path_enter_object_environment
 end
 
@@ -1518,39 +1518,39 @@ handler ThrowIfNullish
     call_slow_path asm_slow_path_throw_if_nullish
 end
 
-handler ThrowConstAssignment
+handler ThrowConstAssignment @cold
     call_slow_path asm_slow_path_throw_const_assignment
 end
 
-handler Throw
+handler Throw @cold
     call_slow_path asm_slow_path_throw
 end
 
-handler Await
+handler Await @cold
     call_slow_path asm_slow_path_await
 end
 
-handler Yield
+handler Yield @cold
     call_slow_path asm_slow_path_yield
 end
 
-handler YieldIteratorResult
+handler YieldIteratorResult @cold
     call_slow_path asm_slow_path_yield_iterator_result
 end
 
-handler ToString
+handler ToString @cold
     call_slow_path asm_slow_path_to_string
 end
 
-handler ToPrimitiveWithStringHint
+handler ToPrimitiveWithStringHint @cold
     call_slow_path asm_slow_path_to_primitive_with_string_hint
 end
 
-handler ToObject
+handler ToObject @cold
     call_slow_path asm_slow_path_to_object
 end
 
-handler ToLength
+handler ToLength @cold
     call_slow_path asm_slow_path_to_length
 end
 
@@ -1974,7 +1974,7 @@ handler GetById
     call_slow_path asm_slow_path_get_by_id
 end
 
-handler GetByIdWithThis
+handler GetByIdWithThis @cold
     call_slow_path asm_slow_path_get_by_id_with_this
 end
 
@@ -2014,7 +2014,7 @@ handler PutById
     call_slow_path asm_slow_path_put_by_id
 end
 
-handler PutByIdWithThis
+handler PutByIdWithThis @cold
     call_slow_path asm_slow_path_put_by_id_with_this
 end
 
@@ -2155,15 +2155,15 @@ handler GetByValue
     call_slow_path asm_slow_path_get_by_value
 end
 
-handler GetByValueWithThis
+handler GetByValueWithThis @cold
     call_slow_path asm_slow_path_get_by_value_with_this
 end
 
-handler PutByValueWithThis
+handler PutByValueWithThis @cold
     call_slow_path asm_slow_path_put_by_value_with_this
 end
 
-handler PutBySpread
+handler PutBySpread @cold
     call_slow_path asm_slow_path_put_by_spread
 end
 
@@ -2216,15 +2216,15 @@ handler GetLength
     call_slow_path asm_slow_path_get_length
 end
 
-handler GetLengthWithThis
+handler GetLengthWithThis @cold
     call_slow_path asm_slow_path_get_length_with_this
 end
 
-handler GetMethod
+handler GetMethod @cold
     call_slow_path asm_slow_path_get_method
 end
 
-handler GetIterator
+handler GetIterator @cold
     call_slow_path asm_slow_path_get_iterator
 end
 
@@ -2872,67 +2872,67 @@ handler CallBuiltinMathExp
     call_slow_path asm_slow_path_call_builtin_math_exp
 end
 
-handler CallBuiltinMathLog
+handler CallBuiltinMathLog @cold
     call_slow_path asm_slow_path_call_builtin_math_log
 end
 
-handler CallBuiltinMathPow
+handler CallBuiltinMathPow @cold
     call_slow_path asm_slow_path_call_builtin_math_pow
 end
 
-handler CallBuiltinMathImul
+handler CallBuiltinMathImul @cold
     call_slow_path asm_slow_path_call_builtin_math_imul
 end
 
-handler CallBuiltinMathRandom
+handler CallBuiltinMathRandom @cold
     call_slow_path asm_slow_path_call_builtin_math_random
 end
 
-handler CallBuiltinMathRound
+handler CallBuiltinMathRound @cold
     call_slow_path asm_slow_path_call_builtin_math_round
 end
 
-handler CallBuiltinMathSin
+handler CallBuiltinMathSin @cold
     call_slow_path asm_slow_path_call_builtin_math_sin
 end
 
-handler CallBuiltinMathCos
+handler CallBuiltinMathCos @cold
     call_slow_path asm_slow_path_call_builtin_math_cos
 end
 
-handler CallBuiltinMathTan
+handler CallBuiltinMathTan @cold
     call_slow_path asm_slow_path_call_builtin_math_tan
 end
 
-handler CallBuiltinRegExpPrototypeExec
+handler CallBuiltinRegExpPrototypeExec @cold
     call_slow_path asm_slow_path_call_builtin_regexp_prototype_exec
 end
 
-handler CallBuiltinRegExpPrototypeReplace
+handler CallBuiltinRegExpPrototypeReplace @cold
     call_slow_path asm_slow_path_call_builtin_regexp_prototype_replace
 end
 
-handler CallBuiltinRegExpPrototypeSplit
+handler CallBuiltinRegExpPrototypeSplit @cold
     call_slow_path asm_slow_path_call_builtin_regexp_prototype_split
 end
 
-handler CallBuiltinOrdinaryHasInstance
+handler CallBuiltinOrdinaryHasInstance @cold
     call_slow_path asm_slow_path_call_builtin_ordinary_has_instance
 end
 
-handler CallBuiltinArrayIteratorPrototypeNext
+handler CallBuiltinArrayIteratorPrototypeNext @cold
     call_slow_path asm_slow_path_call_builtin_array_iterator_prototype_next
 end
 
-handler CallBuiltinMapIteratorPrototypeNext
+handler CallBuiltinMapIteratorPrototypeNext @cold
     call_slow_path asm_slow_path_call_builtin_map_iterator_prototype_next
 end
 
-handler CallBuiltinSetIteratorPrototypeNext
+handler CallBuiltinSetIteratorPrototypeNext @cold
     call_slow_path asm_slow_path_call_builtin_set_iterator_prototype_next
 end
 
-handler CallBuiltinStringIteratorPrototypeNext
+handler CallBuiltinStringIteratorPrototypeNext @cold
     call_slow_path asm_slow_path_call_builtin_string_iterator_prototype_next
 end
 
@@ -3035,7 +3035,7 @@ end
 # because the operation is inherently complex (object allocation, prototype
 # chain walks, etc).
 
-handler GetObjectPropertyIterator
+handler GetObjectPropertyIterator @cold
     call_slow_path asm_slow_path_get_object_property_iterator
 end
 
@@ -3136,87 +3136,87 @@ handler ObjectPropertyIteratorNext
     call_slow_path asm_slow_path_object_property_iterator_next
 end
 
-handler IteratorClose
+handler IteratorClose @cold
     call_slow_path asm_slow_path_iterator_close
 end
 
-handler IteratorNext
+handler IteratorNext @cold
     call_slow_path asm_slow_path_iterator_next
 end
 
-handler IteratorNextUnpack
+handler IteratorNextUnpack @cold
     call_slow_path asm_slow_path_iterator_next_unpack
 end
 
-handler IteratorToArray
+handler IteratorToArray @cold
     call_slow_path asm_slow_path_iterator_to_array
 end
 
-handler CallConstruct
+handler CallConstruct @cold
     call_slow_path asm_slow_path_call_construct
 end
 
-handler CallDirectEval
+handler CallDirectEval @cold
     call_slow_path asm_slow_path_call_direct_eval
 end
 
-handler CallWithArgumentArray
+handler CallWithArgumentArray @cold
     call_slow_path asm_slow_path_call_with_argument_array
 end
 
-handler CallDirectEvalWithArgumentArray
+handler CallDirectEvalWithArgumentArray @cold
     call_slow_path asm_slow_path_call_direct_eval_with_argument_array
 end
 
-handler CallConstructWithArgumentArray
+handler CallConstructWithArgumentArray @cold
     call_slow_path asm_slow_path_call_construct_with_argument_array
 end
 
-handler SuperCallWithArgumentArray
+handler SuperCallWithArgumentArray @cold
     call_slow_path asm_slow_path_super_call_with_argument_array
 end
 
-handler NewObject
+handler NewObject @cold
     call_slow_path asm_slow_path_new_object
 end
 
-handler NewObjectWithNoPrototype
+handler NewObjectWithNoPrototype @cold
     call_slow_path asm_slow_path_new_object_with_no_prototype
 end
 
-handler CacheObjectShape
+handler CacheObjectShape @cold
     call_slow_path asm_slow_path_cache_object_shape
 end
 
-handler InitObjectLiteralProperty
+handler InitObjectLiteralProperty @cold
     call_slow_path asm_slow_path_init_object_literal_property
 end
 
-handler NewArray
+handler NewArray @cold
     call_slow_path asm_slow_path_new_array
 end
 
-handler NewPrimitiveArray
+handler NewPrimitiveArray @cold
     call_slow_path asm_slow_path_new_primitive_array
 end
 
-handler NewRegExp
+handler NewRegExp @cold
     call_slow_path asm_slow_path_new_regexp
 end
 
-handler NewReferenceError
+handler NewReferenceError @cold
     call_slow_path asm_slow_path_new_reference_error
 end
 
-handler NewTypeError
+handler NewTypeError @cold
     call_slow_path asm_slow_path_new_type_error
 end
 
-handler InstanceOf
+handler InstanceOf @cold
     call_slow_path asm_slow_path_instance_of
 end
 
-handler In
+handler In @cold
     call_slow_path asm_slow_path_in
 end
 
@@ -3237,79 +3237,79 @@ handler IsCallable
     dispatch_next
 end
 
-handler IsConstructor
+handler IsConstructor @cold
     call_slow_path asm_slow_path_is_constructor
 end
 
-handler AddPrivateName
+handler AddPrivateName @cold
     call_slow_path asm_slow_path_add_private_name
 end
 
-handler CreateAsyncFromSyncIterator
+handler CreateAsyncFromSyncIterator @cold
     call_slow_path asm_slow_path_create_async_from_sync_iterator
 end
 
-handler CreateDataPropertyOrThrow
+handler CreateDataPropertyOrThrow @cold
     call_slow_path asm_slow_path_create_data_property_or_throw
 end
 
-handler CreateImmutableBinding
+handler CreateImmutableBinding @cold
     call_slow_path asm_slow_path_create_immutable_binding
 end
 
-handler CreateMutableBinding
+handler CreateMutableBinding @cold
     call_slow_path asm_slow_path_create_mutable_binding
 end
 
-handler CreateRestParams
+handler CreateRestParams @cold
     call_slow_path asm_slow_path_create_rest_params
 end
 
-handler CreateArguments
+handler CreateArguments @cold
     call_slow_path asm_slow_path_create_arguments
 end
 
-handler CreateLexicalEnvironment
+handler CreateLexicalEnvironment @cold
     call_slow_path asm_slow_path_create_lexical_environment
 end
 
-handler CreatePrivateEnvironment
+handler CreatePrivateEnvironment @cold
     call_slow_path asm_slow_path_create_private_environment
 end
 
-handler CreateVariableEnvironment
+handler CreateVariableEnvironment @cold
     call_slow_path asm_slow_path_create_variable_environment
 end
 
-handler DeleteById
+handler DeleteById @cold
     call_slow_path asm_slow_path_delete_by_id
 end
 
-handler DeleteByValue
+handler DeleteByValue @cold
     call_slow_path asm_slow_path_delete_by_value
 end
 
-handler DeleteVariable
+handler DeleteVariable @cold
     call_slow_path asm_slow_path_delete_variable
 end
 
-handler GetCompletionFields
+handler GetCompletionFields @cold
     call_slow_path asm_slow_path_get_completion_fields
 end
 
-handler SetCompletionType
+handler SetCompletionType @cold
     call_slow_path asm_slow_path_set_completion_type
 end
 
-handler GetTemplateObject
+handler GetTemplateObject @cold
     call_slow_path asm_slow_path_get_template_object
 end
 
-handler NewFunction
+handler NewFunction @cold
     call_slow_path asm_slow_path_new_function
 end
 
-handler Typeof
+handler Typeof @cold
     call_slow_path asm_slow_path_typeof
 end
 
@@ -3333,10 +3333,10 @@ handler ResolveThisBinding
     call_slow_path asm_slow_path_resolve_this_binding
 end
 
-handler GetPrivateById
+handler GetPrivateById @cold
     call_slow_path asm_slow_path_get_private_by_id
 end
 
-handler PutPrivateById
+handler PutPrivateById @cold
     call_slow_path asm_slow_path_put_private_by_id
 end


### PR DESCRIPTION
Teach AsmIntGen about `@cold` annotations for labels and slow-path-only handlers, then use those annotations to keep uncommon AsmInt paths out of the contiguous hot interpreter region.

The generator now emits hot handler blocks first and appends annotated cold blocks afterwards on both x86-64 and AArch64. It also rejects cold blocks with fallthrough edges so layout changes cannot silently alter control flow.

This marks existing slow paths, uncommon arithmetic results, helper fallbacks, rare numeric results, and slow-path-only handlers cold. On x86-64, this reduces the contiguous hot handler span from about 24 KiB to about 18 KiB. Parser and outlining unit coverage is included for the new annotations.

From a Linux/x86_64 machine with 32 KiB icache:

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ----------------
Kraken          ai-astar.js                             0.986      1.266 ± 1.259 … 1.274              1.285 ± 1.279 … 1.291              -0.1% (-0.0 MB)
Kraken          audio-beat-detection.js                 0.979      0.852 ± 0.850 … 0.853              0.870 ± 0.869 … 0.872              +0.0% (+0.0 MB)
Kraken          audio-dft.js                            1.029      0.652 ± 0.634 … 0.670              0.634 ± 0.624 … 0.645              -0.1% (-0.1 MB)
Kraken          audio-fft.js                            0.958      0.696 ± 0.695 … 0.696              0.726 ± 0.725 … 0.728              +0.1% (+0.1 MB)
Kraken          audio-oscillator.js                     1.051      0.763 ± 0.762 … 0.763              0.725 ± 0.721 … 0.730              -0.1% (-0.1 MB)
Kraken          imaging-darkroom.js                     0.926      0.875 ± 0.871 … 0.879              0.945 ± 0.943 … 0.947              -0.2% (-0.1 MB)
Kraken          imaging-desaturate.js                   0.919      1.113 ± 1.113 … 1.114              1.211 ± 1.211 … 1.211              -0.0% (-0.0 MB)
Kraken          imaging-gaussian-blur.js                0.949      4.574 ± 4.571 … 4.577              4.819 ± 4.800 … 4.838              +0.1% (+0.0 MB)
Kraken          json-parse-financial.js                 1.056      0.085 ± 0.084 … 0.086              0.080 ± 0.080 … 0.081              -0.5% (-0.2 MB)
Kraken          json-stringify-tinderbox.js             0.969      0.125 ± 0.124 … 0.126              0.129 ± 0.129 … 0.129              -0.2% (-0.1 MB)
Kraken          stanford-crypto-aes.js                  1.027      0.366 ± 0.364 … 0.368              0.356 ± 0.356 … 0.357              +0.1% (+0.0 MB)
Kraken          stanford-crypto-ccm.js                  1.055      0.283 ± 0.282 … 0.283              0.268 ± 0.267 … 0.269              -0.1% (-0.1 MB)
Kraken          stanford-crypto-pbkdf2.js               1.000      0.570 ± 0.570 … 0.571              0.570 ± 0.569 … 0.571              +0.3% (+0.1 MB)
Kraken          stanford-crypto-sha256-iterative.js     1.018      0.215 ± 0.213 … 0.216              0.211 ± 0.209 … 0.212              -0.1% (-0.0 MB)
Octane          box2d.js                                1.060      4278.000 ± 4253.000 … 4303.000     4536.000 ± 4536.000 … 4536.000     +0.6% (+0.4 MB)
Octane          code-load.js                            1.012      14176.000 ± 14147.000 … 14205.000  14339.500 ± 14331.000 … 14348.000  +1.1% (+10.3 MB)
Octane          crypto.js                               0.965      2220.000 ± 2212.000 … 2228.000     2143.000 ± 2143.000 … 2143.000     +0.6% (+0.2 MB)
Octane          deltablue.js                            1.054      1305.500 ± 1295.000 … 1316.000     1376.500 ± 1367.000 … 1386.000     +0.3% (+0.1 MB)
Octane          earley-boyer.js                         1.059      2382.500 ± 2368.000 … 2397.000     2522.500 ± 2498.000 … 2547.000     -2.3% (-1.2 MB)
Octane          gbemu.js                                1.027      9293.500 ± 9273.000 … 9314.000     9546.500 ± 9542.000 … 9551.000     +0.4% (+0.4 MB)
Octane          mandreel.js                             0.974      8950.000 ± 8934.000 … 8966.000     8715.500 ± 8700.000 … 8731.000     +0.1% (+0.2 MB)
Octane          navier-stokes.js                        0.865      3509.000 ± 3509.000 … 3509.000     3035.500 ± 3034.000 … 3037.000     -0.3% (-0.1 MB)
Octane          pdfjs.js                                1.036      4532.000 ± 4516.000 … 4548.000     4694.000 ± 4687.000 … 4701.000     -0.1% (-0.1 MB)
Octane          raytrace.js                             1.069      1685.000 ± 1678.000 … 1692.000     1801.000 ± 1787.000 … 1815.000     -0.2% (-0.1 MB)
Octane          regexp.js                               1.069      1119.500 ± 1118.000 … 1121.000     1196.500 ± 1195.000 … 1198.000     -0.2% (-0.1 MB)
Octane          richards.js                             1.042      1406.000 ± 1391.000 … 1421.000     1464.500 ± 1455.000 … 1474.000     +0.3% (+0.1 MB)
Octane          splay.js                                1.070      5629.500 ± 5557.000 … 5702.000     6024.500 ± 5987.000 … 6062.000     -0.3% (-1.4 MB)
Octane          typescript.js                           1.060      11143.000 ± 11132.000 … 11154.000  11809.000 ± 11763.000 … 11855.000  -0.2% (-0.5 MB)
Octane          zlib.js                                 0.907      3861.000 ± 3839.000 … 3883.000     3500.500 ± 3482.000 … 3519.000     -0.1% (-0.1 MB)
LongSpider      3d-cube.js                              0.896      6.099 ± 6.083 … 6.115              6.805 ± 6.785 … 6.826              -0.5% (-0.2 MB)
LongSpider      3d-morph.js                             0.959      2.905 ± 2.891 … 2.920              3.029 ± 3.025 … 3.033              +0.4% (+0.1 MB)
LongSpider      3d-raytrace.js                          1.064      5.688 ± 5.632 … 5.743              5.343 ± 5.281 … 5.405              +0.2% (+0.1 MB)
LongSpider      access-binary-trees.js                  1.072      15.736 ± 15.727 … 15.744           14.673 ± 14.618 … 14.727           +4.1% (+7.6 MB)
LongSpider      access-fannkuch.js                      0.938      2.471 ± 2.462 … 2.480              2.635 ± 2.634 … 2.637              +0.1% (+0.0 MB)
LongSpider      access-nbody.js                         0.983      6.944 ± 6.937 … 6.950              7.066 ± 7.065 … 7.067              +0.1% (+0.0 MB)
LongSpider      access-nsieve.js                        1.022      2.110 ± 2.106 … 2.113              2.065 ± 2.061 … 2.069              -0.0% (-0.0 MB)
LongSpider      bitops-3bit-bits-in-byte.js             0.987      0.692 ± 0.689 … 0.695              0.701 ± 0.700 … 0.702              +0.1% (+0.0 MB)
LongSpider      bitops-bits-in-byte.js                  0.988      1.537 ± 1.536 … 1.539              1.557 ± 1.548 … 1.566              +0.1% (+0.0 MB)
LongSpider      bitops-nsieve-bits.js                   0.986      3.165 ± 3.142 … 3.189              3.209 ± 3.206 … 3.212              -0.3% (-0.1 MB)
LongSpider      controlflow-recursive.js                1.026      3.825 ± 3.822 … 3.828              3.727 ± 3.726 … 3.728              -0.4% (-0.1 MB)
LongSpider      crypto-aes.js                           1.056      8.396 ± 8.379 … 8.413              7.949 ± 7.938 … 7.960              -0.1% (-0.1 MB)
LongSpider      crypto-md5.js                           0.998      8.408 ± 8.405 … 8.412              8.425 ± 8.409 … 8.442              -0.0% (-0.0 MB)
LongSpider      crypto-sha1.js                          0.987      15.647 ± 15.555 … 15.738           15.857 ± 15.828 … 15.886           -0.2% (-0.1 MB)
LongSpider      date-format-tofte.js                    1.028      6.816 ± 6.815 … 6.818              6.630 ± 6.619 … 6.642              -0.0% (-0.0 MB)
LongSpider      date-format-xparb.js                    1.007      8.277 ± 8.169 … 8.384              8.217 ± 8.151 … 8.282              -0.3% (-0.1 MB)
LongSpider      hash-map.js                             1.002      1.851 ± 1.845 … 1.856              1.847 ± 1.831 … 1.863              -0.1% (-0.1 MB)
LongSpider      math-cordic.js                          0.978      8.851 ± 8.848 … 8.855              9.047 ± 9.024 … 9.070              -0.4% (-0.1 MB)
LongSpider      math-partial-sums.js                    0.996      1.444 ± 1.441 … 1.448              1.451 ± 1.447 … 1.454              -0.4% (-0.1 MB)
LongSpider      math-spectral-norm.js                   0.976      7.046 ± 7.045 … 7.046              7.217 ± 7.181 … 7.254              -0.4% (-0.1 MB)
LongSpider      string-base64.js                        1.194      2.842 ± 2.824 … 2.860              2.380 ± 2.375 … 2.385              +6.7% (+21.6 MB)
LongSpider      string-fasta.js                         1.069      2.880 ± 2.869 … 2.891              2.693 ± 2.645 … 2.740              +0.3% (+0.1 MB)
LongSpider      string-tagcloud.js                      1.036      1.094 ± 1.094 … 1.094              1.056 ± 1.048 … 1.063              +1.8% (+1.2 MB)
JetStream       bigfib.cpp.js                           0.922      7.163 ± 7.156 … 7.170              7.768 ± 7.747 … 7.789              +0.0% (+0.1 MB)
JetStream       cdjs.js                                 1.021      3.819 ± 3.818 … 3.820              3.740 ± 3.728 … 3.752              -5.1% (-2.1 MB)
JetStream       container.cpp.js                        0.989      45.310 ± 45.264 … 45.355           45.810 ± 45.632 … 45.988           +0.2% (+0.3 MB)
JetStream       dry.c.js                                0.884      17.904 ± 17.874 … 17.935           20.252 ± 20.237 … 20.267           +0.5% (+0.3 MB)
JetStream       float-mm.c.js                           0.920      20.384 ± 20.078 … 20.690           22.151 ± 22.144 … 22.158           -0.0% (-0.0 MB)
JetStream       gcc-loops.cpp.js                        0.938      119.732 ± 119.478 … 119.987        127.629 ± 127.628 … 127.630        +0.0% (+0.0 MB)
JetStream       hash-map.js                             1.019      1.864 ± 1.856 … 1.872              1.830 ± 1.823 … 1.836              +0.0% (+0.0 MB)
JetStream       n-body.c.js                             0.876      29.558 ± 29.552 … 29.563           33.728 ± 33.714 … 33.742           +0.4% (+0.2 MB)
JetStream       quicksort.c.js                          0.969      3.957 ± 3.948 … 3.967              4.083 ± 4.083 … 4.084              +0.5% (+0.3 MB)
JetStream       towers.c.js                             0.981      11.824 ± 11.789 … 11.860           12.053 ± 11.967 … 12.139           +0.4% (+0.2 MB)
JetStream3      js-tokens.js                            1.089      0.479 ± 0.473 … 0.486              0.440 ± 0.436 … 0.445              -0.2% (-0.1 MB)
JetStream3      lazy-collections.js                     1.098      1.601 ± 1.593 … 1.610              1.459 ± 1.457 … 1.461              -1.5% (-0.7 MB)
JetStream3      raytrace-private-class-fields.js        1.201      8.288 ± 8.276 … 8.299              6.901 ± 6.855 … 6.947              +0.1% (+0.0 MB)
JetStream3      raytrace-public-class-fields.js         1.147      5.224 ± 5.192 … 5.257              4.554 ± 4.523 … 4.585              -0.4% (-0.1 MB)
JetStream3      sync-file-system.js                     1.055      3.738 ± 3.736 … 3.739              3.542 ± 3.515 … 3.570              +3.0% (+1.1 MB)
JetStreamExtra  FlightPlanner.js                        1.058      1.647 ± 1.635 … 1.659              1.556 ± 1.532 … 1.580              -0.1% (-0.2 MB)
JetStreamExtra  OfflineAssembler.js                     1.031      3.024 ± 3.015 … 3.034              2.933 ± 2.926 … 2.939              -1.4% (-0.9 MB)
JetStreamExtra  UniPoker.js                             1.048      3.529 ± 3.525 … 3.532              3.368 ± 3.364 … 3.372              +0.1% (+0.1 MB)
JetStreamExtra  async-fs.js                             1.119      3.637 ± 3.636 … 3.637              3.250 ± 3.247 … 3.254              +0.6% (+0.3 MB)
JetStreamExtra  babylonjs-startup-es5.js                1.039      1.316 ± 1.309 … 1.323              1.267 ± 1.264 … 1.270              +0.0% (+0.1 MB)
JetStreamExtra  babylonjs-startup-es6.js                1.034      1.542 ± 1.532 … 1.552              1.492 ± 1.484 … 1.499              +0.4% (+2.7 MB)
JetStreamExtra  bigint-bigdenary.js                     1.032      3.908 ± 3.904 … 3.911              3.786 ± 3.720 … 3.852              +0.6% (+0.3 MB)
JetStreamExtra  bigint-noble-bls12-381.js               1.038      4.140 ± 4.137 … 4.142              3.987 ± 3.940 … 4.033              -0.1% (-0.1 MB)
JetStreamExtra  bigint-noble-ed25519.js                 1.053      4.071 ± 4.062 … 4.080              3.865 ± 3.860 … 3.870              -0.3% (-0.3 MB)
JetStreamExtra  bigint-noble-secp256k1.js               1.034      3.783 ± 3.767 … 3.799              3.657 ± 3.656 … 3.658              -0.3% (-0.2 MB)
JetStreamExtra  bigint-paillier.js                      1.018      4.303 ± 4.303 … 4.303              4.229 ± 4.222 … 4.236              +0.3% (+0.2 MB)
JetStreamExtra  doxbee-async.js                         1.046      8.394 ± 8.302 … 8.485              8.024 ± 7.956 … 8.092              +1.1% (+1.5 MB)
JetStreamExtra  doxbee-promise.js                       1.086      7.490 ± 7.489 … 7.491              6.895 ± 6.854 … 6.935              -0.7% (-1.5 MB)
JetStreamExtra  first-inspector-code-load.js            1.097      2.908 ± 2.670 … 3.146              2.650 ± 2.629 … 2.671              +0.1% (+2.2 MB)
JetStreamExtra  jsdom-d3-startup.js                     1.061      2.347 ± 2.329 … 2.365              2.213 ± 2.195 … 2.231              +0.3% (+1.3 MB)
JetStreamExtra  json-parse-inspector.js                 1.084      1.556 ± 1.546 … 1.567              1.436 ± 1.436 … 1.436              +0.0% (+0.2 MB)
JetStreamExtra  json-stringify-inspector.js             1.026      2.063 ± 2.059 … 2.068              2.011 ± 2.006 … 2.016              +0.0% (+0.1 MB)
JetStreamExtra  mobx-startup.js                         1.031      3.502 ± 3.485 … 3.519              3.398 ± 3.397 … 3.399              -0.8% (-0.6 MB)
JetStreamExtra  multi-inspector-code-load.js            1.014      2.654 ± 2.642 … 2.665              2.618 ± 2.614 … 2.621              +0.3% (+4.8 MB)
JetStreamExtra  prismjs-startup-es5.js                  1.074      2.998 ± 2.983 … 3.013              2.790 ± 2.788 … 2.793              -0.2% (-0.1 MB)
JetStreamExtra  prismjs-startup-es6.js                  1.068      2.988 ± 2.979 … 2.997              2.797 ± 2.784 … 2.811              +0.3% (+0.2 MB)
JetStreamExtra  proxy-mobx.js                           1.090      2.596 ± 2.595 … 2.598              2.382 ± 2.380 … 2.384              -0.2% (-0.1 MB)
JetStreamExtra  proxy-vue.js                            1.148      0.077 ± 0.076 … 0.078              0.067 ± 0.067 … 0.067              +0.9% (+0.4 MB)
JetStreamExtra  threejs.js                              1.075      3.432 ± 3.416 … 3.447              3.192 ± 3.170 … 3.214              +0.0% (+0.1 MB)
JetStreamExtra  typescript-lib.js                       1.047      1.070 ± 1.062 … 1.078              1.022 ± 1.015 … 1.029              +1.3% (+5.1 MB)
JetStreamExtra  validatorjs.js                          1.060      2.757 ± 2.742 … 2.773              2.600 ± 2.590 … 2.610              +0.2% (+0.1 MB)
JetStreamExtra  web-ssr.js                              1.032      3.042 ± 3.034 … 3.050              2.947 ± 2.943 … 2.951              -0.7% (-2.2 MB)
MicroBench      array-destructuring-assignment-rest.js  1.160      0.750 ± 0.745 … 0.755              0.646 ± 0.645 … 0.647              -0.2% (-0.1 MB)
MicroBench      array-destructuring-assignment.js       1.067      4.988 ± 4.972 … 5.004              4.673 ± 4.672 … 4.673              +0.0% (+0.5 MB)
MicroBench      array-prototype-map.js                  1.097      2.271 ± 2.259 … 2.282              2.071 ± 2.069 … 2.072              -0.0% (-0.0 MB)
MicroBench      array-prototype-shift.js                1.116      0.014 ± 0.010 … 0.019              0.013 ± 0.011 … 0.014              +0.1% (+0.0 MB)
MicroBench      bound-call-00-args.js                   1.027      2.335 ± 2.328 … 2.341              2.275 ± 2.272 … 2.277              +0.1% (+0.0 MB)
MicroBench      bound-call-04-args.js                   1.001      2.581 ± 2.568 … 2.595              2.578 ± 2.514 … 2.643              +0.1% (+0.0 MB)
MicroBench      bound-call-16-args.js                   1.036      2.924 ± 2.866 … 2.983              2.824 ± 2.762 … 2.886              +0.1% (+0.0 MB)
MicroBench      call-00-args.js                         0.995      0.792 ± 0.788 … 0.796              0.797 ± 0.796 … 0.797              +0.1% (+0.0 MB)
MicroBench      call-01-args.js                         1.016      0.879 ± 0.877 … 0.881              0.865 ± 0.863 … 0.867              +0.1% (+0.0 MB)
MicroBench      call-02-args.js                         1.010      0.901 ± 0.898 … 0.904              0.892 ± 0.892 … 0.892              +0.1% (+0.0 MB)
MicroBench      call-03-args.js                         0.997      0.933 ± 0.929 … 0.938              0.936 ± 0.935 … 0.937              +0.1% (+0.0 MB)
MicroBench      call-04-args.js                         0.991      0.959 ± 0.958 … 0.960              0.968 ± 0.967 … 0.968              +0.1% (+0.0 MB)
MicroBench      call-16-args.js                         0.882      1.256 ± 1.254 … 1.258              1.425 ± 1.422 … 1.427              +0.1% (+0.0 MB)
MicroBench      call-32-args.js                         0.828      1.682 ± 1.669 … 1.696              2.031 ± 2.027 … 2.035              +0.1% (+0.0 MB)
MicroBench      call-with-function-environment.js       1.021      0.823 ± 0.821 … 0.824              0.805 ± 0.804 … 0.807              +0.1% (+0.0 MB)
MicroBench      for-in-indexed-properties.js            1.061      0.306 ± 0.305 … 0.307              0.288 ± 0.288 … 0.289              +0.0% (+0.1 MB)
MicroBench      for-in-named-properties.js              0.960      0.299 ± 0.297 … 0.301              0.312 ± 0.311 … 0.312              +0.1% (+0.0 MB)
MicroBench      for-of.js                               1.042      0.938 ± 0.929 … 0.947              0.901 ± 0.899 … 0.902              +0.1% (+0.0 MB)
MicroBench      google-maps-array-iterator.js           1.039      1.238 ± 1.235 … 1.240              1.192 ± 1.186 … 1.198              -0.2% (-0.1 MB)
MicroBench      object-keys.js                          1.139      3.061 ± 3.054 … 3.068              2.687 ± 2.684 … 2.691              -0.1% (-0.1 MB)
MicroBench      object-set-with-rope-strings.js         1.075      0.874 ± 0.873 … 0.876              0.813 ± 0.812 … 0.814              +0.1% (+0.0 MB)
MicroBench      pic-add-own.js                          1.070      1.016 ± 1.014 … 1.017              0.949 ± 0.936 … 0.962              -0.5% (-0.2 MB)
MicroBench      pic-get-own.js                          1.101      1.109 ± 1.108 … 1.111              1.008 ± 1.007 … 1.008              +0.1% (+0.0 MB)
MicroBench      pic-get-pchain.js                       1.126      1.111 ± 1.109 … 1.113              0.987 ± 0.985 … 0.988              +0.1% (+0.0 MB)
MicroBench      pic-put-own.js                          1.051      1.054 ± 1.053 … 1.056              1.003 ± 1.001 … 1.004              +0.1% (+0.0 MB)
MicroBench      pic-put-pchain.js                       1.062      3.657 ± 3.649 … 3.664              3.443 ± 3.418 … 3.467              +0.1% (+0.0 MB)
MicroBench      setter-in-prototype-chain.js            1.009      3.704 ± 3.672 … 3.736              3.671 ± 3.559 … 3.782              +0.1% (+0.0 MB)
MicroBench      short-string-concat.js                  1.015      0.524 ± 0.523 … 0.525              0.516 ± 0.510 … 0.522              +0.1% (+0.0 MB)
MicroBench      strictly-equals-object.js               1.090      1.497 ± 1.495 … 1.499              1.374 ± 1.373 … 1.375              +0.1% (+0.0 MB)
AsyncBench      async-call-return.js                    1.115      0.359 ± 0.356 … 0.361              0.322 ± 0.320 … 0.323              +0.1% (+0.0 MB)
AsyncBench      async-class-method.js                   1.119      0.788 ± 0.783 … 0.793              0.704 ± 0.702 … 0.705              -0.3% (-0.1 MB)
AsyncBench      async-fan-out.js                        1.142      0.372 ± 0.369 … 0.374              0.325 ± 0.325 … 0.326              -0.2% (-0.1 MB)
AsyncBench      async-generator.js                      1.180      0.593 ± 0.591 … 0.595              0.503 ± 0.502 … 0.504              -0.0% (-0.0 MB)
AsyncBench      async-iife.js                           1.147      0.660 ± 0.659 … 0.662              0.576 ± 0.573 … 0.579              +0.0% (+0.0 MB)
AsyncBench      async-nested-calls.js                   1.109      0.973 ± 0.969 … 0.976              0.877 ± 0.876 … 0.877              -0.2% (-0.1 MB)
AsyncBench      async-pipeline.js                       1.129      0.517 ± 0.515 … 0.518              0.458 ± 0.457 … 0.458              -0.0% (-0.0 MB)
AsyncBench      async-sequential-awaits.js              1.070      0.230 ± 0.228 … 0.232              0.215 ± 0.212 … 0.218              -0.2% (-0.1 MB)
AsyncBench      async-try-catch-reject.js               1.079      0.716 ± 0.712 … 0.720              0.663 ± 0.661 … 0.666              -0.2% (-0.1 MB)
AsyncBench      await-primitive.js                      0.991      0.072 ± 0.069 … 0.074              0.072 ± 0.069 … 0.075              -0.2% (-0.1 MB)
AsyncBench      await-resolved-promise.js               1.156      0.724 ± 0.719 … 0.728              0.626 ± 0.624 … 0.628              -0.2% (-0.1 MB)
AsyncBench      await-thenable.js                       1.175      1.587 ± 1.586 … 1.588              1.351 ± 1.349 … 1.352              -0.2% (-0.1 MB)
AsyncBench      promise-all.js                          1.143      1.052 ± 1.052 … 1.052              0.920 ± 0.920 … 0.921              -0.2% (-0.1 MB)
AsyncBench      promise-allSettled.js                   1.173      1.192 ± 1.190 … 1.194              1.017 ± 1.015 … 1.018              -0.2% (-0.1 MB)
AsyncBench      promise-chain.js                        1.149      0.327 ± 0.321 … 0.333              0.285 ± 0.281 … 0.288              -0.1% (-0.1 MB)
AsyncBench      promise-new-resolve.js                  1.193      0.538 ± 0.529 … 0.546              0.451 ± 0.450 … 0.451              -0.2% (-0.1 MB)
AsyncBench      promise-race.js                         1.153      1.103 ± 1.094 … 1.112              0.957 ± 0.955 … 0.959              -0.2% (-0.1 MB)
ARES-6          Air.js                                  1.074      3.397 ± 3.380 … 3.414              3.162 ± 3.161 … 3.162              -1.7% (-1.2 MB)
ARES-6          Babylon.js                              1.080      2.249 ± 2.228 … 2.271              2.083 ± 2.058 … 2.109              +2.1% (+1.2 MB)
ARES-6          Basic.js                                1.094      2.608 ± 2.606 … 2.609              2.384 ± 2.358 … 2.410              -0.2% (-0.1 MB)
ARES-6          ML.js                                   1.052      2.784 ± 2.783 … 2.784              2.646 ± 2.643 … 2.649              -1.8% (-1.0 MB)
Kraken          Total                                   0.969      12.434                             12.830                             -0.0% (-0.3 MB)
Octane          Total                                   1.016      75490.500                          76705.000                          +0.3% (+8.1 MB)
LongSpider      Total                                   1.009      124.724                            123.579                            +1.7% (+29.6 MB)
JetStream       Total                                   0.937      261.515                            279.045                            -0.1% (-0.7 MB)
JetStream3      Total                                   1.144      19.330                             16.897                             +0.1% (+0.3 MB)
JetStreamExtra  Total                                   1.054      84.773                             80.431                             +0.2% (+13.4 MB)
MicroBench      Total                                   1.036      44.478                             42.940                             +0.0% (+0.7 MB)
AsyncBench      Total                                   1.144      11.801                             10.320                             -0.1% (-1.2 MB)
ARES-6          Total                                   1.074      11.038                             10.275                             -0.5% (-1.1 MB)
All Suites      Total                                   0.986      659.940                            669.018                            +0.2% (+48.7 MB)
```