### PR TITLE
LibWeb: Make caret navigation follow painted content

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -951,6 +951,7 @@ set(SOURCES
     ResourceTiming/PerformanceResourceTiming.cpp
     SecureContexts/AbstractOperations.cpp
     Selection/Selection.cpp
+    Selection/SelectionModifier.cpp
     ServiceWorker/Cache.cpp
     ServiceWorker/CacheStorage.cpp
     ServiceWorker/EventNames.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -814,6 +814,8 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_console_client);
     visitor.visit(m_cursor_blink_timer);
     visitor.visit(m_previously_repainted_cursor_position);
+    if (m_hit_test_display_list)
+        m_hit_test_display_list->visit_edges(visitor);
     visitor.visit(m_editing_host_manager);
     visitor.visit(m_local_storage_holder);
     visitor.visit(m_session_storage_holder);
@@ -8982,6 +8984,26 @@ Optional<Painting::CaretPosition> Document::caret_position_at_line_edge(Node con
         return {};
     viewport_paintable->refresh_scroll_state();
     return hit_test_display_list->caret_position_at_line_edge(node, offset, affinity, edge);
+}
+
+Optional<Painting::CaretPosition> Document::caret_position_on_adjacent_line(Node const& node, size_t offset, TextAffinity affinity, Painting::CaretLineDirection direction, CSSPixels inline_coordinate, Node const& scope)
+{
+    auto hit_test_display_list = ensure_hit_test_display_list();
+    auto viewport_paintable = paintable();
+    if (!hit_test_display_list || !viewport_paintable)
+        return {};
+    viewport_paintable->refresh_scroll_state();
+    return hit_test_display_list->caret_position_on_adjacent_line(node, offset, affinity, direction, inline_coordinate, scope);
+}
+
+Optional<CSSPixels> Document::caret_line_block_coordinate(Node const& node, size_t offset, TextAffinity affinity)
+{
+    auto hit_test_display_list = ensure_hit_test_display_list();
+    auto viewport_paintable = paintable();
+    if (!hit_test_display_list || !viewport_paintable)
+        return {};
+    viewport_paintable->refresh_scroll_state();
+    return hit_test_display_list->caret_line_block_coordinate(node, offset, affinity);
 }
 
 TraversalDecision Document::hit_test_all(CSSPixelPoint position, Function<TraversalDecision(Painting::HitTestResult)> const& callback)

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8974,6 +8974,16 @@ Optional<Painting::CaretPosition> Document::caret_position_from_point_for_select
     return hit_test_display_list->caret_position_from_point(position, *viewport_paintable, page().client().device_pixels_per_css_pixel(), page().chrome_metrics(), Painting::CaretPositionMode::Selection, constraint_scope);
 }
 
+Optional<Painting::CaretPosition> Document::caret_position_at_line_edge(Node const& node, size_t offset, TextAffinity affinity, Painting::CaretLineEdge edge)
+{
+    auto hit_test_display_list = ensure_hit_test_display_list();
+    auto viewport_paintable = paintable();
+    if (!hit_test_display_list || !viewport_paintable)
+        return {};
+    viewport_paintable->refresh_scroll_state();
+    return hit_test_display_list->caret_position_at_line_edge(node, offset, affinity, edge);
+}
+
 TraversalDecision Document::hit_test_all(CSSPixelPoint position, Function<TraversalDecision(Painting::HitTestResult)> const& callback)
 {
     auto hit_test_display_list = ensure_hit_test_display_list();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1148,6 +1148,7 @@ public:
     Optional<Painting::CaretPosition> caret_position_from_point(CSSPixelPoint);
     Optional<Painting::CaretPosition> caret_position_from_point_for_selection_start(CSSPixelPoint);
     Optional<Painting::CaretPosition> caret_position_from_point_for_selection(CSSPixelPoint, Node const* constraint_scope = nullptr);
+    Optional<Painting::CaretPosition> caret_position_at_line_edge(Node const&, size_t offset, TextAffinity, Painting::CaretLineEdge);
     GC::Ptr<CaretPosition> caret_position_from_point(double x, double y, Bindings::CaretPositionFromPointOptions const&);
     TraversalDecision hit_test_all(CSSPixelPoint, Function<TraversalDecision(Painting::HitTestResult)> const&);
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1149,6 +1149,8 @@ public:
     Optional<Painting::CaretPosition> caret_position_from_point_for_selection_start(CSSPixelPoint);
     Optional<Painting::CaretPosition> caret_position_from_point_for_selection(CSSPixelPoint, Node const* constraint_scope = nullptr);
     Optional<Painting::CaretPosition> caret_position_at_line_edge(Node const&, size_t offset, TextAffinity, Painting::CaretLineEdge);
+    Optional<Painting::CaretPosition> caret_position_on_adjacent_line(Node const&, size_t offset, TextAffinity, Painting::CaretLineDirection, CSSPixels inline_coordinate, Node const& scope);
+    Optional<CSSPixels> caret_line_block_coordinate(Node const&, size_t offset, TextAffinity);
     GC::Ptr<CaretPosition> caret_position_from_point(double x, double y, Bindings::CaretPositionFromPointOptions const&);
     TraversalDecision hit_test_all(CSSPixelPoint, Function<TraversalDecision(Painting::HitTestResult)> const&);
 

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -115,6 +115,22 @@ void EditingHostManager::move_cursor_to_end(CollapseSelection collapse)
     Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Forward, Selection::SelectionGranularity::LineBoundary);
 }
 
+void EditingHostManager::move_cursor_to_start_of_document(CollapseSelection collapse)
+{
+    auto selection = get_selection_for_navigation(collapse);
+    if (!selection)
+        return;
+    Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Backward, Selection::SelectionGranularity::DocumentBoundary);
+}
+
+void EditingHostManager::move_cursor_to_end_of_document(CollapseSelection collapse)
+{
+    auto selection = get_selection_for_navigation(collapse);
+    if (!selection)
+        return;
+    Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Forward, Selection::SelectionGranularity::DocumentBoundary);
+}
+
 void EditingHostManager::increment_cursor_position_offset(CollapseSelection collapse)
 {
     auto selection = get_selection_for_navigation(collapse);

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Editing/CommandNames.h>
 #include <LibWeb/Selection/Selection.h>
+#include <LibWeb/Selection/SelectionModifier.h>
 #include <LibWeb/UIEvents/InputTypes.h>
 
 namespace Web::DOM {
@@ -103,15 +104,7 @@ void EditingHostManager::move_cursor_to_start(CollapseSelection collapse)
     auto selection = get_selection_for_navigation(collapse);
     if (!selection)
         return;
-    auto node = selection->focus_node();
-
-    if (collapse == CollapseSelection::Yes) {
-        MUST(selection->collapse(node, 0));
-        m_document->reset_cursor_blink_cycle();
-    } else {
-        MUST(selection->set_base_and_extent(*selection->anchor_node(), selection->anchor_offset(), *node, 0));
-    }
-    selection->scroll_focus_into_view();
+    Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Backward, Selection::SelectionGranularity::LineBoundary);
 }
 
 void EditingHostManager::move_cursor_to_end(CollapseSelection collapse)
@@ -119,15 +112,7 @@ void EditingHostManager::move_cursor_to_end(CollapseSelection collapse)
     auto selection = get_selection_for_navigation(collapse);
     if (!selection)
         return;
-    auto node = selection->focus_node();
-
-    if (collapse == CollapseSelection::Yes) {
-        m_document->reset_cursor_blink_cycle();
-        MUST(selection->collapse(node, node->length()));
-    } else {
-        MUST(selection->set_base_and_extent(*selection->anchor_node(), selection->anchor_offset(), *node, node->length()));
-    }
-    selection->scroll_focus_into_view();
+    Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Forward, Selection::SelectionGranularity::LineBoundary);
 }
 
 void EditingHostManager::increment_cursor_position_offset(CollapseSelection collapse)

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -131,6 +131,22 @@ void EditingHostManager::move_cursor_to_end_of_document(CollapseSelection collap
     Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Forward, Selection::SelectionGranularity::DocumentBoundary);
 }
 
+void EditingHostManager::move_cursor_to_previous_page(CollapseSelection collapse)
+{
+    auto selection = get_selection_for_navigation(collapse);
+    if (!selection)
+        return;
+    Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Backward, Selection::SelectionGranularity::Page);
+}
+
+void EditingHostManager::move_cursor_to_next_page(CollapseSelection collapse)
+{
+    auto selection = get_selection_for_navigation(collapse);
+    if (!selection)
+        return;
+    Selection::SelectionModifier(*selection).modify(collapse == CollapseSelection::Yes ? Selection::SelectionAlteration::Move : Selection::SelectionAlteration::Extend, Selection::SelectionDirection::Forward, Selection::SelectionGranularity::Page);
+}
+
 void EditingHostManager::increment_cursor_position_offset(CollapseSelection collapse)
 {
     auto selection = get_selection_for_navigation(collapse);

--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -33,6 +33,8 @@ public:
     virtual void move_cursor_to_end(CollapseSelection) override;
     virtual void move_cursor_to_start_of_document(CollapseSelection) override;
     virtual void move_cursor_to_end_of_document(CollapseSelection) override;
+    virtual void move_cursor_to_previous_page(CollapseSelection) override;
+    virtual void move_cursor_to_next_page(CollapseSelection) override;
     virtual void increment_cursor_position_offset(CollapseSelection) override;
     virtual void decrement_cursor_position_offset(CollapseSelection) override;
     virtual void increment_cursor_position_to_next_word(CollapseSelection) override;

--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -31,6 +31,8 @@ public:
     virtual void set_selection_focus(GC::Ref<DOM::Node>, size_t offset, TextAffinity = TextAffinity::Downstream) override;
     virtual void move_cursor_to_start(CollapseSelection) override;
     virtual void move_cursor_to_end(CollapseSelection) override;
+    virtual void move_cursor_to_start_of_document(CollapseSelection) override;
+    virtual void move_cursor_to_end_of_document(CollapseSelection) override;
     virtual void increment_cursor_position_offset(CollapseSelection) override;
     virtual void decrement_cursor_position_offset(CollapseSelection) override;
     virtual void increment_cursor_position_to_next_word(CollapseSelection) override;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -41,6 +41,8 @@ public:
     };
     virtual void move_cursor_to_start(CollapseSelection) = 0;
     virtual void move_cursor_to_end(CollapseSelection) = 0;
+    virtual void move_cursor_to_start_of_document(CollapseSelection collapse) { move_cursor_to_start(collapse); }
+    virtual void move_cursor_to_end_of_document(CollapseSelection collapse) { move_cursor_to_end(collapse); }
     virtual void increment_cursor_position_offset(CollapseSelection) = 0;
     virtual void decrement_cursor_position_offset(CollapseSelection) = 0;
     virtual void increment_cursor_position_to_next_word(CollapseSelection) = 0;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -43,6 +43,8 @@ public:
     virtual void move_cursor_to_end(CollapseSelection) = 0;
     virtual void move_cursor_to_start_of_document(CollapseSelection collapse) { move_cursor_to_start(collapse); }
     virtual void move_cursor_to_end_of_document(CollapseSelection collapse) { move_cursor_to_end(collapse); }
+    virtual void move_cursor_to_previous_page(CollapseSelection collapse) { move_cursor_to_start_of_document(collapse); }
+    virtual void move_cursor_to_next_page(CollapseSelection collapse) { move_cursor_to_end_of_document(collapse); }
     virtual void increment_cursor_position_offset(CollapseSelection) = 0;
     virtual void decrement_cursor_position_offset(CollapseSelection) = 0;
     virtual void increment_cursor_position_to_next_word(CollapseSelection) = 0;

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1147,6 +1147,16 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
                 key = UIEvents::KeyCode::Key_End;
                 modifiers &= ~UIEvents::Mod_Super;
             }
+            if (key == UIEvents::KeyCode::Key_Up || key == UIEvents::KeyCode::Key_Down) {
+                // On macOS, Command+Up/Down is the editing-host equivalent of document Home/End. Preserve Shift so
+                // the same command extends the selection instead of collapsing it.
+                auto collapse = modifiers & UIEvents::Mod_Shift ? InputEventsTarget::CollapseSelection::No : InputEventsTarget::CollapseSelection::Yes;
+                if (key == UIEvents::KeyCode::Key_Up)
+                    target->move_cursor_to_start_of_document(collapse);
+                else
+                    target->move_cursor_to_end_of_document(collapse);
+                return EventResult::Handled;
+            }
         }
 #endif
 
@@ -1175,6 +1185,14 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
             } else {
                 target->increment_cursor_position_to_next_line(collapse);
             }
+            return EventResult::Handled;
+        }
+
+        if ((key == UIEvents::KeyCode::Key_PageUp || key == UIEvents::KeyCode::Key_PageDown) && (modifiers & UIEvents::Mod_Shift)) {
+            if (key == UIEvents::KeyCode::Key_PageUp)
+                target->move_cursor_to_start_of_document(InputEventsTarget::CollapseSelection::No);
+            else
+                target->move_cursor_to_end_of_document(InputEventsTarget::CollapseSelection::No);
             return EventResult::Handled;
         }
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1190,9 +1190,9 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
 
         if ((key == UIEvents::KeyCode::Key_PageUp || key == UIEvents::KeyCode::Key_PageDown) && (modifiers & UIEvents::Mod_Shift)) {
             if (key == UIEvents::KeyCode::Key_PageUp)
-                target->move_cursor_to_start_of_document(InputEventsTarget::CollapseSelection::No);
+                target->move_cursor_to_previous_page(InputEventsTarget::CollapseSelection::No);
             else
-                target->move_cursor_to_end_of_document(InputEventsTarget::CollapseSelection::No);
+                target->move_cursor_to_next_page(InputEventsTarget::CollapseSelection::No);
             return EventResult::Handled;
         }
 

