### PR TITLE
Map WSAEWOULDBLOCK to EWOULDBLOCK in Windows socket helper

### DIFF
--- a/Libraries/LibCore/SocketWindows.cpp
+++ b/Libraries/LibCore/SocketWindows.cpp
@@ -43,6 +43,8 @@ ErrorOr<Bytes> PosixSocketHelper::read(Bytes buffer, int flags)
     if (WSARecv(m_fd, &buf, 1, &nread, &fl, NULL, NULL) == SOCKET_ERROR) {
         if (GetLastError() == WSAECONNRESET)
             return Error::from_errno(ECONNRESET);
+        if (GetLastError() == WSAEWOULDBLOCK)
+            return Error::from_errno(EWOULDBLOCK);
         return Error::from_windows_error();
     }
 
@@ -73,8 +75,11 @@ ErrorOr<size_t> PosixSocketHelper::write(ReadonlyBytes buffer, int flags)
     WSABUF buf = make_wsa_buf(buffer);
     DWORD nwritten = 0;
 
-    if (WSASend(m_fd, &buf, 1, &nwritten, 0, NULL, NULL) == SOCKET_ERROR)
+    if (WSASend(m_fd, &buf, 1, &nwritten, 0, NULL, NULL) == SOCKET_ERROR) {
+        if (GetLastError() == WSAEWOULDBLOCK)
+            return Error::from_errno(EWOULDBLOCK);
         return Error::from_windows_error();
+    }
 
     return nwritten;
 }


### PR DESCRIPTION
PosixSocketHelper::read()/write() returned raw Windows-domain errors, but callers compare against POSIX errno constants. In particular, TransportSocketWindows::transfer() checks error.code() != EWOULDBLOCK (UCRT 140) while the error carried raw WSAEWOULDBLOCK (10035), so its poll-and-retry path never ran and MUST(transfer(...)) aborted the process whenever the socket send buffer filled up under IPC load:

  UNEXPECTED ERROR: Error 2733: A non-blocking socket operation could
  not be completed immediately.
  (0x2733 == 10035 == WSAEWOULDBLOCK)

Sockets end up non-blocking on Windows because WSAEventSelect() puts a socket into non-blocking mode when the event loop registers a notifier for it, even though PosixSocketHelper::set_blocking() is a no-op.

Translate WSAEWOULDBLOCK into the errno domain in both read() and write(), following the existing WSAECONNRESET -> ECONNRESET mapping in read() and the same translation Core::System::send() already does, so POSIX-style call sites behave identically on Windows.