### PR TITLE
LibWeb: Handle editing host selection boundaries

### DIFF
--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -50,14 +50,10 @@ void EditingHostManager::handle_insert(Utf16FlyString const&, Utf16View value)
 
 void EditingHostManager::select_all()
 {
-    if (!m_active_contenteditable_element) {
+    if (!m_active_contenteditable_element)
         return;
-    }
     auto selection = m_document->get_selection();
-    if (!selection->anchor_node() || !selection->focus_node()) {
-        return;
-    }
-    MUST(selection->set_base_and_extent(*selection->anchor_node(), 0, *selection->focus_node(), selection->focus_node()->length()));
+    Selection::SelectionModifier(*selection).select_all();
 }
 
 void EditingHostManager::set_selection_anchor(GC::Ref<DOM::Node> anchor_node, size_t anchor_offset, TextAffinity affinity)

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1123,8 +1123,12 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     }
 
     // https://w3c.github.io/clipboard-apis/#clipboard-actions
-    // AD-HOC: The clipboard action shortcut keys are not specified anywhere, but these combinations are universal.
+    // AD-HOC: These editing action shortcut keys are not specified anywhere, but the combinations are universal.
     if ((modifiers & UIEvents::Mod_PlatformCtrl) != 0 && (modifiers & (UIEvents::Mod_Shift | UIEvents::Mod_Alt)) == 0) {
+        if (key == UIEvents::KeyCode::Key_A) {
+            m_navigable->select_all();
+            return EventResult::Handled;
+        }
         if (key == UIEvents::KeyCode::Key_C)
             return perform_copy_action();
         if (key == UIEvents::KeyCode::Key_X)

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -489,6 +489,8 @@ Optional<CaretLocation> CaretNavigator::move_to_editing_host_boundary(CaretLocat
         return CaretLocation { *text, position->offset, position->affinity };
     }
 
+    if (is_atomic_inline_caret_host(*target) && target->parent())
+        return CaretLocation { *target->parent(), target->index() + (direction == SelectionDirection::Forward ? 1 : 0), TextAffinity::Downstream };
     if (is<HTML::HTMLBRElement>(*target) && target->parent())
         return CaretLocation { *target->parent(), target->index(), TextAffinity::Downstream };
     return CaretLocation { *target, 0, TextAffinity::Downstream };
@@ -707,6 +709,29 @@ void SelectionModifier::modify(SelectionAlteration alteration, SelectionDirectio
     m_selection->set_focus_affinity(destination->affinity);
     if (is_vertical_movement)
         m_selection->m_preferred_inline_coordinate = preferred_inline_coordinate;
+    m_selection->document()->set_cursor_position_needs_repaint();
+    m_selection->scroll_focus_into_view();
+}
+
+void SelectionModifier::select_all()
+{
+    // INTEROP: Select All in an editing host uses its first and last rendered caret positions, rather than parent
+    // boundaries around the host's child list. Reuse document-boundary navigation so keyboard movement and selection
+    // expose the same DOM endpoints around styled text, empty blocks, and atomic inline content.
+    auto focus = m_selection->focus_node();
+    if (!focus)
+        return;
+
+    CaretNavigator navigator(*m_selection->document());
+    CaretLocation origin { *focus, m_selection->focus_offset(), m_selection->focus_affinity() };
+    auto start = navigator.move(origin, SelectionAlteration::Move, SelectionDirection::Backward, SelectionGranularity::DocumentBoundary);
+    auto end = navigator.move(origin, SelectionAlteration::Move, SelectionDirection::Forward, SelectionGranularity::DocumentBoundary);
+    if (!start.has_value() || !end.has_value())
+        return;
+
+    MUST(m_selection->set_base_and_extent(start->node, start->offset, end->node, end->offset));
+    m_selection->m_preferred_inline_coordinate.clear();
+    m_selection->document()->reset_cursor_blink_cycle();
     m_selection->document()->set_cursor_position_needs_repaint();
     m_selection->scroll_focus_into_view();
 }

--- a/Libraries/LibWeb/Selection/SelectionModifier.cpp
+++ b/Libraries/LibWeb/Selection/SelectionModifier.cpp
@@ -625,8 +625,14 @@ Optional<CaretLocation> CaretNavigator::move(CaretLocation const& location, Sele
     m_document->update_layout_if_needed_for_node(line_origin.node, DOM::UpdateLayoutReason::CursorLineNavigation);
     auto line_direction = direction == SelectionDirection::Forward ? Painting::CaretLineDirection::Next : Painting::CaretLineDirection::Previous;
     auto position = m_document->caret_position_on_adjacent_line(line_origin.node, line_origin.offset, line_origin.affinity, line_direction, *preferred_inline_coordinate, *editing_host);
-    if (!position.has_value())
-        return {};
+    if (!position.has_value()) {
+        // INTEROP: Chromium and WebKit move to the current line's directional edge when there is no visual line in the
+        // requested direction. This makes Up and Down useful at the first and final lines instead of becoming no-ops.
+        auto edge = direction == SelectionDirection::Forward ? Painting::CaretLineEdge::End : Painting::CaretLineEdge::Start;
+        position = m_document->caret_position_at_line_edge(line_origin.node, line_origin.offset, line_origin.affinity, edge);
+        if (!position.has_value())
+            return {};
+    }
 
     CaretLocation destination { position->boundary.node, position->boundary.offset, position->affinity };
     // Point-to-caret resolution naturally returns the parent boundary before an atomic inline. For a collapsed caret,

--- a/Libraries/LibWeb/Selection/SelectionModifier.h
+++ b/Libraries/LibWeb/Selection/SelectionModifier.h
@@ -46,6 +46,7 @@ public:
     }
 
     void modify(SelectionAlteration, SelectionDirection, SelectionGranularity);
+    void select_all();
 
 private:
     GC::Ref<Selection> m_selection;

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,3 +1,1 @@
-FAIL: 2 SCEditor caret assertions failed
-Select All anchor: expected #text@0, got #text@4
-Select All focus: expected #text@13, got #text@4
+PASS: 383 SCEditor caret interactions match Chromium

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,7 +1,3 @@
-FAIL: 6 SCEditor caret assertions failed
-Up from the first visual line: expected #text@0, got #text@7
-Shift+Up from the first visual line focus: expected #text@0, got #text@7
-Down from the final visual line: expected #text@13, got #text@3
-Shift+Down from the final visual line focus: expected #text@13, got #text@3
+FAIL: 2 SCEditor caret assertions failed
 Select All anchor: expected #text@0, got #text@4
 Select All focus: expected #text@13, got #text@4

--- a/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/caret-navigation-sceditor.txt
@@ -1,1 +1,7 @@
-PASS: 378 SCEditor caret interactions match Chromium
+FAIL: 6 SCEditor caret assertions failed
+Up from the first visual line: expected #text@0, got #text@7
+Shift+Up from the first visual line focus: expected #text@0, got #text@7
+Down from the final visual line: expected #text@13, got #text@3
+Shift+Down from the final visual line focus: expected #text@13, got #text@3
+Select All anchor: expected #text@0, got #text@4
+Select All focus: expected #text@13, got #text@4

--- a/Tests/LibWeb/Text/expected/Editing/select-all-editing-host-boundaries.txt
+++ b/Tests/LibWeb/Text/expected/Editing/select-all-editing-host-boundaries.txt
@@ -1,0 +1,2 @@
+Atomic editing-host boundaries: anchor=div#first@0 focus=div#first@3 text="middle"
+Script-moved selection: anchor=#text("other")@0 focus=#text("other")@5 text="other"

--- a/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
+++ b/Tests/LibWeb/Text/input/Editing/caret-navigation-sceditor.html
@@ -76,6 +76,14 @@
             const firstLine = editor.firstElementChild;
             const firstText = firstLine.firstChild;
             const firstEmptyLine = editor.children[1];
+            collapse(firstText, 7);
+            send("Up");
+            assertPoint(point(), [firstText, 0], "Up from the first visual line");
+            collapse(firstText, 7);
+            send("Up", shift);
+            assertPoint(anchorPoint(), [firstText, 7], "Shift+Up from the first visual line anchor");
+            assertPoint(point(), [firstText, 0], "Shift+Up from the first visual line focus");
+
             collapse(editor, 0);
             send("End");
             assertPoint(point(), [firstLine, 2], "End from the editing host start");
@@ -108,6 +116,19 @@
 
             const redText = editor.children[2].firstChild.firstChild;
             const finalText = editor.lastElementChild.lastChild;
+            collapse(finalText, 3);
+            send("Down");
+            assertPoint(point(), [finalText, finalText.length], "Down from the final visual line");
+            collapse(finalText, 3);
+            send("Down", shift);
+            assertPoint(anchorPoint(), [finalText, 3], "Shift+Down from the final visual line anchor");
+            assertPoint(point(), [finalText, finalText.length], "Shift+Down from the final visual line focus");
+
+            collapse(redText, 4);
+            send("A", internals.MOD_CTRL | internals.MOD_SUPER);
+            assertPoint(anchorPoint(), [firstText, 0], "Select All anchor");
+            assertPoint(point(), [finalText, finalText.length], "Select All focus");
+
             collapse(redText, 5);
             send("PageUp", shift);
             assertPoint(point(), [firstText, 0], "Shift+PageUp");

--- a/Tests/LibWeb/Text/input/Editing/select-all-editing-host-boundaries.html
+++ b/Tests/LibWeb/Text/input/Editing/select-all-editing-host-boundaries.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="first" contenteditable="true"><img><span>middle</span><img></div>
+<div id="second" contenteditable="true">other</div>
+<script>
+    test(() => {
+        const first = document.getElementById("first");
+        const second = document.getElementById("second");
+        const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
+        const selection = getSelection();
+        const describeNode = node => node.nodeType === Node.TEXT_NODE
+            ? `#text(${JSON.stringify(node.data)})`
+            : `${node.localName}#${node.id}`;
+        const report = label => {
+            println(`${label}: anchor=${describeNode(selection.anchorNode)}@${selection.anchorOffset} focus=${describeNode(selection.focusNode)}@${selection.focusOffset} text=${JSON.stringify(selection.toString())}`);
+        };
+
+        first.focus();
+        selection.collapse(first.children[1].firstChild, 3);
+        internals.sendKey(first, "A", platformControl);
+        report("Atomic editing-host boundaries");
+
+        // INTEROP: Chromium applies Select All to the selection's editing host, even when focus remains in another
+        // contenteditable element. Script can create this state without dispatching a focus event.
+        second.focus();
+        first.addEventListener("focus", () => selection.collapse(second.firstChild, 2), { once: true });
+        internals.sendKey(first, "A", platformControl);
+        report("Script-moved selection");
+    });
+</script>


### PR DESCRIPTION
Improve `contenteditable` behavior at the boundaries of an editing host.

When vertical caret navigation cannot find an adjacent painted line, move to the directional edge of the current line. This makes Up on the first visual line move to its start and Down on the final visual line move to its end. The same behavior applies when extending a selection with Shift.

Route the platform Select All shortcut through the editing machinery and compute its range using the editing host’s rendered document boundaries. This selects the complete host, including styled runs, blocks, and atomic inline content, with Chromium-compatible DOM endpoints.

Extend the Chromium-derived SCEditor fixture with WebDriver-recorded coverage for these caret and selection behaviors.