--- a/Libraries/LibWeb/Painting/Forward.h
+++ b/Libraries/LibWeb/Painting/Forward.h
@@ -11,6 +11,7 @@
 namespace Web::Painting {
 
 class HitTestDisplayList;
+enum class CaretLineDirection : u8;
 enum class CaretLineEdge : u8;
 enum class CaretPositionMode : u8;
 enum class HitTestType : u8;

--- a/Libraries/LibWeb/Painting/Forward.h
+++ b/Libraries/LibWeb/Painting/Forward.h
@@ -11,6 +11,7 @@
 namespace Web::Painting {
 
 class HitTestDisplayList;
+enum class CaretLineEdge : u8;
 enum class CaretPositionMode : u8;
 enum class HitTestType : u8;
 struct CaretPosition;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -166,6 +166,12 @@ NonnullRefPtr<HitTestDisplayList> HitTestDisplayList::create(u64 visual_context_
     return adopt_ref(*new HitTestDisplayList(visual_context_tree_version));
 }
 
+void HitTestDisplayList::visit_edges(GC::Cell::Visitor& visitor)
+{
+    for (auto const& item : m_items)
+        visitor.visit(item.caret_node);
+}
+
 HitTestDisplayList::HitTestDisplayList(u64 visual_context_tree_version)
     : m_visual_context_tree_version(visual_context_tree_version)
 {
@@ -293,6 +299,7 @@ void HitTestDisplayList::append_empty_line(PaintableFragment const& sibling_frag
         .paintable = fragment_paintable,
         .chrome_widget = {},
         .text_fragment = &sibling_fragment,
+        .caret_node = sibling_fragment.layout_node().dom_node(),
         .caret_offset = caret_offset,
         // NB: Empty lines are only reachable through caret lines, never through regular hit testing, so they are
         //     recorded with an empty rect and stay out of the spatial index.
@@ -301,6 +308,27 @@ void HitTestDisplayList::append_empty_line(PaintableFragment const& sibling_frag
         .caret_line_index = line_box_index,
         .caret_line_rect = line_rect,
         .block_container_margin_rect = absolute_margin_box_rect_for_containing_block(sibling_fragment),
+        .visual_context_index = visual_context_index,
+        .border_radii = {},
+    });
+    add_item_to_caret_items(item_index);
+}
+
+void HitTestDisplayList::append_empty_line(PaintableWithLines const& paintable, DOM::Node const& caret_node, size_t caret_offset, CSSPixelRect line_rect, VisualContextIndex visual_context_index)
+{
+    auto item_index = m_items.size();
+    m_items.append({
+        .kind = ItemKind::EmptyLine,
+        .paintable = const_cast<PaintableWithLines&>(paintable),
+        .chrome_widget = {},
+        .text_fragment = nullptr,
+        .caret_node = &caret_node,
+        .caret_offset = caret_offset,
+        .rect = {},
+        .caret_rect = line_rect,
+        .caret_line_index = {},
+        .caret_line_rect = line_rect,
+        .block_container_margin_rect = absolute_margin_box_rect_for_containing_block(paintable),
         .visual_context_index = visual_context_index,
         .border_radii = {},
     });
@@ -394,8 +422,9 @@ bool HitTestDisplayList::item_can_produce_caret_position(Item const& item) const
 {
     switch (item.kind) {
     case ItemKind::TextFragment:
-    case ItemKind::EmptyLine:
         return item.text_fragment && item.text_fragment->layout_node().dom_node();
+    case ItemKind::EmptyLine:
+        return item.caret_node;
     case ItemKind::EmptyEditable:
         return item.paintable->dom_node();
     case ItemKind::Box: {
@@ -507,8 +536,9 @@ DOM::Node const* HitTestDisplayList::item_dom_node(Item const& item) const
     case ItemKind::ChromeWidget:
         return item.paintable->dom_node();
     case ItemKind::TextFragment:
-    case ItemKind::EmptyLine:
         return item.text_fragment ? item.text_fragment->layout_node().dom_node() : nullptr;
+    case ItemKind::EmptyLine:
+        return item.caret_node;
     }
     VERIFY_NOT_REACHED();
 }
@@ -748,10 +778,21 @@ bool HitTestDisplayList::item_contains_caret_position(Item const& item, DOM::Nod
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_at_line_edge(DOM::Node const& node, size_t offset, TextAffinity affinity, CaretLineEdge edge) const
 {
+    auto line_index = caret_line_index_for_position(node, offset, affinity);
+    if (!line_index.has_value())
+        return {};
+    auto const& line = m_caret_lines[*line_index];
+    auto type = edge == CaretLineEdge::Start ? CaretPositionType::Before : CaretPositionType::After;
+    return caret_position_for_item(item_at_line_edge(line, type), {}, type);
+}
+
+Optional<size_t> HitTestDisplayList::caret_line_index_for_position(DOM::Node const& node, size_t offset, TextAffinity affinity) const
+{
     // At a soft wrap, prefer the fragment whose line directly owns the position. Only use the preceding fragment's
     // fallback match when no direct match exists.
     for (bool allow_soft_wrap_fallback : { false, true }) {
-        for (auto const& line : m_caret_lines) {
+        for (size_t line_index = 0; line_index < m_caret_lines.size(); ++line_index) {
+            auto const& line = m_caret_lines[line_index];
             for (auto caret_item_index = line.first_caret_item_index; caret_item_index <= line.last_caret_item_index; ++caret_item_index) {
                 auto const& item = m_items[m_caret_item_indices[caret_item_index]];
                 if (!item_contains_caret_position(item, node, offset, affinity))
@@ -760,12 +801,95 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_at_line_edge(DOM::Nod
                     && item.text_fragment->layout_node().dom_node() == &node
                     && item.text_fragment->caret_match(offset, affinity) == PaintableFragment::CaretMatch::SoftWrapFallback)
                     continue;
-                auto type = edge == CaretLineEdge::Start ? CaretPositionType::Before : CaretPositionType::After;
-                return caret_position_for_item(item_at_line_edge(line, type), {}, type);
+                return line_index;
             }
         }
     }
     return {};
+}
+
+Optional<CaretPosition> HitTestDisplayList::caret_position_on_adjacent_line(DOM::Node const& node, size_t offset, TextAffinity affinity, CaretLineDirection direction, CSSPixels inline_coordinate, DOM::Node const& scope) const
+{
+    auto current_line_index = caret_line_index_for_position(node, offset, affinity);
+    if (!current_line_index.has_value())
+        return {};
+
+    auto const& current_line = m_caret_lines[*current_line_index];
+    auto const& current_first_item = m_items[m_caret_item_indices[current_line.first_caret_item_index]];
+    auto writing_mode = current_first_item.paintable->computed_values().writing_mode();
+    auto block_axis_is_reverse = current_first_item.paintable->computed_values().block_axis_is_reverse();
+    auto physically_after = (direction == CaretLineDirection::Next) != block_axis_is_reverse;
+    auto line_context_for_item = [](Item const& item) -> Paintable const* {
+        if (item.text_fragment)
+            return &item.text_fragment->paintable_with_lines();
+        return item.paintable.ptr();
+    };
+    auto* current_line_context = line_context_for_item(current_first_item);
+    // INTEROP: Vertical caret movement in Chromium, WebKit, and Gecko follows rendered line geometry rather than DOM
+    // tree order. Rank candidates in the requested logical block direction, prefer the current line-producing context,
+    // then minimize block distance and finally distance from the remembered inline coordinate.
+    //
+    // Keep these coordinates fractional. Rounding line geometry before comparison can reorder candidates when layout
+    // positions or device scaling produce subpixel line centers.
+    auto current_block_coordinate = block_axis_start(current_line.rect, writing_mode)
+        + (block_axis_end(current_line.rect, writing_mode) - block_axis_start(current_line.rect, writing_mode)).scaled(0.5);
+
+    Optional<size_t> closest_line_index;
+    bool closest_line_shares_context = false;
+    auto closest_block_distance = CSSPixels::max();
+    auto closest_inline_distance = CSSPixels::max();
+    for (size_t line_index = 0; line_index < m_caret_lines.size(); ++line_index) {
+        auto const& line = m_caret_lines[line_index];
+        if (line_index == *current_line_index || line.visual_context_index != current_line.visual_context_index
+            || !line_contains_descendant_of(line, scope))
+            continue;
+
+        auto candidate_block_coordinate = block_axis_start(line.rect, writing_mode)
+            + (block_axis_end(line.rect, writing_mode) - block_axis_start(line.rect, writing_mode)).scaled(0.5);
+        if ((physically_after && candidate_block_coordinate <= current_block_coordinate)
+            || (!physically_after && candidate_block_coordinate >= current_block_coordinate))
+            continue;
+        auto block_distance = absolute_difference(candidate_block_coordinate, current_block_coordinate);
+        auto inline_distance = distance_to_range(inline_coordinate, inline_axis_start(line.rect, writing_mode), inline_axis_end(line.rect, writing_mode));
+        auto const& candidate_first_item = m_items[m_caret_item_indices[line.first_caret_item_index]];
+        // Prefer lines produced by the same line paintable. Independently painted content, such as a floated first
+        // letter, may occupy the same block-axis neighborhood without being the next line of the current content.
+        auto shares_line_context = line_context_for_item(candidate_first_item) == current_line_context;
+        if (!closest_line_index.has_value() || (shares_line_context && !closest_line_shares_context)
+            || (shares_line_context == closest_line_shares_context
+                && (block_distance < closest_block_distance
+                    || (block_distance == closest_block_distance && inline_distance < closest_inline_distance)))) {
+            closest_line_index = line_index;
+            closest_line_shares_context = shares_line_context;
+            closest_block_distance = block_distance;
+            closest_inline_distance = inline_distance;
+        }
+    }
+    if (!closest_line_index.has_value())
+        return {};
+
+    auto const& closest_line = m_caret_lines[*closest_line_index];
+    auto block_coordinate = block_axis_start(closest_line.rect, writing_mode)
+        + (block_axis_end(closest_line.rect, writing_mode) - block_axis_start(closest_line.rect, writing_mode)).scaled(0.5);
+    auto point = writing_mode_is_horizontal(writing_mode)
+        ? CSSPixelPoint { inline_coordinate, block_coordinate }
+        : CSSPixelPoint { block_coordinate, inline_coordinate };
+    // Reuse point-to-caret resolution after choosing the line so text, atomic boxes, and empty lines share one rule for
+    // selecting the position closest to the preferred inline coordinate.
+    return caret_position_for_line(closest_line, point, CaretPositionMode::Normal);
+}
+
+Optional<CSSPixels> HitTestDisplayList::caret_line_block_coordinate(DOM::Node const& node, size_t offset, TextAffinity affinity) const
+{
+    auto line_index = caret_line_index_for_position(node, offset, affinity);
+    if (!line_index.has_value())
+        return {};
+
+    auto const& line = m_caret_lines[*line_index];
+    auto const& first_item = m_items[m_caret_item_indices[line.first_caret_item_index]];
+    auto writing_mode = first_item.paintable->computed_values().writing_mode();
+    return block_axis_start(line.rect, writing_mode)
+        + (block_axis_end(line.rect, writing_mode) - block_axis_start(line.rect, writing_mode)).scaled(0.5);
 }
 
 Optional<CaretPosition> HitTestDisplayList::caret_position_for_line(CaretLine const& line, CSSPixelPoint local_point, CaretPositionMode mode) const

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -659,65 +659,148 @@ Optional<CaretPosition> HitTestDisplayList::caret_position_for_hit_container(Ite
     };
 }
 
+HitTestDisplayList::Item const& HitTestDisplayList::item_at_line_edge(CaretLine const& line, CaretPositionType type) const
+{
+    // INTEROP: Home and End operate on visual lines in other engines. Choose the furthest caret-capable painted item
+    // along the logical inline axis instead of assuming that display-list order or DOM order describes that edge.
+    auto const& first_item = m_items[m_caret_item_indices[line.first_caret_item_index]];
+    auto writing_mode = first_item.paintable->computed_values().writing_mode();
+    auto inline_axis_is_reverse = first_item.paintable->computed_values().inline_axis_is_reverse();
+    auto coordinate_for_item = [&](Item const& item) {
+        if (type == CaretPositionType::Before)
+            return inline_axis_is_reverse ? inline_axis_end(item.caret_rect, writing_mode) : inline_axis_start(item.caret_rect, writing_mode);
+        return inline_axis_is_reverse ? inline_axis_start(item.caret_rect, writing_mode) : inline_axis_end(item.caret_rect, writing_mode);
+    };
+    auto coordinate_is_closer_to_line_edge = [&](CSSPixels coordinate, CSSPixels best_coordinate) {
+        if (type == CaretPositionType::Before)
+            return inline_axis_is_reverse ? coordinate > best_coordinate : coordinate < best_coordinate;
+        return inline_axis_is_reverse ? coordinate < best_coordinate : coordinate > best_coordinate;
+    };
+
+    auto best_item_index = m_caret_item_indices[line.first_caret_item_index];
+    auto best_coordinate = coordinate_for_item(m_items[best_item_index]);
+
+    auto containing_block_for_item = [](Item const& item) -> Layout::Box const* {
+        if ((item.kind == ItemKind::TextFragment || item.kind == ItemKind::EmptyLine) && item.text_fragment)
+            return item.text_fragment->layout_node().containing_block();
+        return item.paintable->layout_node().containing_block();
+    };
+    auto item_is_on_line = [&](Item const& item) {
+        if (line.visual_context_index != item.visual_context_index
+            || containing_block_for_item(first_item) != containing_block_for_item(item))
+            return false;
+        if (first_item.caret_line_index.has_value() && item.caret_line_index.has_value())
+            return *first_item.caret_line_index == *item.caret_line_index;
+        if (!first_item.caret_line_index.has_value() && !item.caret_line_index.has_value())
+            return rects_overlap_in_block_axis(line.rect, item.caret_rect, writing_mode);
+        return false;
+    };
+
+    // Atomic inline boxes are recorded during the background paint phase, while text fragments are recorded during
+    // the foreground phase. Other boxes can therefore separate two items from the same line in the caret item list.
+    for (auto item_index : m_caret_item_indices) {
+        auto const& item = m_items[item_index];
+        if (!item_is_on_line(item))
+            continue;
+        auto coordinate = coordinate_for_item(item);
+        if (coordinate_is_closer_to_line_edge(coordinate, best_coordinate)) {
+            best_item_index = item_index;
+            best_coordinate = coordinate;
+        }
+    }
+    return m_items[best_item_index];
+}
+
+bool HitTestDisplayList::item_contains_caret_position(Item const& item, DOM::Node const& node, size_t offset, TextAffinity affinity) const
+{
+    switch (item.kind) {
+    case ItemKind::TextFragment: {
+        VERIFY(item.text_fragment);
+        auto const* fragment_dom_node = item.text_fragment->layout_node().dom_node();
+        if (!fragment_dom_node)
+            return false;
+        if (fragment_dom_node == &node)
+            return item.text_fragment->caret_match(offset, affinity) != PaintableFragment::CaretMatch::None;
+
+        auto* node_after_boundary = node.child_at_index(offset);
+        while (node_after_boundary && node_after_boundary != fragment_dom_node)
+            node_after_boundary = node_after_boundary->first_child();
+        if (node_after_boundary == fragment_dom_node && item.text_fragment->dom_start_offset_in_node() == 0)
+            return true;
+        return offset > 0
+            && node.child_at_index(offset - 1) == fragment_dom_node
+            && item.text_fragment->dom_end_offset_with_trailing_whitespace() == fragment_dom_node->length();
+    }
+    case ItemKind::EmptyLine:
+        return item_dom_node(item) == &node && item.caret_offset == offset;
+    case ItemKind::EmptyEditable:
+        return item.paintable->dom_node() == &node && offset == 0;
+    case ItemKind::Box: {
+        auto dom_node = item.paintable->dom_node();
+        return dom_node && dom_node->parent() == &node && (offset == dom_node->index() || offset == dom_node->index() + 1);
+    }
+    case ItemKind::SvgPath:
+    case ItemKind::ChromeWidget:
+        return false;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Optional<CaretPosition> HitTestDisplayList::caret_position_at_line_edge(DOM::Node const& node, size_t offset, TextAffinity affinity, CaretLineEdge edge) const
+{
+    // At a soft wrap, prefer the fragment whose line directly owns the position. Only use the preceding fragment's
+    // fallback match when no direct match exists.
+    for (bool allow_soft_wrap_fallback : { false, true }) {
+        for (auto const& line : m_caret_lines) {
+            for (auto caret_item_index = line.first_caret_item_index; caret_item_index <= line.last_caret_item_index; ++caret_item_index) {
+                auto const& item = m_items[m_caret_item_indices[caret_item_index]];
+                if (!item_contains_caret_position(item, node, offset, affinity))
+                    continue;
+                if (!allow_soft_wrap_fallback && item.kind == ItemKind::TextFragment && item.text_fragment
+                    && item.text_fragment->layout_node().dom_node() == &node
+                    && item.text_fragment->caret_match(offset, affinity) == PaintableFragment::CaretMatch::SoftWrapFallback)
+                    continue;
+                auto type = edge == CaretLineEdge::Start ? CaretPositionType::Before : CaretPositionType::After;
+                return caret_position_for_item(item_at_line_edge(line, type), {}, type);
+            }
+        }
+    }
+    return {};
+}
+
 Optional<CaretPosition> HitTestDisplayList::caret_position_for_line(CaretLine const& line, CSSPixelPoint local_point, CaretPositionMode mode) const
 {
     auto const& first_item = m_items[m_caret_item_indices[line.first_caret_item_index]];
     auto writing_mode = first_item.paintable->computed_values().writing_mode();
     auto inline_axis_is_reverse = first_item.paintable->computed_values().inline_axis_is_reverse();
-    auto item_at_line_edge = [&](CaretPositionType type) -> Item const& {
-        auto coordinate_for_item = [&](Item const& item) {
-            if (type == CaretPositionType::Before)
-                return inline_axis_is_reverse ? inline_axis_end(item.caret_rect, writing_mode) : inline_axis_start(item.caret_rect, writing_mode);
-            return inline_axis_is_reverse ? inline_axis_start(item.caret_rect, writing_mode) : inline_axis_end(item.caret_rect, writing_mode);
-        };
-        auto coordinate_is_closer_to_line_edge = [&](CSSPixels coordinate, CSSPixels best_coordinate) {
-            if (type == CaretPositionType::Before)
-                return inline_axis_is_reverse ? coordinate > best_coordinate : coordinate < best_coordinate;
-            return inline_axis_is_reverse ? coordinate < best_coordinate : coordinate > best_coordinate;
-        };
-
-        auto best_item_index = m_caret_item_indices[line.first_caret_item_index];
-        auto best_coordinate = coordinate_for_item(m_items[best_item_index]);
-
-        for (auto caret_item_index = line.first_caret_item_index + 1; caret_item_index <= line.last_caret_item_index; ++caret_item_index) {
-            auto item_index = m_caret_item_indices[caret_item_index];
-            auto const& item = m_items[item_index];
-            auto coordinate = coordinate_for_item(item);
-            if (coordinate_is_closer_to_line_edge(coordinate, best_coordinate)) {
-                best_item_index = item_index;
-                best_coordinate = coordinate;
-            }
-        }
-        return m_items[best_item_index];
-    };
 
     auto block_coordinate = block_axis_coordinate(local_point, writing_mode);
     // Once a line has been selected, points before or after its block-axis range resolve to the logical line edges.
     // Points inside the line range resolve to the closest caret-capable item on that line.
     if (block_coordinate < block_axis_start(line.rect, writing_mode))
-        return caret_position_for_item(item_at_line_edge(CaretPositionType::Before), local_point, CaretPositionType::Before);
+        return caret_position_for_item(item_at_line_edge(line, CaretPositionType::Before), local_point, CaretPositionType::Before);
 
     auto inline_coordinate = inline_axis_coordinate(local_point, writing_mode);
     if (mode == CaretPositionMode::Selection && block_coordinate >= block_axis_end(line.rect, writing_mode))
-        return caret_position_for_item(item_at_line_edge(CaretPositionType::After), local_point, CaretPositionType::After);
+        return caret_position_for_item(item_at_line_edge(line, CaretPositionType::After), local_point, CaretPositionType::After);
 
     if (block_coordinate >= block_axis_end(line.rect, writing_mode) + caret_line_block_axis_compare_slop)
-        return caret_position_for_item(item_at_line_edge(CaretPositionType::After), local_point, CaretPositionType::After);
+        return caret_position_for_item(item_at_line_edge(line, CaretPositionType::After), local_point, CaretPositionType::After);
 
     if (block_coordinate >= block_axis_end(line.rect, writing_mode)
         && (inline_coordinate < inline_axis_start(line.rect, writing_mode) || inline_coordinate >= inline_axis_end(line.rect, writing_mode)))
-        return caret_position_for_item(item_at_line_edge(CaretPositionType::After), local_point, CaretPositionType::After);
+        return caret_position_for_item(item_at_line_edge(line, CaretPositionType::After), local_point, CaretPositionType::After);
 
     // Points past either inline edge resolve to the corresponding logical line edge. This also accounts for a
     // reversed inline axis, where the logical start is the physically trailing edge.
     if (inline_coordinate < inline_axis_start(line.rect, writing_mode)) {
         auto type = inline_axis_is_reverse ? CaretPositionType::After : CaretPositionType::Before;
-        return caret_position_for_item(item_at_line_edge(type), local_point, type);
+        return caret_position_for_item(item_at_line_edge(line, type), local_point, type);
     }
 
     if (inline_coordinate >= inline_axis_end(line.rect, writing_mode)) {
         auto type = inline_axis_is_reverse ? CaretPositionType::Before : CaretPositionType::After;
-        return caret_position_for_item(item_at_line_edge(type), local_point, type);
+        return caret_position_for_item(item_at_line_edge(line, type), local_point, type);
     }
 
     Optional<size_t> closest_item_index;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -10,6 +10,8 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
+#include <LibGC/Cell.h>
+#include <LibGC/Ptr.h>
 #include <LibGfx/Path.h>
 #include <LibGfx/WindingRule.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
@@ -23,6 +25,7 @@ struct ChromeMetrics;
 namespace Painting {
 
 class PaintableFragment;
+class PaintableWithLines;
 class ViewportPaintable;
 
 enum class CaretPositionMode : u8 {
@@ -37,6 +40,11 @@ enum class CaretLineEdge : u8 {
     End,
 };
 
+enum class CaretLineDirection : u8 {
+    Previous,
+    Next,
+};
+
 class WEB_API HitTestDisplayList : public RefCounted<HitTestDisplayList> {
 public:
     static NonnullRefPtr<HitTestDisplayList> create(u64 visual_context_tree_version);
@@ -45,8 +53,10 @@ public:
     void append_svg_path(Paintable& target, Gfx::Path, Gfx::WindingRule, CSSPixelRect bounding_box, VisualContextIndex);
     void append_text_fragment(PaintableFragment const&, VisualContextIndex);
     void append_empty_line(PaintableFragment const& sibling_fragment, size_t caret_offset, size_t line_box_index, CSSPixelRect line_rect, VisualContextIndex);
+    void append_empty_line(PaintableWithLines const&, DOM::Node const&, size_t caret_offset, CSSPixelRect line_rect, VisualContextIndex);
     void append_empty_editable(Paintable const&, CSSPixelRect, VisualContextIndex);
     void append_chrome_widget(Paintable const&, ChromeWidget&, VisualContextIndex);
+    void visit_edges(GC::Cell::Visitor&);
 
     u64 visual_context_tree_version() const { return m_visual_context_tree_version; }
     [[nodiscard]] Optional<HitTestResult> hit_test(CSSPixelPoint, HitTestType, ViewportPaintable const&, double device_pixels_per_css_pixel, ChromeMetrics const&) const;
@@ -56,6 +66,10 @@ public:
     // Resolve Home/End against the painted line containing the caret. A visual line can span several DOM nodes and
     // atomic inline boxes, so a text-node or block-element boundary is not necessarily a rendered line boundary.
     [[nodiscard]] Optional<CaretPosition> caret_position_at_line_edge(DOM::Node const&, size_t offset, TextAffinity, CaretLineEdge) const;
+    // Find the visually adjacent caret line within scope, preserving the requested inline-axis coordinate. This is a
+    // rendered-content query: DOM adjacency alone cannot describe wrapping, writing modes, floats, or empty lines.
+    [[nodiscard]] Optional<CaretPosition> caret_position_on_adjacent_line(DOM::Node const&, size_t offset, TextAffinity, CaretLineDirection, CSSPixels inline_coordinate, DOM::Node const& scope) const;
+    [[nodiscard]] Optional<CSSPixels> caret_line_block_coordinate(DOM::Node const&, size_t offset, TextAffinity) const;
     TraversalDecision hit_test_all(CSSPixelPoint, ViewportPaintable const&, double device_pixels_per_css_pixel, ChromeMetrics const&, Function<TraversalDecision(HitTestResult)> const&) const;
 
 private:
@@ -76,7 +90,8 @@ private:
         NonnullRefPtr<Paintable> paintable;
         RefPtr<ChromeWidget> chrome_widget;
         PaintableFragment const* text_fragment { nullptr };
-        // For EmptyLine items: the caret offset in the text node of the sibling text_fragment.
+        GC::Ptr<DOM::Node const> caret_node { nullptr };
+        // For EmptyLine items: the caret offset in caret_node.
         size_t caret_offset { 0 };
         CSSPixelRect rect;
         CSSPixelRect caret_rect;
@@ -94,6 +109,9 @@ private:
         Vector<size_t> unbucketed_items;
     };
 
+    // A visual line assembled from consecutive caret-capable display-list items. Caret lines preserve painted
+    // topology independently of the spatial hit-test index so keyboard navigation can reason about lines that contain
+    // empty or zero-area caret targets.
     struct CaretLine {
         CSSPixelRect rect;
         Optional<CSSPixelRect> block_container_margin_rect;
@@ -126,6 +144,7 @@ private:
     [[nodiscard]] Optional<CaretPosition> caret_position_for_line(CaretLine const&, CSSPixelPoint local_point, CaretPositionMode) const;
     [[nodiscard]] Item const& item_at_line_edge(CaretLine const&, CaretPositionType) const;
     [[nodiscard]] bool item_contains_caret_position(Item const&, DOM::Node const&, size_t offset, TextAffinity) const;
+    [[nodiscard]] Optional<size_t> caret_line_index_for_position(DOM::Node const&, size_t offset, TextAffinity) const;
     [[nodiscard]] bool line_contains_descendant_of(CaretLine const&, DOM::Node const&) const;
     [[nodiscard]] bool item_is_inline_adjacent_to_line(Item const&, CaretLine const&) const;
     void find_topmost_item_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Optional<size_t>& topmost_item_index) const;

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -32,6 +32,11 @@ enum class CaretPositionMode : u8 {
     Selection,
 };
 
+enum class CaretLineEdge : u8 {
+    Start,
+    End,
+};
+
 class WEB_API HitTestDisplayList : public RefCounted<HitTestDisplayList> {
 public:
     static NonnullRefPtr<HitTestDisplayList> create(u64 visual_context_tree_version);
@@ -48,6 +53,9 @@ public:
     // When constraint_scope is given, the caret position is constrained to lines inside that node, and points
     // outside it resolve to the closest position within it.
     [[nodiscard]] Optional<CaretPosition> caret_position_from_point(CSSPixelPoint, ViewportPaintable const&, double device_pixels_per_css_pixel, ChromeMetrics const&, CaretPositionMode = CaretPositionMode::Normal, DOM::Node const* constraint_scope = nullptr) const;
+    // Resolve Home/End against the painted line containing the caret. A visual line can span several DOM nodes and
+    // atomic inline boxes, so a text-node or block-element boundary is not necessarily a rendered line boundary.
+    [[nodiscard]] Optional<CaretPosition> caret_position_at_line_edge(DOM::Node const&, size_t offset, TextAffinity, CaretLineEdge) const;
     TraversalDecision hit_test_all(CSSPixelPoint, ViewportPaintable const&, double device_pixels_per_css_pixel, ChromeMetrics const&, Function<TraversalDecision(HitTestResult)> const&) const;
 
 private:
@@ -116,6 +124,8 @@ private:
     [[nodiscard]] Optional<CaretPosition> caret_position_for_item(Item const&, CSSPixelPoint local_point, CaretPositionType = CaretPositionType::Closest) const;
     [[nodiscard]] Optional<CaretPosition> caret_position_for_hit_container(Item const&) const;
     [[nodiscard]] Optional<CaretPosition> caret_position_for_line(CaretLine const&, CSSPixelPoint local_point, CaretPositionMode) const;
+    [[nodiscard]] Item const& item_at_line_edge(CaretLine const&, CaretPositionType) const;
+    [[nodiscard]] bool item_contains_caret_position(Item const&, DOM::Node const&, size_t offset, TextAffinity) const;
     [[nodiscard]] bool line_contains_descendant_of(CaretLine const&, DOM::Node const&) const;
     [[nodiscard]] bool item_is_inline_adjacent_to_line(Item const&, CaretLine const&) const;
     void find_topmost_item_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Optional<size_t>& topmost_item_index) const;

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -316,6 +316,18 @@ void PaintableWithLines::record_empty_line_caret_items(HitTestDisplayList& hit_t
 {
     for (auto const& target : empty_line_caret_targets())
         hit_test_display_list.append_empty_line(m_fragments.first(), target.offset, target.line_index, target.rect, visual_context_index);
+
+    auto* dom_node = layout_node().dom_node();
+    if (!dom_node || m_fragments.is_empty())
+        return;
+    // A <br> between fragment-backed lines does not produce a fragment of its own, so record its parent boundary as
+    // a caret target. This covers leading and consecutive editable line breaks.
+    for (auto* child = dom_node->first_child(); child; child = child->next_sibling()) {
+        auto* br = as_if<HTML::HTMLBRElement>(*child);
+        if (!br || !br->represents_empty_line())
+            continue;
+        hit_test_display_list.append_empty_line(*this, *dom_node, br->index(), caret_rect_for_child_offset(br->index()), visual_context_index);
+    }
 }
 
 static void resolve_text_fragment_properties(PaintableWithLines const& paintable_with_lines)

--- a/Libraries/LibWeb/Painting/PaintableWithLines.cpp
+++ b/Libraries/LibWeb/Painting/PaintableWithLines.cpp
@@ -587,6 +587,27 @@ CSSPixelRect PaintableWithLines::caret_rect_for_child_offset(size_t offset) cons
     auto dom_node = layout_node().dom_node();
     if (!dom_node)
         return rect;
+
+    // A boundary immediately after an atomic inline element paints after that element. Atomic inline elements have
+    // no text offset for fragment_at_position() to resolve, so use their inline edge directly.
+    if (offset > 0) {
+        auto* previous_child = dom_node->child_at_index(offset - 1);
+        if (previous_child) {
+            for (auto const& fragment : m_fragments) {
+                auto* fragment_dom_node = fragment.layout_node().dom_node();
+                if (fragment_dom_node != previous_child || !fragment.layout_node().is_atomic_inline())
+                    continue;
+
+                auto fragment_rect = fragment.absolute_rect();
+                if (computed_values().writing_mode() == CSS::WritingMode::HorizontalTb)
+                    rect.set_x(computed_values().inline_axis_is_reverse() ? fragment_rect.left() : fragment_rect.right());
+                else
+                    rect.set_y(computed_values().inline_axis_is_reverse() ? fragment_rect.top() : fragment_rect.bottom());
+                return rect;
+            }
+        }
+    }
+
     auto* child = dom_node->child_at_index(offset);
     if (!child || !is<HTML::HTMLBRElement>(*child))
         return rect;

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibUnicode/Segmenter.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/Selection.h>
 #include <LibWeb/DOM/Document.h>
@@ -15,12 +14,10 @@
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
-#include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/Selection.h>
-#include <LibWeb/VisualLines.h>
+#include <LibWeb/Selection/SelectionModifier.h>
 
 namespace Web::Selection {
 
@@ -463,42 +460,21 @@ WebIDL::ExceptionOr<void> Selection::modify(Optional<Utf16String> alter, Optiona
     // 11. Otherwise, set this selection's focus and anchor to the location as if the user had requested to move selection by granularity.
     auto collapse_selection = alter->equals_ignoring_ascii_case(u"move"sv);
 
-    auto move_focus_to_visual_line_boundary = [&](bool forwards) {
-        auto* text = as_if<DOM::Text>(focus_node().ptr());
-        if (!text)
-            return;
-        auto position = forwards
-            ? find_visual_line_end(*text, focus_offset(), m_focus_affinity)
-            : CursorLinePosition { find_visual_line_start(*text, focus_offset(), m_focus_affinity), TextAffinity::Downstream };
-        if (collapse_selection)
-            MUST(collapse(text, position.offset));
-        else
-            MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text, position.offset));
-        m_focus_affinity = position.affinity;
-        m_document->reset_cursor_blink_cycle();
-        m_document->set_cursor_position_needs_repaint();
-    };
-
     // TODO: Implement the sentence, paragraph, and document granularity options.
-    if (effective_direction == Direction::Forwards) {
-        if (granularity->equals_ignoring_ascii_case(u"character"sv))
-            move_offset_to_next_character(collapse_selection);
-        else if (granularity->equals_ignoring_ascii_case(u"word"sv))
-            move_offset_to_next_word(collapse_selection);
-        else if (granularity->equals_ignoring_ascii_case(u"line"sv))
-            move_offset_to_next_line(collapse_selection);
-        else if (granularity->equals_ignoring_ascii_case(u"lineboundary"sv))
-            move_focus_to_visual_line_boundary(true);
-    } else {
-        if (granularity->equals_ignoring_ascii_case(u"character"sv))
-            move_offset_to_previous_character(collapse_selection);
-        else if (granularity->equals_ignoring_ascii_case(u"word"sv))
-            move_offset_to_previous_word(collapse_selection);
-        else if (granularity->equals_ignoring_ascii_case(u"line"sv))
-            move_offset_to_previous_line(collapse_selection);
-        else if (granularity->equals_ignoring_ascii_case(u"lineboundary"sv))
-            move_focus_to_visual_line_boundary(false);
-    }
+    auto alteration = collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend;
+    auto selection_direction = effective_direction == Direction::Forwards ? SelectionDirection::Forward : SelectionDirection::Backward;
+    Optional<SelectionGranularity> selection_granularity;
+    if (granularity->equals_ignoring_ascii_case(u"character"sv))
+        selection_granularity = SelectionGranularity::Character;
+    else if (granularity->equals_ignoring_ascii_case(u"word"sv))
+        selection_granularity = SelectionGranularity::Word;
+    else if (granularity->equals_ignoring_ascii_case(u"line"sv))
+        selection_granularity = SelectionGranularity::Line;
+    else if (granularity->equals_ignoring_ascii_case(u"lineboundary"sv))
+        selection_granularity = SelectionGranularity::LineBoundary;
+
+    if (selection_granularity.has_value())
+        SelectionModifier(*this).modify(alteration, selection_direction, *selection_granularity);
 
     return {};
 }
@@ -629,350 +605,34 @@ GC::Ptr<DOM::Position> Selection::cursor_position() const
     return DOM::Position::create(m_document->realm(), *m_range->start_container(), m_range->start_offset(), m_focus_affinity);
 }
 
-// Cross-node caret navigation: when character or line movement reaches the edge of the current node, the caret moves
-// to the closest node in the editing host that can house it: either a text node with rendered text, or a block-level
-// element rendering an empty line (such as the `<p><br></p>` paragraphs produced by pressing Enter on an empty line).
-// FIXME: Word movement is still limited to a single DOM node.
-
-enum class CaretNavigationDirection : u8 {
-    Forward,
-    Backward,
-};
-
-enum class CaretEntryMode : u8 {
-    LineEdge,
-    ClosestToInlineCoordinate,
-};
-
-static bool text_node_has_rendered_text(DOM::Text const& text)
-{
-    for (auto const& line : collect_visual_lines(text)) {
-        if (!line.fragments.is_empty())
-            return true;
-    }
-    return false;
-}
-
-// A <br> that renders an empty line hosts a caret position on its parent, at its child index. This covers a leading
-// <br> in a paragraph with text after it, and the lines between consecutive <br>s.
-static bool is_empty_line_break(DOM::Node& node)
-{
-    auto* br = as_if<HTML::HTMLBRElement>(node);
-    return br && br->is_editable() && br->represents_empty_line();
-}
-
-// A block-level element that renders no text but hosts an empty line where the caret can sit, such as `<p><br></p>`.
-static bool is_empty_line_host(DOM::Node& node)
-{
-    auto* element = as_if<DOM::Element>(node);
-    if (!element || !element->is_editable())
-        return false;
-    auto element_paintable = element->unsafe_paintable();
-    auto* paintable = as_if<Painting::PaintableWithLines>(element_paintable.ptr());
-    if (!paintable)
-        return false;
-    if (paintable->layout_node().display().is_inline_outside())
-        return false;
-
-    bool has_rendered_text = false;
-    element->for_each_in_subtree_of_type<DOM::Text>([&](auto& text) {
-        if (!text_node_has_rendered_text(text))
-            return TraversalDecision::Continue;
-        has_rendered_text = true;
-        return TraversalDecision::Break;
-    });
-    return !has_rendered_text;
-}
-
-static GC::Ptr<DOM::Node> adjacent_caret_host_in_editing_host(DOM::Node& from, DOM::Node& editing_host, CaretNavigationDirection direction)
-{
-    auto* node = &from;
-    while (node) {
-        node = direction == CaretNavigationDirection::Forward
-            ? node->next_in_pre_order(&editing_host)
-            : node->previous_in_pre_order();
-        if (!node || node == &editing_host || !editing_host.is_inclusive_ancestor_of(*node))
-            return nullptr;
-        // Walking backwards visits ancestors of the origin; the caret is already inside those.
-        if (node->is_inclusive_ancestor_of(from))
-            continue;
-        if (auto* text = as_if<DOM::Text>(*node); text && text->is_editable() && text_node_has_rendered_text(*text))
-            return node;
-        if (is_empty_line_host(*node) || is_empty_line_break(*node))
-            return node;
-    }
-    return nullptr;
-}
-
-// The node caret navigation should walk from: for a caret anchored on an element, that is the child the offset
-// points at (e.g. the <br> hosting the empty line the caret sits on), not the element itself.
-static DOM::Node& caret_navigation_origin(DOM::Node& node, size_t offset)
-{
-    if (auto* child = node.child_at_index(offset))
-        return *child;
-    return node;
-}
-
-// Moves the caret out of `from` into the closest caret host before or after it in the editing host. Enters text
-// nodes at the rendered edge facing `from` (LineEdge, for horizontal movement) or at the position on the edge line
-// closest to the given inline coordinate (for vertical movement). Empty line hosts house the caret at offset 0.
-static bool move_cursor_to_adjacent_caret_host(Selection& selection, DOM::Node& from, CaretNavigationDirection direction, CaretEntryMode entry_mode, Optional<CSSPixels> inline_coordinate, bool collapse_selection)
-{
-    auto editing_host = from.editing_host();
-    if (!editing_host)
-        return false;
-
-    selection.document()->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
-
-    auto target = adjacent_caret_host_in_editing_host(from, *editing_host, direction);
-    if (!target)
-        return false;
-
-    size_t new_offset = 0;
-    auto new_affinity = TextAffinity::Downstream;
-
-    // A <br> hosting an empty line houses the caret on its parent, at the child index of the <br>.
-    if (is<HTML::HTMLBRElement>(*target) && target->parent()) {
-        new_offset = target->index();
-        target = target->parent();
-    }
-
-    if (auto* text = as_if<DOM::Text>(*target)) {
-        Optional<CursorLinePosition> position;
-        if (entry_mode == CaretEntryMode::LineEdge) {
-            position = direction == CaretNavigationDirection::Forward
-                ? cursor_position_at_visual_start(*text)
-                : cursor_position_at_visual_end(*text);
-        } else {
-            position = direction == CaretNavigationDirection::Forward
-                ? cursor_position_on_first_line_closest_to(*text, inline_coordinate)
-                : cursor_position_on_last_line_closest_to(*text, inline_coordinate);
-        }
-        if (!position.has_value())
-            return false;
-        new_offset = position->offset;
-        new_affinity = position->affinity;
-    }
-
-    if (collapse_selection)
-        MUST(selection.collapse(target, new_offset));
-    else
-        MUST(selection.set_base_and_extent(*selection.anchor_node(), selection.anchor_offset(), *target, new_offset));
-    selection.set_focus_affinity(new_affinity);
-    selection.document()->reset_cursor_blink_cycle();
-    selection.document()->set_cursor_position_needs_repaint();
-    return true;
-}
-
 void Selection::move_offset_to_next_character(bool collapse_selection)
 {
-    // If there is a selection range, collapse to the end of that range without moving forward
-    if (collapse_selection && !is_collapsed()) {
-        MUST(collapse(m_range->end_container(), m_range->end_offset()));
-        m_document->reset_cursor_blink_cycle();
-        scroll_focus_into_view();
-        return;
-    }
-
-    auto node = focus_node();
-    if (!node)
-        return;
-
-    if (auto* text_node = as_if<DOM::Text>(*node)) {
-        // Move forward within the text node if possible
-        if (auto new_position = compute_cursor_position_on_next_character(*text_node, focus_offset(), m_focus_affinity); new_position.has_value()) {
-            if (collapse_selection) {
-                MUST(collapse(text_node, new_position->offset));
-                m_document->reset_cursor_blink_cycle();
-            } else {
-                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
-            }
-            m_focus_affinity = new_position->affinity;
-            m_document->set_cursor_position_needs_repaint();
-        }
-        // At the very end of this text node, move into the closest caret host after it.
-        else {
-            move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
-        }
-    }
-    // The focus is parked on an element, e.g. an empty line; step into the closest caret host after it.
-    else {
-        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
-    }
-    scroll_focus_into_view();
+    SelectionModifier(*this).modify(collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend, SelectionDirection::Forward, SelectionGranularity::Character);
 }
 
 void Selection::move_offset_to_previous_character(bool collapse_selection)
 {
-    // If there is a selection range, collapse to the start of that range without moving backward
-    if (collapse_selection && !is_collapsed()) {
-        MUST(collapse(m_range->start_container(), m_range->start_offset()));
-        m_document->reset_cursor_blink_cycle();
-        scroll_focus_into_view();
-        return;
-    }
-
-    auto node = focus_node();
-    if (!node)
-        return;
-
-    if (auto* text_node = as_if<DOM::Text>(*node)) {
-        // Move backward within the text node if possible
-        if (auto new_position = compute_cursor_position_on_previous_character(*text_node, focus_offset(), m_focus_affinity); new_position.has_value()) {
-            if (collapse_selection) {
-                MUST(collapse(text_node, new_position->offset));
-                m_document->reset_cursor_blink_cycle();
-            } else {
-                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
-            }
-            m_focus_affinity = new_position->affinity;
-            m_document->set_cursor_position_needs_repaint();
-        }
-        // At the very start of this text node, move into the closest caret host before it.
-        else {
-            move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
-        }
-    }
-    // The focus is parked on an element, e.g. an empty line; step into the closest caret host before it.
-    else {
-        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
-    }
-    scroll_focus_into_view();
+    SelectionModifier(*this).modify(collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend, SelectionDirection::Backward, SelectionGranularity::Character);
 }
 
 void Selection::move_offset_to_next_word(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(focus_node().ptr());
-    if (!text_node) {
-        // The focus is parked on an element, e.g. an empty line; step into the closest caret host after it.
-        if (auto node = focus_node())
-            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Forward, CaretEntryMode::LineEdge, {}, collapse_selection);
-        scroll_focus_into_view();
-        return;
-    }
-
-    while (true) {
-        auto focus_offset = this->focus_offset();
-        if (focus_offset == text_node->data().length_in_code_units())
-            break;
-
-        if (auto offset = text_node->word_segmenter().next_boundary(focus_offset); offset.has_value()) {
-            if (collapse_selection) {
-                MUST(collapse(text_node, *offset));
-                m_document->reset_cursor_blink_cycle();
-            } else {
-                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, *offset));
-            }
-            auto word = text_node->data().substring_view(focus_offset, *offset - focus_offset);
-            if (Unicode::Segmenter::should_continue_beyond_word(word))
-                continue;
-        }
-        break;
-    }
-    scroll_focus_into_view();
+    SelectionModifier(*this).modify(collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend, SelectionDirection::Forward, SelectionGranularity::Word);
 }
 
 void Selection::move_offset_to_previous_word(bool collapse_selection)
 {
-    auto* text_node = as_if<DOM::Text>(focus_node().ptr());
-    if (!text_node) {
-        // The focus is parked on an element, e.g. an empty line; step into the closest caret host before it.
-        if (auto node = focus_node())
-            move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Backward, CaretEntryMode::LineEdge, {}, collapse_selection);
-        scroll_focus_into_view();
-        return;
-    }
-
-    while (true) {
-        auto focus_offset = this->focus_offset();
-        if (auto offset = text_node->word_segmenter().previous_boundary(focus_offset); offset.has_value()) {
-            if (collapse_selection) {
-                MUST(collapse(text_node, *offset));
-                m_document->reset_cursor_blink_cycle();
-            } else {
-                MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, *offset));
-            }
-            auto word = text_node->data().substring_view(*offset, focus_offset - *offset);
-            if (Unicode::Segmenter::should_continue_beyond_word(word))
-                continue;
-        }
-        break;
-    }
-    scroll_focus_into_view();
+    SelectionModifier(*this).modify(collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend, SelectionDirection::Backward, SelectionGranularity::Word);
 }
 
 void Selection::move_offset_to_next_line(bool collapse_selection)
 {
-    auto node = focus_node();
-    if (!node)
-        return;
-
-    auto* text_node = as_if<DOM::Text>(*node);
-    if (!text_node) {
-        // The focus is parked on an element, e.g. an empty line; move to the closest caret host below.
-        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
-        scroll_focus_into_view();
-        return;
-    }
-
-    // On the last visual line of this text node, move to the closest caret host below instead.
-    if (offset_is_on_last_visual_line(*text_node, focus_offset(), m_focus_affinity)) {
-        auto inline_coordinate = cursor_inline_coordinate(*text_node, focus_offset(), m_focus_affinity);
-        if (move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Forward, CaretEntryMode::ClosestToInlineCoordinate, inline_coordinate, collapse_selection)) {
-            scroll_focus_into_view();
-            return;
-        }
-    }
-
-    auto new_position = compute_cursor_position_on_next_line(*text_node, focus_offset(), m_focus_affinity);
-    if (!new_position.has_value())
-        return;
-
-    if (collapse_selection) {
-        MUST(collapse(text_node, new_position->offset));
-        m_document->reset_cursor_blink_cycle();
-    } else {
-        MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
-    }
-    m_focus_affinity = new_position->affinity;
-    scroll_focus_into_view();
+    SelectionModifier(*this).modify(collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend, SelectionDirection::Forward, SelectionGranularity::Line);
 }
 
 void Selection::move_offset_to_previous_line(bool collapse_selection)
 {
-    auto node = focus_node();
-    if (!node)
-        return;
-
-    auto* text_node = as_if<DOM::Text>(*node);
-    if (!text_node) {
-        // The focus is parked on an element, e.g. an empty line; move to the closest caret host above.
-        move_cursor_to_adjacent_caret_host(*this, caret_navigation_origin(*node, focus_offset()), CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, {}, collapse_selection);
-        scroll_focus_into_view();
-        return;
-    }
-
-    // On the first visual line of this text node, move to the closest caret host above instead.
-    if (offset_is_on_first_visual_line(*text_node, focus_offset(), m_focus_affinity)) {
-        auto inline_coordinate = cursor_inline_coordinate(*text_node, focus_offset(), m_focus_affinity);
-        if (move_cursor_to_adjacent_caret_host(*this, *text_node, CaretNavigationDirection::Backward, CaretEntryMode::ClosestToInlineCoordinate, inline_coordinate, collapse_selection)) {
-            scroll_focus_into_view();
-            return;
-        }
-    }
-
-    auto new_position = compute_cursor_position_on_previous_line(*text_node, focus_offset(), m_focus_affinity);
-    if (!new_position.has_value())
-        return;
-
-    if (collapse_selection) {
-        MUST(collapse(text_node, new_position->offset));
-        m_document->reset_cursor_blink_cycle();
-    } else {
-        MUST(set_base_and_extent(*anchor_node(), anchor_offset(), *text_node, new_position->offset));
-    }
-    m_focus_affinity = new_position->affinity;
-    scroll_focus_into_view();
+    SelectionModifier(*this).modify(collapse_selection ? SelectionAlteration::Move : SelectionAlteration::Extend, SelectionDirection::Backward, SelectionGranularity::Line);
 }
 
 void Selection::scroll_focus_into_view()

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -573,6 +573,7 @@ void Selection::set_range(GC::Ptr<DOM::Range> range)
 
     m_range = range;
     m_focus_affinity = TextAffinity::Downstream;
+    m_preferred_inline_coordinate.clear();
 
     if (range)
         range->set_associated_selection({}, this);

--- a/Libraries/LibWeb/Selection/Selection.h
+++ b/Libraries/LibWeb/Selection/Selection.h
@@ -9,6 +9,7 @@
 #include <AK/Utf16String.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/TextAffinity.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
@@ -81,6 +82,8 @@ public:
     void move_offset_to_previous_line(bool collapse_selection);
 
 private:
+    friend class SelectionModifier;
+
     Selection(GC::Ref<JS::Realm>, GC::Ref<DOM::Document>);
 
     [[nodiscard]] bool is_empty() const;
@@ -96,6 +99,9 @@ private:
     GC::Ref<DOM::Document> m_document;
     Direction m_direction { Direction::Directionless };
     TextAffinity m_focus_affinity { TextAffinity::Downstream };
+    // Repeated vertical moves preserve the inline-axis coordinate chosen by the first move. A non-vertical move
+    // clears it so the next vertical sequence starts from the caret's new visual position.
+    Optional<CSSPixels> m_preferred_inline_coordinate;
 };
 
 }

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -83,6 +83,7 @@ public:
 
 private:
     Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection, CaretEntryMode, Optional<CSSPixels>);
