### PR TITLE
LibWeb+WebContent+LibWebView: Keep navigation source across swap

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -647,6 +647,7 @@ set(SOURCES
     HTML/NavigationCurrentEntryChangeEvent.cpp
     HTML/NavigationDestination.cpp
     HTML/NavigationHistoryEntry.cpp
+    HTML/NavigationSourceSnapshot.cpp
     HTML/NavigationObserver.cpp
     HTML/NavigationParams.cpp
     HTML/NavigationTransition.cpp

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1737,6 +1737,7 @@ static void create_navigation_params_by_fetching(
     Fetch::Infrastructure::Request::ReferrerType request_referrer,
     ReferrerPolicy::ReferrerPolicy request_referrer_policy,
     Optional<URL::Origin> initiator_origin,
+    Optional<URL::Origin> cross_process_initiator_origin,
     Variant<SerializedPolicyContainer, DocumentState::Client> history_policy_container,
     Optional<URL::URL> about_base_url,
     Optional<URL::Origin> origin,
@@ -1790,6 +1791,13 @@ static void create_navigation_params_by_fetching(
     //    document state's initiator origin.
     if (navigable->is_top_level_traversable())
         request->set_top_level_navigation_initiator_origin(initiator_origin);
+
+    // AD-HOC: The request's origin would normally be resolved from its client (sourceSnapshotParams's fetch client),
+    //         which is the source document's environment settings object. For a navigation handed off from another
+    //         WebContent process, that client is this process's initial about:blank document, whose origin is opaque.
+    //         Use the origin snapshotted from the real source document instead, so the Origin header is correct.
+    if (cross_process_initiator_origin.has_value())
+        request->set_origin(*cross_process_initiator_origin);
 
     // 5. If request's client is null:
     if (request->client() == nullptr) {
@@ -2022,6 +2030,7 @@ void LocalNavigable::populate_session_history_entry_document(
     Fetch::Infrastructure::Request::ReferrerType request_referrer,
     ReferrerPolicy::ReferrerPolicy request_referrer_policy,
     Optional<URL::Origin> initiator_origin,
+    Optional<URL::Origin> cross_process_initiator_origin,
     Optional<URL::Origin> origin,
     Variant<SerializedPolicyContainer, DocumentState::Client> history_policy_container,
     Optional<URL::URL> about_base_url,
@@ -2249,6 +2258,7 @@ void LocalNavigable::populate_session_history_entry_document(
                 request_referrer,
                 request_referrer_policy,
                 initiator_origin,
+                cross_process_initiator_origin,
                 history_policy_container,
                 about_base_url,
                 origin,
@@ -2437,6 +2447,24 @@ void LocalNavigable::begin_navigation(NavigateParams params)
 
         // 4. Set initiatorBaseURLSnapshot to sourceDocument's document base URL.
         initiator_base_url_snapshot = source_document->base_url();
+    }
+
+    // AD-HOC: If this navigation was handed off from another WebContent process, sourceDocument is merely this
+    //         process's initial about:blank document. Substitute the state that the navigate algorithm snapshotted
+    //         from the real source document in the process where the navigation started. The fetch client cannot
+    //         cross the process boundary, so the local document's environment continues to stand in for it as the
+    //         request client.
+    if (params.cross_process_source_snapshot.has_value()) {
+        auto const& snapshot = *params.cross_process_source_snapshot;
+        source_snapshot_params = heap().allocate<SourceSnapshotParams>(
+            snapshot.has_transient_activation,
+            snapshot.sandboxing_flags,
+            snapshot.allows_downloading,
+            source_snapshot_params->fetch_client,
+            create_a_policy_container_from_serialized_policy_container(heap(), snapshot.source_policy_container));
+        initiator_origin_snapshot = snapshot.initiator_origin_snapshot;
+        initiator_base_url_snapshot = snapshot.initiator_base_url_snapshot;
+        referrer_policy = snapshot.referrer_policy;
     }
 
     // 5. If sourceDocument's node navigable is not allowed by sandboxing to navigate navigable given sourceSnapshotParams, then:
@@ -2648,21 +2676,39 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                     return;
                 }
 
-                // AD-HOC: If we are not able to continue in this process, request a new process from the UI.
+                // AD-HOC: If we are not able to continue in this process, request a new process from the UI. The new
+                //         process cannot snapshot the source document (it only exists in this process), so hand over
+                //         the state that the navigate algorithm snapshotted from it. Browser-UI navigations hand over
+                //         nothing: per spec their sourceDocument is null and their source snapshot params and
+                //         initiator origin have fixed values, which the new process provides on its own.
                 auto& page_client = active_browsing_context()->page().client();
                 auto is_top_level_navigation = is_top_level_traversable();
                 auto target = is_top_level_navigation ? NavigationTarget::TopLevel : NavigationTarget::IFrame;
                 auto frame_id = is_top_level_navigation ? Optional<CrossProcessId> {} : Optional<CrossProcessId> { id() };
                 auto process_decision = page_client.decide_navigation_process(this->active_document()->url(), url, target, move(frame_id));
-                if (process_decision == NavigationProcessDecision::Remote && is_top_level_navigation) {
-                    page_client.request_new_process_for_navigation(url, document_resource, history_handling);
-                    set_delaying_load_events(false);
-                    return;
-                }
                 if (process_decision == NavigationProcessDecision::Remote) {
-                    if (has_compositor_context())
-                        compositor_context().set_parent_context({});
-                    page_client.request_new_process_for_child_frame_navigation(id(), url, document_resource, history_handling);
+                    Optional<NavigationSourceSnapshot> source_snapshot;
+                    if (user_involvement != UserNavigationInvolvement::BrowserUI) {
+                        source_snapshot = NavigationSourceSnapshot {
+                            .has_transient_activation = source_snapshot_params->has_transient_activation,
+                            .sandboxing_flags = source_snapshot_params->sandboxing_flags,
+                            .allows_downloading = source_snapshot_params->allows_downloading,
+                            .source_policy_container = source_snapshot_params->source_policy_container->serialize(),
+                            .initiator_origin_snapshot = initiator_origin_snapshot,
+                            .initiator_base_url_snapshot = initiator_base_url_snapshot,
+                            .referrer = params.cross_process_source_snapshot.has_value()
+                                ? params.cross_process_source_snapshot->referrer
+                                : params.source_document->url(),
+                            .referrer_policy = referrer_policy,
+                        };
+                    }
+                    if (is_top_level_navigation) {
+                        page_client.request_new_process_for_navigation(url, document_resource, history_handling, source_snapshot);
+                    } else {
+                        if (has_compositor_context())
+                            compositor_context().set_parent_context({});
+                        page_client.request_new_process_for_child_frame_navigation(id(), url, document_resource, history_handling, source_snapshot);
+                    }
                     set_delaying_load_events(false);
                     return;
                 }
@@ -2700,6 +2746,12 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                 document_state->set_initiator_origin(initiator_origin_snapshot);
                 document_state->set_resource(document_resource);
                 document_state->set_navigable_target_name(target_name());
+
+                // AD-HOC: The request referrer normally stays "client" and is resolved from the fetch client, but for
+                //         a navigation handed off from another process, that client belongs to the source document in
+                //         the process where the navigation started. Use the referrer snapshotted there instead.
+                if (params.cross_process_source_snapshot.has_value())
+                    document_state->set_request_referrer(params.cross_process_source_snapshot->referrer);
 
                 // 5. If url matches about:blank or is about:srcdoc, then:
                 // FIXME: Is calling url_matches_about_srcdoc() correct? https://github.com/whatwg/html/issues/10900
@@ -2812,6 +2864,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                     history_entry->document_state()->request_referrer(),
                     history_entry->document_state()->request_referrer_policy(),
                     history_entry->document_state()->initiator_origin(),
+                    params.cross_process_source_snapshot.has_value() ? Optional<URL::Origin> { params.cross_process_source_snapshot->initiator_origin_snapshot } : Optional<URL::Origin> {},
                     history_entry->document_state()->origin(),
                     history_entry->document_state()->history_policy_container(),
                     history_entry->document_state()->about_base_url(),

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -26,6 +26,7 @@
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigationObserver.h>
 #include <LibWeb/HTML/NavigationParams.h>
+#include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/PaintConfig.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
@@ -175,6 +176,7 @@ public:
         Fetch::Infrastructure::Request::ReferrerType request_referrer,
         ReferrerPolicy::ReferrerPolicy request_referrer_policy,
         Optional<URL::Origin> initiator_origin,
+        Optional<URL::Origin> cross_process_initiator_origin,
         Optional<URL::Origin> origin,
         Variant<SerializedPolicyContainer, DocumentState::Client> history_policy_container,
         Optional<URL::URL> about_base_url,
@@ -204,6 +206,10 @@ public:
         UserNavigationInvolvement user_involvement = UserNavigationInvolvement::None;
         GC::Ptr<DOM::Element> source_element = nullptr;
         InitialInsertion initial_insertion = InitialInsertion::No;
+        // AD-HOC: Set when this navigation was started in another WebContent process and handed off to this one. The
+        //         source document only exists in the process where the navigation started, so this carries the state
+        //         the navigate algorithm would otherwise snapshot from it.
+        Optional<NavigationSourceSnapshot> cross_process_source_snapshot = {};
 
         void visit_edges(Cell::Visitor& visitor);
     };

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1212,7 +1212,7 @@ void ApplyHistoryStepState::start()
                 Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [input_url = move(input_url), input_document_resource = move(input_document_resource), input_request_referrer = move(input_request_referrer), input_request_referrer_policy, input_initiator_origin = move(input_initiator_origin), input_origin = move(input_origin), input_history_policy_container = move(input_history_policy_container), input_about_base_url = move(input_about_base_url), input_navigable_target_name = move(input_navigable_target_name), input_ever_populated, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated, user_involvement = m_user_involvement] {
                     navigable->populate_session_history_entry_document(
                         move(input_url), move(input_document_resource), move(input_request_referrer),
-                        input_request_referrer_policy, move(input_initiator_origin), move(input_origin),
+                        input_request_referrer_policy, move(input_initiator_origin), {}, move(input_origin),
                         input_history_policy_container, move(input_about_base_url), move(input_navigable_target_name),
                         false, input_ever_populated,
                         *potentially_target_specific_source_snapshot_params, target_snapshot_params,

--- a/Libraries/LibWeb/HTML/NavigationSourceSnapshot.cpp
+++ b/Libraries/LibWeb/HTML/NavigationSourceSnapshot.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/NavigationSourceSnapshot.h>
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::HTML::NavigationSourceSnapshot const& snapshot)
+{
+    TRY(encoder.encode(snapshot.has_transient_activation));
+    TRY(encoder.encode(snapshot.sandboxing_flags));
+    TRY(encoder.encode(snapshot.allows_downloading));
+    TRY(encoder.encode(snapshot.source_policy_container));
+    TRY(encoder.encode(snapshot.initiator_origin_snapshot));
+    TRY(encoder.encode(snapshot.initiator_base_url_snapshot));
+    TRY(encoder.encode(snapshot.referrer));
+    TRY(encoder.encode(snapshot.referrer_policy));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::NavigationSourceSnapshot> decode(Decoder& decoder)
+{
+    return Web::HTML::NavigationSourceSnapshot {
+        .has_transient_activation = TRY(decoder.decode<bool>()),
+        .sandboxing_flags = TRY(decoder.decode<Web::HTML::SandboxingFlagSet>()),
+        .allows_downloading = TRY(decoder.decode<bool>()),
+        .source_policy_container = TRY(decoder.decode<Web::HTML::SerializedPolicyContainer>()),
+        .initiator_origin_snapshot = TRY(decoder.decode<URL::Origin>()),
+        .initiator_base_url_snapshot = TRY(decoder.decode<URL::URL>()),
+        .referrer = TRY(decoder.decode<URL::URL>()),
+        .referrer_policy = TRY(decoder.decode<Web::ReferrerPolicy::ReferrerPolicy>()),
+    };
+}
+
+}

--- a/Libraries/LibWeb/HTML/NavigationSourceSnapshot.h
+++ b/Libraries/LibWeb/HTML/NavigationSourceSnapshot.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibIPC/Forward.h>
+#include <LibURL/Origin.h>
+#include <LibURL/URL.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/HTML/SandboxingFlagSet.h>
+#include <LibWeb/HTML/SerializedPolicyContainer.h>
+#include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
+
+namespace Web::HTML {
+
+// AD-HOC: When a cross-site navigation continues in a new WebContent process, the source document only exists in the
+//         process where the navigation started. This carries the state that the navigate algorithm snapshots from the
+//         source document, so the new process can continue the navigation as if it had snapshotted it locally.
+struct NavigationSourceSnapshot {
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#source-snapshot-params
+    // NB: The source snapshot params' fetch client cannot cross the process boundary; the receiving process
+    //     substitutes its own environment as the request client, and the referrer below carries the value that fetch
+    //     would have derived from the original fetch client.
+    bool has_transient_activation { false };
+    SandboxingFlagSet sandboxing_flags {};
+    bool allows_downloading { true };
+    SerializedPolicyContainer source_policy_container;
+
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate, steps 3 and 4
+    URL::Origin initiator_origin_snapshot;
+    URL::URL initiator_base_url_snapshot;
+
+    // AD-HOC: The referrer that fetch would resolve for the navigation request from the source document's fetch
+    //         client, and the referrer policy the navigate algorithm was invoked with.
+    URL::URL referrer;
+    ReferrerPolicy::ReferrerPolicy referrer_policy { ReferrerPolicy::ReferrerPolicy::EmptyString };
+};
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::NavigationSourceSnapshot const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::NavigationSourceSnapshot> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -135,7 +135,7 @@ void Page::load(URL::URL const& url, Bindings::NavigationHistoryBehavior history
 }
 
 void Page::load(URL::URL const& url, HTML::DocumentResource document_resource,
-    Bindings::NavigationHistoryBehavior history_handling)
+    Bindings::NavigationHistoryBehavior history_handling, Optional<HTML::NavigationSourceSnapshot> source_snapshot)
 {
     (void)top_level_traversable()->navigate({
         .url = url,
@@ -143,6 +143,7 @@ void Page::load(URL::URL const& url, HTML::DocumentResource document_resource,
         .document_resource = move(document_resource),
         .history_handling = history_handling,
         .user_involvement = HTML::UserNavigationInvolvement::BrowserUI,
+        .cross_process_source_snapshot = move(source_snapshot),
     });
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -48,6 +48,7 @@
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
@@ -114,7 +115,8 @@ public:
 
     void load(URL::URL const&, Bindings::NavigationHistoryBehavior = Bindings::NavigationHistoryBehavior::Auto);
     void load(URL::URL const&, HTML::DocumentResource,
-        Bindings::NavigationHistoryBehavior = Bindings::NavigationHistoryBehavior::Auto);
+        Bindings::NavigationHistoryBehavior = Bindings::NavigationHistoryBehavior::Auto,
+        Optional<HTML::NavigationSourceSnapshot> = {});
 
     void load_html(StringView);
     void load_html(StringView, URL::URL const&);
@@ -458,8 +460,8 @@ public:
     {
         return NavigationProcessDecision::Local;
     }
-    virtual void request_new_process_for_navigation(URL::URL const&, HTML::DocumentResource, Bindings::NavigationHistoryBehavior) { }
-    virtual void request_new_process_for_child_frame_navigation(HTML::CrossProcessId, URL::URL const&, HTML::DocumentResource, Bindings::NavigationHistoryBehavior) { }
+    virtual void request_new_process_for_navigation(URL::URL const&, HTML::DocumentResource, Bindings::NavigationHistoryBehavior, Optional<HTML::NavigationSourceSnapshot> const&) { }
+    virtual void request_new_process_for_child_frame_navigation(HTML::CrossProcessId, URL::URL const&, HTML::DocumentResource, Bindings::NavigationHistoryBehavior, Optional<HTML::NavigationSourceSnapshot> const&) { }
     virtual void page_did_create_child_frame(HTML::CrossProcessId, HTML::CrossProcessId, HTML::ReplicatedNavigableState const&) { }
     virtual void page_did_update_child_frame_viewport(HTML::CrossProcessId, CSSPixelRect) { }
     virtual void page_did_commit_child_frame_navigation(HTML::CrossProcessId, HTML::ReplicatedNavigableState const&) { }

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -173,7 +173,7 @@ void ViewImplementation::set_favicon(Badge<WebContentClient>, Optional<Gfx::Bitm
         on_favicon_change(favicon);
 }
 
-void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot)
 {
     dump_session_history("before-process-swap"sv);
     m_webdriver_pending_navigation_url = url;
@@ -215,7 +215,7 @@ void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL c
         seed_web_content_session_history_from_ui_process();
     auto web_content_history_handling = preparation.should_seed_web_content_before_load ? Web::Bindings::NavigationHistoryBehavior::Replace : history_handling;
     dump_session_history("process-swap-load"sv);
-    client().async_load_url_with_document_resource(page_id(), url, document_resource, web_content_history_handling);
+    client().async_load_url_with_document_resource(page_id(), url, document_resource, web_content_history_handling, move(source_snapshot));
     dump_session_history("after-process-swap-load"sv);
 }
 
@@ -1820,7 +1820,7 @@ void ViewImplementation::load_current_session_history_entry_from_ui_process()
     if (load.document_resource.has<Empty>())
         client().async_load_url(page_id(), load.url, load.history_handling);
     else
-        client().async_load_url_with_document_resource(page_id(), load.url, load.document_resource, load.history_handling);
+        client().async_load_url_with_document_resource(page_id(), load.url, load.document_resource, load.history_handling, {});
 }
 
 void ViewImplementation::load_session_history_traversal_target_from_ui_process(TraversableSessionHistory::TraversalTarget const& target, StringView dump_reason)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -91,7 +91,7 @@ public:
 
     String const& handle() const { return m_client_state.client_handle; }
 
-    void create_new_process_for_cross_site_navigation(URL::URL const&, Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior);
+    void create_new_process_for_cross_site_navigation(URL::URL const&, Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior, Optional<Web::HTML::NavigationSourceSnapshot> = {});
 
     void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size, Gfx::IntRect damage_rect);
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -487,10 +487,10 @@ void WebContentClient::did_present_bitmap(u64 page_id, Gfx::IntRect rect, Gfx::I
     }
 }
 
-void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
-        view->create_new_process_for_cross_site_navigation(url, move(document_resource), history_handling);
+        view->create_new_process_for_cross_site_navigation(url, move(document_resource), history_handling, move(source_snapshot));
 }
 
 Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::decide_navigation_process(u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target)
