### PR TITLE
LibRequests: Tolerate a lost connection when stopping a request

### DIFF
--- a/Libraries/LibRequests/Request.cpp
+++ b/Libraries/LibRequests/Request.cpp
@@ -69,7 +69,10 @@ int Request::request_server_client_id() const
 bool Request::stop()
 {
     RefPtr keep_alive = *this;
-    auto had_active_request = m_client->stop_request({}, *this);
+
+    // The client may already be gone if the RequestServer connection was lost while this request was in flight.
+    auto client = m_client.strong_ref();
+    auto had_active_request = client && client->stop_request({}, *this);
     auto on_stop = move(m_on_stop);
 
     defer_teardown();

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -124,7 +124,9 @@ bool RequestClient::stop_request(Badge<Request>, Request& request)
     if (!stopped_request.has_value())
         return false;
 
-    (void)IPCProxy::stop_request(request.id());
+    // This is sent asynchronously so that stopping a request whose RequestServer connection has been lost does not
+    // crash on a synchronous send to a dead connection.
+    async_stop_request(request.id());
     return true;
 }
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -560,6 +560,15 @@ bool Internals::set_http_memory_cache_enabled(bool enabled)
     return was_enabled;
 }
 
+void Internals::simulate_request_server_connection_loss()
+{
+    ResourceLoader::the().request_client() = nullptr;
+
+    // Synchronously obtain a replacement connection from the UI process, so that this process is not left unable to
+    // load resources.
+    page().client().page_did_lose_request_server_connection();
+}
+
 WebIDL::ExceptionOr<void> Internals::set_content_blockers(Utf16String const& patterns_source)
 {
     Utf16StringBuilder patterns_builder;

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -90,6 +90,7 @@ public:
     GC::Ref<WebIDL::Promise> delete_all_cookies();
 
     bool set_http_memory_cache_enabled(bool enabled);
+    void simulate_request_server_connection_loss();
     WebIDL::ExceptionOr<void> set_content_blockers(Utf16String const& patterns);
     void set_content_blocking_enabled(bool enabled);
     WebIDL::UnsignedLongLong partial_layout_count();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -80,6 +80,7 @@ interface Internals {
     Promise<undefined> deleteAllCookies();
 
     boolean setHttpMemoryCacheEnabled(boolean enabled);
+    undefined simulateRequestServerConnectionLoss();
     undefined setContentBlockers(Utf16DOMString patterns);
     undefined setContentBlockingEnabled(boolean enabled);
     unsigned long long partialLayoutCount();

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -564,6 +564,7 @@ public:
     virtual void page_did_update_cookie(HTTP::Cookie::Cookie const&) { }
     virtual void page_did_expire_cookies_with_time_offset(AK::Duration) { }
     virtual void page_did_delete_all_cookies(URL::URL const&, GC::Ref<WebIDL::Promise>) { }
+    virtual void page_did_lose_request_server_connection() { }
     virtual void page_did_store_hsts_policy(String const&, HTTP::HSTS::ParsedHSTSPolicy const&) { }
     virtual bool page_did_is_known_hsts_host(String const&) { return false; }
     virtual Optional<Utf16String> page_did_request_storage_item([[maybe_unused]] Web::StorageAPI::StorageEndpointType storage_endpoint, [[maybe_unused]] String const& storage_key, [[maybe_unused]] Utf16String const& bottle_key) { return {}; }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1374,6 +1374,17 @@ Messages::WebContentClient::DidIsKnownHstsHostResponse WebContentClient::did_is_
     return Application::hsts_store(m_is_private).is_known_hsts_host(domain);
 }
 
+Messages::WebContentClient::DidLoseRequestServerConnectionResponse WebContentClient::did_lose_request_server_connection()
+{
+    auto handle = connect_new_request_server_client(m_is_private);
+    if (handle.is_error()) {
+        warnln("Unable to connect a replacement RequestServer client: {}", handle.error());
+        return OptionalNone {};
+    }
+
+    return handle.release_value();
+}
+
 Messages::WebContentClient::DidRequestStorageItemResponse WebContentClient::did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key)
 {
     return Application::storage_jar(m_is_private).get_item(storage_endpoint, storage_key, bottle_key);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -202,6 +202,7 @@ private:
     virtual void did_request_delete_all_cookies(u64 page_id, u64 request_id, URL::URL) override;
     virtual void did_store_hsts_policy(String, HTTP::HSTS::ParsedHSTSPolicy) override;
     virtual Messages::WebContentClient::DidIsKnownHstsHostResponse did_is_known_hsts_host(String) override;
+    virtual Messages::WebContentClient::DidLoseRequestServerConnectionResponse did_lose_request_server_connection() override;
     virtual Messages::WebContentClient::DidRequestStorageItemResponse did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key) override;
     virtual Messages::WebContentClient::DidSetStorageItemResponse did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key, Utf16String value) override;
     virtual void did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -932,6 +932,20 @@ void PageClient::did_delete_all_cookies(u64 request_id)
     Web::WebIDL::resolve_promise(realm, promise);
 }
 