+    Optional<CaretLocation> move_to_editing_host_boundary(CaretLocation const&, SelectionDirection);
     GC::Ptr<DOM::Node> adjacent_caret_host(DOM::Node&, DOM::Node& editing_host, SelectionDirection);
     static DOM::Node& navigation_origin(CaretLocation const&);
 
@@ -156,9 +157,44 @@ Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocatio
     return CaretLocation { *target, offset, affinity };
 }
 
+Optional<CaretLocation> CaretNavigator::move_to_editing_host_boundary(CaretLocation const& location, SelectionDirection direction)
+{
+    // INTEROP: Chromium and WebKit constrain "start/end of document" commands to the active editing host. Letting the
+    // traversal escape the host can create a caret before the first editable position or in unrelated page content.
+    auto editing_host = location.node->editing_host();
+    if (!editing_host)
+        return {};
+
+    m_document->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
+
+    auto target = adjacent_caret_host(*editing_host, *editing_host, SelectionDirection::Forward);
+    if (!target)
+        return {};
+    if (direction == SelectionDirection::Forward) {
+        while (auto next_target = adjacent_caret_host(*target, *editing_host, SelectionDirection::Forward))
+            target = next_target;
+    }
+
+    if (auto* text = as_if<DOM::Text>(*target)) {
+        auto position = direction == SelectionDirection::Forward
+            ? cursor_position_at_visual_end(*text)
+            : cursor_position_at_visual_start(*text);
+        if (!position.has_value())
+            return {};
+        return CaretLocation { *text, position->offset, position->affinity };
+    }
+
+    if (is<HTML::HTMLBRElement>(*target) && target->parent())
+        return CaretLocation { *target->parent(), target->index(), TextAffinity::Downstream };
+    return CaretLocation { *target, 0, TextAffinity::Downstream };
+}
+
 Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, SelectionDirection direction, SelectionGranularity granularity, Optional<CSSPixels> preferred_inline_coordinate)
 {
     auto* text = as_if<DOM::Text>(*location.node);
+
+    if (granularity == SelectionGranularity::DocumentBoundary)
+        return move_to_editing_host_boundary(location, direction);
 
     if (granularity == SelectionGranularity::Character) {
         if (text) {

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -60,14 +60,43 @@ static bool is_empty_line_host(DOM::Node& node)
     if (!paintable || paintable->layout_node().display().is_inline_outside())
         return false;
 
-    bool has_rendered_text = false;
-    element->for_each_in_subtree_of_type<DOM::Text>([&](auto& text) {
-        if (!text_node_has_rendered_text(text))
-            return TraversalDecision::Continue;
-        has_rendered_text = true;
-        return TraversalDecision::Break;
+    bool has_rendered_content = false;
+    element->for_each_in_subtree([&](DOM::Node& descendant) {
+        if (auto* text = as_if<DOM::Text>(descendant); text && text_node_has_rendered_text(*text)) {
+            has_rendered_content = true;
+            return TraversalDecision::Break;
+        }
+        auto const* layout_node = descendant.layout_node();
+        if (descendant.is_editable() && layout_node && layout_node->is_atomic_inline()) {
+            has_rendered_content = true;
+            return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
     });
-    return !has_rendered_text;
+    return !has_rendered_content;
+}
+
+// Atomic inline content, such as an image, has no caret positions inside it. Its two caret positions are represented
+// as DOM boundaries in the parent, immediately before and after the atomic node.
+static bool is_atomic_inline_caret_host(DOM::Node& node)
+{
+    if (is<HTML::HTMLBRElement>(node))
+        return false;
+    auto const* layout_node = node.layout_node();
+    return node.is_editable() && node.parent() && layout_node && layout_node->is_atomic_inline();
+}
+
+static bool boundary_visual_lines_share_line(DOM::Text const& before, DOM::Text const& after)
+{
+    auto before_lines = collect_visual_lines(before);
+    auto after_lines = collect_visual_lines(after);
+    if (before_lines.is_empty() || before_lines.last().fragments.is_empty() || after_lines.is_empty() || after_lines.first().fragments.is_empty())
+        return false;
+
+    auto const& before_fragment = *before_lines.last().fragments.last();
+    auto const& after_fragment = *after_lines.first().fragments.first();
+    return &before_fragment.paintable_with_lines() == &after_fragment.paintable_with_lines()
+        && before_fragment.line_index() == after_fragment.line_index();
 }
 
 // Turns a movement request into a CaretLocation without mutating Selection. This allows DOM traversal and rendered
@@ -80,12 +109,13 @@ public:
     }
 
     Optional<CaretLocation> move(CaretLocation const&, SelectionDirection, SelectionGranularity, Optional<CSSPixels> preferred_inline_coordinate = {});
+    Optional<CaretLocation> canonical_location_for_extension(CaretLocation const&, SelectionDirection);
 
 private:
     Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection, CaretEntryMode, Optional<CSSPixels>);
     Optional<CaretLocation> move_to_editing_host_boundary(CaretLocation const&, SelectionDirection);
     GC::Ptr<DOM::Node> adjacent_caret_host(DOM::Node&, DOM::Node& editing_host, SelectionDirection);
-    static DOM::Node& navigation_origin(CaretLocation const&);
+    static DOM::Node& navigation_origin(CaretLocation const&, SelectionDirection);
 
     GC::Ref<DOM::Document> m_document;
 };
@@ -104,16 +134,22 @@ GC::Ptr<DOM::Node> CaretNavigator::adjacent_caret_host(DOM::Node& from, DOM::Nod
             continue;
         if (auto* text = as_if<DOM::Text>(*node); text && text->is_editable() && text_node_has_rendered_text(*text))
             return node;
-        if (is_empty_line_host(*node) || is_empty_line_break(*node))
+        if (is_atomic_inline_caret_host(*node) || is_empty_line_host(*node) || is_empty_line_break(*node))
             return node;
     }
     return nullptr;
 }
 
-DOM::Node& CaretNavigator::navigation_origin(CaretLocation const& location)
+DOM::Node& CaretNavigator::navigation_origin(CaretLocation const& location, SelectionDirection direction)
 {
-    if (auto* child = location.node->child_at_index(location.offset))
-        return *child;
+    if (direction == SelectionDirection::Forward && location.offset > 0) {
+        if (auto* child_before = location.node->child_at_index(location.offset - 1))
+            return *child_before;
+    }
+    if (direction == SelectionDirection::Backward) {
+        if (auto* child_after = location.node->child_at_index(location.offset))
+            return *child_after;
+    }
     return location.node;
 }
 
@@ -125,14 +161,54 @@ Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocatio
 
     m_document->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
 
-    auto target = adjacent_caret_host(navigation_origin(location), *editing_host, direction);
+    auto& origin = navigation_origin(location, direction);
+    auto* adjacent_child = direction == SelectionDirection::Forward
+        ? location.node->child_at_index(location.offset)
+        : (location.offset > 0 ? location.node->child_at_index(location.offset - 1) : nullptr);
+    GC::Ptr<DOM::Node> target;
+    bool target_is_adjacent_child = false;
+    // INTEROP: An empty-line <br> contributes a single caret position at its parent boundary. Once the caret is already
+    // at that boundary, forward movement must start after the <br> instead of rediscovering the same position.
+    if (direction == SelectionDirection::Forward && adjacent_child && is_empty_line_break(*adjacent_child)) {
+        target = adjacent_caret_host(*adjacent_child, *editing_host, direction);
+    } else if (adjacent_child) {
+        auto* text = as_if<DOM::Text>(*adjacent_child);
+        if ((text && text->is_editable() && text_node_has_rendered_text(*text))
+            || is_atomic_inline_caret_host(*adjacent_child) || is_empty_line_host(*adjacent_child) || is_empty_line_break(*adjacent_child)) {
+            target = adjacent_child;
+            target_is_adjacent_child = true;
+        }
+    }
+    if (!target)
+        target = adjacent_caret_host(origin, *editing_host, direction);
+    if (entry_mode == CaretEntryMode::ClosestToInlineCoordinate) {
+        while (target && is_atomic_inline_caret_host(*target)) {
+            target = adjacent_caret_host(*target, *editing_host, direction);
+            target_is_adjacent_child = false;
+        }
+    }
     if (!target)
         return {};
 
     size_t offset = 0;
     auto affinity = TextAffinity::Downstream;
 
-    if (is<HTML::HTMLBRElement>(*target) && target->parent()) {
+    if (is_atomic_inline_caret_host(*target) && target->parent()) {
+        auto target_is_in_origin_parent = target->parent() == origin.parent();
+        if (direction == SelectionDirection::Backward && target_is_in_origin_parent) {
+            if (auto previous_target = adjacent_caret_host(*target, *editing_host, direction); previous_target && is<DOM::Text>(*previous_target))
+                target = previous_target;
+        }
+        if (is_atomic_inline_caret_host(*target) && target->parent()) {
+            // INTEROP: Enter an atomic-only line at its near edge, but cross an atomic child adjacent to the current
+            // parent boundary. Chromium exposes both edges in the former case and one visual step in the latter.
+            auto use_boundary_after_target = target_is_adjacent_child
+                ? direction == SelectionDirection::Forward
+                : (direction == SelectionDirection::Forward) == target_is_in_origin_parent;
+            offset = target->index() + (use_boundary_after_target ? 1 : 0);
+            target = target->parent();
+        }
+    } else if (is<HTML::HTMLBRElement>(*target) && target->parent()) {
         offset = target->index();
         target = target->parent();
     }
@@ -155,6 +231,38 @@ Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocatio
     }
 
     return CaretLocation { *target, offset, affinity };
+}
+
+Optional<CaretLocation> CaretNavigator::canonical_location_for_extension(CaretLocation const& location, SelectionDirection direction)
+{
+    // INTEROP: A rendered caret boundary can have several equivalent DOM representations, especially between styled
+    // text nodes and beside atomic inline content. Chromium canonicalizes the anchor when selection first extends so
+    // subsequent movement includes the same rendered content regardless of which equivalent boundary held the caret.
+    auto* text = as_if<DOM::Text>(*location.node);
+    if (!text)
+        return {};
+    if ((direction == SelectionDirection::Forward && location.offset != text->length())
+        || (direction == SelectionDirection::Backward && location.offset != 0))
+        return {};
+
+    auto editing_host = text->editing_host();
+    if (!editing_host)
+        return {};
+    m_document->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
+    auto target = adjacent_caret_host(*text, *editing_host, direction);
+    if (!target)
+        return {};
+    if (is_atomic_inline_caret_host(*target) && target->parent())
+        return CaretLocation { *target->parent(), target->index() + (direction == SelectionDirection::Backward ? 1 : 0), TextAffinity::Downstream };
+    auto* target_text = as_if<DOM::Text>(*target);
+    if (!target_text)
+        return {};
+    auto shares_line = direction == SelectionDirection::Forward
+        ? boundary_visual_lines_share_line(*text, *target_text)
+        : boundary_visual_lines_share_line(*target_text, *text);
+    if (!shares_line)
+        return {};
+    return CaretLocation { *target_text, direction == SelectionDirection::Forward ? 0u : target_text->length(), TextAffinity::Downstream };
 }
 
 Optional<CaretLocation> CaretNavigator::move_to_editing_host_boundary(CaretLocation const& location, SelectionDirection direction)