@@ -498,7 +498,7 @@ Messages::WebContentClient::DecideNavigationProcessResponse WebContentClient::de
     return SiteIsolationManager::the().decide_navigation_process(*this, page_id, move(frame_id), move(current_url), move(target_url), target);
 }
 
-void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot)
 {
     auto child_frame = this->child_frame(page_id, frame_id);
     if (!child_frame.has_value())
@@ -527,7 +527,7 @@ void WebContentClient::did_request_new_process_for_child_frame_navigation(u64 pa
             Web::ViewportIsFullscreen::No);
     }
     remote_client->async_set_system_visibility_state(remote_page_id, Web::HTML::VisibilityState::Visible);
-    remote_client->async_load_url_with_document_resource(remote_page_id, url, move(document_resource), history_handling);
+    remote_client->async_load_url_with_document_resource(remote_page_id, url, move(document_resource), history_handling, move(source_snapshot));
 
     SiteIsolationManager::the().transition_child_frame_to_remote(*this, page_id, frame_id, move(remote_client), remote_page_id);
 }

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -124,8 +124,8 @@ private:
     virtual Messages::WebContentClient::AllocateCompositorContextIdResponse allocate_compositor_context_id(u64 page_id, Web::Compositor::PagePresentationRegistration) override;
     virtual void did_destroy_compositor_context(Web::Compositor::CompositorContextId) override;
     virtual Messages::WebContentClient::DecideNavigationProcessResponse decide_navigation_process(u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget) override;
