### PR TITLE
LibWeb: Allow documents matching about:srcdoc to have no about base URL

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1623,7 +1623,11 @@ URL::URL Document::fallback_base_url() const
     // 1. If document is an iframe srcdoc document, then:
     if (HTML::url_matches_about_srcdoc(m_url)) {
         // 1. Assert: document's about base URL is non-null.
-        VERIFY(m_about_base_url.has_value());
+        // AD-HOC: Documents created by DOMParser or by cloning can have a URL that matches about:srcdoc
+        //         without an about base URL being set. Returning the document's URL in this case matches
+        //         the behavior of other engines.
+        if (!m_about_base_url.has_value())
+            return m_url;
 
         // 2. Return document's about base URL.
         return m_about_base_url.value();

--- a/Tests/LibWeb/Crash/DOM/clone-srcdoc-document-base-uri.html
+++ b/Tests/LibWeb/Crash/DOM/clone-srcdoc-document-base-uri.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<body>
+<script>
+    const iframe = document.createElement("iframe");
+    iframe.srcdoc = "<p></p>";
+    iframe.onload = () => {
+        iframe.contentDocument.cloneNode().baseURI;
+        document.documentElement.classList.remove("test-wait");
+    };
+    document.body.appendChild(iframe);
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/expected/HTML/DOMParser-parseFromString-srcdoc-base-url.txt
+++ b/Tests/LibWeb/Text/expected/HTML/DOMParser-parseFromString-srcdoc-base-url.txt
@@ -1,0 +1,4 @@
+iframe URL: about:srcdoc
+iframe base URI inherited: true
+parsed URL: about:srcdoc
+parsed base URI: about:srcdoc

--- a/Tests/LibWeb/Text/input/HTML/DOMParser-parseFromString-srcdoc-base-url.html
+++ b/Tests/LibWeb/Text/input/HTML/DOMParser-parseFromString-srcdoc-base-url.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        window.reportResult = (iframeDocument, parsedDocument) => {
+            println(`iframe URL: ${iframeDocument.URL}`);
+            println(`iframe base URI inherited: ${iframeDocument.baseURI === document.baseURI}`);
+            println(`parsed URL: ${parsedDocument.URL}`);
+            println(`parsed base URI: ${parsedDocument.baseURI}`);
+            done();
+        };
+
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `<script>
+            const parsedDocument = new DOMParser().parseFromString("<x></x>", "application/xml");
+            parent.reportResult(document, parsedDocument);
+        <\/script>`;
+        document.body.appendChild(iframe);
+    });
+</script>


### PR DESCRIPTION
The specification asserts that a document whose URL matches `about:srcdoc` has a non-null about base URL, but this only holds for documents created by navigation. DOMParser and document cloning copy the URL of an existing document without copying its about base URL, so reading the base URI of such a document created inside a srcdoc frame failed the assertion. Return the document's own URL in this case, which matches the behavior of other engines.