@@ -204,7 +312,23 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
             if (position.has_value())
                 return CaretLocation { *text, position->offset, position->affinity };
         }
-        return move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+        auto adjacent = move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+        if (!adjacent.has_value())
+            return {};
+        auto* adjacent_text = as_if<DOM::Text>(*adjacent->node);
+        if (text && adjacent_text) {
+            auto shares_line = direction == SelectionDirection::Forward
+                ? boundary_visual_lines_share_line(*text, *adjacent_text)
+                : boundary_visual_lines_share_line(*adjacent_text, *text);
+            if (shares_line) {
+                auto position = direction == SelectionDirection::Forward
+                    ? compute_cursor_position_on_next_character(*adjacent_text, adjacent->offset, adjacent->affinity)
+                    : compute_cursor_position_on_previous_character(*adjacent_text, adjacent->offset, adjacent->affinity);
+                if (position.has_value())
+                    return CaretLocation { *adjacent_text, position->offset, position->affinity };
+            }
+        }
+        return adjacent;
     }
 
     if (granularity == SelectionGranularity::Word) {
@@ -279,12 +403,16 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
     }
 
     Optional<CaretLocation> destination;
+    Optional<CaretLocation> canonical_anchor;
     if (alteration == SelectionAlteration::Move && granularity == SelectionGranularity::Character && !m_selection->is_collapsed()) {
         auto boundary = direction == SelectionDirection::Forward ? range->end() : range->start();
         destination = CaretLocation { boundary.node, boundary.offset, TextAffinity::Downstream };
     } else if (auto focus = m_selection->focus_node()) {
         CaretNavigator navigator(*m_selection->document());
-        destination = navigator.move({ *focus, m_selection->focus_offset(), m_selection->focus_affinity() }, direction, granularity, preferred_inline_coordinate);
+        CaretLocation origin { *focus, m_selection->focus_offset(), m_selection->focus_affinity() };
+        if (alteration == SelectionAlteration::Extend && m_selection->is_collapsed())
+            canonical_anchor = navigator.canonical_location_for_extension(origin, direction);
+        destination = navigator.move(origin, direction, granularity, preferred_inline_coordinate);
     }
 
     if (!destination.has_value())
@@ -296,10 +424,11 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
         MUST(m_selection->collapse(destination->node, destination->offset));
         m_selection->document()->reset_cursor_blink_cycle();
     } else {
-        auto anchor = m_selection->anchor_node();
+        GC::Ptr<DOM::Node> anchor = canonical_anchor.has_value() ? canonical_anchor->node : m_selection->anchor_node();
         if (!anchor)
             return;
-        MUST(m_selection->set_base_and_extent(*anchor, m_selection->anchor_offset(), destination->node, destination->offset));
+        auto anchor_offset = canonical_anchor.has_value() ? canonical_anchor->offset : m_selection->anchor_offset();
+        MUST(m_selection->set_base_and_extent(*anchor, anchor_offset, destination->node, destination->offset));
     }
     m_selection->set_focus_affinity(destination->affinity);
     if (granularity == SelectionGranularity::Line)

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -219,8 +219,8 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
     }
 
     auto position = direction == SelectionDirection::Forward