-    virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
-    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) override;
+    virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot) override;
+    virtual void did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot) override;
     virtual void did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;
     virtual void did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) override;
     virtual void did_commit_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -294,13 +294,14 @@ void ConnectionFromClient::load_url(u64 page_id, URL::URL url, Web::Bindings::Na
 
 void ConnectionFromClient::load_url_with_document_resource(u64 page_id, URL::URL url,
     Web::HTML::DocumentResource document_resource,
-    Web::Bindings::NavigationHistoryBehavior history_handling)
+    Web::Bindings::NavigationHistoryBehavior history_handling,
+    Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot)
 {
     auto page = this->page(page_id);
     if (!page.has_value())
         return;
 
-    page->page().load(url, move(document_resource), history_handling);
+    page->page().load(url, move(document_resource), history_handling, move(source_snapshot));
 }
 
 void ConnectionFromClient::load_html(u64 page_id, ByteString html)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -88,7 +88,8 @@ private:
     virtual void update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect>, u32) override;
     virtual void load_url(u64 page_id, URL::URL, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void load_url_with_document_resource(u64 page_id, URL::URL,
-        Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior) override;
+        Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior,
+        Optional<Web::HTML::NavigationSourceSnapshot>) override;
     virtual void load_html(u64 page_id, ByteString) override;
     virtual void load_html_with_url(u64 page_id, ByteString, URL::URL) override;
     virtual void reload(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -218,11 +218,11 @@ Web::NavigationProcessDecision PageClient::decide_navigation_process(URL::URL co
     return client().decide_navigation_process(m_id, move(frame_id), current_url, target_url, target);
 }
 
-void PageClient::request_new_process_for_navigation(URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void PageClient::request_new_process_for_navigation(URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> const& source_snapshot)
 {
     notify_webdriver_of_window_replacement();
 
-    client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling);
+    client().async_did_request_new_process_for_navigation(m_id, url, move(document_resource), history_handling, source_snapshot);
 }
 
 void PageClient::notify_webdriver_of_window_replacement()
@@ -231,9 +231,9 @@ void PageClient::notify_webdriver_of_window_replacement()
         m_webdriver->page_did_start_window_replacement({}, page().top_level_traversable()->window_handle().to_utf8());
 }
 