+void PageClient::page_did_lose_request_server_connection()
+{
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidLoseRequestServerConnection>();
+    if (!response)
+        return;
+
+    auto handle = response->take_handle();
+    if (!handle.has_value())
+        return;
+
+    if (client().on_request_server_connection)
+        client().on_request_server_connection(*handle);
+}
+
 void PageClient::page_did_store_hsts_policy(String const& domain, HTTP::HSTS::ParsedHSTSPolicy const& policy)
 {
     client().async_did_store_hsts_policy(domain, policy);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -226,6 +226,7 @@ private:
     virtual void page_did_update_cookie(HTTP::Cookie::Cookie const&) override;
     virtual void page_did_expire_cookies_with_time_offset(AK::Duration) override;
     virtual void page_did_delete_all_cookies(URL::URL const&, GC::Ref<Web::WebIDL::Promise>) override;
+    virtual void page_did_lose_request_server_connection() override;
     virtual void page_did_store_hsts_policy(String const&, HTTP::HSTS::ParsedHSTSPolicy const&) override;
     virtual bool page_did_is_known_hsts_host(String const&) override;
     virtual Optional<Utf16String> page_did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String const& storage_key, Utf16String const& bottle_key) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -130,6 +130,8 @@ endpoint WebContentClient
     did_store_hsts_policy(String domain, HTTP::HSTS::ParsedHSTSPolicy policy) =|
     did_is_known_hsts_host(String domain) => (bool result)
 
+    did_lose_request_server_connection() => (Optional<IPC::TransportHandle> handle)
+
     did_request_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key) => (Optional<Utf16String> value)
     did_set_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key, Utf16String value) => (WebView::StorageSetResult result)
     did_remove_storage_item(Web::StorageAPI::StorageEndpointType storage_endpoint, String storage_key, Utf16String bottle_key) => ()

--- a/Tests/LibWeb/Crash/Fetch/abort-fetch-after-request-server-connection-loss.html
+++ b/Tests/LibWeb/Crash/Fetch/abort-fetch-after-request-server-connection-loss.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<body>
+<script>
+    (async () => {
+        const port = internals.getEchoServerPort();
+        const base = `http://localhost:${port}`;
+        const path = "/echo/stranded-request";
+
+        await fetch(`${base}/echo`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                method: "GET",
+                path,
+                status: 200,
+                headers: { "Cache-Control": "no-store", "Access-Control-Allow-Origin": "*" },
+                body: "",
+                wait_for_unblock: "stranded-request",
+            }),
+        });
+
+        // Start the blocking fetch from within an iframe, so removing the iframe aborts it.
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `<script>fetch(${JSON.stringify(`${base}${path}`)}).catch(() => {});<\/script>`;
+        document.body.appendChild(iframe);
+
+        while (true) {
+            try {
+                const response = await fetch(`${base}/recorded-request-headers${path}`, { cache: "no-store" });
+                if (response.ok)
+                    break;
+            } catch (error) {
+            }
+            await new Promise(resolve => setTimeout(resolve, 0));
+        }
+
+        // Let transient references on the shared request client drain, so dropping the connection below
+        // actually destroys the client and revokes the in-flight request's reference to it.
+        for (let i = 0; i < 10; ++i)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        internals.simulateRequestServerConnectionLoss();
+
+        // Destroying the iframe's document aborts the stranded fetch, which used to dereference the freed client.
+        iframe.remove();
+
+        // Allow the queued document-destruction task, which performs the abort, to run.
+        for (let i = 0; i < 10; ++i)
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+        document.documentElement.classList.remove("test-wait");
+    })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
When the RequestServer connection is lost, an in-flight request can outlive the client that owns it. Stopping it then crashed either by dereferencing the freed client or by sending a synchronous message over the dead connection.

Guard the client access with a strong reference, and send the stop message asynchronously.

First seen on: https://www.whathifi.com/best-buys/best-wireless-headphones - although I struggled to reproduce the issue there.

I generated [this script](https://gist.github.com/tcl3/df1b6d4305deab6ff18f16401f58bcf9) (Linux only) to reproduce the crash and test the fix.