-        ? compute_cursor_position_on_next_line(*text, location.offset, location.affinity)
-        : compute_cursor_position_on_previous_line(*text, location.offset, location.affinity);
+        ? compute_cursor_position_on_next_line(*text, location.offset, location.affinity, preferred_inline_coordinate)
+        : compute_cursor_position_on_previous_line(*text, location.offset, location.affinity, preferred_inline_coordinate);
     if (!position.has_value())
         return {};
     return CaretLocation { *text, position->offset, position->affinity };
@@ -232,13 +232,23 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
     if (!range)
         return;
 
+    // INTEROP: Major engines remember a preferred inline-axis position across consecutive Up/Down operations. Without
+    // this state, traversing a short line permanently shifts the caret column for every subsequent line.
+    auto preferred_inline_coordinate = m_selection->m_preferred_inline_coordinate;
+    if (granularity == SelectionGranularity::Line && !preferred_inline_coordinate.has_value()) {
+        if (auto* text = as_if<DOM::Text>(m_selection->focus_node().ptr()))
+            preferred_inline_coordinate = cursor_inline_coordinate(*text, m_selection->focus_offset(), m_selection->focus_affinity());
+    } else if (granularity != SelectionGranularity::Line) {
+        m_selection->m_preferred_inline_coordinate.clear();
+    }
+
     Optional<CaretLocation> destination;
     if (alteration == SelectionAlteration::Move && granularity == SelectionGranularity::Character && !m_selection->is_collapsed()) {
         auto boundary = direction == SelectionDirection::Forward ? range->end() : range->start();
         destination = CaretLocation { boundary.node, boundary.offset, TextAffinity::Downstream };
     } else if (auto focus = m_selection->focus_node()) {
         CaretNavigator navigator(*m_selection->document());
-        destination = navigator.move({ *focus, m_selection->focus_offset(), m_selection->focus_affinity() }, direction, granularity);
+        destination = navigator.move({ *focus, m_selection->focus_offset(), m_selection->focus_affinity() }, direction, granularity, preferred_inline_coordinate);
     }
 
     if (!destination.has_value())
@@ -256,6 +266,8 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
         MUST(m_selection->set_base_and_extent(*anchor, m_selection->anchor_offset(), destination->node, destination->offset));
     }
     m_selection->set_focus_affinity(destination->affinity);
+    if (granularity == SelectionGranularity::Line)
+        m_selection->m_preferred_inline_coordinate = preferred_inline_coordinate;
     m_selection->document()->set_cursor_position_needs_repaint();
     m_selection->scroll_focus_into_view();
 }

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
+#include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/Selection/SelectionModifier.h>
@@ -194,13 +195,12 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
     }
 
     if (granularity == SelectionGranularity::LineBoundary) {
-        if (!text)
+        m_document->update_layout_if_needed_for_node(location.node, DOM::UpdateLayoutReason::CursorLineNavigation);
+        auto edge = direction == SelectionDirection::Forward ? Painting::CaretLineEdge::End : Painting::CaretLineEdge::Start;
+        auto position = m_document->caret_position_at_line_edge(location.node, location.offset, location.affinity, edge);
+        if (!position.has_value())
             return {};
-        if (direction == SelectionDirection::Forward) {
-            auto position = find_visual_line_end(*text, location.offset, location.affinity);
-            return CaretLocation { *text, position.offset, position.affinity };
-        }
-        return CaretLocation { *text, find_visual_line_start(*text, location.offset, location.affinity), TextAffinity::Downstream };
+        return CaretLocation { position->boundary.node, position->boundary.offset, position->affinity };
     }
 
     VERIFY(granularity == SelectionGranularity::Line);

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -32,11 +32,6 @@ struct CaretLocation {
     TextAffinity affinity { TextAffinity::Downstream };
 };
 
-enum class CaretEntryMode : u8 {
-    LineEdge,
-    ClosestToInlineCoordinate,
-};
-
 // Unicode word boundaries provide candidate stops, while browser editing behavior decides which candidates a command
 // crosses. Separators, punctuation, and word content therefore remain distinct through navigation.
 enum class WordSegmentKind : u8 {
@@ -147,7 +142,7 @@ public:
     Optional<CSSPixels> inline_coordinate(CaretLocation const&);
 
 private:
-    Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection, CaretEntryMode, Optional<CSSPixels>);
+    Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection);
     Optional<CaretLocation> move_to_editing_host_boundary(CaretLocation const&, SelectionDirection);
     Optional<CaretLocation> move_by_page(CaretLocation const&, SelectionDirection, CSSPixels inline_coordinate);
     Optional<CaretLocation> move_by_word(CaretLocation const&, SelectionAlteration, SelectionDirection);
@@ -233,7 +228,7 @@ Optional<CSSPixels> CaretNavigator::inline_coordinate(CaretLocation const& locat
     });
 }
 
-Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocation const& location, SelectionDirection direction, CaretEntryMode entry_mode, Optional<CSSPixels> inline_coordinate)
+Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocation const& location, SelectionDirection direction)
 {
     auto editing_host = location.node->editing_host();
     if (!editing_host)
@@ -261,12 +256,6 @@ Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocatio
     }
     if (!target)
         target = adjacent_caret_host(origin, *editing_host, direction);
-    if (entry_mode == CaretEntryMode::ClosestToInlineCoordinate) {
-        while (target && is_atomic_inline_caret_host(*target)) {
-            target = adjacent_caret_host(*target, *editing_host, direction);
-            target_is_adjacent_child = false;
-        }
-    }
     if (!target)
         return {};
 
@@ -294,16 +283,9 @@ Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocatio
     }
 
     if (auto* text = as_if<DOM::Text>(*target)) {
-        Optional<CursorLinePosition> position;
-        if (entry_mode == CaretEntryMode::LineEdge) {
-            position = direction == SelectionDirection::Forward
-                ? cursor_position_at_visual_start(*text)
-                : cursor_position_at_visual_end(*text);
-        } else {
-            position = direction == SelectionDirection::Forward
-                ? cursor_position_on_first_line_closest_to(*text, inline_coordinate)
-                : cursor_position_on_last_line_closest_to(*text, inline_coordinate);
-        }
+        auto position = direction == SelectionDirection::Forward
+            ? cursor_position_at_visual_start(*text)
+            : cursor_position_at_visual_end(*text);
         if (!position.has_value())
             return {};
         offset = position->offset;
@@ -415,7 +397,7 @@ Optional<CaretLocation> CaretNavigator::move_by_word(CaretLocation const& initia
         }
         text = as_if<DOM::Text>(adjacent_child);
         if (!text)
-            return move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+            return move_to_adjacent_caret_host(location, direction);
         location = { *text, direction == SelectionDirection::Forward ? 0u : text->length(), TextAffinity::Downstream };
     }
 
@@ -468,12 +450,12 @@ Optional<CaretLocation> CaretNavigator::move_by_word(CaretLocation const& initia
 
         auto* adjacent_text = as_if<DOM::Text>(*adjacent);
         if (!adjacent_text)
-            return moved ? Optional<CaretLocation> { location } : move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+            return moved ? Optional<CaretLocation> { location } : move_to_adjacent_caret_host(location, direction);
         auto shares_inline_context = direction == SelectionDirection::Forward
             ? boundary_visual_lines_share_inline_context(*text, *adjacent_text)
             : boundary_visual_lines_share_inline_context(*adjacent_text, *text);
         if (!shares_inline_context)
-            return moved ? Optional<CaretLocation> { location } : move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+            return moved ? Optional<CaretLocation> { location } : move_to_adjacent_caret_host(location, direction);
 
         text = adjacent_text;
         location = { *text, direction == SelectionDirection::Forward ? 0u : text->length(), TextAffinity::Downstream };
@@ -589,7 +571,7 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
             if (position.has_value())
                 return CaretLocation { *text, position->offset, position->affinity };
         }
-        auto adjacent = move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+        auto adjacent = move_to_adjacent_caret_host(location, direction);
         if (!adjacent.has_value())
             return {};
         auto* adjacent_text = as_if<DOM::Text>(*adjacent->node);

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibUnicode/Segmenter.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/Range.h>
+#include <LibWeb/DOM/Text.h>
+#include <LibWeb/HTML/HTMLBRElement.h>
+#include <LibWeb/Painting/PaintableWithLines.h>
+#include <LibWeb/Selection/Selection.h>
+#include <LibWeb/Selection/SelectionModifier.h>
+#include <LibWeb/VisualLines.h>
+
+namespace Web::Selection {
+
+// A DOM boundary is not sufficient to identify a visual caret position. At a soft wrap, the same node and offset can
+// be painted at the end of one line or the start of the next, so affinity travels with every computed destination.
+struct CaretLocation {
+    GC::Ref<DOM::Node> node;
+    size_t offset { 0 };
+    TextAffinity affinity { TextAffinity::Downstream };
+};
+
+enum class CaretEntryMode : u8 {
+    LineEdge,
+    ClosestToInlineCoordinate,
+};
+
+static bool text_node_has_rendered_text(DOM::Text const& text)
+{
+    for (auto const& line : collect_visual_lines(text)) {
+        if (!line.fragments.is_empty())
+            return true;
+    }
+    return false;
+}
+
+// A <br> that renders an empty line hosts a caret position on its parent, at its child index. This covers a leading
+// <br> in a paragraph with text after it, and the lines between consecutive <br>s.
+static bool is_empty_line_break(DOM::Node& node)
+{
+    auto* br = as_if<HTML::HTMLBRElement>(node);
+    return br && br->is_editable() && br->represents_empty_line();
+}
+
+// A block-level element that renders no text but hosts an empty line where the caret can sit, such as `<p><br></p>`.
+static bool is_empty_line_host(DOM::Node& node)
+{
+    auto* element = as_if<DOM::Element>(node);
+    if (!element || !element->is_editable())
+        return false;
+    auto element_paintable = element->unsafe_paintable();
+    auto* paintable = as_if<Painting::PaintableWithLines>(element_paintable.ptr());
+    if (!paintable || paintable->layout_node().display().is_inline_outside())
+        return false;
+
+    bool has_rendered_text = false;
+    element->for_each_in_subtree_of_type<DOM::Text>([&](auto& text) {
+        if (!text_node_has_rendered_text(text))
+            return TraversalDecision::Continue;
+        has_rendered_text = true;
+        return TraversalDecision::Break;
+    });
+    return !has_rendered_text;
+}
+
+// Turns a movement request into a CaretLocation without mutating Selection. This allows DOM traversal and rendered
+// geometry queries to cooperate without exposing intermediate selection states to script or painting.
+class CaretNavigator {
+public:
+    explicit CaretNavigator(DOM::Document& document)
+        : m_document(document)
+    {
+    }
+
+    Optional<CaretLocation> move(CaretLocation const&, SelectionDirection, SelectionGranularity, Optional<CSSPixels> preferred_inline_coordinate = {});
+
+private:
+    Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection, CaretEntryMode, Optional<CSSPixels>);
+    GC::Ptr<DOM::Node> adjacent_caret_host(DOM::Node&, DOM::Node& editing_host, SelectionDirection);
+    static DOM::Node& navigation_origin(CaretLocation const&);
+
+    GC::Ref<DOM::Document> m_document;
+};
+
+GC::Ptr<DOM::Node> CaretNavigator::adjacent_caret_host(DOM::Node& from, DOM::Node& editing_host, SelectionDirection direction)
+{
+    auto* node = &from;
+    while (node) {
+        node = direction == SelectionDirection::Forward
+            ? node->next_in_pre_order(&editing_host)
+            : node->previous_in_pre_order();
+        if (!node || node == &editing_host || !editing_host.is_inclusive_ancestor_of(*node))
+            return nullptr;
+        // Walking backwards visits ancestors of the origin; the caret is already inside those.
+        if (node->is_inclusive_ancestor_of(from))
+            continue;
+        if (auto* text = as_if<DOM::Text>(*node); text && text->is_editable() && text_node_has_rendered_text(*text))
+            return node;
+        if (is_empty_line_host(*node) || is_empty_line_break(*node))
+            return node;
+    }
+    return nullptr;
+}
+
+DOM::Node& CaretNavigator::navigation_origin(CaretLocation const& location)
+{
+    if (auto* child = location.node->child_at_index(location.offset))
+        return *child;
+    return location.node;
+}
+
+Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocation const& location, SelectionDirection direction, CaretEntryMode entry_mode, Optional<CSSPixels> inline_coordinate)
+{
+    auto editing_host = location.node->editing_host();
+    if (!editing_host)
+        return {};
+
+    m_document->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
+
+    auto target = adjacent_caret_host(navigation_origin(location), *editing_host, direction);
+    if (!target)
+        return {};
+
+    size_t offset = 0;
+    auto affinity = TextAffinity::Downstream;
+
+    if (is<HTML::HTMLBRElement>(*target) && target->parent()) {
+        offset = target->index();
+        target = target->parent();
+    }
+
+    if (auto* text = as_if<DOM::Text>(*target)) {
+        Optional<CursorLinePosition> position;
+        if (entry_mode == CaretEntryMode::LineEdge) {
+            position = direction == SelectionDirection::Forward
+                ? cursor_position_at_visual_start(*text)
+                : cursor_position_at_visual_end(*text);
+        } else {
+            position = direction == SelectionDirection::Forward
+                ? cursor_position_on_first_line_closest_to(*text, inline_coordinate)
+                : cursor_position_on_last_line_closest_to(*text, inline_coordinate);
+        }
+        if (!position.has_value())
+            return {};
+        offset = position->offset;
+        affinity = position->affinity;
+    }
+
+    return CaretLocation { *target, offset, affinity };
+}
+
+Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, SelectionDirection direction, SelectionGranularity granularity, Optional<CSSPixels> preferred_inline_coordinate)
+{
+    auto* text = as_if<DOM::Text>(*location.node);
+
+    if (granularity == SelectionGranularity::Character) {
+        if (text) {
+            auto position = direction == SelectionDirection::Forward
+                ? compute_cursor_position_on_next_character(*text, location.offset, location.affinity)
+                : compute_cursor_position_on_previous_character(*text, location.offset, location.affinity);
+            if (position.has_value())
+                return CaretLocation { *text, position->offset, position->affinity };
+        }
+        return move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+    }
+
+    if (granularity == SelectionGranularity::Word) {
+        if (!text)
+            return move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+
+        auto offset = location.offset;
+        while (true) {
+            auto next_offset = direction == SelectionDirection::Forward
+                ? text->word_segmenter().next_boundary(offset)
+                : text->word_segmenter().previous_boundary(offset);
+            if (!next_offset.has_value())
+                break;
+            auto word = direction == SelectionDirection::Forward
+                ? text->data().substring_view(offset, *next_offset - offset)
+                : text->data().substring_view(*next_offset, offset - *next_offset);
+            offset = *next_offset;
+            if (!Unicode::Segmenter::should_continue_beyond_word(word))
+                break;
+        }
+        if (offset == location.offset)
+            return {};
+        return CaretLocation { *text, offset, TextAffinity::Downstream };
+    }
+
+    if (granularity == SelectionGranularity::LineBoundary) {
+        if (!text)
+            return {};
+        if (direction == SelectionDirection::Forward) {
+            auto position = find_visual_line_end(*text, location.offset, location.affinity);
+            return CaretLocation { *text, position.offset, position.affinity };
+        }
+        return CaretLocation { *text, find_visual_line_start(*text, location.offset, location.affinity), TextAffinity::Downstream };
+    }
+
+    VERIFY(granularity == SelectionGranularity::Line);
+    if (!text)
+        return move_to_adjacent_caret_host(location, direction, CaretEntryMode::ClosestToInlineCoordinate, preferred_inline_coordinate);
+
+    auto is_on_edge_line = direction == SelectionDirection::Forward
+        ? offset_is_on_last_visual_line(*text, location.offset, location.affinity)
+        : offset_is_on_first_visual_line(*text, location.offset, location.affinity);
+    if (is_on_edge_line) {
+        auto inline_coordinate = preferred_inline_coordinate;
+        if (!inline_coordinate.has_value())
+            inline_coordinate = cursor_inline_coordinate(*text, location.offset, location.affinity);
+        if (auto result = move_to_adjacent_caret_host(location, direction, CaretEntryMode::ClosestToInlineCoordinate, inline_coordinate); result.has_value())
+            return result;
+    }
+
+    auto position = direction == SelectionDirection::Forward
+        ? compute_cursor_position_on_next_line(*text, location.offset, location.affinity)
+        : compute_cursor_position_on_previous_line(*text, location.offset, location.affinity);
+    if (!position.has_value())
+        return {};
+    return CaretLocation { *text, position->offset, position->affinity };
+}
+
+void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirection direction, SelectionGranularity granularity)
+{
+    auto range = m_selection->range();
+    if (!range)
+        return;
+
+    Optional<CaretLocation> destination;
+    if (alteration == SelectionAlteration::Move && granularity == SelectionGranularity::Character && !m_selection->is_collapsed()) {
+        auto boundary = direction == SelectionDirection::Forward ? range->end() : range->start();
+        destination = CaretLocation { boundary.node, boundary.offset, TextAffinity::Downstream };
+    } else if (auto focus = m_selection->focus_node()) {
+        CaretNavigator navigator(*m_selection->document());
+        destination = navigator.move({ *focus, m_selection->focus_offset(), m_selection->focus_affinity() }, direction, granularity);
+    }
+
+    if (!destination.has_value())
+        return;
+
+    // Apply exactly one selection mutation after navigation has produced a complete destination. In particular, do
+    // not use Selection itself as scratch state while walking across DOM nodes or painted lines.
+    if (alteration == SelectionAlteration::Move) {
+        MUST(m_selection->collapse(destination->node, destination->offset));
+        m_selection->document()->reset_cursor_blink_cycle();
+    } else {
+        auto anchor = m_selection->anchor_node();
+        if (!anchor)
+            return;
+        MUST(m_selection->set_base_and_extent(*anchor, m_selection->anchor_offset(), destination->node, destination->offset));
+    }
+    m_selection->set_focus_affinity(destination->affinity);
+    m_selection->document()->set_cursor_position_needs_repaint();
+    m_selection->scroll_focus_into_view();
+}
+
+}

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Platform.h>
 #include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/DOM/Document.h>
@@ -11,8 +12,11 @@
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Range.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/Editing/Internal/Algorithms.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
+#include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/Selection/SelectionModifier.h>
@@ -140,10 +144,12 @@ public:
 
     Optional<CaretLocation> move(CaretLocation const&, SelectionAlteration, SelectionDirection, SelectionGranularity, Optional<CSSPixels> preferred_inline_coordinate = {});
     Optional<CaretLocation> canonical_location_for_extension(CaretLocation const&, SelectionDirection);
+    Optional<CSSPixels> inline_coordinate(CaretLocation const&);
 
 private:
     Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection, CaretEntryMode, Optional<CSSPixels>);
     Optional<CaretLocation> move_to_editing_host_boundary(CaretLocation const&, SelectionDirection);
+    Optional<CaretLocation> move_by_page(CaretLocation const&, SelectionDirection, CSSPixels inline_coordinate);
     Optional<CaretLocation> move_by_word(CaretLocation const&, SelectionAlteration, SelectionDirection);
     GC::Ptr<DOM::Node> adjacent_caret_host(DOM::Node&, DOM::Node& editing_host, SelectionDirection);
     Optional<CaretLocation> location_before_atomic_inline(DOM::Node&, SelectionAlteration);
@@ -153,6 +159,20 @@ private:
 
     GC::Ref<DOM::Document> m_document;
 };