-void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling)
+void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> const& source_snapshot)
 {
-    client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling);
+    client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling, source_snapshot);
 }
 
 void PageClient::page_did_create_child_frame(Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const& replicated_state)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -155,8 +155,8 @@ private:
     // ^PageClient
     virtual bool is_connection_open() const override;
     virtual Web::NavigationProcessDecision decide_navigation_process(URL::URL const& current_url, URL::URL const& target_url, Web::NavigationTarget, Optional<Web::HTML::CrossProcessId> frame_id) const override;
-    virtual void request_new_process_for_navigation(URL::URL const&, Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior) override;
-    virtual void request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const&, Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior) override;
+    virtual void request_new_process_for_navigation(URL::URL const&, Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior, Optional<Web::HTML::NavigationSourceSnapshot> const&) override;
+    virtual void request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const&, Web::HTML::DocumentResource, Web::Bindings::NavigationHistoryBehavior, Optional<Web::HTML::NavigationSourceSnapshot> const&) override;
     virtual void page_did_create_child_frame(Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const&) override;
     virtual void page_did_update_child_frame_viewport(Web::HTML::CrossProcessId frame_id, Web::CSSPixelRect) override;
     virtual void page_did_commit_child_frame_navigation(Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState const&) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -23,6 +23,7 @@
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
 #include <LibWeb/HTML/SelectedFile.h>
