### PR TITLE
LibJS: Accept HTML close comments after trailing whitespace

### DIFF
--- a/Libraries/LibJS/Rust/src/lexer.rs
+++ b/Libraries/LibJS/Rust/src/lexer.rs
@@ -913,11 +913,15 @@ impl<'a> Lexer<'a> {
                         }
                     }
                 } else if self.is_whitespace() {
+                    let start_line_number = self.line_number;
                     loop {
                         self.consume();
                         if !self.is_whitespace() {
                             break;
                         }
+                    }
+                    if start_line_number != self.line_number {
+                        line_has_token_yet = false;
                     }
                 } else if self.is_line_comment_start(line_has_token_yet) {
                     self.consume();

--- a/Tests/LibJS/Runtime/comments-basic.js
+++ b/Tests/LibJS/Runtime/comments-basic.js
@@ -26,6 +26,14 @@ i;`;
     expect(source).toEvalTo(2);
 });
 
+test("html close comments after trailing whitespace", () => {
+    const wrapped = ["var server;", "<!--", 'server = "server_41" ', " -->", "server;"].join("\n");
+    expect(wrapped).toEvalTo("server_41");
+
+    const after_statement = ["var i = 0;", "i++ ", "--> i++;", "i;"].join("\n");
+    expect(after_statement).toEvalTo(1);
+});
+
 test("html comments directly after block comment", () => {
     expect("0 /* */-->i").not.toEval();
     expect(`0 /* 


### PR DESCRIPTION
Treat whitespace runs that cross a line terminator as starting a fresh line for Annex B HTML-like comment parsing. This lets classic scripts accept `-->` after trailing whitespace on the previous line, as the ECMAScript HTMLCloseComment grammar requires.

Fixes a JS parse error on https://skatteverket.se