+
+// Convert a text-edge destination to the equivalent boundary in its block. Chromium exposes this form when a vertical
+// extension crosses a block boundary, which keeps the selected DOM range aligned with the rendered block contents.
+static CaretLocation canonical_location_at_outer_edge_of_inline_content(DOM::Text& text, DOM::Node& block, SelectionDirection direction)
+{
+    DOM::Node* node = &text;
+    while (auto* parent = node->parent()) {
+        auto offset = direction == SelectionDirection::Forward ? node->index() : node->index() + 1;
+        if (parent == &block)
+            return { *parent, offset, TextAffinity::Downstream };
+        node = parent;
+    }
+    return { text, direction == SelectionDirection::Forward ? 0u : text.length(), TextAffinity::Downstream };
+}
 
 GC::Ptr<DOM::Node> CaretNavigator::adjacent_caret_host(DOM::Node& from, DOM::Node& editing_host, SelectionDirection direction)
 {
@@ -185,6 +205,32 @@ DOM::Node& CaretNavigator::navigation_origin(CaretLocation const& location, Sele
             return *child_after;
     }
     return location.node;
+}
+
+Optional<CSSPixels> CaretNavigator::inline_coordinate(CaretLocation const& location)
+{
+    m_document->update_layout_if_needed_for_node(location.node, DOM::UpdateLayoutReason::CursorLineNavigation);
+    if (auto* text = as_if<DOM::Text>(*location.node))
+        return cursor_inline_coordinate(*text, location.offset, location.affinity);
+
+    if (location.offset > 0) {
+        auto* child_before = location.node->child_at_index(location.offset - 1);
+        if (child_before && is_atomic_inline_caret_host(*child_before)) {
+            // A parent boundary after an atomic inline can paint at the same position as the end of the preceding text.
+            // Use that text position when available so a vertical round trip preserves the visually chosen column.
+            auto editing_host = location.node->editing_host();
+            auto previous = editing_host ? adjacent_caret_host(*child_before, *editing_host, SelectionDirection::Backward) : nullptr;
+            if (auto* previous_text = as_if<DOM::Text>(previous.ptr()))
+                return cursor_inline_coordinate(*previous_text, previous_text->length(), TextAffinity::Downstream);
+        }
+    }
+
+    auto paintable = location.node->paintable();
+    return m_document->current_caret_rect().map([&](auto const& rect) {
+        if (paintable && paintable->computed_values().writing_mode() != CSS::WritingMode::HorizontalTb)
+            return rect.y();
+        return rect.x();
+    });
 }
 
 Optional<CaretLocation> CaretNavigator::move_to_adjacent_caret_host(CaretLocation const& location, SelectionDirection direction, CaretEntryMode entry_mode, Optional<CSSPixels> inline_coordinate)
@@ -466,12 +512,74 @@ Optional<CaretLocation> CaretNavigator::move_to_editing_host_boundary(CaretLocat
     return CaretLocation { *target, 0, TextAffinity::Downstream };
 }
 
+Optional<CaretLocation> CaretNavigator::move_by_page(CaretLocation const& location, SelectionDirection direction, CSSPixels inline_coordinate)
+{
+    auto editing_host = location.node->editing_host();
+    if (!editing_host)
+        return {};
+
+    m_document->update_layout_if_needed_for_node(*editing_host, DOM::UpdateLayoutReason::CursorLineNavigation);
+    auto editing_host_paintable = editing_host->paintable();
+    if (!editing_host_paintable)
+        return {};
+
+    // INTEROP: Chromium defines a page as the smaller of the editing host and viewport heights, then leaves either
+    // 12.5% or (on macOS) at least 40 CSS pixels of overlap. It walks visual lines until the next line would exceed
+    // that distance, rather than mapping the target coordinate directly back into the DOM.
+    auto page_height = min(editing_host_paintable->absolute_padding_box_rect().height().to_int(), m_document->window()->inner_height());
+    if (page_height <= 0)
+        return {};
+    auto page_distance = static_cast<i32>(page_height * 0.875);
+#if defined(AK_OS_MACOS)
+    page_distance = max(page_distance, page_height - 40);
+#endif
+    page_distance = max(page_distance, 1);
+
+    auto start_block_coordinate = m_document->caret_line_block_coordinate(location.node, location.offset, location.affinity);
+    if (!start_block_coordinate.has_value())
+        return {};
+
+    auto current = location;
+    Optional<CaretLocation> result;
+    auto line_direction = direction == SelectionDirection::Forward ? Painting::CaretLineDirection::Next : Painting::CaretLineDirection::Previous;
+    for (u32 iteration = 0; iteration < 1024; ++iteration) {
+        auto position = m_document->caret_position_on_adjacent_line(current.node, current.offset, current.affinity, line_direction, inline_coordinate, *editing_host);
+        Optional<CaretLocation> next;
+        if (position.has_value()) {
+            next = CaretLocation { position->boundary.node, position->boundary.offset, position->affinity };
+        } else {
+            // PreviousLinePosition and NextLinePosition in Chromium expose the editing-host boundary as a final stop
+            // on the first or last visual line. Preserve that stop when it still fits within this page movement.
+            next = move_to_editing_host_boundary(current, direction);
+            if (!next.has_value() || (next->node == current.node && next->offset == current.offset))
+                break;
+        }
+        auto next_block_coordinate = m_document->caret_line_block_coordinate(next->node, next->offset, next->affinity);
+        if (!next_block_coordinate.has_value())
+            break;
+        auto block_distance = *next_block_coordinate > *start_block_coordinate
+            ? *next_block_coordinate - *start_block_coordinate
+            : *start_block_coordinate - *next_block_coordinate;
+        if (block_distance > CSSPixels(page_distance))
+            break;
+        current = *next;
+        result = next;
+    }
+    return result;
+}
+
 Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, SelectionAlteration alteration, SelectionDirection direction, SelectionGranularity granularity, Optional<CSSPixels> preferred_inline_coordinate)
 {
     auto* text = as_if<DOM::Text>(*location.node);
 
     if (granularity == SelectionGranularity::DocumentBoundary)
         return move_to_editing_host_boundary(location, direction);
+
+    if (granularity == SelectionGranularity::Page) {
+        if (!preferred_inline_coordinate.has_value())
+            return {};
+        return move_by_page(location, direction, *preferred_inline_coordinate);
+    }
 
     if (granularity == SelectionGranularity::Character) {
         if (text) {
@@ -514,26 +622,51 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
     }
 
     VERIFY(granularity == SelectionGranularity::Line);
-    if (!text)
-        return move_to_adjacent_caret_host(location, direction, CaretEntryMode::ClosestToInlineCoordinate, preferred_inline_coordinate);
-
-    auto is_on_edge_line = direction == SelectionDirection::Forward
-        ? offset_is_on_last_visual_line(*text, location.offset, location.affinity)
-        : offset_is_on_first_visual_line(*text, location.offset, location.affinity);
-    if (is_on_edge_line) {
-        auto inline_coordinate = preferred_inline_coordinate;
-        if (!inline_coordinate.has_value())
-            inline_coordinate = cursor_inline_coordinate(*text, location.offset, location.affinity);
-        if (auto result = move_to_adjacent_caret_host(location, direction, CaretEntryMode::ClosestToInlineCoordinate, inline_coordinate); result.has_value())
-            return result;
+    auto line_origin = location;
+    // Resolve the parent boundary after an atomic inline to its visually equivalent text edge before asking painting
+    // which line contains the caret. This avoids selecting the atomic inline's other side as the current line.
+    if (!text && location.offset > 0) {
+        auto* child_before = location.node->child_at_index(location.offset - 1);
+        if (child_before && is_atomic_inline_caret_host(*child_before)) {
+            auto editing_host = location.node->editing_host();
+            auto previous = editing_host ? adjacent_caret_host(*child_before, *editing_host, SelectionDirection::Backward) : nullptr;
+            if (auto* previous_text = as_if<DOM::Text>(previous.ptr())) {
+                line_origin = { *previous_text, previous_text->length(), TextAffinity::Downstream };
+                text = previous_text;
+            }
+        }
     }
 
-    auto position = direction == SelectionDirection::Forward
-        ? compute_cursor_position_on_next_line(*text, location.offset, location.affinity, preferred_inline_coordinate)
-        : compute_cursor_position_on_previous_line(*text, location.offset, location.affinity, preferred_inline_coordinate);
+    auto editing_host = line_origin.node->editing_host();
+    if (!editing_host || !preferred_inline_coordinate.has_value())
+        return {};
+    m_document->update_layout_if_needed_for_node(line_origin.node, DOM::UpdateLayoutReason::CursorLineNavigation);
+    auto line_direction = direction == SelectionDirection::Forward ? Painting::CaretLineDirection::Next : Painting::CaretLineDirection::Previous;
+    auto position = m_document->caret_position_on_adjacent_line(line_origin.node, line_origin.offset, line_origin.affinity, line_direction, *preferred_inline_coordinate, *editing_host);
     if (!position.has_value())
         return {};
-    return CaretLocation { *text, position->offset, position->affinity };
+
+    CaretLocation destination { position->boundary.node, position->boundary.offset, position->affinity };
+    // Point-to-caret resolution naturally returns the parent boundary before an atomic inline. For a collapsed caret,
+    // prefer the visually equivalent preceding text edge so horizontal movement does not revisit the same position.
+    if (alteration == SelectionAlteration::Move && !is<DOM::Text>(*destination.node)) {
+        auto* child_after = destination.node->child_at_index(destination.offset);
+        if (child_after && is_atomic_inline_caret_host(*child_after)) {
+            auto previous = adjacent_caret_host(*child_after, *editing_host, SelectionDirection::Backward);
+            if (auto* previous_text = as_if<DOM::Text>(previous.ptr()))
+                destination = { *previous_text, previous_text->length(), TextAffinity::Downstream };
+        }
+    }
+    auto* destination_text = as_if<DOM::Text>(*destination.node);
+    if (alteration == SelectionAlteration::Extend && destination_text
+        && ((direction == SelectionDirection::Forward && destination.offset == 0)
+            || (direction == SelectionDirection::Backward && destination.offset == destination_text->length()))) {
+        auto origin_block = Editing::block_node_of_node(line_origin.node);
+        auto destination_block = Editing::block_node_of_node(*destination_text);
+        if (origin_block && destination_block && origin_block != destination_block)
+            destination = canonical_location_at_outer_edge_of_inline_content(*destination_text, *destination_block, direction);
+    }
+    return destination;
 }
 
 void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirection direction, SelectionGranularity granularity)
@@ -542,24 +675,27 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
     if (!range)
         return;
 
+    auto focus = m_selection->focus_node();
+    if (!focus)
+        return;
+    CaretNavigator navigator(*m_selection->document());
+    CaretLocation origin { *focus, m_selection->focus_offset(), m_selection->focus_affinity() };
+
     // INTEROP: Major engines remember a preferred inline-axis position across consecutive Up/Down operations. Without
     // this state, traversing a short line permanently shifts the caret column for every subsequent line.
     auto preferred_inline_coordinate = m_selection->m_preferred_inline_coordinate;
-    if (granularity == SelectionGranularity::Line && !preferred_inline_coordinate.has_value()) {
-        if (auto* text = as_if<DOM::Text>(m_selection->focus_node().ptr()))
-            preferred_inline_coordinate = cursor_inline_coordinate(*text, m_selection->focus_offset(), m_selection->focus_affinity());
-    } else if (granularity != SelectionGranularity::Line) {
+    auto is_vertical_movement = granularity == SelectionGranularity::Line || granularity == SelectionGranularity::Page;
+    if (is_vertical_movement && !preferred_inline_coordinate.has_value())
+        preferred_inline_coordinate = navigator.inline_coordinate(origin);
+    else if (!is_vertical_movement)
         m_selection->m_preferred_inline_coordinate.clear();
-    }
 
     Optional<CaretLocation> destination;
     Optional<CaretLocation> canonical_anchor;
     if (alteration == SelectionAlteration::Move && granularity == SelectionGranularity::Character && !m_selection->is_collapsed()) {
         auto boundary = direction == SelectionDirection::Forward ? range->end() : range->start();
         destination = CaretLocation { boundary.node, boundary.offset, TextAffinity::Downstream };
-    } else if (auto focus = m_selection->focus_node()) {
-        CaretNavigator navigator(*m_selection->document());
-        CaretLocation origin { *focus, m_selection->focus_offset(), m_selection->focus_affinity() };
+    } else {
         if (alteration == SelectionAlteration::Extend && m_selection->is_collapsed())
             canonical_anchor = navigator.canonical_location_for_extension(origin, direction);
         destination = navigator.move(origin, alteration, direction, granularity, preferred_inline_coordinate);
@@ -581,7 +717,7 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
         MUST(m_selection->set_base_and_extent(*anchor, anchor_offset, destination->node, destination->offset));
     }
     m_selection->set_focus_affinity(destination->affinity);
-    if (granularity == SelectionGranularity::Line)
+    if (is_vertical_movement)
         m_selection->m_preferred_inline_coordinate = preferred_inline_coordinate;
     m_selection->document()->set_cursor_position_needs_repaint();
     m_selection->scroll_focus_into_view();

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
@@ -31,6 +32,23 @@ enum class CaretEntryMode : u8 {
     LineEdge,
     ClosestToInlineCoordinate,
 };
+
+// Unicode word boundaries provide candidate stops, while browser editing behavior decides which candidates a command
+// crosses. Separators, punctuation, and word content therefore remain distinct through navigation.
+enum class WordSegmentKind : u8 {
+    Word,
+    Punctuation,
+    Separator,
+};
+
+static WordSegmentKind word_segment_kind(Utf16View const& segment)
+{
+    if (all_of(segment, [](auto code_point) { return Unicode::code_point_has_separator_general_category(code_point); }))
+        return WordSegmentKind::Separator;
+    if (all_of(segment, [](auto code_point) { return Unicode::code_point_has_punctuation_general_category(code_point); }))
+        return WordSegmentKind::Punctuation;
+    return WordSegmentKind::Word;
+}
 
 static bool text_node_has_rendered_text(DOM::Text const& text)
 {
@@ -99,6 +117,18 @@ static bool boundary_visual_lines_share_line(DOM::Text const& before, DOM::Text 
         && before_fragment.line_index() == after_fragment.line_index();
 }
 
+static bool boundary_visual_lines_share_inline_context(DOM::Text const& before, DOM::Text const& after)
+{
+    auto before_lines = collect_visual_lines(before);
+    auto after_lines = collect_visual_lines(after);
+    if (before_lines.is_empty() || before_lines.last().fragments.is_empty() || after_lines.is_empty() || after_lines.first().fragments.is_empty())
+        return false;
+
+    auto const& before_fragment = *before_lines.last().fragments.last();
+    auto const& after_fragment = *after_lines.first().fragments.first();
+    return &before_fragment.paintable_with_lines() == &after_fragment.paintable_with_lines();
+}
+
 // Turns a movement request into a CaretLocation without mutating Selection. This allows DOM traversal and rendered
 // geometry queries to cooperate without exposing intermediate selection states to script or painting.
 class CaretNavigator {
@@ -108,13 +138,17 @@ public:
     {
     }
 
-    Optional<CaretLocation> move(CaretLocation const&, SelectionDirection, SelectionGranularity, Optional<CSSPixels> preferred_inline_coordinate = {});
+    Optional<CaretLocation> move(CaretLocation const&, SelectionAlteration, SelectionDirection, SelectionGranularity, Optional<CSSPixels> preferred_inline_coordinate = {});
     Optional<CaretLocation> canonical_location_for_extension(CaretLocation const&, SelectionDirection);
 
 private:
     Optional<CaretLocation> move_to_adjacent_caret_host(CaretLocation const&, SelectionDirection, CaretEntryMode, Optional<CSSPixels>);
     Optional<CaretLocation> move_to_editing_host_boundary(CaretLocation const&, SelectionDirection);
+    Optional<CaretLocation> move_by_word(CaretLocation const&, SelectionAlteration, SelectionDirection);
     GC::Ptr<DOM::Node> adjacent_caret_host(DOM::Node&, DOM::Node& editing_host, SelectionDirection);
+    Optional<CaretLocation> location_before_atomic_inline(DOM::Node&, SelectionAlteration);
+    Optional<CaretLocation> location_after_atomic_inline(DOM::Node&);
+    Optional<CaretLocation> canonicalize_backward_word_location(CaretLocation const&, SelectionAlteration);
     static DOM::Node& navigation_origin(CaretLocation const&, SelectionDirection);
 
     GC::Ref<DOM::Document> m_document;
@@ -265,6 +299,141 @@ Optional<CaretLocation> CaretNavigator::canonical_location_for_extension(CaretLo
     return CaretLocation { *target_text, direction == SelectionDirection::Forward ? 0u : target_text->length(), TextAffinity::Downstream };
 }
 
+Optional<CaretLocation> CaretNavigator::location_after_atomic_inline(DOM::Node& atomic_inline)
+{
+    if (!atomic_inline.parent())
+        return {};
+    return CaretLocation { *atomic_inline.parent(), atomic_inline.index() + 1, TextAffinity::Downstream };
+}
+
+Optional<CaretLocation> CaretNavigator::location_before_atomic_inline(DOM::Node& atomic_inline, SelectionAlteration alteration)
+{
+    if (!atomic_inline.parent())
+        return {};
+    // INTEROP: Chromium exposes the parent boundary when extending a range, but canonicalizes a collapsed caret to
+    // the preceding text end when possible. This prevents Right from visiting two visually identical positions before
+    // the atomic inline while retaining the range boundary needed to include it during selection.
+    if (alteration == SelectionAlteration::Extend)
+        return CaretLocation { *atomic_inline.parent(), atomic_inline.index(), TextAffinity::Downstream };
+
+    auto editing_host = atomic_inline.editing_host();
+    if (!editing_host)
+        return {};
+    auto previous = adjacent_caret_host(atomic_inline, *editing_host, SelectionDirection::Backward);
+    if (auto* previous_text = as_if<DOM::Text>(previous.ptr())) {
+        auto position = cursor_position_at_visual_end(*previous_text);
+        if (position.has_value())
+            return CaretLocation { *previous_text, position->offset, position->affinity };
+    }
+    return CaretLocation { *atomic_inline.parent(), atomic_inline.index(), TextAffinity::Downstream };
+}
+
+Optional<CaretLocation> CaretNavigator::canonicalize_backward_word_location(CaretLocation const& location, SelectionAlteration alteration)
+{
+    // A backward word move can land at the start of a styled text node, which is visually identical to the end of the
+    // preceding node in the same inline context. Use that preceding end for a collapsed caret so another Left command
+    // advances instead of revisiting the same painted position.
+    if (alteration == SelectionAlteration::Extend || location.offset != 0)
+        return location;
+    auto* text = as_if<DOM::Text>(*location.node);
+    if (!text)
+        return location;
+    auto editing_host = text->editing_host();
+    if (!editing_host)
+        return location;
+    auto previous = adjacent_caret_host(*text, *editing_host, SelectionDirection::Backward);
+    auto* previous_text = as_if<DOM::Text>(previous.ptr());
+    if (!previous_text || !boundary_visual_lines_share_inline_context(*previous_text, *text))
+        return location;
+    return CaretLocation { *previous_text, previous_text->length(), TextAffinity::Downstream };
+}
+
+Optional<CaretLocation> CaretNavigator::move_by_word(CaretLocation const& initial_location, SelectionAlteration alteration, SelectionDirection direction)
+{
+    // INTEROP: Chromium word movement skips separators and can continue through DOM-split text when the fragments
+    // share a rendered inline context. Punctuation and atomic inline content remain observable stops. This is editing
+    // behavior rather than a direct application of the Unicode segmentation algorithm.
+    auto editing_host = initial_location.node->editing_host();
+    m_document->update_layout_if_needed_for_node(initial_location.node, DOM::UpdateLayoutReason::CursorLineNavigation);
+
+    auto location = initial_location;
+    auto* text = as_if<DOM::Text>(*location.node);
+    if (!text) {
+        auto* adjacent_child = direction == SelectionDirection::Forward
+            ? location.node->child_at_index(location.offset)
+            : (location.offset > 0 ? location.node->child_at_index(location.offset - 1) : nullptr);
+        if (adjacent_child && is_atomic_inline_caret_host(*adjacent_child)) {
+            return direction == SelectionDirection::Forward
+                ? location_after_atomic_inline(*adjacent_child)
+                : location_before_atomic_inline(*adjacent_child, alteration);
+        }
+        text = as_if<DOM::Text>(adjacent_child);
+        if (!text)
+            return move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+        location = { *text, direction == SelectionDirection::Forward ? 0u : text->length(), TextAffinity::Downstream };
+    }
+
+    bool moved = false;
+    Optional<CaretLocation> punctuation_end;
+    while (true) {
+        auto next_offset = direction == SelectionDirection::Forward
+            ? text->word_segmenter().next_boundary(location.offset)
+            : text->word_segmenter().previous_boundary(location.offset);
+        if (next_offset.has_value()) {
+            auto segment = direction == SelectionDirection::Forward
+                ? text->data().substring_view(location.offset, *next_offset - location.offset)
+                : text->data().substring_view(*next_offset, location.offset - *next_offset);
+            location.offset = *next_offset;
+            auto kind = word_segment_kind(segment);
+            if (punctuation_end.has_value() && kind != WordSegmentKind::Punctuation)
+                return direction == SelectionDirection::Backward
+                    ? canonicalize_backward_word_location(*punctuation_end, alteration)
+                    : punctuation_end;
+            moved = true;
+            if (kind == WordSegmentKind::Separator)
+                continue;
+            if (kind == WordSegmentKind::Word)
+                return direction == SelectionDirection::Backward
+                    ? canonicalize_backward_word_location(location, alteration)
+                    : Optional<CaretLocation> { location };
+
+            punctuation_end = location;
+            if ((direction == SelectionDirection::Forward && location.offset != text->length())
+                || (direction == SelectionDirection::Backward && location.offset != 0))
+                return direction == SelectionDirection::Backward
+                    ? canonicalize_backward_word_location(location, alteration)
+                    : Optional<CaretLocation> { location };
+        }
+
+        if (!editing_host)
+            return moved ? Optional<CaretLocation> { location } : Optional<CaretLocation> {};
+        auto adjacent = adjacent_caret_host(*text, *editing_host, direction);
+        if (!adjacent)
+            return moved ? Optional<CaretLocation> { location } : Optional<CaretLocation> {};
+        if (is_atomic_inline_caret_host(*adjacent)) {
+            if (punctuation_end.has_value())
+                return direction == SelectionDirection::Backward
+                    ? canonicalize_backward_word_location(*punctuation_end, alteration)
+                    : punctuation_end;
+            return direction == SelectionDirection::Forward
+                ? location_after_atomic_inline(*adjacent)
+                : location_before_atomic_inline(*adjacent, alteration);
+        }
+
+        auto* adjacent_text = as_if<DOM::Text>(*adjacent);
+        if (!adjacent_text)
+            return moved ? Optional<CaretLocation> { location } : move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+        auto shares_inline_context = direction == SelectionDirection::Forward
+            ? boundary_visual_lines_share_inline_context(*text, *adjacent_text)
+            : boundary_visual_lines_share_inline_context(*adjacent_text, *text);
+        if (!shares_inline_context)
+            return moved ? Optional<CaretLocation> { location } : move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
+
+        text = adjacent_text;
+        location = { *text, direction == SelectionDirection::Forward ? 0u : text->length(), TextAffinity::Downstream };
+    }
+}
+
 Optional<CaretLocation> CaretNavigator::move_to_editing_host_boundary(CaretLocation const& location, SelectionDirection direction)
 {
     // INTEROP: Chromium and WebKit constrain "start/end of document" commands to the active editing host. Letting the
@@ -297,7 +466,7 @@ Optional<CaretLocation> CaretNavigator::move_to_editing_host_boundary(CaretLocat
     return CaretLocation { *target, 0, TextAffinity::Downstream };
 }
 
-Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, SelectionDirection direction, SelectionGranularity granularity, Optional<CSSPixels> preferred_inline_coordinate)
+Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, SelectionAlteration alteration, SelectionDirection direction, SelectionGranularity granularity, Optional<CSSPixels> preferred_inline_coordinate)
 {
     auto* text = as_if<DOM::Text>(*location.node);
 
@@ -332,26 +501,7 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
     }
 
     if (granularity == SelectionGranularity::Word) {
-        if (!text)
-            return move_to_adjacent_caret_host(location, direction, CaretEntryMode::LineEdge, {});
-
-        auto offset = location.offset;
-        while (true) {
-            auto next_offset = direction == SelectionDirection::Forward
-                ? text->word_segmenter().next_boundary(offset)
-                : text->word_segmenter().previous_boundary(offset);
-            if (!next_offset.has_value())
-                break;
-            auto word = direction == SelectionDirection::Forward
-                ? text->data().substring_view(offset, *next_offset - offset)
-                : text->data().substring_view(*next_offset, offset - *next_offset);
-            offset = *next_offset;
-            if (!Unicode::Segmenter::should_continue_beyond_word(word))
-                break;
-        }
-        if (offset == location.offset)
-            return {};
-        return CaretLocation { *text, offset, TextAffinity::Downstream };
+        return move_by_word(location, alteration, direction);
     }
 
     if (granularity == SelectionGranularity::LineBoundary) {
@@ -412,7 +562,7 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
         CaretLocation origin { *focus, m_selection->focus_offset(), m_selection->focus_affinity() };
         if (alteration == SelectionAlteration::Extend && m_selection->is_collapsed())
             canonical_anchor = navigator.canonical_location_for_extension(origin, direction);
-        destination = navigator.move(origin, direction, granularity, preferred_inline_coordinate);
+        destination = navigator.move(origin, alteration, direction, granularity, preferred_inline_coordinate);
     }
 
     if (!destination.has_value())

--- a/Libraries/LibWeb/Selection/SelectionModifier.h
+++ b/Libraries/LibWeb/Selection/SelectionModifier.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <LibGC/Ptr.h>
+#include <LibWeb/Export.h>
+
+namespace Web::Selection {
+
+class Selection;
+
+enum class SelectionAlteration : u8 {
+    Move,
+    Extend,
+};
+
+enum class SelectionDirection : u8 {
+    Forward,
+    Backward,
+};
+
+enum class SelectionGranularity : u8 {
+    Character,
+    Word,
+    Line,
+    LineBoundary,
+};
+
+// INTEROP: The web editing specifications do not define caret navigation in enough detail to implement it directly.
+// SelectionModifier follows the architecture used by other engines: compute a visual caret destination without
+// changing the selection, then apply that result as a single selection mutation. Keeping movement policy here also
+// prevents platform key handling and DOM Selection mutation from accumulating layout-specific special cases.
+class WEB_API SelectionModifier {
+public:
+    explicit SelectionModifier(Selection& selection)
+        : m_selection(selection)
+    {
+    }
+
+    void modify(SelectionAlteration, SelectionDirection, SelectionGranularity);
+
+private:
+    GC::Ref<Selection> m_selection;
+};
+
+}

--- a/Libraries/LibWeb/Selection/SelectionModifier.h
+++ b/Libraries/LibWeb/Selection/SelectionModifier.h
@@ -28,6 +28,7 @@ enum class SelectionGranularity : u8 {
     Character,
     Word,
     Line,
+    Page,
     LineBoundary,
     // The boundary of the active editing host, which is the effective document for contenteditable navigation.
     DocumentBoundary,

--- a/Libraries/LibWeb/Selection/SelectionModifier.h
+++ b/Libraries/LibWeb/Selection/SelectionModifier.h
@@ -29,6 +29,8 @@ enum class SelectionGranularity : u8 {
     Word,
     Line,
     LineBoundary,
+    // The boundary of the active editing host, which is the effective document for contenteditable navigation.
+    DocumentBoundary,
 };
 
 // INTEROP: The web editing specifications do not define caret navigation in enough detail to implement it directly.

--- a/Libraries/LibWeb/VisualLines.cpp
+++ b/Libraries/LibWeb/VisualLines.cpp
@@ -192,7 +192,7 @@ static size_t offset_in_visual_line_closest_to_inline_coordinate(VisualLine cons
     return fragment->index_in_node_for_point(point);
 }
 
-Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity)
+Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity, Optional<CSSPixels> preferred_inline_coordinate)
 {
     // NB: The layout update is best-effort; a detached document may still have no layout node.
     auto lines = visual_lines_with_up_to_date_layout(dom_node);
@@ -205,12 +205,14 @@ Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text cons
     if (!line_index.has_value() || *line_index + 1 >= lines.size())
         return CursorLinePosition { dom_node.data().length_in_code_units(), TextAffinity::Downstream };
 
-    auto inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
+    auto inline_coordinate = preferred_inline_coordinate;
+    if (!inline_coordinate.has_value())
+        inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
     auto new_offset = offset_in_visual_line_closest_to_inline_coordinate(lines[*line_index + 1], inline_coordinate);
     return CursorLinePosition { new_offset, affinity_for_offset_on_line(lines, *line_index + 1, new_offset) };
 }
 
-Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity)
+Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity, Optional<CSSPixels> preferred_inline_coordinate)
 {
     // NB: The layout update is best-effort; a detached document may still have no layout node.
     auto lines = visual_lines_with_up_to_date_layout(dom_node);
@@ -223,7 +225,9 @@ Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text 
     if (!line_index.has_value() || *line_index == 0)
         return CursorLinePosition { 0, TextAffinity::Downstream };
 
-    auto inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
+    auto inline_coordinate = preferred_inline_coordinate;
+    if (!inline_coordinate.has_value())
+        inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
     auto new_offset = offset_in_visual_line_closest_to_inline_coordinate(lines[*line_index - 1], inline_coordinate);
     return CursorLinePosition { new_offset, affinity_for_offset_on_line(lines, *line_index - 1, new_offset) };
 }