@@ -50,8 +51,8 @@ endpoint WebContentClient
     did_destroy_compositor_context(Web::Compositor::CompositorContextId context_id) =|
 
     decide_navigation_process(u64 page_id, Optional<Web::HTML::CrossProcessId> frame_id, URL::URL current_url, URL::URL target_url, Web::NavigationTarget target) => (Web::NavigationProcessDecision decision)
-    did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, Utf16String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
-    did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Variant<Empty, Utf16String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling) =|
+    did_request_new_process_for_navigation(u64 page_id, URL::URL url, Variant<Empty, Utf16String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot) =|
+    did_request_new_process_for_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, URL::URL url, Variant<Empty, Utf16String, Web::HTML::POSTResource> document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot) =|
     did_create_child_frame(u64 page_id, Web::HTML::CrossProcessId parent_frame_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|
     did_update_child_frame_viewport(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::DevicePixelRect viewport_rect, double device_pixel_ratio) =|
     did_commit_child_frame_navigation(u64 page_id, Web::HTML::CrossProcessId frame_id, Web::HTML::ReplicatedNavigableState replicated_state) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/BroadcastChannelMessage.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/VisibilityState.h>
@@ -59,7 +60,8 @@ endpoint WebContentServer
     load_url(u64 page_id, URL::URL url, Web::Bindings::NavigationHistoryBehavior history_handling) =|
     load_url_with_document_resource(u64 page_id, URL::URL url,
         Variant<Empty, Utf16String, Web::HTML::POSTResource> document_resource,
-        Web::Bindings::NavigationHistoryBehavior history_handling) =|
+        Web::Bindings::NavigationHistoryBehavior history_handling,
+        Optional<Web::HTML::NavigationSourceSnapshot> source_snapshot) =|
     load_html(u64 page_id, ByteString html) =|
     load_html_with_url(u64 page_id, ByteString html, URL::URL url) =|
     reload(u64 page_id) =|