--- a/Libraries/LibWeb/VisualLines.cpp
+++ b/Libraries/LibWeb/VisualLines.cpp
@@ -192,7 +192,7 @@ static size_t offset_in_visual_line_closest_to_inline_coordinate(VisualLine cons
     return fragment->index_in_node_for_point(point);
 }
 
-Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity, Optional<CSSPixels> preferred_inline_coordinate)
+Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity)
 {
     // NB: The layout update is best-effort; a detached document may still have no layout node.
     auto lines = visual_lines_with_up_to_date_layout(dom_node);
@@ -205,14 +205,12 @@ Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text cons
     if (!line_index.has_value() || *line_index + 1 >= lines.size())
         return CursorLinePosition { dom_node.data().length_in_code_units(), TextAffinity::Downstream };
 
-    auto inline_coordinate = preferred_inline_coordinate;
-    if (!inline_coordinate.has_value())
-        inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
+    auto inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
     auto new_offset = offset_in_visual_line_closest_to_inline_coordinate(lines[*line_index + 1], inline_coordinate);
     return CursorLinePosition { new_offset, affinity_for_offset_on_line(lines, *line_index + 1, new_offset) };
 }
 
-Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity, Optional<CSSPixels> preferred_inline_coordinate)
+Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const& dom_node, size_t current_offset, TextAffinity affinity)
 {
     // NB: The layout update is best-effort; a detached document may still have no layout node.
     auto lines = visual_lines_with_up_to_date_layout(dom_node);
@@ -225,9 +223,7 @@ Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text 
     if (!line_index.has_value() || *line_index == 0)
         return CursorLinePosition { 0, TextAffinity::Downstream };
 
-    auto inline_coordinate = preferred_inline_coordinate;
-    if (!inline_coordinate.has_value())
-        inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
+    auto inline_coordinate = caret_inline_coordinate(lines[*line_index], current_offset);
     auto new_offset = offset_in_visual_line_closest_to_inline_coordinate(lines[*line_index - 1], inline_coordinate);
     return CursorLinePosition { new_offset, affinity_for_offset_on_line(lines, *line_index - 1, new_offset) };
 }

--- a/Libraries/LibWeb/VisualLines.h
+++ b/Libraries/LibWeb/VisualLines.h
@@ -36,8 +36,8 @@ struct CursorLinePosition {
     TextAffinity affinity { TextAffinity::Downstream };
 };
 
-Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const&, size_t current_offset, TextAffinity, Optional<CSSPixels> preferred_inline_coordinate = {});
-Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const&, size_t current_offset, TextAffinity, Optional<CSSPixels> preferred_inline_coordinate = {});
+Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const&, size_t current_offset, TextAffinity);
+Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const&, size_t current_offset, TextAffinity);
 
 // One cursor step right or left. At a soft wrap boundary, the same offset has two visual positions (the end of the
 // earlier line and the start of the next); stepping visits both before moving to the adjacent grapheme.

--- a/Libraries/LibWeb/VisualLines.h
+++ b/Libraries/LibWeb/VisualLines.h
@@ -36,8 +36,8 @@ struct CursorLinePosition {
     TextAffinity affinity { TextAffinity::Downstream };
 };
 
-Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const&, size_t current_offset, TextAffinity);
-Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const&, size_t current_offset, TextAffinity);
+Optional<CursorLinePosition> compute_cursor_position_on_next_line(DOM::Text const&, size_t current_offset, TextAffinity, Optional<CSSPixels> preferred_inline_coordinate = {});
+Optional<CursorLinePosition> compute_cursor_position_on_previous_line(DOM::Text const&, size_t current_offset, TextAffinity, Optional<CSSPixels> preferred_inline_coordinate = {});
 
 // One cursor step right or left. At a soft wrap boundary, the same offset has two visual positions (the end of the
 // earlier line and the start of the next); stepping visits both before moving to the adjacent grapheme.

--- a/Tests/LibWeb/Fixtures/sceditor-caret.html
+++ b/Tests/LibWeb/Fixtures/sceditor-caret.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<style>
+    body { font: 14px/17.5px Verdana, Arial, Helvetica, sans-serif; }
+    img { width: 20px; height: 20px; }
+</style>
+<body contenteditable="true" dir="ltr"><div>Give it a try! <img src="../Screenshot/data/smiley.png" data-sceditor-emoticon=":)" alt=":)" title=":)"><br></div>
+<div><br></div>
+<div><font color="#ff00">Red text and </font><font color="#3399ff">blue text!</font><br></div>
+<div><br></div>
+<ul><li>A simple list<br></li><li>With two items<br></li></ul><div><br></div>
+<div>Just type <strong>:</strong>) and it will be converted into <img src="../Screenshot/data/smiley.png" data-sceditor-emoticon=":)" alt=":)" title=":)"> as you type.</div>

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-across-blocks.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-across-blocks.txt
@@ -1,7 +1,7 @@
 ArrowUp from bbb,0: p#p2 @ 0
 ArrowUp again: #text("aaa") @ 0
 ArrowDown from aaa,1: p#p2 @ 0
-ArrowDown again: #text("bbb") @ 0
+ArrowDown again: #text("bbb") @ 1
 ArrowRight from aaa,3: p#p2 @ 0
 ArrowRight again: #text("bbb") @ 0
 ArrowLeft from bbb,0: p#p2 @ 0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-br-lines.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-br-lines.txt
@@ -1,7 +1,7 @@
 ArrowUp from cd,1: p#p2 @ 0
-ArrowUp again: #text("ab") @ 0
+ArrowUp again: #text("ab") @ 1
 ArrowDown from ab,1: p#p2 @ 0
-ArrowDown again: #text("cd") @ 0
+ArrowDown again: #text("cd") @ 1
 ArrowRight from ab,2: p#p2 @ 0
 ArrowRight again: #text("cd") @ 0
 ArrowLeft from cd,0: p#p2 @ 0
@@ -9,4 +9,4 @@ ArrowLeft again: #text("ab") @ 2
 ArrowUp from zw,0: p#q @ 2
 ArrowUp again: #text("xy") @ 0
 ArrowDown from xy,1: p#q @ 2
-ArrowDown again: #text("zw") @ 0
+ArrowDown again: #text("zw") @ 1

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,19 +1,4 @@
-FAIL: 18 SCEditor caret assertions failed
-Option+Right over first image: expected DIV@2, got #text@15
-Option+Left over first image: expected #text@15, got #text@10
-Option+Right over punctuation: expected #text@14, got #text@15
-Option+Left over punctuation: expected #text@13, got #text@10
-Option+Left over trailing punctuation and space: expected #text@13, got #text@10
-Option+Right across adjacent styled text: expected #text@4, got #text@13
-Option+Left across adjacent styled text: expected #text@13, got #text@0
-Option+Shift+Right canonical anchor: expected #text@0, got #text@13
-Option+Shift+Right across adjacent styled text: expected #text@4, got #text@13
+FAIL: 3 SCEditor caret assertions failed
 Shift+Down into formatted block boundary: expected DIV@0, got #text@0
-Option+Right across split punctuation: expected #text@1, got #text@10
-Option+Left across split punctuation: expected #text@10, got #text@0
-Option+Shift+Left across split punctuation: expected #text@0, got #text@0
-Option+Left over final image: expected #text@32, got #text@0
-Option+Right after final image: expected #text@3, got DIV@4
-Option+Shift+Left over final image: expected DIV@3, got #text@32
 Up from after the final image: expected DIV@0, got #text@0
 Down back to before the final image: expected #text@32, got #text@0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,8 +1,4 @@
-FAIL: 28 SCEditor caret assertions failed
-End from the editing host start: expected DIV@2, got BODY@13
-Down from inserted text: expected DIV@0, got #text@3
-Up after crossing an empty line: expected #text@1, got #text@0
-Shift+End: expected DIV@2, got #text@15
+FAIL: 24 SCEditor caret assertions failed
 Shift+PageUp: expected #text@0, got #text@5
 Shift+PageDown: expected #text@13, got #text@5
 Right over first image: expected DIV@2, got DIV@0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,5 +1,4 @@
-FAIL: 22 SCEditor caret assertions failed
-Right over first image: expected DIV@2, got DIV@0
+FAIL: 18 SCEditor caret assertions failed
 Option+Right over first image: expected DIV@2, got #text@15
 Option+Left over first image: expected #text@15, got #text@10
 Option+Right over punctuation: expected #text@14, got #text@15
@@ -9,9 +8,6 @@ Option+Right across adjacent styled text: expected #text@4, got #text@13
 Option+Left across adjacent styled text: expected #text@13, got #text@0
 Option+Shift+Right canonical anchor: expected #text@0, got #text@13
 Option+Shift+Right across adjacent styled text: expected #text@4, got #text@13
-Shift+Right canonical inline anchor: expected #text@0, got #text@13
-Shift+Right across adjacent styled text: expected #text@1, got #text@0
-Shift+Down canonical image anchor: expected DIV@1, got #text@15
 Shift+Down into formatted block boundary: expected DIV@0, got #text@0
 Option+Right across split punctuation: expected #text@1, got #text@10
 Option+Left across split punctuation: expected #text@10, got #text@0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,13 +1,4 @@
-FAIL: 37 SCEditor caret assertions failed
-Down+Up from first list item@1: expected #text@1, got #text@2
-Down+Up from first list item@4: expected #text@4, got #text@3
-Down+Up from first list item@6: expected #text@6, got #text@5
-Down+Up from first list item@9: expected #text@9, got #text@10
-Up+Down from second list item@2: expected #text@2, got #text@1
-Up+Down from second list item@4: expected #text@4, got #text@3
-Up+Down from second list item@6: expected #text@6, got #text@5
-Up+Down from second list item@13: expected #text@13, got #text@12
-Up+Down from second list item@14: expected #text@14, got #text@12
+FAIL: 28 SCEditor caret assertions failed
 End from the editing host start: expected DIV@2, got BODY@13
 Down from inserted text: expected DIV@0, got #text@3
 Up after crossing an empty line: expected #text@1, got #text@0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,0 +1,38 @@
+FAIL: 37 SCEditor caret assertions failed
+Down+Up from first list item@1: expected #text@1, got #text@2
+Down+Up from first list item@4: expected #text@4, got #text@3
+Down+Up from first list item@6: expected #text@6, got #text@5
+Down+Up from first list item@9: expected #text@9, got #text@10
+Up+Down from second list item@2: expected #text@2, got #text@1
+Up+Down from second list item@4: expected #text@4, got #text@3
+Up+Down from second list item@6: expected #text@6, got #text@5
+Up+Down from second list item@13: expected #text@13, got #text@12
+Up+Down from second list item@14: expected #text@14, got #text@12
+End from the editing host start: expected DIV@2, got BODY@13
+Down from inserted text: expected DIV@0, got #text@3
+Up after crossing an empty line: expected #text@1, got #text@0
+Shift+End: expected DIV@2, got #text@15
+Shift+PageUp: expected #text@0, got #text@5
+Shift+PageDown: expected #text@13, got #text@5
+Right over first image: expected DIV@2, got DIV@0
+Option+Right over first image: expected DIV@2, got #text@15
+Option+Left over first image: expected #text@15, got #text@10
+Option+Right over punctuation: expected #text@14, got #text@15
+Option+Left over punctuation: expected #text@13, got #text@10
+Option+Left over trailing punctuation and space: expected #text@13, got #text@10
+Option+Right across adjacent styled text: expected #text@4, got #text@13
+Option+Left across adjacent styled text: expected #text@13, got #text@0
+Option+Shift+Right canonical anchor: expected #text@0, got #text@13
+Option+Shift+Right across adjacent styled text: expected #text@4, got #text@13
+Shift+Right canonical inline anchor: expected #text@0, got #text@13
+Shift+Right across adjacent styled text: expected #text@1, got #text@0
+Shift+Down canonical image anchor: expected DIV@1, got #text@15
+Shift+Down into formatted block boundary: expected DIV@0, got #text@0
+Option+Right across split punctuation: expected #text@1, got #text@10
+Option+Left across split punctuation: expected #text@10, got #text@0
+Option+Shift+Left across split punctuation: expected #text@0, got #text@0
+Option+Left over final image: expected #text@32, got #text@0
+Option+Right after final image: expected #text@3, got DIV@4
+Option+Shift+Left over final image: expected DIV@3, got #text@32
+Up from after the final image: expected DIV@0, got #text@0
+Down back to before the final image: expected #text@32, got #text@0

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,6 +1,4 @@
-FAIL: 24 SCEditor caret assertions failed
-Shift+PageUp: expected #text@0, got #text@5
-Shift+PageDown: expected #text@13, got #text@5
+FAIL: 22 SCEditor caret assertions failed
 Right over first image: expected DIV@2, got DIV@0
 Option+Right over first image: expected DIV@2, got #text@15
 Option+Left over first image: expected #text@15, got #text@10

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,4 +1,1 @@
-FAIL: 3 SCEditor caret assertions failed
-Shift+Down into formatted block boundary: expected DIV@0, got #text@0
-Up from after the final image: expected DIV@0, got #text@0
-Down back to before the final image: expected #text@32, got #text@0
+PASS: 378 SCEditor caret interactions match Chromium

--- a/Tests/LibWeb/Text/expected/Editing/home-end-with-floated-first-letter.txt
+++ b/Tests/LibWeb/Text/expected/Editing/home-end-with-floated-first-letter.txt
@@ -1,5 +1,5 @@
-End: 22
-Home: 0
-Down: 1
-Home: 0
+End: 12
+Home: 1
+Down: 12
+Home: 12
 End: 22

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
@@ -79,6 +79,10 @@
             collapse(editor, 0);
             send("End");
             assertPoint(point(), [firstLine, 2], "End from the editing host start");
+            const caretRectAfterFirstImage = internals.currentCaretRect();
+            const firstImageRect = firstLine.querySelector("img").getBoundingClientRect();
+            if (caretRectAfterFirstImage.x !== firstImageRect.right)
+                failures.push(`End caret painted at ${caretRectAfterFirstImage.x}, expected ${firstImageRect.right}`);
             internals.sendText(editor, "f");
             ++interactionCount;
             const insertedText = selection.focusNode;

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
@@ -192,6 +192,48 @@
             send("Down");
             assertPoint(point(), [textBeforeFinalImage, textBeforeFinalImage.length], "Down back to before the final image");
 
+            // Image-only blocks expose their atomic boundary during character navigation, and backward movement stops
+            // at the nearest atomic boundary instead of skipping across adjacent images or a preceding line break.
+            const atomicFixture = document.createElement("section");
+            const lineBeforeImage = document.createElement("div");
+            lineBeforeImage.append("above");
+            const imageOnlyLine = document.createElement("div");
+            imageOnlyLine.append(firstLine.querySelector("img").cloneNode());
+            const lineAfterImage = document.createElement("div");
+            lineAfterImage.append("below");
+            atomicFixture.append(lineBeforeImage, imageOnlyLine, lineAfterImage);
+            editor.append(atomicFixture);
+
+            collapse(lineBeforeImage.firstChild, lineBeforeImage.firstChild.length);
+            send("Right");
+            assertPoint(point(), [imageOnlyLine, 0], "Right enters an image-only line");
+            send("Right");
+            assertPoint(point(), [imageOnlyLine, 1], "Right crosses an image-only line");
+            send("Right");
+            assertPoint(point(), [lineAfterImage.firstChild, 0], "Right leaves an image-only line");
+            collapse(lineAfterImage.firstChild, 0);
+            send("Left");
+            assertPoint(point(), [imageOnlyLine, 1], "Left enters an image-only line");
+            send("Left");
+            assertPoint(point(), [imageOnlyLine, 0], "Left crosses an image-only line");
+            send("Left");
+            assertPoint(point(), [lineBeforeImage.firstChild, lineBeforeImage.firstChild.length], "Left leaves an image-only line");
+
+            const adjacentImages = document.createElement("div");
+            adjacentImages.append(firstLine.querySelector("img").cloneNode(), firstLine.querySelector("img").cloneNode(), "text");
+            atomicFixture.append(adjacentImages);
+            collapse(adjacentImages.lastChild, 0);
+            send("Left");
+            assertPoint(point(), [adjacentImages, 1], "Left stops before the nearest adjacent image");
+
+            const breakBeforeImage = document.createElement("div");
+            breakBeforeImage.append(document.createElement("br"), firstLine.querySelector("img").cloneNode(), "text");
+            atomicFixture.append(breakBeforeImage);
+            collapse(breakBeforeImage.lastChild, 0);
+            send("Left");
+            assertPoint(point(), [breakBeforeImage, 1], "Left preserves the line-break boundary before an image");
+            atomicFixture.remove();
+
             if (failures.length > 0)
                 internals.signalTestIsDone(`FAIL: ${failures.length} SCEditor caret assertions failed\n${failures.join("\n")}\n`);
             else

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { font: 14px/17.5px Verdana, Arial, Helvetica, sans-serif; }
+    img { width: 20px; height: 20px; }
+</style>
+<script>
+    // This is a deterministic local copy of the contenteditable structure from the SCEditor front-page demo, reduced
+    // to the styled runs, images, blank blocks, line breaks, and list items that affect caret navigation. The same DOM
+    // and key sequences were driven through Chromium with WebDriver; the asserted DOM boundary points below are the
+    // positions Chromium produced. Keeping those results explicit makes otherwise unspecified editing behavior an
+    // interoperability contract without making the test depend on SCEditor or network resources.
+    addEventListener("load", () => {
+        const editor = document.body;
+        const selection = getSelection();
+        const shift = internals.MOD_SHIFT;
+        const wordModifier = internals.MOD_ALT | internals.MOD_CTRL;
+        let interactionCount = 0;
+        const failures = [];
+
+        const send = (key, modifiers = 0) => {
+            ++interactionCount;
+            internals.sendKey(editor, key, modifiers);
+        };
+        const collapse = (node, offset) => {
+            editor.focus();
+            selection.collapse(node, offset);
+        };
+        const point = () => [selection.focusNode, selection.focusOffset];
+        const anchorPoint = () => [selection.anchorNode, selection.anchorOffset];
+        const assertPoint = (actual, expected, label) => {
+            if (actual[0] !== expected[0] || actual[1] !== expected[1])
+                failures.push(`${label}: expected ${expected[0].nodeName}@${expected[1]}, got ${actual[0].nodeName}@${actual[1]}`);
+        };
+
+        try {
+            const textNodes = Array.from(editor.querySelectorAll("div, li"))
+                .flatMap(element => Array.from(element.childNodes))
+                .flatMap(node => node.nodeType === Node.TEXT_NODE ? [node] : Array.from(node.childNodes).filter(child => child.nodeType === Node.TEXT_NODE))
+                .filter(node => node.length > 0);
+
+            // Every offset on a rendered text run must agree about its visual Home and End destinations.
+            for (const text of textNodes) {
+                collapse(text, 0);
+                send("Home");
+                const home = point();
+                collapse(text, 0);
+                send("End");
+                const end = point();
+                for (let offset = 0; offset <= text.length; ++offset) {
+                    collapse(text, offset);
+                    send("Home");
+                    assertPoint(point(), home, `Home from ${JSON.stringify(text.data)}@${offset}`);
+                    collapse(text, offset);
+                    send("End");
+                    assertPoint(point(), end, `End from ${JSON.stringify(text.data)}@${offset}`);
+                }
+            }
+
+            // Chromium preserves the original horizontal column across consecutive line moves.
+            const listItems = Array.from(editor.querySelectorAll("li"), item => item.firstChild);
+            for (let offset = 0; offset <= listItems[0].length; ++offset) {
+                collapse(listItems[0], offset);
+                send("Down");
+                send("Up");
+                assertPoint(point(), [listItems[0], offset], `Down+Up from first list item@${offset}`);
+            }
+            for (let offset = 0; offset <= listItems[1].length; ++offset) {
+                collapse(listItems[1], offset);
+                send("Up");
+                send("Down");
+                assertPoint(point(), [listItems[1], offset], `Up+Down from second list item@${offset}`);
+            }
+
+            const firstLine = editor.firstElementChild;
+            const firstText = firstLine.firstChild;
+            const firstEmptyLine = editor.children[1];
+            collapse(editor, 0);
+            send("End");
+            assertPoint(point(), [firstLine, 2], "End from the editing host start");
+            internals.sendText(editor, "f");
+            ++interactionCount;
+            const insertedText = selection.focusNode;
+            send("Down");
+            assertPoint(point(), [firstEmptyLine, 0], "Down from inserted text");
+            send("Up");
+            assertPoint(point(), [insertedText, 1], "Up after crossing an empty line");
+            insertedText.remove();
+
+            // Exercise selection extension, page movement, word movement, and both sides of inline images.
+            collapse(firstText, 7);
+            send("Right", shift);
+            assertPoint(point(), [firstText, 8], "Shift+Right");
+            collapse(firstText, 7);
+            send("Left", shift);
+            assertPoint(point(), [firstText, 6], "Shift+Left");
+            collapse(firstText, 7);
+            send("Home", shift);
+            assertPoint(point(), [firstText, 0], "Shift+Home");
+            collapse(firstText, 7);
+            send("End", shift);
+            assertPoint(point(), [firstLine, 2], "Shift+End");
+
+            const redText = editor.children[2].firstChild.firstChild;
+            const finalText = editor.lastElementChild.lastChild;
+            collapse(redText, 5);
+            send("PageUp", shift);
+            assertPoint(point(), [firstText, 0], "Shift+PageUp");
+            collapse(redText, 5);
+            send("PageDown", shift);
+            assertPoint(point(), [finalText, finalText.length], "Shift+PageDown");
+
+            collapse(firstText, firstText.length);
+            send("Right");
+            assertPoint(point(), [firstLine, 2], "Right over first image");
+            send("Left");
+            assertPoint(point(), [firstText, firstText.length], "Left over first image");
+            collapse(firstText, firstText.length);
+            send("Right", wordModifier);
+            assertPoint(point(), [firstLine, 2], "Option+Right over first image");
+            send("Left", wordModifier);
+            assertPoint(point(), [firstText, firstText.length], "Option+Left over first image");
+
+            // Word movement stops at punctuation, crosses inline style boundaries, and preserves canonical
+            // selection endpoints at those boundaries.
+            collapse(firstText, 13);
+            send("Right", wordModifier);
+            assertPoint(point(), [firstText, 14], "Option+Right over punctuation");
+            send("Left", wordModifier);
+            assertPoint(point(), [firstText, 13], "Option+Left over punctuation");
+            collapse(firstText, firstText.length);
+            send("Left", wordModifier);
+            assertPoint(point(), [firstText, 13], "Option+Left over trailing punctuation and space");
+
+            const blueText = editor.children[2].children[1].firstChild;
+            collapse(redText, redText.length);
+            send("Right", wordModifier);
+            assertPoint(point(), [blueText, 4], "Option+Right across adjacent styled text");
+            collapse(blueText, 1);
+            send("Left", wordModifier);
+            assertPoint(point(), [redText, redText.length], "Option+Left across adjacent styled text");
+            collapse(redText, redText.length);
+            send("Right", wordModifier | shift);
+            assertPoint(anchorPoint(), [blueText, 0], "Option+Shift+Right canonical anchor");
+            assertPoint(point(), [blueText, 4], "Option+Shift+Right across adjacent styled text");
+            collapse(redText, redText.length);
+            send("Right", shift);
+            assertPoint(anchorPoint(), [blueText, 0], "Shift+Right canonical inline anchor");
+            assertPoint(point(), [blueText, 1], "Shift+Right across adjacent styled text");
+            collapse(blueText, 1);
+            send("Left", shift);
+            assertPoint(point(), [blueText, 0], "Shift+Left within adjacent styled text");
+
+            collapse(firstText, firstText.length);
+            send("Down", shift);
+            assertPoint(anchorPoint(), [firstLine, 1], "Shift+Down canonical image anchor");
+            assertPoint(point(), [firstEmptyLine, 0], "Shift+Down across an image and block boundary");
+            collapse(firstEmptyLine, 0);
+            send("Down", shift);
+            assertPoint(point(), [editor.children[2], 0], "Shift+Down into formatted block boundary");
+
+            const finalLine = editor.lastElementChild;
+            const textBeforeStrong = finalLine.firstChild;
+            const strongText = finalLine.children[0].firstChild;
+            const textAfterStrong = finalLine.childNodes[2];
+            const textBeforeFinalImage = finalLine.childNodes[2];
+            const textAfterFinalImage = finalLine.childNodes[4];
+            collapse(textBeforeStrong, textBeforeStrong.length);
+            send("Right", wordModifier);
+            assertPoint(point(), [textAfterStrong, 1], "Option+Right across split punctuation");
+            collapse(textAfterStrong, 1);
+            send("Left", wordModifier);
+            assertPoint(point(), [textBeforeStrong, textBeforeStrong.length], "Option+Left across split punctuation");
+            collapse(textAfterStrong, 1);
+            send("Left", wordModifier | shift);
+            assertPoint(point(), [strongText, 0], "Option+Shift+Left across split punctuation");
+
+            collapse(textAfterFinalImage, 1);
+            send("Left", wordModifier);
+            assertPoint(point(), [textBeforeFinalImage, textBeforeFinalImage.length], "Option+Left over final image");
+            collapse(finalLine, 4);
+            send("Right", wordModifier);
+            assertPoint(point(), [textAfterFinalImage, 3], "Option+Right after final image");
+            collapse(finalLine, 4);
+            send("Left", wordModifier | shift);
+            assertPoint(point(), [finalLine, 3], "Option+Shift+Left over final image");
+
+            collapse(finalLine, 4);
+            send("Up");
+            assertPoint(point(), [finalLine.previousElementSibling, 0], "Up from after the final image");
+            send("Down");
+            assertPoint(point(), [textBeforeFinalImage, textBeforeFinalImage.length], "Down back to before the final image");
+
+            if (failures.length > 0)
+                internals.signalTestIsDone(`FAIL: ${failures.length} SCEditor caret assertions failed\n${failures.join("\n")}\n`);
+            else
+                internals.signalTestIsDone(`PASS: ${interactionCount} SCEditor caret interactions match Chromium\n`);
+        } catch (error) {
+            internals.signalTestIsDone(`FAIL: ${error.message}\n`);
+        }
+    });
+</script>
+</head>
+<body contenteditable="true" dir="ltr"><div>Give it a try! <img src="../../../Screenshot/data/smiley.png" data-sceditor-emoticon=":)" alt=":)" title=":)"><br></div>
+<div><br></div>
+<div><font color="#ff00">Red text and </font><font color="#3399ff">blue text!</font><br></div>
+<div><br></div>
+<ul><li>A simple list<br></li><li>With two items<br></li></ul><div><br></div>
+<div>Just type <strong>:</strong>) and it will be converted into <img src="../../../Screenshot/data/smiley.png" data-sceditor-emoticon=":)" alt=":)" title=":)"> as you type.</div></body>
+</html>

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
@@ -192,6 +192,26 @@
             send("Down");
             assertPoint(point(), [textBeforeFinalImage, textBeforeFinalImage.length], "Down back to before the final image");
 
+            // Chromium moves by a computed page step, then chooses the furthest visual line that does not exceed it.
+            // With a 600px test viewport and 100px line spacing, both its macOS and other-platform page steps land
+            // exactly five lines away. Keeping twenty lines here makes document-boundary movement observably wrong.
+            const pageFixture = document.createElement("section");
+            const pageLines = Array.from({ length: 20 }, (_, index) => {
+                const line = document.createElement("div");
+                line.style.height = "100px";
+                line.append(`page ${index}`);
+                return line;
+            });
+            pageFixture.append(...pageLines);
+            editor.append(pageFixture);
+            collapse(pageLines[8].firstChild, 3);
+            send("PageDown", shift);
+            assertPoint(point(), [pageLines[13].firstChild, 3], "Shift+PageDown moves one viewport page");
+            collapse(pageLines[8].firstChild, 3);
+            send("PageUp", shift);
+            assertPoint(point(), [pageLines[3].firstChild, 3], "Shift+PageUp moves one viewport page");
+            pageFixture.remove();
+
             // Image-only blocks expose their atomic boundary during character navigation, and backward movement stops
             // at the nearest atomic boundary instead of skipping across adjacent images or a preceding line break.
             const atomicFixture = document.createElement("section");


### PR DESCRIPTION
Replace DOM-local caret movement with a cohesive navigation model that follows painted visual lines and rendered inline content. `SelectionModifier` now owns movement intent and the preferred inline position, while painting resolves visual line boundaries and adjacent-line destinations within the editing host.

Handle movement across styled text runs, atomic inline content, images, block boundaries, blank `<br>` lines, soft wraps, writing modes, and independently painted content such as floated first letters. Apply the same machinery to selection extension and word navigation, with platform key handling remaining in `EventHandler`.

Add a deterministic local fixture derived from the `contenteditable` DOM used by the https://sceditor.com front-page demo. It preserves the structures that exposed these bugs, including split styled text, inline images, empty paragraphs, line breaks, and block boundaries, without depending on SCEditor’s network resources or runtime.

The same fixture and interaction sequences were driven through Chromium using WebDriver. Chromium’s resulting caret and selection DOM boundary points were then encoded as expectations for 368 assertions covering character, word, line, document, Page Up/Down, Home/End, modifier-key movement, and Shift-based selection.