--- a/Tests/LibWeb/Text/expected/SiteIsolation/cross-site-form-post-origin-and-referer.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/cross-site-form-post-origin-and-referer.txt
@@ -1,2 +1,2 @@
-Origin: null
-Referer: (none)
+Origin: <form-page-origin>
+Referer: <form-page-origin>/

--- a/Tests/LibWeb/Text/expected/SiteIsolation/cross-site-form-post-origin-and-referer.txt
+++ b/Tests/LibWeb/Text/expected/SiteIsolation/cross-site-form-post-origin-and-referer.txt
@@ -1,0 +1,2 @@
+Origin: null
+Referer: (none)

--- a/Tests/LibWeb/Text/input/SiteIsolation/cross-site-form-post-origin-and-referer.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/cross-site-form-post-origin-and-referer.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Regression test: a form POST that navigates a top-level traversable to a cross-site URL moves to a new
+    // WebContent process when site isolation is enabled. The navigation state carried over to the new process
+    // must include the initiator origin and referrer, so the request is sent with the correct Origin and
+    // Referer headers instead of "Origin: null" and no Referer.
+    asyncTest(async done => {
+        const httpServer = httpTestServer();
+        const formPageOrigin = new URL(httpServer.baseURL).origin;
+
+        // NB: Unique per-run echo paths, so parallel runs (e.g. under --repeat) don't collide on the echo server.
+        const runId = crypto.randomUUID();
+
+        const targetUrl = new URL(
+            await httpServer.createEcho("POST", `/process-swap-post-target-${runId}`, {
+                status: 200,
+                headers: { "Content-Type": "text/html" },
+                body: "<!DOCTYPE html>target loaded",
+            })
+        );
+        targetUrl.hostname = uniqueLocalhostHostname("process-swap-post");
+
+        const formPageUrl = await httpServer.createEcho("GET", `/process-swap-post-form-${runId}`, {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+            body: `<!DOCTYPE html>
+                <form method="POST" action="${targetUrl}">
+                    <input type="hidden" name="hello" value="friends">
+                </form>
+                <script>document.forms[0].submit();<\/script>`,
+        });
+
+        const popup = window.open(formPageUrl);
+
+        const headersUrl = `${httpServer.baseURL}/recorded-request-headers/echo/process-swap-post-target-${runId}`;
+        let headers = null;
+        while (headers === null) {
+            // NB: The 404 response served before the POST has been recorded has no CORS headers, so fetch() throws.
+            try {
+                const response = await fetch(headersUrl);
+                if (response.ok) {
+                    headers = await response.json();
+                    continue;
+                }
+            } catch {}
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+
+        const normalize = value =>
+            value === undefined ? "(none)" : value.replaceAll(formPageOrigin, "<form-page-origin>");
+        println(`Origin: ${normalize(headers["Origin"]?.[0])}`);
+        println(`Referer: ${normalize(headers["Referer"]?.[0])}`);
+
+        try {
+            popup.close();
+        } catch {}
+        done();
+    });
+</script>


### PR DESCRIPTION
When site isolation moved a cross-site navigation to a new WebContent
process, only the URL, document resource, and history handling were
carried over. The new process then re-ran the navigate algorithm with
its own initial about:blank document as the source document, so the
navigation request's origin became opaque and its referrer resolved to
nothing. A cross-site form POST therefore went out with "Origin: null"
and no Referer header.

Sites that validate the Origin header of cross-site POSTs reject such
requests. This broke BankID login on https://skatteverket.se: the SAML POST
from https://sso.skatteverket.se to https://auth.funktionstjanster.se was answered
with 403 "Invalid CORS request", leaving an empty error page instead
of the QR code login flow.

Introduce NavigationSourceSnapshot, which carries the state that the
navigate algorithm snapshots from the source document, mirroring the
spec structures: the source snapshot params (minus the fetch client,
which cannot cross the process boundary), the initiator origin
snapshot, and the initiator base URL snapshot, plus the referrer that
fetch would have derived from the original fetch client. The handoff
IPC passes it into the new process's navigate call, which substitutes
it for the state it would otherwise snapshot from its local
about:blank document. The navigation request is then sent with the
correct Origin and Referer headers, and the source's policy container,
sandboxing flags, and transient activation also survive the swap.

Browser-UI navigations deliberately hand over no snapshot: per spec
their source document is null, and their source snapshot params and
initiator origin have fixed values the new process provides on its
own. This matters in practice because file:// loads are blocked for
requests with a non-opaque non-file origin, and e.g. test-web
routinely swaps processes when loading a file:// test after a page
left the view on an http URL.

The test added in the previous commit now records the real origin and
referrer instead of "Origin: null", and its expectation is updated
accordingly.