### PR TITLE
 LibWeb: Use logical dimensions throughout layout

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1734,8 +1734,8 @@ static void compute_subtree_layout(Layout::Box& subtree_root, Layout::LayoutStat
 
     auto const& root_state = layout_state.get(subtree_root);
     auto available_space = Layout::AvailableSpace(
-        Layout::AvailableSize::make_definite(root_state.content_width()),
-        Layout::AvailableSize::make_definite(root_state.content_height()));
+        Layout::AvailableSize::make_definite(root_state.content_inline_size()),
+        Layout::AvailableSize::make_definite(root_state.content_block_size()));
 
     auto context = Layout::FormattingContext::create_independent_formatting_context_if_needed(
         layout_state, Layout::LayoutMode::Normal, subtree_root, nullptr);
@@ -2167,8 +2167,8 @@ void Document::update_layout(UpdateLayoutReason reason)
                 viewport,
                 Optional<CSSPixels> { viewport_rect.width() },
                 Optional<CSSPixels> { viewport_rect.height() });
-            viewport_state.set_content_width(viewport_rect.width());
-            viewport_state.set_content_height(viewport_rect.height());
+            viewport_state.set_content_inline_size(viewport_rect.width());
+            viewport_state.set_content_block_size(viewport_rect.height());
 
             // NB: Called during layout update.
             if (document_element && document_element->unsafe_layout_node()) {
@@ -2177,7 +2177,7 @@ void Document::update_layout(UpdateLayoutReason reason)
                     as<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->unsafe_layout_node()),
                     percentage_basis.percentage_basis_inline_size,
                     percentage_basis.percentage_basis_block_size);
-                icb_state.set_content_width(viewport_rect.width());
+                icb_state.set_content_inline_size(viewport_rect.width());
             }
 
             auto available_space = Layout::AvailableSpace(
@@ -2189,8 +2189,8 @@ void Document::update_layout(UpdateLayoutReason reason)
                 //       The root <svg> container gets the same size as the viewport,
                 //       and we call directly into the SVG layout code from here.
                 auto const& svg_root = as<Layout::SVGSVGBox>(*m_layout_root->first_child());
-                auto content_height = layout_state.get(*svg_root.containing_block()).content_height();
-                layout_state.get_mutable(svg_root).set_content_height(content_height);
+                auto content_block_size = layout_state.get(*svg_root.containing_block()).content_block_size();
+                layout_state.get_mutable(svg_root).set_content_block_size(content_block_size);
                 Layout::SVGFormattingContext svg_formatting_context(layout_state, Layout::LayoutMode::Normal, svg_root, nullptr);
                 svg_formatting_context.run(Layout::LayoutInput { available_space });
             } else {

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2175,8 +2175,8 @@ void Document::update_layout(UpdateLayoutReason reason)
                 auto percentage_basis = Layout::FormattingContext::constraints_for_child_context(viewport_state, {});
                 auto& icb_state = layout_state.create(
                     as<Layout::NodeWithStyleAndBoxModelMetrics>(*document_element->unsafe_layout_node()),
-                    percentage_basis.percentage_basis_width,
-                    percentage_basis.percentage_basis_height);
+                    percentage_basis.percentage_basis_inline_size,
+                    percentage_basis.percentage_basis_block_size);
                 icb_state.set_content_width(viewport_rect.width());
             }
 

--- a/Libraries/LibWeb/Layout/AbsposLayoutInputs.h
+++ b/Libraries/LibWeb/Layout/AbsposLayoutInputs.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Optional.h>
+#include <LibWeb/Layout/LogicalGeometry.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Layout {
@@ -65,20 +66,20 @@ struct StaticPositionRect {
     // a style change on the box itself.
     bool alignment_derives_from_own_computed_values { false };
 
-    CSSPixelPoint aligned_position_for_box_with_size(CSSPixelSize const& size) const
+    LogicalOffset aligned_offset_for_box_with_size(LogicalSize const& size) const
     {
-        CSSPixelPoint position = rect.location();
+        LogicalOffset offset { rect.x(), rect.y() };
         if (inline_alignment == Alignment::Center)
-            position.set_x(position.x() + (rect.width() - size.width()) / 2);
+            offset.inline_offset += (rect.width() - size.inline_size) / 2;
         else if (inline_alignment == Alignment::End)
-            position.set_x(position.x() + rect.width() - size.width());
+            offset.inline_offset += rect.width() - size.inline_size;
 
         if (block_alignment == Alignment::Center)
-            position.set_y(position.y() + (rect.height() - size.height()) / 2);
+            offset.block_offset += (rect.height() - size.block_size) / 2;
         else if (block_alignment == Alignment::End)
-            position.set_y(position.y() + rect.height() - size.height());
+            offset.block_offset += rect.height() - size.block_size;
 
-        return position;
+        return offset;
     }
 };
 

--- a/Libraries/LibWeb/Layout/AbsposLayoutInputs.h
+++ b/Libraries/LibWeb/Layout/AbsposLayoutInputs.h
@@ -37,12 +37,12 @@ enum class AbsposAxisMode {
 struct AbsposContainingBlockInfo {
     // Containing block rect in CB Box's content-edge coordinates.
     CSSPixelRect rect;
-    AbsposAxisMode horizontal_axis_mode;
-    AbsposAxisMode vertical_axis_mode;
+    AbsposAxisMode inline_axis_mode;
+    AbsposAxisMode block_axis_mode;
     // Grid alignment for axes with auto CSS insets.
     // When set, the base method applies alignment-driven insets after sizing.
-    Optional<Alignment> horizontal_alignment;
-    Optional<Alignment> vertical_alignment;
+    Optional<Alignment> inline_alignment;
+    Optional<Alignment> block_alignment;
     // Whether the rect, alignments or axis modes were derived from the box's own computed
     // values (grid placement does this); a saved copy of such inputs cannot be replayed after
     // a style change on the box itself, and its axis modes must not be recomputed at replay.
@@ -58,8 +58,8 @@ struct StaticPositionRect {
     };
 
     CSSPixelRect rect;
-    Alignment horizontal_alignment { Alignment::Start };
-    Alignment vertical_alignment { Alignment::Start };
+    Alignment inline_alignment { Alignment::Start };
+    Alignment block_alignment { Alignment::Start };
     // Whether the alignments were derived from the box's own computed values (self-alignment
     // under a flex container does this); a saved copy of such a rect cannot be replayed after
     // a style change on the box itself.
@@ -68,14 +68,14 @@ struct StaticPositionRect {
     CSSPixelPoint aligned_position_for_box_with_size(CSSPixelSize const& size) const
     {
         CSSPixelPoint position = rect.location();
-        if (horizontal_alignment == Alignment::Center)
+        if (inline_alignment == Alignment::Center)
             position.set_x(position.x() + (rect.width() - size.width()) / 2);
-        else if (horizontal_alignment == Alignment::End)
+        else if (inline_alignment == Alignment::End)
             position.set_x(position.x() + rect.width() - size.width());
 
-        if (vertical_alignment == Alignment::Center)
+        if (block_alignment == Alignment::Center)
             position.set_y(position.y() + (rect.height() - size.height()) / 2);
-        else if (vertical_alignment == Alignment::End)
+        else if (block_alignment == Alignment::End)
             position.set_y(position.y() + rect.height() - size.height());
 
         return position;

--- a/Libraries/LibWeb/Layout/AbsposLayoutInputs.h
+++ b/Libraries/LibWeb/Layout/AbsposLayoutInputs.h
@@ -37,7 +37,7 @@ enum class AbsposAxisMode {
 
 struct AbsposContainingBlockInfo {
     // Containing block rect in CB Box's content-edge coordinates.
-    CSSPixelRect rect;
+    LogicalRect rect;
     AbsposAxisMode inline_axis_mode;
     AbsposAxisMode block_axis_mode;
     // Grid alignment for axes with auto CSS insets.
@@ -58,7 +58,7 @@ struct StaticPositionRect {
         End,
     };
 
-    CSSPixelRect rect;
+    LogicalRect rect;
     Alignment inline_alignment { Alignment::Start };
     Alignment block_alignment { Alignment::Start };
     // Whether the alignments were derived from the box's own computed values (self-alignment
@@ -68,16 +68,16 @@ struct StaticPositionRect {
 
     LogicalOffset aligned_offset_for_box_with_size(LogicalSize const& size) const
     {
-        LogicalOffset offset { rect.x(), rect.y() };
+        auto offset = rect.offset;
         if (inline_alignment == Alignment::Center)
-            offset.inline_offset += (rect.width() - size.inline_size) / 2;
+            offset.inline_offset += (rect.size.inline_size - size.inline_size) / 2;
         else if (inline_alignment == Alignment::End)
-            offset.inline_offset += rect.width() - size.inline_size;
+            offset.inline_offset += rect.size.inline_size - size.inline_size;
 
         if (block_alignment == Alignment::Center)
-            offset.block_offset += (rect.height() - size.block_size) / 2;
+            offset.block_offset += (rect.size.block_size - size.block_size) / 2;
         else if (block_alignment == Alignment::End)
-            offset.block_offset += rect.height() - size.block_size;
+            offset.block_offset += rect.size.block_size - size.block_size;
 
         return offset;
     }

--- a/Libraries/LibWeb/Layout/AvailableSpace.cpp
+++ b/Libraries/LibWeb/Layout/AvailableSpace.cpp
@@ -47,7 +47,7 @@ String AvailableSize::to_string() const
 
 String AvailableSpace::to_string() const
 {
-    return MUST(String::formatted("{} x {}", width, height));
+    return MUST(String::formatted("inline: {}, block: {}", inline_size, block_size));
 }
 
 AvailableSize::AvailableSize(Type type, CSSPixels value)

--- a/Libraries/LibWeb/Layout/AvailableSpace.h
+++ b/Libraries/LibWeb/Layout/AvailableSpace.h
@@ -81,16 +81,16 @@ inline bool operator<(AvailableSize const& left, CSSPixels right)
 
 class AvailableSpace {
 public:
-    AvailableSpace(AvailableSize w, AvailableSize h)
-        : width(move(w))
-        , height(move(h))
+    AvailableSpace(AvailableSize inline_size, AvailableSize block_size)
+        : inline_size(move(inline_size))
+        , block_size(move(block_size))
     {
     }
 
     bool operator==(AvailableSpace const& other) const = default;
 
-    AvailableSize width;
-    AvailableSize height;
+    AvailableSize inline_size;
+    AvailableSize block_size;
 
     String to_string() const;
 };

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -764,8 +764,8 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     box_state.padding_left = padding_left;
     box_state.padding_right = padding_right;
 
-    auto width = compute_width_for_replaced_element(box, available_space, containing_block_constraints);
-    box_state.set_content_inline_size(width);
+    auto inline_size = compute_inline_size_for_replaced_element(box, available_space, containing_block_constraints);
+    box_state.set_content_inline_size(inline_size);
 }
 
 void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
@@ -805,7 +805,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
 
     CSSPixels height = 0;
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
-        height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
+        height = compute_block_size_for_replaced_element(box, available_space, containing_block_constraints);
     } else {
         if (box_formatting_context) {
             height = box_formatting_context->automatic_content_block_size();

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -64,7 +64,7 @@ CSSPixels BlockFormattingContext::automatic_content_inline_size() const
         });
         return m_state.get(*table_box).border_box_inline_size();
     }
-    return greatest_child_width(root());
+    return greatest_child_inline_size(root());
 }
 
 CSSPixels BlockFormattingContext::automatic_content_block_size() const
@@ -1343,7 +1343,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);
         if (!block_container_state.has_definite_inline_size()) {
-            auto inline_size = greatest_child_width_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
+            auto inline_size = greatest_child_inline_size_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
             auto const& computed_values = block_container.computed_values();
             // NOTE: Min and max constraints are not applied to a box that is being sized as intrinsic because
             //       according to css-sizing-3 spec:
@@ -1416,7 +1416,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     }
 
     if (m_layout_mode == LayoutMode::IntrinsicSizing && !fieldset_state.has_definite_inline_size()) {
-        auto inline_size = greatest_child_width(fieldset_box);
+        auto inline_size = greatest_child_inline_size(fieldset_box);
         auto const& computed_values = fieldset_box.computed_values();
         if (fieldset_state.inline_size_constraint == SizeConstraint::None) {
             if (!should_treat_max_inline_size_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
@@ -1660,20 +1660,20 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
         list_item_state.set_content_block_size(marker.computed_values().line_height());
 }
 
-CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
+CSSPixels BlockFormattingContext::greatest_child_inline_size(Box const& box) const
 {
     auto box_in_root_rect = content_box_rect_in_ancestor_coordinate_space(m_state.get(box), root());
-    return greatest_child_width_in_rect(box, box_in_root_rect);
+    return greatest_child_inline_size_in_rect(box, box_in_root_rect);
 }
 
-CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, CSSPixelRect const& box_in_root_rect) const
+CSSPixels BlockFormattingContext::greatest_child_inline_size_in_rect(Box const& box, CSSPixelRect const& box_in_root_rect) const
 {
-    // Similar to FormattingContext::greatest_child_width()
+    // Similar to FormattingContext::greatest_child_inline_size()
     // but this one takes floats into account!
-    CSSPixels max_width = 0;
+    CSSPixels max_inline_size = 0;
     for (auto const& band : m_bands) {
         auto intrusions = intrusions_for_band_into_rect(band, box_in_root_rect);
-        max_width = max(max_width, intrusions.left + intrusions.right);
+        max_inline_size = max(max_inline_size, intrusions.left + intrusions.right);
     }
 
     if (box.children_are_inline()) {
@@ -1681,7 +1681,7 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
             auto inline_size_here = line_box_physical_width(box, line_box);
             auto line_top = line_box.bottom() - line_box.height();
             auto line_bottom = line_box.bottom();
-            CSSPixels extra_width_from_left_floats = 0;
+            CSSPixels extra_inline_size_from_left_floats = 0;
             for (auto& left_float : m_floats) {
                 if (left_float->side != FloatSide::Left)
                     continue;
@@ -1689,10 +1689,10 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
                 if (left_float->box.containing_block() != &box)
                     continue;
                 if (line_top < left_float->bottom_margin_edge && line_bottom > left_float->top_margin_edge) {
-                    extra_width_from_left_floats = max(extra_width_from_left_floats, left_float->offset_from_edge + left_float->used_values.content_inline_size() + left_float->used_values.margin_box_right());
+                    extra_inline_size_from_left_floats = max(extra_inline_size_from_left_floats, left_float->offset_from_edge + left_float->used_values.content_inline_size() + left_float->used_values.margin_box_right());
                 }
             }
-            CSSPixels extra_width_from_right_floats = 0;
+            CSSPixels extra_inline_size_from_right_floats = 0;
             for (auto& right_float : m_floats) {
                 if (right_float->side != FloatSide::Right)
                     continue;
@@ -1700,22 +1700,22 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
                 if (right_float->box.containing_block() != &box)
                     continue;
                 if (line_top < right_float->bottom_margin_edge && line_bottom > right_float->top_margin_edge) {
-                    extra_width_from_right_floats = max(extra_width_from_right_floats, right_float->offset_from_edge + right_float->used_values.margin_box_left());
+                    extra_inline_size_from_right_floats = max(extra_inline_size_from_right_floats, right_float->offset_from_edge + right_float->used_values.margin_box_left());
                 }
             }
-            inline_size_here += extra_width_from_left_floats + extra_width_from_right_floats;
-            max_width = max(max_width, inline_size_here);
+            inline_size_here += extra_inline_size_from_left_floats + extra_inline_size_from_right_floats;
+            max_inline_size = max(max_inline_size, inline_size_here);
         }
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {
             if (child.is_absolutely_positioned())
                 return IterationDecision::Continue;
             if (auto const* child_state = m_state.try_get(child))
-                max_width = max(max_width, child_state->margin_box_inline_size());
+                max_inline_size = max(max_inline_size, child_state->margin_box_inline_size());
             return IterationDecision::Continue;
         });
     }
-    return max_width;
+    return max_inline_size;
 }
 
 // https://drafts.csswg.org/css-multicol/#pseudo-algorithm

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -69,7 +69,7 @@ CSSPixels BlockFormattingContext::automatic_content_inline_size() const
 
 CSSPixels BlockFormattingContext::automatic_content_block_size() const
 {
-    return compute_auto_height_for_block_formatting_context_root(root());
+    return compute_automatic_block_size_for_block_formatting_context_root(root());
 }
 
 static bool margins_collapse_through(Box const& box, LayoutState& state)
@@ -769,7 +769,7 @@ void BlockFormattingContext::compute_inline_size_for_block_level_replaced_elemen
     box_state.set_content_inline_size(inline_size);
 }
 
-void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void BlockFormattingContext::resolve_used_block_size_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     if (should_treat_block_size_as_auto(box, available_space, containing_block_constraints)) {
         return;
@@ -778,24 +778,24 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
 
-    auto height = calculate_inner_block_size(box, available_space, box.computed_values().height(), containing_block_constraints);
+    auto block_size = calculate_inner_block_size(box, available_space, box.computed_values().height(), containing_block_constraints);
 
     if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
-            auto max_height = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
-            height = min(height, max_height);
+            auto max_block_size = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
+            block_size = min(block_size, max_block_size);
         }
     }
     if (!computed_values.min_height().is_auto()) {
-        height = max(height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
+        block_size = max(block_size, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
-    box_state.set_content_block_size(height);
+    box_state.set_content_block_size(block_size);
     if (computed_block_size_establishes_definite_containing_block_size(computed_values.height()))
         box_state.set_has_definite_block_size(true);
 }
 
-void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context)
+void BlockFormattingContext::resolve_used_block_size_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context)
 {
     if (!should_treat_block_size_as_auto(box, available_space, containing_block_constraints)) {
         return;
@@ -804,25 +804,25 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
 
-    CSSPixels height = 0;
+    CSSPixels block_size = 0;
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
-        height = compute_block_size_for_replaced_element(box, available_space, containing_block_constraints);
+        block_size = compute_block_size_for_replaced_element(box, available_space, containing_block_constraints);
     } else {
         if (box_formatting_context) {
-            height = box_formatting_context->automatic_content_block_size();
+            block_size = box_formatting_context->automatic_content_block_size();
         } else {
-            height = compute_auto_height_for_block_level_element(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
+            block_size = compute_automatic_block_size_for_block_level_element(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
         }
     }
 
     if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
-            auto max_height = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
-            height = min(height, max_height);
+            auto max_block_size = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
+            block_size = min(block_size, max_block_size);
         }
     }
     if (!computed_values.min_height().is_auto()) {
-        height = max(height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
+        block_size = max(block_size, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
     if (box.document().in_quirks_mode()
@@ -843,9 +843,9 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
 
         // 3. Return the bigger value of size and the normal border box size the element would have
         //    according to the CSS specification.
-        height = max(size, height);
+        block_size = max(size, block_size);
 
-        // NOTE: The height of the root element when affected by this quirk is considered to be definite.
+        // NOTE: The block size of the root element when affected by this quirk is considered to be definite.
         box_state.set_has_definite_block_size(true);
     }
 
@@ -874,11 +874,11 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
 
             // 3. Return the bigger value of size and the normal border box size the element would have
             //    according to the CSS specification.
-            height = max(size, height);
+            block_size = max(size, block_size);
         }
     }
 
-    box_state.set_content_block_size(height);
+    box_state.set_content_block_size(block_size);
 }
 
 void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, LayoutInput const& layout_input, AvailableSpace const& available_space_for_children)
@@ -936,10 +936,10 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
     }
 }
 
-CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+CSSPixels BlockFormattingContext::compute_automatic_block_size_for_block_level_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     if (creates_block_formatting_context(box)) {
-        return compute_auto_height_for_block_formatting_context_root(box);
+        return compute_automatic_block_size_for_block_formatting_context_root(box);
     }
 
     auto const& box_state = m_state.get(box);
@@ -963,35 +963,35 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
     // https://www.w3.org/TR/CSS22/visudet.html#normal-block
     // 10.6.3 Block-level non-replaced elements in normal flow when 'overflow' computes to 'visible'
 
-    // The element's height is the distance from its top content edge to the first applicable of the following:
+    // The element's block size is the distance from its block-start content edge to the first applicable edge below.
 
     // 1. the bottom edge of the last line box, if the box establishes a inline formatting context with one or more lines
     if (box.children_are_inline() && !box_state.line_boxes.is_empty()) {
-        auto height = box_state.line_boxes.last().bottom();
+        auto block_size = box_state.line_boxes.last().bottom();
         if (box_state.line_boxes.last().has_block_level_box()) {
             auto margin_bottom = m_margin_state.current_collapsed_margin();
             if (box_state.padding_bottom == 0 && box_state.border_bottom == 0) {
                 m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(true);
                 margin_bottom = 0;
             }
-            height = max(CSSPixels(0), height + margin_bottom);
+            block_size = max(CSSPixels(0), block_size + margin_bottom);
         }
-        return height;
+        return block_size;
     }
 
     // 2. the bottom edge of the bottom (possibly collapsed) margin of its last in-flow child, if the child's bottom margin does not collapse with the element's bottom margin
     // 3. the bottom border edge of the last in-flow child whose top margin doesn't collapse with the element's bottom margin
     if (!box.children_are_inline()) {
-        CSSPixels marker_line_height = 0;
+        CSSPixels marker_line_block_size = 0;
         for (auto* child_box = box.last_child_of_type<Box>(); child_box; child_box = child_box->previous_sibling_of_type<Box>()) {
             if (child_box->is_absolutely_positioned() || child_box->is_floating())
                 continue;
 
             // NOTE: Markers are not in-flow, but for list items that contain only floats (or are otherwise empty),
-            //       the marker's line-height determines the list item's height. This ensures proper vertical stacking
-            //       of list items and alignment with their floated content.
+            //       the marker's line-height determines the list item's block size. This ensures proper stacking of
+            //       list items and alignment with their floated content.
             if (child_box->is_list_item_marker_box()) {
-                marker_line_height = child_box->computed_values().line_height();
+                marker_line_block_size = child_box->computed_values().line_height();
                 continue;
             }
 
@@ -1010,12 +1010,12 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
         }
 
         // If no in-flow children were found but there's a marker, use the marker's line-height.
-        if (marker_line_height > 0)
-            return marker_line_height;
+        if (marker_line_block_size > 0)
+            return marker_line_block_size;
     }
 
-    // AD-HOC: Contenteditable elements must have a minimum height (line-height) when empty, to remain clickable and
-    //         usable for text input, even though this is not specified.
+    // AD-HOC: Contenteditable elements must have a minimum block size (line-height) when empty, to remain clickable
+    //         and usable for text input, even though this is not specified.
     //         See: https://github.com/w3c/editing/issues/70.
     if (auto const* element = as_if<DOM::Element>(box.dom_node()); element && element->is_editing_host())
         return box.computed_values().line_height();
@@ -1113,9 +1113,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         && box.dom_node()->is_html_html_element()
         && box.computed_values().height().is_auto();
 
-    // NOTE: In quirks mode, the html element's height matches the viewport so it can be treated as definite
+    // NOTE: In quirks mode, the html element's block size matches the viewport so it can be treated as definite.
     if (box_state.has_definite_block_size() || box_is_html_element_in_quirks_mode)
-        resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
+        resolve_used_block_size_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
     auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, box, this);
 
@@ -1187,20 +1187,20 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         pending_position = CSSPixelPoint { content_x, content_y };
     }
 
-    AvailableSpace available_space_for_height_resolution = available_space;
+    AvailableSpace available_space_for_block_size_resolution = available_space;
     auto is_table_box = box.display().is_table_row() || box.display().is_table_row_group() || box.display().is_table_header_group() || box.display().is_table_footer_group() || box.display().is_table_cell() || box.display().is_table_caption();
     // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
     auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
     bool is_in_ua_internal_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
     if (box.document().in_quirks_mode() && box.computed_values().height().is_percentage() && !is_table_box && !is_in_ua_internal_shadow_tree) {
-        available_space_for_height_resolution.block_size = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_block_size.value_or(0));
+        available_space_for_block_size_resolution.block_size = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_block_size.value_or(0));
     }
 
-    resolve_used_height_if_not_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
+    resolve_used_block_size_if_not_treated_as_auto(box, available_space_for_block_size_resolution, layout_input.containing_block_constraints);
 
-    // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
+    // NOTE: Flex containers with an automatic block size are treated as max-content, so resolve it early.
     if (box.has_auto_content_box_size() || box.display().is_flex_inside()) {
-        resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
+        resolve_used_block_size_if_treated_as_auto(box, available_space_for_block_size_resolution, layout_input.containing_block_constraints);
     }
 
     // Before we insert the children of a list item we need to know the location of the marker.
@@ -1222,19 +1222,19 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // This box establishes a new formatting context. Pass control to it.
         auto inner_available_space = box_state.available_inner_space_or_constraints_from(available_space);
 
-        // For boxes with auto height but non-auto min-height, we need to determine if the content height is less than
-        // min-height. If so, we run layout with min-height as the available height.
-        Optional<CSSPixels> measured_content_height;
+        // For boxes with an automatic block size but non-auto min-height, determine whether the content block size is
+        // less than min-height. If so, run layout with min-height as the available block size.
+        Optional<CSSPixels> measured_content_block_size;
         if (should_treat_block_size_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
             auto content_block_size = measure_automatic_content_block_size(box, inner_available_space, layout_input.containing_block_constraints);
-            measured_content_height = content_block_size;
-            auto min_height = calculate_inner_block_size(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
-            if (content_block_size < min_height) {
-                inner_available_space.block_size = AvailableSize::make_definite(min_height);
+            measured_content_block_size = content_block_size;
+            auto min_block_size = calculate_inner_block_size(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
+            if (content_block_size < min_block_size) {
+                inner_available_space.block_size = AvailableSize::make_definite(min_block_size);
             }
         }
 
-        make_button_content_box_definite(box, available_space, layout_input.containing_block_constraints, measured_content_height);
+        make_button_content_box_definite(box, available_space, layout_input.containing_block_constraints, measured_content_block_size);
 
         auto inside_layout_input = [&] {
             auto input = layout_input.for_child_formatting_context(inner_available_space);
@@ -1283,10 +1283,10 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         }
     }
 
-    // Tables already set their height during the independent formatting context run. When multi-line text cells are involved, using different
-    // available space here than during the independent formatting context run can result in different line breaks and thus a different height.
+    // Tables already set their block size during the independent formatting context run. With multi-line text cells,
+    // using different available space here can produce different line breaks and therefore a different block size.
     if (!box.display().is_table_inside()) {
-        resolve_used_height_if_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints, independent_formatting_context);
+        resolve_used_block_size_if_treated_as_auto(box, available_space_for_block_size_resolution, layout_input.containing_block_constraints, independent_formatting_context);
     }
 
     // Now that our children are formatted we place the ListItemBox with the left space we remembered.
@@ -1553,11 +1553,11 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     compute_inline_size(box, available_space, layout_input.containing_block_constraints, containing_block_rect_in_root_now.location());
 
-    resolve_used_height_if_not_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
+    resolve_used_block_size_if_not_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
-    // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
+    // NOTE: Flex containers with an automatic block size are treated as max-content, so resolve it early.
     if (box.has_auto_content_box_size() || box.display().is_flex_inside()) {
-        resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
+        resolve_used_block_size_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
     }
 
     auto independent_formatting_context = layout_inside(box, m_layout_mode, layout_input.for_child_formatting_context(box_state.available_inner_space_or_constraints_from(available_space)));
@@ -1565,7 +1565,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     // the inline size table layout just produced; the wrapper has the same inline size as the table grid box.
     if (is<TableWrapper>(box) && independent_formatting_context)
         box_state.set_content_inline_size(independent_formatting_context->automatic_content_inline_size());
-    resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
+    resolve_used_block_size_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
 
     // Next, float to the left and/or right
     // FIXME: Honor writing-mode, direction and text-orientation.

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1006,7 +1006,7 @@ CSSPixels BlockFormattingContext::compute_automatic_block_size_for_block_level_e
                 margin_bottom = 0;
             }
 
-            return max(CSSPixels(0), child_box_state.content_offset().y() + child_box_state.content_block_size() + child_box_state.border_box_bottom() + margin_bottom);
+            return max(CSSPixels(0), child_box_state.content_logical_offset().block_offset + child_box_state.content_block_size() + child_box_state.border_box_bottom() + margin_bottom);
         }
 
         // If no in-flow children were found but there's a marker, use the marker's line-height.
@@ -1304,7 +1304,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_block_offset_of_current_block_container = box_state.content_offset().y() + box_state.content_block_size() + box_state.border_box_bottom();
+        m_block_offset_of_current_block_container = box_state.content_logical_offset().block_offset + box_state.content_block_size() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -1313,7 +1313,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     compute_inset(box, content_box_rect(block_container_state).size());
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.content_offset().y() + box_state.content_block_size() + box_state.margin_box_bottom());
+    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.content_logical_offset().block_offset + box_state.content_block_size() + box_state.margin_box_bottom());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -166,10 +166,10 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
     m_was_notified_after_parent_dimensioned_my_root_box = true;
 
     for (auto& floating_box : m_floats) {
-        auto content_y = floating_box->top_margin_edge + floating_box->used_values.margin_box_top();
+        auto content_block_offset = floating_box->top_margin_edge + floating_box->used_values.margin_box_top();
         if (floating_box->side == FloatSide::Left) {
             // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
-            place_child(floating_box->box, { floating_box->offset_from_edge, content_y });
+            place_child(floating_box->box, { floating_box->offset_from_edge, content_block_offset });
         } else {
             // Right-side floats: offset_from_edge is from right edge (float_containing_block_inline_size) to the left content edge of floating_box.
             auto float_containing_block_inline_size = [&] {
@@ -183,7 +183,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
                 }
                 VERIFY_NOT_REACHED();
             }();
-            place_child(floating_box->box, { float_containing_block_inline_size - floating_box->offset_from_edge, content_y });
+            place_child(floating_box->box, { float_containing_block_inline_size - floating_box->offset_from_edge, content_block_offset });
         }
     }
 
@@ -393,28 +393,28 @@ void BlockFormattingContext::compute_inline_size(Box const& box, AvailableSpace 
     box_state.margin_right = margin_right.to_px_or_zero();
 }
 
-size_t BlockFormattingContext::band_index_at(CSSPixels y) const
+size_t BlockFormattingContext::band_index_at(CSSPixels block_offset) const
 {
     VERIFY(!m_bands.is_empty());
 
     size_t index = 0;
     for (size_t i = 1; i < m_bands.size(); ++i) {
-        if (m_bands[i].block_start > y)
+        if (m_bands[i].block_start > block_offset)
             break;
         index = i;
     }
     return index;
 }
 
-BlockFormattingContext::FloatBand const& BlockFormattingContext::band_at(CSSPixels y) const
+BlockFormattingContext::FloatBand const& BlockFormattingContext::band_at(CSSPixels block_offset) const
 {
-    return m_bands[band_index_at(y)];
+    return m_bands[band_index_at(block_offset)];
 }
 
-Optional<CSSPixels> BlockFormattingContext::next_float_band_block_start_after(CSSPixels y_in_root) const
+Optional<CSSPixels> BlockFormattingContext::next_float_band_block_start_after(CSSPixels block_offset_in_root) const
 {
     for (auto const& band : m_bands) {
-        if (band.block_start > y_in_root)
+        if (band.block_start > block_offset_in_root)
             return band.block_start;
     }
     return {};
@@ -445,20 +445,20 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_sp
 
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusions_for_band_into_rect(FloatBand const& band, CSSPixelRect const& rect_in_root) const
 {
-    auto root_content_width = m_state.get(root()).content_inline_size();
+    auto root_content_inline_size = m_state.get(root()).content_inline_size();
     return {
         .left = band.left_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.left_intrusion - rect_in_root.x()),
-        .right = band.right_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.right_intrusion - (root_content_width - rect_in_root.right())),
+        .right = band.right_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.right_intrusion - (root_content_inline_size - rect_in_root.right())),
     };
 }
 
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
 {
     auto intrusions = available_inline_space(box_in_root_rect.y() + block_start_in_box, box_in_root_rect.y() + block_end_in_box);
-    auto root_content_width = m_state.get(root()).content_inline_size();
+    auto root_content_inline_size = m_state.get(root()).content_inline_size();
     return {
         .left = intrusions.left == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.left - box_in_root_rect.x()),
-        .right = intrusions.right == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.right - (root_content_width - box_in_root_rect.right())),
+        .right = intrusions.right == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.right - (root_content_inline_size - box_in_root_rect.right())),
     };
 }
 
@@ -518,12 +518,12 @@ void BlockFormattingContext::ensure_band_boundary(CSSPixels block_start)
 
 void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box, CSSPixelRect containing_block_rect_in_root)
 {
-    auto const pending_y_adjustment = y_adjustment_from_pending_ancestor_top_margins(floating_box.box);
-    containing_block_rect_in_root.translate_by(0, pending_y_adjustment);
+    auto const pending_block_offset_adjustment = block_offset_adjustment_from_pending_ancestor_block_start_margins(floating_box.box);
+    containing_block_rect_in_root.translate_by(0, pending_block_offset_adjustment);
 
     auto const& box_state = floating_box.used_values;
-    auto const root_content_width = m_state.get(root()).content_inline_size();
-    auto const margin_box_rect_in_root = floating_box.margin_box_rect_in_root_coordinate_space.translated(0, pending_y_adjustment);
+    auto const root_content_inline_size = m_state.get(root()).content_inline_size();
+    auto const margin_box_rect_in_root = floating_box.margin_box_rect_in_root_coordinate_space.translated(0, pending_block_offset_adjustment);
     auto const block_start = margin_box_rect_in_root.top();
     auto const block_end = margin_box_rect_in_root.bottom();
 
@@ -540,7 +540,7 @@ void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box,
 
     auto intrusion = floating_box.side == FloatSide::Left
         ? containing_block_rect_in_root.x() + floating_box.offset_from_edge + box_state.content_inline_size() + box_state.margin_box_right()
-        : (root_content_width - containing_block_rect_in_root.right()) + floating_box.offset_from_edge + box_state.margin_box_left();
+        : (root_content_inline_size - containing_block_rect_in_root.right()) + floating_box.offset_from_edge + box_state.margin_box_left();
 
     for (auto& band : m_bands) {
         if (band.block_start < block_start)
@@ -612,23 +612,23 @@ CSSPixels BlockFormattingContext::border_box_left_of_box_avoiding_floats(Box con
     return space_used_by_floats.left + box_state.margin_left;
 }
 
-CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixels content_y, CSSPixelRect const& containing_block_rect_in_root)
+CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixels content_block_offset, CSSPixelRect const& containing_block_rect_in_root)
 {
     if (!available_space.inline_size.is_definite())
-        return content_y;
+        return content_block_offset;
     if (!box_should_avoid_floats_because_it_establishes_fc(box))
-        return content_y;
+        return content_block_offset;
 
     // https://drafts.csswg.org/css2/#floats
     // If necessary, implementations should clear the said element by placing it below any preceding floats, but may
     // place it adjacent to such floats if there is sufficient space.
     auto const& box_state = m_state.get(box);
     while (true) {
-        auto border_box_y_in_root = containing_block_rect_in_root.y() + content_y - box_state.border_box_top();
+        auto border_box_block_offset_in_root = containing_block_rect_in_root.y() + content_block_offset - box_state.border_box_top();
         auto band_containing_block_rect = containing_block_rect_in_root;
-        band_containing_block_rect.set_y(border_box_y_in_root);
+        band_containing_block_rect.set_y(border_box_block_offset_in_root);
         band_containing_block_rect.set_height(box_state.border_box_block_size());
-        auto const& band = band_at(border_box_y_in_root);
+        auto const& band = band_at(border_box_block_offset_in_root);
         auto space_used_by_floats = intrusions_for_band_into_rect(band, band_containing_block_rect);
         bool const constrained_by_floats = space_used_by_floats.left > 0 || space_used_by_floats.right > 0;
         auto border_box_left_in_containing_block = border_box_left_of_box_avoiding_floats(box, box_state, space_used_by_floats);
@@ -639,28 +639,28 @@ CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, Availab
         if (!must_clear_below_current_band) {
             CSSPixelRect border_box_rect_in_root {
                 band_containing_block_rect.x() + border_box_left_in_containing_block,
-                border_box_y_in_root,
+                border_box_block_offset_in_root,
                 box_state.border_box_inline_size(),
                 box_state.border_box_block_size(),
             };
             must_clear_below_current_band = any_of(m_floats, [&](auto const& floating_box) {
                 auto margin_box_rect_in_root = floating_box->margin_box_rect_in_root_coordinate_space.translated(
-                    0, y_adjustment_from_pending_ancestor_top_margins(floating_box->box));
+                    0, block_offset_adjustment_from_pending_ancestor_block_start_margins(floating_box->box));
                 return !margin_box_rect_in_root.intersected(border_box_rect_in_root).is_empty();
             });
         }
         if (!must_clear_below_current_band)
             break;
 
-        auto next_band_start = next_float_band_block_start_after(border_box_y_in_root);
+        auto next_band_start = next_float_band_block_start_after(border_box_block_offset_in_root);
         if (!next_band_start.has_value())
             break;
 
-        content_y += next_band_start.value() - border_box_y_in_root;
-        auto content_position_in_root = containing_block_rect_in_root.location().translated(0, content_y);
+        content_block_offset += next_band_start.value() - border_box_block_offset_in_root;
+        auto content_position_in_root = containing_block_rect_in_root.location().translated(0, content_block_offset);
         compute_inline_size(box, available_space, containing_block_constraints, content_position_in_root);
     }
-    return content_y;
+    return content_block_offset;
 }
 
 void BlockFormattingContext::compute_inline_size_for_floating_box(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
@@ -1029,9 +1029,9 @@ void BlockFormattingContext::layout_interrupting_block_inside_inline_context(Box
     CSSPixels dummy_bottom_of_lowest_margin_box = 0;
     CSSPixels block_bottom;
     {
-        TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, line_builder.current_block_offset() };
+        TemporaryChange<Optional<CSSPixels>> change { m_block_offset_of_current_block_container, line_builder.current_block_offset() };
         layout_block_level_box(box, containing_block, dummy_bottom_of_lowest_margin_box, layout_input);
-        block_bottom = m_y_offset_of_current_block_container.value_or(line_builder.current_block_offset());
+        block_bottom = m_block_offset_of_current_block_container.value_or(line_builder.current_block_offset());
     }
     line_builder.append_block_level_box(box, block_bottom, m_margin_state.current_collapsed_margin());
 }
@@ -1057,7 +1057,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             //     builder keeps out-of-flow boxes in inline context, where static position markers
             //     pin them at their exact flow position.
             StaticPositionRect static_position;
-            static_position.rect = { { 0, m_y_offset_of_current_block_container.value() }, { 0, 0 } };
+            static_position.rect = { { 0, m_block_offset_of_current_block_container.value() }, { 0, 0 } };
             register_contained_abspos_child(box, static_position);
         }
         return;
@@ -1093,9 +1093,9 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto containing_block_position_in_root = layout_input.content_box_position_in_bfc_root.value();
 
     if (box.is_floating()) {
-        auto const y = m_y_offset_of_current_block_container.value();
+        auto const block_offset = m_block_offset_of_current_block_container.value();
         auto margin_top = m_margin_state.has_open_top_margin_group() ? 0 : m_margin_state.current_collapsed_margin();
-        layout_floating_box(box, block_container, layout_input, margin_top + y);
+        layout_floating_box(box, block_container, layout_input, margin_top + block_offset);
         bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, m_floats.last()->bottom_margin_edge);
         return;
     }
@@ -1106,7 +1106,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         m_margin_state.reset();
     m_margin_state.update_open_top_margin_group();
 
-    auto const y = m_y_offset_of_current_block_container.value();
+    auto const block_offset = m_block_offset_of_current_block_container.value();
 
     auto box_is_html_element_in_quirks_mode = box.document().in_quirks_mode()
         && box.dom_node()
@@ -1141,19 +1141,19 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     // Earlier sibling placement may have invalidated cached float bands.
     rebuild_float_bands();
 
-    auto content_y = y + margin_top + box_state.border_box_top();
+    auto content_block_offset = block_offset + margin_top + box_state.border_box_top();
 
     auto const containing_block_rect_in_root = CSSPixelRect { containing_block_position_in_root, block_container_state.content_size() };
 
-    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(box));
-    auto content_position_in_root_now = [&](CSSPixels content_y) {
-        return containing_block_rect_in_root_now.location().translated(0, content_y);
+    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, block_offset_adjustment_from_pending_ancestor_block_start_margins(box));
+    auto content_position_in_root_now = [&](CSSPixels content_block_offset) {
+        return containing_block_rect_in_root_now.location().translated(0, content_block_offset);
     };
 
-    compute_inline_size(box, available_space, layout_input.containing_block_constraints, content_position_in_root_now(content_y));
-    content_y = avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints, content_y, containing_block_rect_in_root_now);
+    compute_inline_size(box, available_space, layout_input.containing_block_constraints, content_position_in_root_now(content_block_offset));
+    content_block_offset = avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints, content_block_offset, containing_block_rect_in_root_now);
 
-    auto content_x = compute_normal_flow_x(box, available_space, content_position_in_root_now(content_y));
+    auto content_inline_offset = compute_normal_flow_inline_offset(box, available_space, content_position_in_root_now(content_block_offset));
 
     // FIXME: We currently so not support ListItemBox-es generated by pseudo-elements. We will need to, eventually.
     auto const* list_item_box = as_if<ListItemBox>(box);
@@ -1169,7 +1169,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         auto const& marker = *list_item_box->marker();
         if (marker.list_style_position() == CSS::ListStylePosition::Inside
             && box.computed_values().direction() == CSS::Direction::Ltr) {
-            content_x += m_state.get(marker).content_inline_size() + distance_between_marker_and_list_item(marker);
+            content_inline_offset += m_state.get(marker).content_inline_size() + distance_between_marker_and_list_item(marker);
         }
     }
 
@@ -1180,11 +1180,11 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     Optional<CSSPixelPoint> pending_position;
 
     if (box_is_positioned_by_fieldset_layout) {
-        m_pending_legend_flow_position = CSSPixelPoint { content_x, content_y };
+        m_pending_legend_flow_position = LogicalOffset { content_inline_offset, content_block_offset };
     } else if (table_formatting_context) {
-        table_formatting_context->set_pending_table_box_content_offset_in_wrapper({ content_x, content_y });
+        table_formatting_context->set_pending_table_box_content_offset_in_wrapper({ content_inline_offset, content_block_offset });
     } else if (!box_opens_top_margin_group) {
-        pending_position = CSSPixelPoint { content_x, content_y };
+        pending_position = CSSPixelPoint { content_inline_offset, content_block_offset };
     }
 
     AvailableSpace available_space_for_block_size_resolution = available_space;
@@ -1211,8 +1211,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         auto const& list_item_state = m_state.get(*list_item_box);
         auto const& marker_state = m_state.get(*list_item_box->marker());
 
-        auto offset_y = max(CSSPixels(0), (list_item_box->marker()->computed_values().line_height() - marker_state.content_block_size()) / 2);
-        inline_space_used_before_children_formatted = intrusion_by_floats_into_rect({ content_position_in_root_now(content_y).translated(content_x, 0), list_item_state.content_size() }, offset_y, offset_y);
+        auto marker_block_offset = max(CSSPixels(0), (list_item_box->marker()->computed_values().line_height() - marker_state.content_block_size()) / 2);
+        inline_space_used_before_children_formatted = intrusion_by_floats_into_rect({ content_position_in_root_now(content_block_offset).translated(content_inline_offset, 0), list_item_state.content_size() }, marker_block_offset, marker_block_offset);
     }
 
     if (independent_formatting_context) {
@@ -1264,7 +1264,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         }
 
         auto inside_layout_input = layout_input.with_content_box_position_in_bfc_root(
-            containing_block_position_in_root.translated(content_x, content_y));
+            containing_block_position_in_root.translated(content_inline_offset, content_block_offset));
 
         if (box.children_are_inline())
             layout_inline_children(as<BlockContainer>(box), inside_layout_input, space_available_for_children);
@@ -1273,15 +1273,15 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         if (box_opens_top_margin_group) {
             auto resolved_margin_top = m_margin_state.take_pending_top_margin();
-            auto final_content_y = introduce_clearance == DidIntroduceClearance::No
-                ? y + resolved_margin_top + box_state.border_box_top()
-                : content_y;
+            auto final_content_block_offset = introduce_clearance == DidIntroduceClearance::No
+                ? block_offset + resolved_margin_top + box_state.border_box_top()
+                : content_block_offset;
             if (box_is_positioned_by_fieldset_layout) {
-                m_pending_legend_flow_position = CSSPixelPoint { content_x, final_content_y };
+                m_pending_legend_flow_position = LogicalOffset { content_inline_offset, final_content_block_offset };
             } else {
-                pending_position = CSSPixelPoint { content_x, final_content_y };
+                pending_position = CSSPixelPoint { content_inline_offset, final_content_block_offset };
             }
-            translate_floats_in_subtree(box, { 0, final_content_y - content_y });
+            translate_floats_in_subtree(box, { 0, final_content_block_offset - content_block_offset });
         }
     }
 
@@ -1304,7 +1304,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_y_offset_of_current_block_container = box_state.content_offset().y() + box_state.content_block_size() + box_state.border_box_bottom();
+        m_block_offset_of_current_block_container = box_state.content_offset().y() + box_state.content_block_size() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -1336,7 +1336,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 
     CSSPixels bottom_of_lowest_margin_box = 0;
 
-    TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
+    TemporaryChange<Optional<CSSPixels>> change { m_block_offset_of_current_block_container, CSSPixels(0) };
     block_container.for_each_child_of_type<Box>([&](Box& box) {
         layout_block_level_box(box, block_container, bottom_of_lowest_margin_box, child_layout_input);
         return IterationDecision::Continue;
@@ -1345,7 +1345,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);
         if (!block_container_state.has_definite_inline_size()) {
-            auto inline_size = greatest_child_inline_size_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
+            auto inline_size = greatest_child_inline_size_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, block_offset_adjustment_from_pending_ancestor_block_start_margins(block_container)), block_container_state.content_size() });
             auto const& computed_values = block_container.computed_values();
             // NOTE: Min and max constraints are not applied to a box that is being sized as intrinsic because
             //       according to css-sizing-3 spec:
@@ -1385,7 +1385,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
 
     // Lay out the legend to determine its dimensions.
     {
-        TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, CSSPixels(0) };
+        TemporaryChange<Optional<CSSPixels>> change { m_block_offset_of_current_block_container, CSSPixels(0) };
         CSSPixels dummy_bottom = 0;
         layout_block_level_box(*legend, fieldset_box, dummy_bottom, child_layout_input);
     }
@@ -1408,7 +1408,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
 
     CSSPixels bottom_of_lowest_margin_box = 0;
     {
-        TemporaryChange<Optional<CSSPixels>> change { m_y_offset_of_current_block_container, extra_top };
+        TemporaryChange<Optional<CSSPixels>> change { m_block_offset_of_current_block_container, extra_top };
         fieldset_box.for_each_child_of_type<Box>([&](Box& child) {
             if (&child == legend)
                 return IterationDecision::Continue;
@@ -1438,12 +1438,12 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     // the border on the block-start side of the fieldset element.
     // FIXME: Take writing modes into consideration.
     auto legend_border_box_centering_offset = (effective_border - legend_state.border_box_block_size()) / 2;
-    auto fieldset_border_box_top_in_content = -(fieldset_state.border_top + fieldset_state.padding_top);
-    auto legend_content_y = fieldset_border_box_top_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
+    auto fieldset_border_box_block_start_in_content = -(fieldset_state.border_top + fieldset_state.padding_top);
+    auto legend_content_block_offset = fieldset_border_box_block_start_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
     if (auto legend_flow_position = m_pending_legend_flow_position; legend_flow_position.has_value()) {
         m_pending_legend_flow_position = {};
-        place_child(*legend, { legend_flow_position->x(), legend_content_y });
-        translate_floats_in_subtree(*legend, { 0, legend_content_y - legend_flow_position->y() });
+        place_child(*legend, { legend_flow_position->inline_offset, legend_content_block_offset });
+        translate_floats_in_subtree(*legend, { 0, legend_content_block_offset - legend_flow_position->block_offset });
     }
 
     compute_and_store_baselines(fieldset_state);
@@ -1480,26 +1480,26 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
     auto const& computed_values = child_box.computed_values();
     auto result = DidIntroduceClearance::No;
 
-    auto clear_floating_boxes = [&](CSSPixels clearance_y_in_root) {
-        if (clearance_y_in_root == 0)
+    auto clear_floating_boxes = [&](CSSPixels clearance_block_offset_in_root) {
+        if (clearance_block_offset_in_root == 0)
             return;
 
         // NOTE: Floating boxes are globally relevant within this BFC, *but* their offset coordinates
         //       are relative to their containing block.
-        //       This means that we have to first convert to a root-space Y coordinate before clearing,
-        //       and then convert back to a local Y coordinate when assigning the cleared offset to
+        //       This means that we have to first convert to a root-space block offset before clearing,
+        //       and then convert back to a local block offset when assigning the cleared offset to
         //       the `child_box` layout state.
-        CSSPixels clearance_y_in_containing_block = clearance_y_in_root
-            - containing_block_position_in_root.y() - y_adjustment_from_pending_ancestor_top_margins(child_box);
+        CSSPixels clearance_block_offset_in_containing_block = clearance_block_offset_in_root
+            - containing_block_position_in_root.y() - block_offset_adjustment_from_pending_ancestor_block_start_margins(child_box);
 
         if (inline_formatting_context.has_value()) {
-            if (clearance_y_in_containing_block > inline_formatting_context->vertical_float_clearance()) {
+            if (clearance_block_offset_in_containing_block > inline_formatting_context->block_axis_float_clearance()) {
                 result = DidIntroduceClearance::Yes;
-                inline_formatting_context->set_vertical_float_clearance(clearance_y_in_containing_block);
+                inline_formatting_context->set_block_axis_float_clearance(clearance_block_offset_in_containing_block);
             }
-        } else if (clearance_y_in_containing_block > m_y_offset_of_current_block_container.value()) {
+        } else if (clearance_block_offset_in_containing_block > m_block_offset_of_current_block_container.value()) {
             result = DidIntroduceClearance::Yes;
-            m_y_offset_of_current_block_container = clearance_y_in_containing_block;
+            m_block_offset_of_current_block_container = clearance_block_offset_in_containing_block;
         }
     };
 
@@ -1512,11 +1512,11 @@ BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floa
     return result;
 }
 
-CSSPixels BlockFormattingContext::compute_normal_flow_x(Box const& child_box, AvailableSpace const& available_space, CSSPixelPoint content_position_in_root) const
+CSSPixels BlockFormattingContext::compute_normal_flow_inline_offset(Box const& child_box, AvailableSpace const& available_space, CSSPixelPoint content_position_in_root) const
 {
     auto const& box_state = m_state.get(child_box);
 
-    CSSPixels x = 0;
+    CSSPixels inline_offset = 0;
     CSSPixels available_inline_size_within_containing_block = available_space.inline_size.to_px_or_zero();
 
     if (box_should_avoid_floats_because_it_establishes_fc(child_box)) {
@@ -1524,22 +1524,22 @@ CSSPixels BlockFormattingContext::compute_normal_flow_x(Box const& child_box, Av
         available_inline_size_within_containing_block -= space_used_by_floats.left + space_used_by_floats.right;
 
         // Subtracting the left margin here because it is applied again when the margin box offset is added below.
-        x = border_box_left_of_box_avoiding_floats(child_box, box_state, space_used_by_floats) - box_state.margin_left;
+        inline_offset = border_box_left_of_box_avoiding_floats(child_box, box_state, space_used_by_floats) - box_state.margin_left;
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {
-        x += (available_inline_size_within_containing_block / 2) - box_state.content_inline_size() / 2;
+        inline_offset += (available_inline_size_within_containing_block / 2) - box_state.content_inline_size() / 2;
     } else if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebRight) {
         // Subtracting the left margin here because left and right margins need to be swapped when aligning to the right
-        x += available_inline_size_within_containing_block - box_state.content_inline_size() - box_state.margin_box_left();
+        inline_offset += available_inline_size_within_containing_block - box_state.content_inline_size() - box_state.margin_box_left();
     } else {
-        x += box_state.margin_box_left();
+        inline_offset += box_state.margin_box_left();
     }
 
-    return x;
+    return inline_offset;
 }
 
-void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, LayoutInput const& layout_input, CSSPixels y, LineBuilder* line_builder)
+void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, LayoutInput const& layout_input, CSSPixels block_offset, LineBuilder* line_builder)
 {
     auto const& available_space = layout_input.available_space;
     VERIFY(box.is_floating());
@@ -1551,7 +1551,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     resolve_vertical_box_model_metrics(box, block_container_state.content_inline_size());
 
     auto const containing_block_rect_in_root = CSSPixelRect { layout_input.content_box_position_in_bfc_root.value(), block_container_state.content_size() };
-    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container));
+    auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, block_offset_adjustment_from_pending_ancestor_block_start_margins(block_container));
 
     compute_inline_size(box, available_space, layout_input.containing_block_constraints, containing_block_rect_in_root_now.location());
 
@@ -1581,7 +1581,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     if (!side.has_value())
         return;
 
-    auto margin_box_ceiling = line_builder ? line_builder->ceiling_for_float_to_be_inserted_here(box) : y;
+    auto margin_box_ceiling = line_builder ? line_builder->ceiling_for_float_to_be_inserted_here(box) : block_offset;
     auto clearance = computed_values.clear();
     if (side.value() == FloatSide::Left && first_is_one_of(clearance, CSS::Clear::Left, CSS::Clear::Both, CSS::Clear::InlineStart))
         margin_box_ceiling = max(margin_box_ceiling, m_lowest_left_margin_edge - containing_block_rect_in_root_now.y());
@@ -1590,21 +1590,21 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     auto ceiling_in_root = containing_block_rect_in_root_now.y() + margin_box_ceiling;
     if (!m_floats.is_empty())
-        ceiling_in_root = max(ceiling_in_root, m_floats.last()->margin_box_rect_in_root_coordinate_space.top() + y_adjustment_from_pending_ancestor_top_margins(m_floats.last()->box));
+        ceiling_in_root = max(ceiling_in_root, m_floats.last()->margin_box_rect_in_root_coordinate_space.top() + block_offset_adjustment_from_pending_ancestor_block_start_margins(m_floats.last()->box));
 
     auto placement = place_float(side.value(), box_state, available_space, containing_block_rect_in_root_now, ceiling_in_root);
-    auto content_y = placement.block_start - containing_block_rect_in_root_now.y() + box_state.margin_box_top();
+    auto content_block_offset = placement.block_start - containing_block_rect_in_root_now.y() + box_state.margin_box_top();
 
     auto margin_box_rect_in_root = margin_box_rect(box_state)
-                                       .translated(0, content_y)
+                                       .translated(0, content_block_offset)
                                        .translated(containing_block_rect_in_root.location());
     m_floats.append(adopt_own(*new FloatingBox {
         .box = box,
         .used_values = box_state,
         .side = side.value(),
         .offset_from_edge = placement.offset_from_edge,
-        .top_margin_edge = content_y - box_state.margin_box_top(),
-        .bottom_margin_edge = content_y + box_state.content_block_size() + box_state.margin_box_bottom(),
+        .top_margin_edge = content_block_offset - box_state.margin_box_top(),
+        .bottom_margin_edge = content_block_offset + box_state.content_block_size() + box_state.margin_box_bottom(),
         .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
         .containing_block_rect_in_root_coordinate_space = containing_block_rect_in_root,
         .percentage_basis_inline_size = layout_input.containing_block_constraints.percentage_basis_inline_size,
@@ -1639,24 +1639,24 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     auto marker_distance = distance_between_marker_and_list_item(marker);
 
-    auto marker_height = marker_state.content_block_size();
-    auto marker_width = marker_state.content_inline_size();
+    auto marker_block_size = marker_state.content_block_size();
+    auto marker_inline_size = marker_state.content_inline_size();
 
     auto list_item_direction = list_item_box.computed_values().direction();
-    auto marker_offset_x = list_item_direction == CSS::Direction::Ltr
-        ? inline_space_used_before_list_item_elements_formatted.left - marker_distance - marker_width
+    auto marker_inline_offset = list_item_direction == CSS::Direction::Ltr
+        ? inline_space_used_before_list_item_elements_formatted.left - marker_distance - marker_inline_size
         : list_item_state.content_inline_size() - (inline_space_used_before_list_item_elements_formatted.right - marker_distance);
-    auto marker_offset_y = max(CSSPixels(0), (marker.computed_values().line_height() - marker_height) / 2);
+    auto marker_block_offset = max(CSSPixels(0), (marker.computed_values().line_height() - marker_block_size) / 2);
 
     if (marker.list_style_position() == CSS::ListStylePosition::Inside) {
         // FIXME: Just adjusting the content inline size for an inside marker is wrong, as it will still position
         //        the marker outside of the box, instead of treating it more like an inline child on the first line.
-        list_item_state.set_content_inline_size(list_item_state.content_inline_size() - marker_width - marker_distance);
+        list_item_state.set_content_inline_size(list_item_state.content_inline_size() - marker_inline_size - marker_distance);
     }
 
     // Animations can make `float` or `position` apply to ::marker.
     if (!marker.is_floating() && !marker.is_absolutely_positioned())
-        place_child(marker, { round(marker_offset_x), round(marker_offset_y) });
+        place_child(marker, { round(marker_inline_offset), round(marker_block_offset) });
 
     if (marker.computed_values().line_height() > list_item_state.content_block_size())
         list_item_state.set_content_block_size(marker.computed_values().line_height());

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -52,7 +52,7 @@ BlockFormattingContext::~BlockFormattingContext()
 CSSPixels BlockFormattingContext::automatic_content_width() const
 {
     if (root().children_are_inline())
-        return m_state.get(root()).content_width();
+        return m_state.get(root()).content_inline_size();
     if (is<TableWrapper>(root())) {
         Optional<Box const&> table_box;
         root().for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
@@ -122,9 +122,9 @@ void BlockFormattingContext::run(LayoutInput const& layout_input)
     FORMATTING_CONTEXT_TRACE();
     // https://drafts.csswg.org/css-multicol-2/#the-multi-column-model
     auto const& root_state = m_state.get(root());
-    auto column_count = determine_used_value_for_column_count(root_state.content_width());
+    auto column_count = determine_used_value_for_column_count(root_state.content_inline_size());
     if (column_count.has_value()) {
-        auto column_width = determine_used_value_for_column_width(root_state.content_width(), column_count.value());
+        auto column_width = determine_used_value_for_column_width(root_state.content_inline_size(), column_count.value());
         // FIXME: Do multi-column layout.
         (void)column_width;
     }
@@ -173,7 +173,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
         } else {
             // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
             auto float_containing_block_width = [&] {
-                switch (floating_box->used_values.width_constraint) {
+                switch (floating_box->used_values.inline_size_constraint) {
                 case SizeConstraint::MinContent:
                     return CSSPixels(0);
                 case SizeConstraint::MaxContent:
@@ -275,7 +275,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     // NOTE: If we are calculating the min-content or max-content width of this box,
     //       and the width should be treated as auto, then we can simply return here,
     //       as the preferred width and min/max constraints are irrelevant for intrinsic sizing.
-    if (box_state.width_constraint != SizeConstraint::None)
+    if (box_state.inline_size_constraint != SizeConstraint::None)
         return;
 
     auto const remaining_width_px = remaining_available_space.inline_size.to_px_or_zero();
@@ -350,7 +350,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
             // NOTE: Replaced elements had their width calculated independently above.
             //       We use that width as the input here to ensure that margins get resolved.
-            return CSS::Length::make_px(box_state.content_width());
+            return CSS::Length::make_px(box_state.content_inline_size());
         }
         if (is<TableWrapper>(box))
             return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, remaining_available_space, containing_block_constraints));
@@ -387,7 +387,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     }
 
     if (!box_is_sized_as_replaced_element(box, available_space, containing_block_constraints) && !used_width.is_auto())
-        box_state.set_content_width(used_width.to_px_or_zero());
+        box_state.set_content_inline_size(used_width.to_px_or_zero());
 
     box_state.margin_left = margin_left.to_px_or_zero();
     box_state.margin_right = margin_right.to_px_or_zero();
@@ -445,7 +445,7 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::available_inline_sp
 
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusions_for_band_into_rect(FloatBand const& band, CSSPixelRect const& rect_in_root) const
 {
-    auto root_content_width = m_state.get(root()).content_width();
+    auto root_content_width = m_state.get(root()).content_inline_size();
     return {
         .left = band.left_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.left_intrusion - rect_in_root.x()),
         .right = band.right_intrusion == 0 ? CSSPixels(0) : max(CSSPixels(0), band.right_intrusion - (root_content_width - rect_in_root.right())),
@@ -455,7 +455,7 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusions_for_band
 FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const
 {
     auto intrusions = available_inline_space(box_in_root_rect.y() + block_start_in_box, box_in_root_rect.y() + block_end_in_box);
-    auto root_content_width = m_state.get(root()).content_width();
+    auto root_content_width = m_state.get(root()).content_inline_size();
     return {
         .left = intrusions.left == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.left - box_in_root_rect.x()),
         .right = intrusions.right == 0 ? CSSPixels(0) : max(CSSPixels(0), intrusions.right - (root_content_width - box_in_root_rect.right())),
@@ -476,7 +476,7 @@ BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(Float
         if (available_space.inline_size.is_max_content() || available_space.inline_size.is_indefinite() || margin_box_width <= available_width || !has_floats_present) {
             auto offset_from_edge = side == FloatSide::Left
                 ? intrusions.left + box_state.margin_box_left()
-                : intrusions.right + box_state.content_width() + box_state.margin_box_right();
+                : intrusions.right + box_state.content_inline_size() + box_state.margin_box_right();
             return {
                 .block_start = candidate_block_start,
                 .offset_from_edge = offset_from_edge,
@@ -489,7 +489,7 @@ BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(Float
                 .block_start = candidate_block_start,
                 .offset_from_edge = side == FloatSide::Left
                     ? intrusions.left + box_state.margin_box_left()
-                    : intrusions.right + box_state.content_width() + box_state.margin_box_right(),
+                    : intrusions.right + box_state.content_inline_size() + box_state.margin_box_right(),
             };
 
         candidate_block_start = next_band_start.value();
@@ -522,7 +522,7 @@ void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box,
     containing_block_rect_in_root.translate_by(0, pending_y_adjustment);
 
     auto const& box_state = floating_box.used_values;
-    auto const root_content_width = m_state.get(root()).content_width();
+    auto const root_content_width = m_state.get(root()).content_inline_size();
     auto const margin_box_rect_in_root = floating_box.margin_box_rect_in_root_coordinate_space.translated(0, pending_y_adjustment);
     auto const block_start = margin_box_rect_in_root.top();
     auto const block_end = margin_box_rect_in_root.bottom();
@@ -539,7 +539,7 @@ void BlockFormattingContext::add_float_to_bands(FloatingBox const& floating_box,
     ensure_band_boundary(block_end);
 
     auto intrusion = floating_box.side == FloatSide::Left
-        ? containing_block_rect_in_root.x() + floating_box.offset_from_edge + box_state.content_width() + box_state.margin_box_right()
+        ? containing_block_rect_in_root.x() + floating_box.offset_from_edge + box_state.content_inline_size() + box_state.margin_box_right()
         : (root_content_width - containing_block_rect_in_root.right()) + floating_box.offset_from_edge + box_state.margin_box_left();
 
     for (auto& band : m_bands) {
@@ -737,7 +737,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
             width = compute_width(CSS::Length::make_px(min_width));
     }
 
-    box_state.set_content_width(width.to_px_or_zero());
+    box_state.set_content_inline_size(width.to_px_or_zero());
 }
 
 void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
@@ -765,7 +765,7 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     box_state.padding_right = padding_right;
 
     auto width = compute_width_for_replaced_element(box, available_space, containing_block_constraints);
-    box_state.set_content_width(width);
+    box_state.set_content_inline_size(width);
 }
 
 void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
@@ -789,9 +789,9 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
         height = max(height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
-    box_state.set_content_height(height);
+    box_state.set_content_block_size(height);
     if (computed_height_establishes_definite_containing_block_height(computed_values.height()))
-        box_state.set_has_definite_height(true);
+        box_state.set_has_definite_block_size(true);
 }
 
 void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context)
@@ -845,7 +845,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         height = max(size, height);
 
         // NOTE: The height of the root element when affected by this quirk is considered to be definite.
-        box_state.set_has_definite_height(true);
+        box_state.set_has_definite_block_size(true);
     }
 
     if (box.document().in_quirks_mode()
@@ -877,7 +877,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         }
     }
 
-    box_state.set_content_height(height);
+    box_state.set_content_block_size(height);
 }
 
 void BlockFormattingContext::layout_inline_children(BlockContainer const& block_container, LayoutInput const& layout_input, AvailableSpace const& available_space_for_children)
@@ -890,7 +890,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
     InlineFormattingContext context(m_state, m_layout_mode, block_container, block_container_state, *this);
     context.run(layout_input_for_child_context(block_container_state, layout_input, available_space_for_children));
 
-    if (!block_container_state.has_definite_width()) {
+    if (!block_container_state.has_definite_inline_size()) {
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
         //       is done and width of box content is known
         auto used_width_px = context.automatic_content_width();
@@ -900,7 +900,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         //       Applying them here would bake the box's own min/max-width into its measured intrinsic
         //       size, and the border-box adjustment would consume border/padding that measurement
         //       state does not have.
-        if (block_container_state.width_constraint == SizeConstraint::None) {
+        if (block_container_state.inline_size_constraint == SizeConstraint::None) {
             // https://www.w3.org/TR/css-sizing-3/#sizing-values
             // Percentages are resolved against the width/height, as appropriate, of the box’s containing block.
             auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
@@ -930,8 +930,8 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
                     used_width_px = min_width_px;
             }
         }
-        block_container_state.set_content_width(used_width_px);
-        block_container_state.set_content_height(context.automatic_content_height());
+        block_container_state.set_content_inline_size(used_width_px);
+        block_container_state.set_content_block_size(context.automatic_content_height());
     }
 }
 
@@ -1005,7 +1005,7 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
                 margin_bottom = 0;
             }
 
-            return max(CSSPixels(0), child_box_state.content_offset().y() + child_box_state.content_height() + child_box_state.border_box_bottom() + margin_bottom);
+            return max(CSSPixels(0), child_box_state.content_offset().y() + child_box_state.content_block_size() + child_box_state.border_box_bottom() + margin_bottom);
         }
 
         // If no in-flow children were found but there's a marker, use the marker's line-height.
@@ -1086,7 +1086,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         return m_state.create(box, layout_input.containing_block_constraints.percentage_basis_inline_size, layout_input.containing_block_constraints.percentage_basis_block_size);
     }();
 
-    resolve_vertical_box_model_metrics(box, block_container_state.content_width());
+    resolve_vertical_box_model_metrics(box, block_container_state.content_inline_size());
 
     VERIFY(box.containing_block() == &block_container);
     auto containing_block_position_in_root = layout_input.content_box_position_in_bfc_root.value();
@@ -1113,7 +1113,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         && box.computed_values().height().is_auto();
 
     // NOTE: In quirks mode, the html element's height matches the viewport so it can be treated as definite
-    if (box_state.has_definite_height() || box_is_html_element_in_quirks_mode)
+    if (box_state.has_definite_block_size() || box_is_html_element_in_quirks_mode)
         resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
     auto independent_formatting_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, box, this);
@@ -1168,7 +1168,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         auto const& marker = *list_item_box->marker();
         if (marker.list_style_position() == CSS::ListStylePosition::Inside
             && box.computed_values().direction() == CSS::Direction::Ltr) {
-            content_x += m_state.get(marker).content_width() + distance_between_marker_and_list_item(marker);
+            content_x += m_state.get(marker).content_inline_size() + distance_between_marker_and_list_item(marker);
         }
     }
 
@@ -1210,7 +1210,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         auto const& list_item_state = m_state.get(*list_item_box);
         auto const& marker_state = m_state.get(*list_item_box->marker());
 
-        auto offset_y = max(CSSPixels(0), (list_item_box->marker()->computed_values().line_height() - marker_state.content_height()) / 2);
+        auto offset_y = max(CSSPixels(0), (list_item_box->marker()->computed_values().line_height() - marker_state.content_block_size()) / 2);
         inline_space_used_before_children_formatted = intrusion_by_floats_into_rect({ content_position_in_root_now(content_y).translated(content_x, 0), list_item_state.content_size() }, offset_y, offset_y);
     }
 
@@ -1225,10 +1225,10 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // min-height. If so, we run layout with min-height as the available height.
         Optional<CSSPixels> measured_content_height;
         if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
-            auto content_height = measure_automatic_content_height(box, inner_available_space, layout_input.containing_block_constraints);
-            measured_content_height = content_height;
+            auto content_block_size = measure_automatic_content_height(box, inner_available_space, layout_input.containing_block_constraints);
+            measured_content_height = content_block_size;
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
-            if (content_height < min_height) {
+            if (content_block_size < min_height) {
                 inner_available_space.block_size = AvailableSize::make_definite(min_height);
             }
         }
@@ -1249,7 +1249,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             box_state.margin_right = max(box_state.margin_right, 0);
         }
         if (is<TableWrapper>(box) && !box.is_grid_item())
-            box_state.set_content_width(independent_formatting_context->automatic_content_width());
+            box_state.set_content_inline_size(independent_formatting_context->automatic_content_width());
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
@@ -1301,7 +1301,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (!m_margin_state.box_last_in_flow_child_margin_bottom_collapsed()) {
             m_margin_state.reset();
         }
-        m_y_offset_of_current_block_container = box_state.content_offset().y() + box_state.content_height() + box_state.border_box_bottom();
+        m_y_offset_of_current_block_container = box_state.content_offset().y() + box_state.content_block_size() + box_state.border_box_bottom();
     }
     m_margin_state.set_box_last_in_flow_child_margin_bottom_collapsed(false);
 
@@ -1310,7 +1310,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
     compute_inset(box, content_box_rect(block_container_state).size());
 
-    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.content_offset().y() + box_state.content_height() + box_state.margin_box_bottom());
+    bottom_of_lowest_margin_box = max(bottom_of_lowest_margin_box, box_state.content_offset().y() + box_state.content_block_size() + box_state.margin_box_bottom());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();
@@ -1341,7 +1341,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
 
     if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);
-        if (!block_container_state.has_definite_width()) {
+        if (!block_container_state.has_definite_inline_size()) {
             auto width = greatest_child_width_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
             auto const& computed_values = block_container.computed_values();
             // NOTE: Min and max constraints are not applied to a box that is being sized as intrinsic because
@@ -1349,7 +1349,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             //       The min-content size of a box in each axis is the size it would have if it was a float given an
             //       auto size in that axis (and no minimum or maximum size in that axis) and if its containing block
             //       was zero-sized in that axis.
-            if (block_container_state.width_constraint == SizeConstraint::None) {
+            if (block_container_state.inline_size_constraint == SizeConstraint::None) {
                 if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
                     auto max_width = calculate_inner_width(block_container, available_space.inline_size,
                         computed_values.max_width(), layout_input.containing_block_constraints);
@@ -1361,8 +1361,8 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
                     width = max(width, min_width);
                 }
             }
-            block_container_state.set_content_width(width);
-            block_container_state.set_content_height(bottom_of_lowest_margin_box);
+            block_container_state.set_content_inline_size(width);
+            block_container_state.set_content_block_size(bottom_of_lowest_margin_box);
         }
     }
 
@@ -1391,7 +1391,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     auto& legend_state = m_state.get_mutable(*legend);
     if (legend->computed_values().width().is_auto()) {
         auto width = calculate_fit_content_width(*legend, available_space, child_layout_input.containing_block_constraints);
-        legend_state.set_content_width(width);
+        legend_state.set_content_inline_size(width);
     }
 
     // The space allocated for the element's border on the block-start side is expected to be the element's
@@ -1414,10 +1414,10 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         });
     }
 
-    if (m_layout_mode == LayoutMode::IntrinsicSizing && !fieldset_state.has_definite_width()) {
+    if (m_layout_mode == LayoutMode::IntrinsicSizing && !fieldset_state.has_definite_inline_size()) {
         auto width = greatest_child_width(fieldset_box);
         auto const& computed_values = fieldset_box.computed_values();
-        if (fieldset_state.width_constraint == SizeConstraint::None) {
+        if (fieldset_state.inline_size_constraint == SizeConstraint::None) {
             if (!should_treat_max_width_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
                 auto max_width = calculate_inner_width(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
                 width = min(width, max_width);
@@ -1427,8 +1427,8 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
                 width = max(width, min_width);
             }
         }
-        fieldset_state.set_content_width(width);
-        fieldset_state.set_content_height(bottom_of_lowest_margin_box);
+        fieldset_state.set_content_inline_size(width);
+        fieldset_state.set_content_block_size(bottom_of_lowest_margin_box);
     }
 
     // The element is expected to be positioned in the block-flow direction such that its border box is centered over
@@ -1525,10 +1525,10 @@ CSSPixels BlockFormattingContext::compute_normal_flow_x(Box const& child_box, Av
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {
-        x += (available_width_within_containing_block / 2) - box_state.content_width() / 2;
+        x += (available_width_within_containing_block / 2) - box_state.content_inline_size() / 2;
     } else if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebRight) {
         // Subtracting the left margin here because left and right margins need to be swapped when aligning to the right
-        x += available_width_within_containing_block - box_state.content_width() - box_state.margin_box_left();
+        x += available_width_within_containing_block - box_state.content_inline_size() - box_state.margin_box_left();
     } else {
         x += box_state.margin_box_left();
     }
@@ -1545,7 +1545,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto const& computed_values = box.computed_values();
 
     auto const& block_container_state = m_state.get(block_container);
-    resolve_vertical_box_model_metrics(box, block_container_state.content_width());
+    resolve_vertical_box_model_metrics(box, block_container_state.content_inline_size());
 
     auto const containing_block_rect_in_root = CSSPixelRect { layout_input.content_box_position_in_bfc_root.value(), block_container_state.content_size() };
     auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container));
@@ -1563,7 +1563,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     // A floating table wrapper shrink-to-fits from cached intrinsic sizes, which may not match
     // the width table layout just produced; the wrapper is exactly as wide as the table grid box.
     if (is<TableWrapper>(box) && independent_formatting_context)
-        box_state.set_content_width(independent_formatting_context->automatic_content_width());
+        box_state.set_content_inline_size(independent_formatting_context->automatic_content_width());
     resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
 
     // Next, float to the left and/or right
@@ -1601,7 +1601,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         .side = side.value(),
         .offset_from_edge = placement.offset_from_edge,
         .top_margin_edge = content_y - box_state.margin_box_top(),
-        .bottom_margin_edge = content_y + box_state.content_height() + box_state.margin_box_bottom(),
+        .bottom_margin_edge = content_y + box_state.content_block_size() + box_state.margin_box_bottom(),
         .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
         .containing_block_rect_in_root_coordinate_space = containing_block_rect_in_root,
         .percentage_basis_inline_size = layout_input.containing_block_constraints.percentage_basis_inline_size,
@@ -1636,27 +1636,27 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
 
     auto marker_distance = distance_between_marker_and_list_item(marker);
 
-    auto marker_height = marker_state.content_height();
-    auto marker_width = marker_state.content_width();
+    auto marker_height = marker_state.content_block_size();
+    auto marker_width = marker_state.content_inline_size();
 
     auto list_item_direction = list_item_box.computed_values().direction();
     auto marker_offset_x = list_item_direction == CSS::Direction::Ltr
         ? inline_space_used_before_list_item_elements_formatted.left - marker_distance - marker_width
-        : list_item_state.content_width() - (inline_space_used_before_list_item_elements_formatted.right - marker_distance);
+        : list_item_state.content_inline_size() - (inline_space_used_before_list_item_elements_formatted.right - marker_distance);
     auto marker_offset_y = max(CSSPixels(0), (marker.computed_values().line_height() - marker_height) / 2);
 
     if (marker.list_style_position() == CSS::ListStylePosition::Inside) {
         // FIXME: Just adjusting the content width for an inside marker is wrong, as it will still position
         //        the marker outside of the box, instead of treating it more like an inline child on the first line.
-        list_item_state.set_content_width(list_item_state.content_width() - marker_width - marker_distance);
+        list_item_state.set_content_inline_size(list_item_state.content_inline_size() - marker_width - marker_distance);
     }
 
     // Animations can make `float` or `position` apply to ::marker.
     if (!marker.is_floating() && !marker.is_absolutely_positioned())
         place_child(marker, { round(marker_offset_x), round(marker_offset_y) });
 
-    if (marker.computed_values().line_height() > list_item_state.content_height())
-        list_item_state.set_content_height(marker.computed_values().line_height());
+    if (marker.computed_values().line_height() > list_item_state.content_block_size())
+        list_item_state.set_content_block_size(marker.computed_values().line_height());
 }
 
 CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
@@ -1688,7 +1688,7 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
                 if (left_float->box.containing_block() != &box)
                     continue;
                 if (line_top < left_float->bottom_margin_edge && line_bottom > left_float->top_margin_edge) {
-                    extra_width_from_left_floats = max(extra_width_from_left_floats, left_float->offset_from_edge + left_float->used_values.content_width() + left_float->used_values.margin_box_right());
+                    extra_width_from_left_floats = max(extra_width_from_left_floats, left_float->offset_from_edge + left_float->used_values.content_inline_size() + left_float->used_values.margin_box_right());
                 }
             }
             CSSPixels extra_width_from_right_floats = 0;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -223,8 +223,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     auto remaining_available_space = available_space;
 
     // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
-    if (available_space.width.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
-        auto available_width = available_space.width.to_px_or_zero();
+    if (available_space.inline_size.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
+        auto available_width = available_space.inline_size.to_px_or_zero();
         auto box_in_root_rect = CSSPixelRect { content_position_in_root, m_state.get(box).content_size() };
         box_in_root_rect.set_width(available_width);
         auto intrusion = intrusions_for_band_into_rect(band_at(box_in_root_rect.y()), box_in_root_rect);
@@ -238,7 +238,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
             auto negative_margin_sum = min(margin_left, CSSPixels(0)) + min(margin_right, CSSPixels(0));
             remaining_width = max(remaining_width + negative_margin_sum, CSSPixels(0));
         }
-        remaining_available_space.width = AvailableSize::make_definite(remaining_width);
+        remaining_available_space.inline_size = AvailableSize::make_definite(remaining_width);
     }
 
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
@@ -258,7 +258,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     }
 
     auto const& computed_values = box.computed_values();
-    auto available_width_px = available_space.width.to_px_or_zero();
+    auto available_width_px = available_space.inline_size.to_px_or_zero();
     auto margin_left = computed_values.margin().left().resolved_or_auto(available_width_px);
     auto margin_right = computed_values.margin().right().resolved_or_auto(available_width_px);
     auto const padding_left = computed_values.padding().left().resolved_or_auto(available_width_px);
@@ -278,13 +278,13 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     if (box_state.width_constraint != SizeConstraint::None)
         return;
 
-    auto const remaining_width_px = remaining_available_space.width.to_px_or_zero();
+    auto const remaining_width_px = remaining_available_space.inline_size.to_px_or_zero();
     auto const zero_value = CSS::Length::make_px(0);
 
     auto try_compute_width = [&](CSS::LengthOrAuto const& a_width) {
         auto width = a_width;
-        margin_left = computed_values.margin().left().resolved_or_auto(available_space.width.to_px_or_zero());
-        margin_right = computed_values.margin().right().resolved_or_auto(available_space.width.to_px_or_zero());
+        margin_left = computed_values.margin().left().resolved_or_auto(available_space.inline_size.to_px_or_zero());
+        margin_right = computed_values.margin().right().resolved_or_auto(available_space.inline_size.to_px_or_zero());
         CSSPixels total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { CSS::LengthOrAuto(margin_left), CSS::LengthOrAuto(padding_left), width, CSS::LengthOrAuto(padding_right), CSS::LengthOrAuto(margin_right) })
             total_px += value.to_px_or_zero();
@@ -304,7 +304,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
             // 10.3.3 cont'd.
             auto underflow_px = remaining_width_px - total_px;
-            if (available_space.width.is_intrinsic_sizing_constraint())
+            if (available_space.inline_size.is_intrinsic_sizing_constraint())
                 underflow_px = 0;
 
             if (width.is_auto()) {
@@ -313,16 +313,16 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
                 if (margin_right.is_auto())
                     margin_right = zero_value;
 
-                if (available_space.width.is_definite()) {
+                if (available_space.inline_size.is_definite()) {
                     if (underflow_px >= 0) {
                         width = CSS::Length::make_px(underflow_px);
                     } else {
                         width = zero_value;
                     }
-                } else if (available_space.width.is_min_content()) {
+                } else if (available_space.inline_size.is_min_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
                         width = CSS::Length::make_px(calculate_min_content_width(box, containing_block_constraints));
-                } else if (available_space.width.is_max_content()) {
+                } else if (available_space.inline_size.is_max_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
                         width = CSS::Length::make_px(calculate_max_content_width(box, containing_block_constraints));
                 } else {
@@ -364,7 +364,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_width(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
@@ -372,8 +372,8 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
-        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width(), containing_block_constraints);
+    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width)
             used_width = try_compute_width(CSS::Length::make_px(max_width));
     }
@@ -381,7 +381,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto() && !used_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width(), containing_block_constraints);
+        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() < min_width)
             used_width = try_compute_width(CSS::Length::make_px(min_width));
     }
@@ -470,10 +470,10 @@ BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(Float
     for (;;) {
         auto const& band = band_at(candidate_block_start);
         auto intrusions = intrusions_for_band_into_rect(band, containing_block_rect_in_root);
-        auto available_width = available_space.width.to_px_or_zero() - intrusions.left - intrusions.right;
+        auto available_width = available_space.inline_size.to_px_or_zero() - intrusions.left - intrusions.right;
         auto has_floats_present = band.left_intrusion > 0 || band.right_intrusion > 0;
 
-        if (available_space.width.is_max_content() || available_space.width.is_indefinite() || margin_box_width <= available_width || !has_floats_present) {
+        if (available_space.inline_size.is_max_content() || available_space.inline_size.is_indefinite() || margin_box_width <= available_width || !has_floats_present) {
             auto offset_from_edge = side == FloatSide::Left
                 ? intrusions.left + box_state.margin_box_left()
                 : intrusions.right + box_state.content_width() + box_state.margin_box_right();
@@ -614,7 +614,7 @@ CSSPixels BlockFormattingContext::border_box_left_of_box_avoiding_floats(Box con
 
 CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixels content_y, CSSPixelRect const& containing_block_rect_in_root)
 {
-    if (!available_space.width.is_definite())
+    if (!available_space.inline_size.is_definite())
         return content_y;
     if (!box_should_avoid_floats_because_it_establishes_fc(box))
         return content_y;
@@ -634,7 +634,7 @@ CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, Availab
         auto border_box_left_in_containing_block = border_box_left_of_box_avoiding_floats(box, box_state, space_used_by_floats);
 
         bool must_clear_below_current_band = constrained_by_floats
-            && border_box_left_in_containing_block + box_state.border_box_width() > available_space.width.to_px_or_zero() - space_used_by_floats.right;
+            && border_box_left_in_containing_block + box_state.border_box_width() > available_space.inline_size.to_px_or_zero() - space_used_by_floats.right;
 
         if (!must_clear_below_current_band) {
             CSSPixelRect border_box_rect_in_root {
@@ -668,7 +668,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     // 10.3.5 Floating, non-replaced elements
     auto& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.width.to_px_or_zero();
+    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
@@ -685,11 +685,11 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto compute_width = [&](CSS::LengthOrAuto width) {
         // If 'width' is computed as 'auto', the used value is the "shrink-to-fit" width.
         if (width.is_auto()) {
-            if (available_space.width.is_definite()) {
+            if (available_space.inline_size.is_definite()) {
                 // Find the available width: in this case, this is the width of the containing
                 // block minus the used values of 'margin-left', 'border-left-width', 'padding-left',
                 // 'padding-right', 'border-right-width', 'margin-right', and the widths of any relevant scroll bars.
-                auto available_width = available_space.width.to_px_or_zero()
+                auto available_width = available_space.inline_size.to_px_or_zero()
                     - margin_left - computed_values.border_left().width - box_state.padding_left
                     - box_state.padding_right - computed_values.border_right().width - margin_right;
                 // Then the shrink-to-fit width is: min(max(preferred minimum width, available width), preferred width).
@@ -700,7 +700,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
                     auto preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints);
                     width = CSS::Length::make_px(min(max(preferred_minimum_width, available_width), preferred_width));
                 }
-            } else if (available_space.width.is_indefinite() || available_space.width.is_max_content()) {
+            } else if (available_space.inline_size.is_indefinite() || available_space.inline_size.is_max_content()) {
                 // Fold the formula for shrink-to-fit width for indefinite and max-content available width.
                 width = CSS::Length::make_px(calculate_max_content_width(box, containing_block_constraints));
             } else {
@@ -715,7 +715,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto input_width = [&] -> CSS::LengthOrAuto {
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_width(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
@@ -723,8 +723,8 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
-        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width(), containing_block_constraints);
+    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (width.to_px_or_zero() > max_width)
             width = compute_width(CSS::Length::make_px(max_width));
     }
@@ -732,7 +732,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width(), containing_block_constraints);
+        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
         if (width.to_px_or_zero() < min_width)
             width = compute_width(CSS::Length::make_px(min_width));
     }
@@ -745,7 +745,7 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
     // 10.3.6 Floating, replaced elements
     auto& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.width.to_px_or_zero();
+    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
 
     // 10.3.4 Block-level, replaced elements in normal flow
     // The used value of 'width' is determined as for inline replaced elements. Then the rules for
@@ -779,7 +779,7 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
 
     auto height = calculate_inner_height(box, available_space, box.computed_values().height(), containing_block_constraints);
 
-    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints)) {
+    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
             auto max_height = calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
@@ -814,7 +814,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         }
     }
 
-    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints)) {
+    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
             auto max_height = calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
@@ -905,14 +905,14 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
             // Percentages are resolved against the width/height, as appropriate, of the box’s containing block.
             auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_width.value_or(0);
             auto available_width = AvailableSize::make_definite(containing_block_width);
-            if (!should_treat_max_width_as_none(block_container, available_space.width, layout_input.containing_block_constraints)) {
+            if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
                 auto max_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
                 if (used_width_px > max_width_px)
                     used_width_px = max_width_px;
             }
 
             auto should_treat_min_width_as_auto = [&] {
-                auto const& available_width = available_space.width;
+                auto const& available_width = available_space.inline_size;
                 auto const& min_width = block_container.computed_values().min_width();
                 if (min_width.is_auto())
                     return true;
@@ -947,16 +947,16 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
     if (display.is_flex_inside()) {
         // https://drafts.csswg.org/css-flexbox-1/#algo-main-container
         // NOTE: The automatic block size of a block-level flex container is its max-content size.
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
     if (display.is_grid_inside()) {
         // https://www.w3.org/TR/css-grid-2/#intrinsic-sizes
         // In both inline and block formatting contexts, the grid container’s auto block size is its
         // max-content size.
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
     if (display.is_table_inside()) {
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
 
     // https://www.w3.org/TR/CSS22/visudet.html#normal-block
@@ -1192,7 +1192,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
     bool is_in_ua_internal_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
     if (box.document().in_quirks_mode() && box.computed_values().height().is_percentage() && !is_table_box && !is_in_ua_internal_shadow_tree) {
-        available_space_for_height_resolution.height = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_height.value_or(0));
+        available_space_for_height_resolution.block_size = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_height.value_or(0));
     }
 
     resolve_used_height_if_not_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
@@ -1229,7 +1229,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             measured_content_height = content_height;
             auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
             if (content_height < min_height) {
-                inner_available_space.height = AvailableSize::make_definite(min_height);
+                inner_available_space.block_size = AvailableSize::make_definite(min_height);
             }
         }
 
@@ -1350,13 +1350,13 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             //       auto size in that axis (and no minimum or maximum size in that axis) and if its containing block
             //       was zero-sized in that axis.
             if (block_container_state.width_constraint == SizeConstraint::None) {
-                if (!should_treat_max_width_as_none(block_container, available_space.width, layout_input.containing_block_constraints)) {
-                    auto max_width = calculate_inner_width(block_container, available_space.width,
+                if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
+                    auto max_width = calculate_inner_width(block_container, available_space.inline_size,
                         computed_values.max_width(), layout_input.containing_block_constraints);
                     width = min(width, max_width);
                 }
                 if (!computed_values.min_width().is_auto()) {
-                    auto min_width = calculate_inner_width(block_container, available_space.width,
+                    auto min_width = calculate_inner_width(block_container, available_space.inline_size,
                         computed_values.min_width(), layout_input.containing_block_constraints);
                     width = max(width, min_width);
                 }
@@ -1418,12 +1418,12 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         auto width = greatest_child_width(fieldset_box);
         auto const& computed_values = fieldset_box.computed_values();
         if (fieldset_state.width_constraint == SizeConstraint::None) {
-            if (!should_treat_max_width_as_none(fieldset_box, available_space.width, layout_input.containing_block_constraints)) {
-                auto max_width = calculate_inner_width(fieldset_box, available_space.width, computed_values.max_width(), layout_input.containing_block_constraints);
+            if (!should_treat_max_width_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
+                auto max_width = calculate_inner_width(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
                 width = min(width, max_width);
             }
             if (!computed_values.min_width().is_auto()) {
-                auto min_width = calculate_inner_width(fieldset_box, available_space.width, computed_values.min_width(), layout_input.containing_block_constraints);
+                auto min_width = calculate_inner_width(fieldset_box, available_space.inline_size, computed_values.min_width(), layout_input.containing_block_constraints);
                 width = max(width, min_width);
             }
         }
@@ -1514,7 +1514,7 @@ CSSPixels BlockFormattingContext::compute_normal_flow_x(Box const& child_box, Av
     auto const& box_state = m_state.get(child_box);
 
     CSSPixels x = 0;
-    CSSPixels available_width_within_containing_block = available_space.width.to_px_or_zero();
+    CSSPixels available_width_within_containing_block = available_space.inline_size.to_px_or_zero();
 
     if (box_should_avoid_floats_because_it_establishes_fc(child_box)) {
         auto space_used_by_floats = intrusion_by_floats_into_rect({ content_position_in_root, box_state.content_size() }, 0, 0);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -967,7 +967,7 @@ CSSPixels BlockFormattingContext::compute_automatic_block_size_for_block_level_e
 
     // 1. the bottom edge of the last line box, if the box establishes a inline formatting context with one or more lines
     if (box.children_are_inline() && !box_state.line_boxes.is_empty()) {
-        auto block_size = box_state.line_boxes.last().bottom();
+        auto block_size = box_state.line_boxes.last().physical_vertical_end();
         if (box_state.line_boxes.last().has_block_level_box()) {
             auto margin_bottom = m_margin_state.current_collapsed_margin();
             if (box_state.padding_bottom == 0 && box_state.border_bottom == 0) {
@@ -1678,9 +1678,9 @@ CSSPixels BlockFormattingContext::greatest_child_inline_size_in_rect(Box const& 
 
     if (box.children_are_inline()) {
         for (auto const& line_box : m_state.get(as<BlockContainer>(box)).line_boxes) {
-            auto inline_size_here = line_box_physical_width(box, line_box);
-            auto line_top = line_box.bottom() - line_box.height();
-            auto line_bottom = line_box.bottom();
+            auto inline_size_here = line_box_physical_horizontal_extent(box, line_box);
+            auto line_block_start = line_box.physical_vertical_end() - line_box.physical_vertical_extent();
+            auto line_block_end = line_box.physical_vertical_end();
             CSSPixels extra_inline_size_from_left_floats = 0;
             for (auto& left_float : m_floats) {
                 if (left_float->side != FloatSide::Left)
@@ -1688,7 +1688,7 @@ CSSPixels BlockFormattingContext::greatest_child_inline_size_in_rect(Box const& 
                 // NOTE: Floats directly affect the automatic size of their containing block, but only indirectly anything above in the tree.
                 if (left_float->box.containing_block() != &box)
                     continue;
-                if (line_top < left_float->bottom_margin_edge && line_bottom > left_float->top_margin_edge) {
+                if (line_block_start < left_float->bottom_margin_edge && line_block_end > left_float->top_margin_edge) {
                     extra_inline_size_from_left_floats = max(extra_inline_size_from_left_floats, left_float->offset_from_edge + left_float->used_values.content_inline_size() + left_float->used_values.margin_box_right());
                 }
             }
@@ -1699,7 +1699,7 @@ CSSPixels BlockFormattingContext::greatest_child_inline_size_in_rect(Box const& 
                 // NOTE: Floats directly affect the automatic size of their containing block, but only indirectly anything above in the tree.
                 if (right_float->box.containing_block() != &box)
                     continue;
-                if (line_top < right_float->bottom_margin_edge && line_bottom > right_float->top_margin_edge) {
+                if (line_block_start < right_float->bottom_margin_edge && line_block_end > right_float->top_margin_edge) {
                     extra_inline_size_from_right_floats = max(extra_inline_size_from_right_floats, right_float->offset_from_edge + right_float->used_values.margin_box_left());
                 }
             }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -362,7 +362,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
             return CSS::Length::make_px(calculate_fit_content_inline_size(box, available_space, containing_block_constraints));
         }
 
-        if (should_treat_width_as_auto(box, available_space))
+        if (should_treat_inline_size_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
@@ -372,7 +372,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+    if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
         auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width)
             used_width = try_compute_width(CSS::Length::make_px(max_width));
@@ -713,7 +713,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     };
 
     auto input_width = [&] -> CSS::LengthOrAuto {
-        if (should_treat_width_as_auto(box, available_space))
+        if (should_treat_inline_size_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
@@ -723,7 +723,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+    if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
         auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (width.to_px_or_zero() > max_width)
             width = compute_width(CSS::Length::make_px(max_width));
@@ -770,7 +770,7 @@ void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_n
 
 void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
-    if (should_treat_height_as_auto(box, available_space, containing_block_constraints)) {
+    if (should_treat_block_size_as_auto(box, available_space, containing_block_constraints)) {
         return;
     }
 
@@ -779,7 +779,7 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
 
     auto height = calculate_inner_block_size(box, available_space, box.computed_values().height(), containing_block_constraints);
 
-    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
+    if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
             auto max_height = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
@@ -790,13 +790,13 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
     }
 
     box_state.set_content_block_size(height);
-    if (computed_height_establishes_definite_containing_block_height(computed_values.height()))
+    if (computed_block_size_establishes_definite_containing_block_size(computed_values.height()))
         box_state.set_has_definite_block_size(true);
 }
 
 void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context)
 {
-    if (!should_treat_height_as_auto(box, available_space, containing_block_constraints)) {
+    if (!should_treat_block_size_as_auto(box, available_space, containing_block_constraints)) {
         return;
     }
 
@@ -814,7 +814,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         }
     }
 
-    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
+    if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
             auto max_height = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
@@ -905,7 +905,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
             // Percentages are resolved against the width/height, as appropriate, of the box’s containing block.
             auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
             auto available_width = AvailableSize::make_definite(containing_block_width);
-            if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
+            if (!should_treat_max_inline_size_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
                 auto max_width_px = calculate_inner_inline_size(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
                 if (used_width_px > max_width_px)
                     used_width_px = max_width_px;
@@ -1224,7 +1224,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // For boxes with auto height but non-auto min-height, we need to determine if the content height is less than
         // min-height. If so, we run layout with min-height as the available height.
         Optional<CSSPixels> measured_content_height;
-        if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
+        if (should_treat_block_size_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
             auto content_block_size = measure_automatic_content_block_size(box, inner_available_space, layout_input.containing_block_constraints);
             measured_content_height = content_block_size;
             auto min_height = calculate_inner_block_size(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
@@ -1350,7 +1350,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             //       auto size in that axis (and no minimum or maximum size in that axis) and if its containing block
             //       was zero-sized in that axis.
             if (block_container_state.inline_size_constraint == SizeConstraint::None) {
-                if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
+                if (!should_treat_max_inline_size_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
                     auto max_width = calculate_inner_inline_size(block_container, available_space.inline_size,
                         computed_values.max_width(), layout_input.containing_block_constraints);
                     width = min(width, max_width);
@@ -1418,7 +1418,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         auto width = greatest_child_width(fieldset_box);
         auto const& computed_values = fieldset_box.computed_values();
         if (fieldset_state.inline_size_constraint == SizeConstraint::None) {
-            if (!should_treat_max_width_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
+            if (!should_treat_max_inline_size_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
                 auto max_width = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
                 width = min(width, max_width);
             }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -897,7 +897,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         auto used_inline_size_px = context.automatic_content_inline_size();
         // NOTE: Min and max constraints are not applied to a box that is being sized under an intrinsic
         //       sizing constraint: per css-sizing-3, min/max-width affect a box's intrinsic size
-        //       *contributions*, and the callers of calculate_{min,max}_content_width() apply them.
+        //       *contributions*, and the callers of calculate_{min,max}_content_inline_size() apply them.
         //       Applying them here would bake the box's own min/max-width into its measured intrinsic
         //       size, and the border-box adjustment would consume border/padding that measurement
         //       state does not have.

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -321,10 +321,10 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
                     }
                 } else if (available_space.inline_size.is_min_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
-                        width = CSS::Length::make_px(calculate_min_content_width(box, containing_block_constraints));
+                        width = CSS::Length::make_px(calculate_min_content_inline_size(box, containing_block_constraints));
                 } else if (available_space.inline_size.is_max_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
-                        width = CSS::Length::make_px(calculate_max_content_width(box, containing_block_constraints));
+                        width = CSS::Length::make_px(calculate_max_content_inline_size(box, containing_block_constraints));
                 } else {
                     VERIFY_NOT_REACHED();
                 }
@@ -359,12 +359,12 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
         // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
         if (auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node()); html_element
             && html_element->uses_button_layout() && computed_values.width().is_auto()) {
-            return CSS::Length::make_px(calculate_fit_content_width(box, available_space, containing_block_constraints));
+            return CSS::Length::make_px(calculate_fit_content_inline_size(box, available_space, containing_block_constraints));
         }
 
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
@@ -373,7 +373,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
+        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width)
             used_width = try_compute_width(CSS::Length::make_px(max_width));
     }
@@ -381,7 +381,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto() && !used_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
+        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() < min_width)
             used_width = try_compute_width(CSS::Length::make_px(min_width));
     }
@@ -693,19 +693,19 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
                     - margin_left - computed_values.border_left().width - box_state.padding_left
                     - box_state.padding_right - computed_values.border_right().width - margin_right;
                 // Then the shrink-to-fit width is: min(max(preferred minimum width, available width), preferred width).
-                auto preferred_width = calculate_max_content_width(box, containing_block_constraints);
+                auto preferred_width = calculate_max_content_inline_size(box, containing_block_constraints);
                 if (preferred_width <= available_width) {
                     width = CSS::Length::make_px(preferred_width);
                 } else {
-                    auto preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints);
+                    auto preferred_minimum_width = calculate_min_content_inline_size(box, containing_block_constraints);
                     width = CSS::Length::make_px(min(max(preferred_minimum_width, available_width), preferred_width));
                 }
             } else if (available_space.inline_size.is_indefinite() || available_space.inline_size.is_max_content()) {
                 // Fold the formula for shrink-to-fit width for indefinite and max-content available width.
-                width = CSS::Length::make_px(calculate_max_content_width(box, containing_block_constraints));
+                width = CSS::Length::make_px(calculate_max_content_inline_size(box, containing_block_constraints));
             } else {
                 // Fold the formula for shrink-to-fit width for min-content available width.
-                width = CSS::Length::make_px(calculate_min_content_width(box, containing_block_constraints));
+                width = CSS::Length::make_px(calculate_min_content_inline_size(box, containing_block_constraints));
             }
         }
 
@@ -715,7 +715,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     auto input_width = [&] -> CSS::LengthOrAuto {
         if (should_treat_width_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
@@ -724,7 +724,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
+        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (width.to_px_or_zero() > max_width)
             width = compute_width(CSS::Length::make_px(max_width));
     }
@@ -732,7 +732,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box const& box, Avai
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
+        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
         if (width.to_px_or_zero() < min_width)
             width = compute_width(CSS::Length::make_px(min_width));
     }
@@ -777,16 +777,16 @@ void BlockFormattingContext::resolve_used_height_if_not_treated_as_auto(Box cons
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
 
-    auto height = calculate_inner_height(box, available_space, box.computed_values().height(), containing_block_constraints);
+    auto height = calculate_inner_block_size(box, available_space, box.computed_values().height(), containing_block_constraints);
 
     if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
-            auto max_height = calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints);
+            auto max_height = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
         }
     }
     if (!computed_values.min_height().is_auto()) {
-        height = max(height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
+        height = max(height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
     box_state.set_content_block_size(height);
@@ -816,12 +816,12 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
 
     if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
         if (!computed_values.max_height().is_auto()) {
-            auto max_height = calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints);
+            auto max_height = calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints);
             height = min(height, max_height);
         }
     }
     if (!computed_values.min_height().is_auto()) {
-        height = max(height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
+        height = max(height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
     }
 
     if (box.document().in_quirks_mode()
@@ -906,7 +906,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
             auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
             auto available_width = AvailableSize::make_definite(containing_block_width);
             if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
-                auto max_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
+                auto max_width_px = calculate_inner_inline_size(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
                 if (used_width_px > max_width_px)
                     used_width_px = max_width_px;
             }
@@ -925,7 +925,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
                 return false;
             }();
             if (!should_treat_min_width_as_auto) {
-                auto min_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().min_width(), layout_input.containing_block_constraints);
+                auto min_width_px = calculate_inner_inline_size(block_container, available_width, block_container.computed_values().min_width(), layout_input.containing_block_constraints);
                 if (used_width_px < min_width_px)
                     used_width_px = min_width_px;
             }
@@ -947,16 +947,16 @@ CSSPixels BlockFormattingContext::compute_auto_height_for_block_level_element(Bo
     if (display.is_flex_inside()) {
         // https://drafts.csswg.org/css-flexbox-1/#algo-main-container
         // NOTE: The automatic block size of a block-level flex container is its max-content size.
-        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
     if (display.is_grid_inside()) {
         // https://www.w3.org/TR/css-grid-2/#intrinsic-sizes
         // In both inline and block formatting contexts, the grid container’s auto block size is its
         // max-content size.
-        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
     if (display.is_table_inside()) {
-        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
 
     // https://www.w3.org/TR/CSS22/visudet.html#normal-block
@@ -1227,7 +1227,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
             auto content_block_size = measure_automatic_content_height(box, inner_available_space, layout_input.containing_block_constraints);
             measured_content_height = content_block_size;
-            auto min_height = calculate_inner_height(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
+            auto min_height = calculate_inner_block_size(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
             if (content_block_size < min_height) {
                 inner_available_space.block_size = AvailableSize::make_definite(min_height);
             }
@@ -1351,12 +1351,12 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             //       was zero-sized in that axis.
             if (block_container_state.inline_size_constraint == SizeConstraint::None) {
                 if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
-                    auto max_width = calculate_inner_width(block_container, available_space.inline_size,
+                    auto max_width = calculate_inner_inline_size(block_container, available_space.inline_size,
                         computed_values.max_width(), layout_input.containing_block_constraints);
                     width = min(width, max_width);
                 }
                 if (!computed_values.min_width().is_auto()) {
-                    auto min_width = calculate_inner_width(block_container, available_space.inline_size,
+                    auto min_width = calculate_inner_inline_size(block_container, available_space.inline_size,
                         computed_values.min_width(), layout_input.containing_block_constraints);
                     width = max(width, min_width);
                 }
@@ -1390,7 +1390,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
     auto& legend_state = m_state.get_mutable(*legend);
     if (legend->computed_values().width().is_auto()) {
-        auto width = calculate_fit_content_width(*legend, available_space, child_layout_input.containing_block_constraints);
+        auto width = calculate_fit_content_inline_size(*legend, available_space, child_layout_input.containing_block_constraints);
         legend_state.set_content_inline_size(width);
     }
 
@@ -1419,11 +1419,11 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
         auto const& computed_values = fieldset_box.computed_values();
         if (fieldset_state.inline_size_constraint == SizeConstraint::None) {
             if (!should_treat_max_width_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
-                auto max_width = calculate_inner_width(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
+                auto max_width = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
                 width = min(width, max_width);
             }
             if (!computed_values.min_width().is_auto()) {
-                auto min_width = calculate_inner_width(fieldset_box, available_space.inline_size, computed_values.min_width(), layout_input.containing_block_constraints);
+                auto min_width = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.min_width(), layout_input.containing_block_constraints);
                 width = max(width, min_width);
             }
         }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -179,7 +179,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
                 case SizeConstraint::MaxContent:
                     return CSSPixels::max();
                 case SizeConstraint::None:
-                    return floating_box->percentage_basis_width.value_or(0);
+                    return floating_box->percentage_basis_inline_size.value_or(0);
                 }
                 VERIFY_NOT_REACHED();
             }();
@@ -838,7 +838,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         auto margins = box_state.margin_top + box_state.margin_bottom;
 
         // 2. Let size be the size of the initial containing block in the block flow direction minus margins.
-        auto size = containing_block_constraints.percentage_basis_height.value_or(0) - margins;
+        auto size = containing_block_constraints.percentage_basis_block_size.value_or(0) - margins;
 
         // 3. Return the bigger value of size and the normal border box size the element would have
         //    according to the CSS specification.
@@ -869,7 +869,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
             auto margins = box_state.margin_top + box_state.margin_bottom;
 
             // 2. Let size be the size of element's parent element's content box in the block flow direction minus margins.
-            auto size = containing_block_constraints.percentage_basis_height.value_or(0) - margins;
+            auto size = containing_block_constraints.percentage_basis_block_size.value_or(0) - margins;
 
             // 3. Return the bigger value of size and the normal border box size the element would have
             //    according to the CSS specification.
@@ -903,7 +903,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         if (block_container_state.width_constraint == SizeConstraint::None) {
             // https://www.w3.org/TR/css-sizing-3/#sizing-values
             // Percentages are resolved against the width/height, as appropriate, of the box’s containing block.
-            auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_width.value_or(0);
+            auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
             auto available_width = AvailableSize::make_definite(containing_block_width);
             if (!should_treat_max_width_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
                 auto max_width_px = calculate_inner_width(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
@@ -1083,7 +1083,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             if (auto* existing_state = m_state.try_get_mutable(box))
                 return *existing_state;
         }
-        return m_state.create(box, layout_input.containing_block_constraints.percentage_basis_width, layout_input.containing_block_constraints.percentage_basis_height);
+        return m_state.create(box, layout_input.containing_block_constraints.percentage_basis_inline_size, layout_input.containing_block_constraints.percentage_basis_block_size);
     }();
 
     resolve_vertical_box_model_metrics(box, block_container_state.content_width());
@@ -1192,7 +1192,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
     bool is_in_ua_internal_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
     if (box.document().in_quirks_mode() && box.computed_values().height().is_percentage() && !is_table_box && !is_in_ua_internal_shadow_tree) {
-        available_space_for_height_resolution.block_size = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_height.value_or(0));
+        available_space_for_height_resolution.block_size = AvailableSize::make_definite(layout_input.containing_block_constraints.quirks_mode_percentage_basis_block_size.value_or(0));
     }
 
     resolve_used_height_if_not_treated_as_auto(box, available_space_for_height_resolution, layout_input.containing_block_constraints);
@@ -1604,7 +1604,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
         .bottom_margin_edge = content_y + box_state.content_height() + box_state.margin_box_bottom(),
         .margin_box_rect_in_root_coordinate_space = margin_box_rect_in_root,
         .containing_block_rect_in_root_coordinate_space = containing_block_rect_in_root,
-        .percentage_basis_width = layout_input.containing_block_constraints.percentage_basis_width,
+        .percentage_basis_inline_size = layout_input.containing_block_constraints.percentage_basis_inline_size,
     }));
     auto& floating_box = *m_floats.last();
     floating_box.margin_box_rect_in_root_coordinate_space.set_x(margin_box_left_of_float_in_root(floating_box, containing_block_rect_in_root));

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -62,7 +62,7 @@ CSSPixels BlockFormattingContext::automatic_content_inline_size() const
             }
             return TraversalDecision::Continue;
         });
-        return m_state.get(*table_box).border_box_width();
+        return m_state.get(*table_box).border_box_inline_size();
     }
     return greatest_child_width(root());
 }
@@ -98,7 +98,7 @@ static bool margins_collapse_through(Box const& box, LayoutState& state)
 
     // NB: This should take care of the height and min-height constraints.
     //     ( also see https://github.com/w3c/csswg-drafts/pull/13699#issuecomment-4103045370 for spec ambiguity )
-    if (state.get(box).border_box_height() != 0)
+    if (state.get(box).border_box_block_size() != 0)
         return false;
 
     // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-margin-collapse
@@ -464,7 +464,7 @@ FormattingContext::SpaceUsedByFloats BlockFormattingContext::intrusion_by_floats
 
 BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(FloatSide side, LayoutState::UsedValues const& box_state, AvailableSpace const& available_space, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const
 {
-    auto const margin_box_width = box_state.margin_box_width();
+    auto const margin_box_inline_size = box_state.margin_box_inline_size();
     auto candidate_block_start = ceiling_in_root;
 
     for (;;) {
@@ -473,7 +473,7 @@ BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(Float
         auto available_width = available_space.inline_size.to_px_or_zero() - intrusions.left - intrusions.right;
         auto has_floats_present = band.left_intrusion > 0 || band.right_intrusion > 0;
 
-        if (available_space.inline_size.is_max_content() || available_space.inline_size.is_indefinite() || margin_box_width <= available_width || !has_floats_present) {
+        if (available_space.inline_size.is_max_content() || available_space.inline_size.is_indefinite() || margin_box_inline_size <= available_width || !has_floats_present) {
             auto offset_from_edge = side == FloatSide::Left
                 ? intrusions.left + box_state.margin_box_left()
                 : intrusions.right + box_state.content_inline_size() + box_state.margin_box_right();
@@ -627,21 +627,21 @@ CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, Availab
         auto border_box_y_in_root = containing_block_rect_in_root.y() + content_y - box_state.border_box_top();
         auto band_containing_block_rect = containing_block_rect_in_root;
         band_containing_block_rect.set_y(border_box_y_in_root);
-        band_containing_block_rect.set_height(box_state.border_box_height());
+        band_containing_block_rect.set_height(box_state.border_box_block_size());
         auto const& band = band_at(border_box_y_in_root);
         auto space_used_by_floats = intrusions_for_band_into_rect(band, band_containing_block_rect);
         bool const constrained_by_floats = space_used_by_floats.left > 0 || space_used_by_floats.right > 0;
         auto border_box_left_in_containing_block = border_box_left_of_box_avoiding_floats(box, box_state, space_used_by_floats);
 
         bool must_clear_below_current_band = constrained_by_floats
-            && border_box_left_in_containing_block + box_state.border_box_width() > available_space.inline_size.to_px_or_zero() - space_used_by_floats.right;
+            && border_box_left_in_containing_block + box_state.border_box_inline_size() > available_space.inline_size.to_px_or_zero() - space_used_by_floats.right;
 
         if (!must_clear_below_current_band) {
             CSSPixelRect border_box_rect_in_root {
                 band_containing_block_rect.x() + border_box_left_in_containing_block,
                 border_box_y_in_root,
-                box_state.border_box_width(),
-                box_state.border_box_height(),
+                box_state.border_box_inline_size(),
+                box_state.border_box_block_size(),
             };
             must_clear_below_current_band = any_of(m_floats, [&](auto const& floating_box) {
                 auto margin_box_rect_in_root = floating_box->margin_box_rect_in_root_coordinate_space.translated(
@@ -1397,7 +1397,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     // The space allocated for the element's border on the block-start side is expected to be the element's
     // 'border-block-start-width' or the rendered legend's margin box size in the fieldset's block-flow direction,
     // whichever is greater.
-    auto effective_border = max(fieldset_state.border_top, legend_state.margin_box_height());
+    auto effective_border = max(fieldset_state.border_top, legend_state.margin_box_block_size());
     auto extra_top = effective_border - fieldset_state.border_top;
 
     // Lay out non-legend children below the legend accommodation.
@@ -1434,7 +1434,7 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     // The element is expected to be positioned in the block-flow direction such that its border box is centered over
     // the border on the block-start side of the fieldset element.
     // FIXME: Take writing modes into consideration.
-    auto legend_border_box_centering_offset = (effective_border - legend_state.border_box_height()) / 2;
+    auto legend_border_box_centering_offset = (effective_border - legend_state.border_box_block_size()) / 2;
     auto fieldset_border_box_top_in_content = -(fieldset_state.border_top + fieldset_state.padding_top);
     auto legend_content_y = fieldset_border_box_top_in_content + legend_border_box_centering_offset + legend_state.border_box_top();
     if (auto legend_flow_position = m_pending_legend_flow_position; legend_flow_position.has_value()) {
@@ -1710,7 +1710,7 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
             if (child.is_absolutely_positioned())
                 return IterationDecision::Continue;
             if (auto const* child_state = m_state.try_get(child))
-                max_width = max(max_width, child_state->margin_box_width());
+                max_width = max(max_width, child_state->margin_box_inline_size());
             return IterationDecision::Continue;
         });
     }

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -171,8 +171,8 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
             // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
             place_child(floating_box->box, { floating_box->offset_from_edge, content_y });
         } else {
-            // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
-            auto float_containing_block_width = [&] {
+            // Right-side floats: offset_from_edge is from right edge (float_containing_block_inline_size) to the left content edge of floating_box.
+            auto float_containing_block_inline_size = [&] {
                 switch (floating_box->used_values.inline_size_constraint) {
                 case SizeConstraint::MinContent:
                     return CSSPixels(0);
@@ -183,7 +183,7 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
                 }
                 VERIFY_NOT_REACHED();
             }();
-            place_child(floating_box->box, { float_containing_block_width - floating_box->offset_from_edge, content_y });
+            place_child(floating_box->box, { float_containing_block_inline_size - floating_box->offset_from_edge, content_y });
         }
     }
 
@@ -218,31 +218,31 @@ bool BlockFormattingContext::box_should_avoid_floats_because_it_establishes_fc(B
         && first_is_one_of(formatting_context_type.value(), Type::Block, Type::Flex, Type::Grid);
 }
 
-void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root)
+void BlockFormattingContext::compute_inline_size(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root)
 {
     auto remaining_available_space = available_space;
 
     // Certain formatting contexts do not allow float intrusions, so reduce the available space for them.
     if (available_space.inline_size.is_definite() && box_should_avoid_floats_because_it_establishes_fc(box)) {
-        auto available_width = available_space.inline_size.to_px_or_zero();
+        auto available_inline_size = available_space.inline_size.to_px_or_zero();
         auto box_in_root_rect = CSSPixelRect { content_position_in_root, m_state.get(box).content_size() };
-        box_in_root_rect.set_width(available_width);
+        box_in_root_rect.set_width(available_inline_size);
         auto intrusion = intrusions_for_band_into_rect(band_at(box_in_root_rect.y()), box_in_root_rect);
-        auto remaining_width = available_width - intrusion.left - intrusion.right;
+        auto remaining_inline_size = available_inline_size - intrusion.left - intrusion.right;
         if (intrusion.left > 0 || intrusion.right > 0) {
             // Negative margins do not create additional space next to a float. Reduce the space available for
-            // resolving an automatic width by any negative margins, so that the resulting border box is no wider
-            // than the space next to the float.
-            auto margin_left = box.computed_values().margin().left().resolved_or_auto(available_width).to_px_or_zero();
-            auto margin_right = box.computed_values().margin().right().resolved_or_auto(available_width).to_px_or_zero();
+            // resolving an automatic inline size by any negative margins, so that the resulting border box is no
+            // larger than the space next to the float in the inline axis.
+            auto margin_left = box.computed_values().margin().left().resolved_or_auto(available_inline_size).to_px_or_zero();
+            auto margin_right = box.computed_values().margin().right().resolved_or_auto(available_inline_size).to_px_or_zero();
             auto negative_margin_sum = min(margin_left, CSSPixels(0)) + min(margin_right, CSSPixels(0));
-            remaining_width = max(remaining_width + negative_margin_sum, CSSPixels(0));
+            remaining_inline_size = max(remaining_inline_size + negative_margin_sum, CSSPixels(0));
         }
-        remaining_available_space.inline_size = AvailableSize::make_definite(remaining_width);
+        remaining_available_space.inline_size = AvailableSize::make_definite(remaining_inline_size);
     }
 
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
-        compute_width_for_block_level_replaced_element_in_normal_flow(box, available_space, containing_block_constraints);
+        compute_inline_size_for_block_level_replaced_element_in_normal_flow(box, available_space, containing_block_constraints);
         if (box.is_floating()) {
             // 10.3.6 Floating, replaced elements:
             // https://www.w3.org/TR/CSS22/visudet.html#float-replaced-width
@@ -253,16 +253,16 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     if (box.is_floating()) {
         // 10.3.5 Floating, non-replaced elements:
         // https://www.w3.org/TR/CSS22/visudet.html#float-width
-        compute_width_for_floating_box(box, available_space, containing_block_constraints);
+        compute_inline_size_for_floating_box(box, available_space, containing_block_constraints);
         return;
     }
 
     auto const& computed_values = box.computed_values();
-    auto available_width_px = available_space.inline_size.to_px_or_zero();
-    auto margin_left = computed_values.margin().left().resolved_or_auto(available_width_px);
-    auto margin_right = computed_values.margin().right().resolved_or_auto(available_width_px);
-    auto const padding_left = computed_values.padding().left().resolved_or_auto(available_width_px);
-    auto const padding_right = computed_values.padding().right().resolved_or_auto(available_width_px);
+    auto available_inline_size = available_space.inline_size.to_px_or_zero();
+    auto margin_left = computed_values.margin().left().resolved_or_auto(available_inline_size);
+    auto margin_right = computed_values.margin().right().resolved_or_auto(available_inline_size);
+    auto const padding_left = computed_values.padding().left().resolved_or_auto(available_inline_size);
+    auto const padding_right = computed_values.padding().right().resolved_or_auto(available_inline_size);
 
     auto& box_state = m_state.get_mutable(box);
     box_state.margin_left = margin_left.to_px_or_zero();
@@ -272,21 +272,21 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     box_state.padding_left = padding_left.to_px_or_zero();
     box_state.padding_right = padding_right.to_px_or_zero();
 
-    // NOTE: If we are calculating the min-content or max-content width of this box,
-    //       and the width should be treated as auto, then we can simply return here,
-    //       as the preferred width and min/max constraints are irrelevant for intrinsic sizing.
+    // NOTE: If we are calculating the min-content or max-content inline size of this box,
+    //       and the inline size should be treated as auto, then we can simply return here,
+    //       as the preferred inline size and min/max constraints are irrelevant for intrinsic sizing.
     if (box_state.inline_size_constraint != SizeConstraint::None)
         return;
 
-    auto const remaining_width_px = remaining_available_space.inline_size.to_px_or_zero();
+    auto const remaining_inline_size = remaining_available_space.inline_size.to_px_or_zero();
     auto const zero_value = CSS::Length::make_px(0);
 
-    auto try_compute_width = [&](CSS::LengthOrAuto const& a_width) {
-        auto width = a_width;
+    auto try_compute_inline_size = [&](CSS::LengthOrAuto const& input_inline_size) {
+        auto inline_size = input_inline_size;
         margin_left = computed_values.margin().left().resolved_or_auto(available_space.inline_size.to_px_or_zero());
         margin_right = computed_values.margin().right().resolved_or_auto(available_space.inline_size.to_px_or_zero());
         CSSPixels total_px = computed_values.border_left().width + computed_values.border_right().width;
-        for (auto& value : { CSS::LengthOrAuto(margin_left), CSS::LengthOrAuto(padding_left), width, CSS::LengthOrAuto(padding_right), CSS::LengthOrAuto(margin_right) })
+        for (auto& value : { CSS::LengthOrAuto(margin_left), CSS::LengthOrAuto(padding_left), inline_size, CSS::LengthOrAuto(padding_right), CSS::LengthOrAuto(margin_right) })
             total_px += value.to_px_or_zero();
 
         if (!box.is_inline()) {
@@ -295,7 +295,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
             // 'border-right-width' (plus any of 'margin-left' or 'margin-right' that are not 'auto') is larger than the
             // width of the containing block, then any 'auto' values for 'margin-left' or 'margin-right' are, for the
             // following rules, treated as zero.
-            if (!width.is_auto() && total_px > remaining_width_px) {
+            if (!inline_size.is_auto() && total_px > remaining_inline_size) {
                 if (margin_left.is_auto())
                     margin_left = zero_value;
                 if (margin_right.is_auto())
@@ -303,11 +303,11 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
             }
 
             // 10.3.3 cont'd.
-            auto underflow_px = remaining_width_px - total_px;
+            auto underflow_px = remaining_inline_size - total_px;
             if (available_space.inline_size.is_intrinsic_sizing_constraint())
                 underflow_px = 0;
 
-            if (width.is_auto()) {
+            if (inline_size.is_auto()) {
                 if (margin_left.is_auto())
                     margin_left = zero_value;
                 if (margin_right.is_auto())
@@ -315,16 +315,16 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
 
                 if (available_space.inline_size.is_definite()) {
                     if (underflow_px >= 0) {
-                        width = CSS::Length::make_px(underflow_px);
+                        inline_size = CSS::Length::make_px(underflow_px);
                     } else {
-                        width = zero_value;
+                        inline_size = zero_value;
                     }
                 } else if (available_space.inline_size.is_min_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
-                        width = CSS::Length::make_px(calculate_min_content_inline_size(box, containing_block_constraints));
+                        inline_size = CSS::Length::make_px(calculate_min_content_inline_size(box, containing_block_constraints));
                 } else if (available_space.inline_size.is_max_content()) {
                     if (formatting_context_type_created_by_box(box).has_value())
-                        width = CSS::Length::make_px(calculate_max_content_inline_size(box, containing_block_constraints));
+                        inline_size = CSS::Length::make_px(calculate_max_content_inline_size(box, containing_block_constraints));
                 } else {
                     VERIFY_NOT_REACHED();
                 }
@@ -343,13 +343,13 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
             }
         }
 
-        return width;
+        return inline_size;
     };
 
-    auto input_width = [&] -> CSS::LengthOrAuto {
+    auto input_inline_size = [&] -> CSS::LengthOrAuto {
         if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints)) {
-            // NOTE: Replaced elements had their width calculated independently above.
-            //       We use that width as the input here to ensure that margins get resolved.
+            // NOTE: Replaced elements had their inline size calculated independently above.
+            //       We use that inline size as the input here to ensure that margins get resolved.
             return CSS::Length::make_px(box_state.content_inline_size());
         }
         if (is<TableWrapper>(box))
@@ -368,26 +368,26 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
-    auto used_width = try_compute_width(input_width);
+    auto used_inline_size = try_compute_inline_size(input_inline_size);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
-        if (used_width.to_px_or_zero() > max_width)
-            used_width = try_compute_width(CSS::Length::make_px(max_width));
+        auto max_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
+        if (used_inline_size.to_px_or_zero() > max_inline_size)
+            used_inline_size = try_compute_inline_size(CSS::Length::make_px(max_inline_size));
     }
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    if (!computed_values.min_width().is_auto() && !used_width.is_auto()) {
-        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
-        if (used_width.to_px_or_zero() < min_width)
-            used_width = try_compute_width(CSS::Length::make_px(min_width));
+    if (!computed_values.min_width().is_auto() && !used_inline_size.is_auto()) {
+        auto min_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
+        if (used_inline_size.to_px_or_zero() < min_inline_size)
+            used_inline_size = try_compute_inline_size(CSS::Length::make_px(min_inline_size));
     }
 
-    if (!box_is_sized_as_replaced_element(box, available_space, containing_block_constraints) && !used_width.is_auto())
-        box_state.set_content_inline_size(used_width.to_px_or_zero());
+    if (!box_is_sized_as_replaced_element(box, available_space, containing_block_constraints) && !used_inline_size.is_auto())
+        box_state.set_content_inline_size(used_inline_size.to_px_or_zero());
 
     box_state.margin_left = margin_left.to_px_or_zero();
     box_state.margin_right = margin_right.to_px_or_zero();
@@ -470,10 +470,10 @@ BlockFormattingContext::FloatPlacement BlockFormattingContext::place_float(Float
     for (;;) {
         auto const& band = band_at(candidate_block_start);
         auto intrusions = intrusions_for_band_into_rect(band, containing_block_rect_in_root);
-        auto available_width = available_space.inline_size.to_px_or_zero() - intrusions.left - intrusions.right;
+        auto available_inline_size = available_space.inline_size.to_px_or_zero() - intrusions.left - intrusions.right;
         auto has_floats_present = band.left_intrusion > 0 || band.right_intrusion > 0;
 
-        if (available_space.inline_size.is_max_content() || available_space.inline_size.is_indefinite() || margin_box_inline_size <= available_width || !has_floats_present) {
+        if (available_space.inline_size.is_max_content() || available_space.inline_size.is_indefinite() || margin_box_inline_size <= available_inline_size || !has_floats_present) {
             auto offset_from_edge = side == FloatSide::Left
                 ? intrusions.left + box_state.margin_box_left()
                 : intrusions.right + box_state.content_inline_size() + box_state.margin_box_right();
@@ -658,103 +658,104 @@ CSSPixels BlockFormattingContext::avoid_float_intrusions(Box const& box, Availab
 
         content_y += next_band_start.value() - border_box_y_in_root;
         auto content_position_in_root = containing_block_rect_in_root.location().translated(0, content_y);
-        compute_width(box, available_space, containing_block_constraints, content_position_in_root);
+        compute_inline_size(box, available_space, containing_block_constraints, content_position_in_root);
     }
     return content_y;
 }
 
-void BlockFormattingContext::compute_width_for_floating_box(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void BlockFormattingContext::compute_inline_size_for_floating_box(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     // 10.3.5 Floating, non-replaced elements
     auto& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
-    auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
-    auto margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
+    auto margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
+    auto margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
     box_state.margin_left = margin_left;
     box_state.margin_right = margin_right;
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
 
-    auto compute_width = [&](CSS::LengthOrAuto width) {
+    auto compute_inline_size = [&](CSS::LengthOrAuto inline_size) {
         // If 'width' is computed as 'auto', the used value is the "shrink-to-fit" width.
-        if (width.is_auto()) {
+        if (inline_size.is_auto()) {
             if (available_space.inline_size.is_definite()) {
-                // Find the available width: in this case, this is the width of the containing
+                // Find the available inline size: in this case, this is the inline size of the containing
                 // block minus the used values of 'margin-left', 'border-left-width', 'padding-left',
                 // 'padding-right', 'border-right-width', 'margin-right', and the widths of any relevant scroll bars.
-                auto available_width = available_space.inline_size.to_px_or_zero()
+                auto available_inline_size = available_space.inline_size.to_px_or_zero()
                     - margin_left - computed_values.border_left().width - box_state.padding_left
                     - box_state.padding_right - computed_values.border_right().width - margin_right;
-                // Then the shrink-to-fit width is: min(max(preferred minimum width, available width), preferred width).
-                auto preferred_width = calculate_max_content_inline_size(box, containing_block_constraints);
-                if (preferred_width <= available_width) {
-                    width = CSS::Length::make_px(preferred_width);
+                // Then the shrink-to-fit inline size is:
+                // min(max(preferred minimum inline size, available inline size), preferred inline size).
+                auto preferred_inline_size = calculate_max_content_inline_size(box, containing_block_constraints);
+                if (preferred_inline_size <= available_inline_size) {
+                    inline_size = CSS::Length::make_px(preferred_inline_size);
                 } else {
-                    auto preferred_minimum_width = calculate_min_content_inline_size(box, containing_block_constraints);
-                    width = CSS::Length::make_px(min(max(preferred_minimum_width, available_width), preferred_width));
+                    auto preferred_minimum_inline_size = calculate_min_content_inline_size(box, containing_block_constraints);
+                    inline_size = CSS::Length::make_px(min(max(preferred_minimum_inline_size, available_inline_size), preferred_inline_size));
                 }
             } else if (available_space.inline_size.is_indefinite() || available_space.inline_size.is_max_content()) {
-                // Fold the formula for shrink-to-fit width for indefinite and max-content available width.
-                width = CSS::Length::make_px(calculate_max_content_inline_size(box, containing_block_constraints));
+                // Fold the shrink-to-fit formula for an indefinite or max-content available inline size.
+                inline_size = CSS::Length::make_px(calculate_max_content_inline_size(box, containing_block_constraints));
             } else {
-                // Fold the formula for shrink-to-fit width for min-content available width.
-                width = CSS::Length::make_px(calculate_min_content_inline_size(box, containing_block_constraints));
+                // Fold the shrink-to-fit formula for a min-content available inline size.
+                inline_size = CSS::Length::make_px(calculate_min_content_inline_size(box, containing_block_constraints));
             }
         }
 
-        return width;
+        return inline_size;
     };
 
-    auto input_width = [&] -> CSS::LengthOrAuto {
+    auto input_inline_size = [&] -> CSS::LengthOrAuto {
         if (should_treat_inline_size_as_auto(box, available_space))
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
-    auto width = compute_width(input_width);
+    auto inline_size = compute_inline_size(input_inline_size);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
-        if (width.to_px_or_zero() > max_width)
-            width = compute_width(CSS::Length::make_px(max_width));
+        auto max_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
+        if (inline_size.to_px_or_zero() > max_inline_size)
+            inline_size = compute_inline_size(CSS::Length::make_px(max_inline_size));
     }
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
-        if (width.to_px_or_zero() < min_width)
-            width = compute_width(CSS::Length::make_px(min_width));
+        auto min_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
+        if (inline_size.to_px_or_zero() < min_inline_size)
+            inline_size = compute_inline_size(CSS::Length::make_px(min_inline_size));
     }
 
-    box_state.set_content_inline_size(width.to_px_or_zero());
+    box_state.set_content_inline_size(inline_size.to_px_or_zero());
 }
 
-void BlockFormattingContext::compute_width_for_block_level_replaced_element_in_normal_flow(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
+void BlockFormattingContext::compute_inline_size_for_block_level_replaced_element_in_normal_flow(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     // 10.3.6 Floating, replaced elements
     auto& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
 
     // 10.3.4 Block-level, replaced elements in normal flow
     // The used value of 'width' is determined as for inline replaced elements. Then the rules for
     // non-replaced block-level elements are applied to determine the margins.
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
-    auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
-    auto margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
-    auto const padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
-    auto const padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
+    auto margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
+    auto margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
+    auto const padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
+    auto const padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 
     auto& box_state = m_state.get_mutable(box);
     box_state.margin_left = margin_left;
@@ -892,8 +893,8 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
 
     if (!block_container_state.has_definite_inline_size()) {
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
-        //       is done and width of box content is known
-        auto used_width_px = context.automatic_content_inline_size();
+        //       is done and the inline size of the box content is known
+        auto used_inline_size_px = context.automatic_content_inline_size();
         // NOTE: Min and max constraints are not applied to a box that is being sized under an intrinsic
         //       sizing constraint: per css-sizing-3, min/max-width affect a box's intrinsic size
         //       *contributions*, and the callers of calculate_{min,max}_content_width() apply them.
@@ -902,35 +903,35 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
         //       state does not have.
         if (block_container_state.inline_size_constraint == SizeConstraint::None) {
             // https://www.w3.org/TR/css-sizing-3/#sizing-values
-            // Percentages are resolved against the width/height, as appropriate, of the box’s containing block.
-            auto containing_block_width = layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
-            auto available_width = AvailableSize::make_definite(containing_block_width);
+            // Percentages are resolved against the appropriate inline or block size of the containing block.
+            auto containing_block_inline_size = layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
+            auto available_inline_size = AvailableSize::make_definite(containing_block_inline_size);
             if (!should_treat_max_inline_size_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
-                auto max_width_px = calculate_inner_inline_size(block_container, available_width, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
-                if (used_width_px > max_width_px)
-                    used_width_px = max_width_px;
+                auto max_inline_size = calculate_inner_inline_size(block_container, available_inline_size, block_container.computed_values().max_width(), layout_input.containing_block_constraints);
+                if (used_inline_size_px > max_inline_size)
+                    used_inline_size_px = max_inline_size;
             }
 
-            auto should_treat_min_width_as_auto = [&] {
-                auto const& available_width = available_space.inline_size;
-                auto const& min_width = block_container.computed_values().min_width();
-                if (min_width.is_auto())
+            auto should_treat_min_inline_size_as_auto = [&] {
+                auto const& available_inline_size = available_space.inline_size;
+                auto const& computed_min_inline_size = block_container.computed_values().min_width();
+                if (computed_min_inline_size.is_auto())
                     return true;
-                if (min_width.is_fit_content() && available_width.is_intrinsic_sizing_constraint())
+                if (computed_min_inline_size.is_fit_content() && available_inline_size.is_intrinsic_sizing_constraint())
                     return true;
-                if (min_width.is_max_content() && available_width.is_max_content())
+                if (computed_min_inline_size.is_max_content() && available_inline_size.is_max_content())
                     return true;
-                if (min_width.is_min_content() && available_width.is_min_content())
+                if (computed_min_inline_size.is_min_content() && available_inline_size.is_min_content())
                     return true;
                 return false;
             }();
-            if (!should_treat_min_width_as_auto) {
-                auto min_width_px = calculate_inner_inline_size(block_container, available_width, block_container.computed_values().min_width(), layout_input.containing_block_constraints);
-                if (used_width_px < min_width_px)
-                    used_width_px = min_width_px;
+            if (!should_treat_min_inline_size_as_auto) {
+                auto min_inline_size = calculate_inner_inline_size(block_container, available_inline_size, block_container.computed_values().min_width(), layout_input.containing_block_constraints);
+                if (used_inline_size_px < min_inline_size)
+                    used_inline_size_px = min_inline_size;
             }
         }
-        block_container_state.set_content_inline_size(used_width_px);
+        block_container_state.set_content_inline_size(used_inline_size_px);
         block_container_state.set_content_block_size(context.automatic_content_block_size());
     }
 }
@@ -1149,7 +1150,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         return containing_block_rect_in_root_now.location().translated(0, content_y);
     };
 
-    compute_width(box, available_space, layout_input.containing_block_constraints, content_position_in_root_now(content_y));
+    compute_inline_size(box, available_space, layout_input.containing_block_constraints, content_position_in_root_now(content_y));
     content_y = avoid_float_intrusions(box, available_space, layout_input.containing_block_constraints, content_y, containing_block_rect_in_root_now);
 
     auto content_x = compute_normal_flow_x(box, available_space, content_position_in_root_now(content_y));
@@ -1342,7 +1343,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         auto& block_container_state = m_state.get_mutable(block_container);
         if (!block_container_state.has_definite_inline_size()) {
-            auto width = greatest_child_width_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
+            auto inline_size = greatest_child_width_in_rect(block_container, { layout_input.content_box_position_in_bfc_root->translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container)), block_container_state.content_size() });
             auto const& computed_values = block_container.computed_values();
             // NOTE: Min and max constraints are not applied to a box that is being sized as intrinsic because
             //       according to css-sizing-3 spec:
@@ -1351,17 +1352,17 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
             //       was zero-sized in that axis.
             if (block_container_state.inline_size_constraint == SizeConstraint::None) {
                 if (!should_treat_max_inline_size_as_none(block_container, available_space.inline_size, layout_input.containing_block_constraints)) {
-                    auto max_width = calculate_inner_inline_size(block_container, available_space.inline_size,
+                    auto max_inline_size = calculate_inner_inline_size(block_container, available_space.inline_size,
                         computed_values.max_width(), layout_input.containing_block_constraints);
-                    width = min(width, max_width);
+                    inline_size = min(inline_size, max_inline_size);
                 }
                 if (!computed_values.min_width().is_auto()) {
-                    auto min_width = calculate_inner_inline_size(block_container, available_space.inline_size,
+                    auto min_inline_size = calculate_inner_inline_size(block_container, available_space.inline_size,
                         computed_values.min_width(), layout_input.containing_block_constraints);
-                    width = max(width, min_width);
+                    inline_size = max(inline_size, min_inline_size);
                 }
             }
-            block_container_state.set_content_inline_size(width);
+            block_container_state.set_content_inline_size(inline_size);
             block_container_state.set_content_block_size(bottom_of_lowest_margin_box);
         }
     }
@@ -1390,8 +1391,8 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
     auto& legend_state = m_state.get_mutable(*legend);
     if (legend->computed_values().width().is_auto()) {
-        auto width = calculate_fit_content_inline_size(*legend, available_space, child_layout_input.containing_block_constraints);
-        legend_state.set_content_inline_size(width);
+        auto inline_size = calculate_fit_content_inline_size(*legend, available_space, child_layout_input.containing_block_constraints);
+        legend_state.set_content_inline_size(inline_size);
     }
 
     // The space allocated for the element's border on the block-start side is expected to be the element's
@@ -1415,19 +1416,19 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     }
 
     if (m_layout_mode == LayoutMode::IntrinsicSizing && !fieldset_state.has_definite_inline_size()) {
-        auto width = greatest_child_width(fieldset_box);
+        auto inline_size = greatest_child_width(fieldset_box);
         auto const& computed_values = fieldset_box.computed_values();
         if (fieldset_state.inline_size_constraint == SizeConstraint::None) {
             if (!should_treat_max_inline_size_as_none(fieldset_box, available_space.inline_size, layout_input.containing_block_constraints)) {
-                auto max_width = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
-                width = min(width, max_width);
+                auto max_inline_size = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.max_width(), layout_input.containing_block_constraints);
+                inline_size = min(inline_size, max_inline_size);
             }
             if (!computed_values.min_width().is_auto()) {
-                auto min_width = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.min_width(), layout_input.containing_block_constraints);
-                width = max(width, min_width);
+                auto min_inline_size = calculate_inner_inline_size(fieldset_box, available_space.inline_size, computed_values.min_width(), layout_input.containing_block_constraints);
+                inline_size = max(inline_size, min_inline_size);
             }
         }
-        fieldset_state.set_content_inline_size(width);
+        fieldset_state.set_content_inline_size(inline_size);
         fieldset_state.set_content_block_size(bottom_of_lowest_margin_box);
     }
 
@@ -1446,30 +1447,30 @@ void BlockFormattingContext::layout_fieldset_with_rendered_legend(FieldSetBox co
     compute_and_store_baselines(fieldset_state);
 }
 
-void BlockFormattingContext::resolve_vertical_box_model_metrics(Box const& box, CSSPixels width_of_containing_block)
+void BlockFormattingContext::resolve_vertical_box_model_metrics(Box const& box, CSSPixels containing_block_inline_size)
 {
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_top = computed_values.margin().top().to_px_or_zero(width_of_containing_block);
-    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(width_of_containing_block);
+    box_state.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_inline_size);
+    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_inline_size);
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.padding_top = computed_values.padding().top().to_px_or_zero(width_of_containing_block);
-    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(width_of_containing_block);
+    box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_inline_size);
+    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_inline_size);
 }
 
-void BlockFormattingContext::resolve_horizontal_box_model_metrics(Box const& box, CSSPixels width_of_containing_block)
+void BlockFormattingContext::resolve_horizontal_box_model_metrics(Box const& box, CSSPixels containing_block_inline_size)
 {
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
-    box_state.margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
+    box_state.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
+    box_state.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 }
 
 BlockFormattingContext::DidIntroduceClearance BlockFormattingContext::clear_floating_boxes(NodeWithStyle const& child_box, Optional<InlineFormattingContext&> inline_formatting_context, CSSPixelPoint containing_block_position_in_root)
@@ -1514,21 +1515,21 @@ CSSPixels BlockFormattingContext::compute_normal_flow_x(Box const& child_box, Av
     auto const& box_state = m_state.get(child_box);
 
     CSSPixels x = 0;
-    CSSPixels available_width_within_containing_block = available_space.inline_size.to_px_or_zero();
+    CSSPixels available_inline_size_within_containing_block = available_space.inline_size.to_px_or_zero();
 
     if (box_should_avoid_floats_because_it_establishes_fc(child_box)) {
         auto space_used_by_floats = intrusion_by_floats_into_rect({ content_position_in_root, box_state.content_size() }, 0, 0);
-        available_width_within_containing_block -= space_used_by_floats.left + space_used_by_floats.right;
+        available_inline_size_within_containing_block -= space_used_by_floats.left + space_used_by_floats.right;
 
         // Subtracting the left margin here because it is applied again when the margin box offset is added below.
         x = border_box_left_of_box_avoiding_floats(child_box, box_state, space_used_by_floats) - box_state.margin_left;
     }
 
     if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebCenter) {
-        x += (available_width_within_containing_block / 2) - box_state.content_inline_size() / 2;
+        x += (available_inline_size_within_containing_block / 2) - box_state.content_inline_size() / 2;
     } else if (child_box.containing_block()->computed_values().text_align() == CSS::TextAlign::LibwebRight) {
         // Subtracting the left margin here because left and right margins need to be swapped when aligning to the right
-        x += available_width_within_containing_block - box_state.content_inline_size() - box_state.margin_box_left();
+        x += available_inline_size_within_containing_block - box_state.content_inline_size() - box_state.margin_box_left();
     } else {
         x += box_state.margin_box_left();
     }
@@ -1550,7 +1551,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto const containing_block_rect_in_root = CSSPixelRect { layout_input.content_box_position_in_bfc_root.value(), block_container_state.content_size() };
     auto const containing_block_rect_in_root_now = containing_block_rect_in_root.translated(0, y_adjustment_from_pending_ancestor_top_margins(block_container));
 
-    compute_width(box, available_space, layout_input.containing_block_constraints, containing_block_rect_in_root_now.location());
+    compute_inline_size(box, available_space, layout_input.containing_block_constraints, containing_block_rect_in_root_now.location());
 
     resolve_used_height_if_not_treated_as_auto(box, available_space, layout_input.containing_block_constraints);
 
@@ -1561,7 +1562,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
 
     auto independent_formatting_context = layout_inside(box, m_layout_mode, layout_input.for_child_formatting_context(box_state.available_inner_space_or_constraints_from(available_space)));
     // A floating table wrapper shrink-to-fits from cached intrinsic sizes, which may not match
-    // the width table layout just produced; the wrapper is exactly as wide as the table grid box.
+    // the inline size table layout just produced; the wrapper has the same inline size as the table grid box.
     if (is<TableWrapper>(box) && independent_formatting_context)
         box_state.set_content_inline_size(independent_formatting_context->automatic_content_inline_size());
     resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
@@ -1646,7 +1647,7 @@ void BlockFormattingContext::layout_list_item_marker(ListItemBox const& list_ite
     auto marker_offset_y = max(CSSPixels(0), (marker.computed_values().line_height() - marker_height) / 2);
 
     if (marker.list_style_position() == CSS::ListStylePosition::Inside) {
-        // FIXME: Just adjusting the content width for an inside marker is wrong, as it will still position
+        // FIXME: Just adjusting the content inline size for an inside marker is wrong, as it will still position
         //        the marker outside of the box, instead of treating it more like an inline child on the first line.
         list_item_state.set_content_inline_size(list_item_state.content_inline_size() - marker_width - marker_distance);
     }
@@ -1677,7 +1678,7 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
 
     if (box.children_are_inline()) {
         for (auto const& line_box : m_state.get(as<BlockContainer>(box)).line_boxes) {
-            auto width_here = line_box_physical_width(box, line_box);
+            auto inline_size_here = line_box_physical_width(box, line_box);
             auto line_top = line_box.bottom() - line_box.height();
             auto line_bottom = line_box.bottom();
             CSSPixels extra_width_from_left_floats = 0;
@@ -1702,8 +1703,8 @@ CSSPixels BlockFormattingContext::greatest_child_width_in_rect(Box const& box, C
                     extra_width_from_right_floats = max(extra_width_from_right_floats, right_float->offset_from_edge + right_float->used_values.margin_box_left());
                 }
             }
-            width_here += extra_width_from_left_floats + extra_width_from_right_floats;
-            max_width = max(max_width, width_here);
+            inline_size_here += extra_width_from_left_floats + extra_width_from_right_floats;
+            max_width = max(max_width, inline_size_here);
         }
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -353,7 +353,7 @@ void BlockFormattingContext::compute_width(Box const& box, AvailableSpace const&
             return CSS::Length::make_px(box_state.content_inline_size());
         }
         if (is<TableWrapper>(box))
-            return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, remaining_available_space, containing_block_constraints));
+            return CSS::Length::make_px(compute_table_box_inline_size_inside_table_wrapper(box, remaining_available_space, containing_block_constraints));
 
         // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
         // If the computed value of 'inline-size' is 'auto', then the used value is the fit-content inline size.
@@ -1237,8 +1237,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
 
         auto inside_layout_input = [&] {
             auto input = layout_input.for_child_formatting_context(inner_available_space);
-            if (table_formatting_context && layout_input.table_grid_min_border_box_height.has_value())
-                return input.with_table_grid_min_border_box_height(*layout_input.table_grid_min_border_box_height);
+            if (table_formatting_context && layout_input.table_grid_min_border_box_block_size.has_value())
+                return input.with_table_grid_min_border_box_block_size(*layout_input.table_grid_min_border_box_block_size);
             return input;
         }();
         independent_formatting_context->run(inside_layout_input);
@@ -1326,7 +1326,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     // through to the table box unchanged.
     auto child_layout_input = [&]() -> LayoutInput {
         if (is<TableWrapper>(block_container))
-            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints, layout_input.content_box_position_in_bfc_root, layout_input.table_grid_min_border_box_height };
+            return LayoutInput { available_space_for_children, layout_input.containing_block_constraints, layout_input.content_box_position_in_bfc_root, layout_input.table_grid_min_border_box_block_size };
         else
             return layout_input_for_child_context(m_state.get(block_container), layout_input, available_space_for_children);
     }();

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1243,8 +1243,10 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             return input;
         }();
         independent_formatting_context->run(inside_layout_input);
-        if (table_formatting_context)
-            pending_position = table_formatting_context->pending_table_box_content_offset_in_wrapper();
+        if (table_formatting_context) {
+            auto pending_logical_offset = table_formatting_context->pending_table_box_content_offset_in_wrapper();
+            pending_position = CSSPixelPoint { pending_logical_offset.inline_offset, pending_logical_offset.block_offset };
+        }
         if (is<TableWrapper>(block_container) && box.display().is_table_inside()) {
             box_state.margin_left = max(box_state.margin_left, 0);
             box_state.margin_right = max(box_state.margin_right, 0);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -49,7 +49,7 @@ BlockFormattingContext::~BlockFormattingContext()
     }
 }
 
-CSSPixels BlockFormattingContext::automatic_content_width() const
+CSSPixels BlockFormattingContext::automatic_content_inline_size() const
 {
     if (root().children_are_inline())
         return m_state.get(root()).content_inline_size();
@@ -67,7 +67,7 @@ CSSPixels BlockFormattingContext::automatic_content_width() const
     return greatest_child_width(root());
 }
 
-CSSPixels BlockFormattingContext::automatic_content_height() const
+CSSPixels BlockFormattingContext::automatic_content_block_size() const
 {
     return compute_auto_height_for_block_formatting_context_root(root());
 }
@@ -808,7 +808,7 @@ void BlockFormattingContext::resolve_used_height_if_treated_as_auto(Box const& b
         height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
     } else {
         if (box_formatting_context) {
-            height = box_formatting_context->automatic_content_height();
+            height = box_formatting_context->automatic_content_block_size();
         } else {
             height = compute_auto_height_for_block_level_element(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
         }
@@ -893,7 +893,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
     if (!block_container_state.has_definite_inline_size()) {
         // NOTE: min-width or max-width for boxes with inline children can only be applied after inside layout
         //       is done and width of box content is known
-        auto used_width_px = context.automatic_content_width();
+        auto used_width_px = context.automatic_content_inline_size();
         // NOTE: Min and max constraints are not applied to a box that is being sized under an intrinsic
         //       sizing constraint: per css-sizing-3, min/max-width affect a box's intrinsic size
         //       *contributions*, and the callers of calculate_{min,max}_content_width() apply them.
@@ -931,7 +931,7 @@ void BlockFormattingContext::layout_inline_children(BlockContainer const& block_
             }
         }
         block_container_state.set_content_inline_size(used_width_px);
-        block_container_state.set_content_block_size(context.automatic_content_height());
+        block_container_state.set_content_block_size(context.automatic_content_block_size());
     }
 }
 
@@ -1225,7 +1225,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
         // min-height. If so, we run layout with min-height as the available height.
         Optional<CSSPixels> measured_content_height;
         if (should_treat_height_as_auto(box, available_space, layout_input.containing_block_constraints) && !box.computed_values().min_height().is_auto()) {
-            auto content_block_size = measure_automatic_content_height(box, inner_available_space, layout_input.containing_block_constraints);
+            auto content_block_size = measure_automatic_content_block_size(box, inner_available_space, layout_input.containing_block_constraints);
             measured_content_height = content_block_size;
             auto min_height = calculate_inner_block_size(box, available_space, box.computed_values().min_height(), layout_input.containing_block_constraints);
             if (content_block_size < min_height) {
@@ -1249,7 +1249,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
             box_state.margin_right = max(box_state.margin_right, 0);
         }
         if (is<TableWrapper>(box) && !box.is_grid_item())
-            box_state.set_content_inline_size(independent_formatting_context->automatic_content_width());
+            box_state.set_content_inline_size(independent_formatting_context->automatic_content_inline_size());
     } else {
         // This box participates in the current block container's flow.
         auto space_available_for_children = box.is_anonymous() ? available_space : box_state.available_inner_space_or_constraints_from(available_space);
@@ -1563,7 +1563,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     // A floating table wrapper shrink-to-fits from cached intrinsic sizes, which may not match
     // the width table layout just produced; the wrapper is exactly as wide as the table grid box.
     if (is<TableWrapper>(box) && independent_formatting_context)
-        box_state.set_content_inline_size(independent_formatting_context->automatic_content_width());
+        box_state.set_content_inline_size(independent_formatting_context->automatic_content_inline_size());
     resolve_used_height_if_treated_as_auto(box, available_space, layout_input.containing_block_constraints, independent_formatting_context);
 
     // Next, float to the left and/or right

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -108,7 +108,7 @@ public:
 
         CSSPixelRect margin_box_rect_in_root_coordinate_space;
         CSSPixelRect containing_block_rect_in_root_coordinate_space;
-        Optional<CSSPixels> percentage_basis_width;
+        Optional<CSSPixels> percentage_basis_inline_size;
     };
 
 private:

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -27,7 +27,7 @@ public:
     virtual CSSPixels automatic_content_block_size() const override;
 
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&) const;
-    void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root);
+    void compute_inline_size(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root);
     [[nodiscard]] CSSPixels avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, CSSPixels content_y, CSSPixelRect const& containing_block_rect_in_root);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root
@@ -73,8 +73,8 @@ public:
 
     void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, LayoutInput const&);
 
-    void resolve_vertical_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
-    void resolve_horizontal_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
+    void resolve_vertical_box_model_metrics(Box const&, CSSPixels containing_block_inline_size);
+    void resolve_horizontal_box_model_metrics(Box const&, CSSPixels containing_block_inline_size);
 
     enum class DidIntroduceClearance {
         Yes,
@@ -114,9 +114,9 @@ public:
 private:
     CSSPixels compute_auto_height_for_block_level_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
-    void compute_width_for_floating_box(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    void compute_inline_size_for_floating_box(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
-    void compute_width_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    void compute_inline_size_for_block_level_replaced_element_in_normal_flow(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
     void layout_block_level_children(BlockContainer const&, LayoutInput const&, AvailableSpace const& available_space_for_children);
     void layout_inline_children(BlockContainer const&, LayoutInput const&, AvailableSpace const& available_space_for_children);

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -28,7 +28,7 @@ public:
 
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&) const;
     void compute_inline_size(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root);
-    [[nodiscard]] CSSPixels avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, CSSPixels content_y, CSSPixelRect const& containing_block_rect_in_root);
+    [[nodiscard]] CSSPixels avoid_float_intrusions(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, CSSPixels content_block_offset, CSSPixelRect const& containing_block_rect_in_root);
 
     // https://www.w3.org/TR/css-display/#block-formatting-context-root
     BlockContainer const& root() const { return static_cast<BlockContainer const&>(context_box()); }
@@ -49,9 +49,9 @@ public:
 
     [[nodiscard]] SpaceUsedByFloats available_inline_space(CSSPixels block_start_in_root, CSSPixels block_end_in_root) const;
     [[nodiscard]] SpaceUsedByFloats intrusion_by_floats_into_rect(CSSPixelRect const& box_in_root_rect, CSSPixels block_start_in_box, CSSPixels block_end_in_box) const;
-    [[nodiscard]] Optional<CSSPixels> next_float_band_block_start_after(CSSPixels y_in_root) const;
+    [[nodiscard]] Optional<CSSPixels> next_float_band_block_start_after(CSSPixels block_offset_in_root) const;
 
-    [[nodiscard]] CSSPixels y_adjustment_from_pending_ancestor_top_margins(Node const& box) const
+    [[nodiscard]] CSSPixels block_offset_adjustment_from_pending_ancestor_block_start_margins(Node const& box) const
     {
         CSSPixels adjustment = 0;
         for (auto const& group : m_margin_state.pending_top_margin_groups()) {
@@ -66,7 +66,7 @@ public:
     virtual CSSPixels greatest_child_inline_size(Box const&) const override;
     [[nodiscard]] CSSPixels greatest_child_inline_size_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
 
-    void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels y, LineBuilder* = nullptr);
+    void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels block_offset, LineBuilder* = nullptr);
 
     void layout_interrupting_block_inside_inline_context(Box const&, BlockContainer const& containing_block, LayoutInput const&, LineBuilder&);
     CSSPixels commit_pending_margin_before_inline_content();
@@ -122,7 +122,7 @@ private:
     void layout_inline_children(BlockContainer const&, LayoutInput const&, AvailableSpace const& available_space_for_children);
     void layout_fieldset_with_rendered_legend(FieldSetBox const&, LayoutInput const&);
 
-    [[nodiscard]] CSSPixels compute_normal_flow_x(Box const& child_box, AvailableSpace const&, CSSPixelPoint content_position_in_root) const;
+    [[nodiscard]] CSSPixels compute_normal_flow_inline_offset(Box const& child_box, AvailableSpace const&, CSSPixelPoint content_position_in_root) const;
     void translate_floats_in_subtree(Box const& ancestor, CSSPixelPoint delta);
     void update_lowest_floating_descendant_bottom_margin_edge();
 
@@ -152,8 +152,8 @@ private:
         CSSPixels offset_from_edge { 0 };
     };
 
-    [[nodiscard]] size_t band_index_at(CSSPixels y) const;
-    [[nodiscard]] FloatBand const& band_at(CSSPixels y) const;
+    [[nodiscard]] size_t band_index_at(CSSPixels block_offset) const;
+    [[nodiscard]] FloatBand const& band_at(CSSPixels block_offset) const;
     [[nodiscard]] SpaceUsedByFloats intrusions_for_band_into_rect(FloatBand const&, CSSPixelRect const& rect_in_root) const;
     [[nodiscard]] FloatPlacement place_float(FloatSide, LayoutState::UsedValues const&, AvailableSpace const&, CSSPixelRect const& containing_block_rect_in_root, CSSPixels ceiling_in_root) const;
     void ensure_band_boundary(CSSPixels);
@@ -234,9 +234,9 @@ private:
         bool m_box_last_in_flow_child_margin_bottom_collapsed { false };
     };
 
-    Optional<CSSPixels> m_y_offset_of_current_block_container;
+    Optional<CSSPixels> m_block_offset_of_current_block_container;
 
-    Optional<CSSPixelPoint> m_pending_legend_flow_position;
+    Optional<LogicalOffset> m_pending_legend_flow_position;
 
     BlockMarginState m_margin_state;
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -63,8 +63,8 @@ public:
         return adjustment;
     }
 
-    virtual CSSPixels greatest_child_width(Box const&) const override;
-    [[nodiscard]] CSSPixels greatest_child_width_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
+    virtual CSSPixels greatest_child_inline_size(Box const&) const override;
+    [[nodiscard]] CSSPixels greatest_child_inline_size_in_rect(Box const&, CSSPixelRect const& box_in_root_rect) const;
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutInput const&, CSSPixels y, LineBuilder* = nullptr);
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -35,8 +35,8 @@ public:
 
     virtual void parent_context_did_dimension_child_root_box() override;
 
-    void resolve_used_height_if_not_treated_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints);
-    void resolve_used_height_if_treated_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context = nullptr);
+    void resolve_used_block_size_if_not_treated_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints);
+    void resolve_used_block_size_if_treated_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, FormattingContext const* box_formatting_context = nullptr);
 
     template<typename Callback>
     void for_each_floating_box(Callback callback)
@@ -112,7 +112,7 @@ public:
     };
 
 private:
-    CSSPixels compute_auto_height_for_block_level_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
+    CSSPixels compute_automatic_block_size_for_block_level_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 
     void compute_inline_size_for_floating_box(Box const&, AvailableSpace const&, ContainingBlockConstraints const&);
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -23,8 +23,8 @@ public:
     ~BlockFormattingContext();
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_width() const override;
-    virtual CSSPixels automatic_content_height() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
 
     bool box_should_avoid_floats_because_it_establishes_fc(Box const&) const;
     void compute_width(Box const&, AvailableSpace const&, ContainingBlockConstraints const& containing_block_constraints, CSSPixelPoint content_position_in_root);

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -28,7 +28,7 @@ struct LineBoxFragmentCoordinate {
 };
 
 struct IntrinsicSizeCacheKey {
-    Optional<CSSPixels> measured_at_width;
+    Optional<CSSPixels> measured_at_inline_size;
     Optional<CSSPixels> percentage_basis_inline_size;
     Optional<CSSPixels> percentage_basis_block_size;
     Optional<CSSPixels> quirks_mode_percentage_basis_block_size;
@@ -37,10 +37,10 @@ struct IntrinsicSizeCacheKey {
 };
 
 struct IntrinsicSizes {
-    HashMap<IntrinsicSizeCacheKey, CSSPixels> min_content_width;
-    HashMap<IntrinsicSizeCacheKey, CSSPixels> max_content_width;
-    HashMap<IntrinsicSizeCacheKey, CSSPixels> min_content_height;
-    HashMap<IntrinsicSizeCacheKey, CSSPixels> max_content_height;
+    HashMap<IntrinsicSizeCacheKey, CSSPixels> min_content_inline_size;
+    HashMap<IntrinsicSizeCacheKey, CSSPixels> max_content_inline_size;
+    HashMap<IntrinsicSizeCacheKey, CSSPixels> min_content_block_size;
+    HashMap<IntrinsicSizeCacheKey, CSSPixels> max_content_block_size;
 };
 
 class WEB_API Box : public NodeWithStyleAndBoxModelMetrics {
@@ -140,7 +140,7 @@ struct Traits<Web::Layout::IntrinsicSizeCacheKey> : public DefaultTraits<Web::La
         auto optional_hash = [](Optional<Web::CSSPixels> const& value) -> unsigned {
             return value.has_value() ? pair_int_hash(1u, Traits<Web::CSSPixels>::hash(*value)) : 0u;
         };
-        auto hash = optional_hash(key.measured_at_width);
+        auto hash = optional_hash(key.measured_at_inline_size);
         hash = pair_int_hash(hash, optional_hash(key.percentage_basis_inline_size));
         hash = pair_int_hash(hash, optional_hash(key.percentage_basis_block_size));
         hash = pair_int_hash(hash, optional_hash(key.quirks_mode_percentage_basis_block_size));

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -90,15 +90,15 @@ public:
     bool abspos_descendant_escapes() const { return m_abspos_descendant_escapes; }
     void set_abspos_descendant_escapes(bool value) { m_abspos_descendant_escapes = value; }
 
-    void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_scroll_in_x, bool compensates_for_scroll_in_y)
+    void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll)
     {
         m_default_scroll_shift_anchor = move(anchor);
-        m_compensates_for_scroll_in_x = compensates_for_scroll_in_x;
-        m_compensates_for_scroll_in_y = compensates_for_scroll_in_y;
+        m_compensates_for_horizontal_scroll = compensates_for_horizontal_scroll;
+        m_compensates_for_vertical_scroll = compensates_for_vertical_scroll;
     }
     Node* default_scroll_shift_anchor() const { return m_default_scroll_shift_anchor.ptr(); }
-    bool compensates_for_scroll_in_x() const { return m_compensates_for_scroll_in_x; }
-    bool compensates_for_scroll_in_y() const { return m_compensates_for_scroll_in_y; }
+    bool compensates_for_horizontal_scroll() const { return m_compensates_for_horizontal_scroll; }
+    bool compensates_for_vertical_scroll() const { return m_compensates_for_vertical_scroll; }
 
     IntrinsicSizes& cached_intrinsic_sizes() const
     {
@@ -119,8 +119,8 @@ private:
     OwnPtr<AbsposLayoutInputs> m_saved_abspos_layout_inputs;
 
     WeakPtr<Node> m_default_scroll_shift_anchor;
-    bool m_compensates_for_scroll_in_x { false };
-    bool m_compensates_for_scroll_in_y { false };
+    bool m_compensates_for_horizontal_scroll { false };
+    bool m_compensates_for_vertical_scroll { false };
     bool m_abspos_descendant_escapes { false };
 
     OwnPtr<IntrinsicSizes> mutable m_cached_intrinsic_sizes;

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -29,9 +29,9 @@ struct LineBoxFragmentCoordinate {
 
 struct IntrinsicSizeCacheKey {
     Optional<CSSPixels> measured_at_width;
-    Optional<CSSPixels> percentage_basis_width;
-    Optional<CSSPixels> percentage_basis_height;
-    Optional<CSSPixels> quirks_mode_percentage_basis_height;
+    Optional<CSSPixels> percentage_basis_inline_size;
+    Optional<CSSPixels> percentage_basis_block_size;
+    Optional<CSSPixels> quirks_mode_percentage_basis_block_size;
 
     bool operator==(IntrinsicSizeCacheKey const&) const = default;
 };
@@ -141,9 +141,9 @@ struct Traits<Web::Layout::IntrinsicSizeCacheKey> : public DefaultTraits<Web::La
             return value.has_value() ? pair_int_hash(1u, Traits<Web::CSSPixels>::hash(*value)) : 0u;
         };
         auto hash = optional_hash(key.measured_at_width);
-        hash = pair_int_hash(hash, optional_hash(key.percentage_basis_width));
-        hash = pair_int_hash(hash, optional_hash(key.percentage_basis_height));
-        hash = pair_int_hash(hash, optional_hash(key.quirks_mode_percentage_basis_height));
+        hash = pair_int_hash(hash, optional_hash(key.percentage_basis_inline_size));
+        hash = pair_int_hash(hash, optional_hash(key.percentage_basis_block_size));
+        hash = pair_int_hash(hash, optional_hash(key.quirks_mode_percentage_basis_block_size));
         return hash;
     }
 };

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -26,7 +26,7 @@ static String serialize_flex_basis(CSS::FlexBasis const& flex_basis)
 
 CSSPixels FlexFormattingContext::get_pixel_width(FlexItem const& item, CSS::Size const& size) const
 {
-    return calculate_inner_width(item.box, m_available_space->inline_size, size, item_containing_block_constraints());
+    return calculate_inner_inline_size(item.box, m_available_space->inline_size, size, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Size const& size) const
@@ -38,9 +38,9 @@ CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Siz
         auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
         auto available_height = AvailableSize::make_indefinite();
         auto available_space = AvailableSpace { available_width, available_height };
-        return calculate_inner_height(item.box, available_space, size, item_containing_block_constraints());
+        return calculate_inner_block_size(item.box, available_space, size, item_containing_block_constraints());
     }
-    return calculate_inner_height(item.box, m_available_space.value(), size, item_containing_block_constraints());
+    return calculate_inner_block_size(item.box, m_available_space.value(), size, item_containing_block_constraints());
 }
 
 FlexFormattingContext::FlexFormattingContext(LayoutState& state, LayoutMode layout_mode, Box const& flex_container, FormattingContext* parent)
@@ -498,15 +498,15 @@ CSSPixels FlexFormattingContext::specified_cross_min_size(FlexItem const& item) 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_min_size() const
 {
     return cross_axis_is_horizontal()
-        ? calculate_inner_width(flex_container(), m_available_space.value().inline_size, computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints)
-        : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints);
+        ? calculate_inner_inline_size(flex_container(), m_available_space.value().inline_size, computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints)
+        : calculate_inner_block_size(flex_container(), m_available_space.value(), computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints);
 }
 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_max_size() const
 {
     return cross_axis_is_horizontal()
-        ? calculate_inner_width(flex_container(), m_available_space.value().inline_size, computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints)
-        : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints);
+        ? calculate_inner_inline_size(flex_container(), m_available_space.value().inline_size, computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints)
+        : calculate_inner_block_size(flex_container(), m_available_space.value(), computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints);
 }
 
 bool FlexFormattingContext::has_main_max_size(Box const& box) const
@@ -1391,9 +1391,9 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
     if (!cross_axis_is_horizontal()) {
         auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
         auto available_height = AvailableSize::make_indefinite();
-        fit_content_cross_size = calculate_fit_content_height(item.box, AvailableSpace(available_width, available_height), item_containing_block_constraints());
+        fit_content_cross_size = calculate_fit_content_block_size(item.box, AvailableSpace(available_width, available_height), item_containing_block_constraints());
     } else {
-        fit_content_cross_size = calculate_fit_content_width(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+        fit_content_cross_size = calculate_fit_content_inline_size(item.box, m_available_space_for_items->space, item_containing_block_constraints());
     }
     item.hypothetical_cross_size = css_clamp(fit_content_cross_size, clamp_min, clamp_max);
 }
@@ -2332,11 +2332,11 @@ CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrins
 
     CSSPixels width;
     if (should_treat_width_as_auto(box, m_available_space_for_items->space) || computed_width.is_fit_content())
-        width = calculate_fit_content_width(box, m_available_space_for_items->space, item_containing_block_constraints());
+        width = calculate_fit_content_inline_size(box, m_available_space_for_items->space, item_containing_block_constraints());
     else if (computed_width.is_min_content())
-        width = calculate_min_content_width(box, item_containing_block_constraints());
+        width = calculate_min_content_inline_size(box, item_containing_block_constraints());
     else if (computed_width.is_max_content())
-        width = calculate_max_content_width(box, item_containing_block_constraints());
+        width = calculate_max_content_inline_size(box, item_containing_block_constraints());
 
     return css_clamp(width, clamp_min, clamp_max);
 }
@@ -2344,39 +2344,39 @@ CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrins
 CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const& item) const
 {
     if (main_axis_is_horizontal()) {
-        return calculate_min_content_width(item.box, item_containing_block_constraints());
+        return calculate_min_content_inline_size(item.box, item_containing_block_constraints());
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.inline_size.is_indefinite()) {
         available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
     }
-    return calculate_min_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
+    return calculate_min_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_max_content_main_size(FlexItem const& item) const
 {
     if (main_axis_is_horizontal()) {
-        return calculate_max_content_width(item.box, item_containing_block_constraints());
+        return calculate_max_content_inline_size(item.box, item_containing_block_constraints());
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.inline_size.is_indefinite()) {
         available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
     }
-    return calculate_max_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
+    return calculate_max_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_fit_content_main_size(FlexItem const& item) const
 {
     if (main_axis_is_horizontal())
-        return calculate_fit_content_width(item.box, m_available_space_for_items->space, item_containing_block_constraints());
-    return calculate_fit_content_height(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+        return calculate_fit_content_inline_size(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+    return calculate_fit_content_block_size(item.box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_fit_content_cross_size(FlexItem const& item) const
 {
     if (cross_axis_is_horizontal())
-        return calculate_fit_content_width(item.box, m_available_space_for_items->space, item_containing_block_constraints());
-    return calculate_fit_content_height(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+        return calculate_fit_content_inline_size(item.box, m_available_space_for_items->space, item_containing_block_constraints());
+    return calculate_fit_content_block_size(item.box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const& item) const
@@ -2386,9 +2386,9 @@ CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const
         if (available_space.inline_size.is_indefinite()) {
             available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
         }
-        return calculate_min_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
+        return calculate_min_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
     }
-    return calculate_min_content_width(item.box, item_containing_block_constraints());
+    return calculate_min_content_inline_size(item.box, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const& item) const
@@ -2398,9 +2398,9 @@ CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const
         if (available_space.inline_size.is_indefinite()) {
             available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
         }
-        return calculate_max_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
+        return calculate_max_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
     }
-    return calculate_max_content_width(item.box, item_containing_block_constraints());
+    return calculate_max_content_inline_size(item.box, item_containing_block_constraints());
 }
 
 // https://drafts.csswg.org/css-flexbox-1/#stretched

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2240,29 +2240,29 @@ CSSPixels FlexFormattingContext::calculate_main_max_content_contribution(FlexIte
 bool FlexFormattingContext::should_treat_main_size_as_auto(Box const& box) const
 {
     if (main_axis_is_horizontal())
-        return should_treat_width_as_auto(box, m_available_space_for_items->space);
-    return should_treat_height_as_auto(box, m_available_space_for_items->space, item_containing_block_constraints());
+        return should_treat_inline_size_as_auto(box, m_available_space_for_items->space);
+    return should_treat_block_size_as_auto(box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_cross_size_as_auto(Box const& box) const
 {
     if (cross_axis_is_horizontal())
-        return should_treat_width_as_auto(box, m_available_space_for_items->space);
-    return should_treat_height_as_auto(box, m_available_space_for_items->space, item_containing_block_constraints());
+        return should_treat_inline_size_as_auto(box, m_available_space_for_items->space);
+    return should_treat_block_size_as_auto(box, m_available_space_for_items->space, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_main_max_size_as_none(Box const& box) const
 {
     if (main_axis_is_horizontal())
-        return should_treat_max_width_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints());
-    return should_treat_max_height_as_none(box, m_available_space_for_items->space.block_size, item_containing_block_constraints());
+        return should_treat_max_inline_size_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints());
+    return should_treat_max_block_size_as_none(box, m_available_space_for_items->space.block_size, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_cross_max_size_as_none(Box const& box) const
 {
     if (cross_axis_is_horizontal())
-        return should_treat_max_width_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints());
-    return should_treat_max_height_as_none(box, m_available_space_for_items->space.block_size, item_containing_block_constraints());
+        return should_treat_max_inline_size_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints());
+    return should_treat_max_block_size_as_none(box, m_available_space_for_items->space.block_size, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_cross_min_content_contribution(FlexItem const& item, bool resolve_percentage_min_max_sizes) const
@@ -2328,10 +2328,10 @@ CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrins
     bool can_resolve_percentages = m_available_space_for_items->space.inline_size.is_definite();
 
     auto clamp_min = (!computed_min_width.is_auto() && (!computed_min_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_min_width) : 0;
-    auto clamp_max = (!should_treat_max_width_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints()) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
+    auto clamp_max = (!should_treat_max_inline_size_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints()) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
 
     CSSPixels width;
-    if (should_treat_width_as_auto(box, m_available_space_for_items->space) || computed_width.is_fit_content())
+    if (should_treat_inline_size_as_auto(box, m_available_space_for_items->space) || computed_width.is_fit_content())
         width = calculate_fit_content_inline_size(box, m_available_space_for_items->space, item_containing_block_constraints());
     else if (computed_width.is_min_content())
         width = calculate_min_content_inline_size(box, item_containing_block_constraints());

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -62,12 +62,12 @@ ContainingBlockConstraints FlexFormattingContext::item_containing_block_constrai
 
 CSSPixels FlexFormattingContext::automatic_content_width() const
 {
-    return m_flex_container_state.content_width();
+    return m_flex_container_state.content_inline_size();
 }
 
 CSSPixels FlexFormattingContext::automatic_content_height() const
 {
-    return m_flex_container_state.content_height();
+    return m_flex_container_state.content_block_size();
 }
 
 void FlexFormattingContext::run(LayoutInput const& layout_input)
@@ -451,17 +451,17 @@ void FlexFormattingContext::generate_anonymous_flex_items()
 
 bool FlexFormattingContext::has_definite_main_size(LayoutState::UsedValues const& used_values) const
 {
-    return main_axis_is_horizontal() ? used_values.has_definite_width() : used_values.has_definite_height();
+    return main_axis_is_horizontal() ? used_values.has_definite_inline_size() : used_values.has_definite_block_size();
 }
 
 CSSPixels FlexFormattingContext::inner_main_size(LayoutState::UsedValues const& used_values) const
 {
-    return main_axis_is_horizontal() ? used_values.content_width() : used_values.content_height();
+    return main_axis_is_horizontal() ? used_values.content_inline_size() : used_values.content_block_size();
 }
 
 CSSPixels FlexFormattingContext::inner_cross_size(LayoutState::UsedValues const& used_values) const
 {
-    return cross_axis_is_horizontal() ? used_values.content_width() : used_values.content_height();
+    return cross_axis_is_horizontal() ? used_values.content_inline_size() : used_values.content_block_size();
 }
 
 bool FlexFormattingContext::has_main_min_size(Box const& box) const
@@ -478,7 +478,7 @@ bool FlexFormattingContext::has_cross_min_size(Box const& box) const
 
 bool FlexFormattingContext::has_definite_cross_size(LayoutState::UsedValues const& used_values) const
 {
-    return cross_axis_is_horizontal() ? used_values.has_definite_width() : used_values.has_definite_height();
+    return cross_axis_is_horizontal() ? used_values.has_definite_inline_size() : used_values.has_definite_block_size();
 }
 
 CSSPixels FlexFormattingContext::specified_main_min_size(FlexItem const& item) const
@@ -553,49 +553,49 @@ CSSPixels FlexFormattingContext::specified_main_max_size_for_intrinsic_contribut
 void FlexFormattingContext::set_has_definite_main_size(FlexItem& item)
 {
     if (main_axis_is_horizontal())
-        item.used_values.set_has_definite_width(true);
+        item.used_values.set_has_definite_inline_size(true);
     else
-        item.used_values.set_has_definite_height(true);
+        item.used_values.set_has_definite_block_size(true);
 }
 
 void FlexFormattingContext::set_has_definite_cross_size(FlexItem& item)
 {
     if (cross_axis_is_horizontal())
-        item.used_values.set_has_definite_width(true);
+        item.used_values.set_has_definite_inline_size(true);
     else
-        item.used_values.set_has_definite_height(true);
+        item.used_values.set_has_definite_block_size(true);
 }
 
 void FlexFormattingContext::set_main_size(Box const& box, CSSPixels size)
 {
     if (main_axis_is_horizontal())
-        m_state.get_mutable(box).set_content_width(size);
+        m_state.get_mutable(box).set_content_inline_size(size);
     else
-        m_state.get_mutable(box).set_content_height(size);
+        m_state.get_mutable(box).set_content_block_size(size);
 }
 
 void FlexFormattingContext::set_cross_size(Box const& box, CSSPixels size)
 {
     if (cross_axis_is_horizontal())
-        m_state.get_mutable(box).set_content_width(size);
+        m_state.get_mutable(box).set_content_inline_size(size);
     else
-        m_state.get_mutable(box).set_content_height(size);
+        m_state.get_mutable(box).set_content_block_size(size);
 }
 
 void FlexFormattingContext::set_main_size(FlexItem& item, CSSPixels size)
 {
     if (main_axis_is_horizontal())
-        item.used_values.set_content_width(size);
+        item.used_values.set_content_inline_size(size);
     else
-        item.used_values.set_content_height(size);
+        item.used_values.set_content_block_size(size);
 }
 
 void FlexFormattingContext::set_cross_size(FlexItem& item, CSSPixels size)
 {
     if (cross_axis_is_horizontal())
-        item.used_values.set_content_width(size);
+        item.used_values.set_content_inline_size(size);
     else
-        item.used_values.set_content_height(size);
+        item.used_values.set_content_block_size(size);
 }
 
 void FlexFormattingContext::set_main_axis_first_margin(FlexItem& item, CSSPixels margin)
@@ -700,12 +700,12 @@ Optional<CSSPixels> FlexFormattingContext::cross_size_transferred_from_definite_
 CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const& box, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const
 {
     if (!should_treat_cross_max_size_as_none(box)) {
-        auto max_cross_size_px = max_cross_size.to_px(cross_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto max_cross_size_px = max_cross_size.to_px(cross_axis_is_horizontal() ? m_flex_container_state.content_inline_size() : m_flex_container_state.content_block_size());
         main_size = min(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(max_cross_size_px, box.preferred_aspect_ratio().value()));
     }
 
     if (!min_cross_size.is_auto()) {
-        auto min_cross_size_px = min_cross_size.to_px(cross_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto min_cross_size_px = min_cross_size.to_px(cross_axis_is_horizontal() ? m_flex_container_state.content_inline_size() : m_flex_container_state.content_block_size());
         main_size = max(main_size, calculate_main_size_from_cross_size_and_aspect_ratio(min_cross_size_px, box.preferred_aspect_ratio().value()));
     }
 
@@ -715,12 +715,12 @@ CSSPixels FlexFormattingContext::adjust_main_size_through_aspect_ratio_for_cross
 CSSPixels FlexFormattingContext::adjust_cross_size_through_aspect_ratio_for_main_size_min_max_constraints(Box const& box, CSSPixels cross_size, CSS::Size const& min_main_size, CSS::Size const& max_main_size) const
 {
     if (!should_treat_main_max_size_as_none(box)) {
-        auto max_main_size_px = max_main_size.to_px(main_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto max_main_size_px = max_main_size.to_px(main_axis_is_horizontal() ? m_flex_container_state.content_inline_size() : m_flex_container_state.content_block_size());
         cross_size = min(cross_size, calculate_cross_size_from_main_size_and_aspect_ratio(max_main_size_px, box.preferred_aspect_ratio().value()));
     }
 
     if (!min_main_size.is_auto()) {
-        auto min_main_size_px = min_main_size.to_px(main_axis_is_horizontal() ? m_flex_container_state.content_width() : m_flex_container_state.content_height());
+        auto min_main_size_px = min_main_size.to_px(main_axis_is_horizontal() ? m_flex_container_state.content_inline_size() : m_flex_container_state.content_block_size());
         cross_size = max(cross_size, calculate_cross_size_from_main_size_and_aspect_ratio(min_main_size_px, box.preferred_aspect_ratio().value()));
     }
 
@@ -745,8 +745,8 @@ void FlexFormattingContext::determine_flex_base_size(FlexItem& item)
                 return true;
 
             bool can_resolve_percentages = main_axis_is_horizontal()
-                ? m_flex_container_state.has_definite_width()
-                : m_flex_container_state.has_definite_height();
+                ? m_flex_container_state.has_definite_inline_size()
+                : m_flex_container_state.has_definite_block_size();
 
             if (size.is_calculated()) {
                 auto const& calc_value = size.calculated();
@@ -1687,7 +1687,7 @@ void FlexFormattingContext::distribute_any_remaining_free_space()
 
 void FlexFormattingContext::dump_items() const
 {
-    dbgln("\033[34;1mflex-container\033[0m {}, direction: {}, current-size: {}x{}", flex_container().debug_description(), is_row_layout() ? "row" : "column", m_flex_container_state.content_width(), m_flex_container_state.content_height());
+    dbgln("\033[34;1mflex-container\033[0m {}, direction: {}, current-size: {}x{}", flex_container().debug_description(), is_row_layout() ? "row" : "column", m_flex_container_state.content_inline_size(), m_flex_container_state.content_block_size());
     for (size_t i = 0; i < m_flex_lines.size(); ++i) {
         dbgln("{} flex-line #{}:", flex_container().debug_description(), i);
         for (size_t j = 0; j < m_flex_lines[i].items.size(); ++j) {
@@ -1971,10 +1971,10 @@ void FlexFormattingContext::copy_dimensions_from_flex_items_to_boxes()
     for (auto& item : m_flex_items) {
         auto const& box = item.box;
 
-        item.used_values.margin_left = box.computed_values().margin().left().to_px_or_zero(m_flex_container_state.content_width());
-        item.used_values.margin_right = box.computed_values().margin().right().to_px_or_zero(m_flex_container_state.content_width());
-        item.used_values.margin_top = box.computed_values().margin().top().to_px_or_zero(m_flex_container_state.content_width());
-        item.used_values.margin_bottom = box.computed_values().margin().bottom().to_px_or_zero(m_flex_container_state.content_width());
+        item.used_values.margin_left = box.computed_values().margin().left().to_px_or_zero(m_flex_container_state.content_inline_size());
+        item.used_values.margin_right = box.computed_values().margin().right().to_px_or_zero(m_flex_container_state.content_inline_size());
+        item.used_values.margin_top = box.computed_values().margin().top().to_px_or_zero(m_flex_container_state.content_inline_size());
+        item.used_values.margin_bottom = box.computed_values().margin().bottom().to_px_or_zero(m_flex_container_state.content_inline_size());
 
         item.used_values.border_left = box.computed_values().border_left().width;
         item.used_values.border_right = box.computed_values().border_right().width;

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -24,20 +24,19 @@ static String serialize_flex_basis(CSS::FlexBasis const& flex_basis)
     return MUST(String::formatted("{}", flex_basis.get<CSS::Size>()));
 }
 
-CSSPixels FlexFormattingContext::get_pixel_width(FlexItem const& item, CSS::Size const& size) const
+CSSPixels FlexFormattingContext::resolve_inner_inline_size(FlexItem const& item, CSS::Size const& size) const
 {
     return calculate_inner_inline_size(item.box, m_available_space->inline_size, size, item_containing_block_constraints());
 }
 
-CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Size const& size) const
+CSSPixels FlexFormattingContext::resolve_inner_block_size(FlexItem const& item, CSS::Size const& size) const
 {
     if (main_axis_is_horizontal() && size.is_intrinsic_sizing_constraint()) {
         // NOTE: When the main axis is horizontal, after we've determined the main size, we use that as the
-        //       available width for any
-        //       intrinsic sizing layout needed to resolve the height.
-        auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
-        auto available_height = AvailableSize::make_indefinite();
-        auto available_space = AvailableSpace { available_width, available_height };
+        //       available inline size for any intrinsic sizing layout needed to resolve the block size.
+        auto available_inline_size = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
+        auto available_block_size = AvailableSize::make_indefinite();
+        auto available_space = AvailableSpace { available_inline_size, available_block_size };
         return calculate_inner_block_size(item.box, available_space, size, item_containing_block_constraints());
     }
     return calculate_inner_block_size(item.box, m_available_space.value(), size, item_containing_block_constraints());
@@ -190,7 +189,7 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
         // NOTE: The automatic block size of a block-level flex container is its max-content size.
 
         // NOTE: We've already handled this in the parent formatting context.
-        //       Specifically, all formatting contexts will have assigned width & height to the flex container
+        //       Specifically, all formatting contexts will have assigned inline and block sizes to the flex container
         //       before this formatting context runs.
     }
 
@@ -351,12 +350,12 @@ bool FlexFormattingContext::is_direction_reverse() const
 void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::FlexDirection) const
 {
     // Percentages on flex item box-model metrics resolve against the flex container's inline size.
-    auto width_of_containing_block = m_item_percentage_bases.percentage_basis_inline_size.value_or(0);
+    auto containing_block_inline_size = m_item_percentage_bases.percentage_basis_inline_size.value_or(0);
 
-    item.used_values.padding_left = item.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
-    item.used_values.padding_right = item.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
-    item.used_values.padding_top = item.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
-    item.used_values.padding_bottom = item.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
+    item.used_values.padding_left = item.box.computed_values().padding().left().to_px_or_zero(containing_block_inline_size);
+    item.used_values.padding_right = item.box.computed_values().padding().right().to_px_or_zero(containing_block_inline_size);
+    item.used_values.padding_top = item.box.computed_values().padding().top().to_px_or_zero(containing_block_inline_size);
+    item.used_values.padding_bottom = item.box.computed_values().padding().bottom().to_px_or_zero(containing_block_inline_size);
 
     if (main_axis_is_horizontal()) {
         item.borders.main_before = item.box.computed_values().border_left().width;
@@ -364,15 +363,15 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
         item.borders.cross_before = item.box.computed_values().border_top().width;
         item.borders.cross_after = item.box.computed_values().border_bottom().width;
 
-        item.padding.main_before = item.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
-        item.padding.main_after = item.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
-        item.padding.cross_before = item.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
-        item.padding.cross_after = item.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
+        item.padding.main_before = item.box.computed_values().padding().left().to_px_or_zero(containing_block_inline_size);
+        item.padding.main_after = item.box.computed_values().padding().right().to_px_or_zero(containing_block_inline_size);
+        item.padding.cross_before = item.box.computed_values().padding().top().to_px_or_zero(containing_block_inline_size);
+        item.padding.cross_after = item.box.computed_values().padding().bottom().to_px_or_zero(containing_block_inline_size);
 
-        item.margins.main_before = item.box.computed_values().margin().left().to_px_or_zero(width_of_containing_block);
-        item.margins.main_after = item.box.computed_values().margin().right().to_px_or_zero(width_of_containing_block);
-        item.margins.cross_before = item.box.computed_values().margin().top().to_px_or_zero(width_of_containing_block);
-        item.margins.cross_after = item.box.computed_values().margin().bottom().to_px_or_zero(width_of_containing_block);
+        item.margins.main_before = item.box.computed_values().margin().left().to_px_or_zero(containing_block_inline_size);
+        item.margins.main_after = item.box.computed_values().margin().right().to_px_or_zero(containing_block_inline_size);
+        item.margins.cross_before = item.box.computed_values().margin().top().to_px_or_zero(containing_block_inline_size);
+        item.margins.cross_after = item.box.computed_values().margin().bottom().to_px_or_zero(containing_block_inline_size);
 
         item.margins.main_before_is_auto = item.box.computed_values().margin().left().is_auto();
         item.margins.main_after_is_auto = item.box.computed_values().margin().right().is_auto();
@@ -389,10 +388,10 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
         item.padding.cross_before = item.used_values.padding_left;
         item.padding.cross_after = item.used_values.padding_right;
 
-        item.margins.main_before = item.box.computed_values().margin().top().to_px_or_zero(width_of_containing_block);
-        item.margins.main_after = item.box.computed_values().margin().bottom().to_px_or_zero(width_of_containing_block);
-        item.margins.cross_before = item.box.computed_values().margin().left().to_px_or_zero(width_of_containing_block);
-        item.margins.cross_after = item.box.computed_values().margin().right().to_px_or_zero(width_of_containing_block);
+        item.margins.main_before = item.box.computed_values().margin().top().to_px_or_zero(containing_block_inline_size);
+        item.margins.main_after = item.box.computed_values().margin().bottom().to_px_or_zero(containing_block_inline_size);
+        item.margins.cross_before = item.box.computed_values().margin().left().to_px_or_zero(containing_block_inline_size);
+        item.margins.cross_after = item.box.computed_values().margin().right().to_px_or_zero(containing_block_inline_size);
 
         item.margins.main_before_is_auto = item.box.computed_values().margin().top().is_auto();
         item.margins.main_after_is_auto = item.box.computed_values().margin().bottom().is_auto();
@@ -484,15 +483,15 @@ bool FlexFormattingContext::has_definite_cross_size(LayoutState::UsedValues cons
 CSSPixels FlexFormattingContext::specified_main_min_size(FlexItem const& item) const
 {
     return main_axis_is_horizontal()
-        ? get_pixel_width(item, computed_main_min_size(item.box))
-        : get_pixel_height(item, computed_main_min_size(item.box));
+        ? resolve_inner_inline_size(item, computed_main_min_size(item.box))
+        : resolve_inner_block_size(item, computed_main_min_size(item.box));
 }
 
 CSSPixels FlexFormattingContext::specified_cross_min_size(FlexItem const& item) const
 {
     return cross_axis_is_horizontal()
-        ? get_pixel_width(item, computed_cross_min_size(item.box))
-        : get_pixel_height(item, computed_cross_min_size(item.box));
+        ? resolve_inner_inline_size(item, computed_cross_min_size(item.box))
+        : resolve_inner_block_size(item, computed_cross_min_size(item.box));
 }
 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_min_size() const
@@ -522,15 +521,15 @@ bool FlexFormattingContext::has_cross_max_size(Box const& box) const
 CSSPixels FlexFormattingContext::specified_main_max_size(FlexItem const& item) const
 {
     return main_axis_is_horizontal()
-        ? get_pixel_width(item, computed_main_max_size(item.box))
-        : get_pixel_height(item, computed_main_max_size(item.box));
+        ? resolve_inner_inline_size(item, computed_main_max_size(item.box))
+        : resolve_inner_block_size(item, computed_main_max_size(item.box));
 }
 
 CSSPixels FlexFormattingContext::specified_cross_max_size(FlexItem const& item) const
 {
     return cross_axis_is_horizontal()
-        ? get_pixel_width(item, computed_cross_max_size(item.box))
-        : get_pixel_height(item, computed_cross_max_size(item.box));
+        ? resolve_inner_inline_size(item, computed_cross_max_size(item.box))
+        : resolve_inner_block_size(item, computed_cross_max_size(item.box));
 }
 
 CSSPixels FlexFormattingContext::specified_main_max_size_for_intrinsic_contribution(FlexItem const& item, AvailableSize const& available_size) const
@@ -767,8 +766,8 @@ void FlexFormattingContext::determine_flex_base_size(FlexItem& item)
         if (item.used_flex_basis_is_definite) {
             auto const& size = item.used_flex_basis->get<CSS::Size>();
             if (main_axis_is_horizontal())
-                return get_pixel_width(item, size);
-            return get_pixel_height(item, size);
+                return resolve_inner_inline_size(item, size);
+            return resolve_inner_block_size(item, size);
         }
 
         // AD-HOC: If we're sizing the flex container under a min-content constraint in the main axis,
@@ -841,16 +840,16 @@ void FlexFormattingContext::determine_flex_base_size(FlexItem& item)
             return inner_main_size(item);
 
         // NOTE: There's a fundamental problem with many CSS specifications in that they neglect to mention
-        //       which width to provide when calculating the intrinsic height of a box in various situations.
+        //       which inline size to provide when calculating the intrinsic block size of a box in various situations.
         //       Spec bug: https://github.com/w3c/csswg-drafts/issues/2890
 
         // NOTE: This is one of many situations where that causes trouble: if this is a flex column layout,
-        //       we may need to calculate the intrinsic height of a flex item. This requires a width, but a
-        //       width won't be determined until later on in the flex layout algorithm.
+        //       we may need to calculate the intrinsic block size of a flex item. This requires an inline size,
+        //       but an inline size won't be determined until later on in the flex layout algorithm.
         //       In the specific case above (E), the spec mentions using `fit-content` in place of `auto`
         //       if "a cross size is needed to determine the main size", so that's exactly what we do.
 
-        // NOTE: Finding a suitable width for intrinsic height determination actually happens elsewhere,
+        // NOTE: Finding a suitable inline size for intrinsic block-size determination actually happens elsewhere,
         //       in the various helpers that calculate the intrinsic sizes of a flex item,
         //       e.g. calculate_min_content_main_size().
 
@@ -893,8 +892,8 @@ Optional<CSSPixels> FlexFormattingContext::specified_size_suggestion(FlexItem co
     // If the item’s preferred main size is definite and not automatic,
     // then the specified size suggestion is that size. It is otherwise undefined.
     if (has_definite_main_size(item) && !should_treat_main_size_as_auto(item.box)) {
-        // NOTE: We use get_pixel_{width,height} to ensure that CSS box-sizing is respected.
-        return main_axis_is_horizontal() ? get_pixel_width(item, computed_main_size(item.box)) : get_pixel_height(item, computed_main_size(item.box));
+        // NOTE: We use resolve_inner_{inline,block}_size to ensure that CSS box-sizing is respected.
+        return main_axis_is_horizontal() ? resolve_inner_inline_size(item, computed_main_size(item.box)) : resolve_inner_block_size(item, computed_main_size(item.box));
     }
     return {};
 }
@@ -1300,7 +1299,7 @@ void FlexFormattingContext::save_flex_layout_data() const
                 ? CSSPixelRect { item.main_offset, item.cross_offset, item_main_size, item_cross_size }
                 : CSSPixelRect { item.cross_offset, item.main_offset, item_cross_size, item_main_size };
 
-            auto item_cross_start = main_axis_is_horizontal() ? item_rect.y() : item_rect.x();
+            auto item_cross_start = item.cross_offset;
             cross_start = cross_start.has_value() ? min(cross_start.value(), item_cross_start) : item_cross_start;
 
             FlexLayoutItem layout_item;
@@ -1389,9 +1388,9 @@ void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& 
     // "... treating auto as fit-content"
     CSSPixels fit_content_cross_size;
     if (!cross_axis_is_horizontal()) {
-        auto available_width = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
-        auto available_height = AvailableSize::make_indefinite();
-        fit_content_cross_size = calculate_fit_content_block_size(item.box, AvailableSpace(available_width, available_height), item_containing_block_constraints());
+        auto available_inline_size = item.main_size.has_value() ? AvailableSize::make_definite(clamp_to_max_dimension_value(item.main_size.value())) : AvailableSize::make_indefinite();
+        auto available_block_size = AvailableSize::make_indefinite();
+        fit_content_cross_size = calculate_fit_content_block_size(item.box, AvailableSpace(available_inline_size, available_block_size), item_containing_block_constraints());
     } else {
         fit_content_cross_size = calculate_fit_content_inline_size(item.box, m_available_space_for_items->space, item_containing_block_constraints());
     }
@@ -2205,7 +2204,7 @@ CSSPixels FlexFormattingContext::calculate_main_min_content_contribution(FlexIte
         auto inner_min_content_size = calculate_min_content_main_size(item);
         if (computed_main_size(item.box).is_auto())
             return inner_min_content_size;
-        auto inner_preferred_size = main_axis_is_horizontal() ? get_pixel_width(item, computed_main_size(item.box)) : get_pixel_height(item, computed_main_size(item.box));
+        auto inner_preferred_size = main_axis_is_horizontal() ? resolve_inner_inline_size(item, computed_main_size(item.box)) : resolve_inner_block_size(item, computed_main_size(item.box));
         return max(inner_min_content_size, inner_preferred_size);
     }();
 
@@ -2226,7 +2225,7 @@ CSSPixels FlexFormattingContext::calculate_main_max_content_contribution(FlexIte
         auto inner_max_content_size = calculate_max_content_main_size(item);
         if (computed_main_size(item.box).is_auto())
             return inner_max_content_size;
-        auto inner_preferred_size = main_axis_is_horizontal() ? get_pixel_width(item, computed_main_size(item.box)) : get_pixel_height(item, computed_main_size(item.box));
+        auto inner_preferred_size = main_axis_is_horizontal() ? resolve_inner_inline_size(item, computed_main_size(item.box)) : resolve_inner_block_size(item, computed_main_size(item.box));
         return max(inner_max_content_size, inner_preferred_size);
     }();
 
@@ -2274,7 +2273,7 @@ CSSPixels FlexFormattingContext::calculate_cross_min_content_contribution(FlexIt
                 return *transferred_cross_size;
             return calculate_min_content_cross_size(item);
         }
-        return cross_axis_is_horizontal() ? get_pixel_width(item, computed_cross_size(item.box)) : get_pixel_height(item, computed_cross_size(item.box));
+        return cross_axis_is_horizontal() ? resolve_inner_inline_size(item, computed_cross_size(item.box)) : resolve_inner_block_size(item, computed_cross_size(item.box));
     }();
 
     if (cross_size_auto && item.box.has_preferred_aspect_ratio())
@@ -2300,7 +2299,7 @@ CSSPixels FlexFormattingContext::calculate_cross_max_content_contribution(FlexIt
                 return *transferred_cross_size;
             return calculate_max_content_cross_size(item);
         }
-        return cross_axis_is_horizontal() ? get_pixel_width(item, computed_cross_size(item.box)) : get_pixel_height(item, computed_cross_size(item.box));
+        return cross_axis_is_horizontal() ? resolve_inner_inline_size(item, computed_cross_size(item.box)) : resolve_inner_block_size(item, computed_cross_size(item.box));
     }();
 
     if (cross_size_auto && item.box.has_preferred_aspect_ratio())
@@ -2317,28 +2316,28 @@ CSSPixels FlexFormattingContext::calculate_cross_max_content_contribution(FlexIt
     return item.add_cross_margin_box_sizes(clamped_inner_size);
 }
 
-CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrinsic_height_of_item(FlexItem const& item) const
+CSSPixels FlexFormattingContext::calculate_inline_size_for_intrinsic_block_size(FlexItem const& item) const
 {
     auto const& box = item.box;
-    auto computed_width = box.computed_values().width();
-    auto const& computed_min_width = box.computed_values().min_width();
-    auto const& computed_max_width = box.computed_values().max_width();
+    auto computed_inline_size = box.computed_values().width();
+    auto const& computed_min_inline_size = box.computed_values().min_width();
+    auto const& computed_max_inline_size = box.computed_values().max_width();
 
-    // We can resolve percentage min/max-width if the available width is definite.
+    // We can resolve percentage min/max-width if the available inline size is definite.
     bool can_resolve_percentages = m_available_space_for_items->space.inline_size.is_definite();
 
-    auto clamp_min = (!computed_min_width.is_auto() && (!computed_min_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_min_width) : 0;
-    auto clamp_max = (!should_treat_max_inline_size_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints()) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
+    auto min_inline_size = (!computed_min_inline_size.is_auto() && (!computed_min_inline_size.contains_percentage() || can_resolve_percentages)) ? resolve_inner_inline_size(item, computed_min_inline_size) : 0;
+    auto max_inline_size = (!should_treat_max_inline_size_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints()) && (!computed_max_inline_size.contains_percentage() || can_resolve_percentages)) ? resolve_inner_inline_size(item, computed_max_inline_size) : CSSPixels::max();
 
-    CSSPixels width;
-    if (should_treat_inline_size_as_auto(box, m_available_space_for_items->space) || computed_width.is_fit_content())
-        width = calculate_fit_content_inline_size(box, m_available_space_for_items->space, item_containing_block_constraints());
-    else if (computed_width.is_min_content())
-        width = calculate_min_content_inline_size(box, item_containing_block_constraints());
-    else if (computed_width.is_max_content())
-        width = calculate_max_content_inline_size(box, item_containing_block_constraints());
+    CSSPixels inline_size;
+    if (should_treat_inline_size_as_auto(box, m_available_space_for_items->space) || computed_inline_size.is_fit_content())
+        inline_size = calculate_fit_content_inline_size(box, m_available_space_for_items->space, item_containing_block_constraints());
+    else if (computed_inline_size.is_min_content())
+        inline_size = calculate_min_content_inline_size(box, item_containing_block_constraints());
+    else if (computed_inline_size.is_max_content())
+        inline_size = calculate_max_content_inline_size(box, item_containing_block_constraints());
 
-    return css_clamp(width, clamp_min, clamp_max);
+    return css_clamp(inline_size, min_inline_size, max_inline_size);
 }
 
 CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const& item) const
@@ -2348,7 +2347,7 @@ CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const&
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.inline_size.is_indefinite()) {
-        available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+        available_space.inline_size = AvailableSize::make_definite(calculate_inline_size_for_intrinsic_block_size(item));
     }
     return calculate_min_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
 }
@@ -2360,7 +2359,7 @@ CSSPixels FlexFormattingContext::calculate_max_content_main_size(FlexItem const&
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
     if (available_space.inline_size.is_indefinite()) {
-        available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+        available_space.inline_size = AvailableSize::make_definite(calculate_inline_size_for_intrinsic_block_size(item));
     }
     return calculate_max_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
 }
@@ -2384,7 +2383,7 @@ CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const
     if (!cross_axis_is_horizontal()) {
         auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
         if (available_space.inline_size.is_indefinite()) {
-            available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+            available_space.inline_size = AvailableSize::make_definite(calculate_inline_size_for_intrinsic_block_size(item));
         }
         return calculate_min_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
     }
@@ -2396,7 +2395,7 @@ CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const
     if (!cross_axis_is_horizontal()) {
         auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
         if (available_space.inline_size.is_indefinite()) {
-            available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+            available_space.inline_size = AvailableSize::make_definite(calculate_inline_size_for_intrinsic_block_size(item));
         }
         return calculate_max_content_block_size(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
     }
@@ -2578,11 +2577,11 @@ StaticPositionRect FlexFormattingContext::calculate_static_position_rect(Box con
         break;
     }
 
-    auto flex_container_width = main_axis_is_horizontal() ? inner_main_size(m_flex_container_state) : inner_cross_size(m_flex_container_state);
-    auto flex_container_height = main_axis_is_horizontal() ? inner_cross_size(m_flex_container_state) : inner_main_size(m_flex_container_state);
+    auto flex_container_inline_size = main_axis_is_horizontal() ? inner_main_size(m_flex_container_state) : inner_cross_size(m_flex_container_state);
+    auto flex_container_block_size = main_axis_is_horizontal() ? inner_cross_size(m_flex_container_state) : inner_main_size(m_flex_container_state);
 
     StaticPositionRect static_position_rect;
-    static_position_rect.rect = { { 0, 0 }, { flex_container_width, flex_container_height } };
+    static_position_rect.rect = { { 0, 0 }, { flex_container_inline_size, flex_container_block_size } };
     static_position_rect.inline_alignment = main_axis_is_horizontal() ? main_axis_alignment : cross_axis_alignment;
     static_position_rect.block_alignment = main_axis_is_horizontal() ? cross_axis_alignment : main_axis_alignment;
     // alignment_for_item() consulted the box's own align-self.

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -55,8 +55,8 @@ FlexFormattingContext::~FlexFormattingContext() = default;
 ContainingBlockConstraints FlexFormattingContext::item_containing_block_constraints() const
 {
     auto constraints = constraints_for_child_context(m_flex_container_state, m_layout_input->containing_block_constraints);
-    constraints.percentage_basis_width = m_item_percentage_bases.percentage_basis_width;
-    constraints.percentage_basis_height = m_item_percentage_bases.percentage_basis_height;
+    constraints.percentage_basis_inline_size = m_item_percentage_bases.percentage_basis_inline_size;
+    constraints.percentage_basis_block_size = m_item_percentage_bases.percentage_basis_block_size;
     return constraints;
 }
 
@@ -351,7 +351,7 @@ bool FlexFormattingContext::is_direction_reverse() const
 void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::FlexDirection) const
 {
     // Percentages on flex item box-model metrics resolve against the flex container's inline size.
-    auto width_of_containing_block = m_item_percentage_bases.percentage_basis_width.value_or(0);
+    auto width_of_containing_block = m_item_percentage_bases.percentage_basis_inline_size.value_or(0);
 
     item.used_values.padding_left = item.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
     item.used_values.padding_right = item.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
@@ -421,7 +421,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
             return IterationDecision::Continue;
 
         child_box.set_flex_item(true);
-        FlexItem item = { child_box, m_state.create(child_box, m_item_percentage_bases.percentage_basis_width, m_item_percentage_bases.percentage_basis_height) };
+        FlexItem item = { child_box, m_state.create(child_box, m_item_percentage_bases.percentage_basis_inline_size, m_item_percentage_bases.percentage_basis_block_size) };
         populate_specified_margins(item, m_flex_direction);
 
         auto& order_bucket = order_item_bucket.ensure(child_box.computed_values().order());

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -60,12 +60,12 @@ ContainingBlockConstraints FlexFormattingContext::item_containing_block_constrai
     return constraints;
 }
 
-CSSPixels FlexFormattingContext::automatic_content_width() const
+CSSPixels FlexFormattingContext::automatic_content_inline_size() const
 {
     return m_flex_container_state.content_inline_size();
 }
 
-CSSPixels FlexFormattingContext::automatic_content_height() const
+CSSPixels FlexFormattingContext::automatic_content_block_size() const
 {
     return m_flex_container_state.content_block_size();
 }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -2583,8 +2583,8 @@ StaticPositionRect FlexFormattingContext::calculate_static_position_rect(Box con
 
     StaticPositionRect static_position_rect;
     static_position_rect.rect = { { 0, 0 }, { flex_container_width, flex_container_height } };
-    static_position_rect.horizontal_alignment = main_axis_is_horizontal() ? main_axis_alignment : cross_axis_alignment;
-    static_position_rect.vertical_alignment = main_axis_is_horizontal() ? cross_axis_alignment : main_axis_alignment;
+    static_position_rect.inline_alignment = main_axis_is_horizontal() ? main_axis_alignment : cross_axis_alignment;
+    static_position_rect.block_alignment = main_axis_is_horizontal() ? cross_axis_alignment : main_axis_alignment;
     // alignment_for_item() consulted the box's own align-self.
     static_position_rect.alignment_derives_from_own_computed_values = true;
     return static_position_rect;

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -26,7 +26,7 @@ static String serialize_flex_basis(CSS::FlexBasis const& flex_basis)
 
 CSSPixels FlexFormattingContext::get_pixel_width(FlexItem const& item, CSS::Size const& size) const
 {
-    return calculate_inner_width(item.box, m_available_space->width, size, item_containing_block_constraints());
+    return calculate_inner_width(item.box, m_available_space->inline_size, size, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::get_pixel_height(FlexItem const& item, CSS::Size const& size) const
@@ -81,8 +81,8 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
     //               However, an inline-level container must still lay out its items, since the
     //               parent inline formatting context derives the fragment's baseline from them.
     if (m_layout_mode == LayoutMode::IntrinsicSizing
-        && !available_space.width.is_intrinsic_sizing_constraint()
-        && !available_space.height.is_intrinsic_sizing_constraint()
+        && !available_space.inline_size.is_intrinsic_sizing_constraint()
+        && !available_space.block_size.is_intrinsic_sizing_constraint()
         && !flex_container().display().is_inline_outside()) {
         return;
     }
@@ -182,7 +182,7 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
         item.hypothetical_main_size = max(CSSPixels(0), css_clamp(item.flex_base_size, clamp_min, clamp_max));
     }
 
-    if (available_space.width.is_intrinsic_sizing_constraint() || available_space.height.is_intrinsic_sizing_constraint()) {
+    if (available_space.inline_size.is_intrinsic_sizing_constraint() || available_space.block_size.is_intrinsic_sizing_constraint()) {
         // We're computing intrinsic size for the flex container. This happens at the end of run().
     } else {
         // 4. Determine the main size of the flex container
@@ -245,7 +245,7 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
     // 16. Align all flex lines (per align-content)
     align_all_flex_lines();
 
-    if (available_space.width.is_intrinsic_sizing_constraint() || available_space.height.is_intrinsic_sizing_constraint()) {
+    if (available_space.inline_size.is_intrinsic_sizing_constraint() || available_space.block_size.is_intrinsic_sizing_constraint()) {
         // We're computing intrinsic size for the flex container.
         determine_intrinsic_size_of_flex_container();
     } else {
@@ -269,7 +269,7 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
                 // were all part of the table box's border+padding area,
                 // and the table box were the flex item.
                 auto intrinsic_available_space = input.available_space;
-                intrinsic_available_space.height = AvailableSize::make_indefinite();
+                intrinsic_available_space.block_size = AvailableSize::make_indefinite();
                 auto intrinsic_table_grid_height = compute_table_box_height_inside_table_wrapper(item.box, intrinsic_available_space, input.containing_block_constraints);
                 auto extra_height = max(CSSPixels(0), item.cross_size.value() - item.hypothetical_cross_size);
                 return input.with_table_grid_min_border_box_height(intrinsic_table_grid_height + extra_height);
@@ -498,14 +498,14 @@ CSSPixels FlexFormattingContext::specified_cross_min_size(FlexItem const& item) 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_min_size() const
 {
     return cross_axis_is_horizontal()
-        ? calculate_inner_width(flex_container(), m_available_space.value().width, computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints)
+        ? calculate_inner_width(flex_container(), m_available_space.value().inline_size, computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints)
         : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_min_size(flex_container()), m_layout_input->containing_block_constraints);
 }
 
 CSSPixels FlexFormattingContext::calculate_inner_flex_container_cross_max_size() const
 {
     return cross_axis_is_horizontal()
-        ? calculate_inner_width(flex_container(), m_available_space.value().width, computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints)
+        ? calculate_inner_width(flex_container(), m_available_space.value().inline_size, computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints)
         : calculate_inner_height(flex_container(), m_available_space.value(), computed_cross_max_size(flex_container()), m_layout_input->containing_block_constraints);
 }
 
@@ -621,15 +621,15 @@ void FlexFormattingContext::determine_available_space_for_items(AvailableSpace c
 {
     if (main_axis_is_horizontal()) {
         m_available_space_for_items = AxisAgnosticAvailableSpace {
-            .main = available_space.width,
-            .cross = available_space.height,
-            .space = { available_space.width, available_space.height },
+            .main = available_space.inline_size,
+            .cross = available_space.block_size,
+            .space = { available_space.inline_size, available_space.block_size },
         };
     } else {
         m_available_space_for_items = AxisAgnosticAvailableSpace {
-            .main = available_space.height,
-            .cross = available_space.width,
-            .space = { available_space.width, available_space.height },
+            .main = available_space.block_size,
+            .cross = available_space.inline_size,
+            .space = { available_space.inline_size, available_space.block_size },
         };
     }
 }
@@ -2254,15 +2254,15 @@ bool FlexFormattingContext::should_treat_cross_size_as_auto(Box const& box) cons
 bool FlexFormattingContext::should_treat_main_max_size_as_none(Box const& box) const
 {
     if (main_axis_is_horizontal())
-        return should_treat_max_width_as_none(box, m_available_space_for_items->space.width, item_containing_block_constraints());
-    return should_treat_max_height_as_none(box, m_available_space_for_items->space.height, item_containing_block_constraints());
+        return should_treat_max_width_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints());
+    return should_treat_max_height_as_none(box, m_available_space_for_items->space.block_size, item_containing_block_constraints());
 }
 
 bool FlexFormattingContext::should_treat_cross_max_size_as_none(Box const& box) const
 {
     if (cross_axis_is_horizontal())
-        return should_treat_max_width_as_none(box, m_available_space_for_items->space.width, item_containing_block_constraints());
-    return should_treat_max_height_as_none(box, m_available_space_for_items->space.height, item_containing_block_constraints());
+        return should_treat_max_width_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints());
+    return should_treat_max_height_as_none(box, m_available_space_for_items->space.block_size, item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_cross_min_content_contribution(FlexItem const& item, bool resolve_percentage_min_max_sizes) const
@@ -2325,10 +2325,10 @@ CSSPixels FlexFormattingContext::calculate_width_to_use_when_determining_intrins
     auto const& computed_max_width = box.computed_values().max_width();
 
     // We can resolve percentage min/max-width if the available width is definite.
-    bool can_resolve_percentages = m_available_space_for_items->space.width.is_definite();
+    bool can_resolve_percentages = m_available_space_for_items->space.inline_size.is_definite();
 
     auto clamp_min = (!computed_min_width.is_auto() && (!computed_min_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_min_width) : 0;
-    auto clamp_max = (!should_treat_max_width_as_none(box, m_available_space_for_items->space.width, item_containing_block_constraints()) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
+    auto clamp_max = (!should_treat_max_width_as_none(box, m_available_space_for_items->space.inline_size, item_containing_block_constraints()) && (!computed_max_width.contains_percentage() || can_resolve_percentages)) ? get_pixel_width(item, computed_max_width) : CSSPixels::max();
 
     CSSPixels width;
     if (should_treat_width_as_auto(box, m_available_space_for_items->space) || computed_width.is_fit_content())
@@ -2347,10 +2347,10 @@ CSSPixels FlexFormattingContext::calculate_min_content_main_size(FlexItem const&
         return calculate_min_content_width(item.box, item_containing_block_constraints());
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
-    if (available_space.width.is_indefinite()) {
-        available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+    if (available_space.inline_size.is_indefinite()) {
+        available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
     }
-    return calculate_min_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
+    return calculate_min_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_max_content_main_size(FlexItem const& item) const
@@ -2359,10 +2359,10 @@ CSSPixels FlexFormattingContext::calculate_max_content_main_size(FlexItem const&
         return calculate_max_content_width(item.box, item_containing_block_constraints());
     }
     auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
-    if (available_space.width.is_indefinite()) {
-        available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+    if (available_space.inline_size.is_indefinite()) {
+        available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
     }
-    return calculate_max_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
+    return calculate_max_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
 }
 
 CSSPixels FlexFormattingContext::calculate_fit_content_main_size(FlexItem const& item) const
@@ -2383,10 +2383,10 @@ CSSPixels FlexFormattingContext::calculate_min_content_cross_size(FlexItem const
 {
     if (!cross_axis_is_horizontal()) {
         auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
-        if (available_space.width.is_indefinite()) {
-            available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+        if (available_space.inline_size.is_indefinite()) {
+            available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
         }
-        return calculate_min_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
+        return calculate_min_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
     }
     return calculate_min_content_width(item.box, item_containing_block_constraints());
 }
@@ -2395,10 +2395,10 @@ CSSPixels FlexFormattingContext::calculate_max_content_cross_size(FlexItem const
 {
     if (!cross_axis_is_horizontal()) {
         auto available_space = item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space);
-        if (available_space.width.is_indefinite()) {
-            available_space.width = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
+        if (available_space.inline_size.is_indefinite()) {
+            available_space.inline_size = AvailableSize::make_definite(calculate_width_to_use_when_determining_intrinsic_height_of_item(item));
         }
-        return calculate_max_content_height(item.box, available_space.width.to_px_or_zero(), item_containing_block_constraints());
+        return calculate_max_content_height(item.box, available_space.inline_size.to_px_or_zero(), item_containing_block_constraints());
     }
     return calculate_max_content_width(item.box, item_containing_block_constraints());
 }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -270,9 +270,9 @@ void FlexFormattingContext::run(LayoutInput const& layout_input)
                 // and the table box were the flex item.
                 auto intrinsic_available_space = input.available_space;
                 intrinsic_available_space.block_size = AvailableSize::make_indefinite();
-                auto intrinsic_table_grid_height = compute_table_box_height_inside_table_wrapper(item.box, intrinsic_available_space, input.containing_block_constraints);
-                auto extra_height = max(CSSPixels(0), item.cross_size.value() - item.hypothetical_cross_size);
-                return input.with_table_grid_min_border_box_height(intrinsic_table_grid_height + extra_height);
+                auto intrinsic_table_grid_block_size = compute_table_box_block_size_inside_table_wrapper(item.box, intrinsic_available_space, input.containing_block_constraints);
+                auto extra_block_size = max(CSSPixels(0), item.cross_size.value() - item.hypothetical_cross_size);
+                return input.with_table_grid_min_border_box_block_size(intrinsic_table_grid_block_size + extra_block_size);
             }();
             if (auto independent_formatting_context = layout_inside(item.box, LayoutMode::Normal, item_layout_input))
                 independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -20,8 +20,8 @@ public:
     virtual bool inhibits_floating() const override { return true; }
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_width() const override;
-    virtual CSSPixels automatic_content_height() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
 
     Box const& flex_container() const { return context_box(); }
 

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -158,8 +158,8 @@ private:
     CSS::Size const& computed_cross_min_size(Box const&) const;
     CSS::Size const& computed_cross_max_size(Box const&) const;
 
-    CSSPixels get_pixel_width(FlexItem const&, CSS::Size const&) const;
-    CSSPixels get_pixel_height(FlexItem const&, CSS::Size const&) const;
+    CSSPixels resolve_inner_inline_size(FlexItem const&, CSS::Size const&) const;
+    CSSPixels resolve_inner_block_size(FlexItem const&, CSS::Size const&) const;
 
     bool flex_item_is_stretched(FlexItem const&) const;
 
@@ -236,7 +236,7 @@ private:
     [[nodiscard]] CSSPixels calculate_fit_content_main_size(FlexItem const&) const;
     [[nodiscard]] CSSPixels calculate_fit_content_cross_size(FlexItem const&) const;
 
-    [[nodiscard]] CSSPixels calculate_width_to_use_when_determining_intrinsic_height_of_item(FlexItem const&) const;
+    [[nodiscard]] CSSPixels calculate_inline_size_for_intrinsic_block_size(FlexItem const&) const;
 
     virtual void parent_context_did_dimension_child_root_box() override;
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -687,41 +687,41 @@ LogicalSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_in
 
 Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout) const
 {
-    // NOTE: CSS 2.2 tells us to use the "auto height for block formatting context roots" here.
+    // NOTE: CSS 2.2 tells us to use the automatic block size for block formatting context roots here.
     //       That's fine as long as the box is a BFC root.
     if (creates_block_formatting_context(box)) {
         if (before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
             return {};
-        return compute_auto_height_for_block_formatting_context_root(box);
+        return compute_automatic_block_size_for_block_formatting_context_root(box);
     }
 
-    // NOTE: For anything else, we use the fit-content height.
+    // NOTE: For anything else, we use the fit-content block size.
     //       This should eventually be replaced by the new absolute positioning model:
     //       https://www.w3.org/TR/css-position-3/#abspos-layout
     return calculate_fit_content_block_size(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
 }
 
 // https://www.w3.org/TR/CSS22/visudet.html#root-height
-CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_root(Box const& root) const
+CSSPixels FormattingContext::compute_automatic_block_size_for_block_formatting_context_root(Box const& root) const
 {
     // 10.6.7 'Auto' heights for block formatting context roots
     Optional<CSSPixels> top;
     Optional<CSSPixels> bottom;
 
     if (root.children_are_inline()) {
-        // If it only has inline-level children, the height is the distance between
+        // If it only has inline-level children, the block size is the distance between
         // the top content edge and the bottom of the bottommost line box.
         auto const& line_boxes = m_state.get(root).line_boxes;
         top = 0;
         if (!line_boxes.is_empty()) {
             bottom = line_boxes.last().bottom();
             // A trailing interrupting block's bottom margin cannot collapse out of a BFC root,
-            // so it contributes to the root's auto height. The line box bottom excludes it.
+            // so it contributes to the root's automatic block size. The line box bottom excludes it.
             if (line_boxes.last().has_block_level_box())
                 bottom = max(CSSPixels(0), bottom.value() + line_boxes.last().block_level_box_bottom_margin());
         }
     } else {
-        // If it has block-level children, the height is the distance between
+        // If it has block-level children, the block size is the distance between
         // the top margin-edge of the topmost block-level child box
         // and the bottom margin-edge of the bottommost block-level child box.
 
@@ -738,7 +738,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
             if (child_box.is_floating())
                 return IterationDecision::Continue;
 
-            // Children that have not been laid out yet contribute nothing to the auto height.
+            // Children that have not been laid out yet contribute nothing to the automatic block size.
             auto const* child_box_state = m_state.try_get(child_box);
             if (!child_box_state)
                 return IterationDecision::Continue;
@@ -754,7 +754,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
 
     // In addition, if the element has any floating descendants
     // whose bottom margin edge is below the element's bottom content edge,
-    // then the height is increased to include those edges.
+    // then the block size is increased to include those edges.
     if (auto lowest_float_bottom_margin_edge = m_state.get(root).lowest_floating_descendant_bottom_margin_edge(); lowest_float_bottom_margin_edge.has_value()) {
         if (!bottom.has_value() || *lowest_float_bottom_margin_edge > bottom.value())
             bottom = lowest_float_bottom_margin_edge;
@@ -772,7 +772,7 @@ CSSPixels FormattingContext::measure_automatic_content_block_size(Box const& box
     return measuring_context->automatic_content_block_size();
 }
 
-void FormattingContext::make_button_content_box_definite(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, Optional<CSSPixels> measured_content_height)
+void FormattingContext::make_button_content_box_definite(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, Optional<CSSPixels> measured_content_block_size)
 {
     auto const* html_element = as_if<HTML::HTMLElement>(box.dom_node());
     if (!html_element || !html_element->uses_button_layout())
@@ -795,25 +795,25 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
     if (box_state.has_definite_block_size())
         return;
 
-    auto natural_content_height = measured_content_height.value_or_lazy_evaluated([&] {
+    auto natural_content_block_size = measured_content_block_size.value_or_lazy_evaluated([&] {
         return measure_automatic_content_block_size(box, box_state.available_inner_space_or_constraints_from(available_space), containing_block_constraints);
     });
 
-    auto used_height = should_treat_block_size_as_auto(box, available_space, containing_block_constraints)
-        ? natural_content_height
+    auto used_block_size = should_treat_block_size_as_auto(box, available_space, containing_block_constraints)
+        ? natural_content_block_size
         : calculate_inner_block_size(box, available_space, computed_values.height(), containing_block_constraints);
     if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints) && !computed_values.max_height().is_auto())
-        used_height = min(used_height, calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints));
+        used_block_size = min(used_block_size, calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints));
     if (!computed_values.min_height().is_auto())
-        used_height = max(used_height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
+        used_block_size = max(used_block_size, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
 
-    // Only force a definite content box when the button is taller than its content, so a min-height or a larger height
-    // has room to center within. A content-sized box stays indefinite, so an intrinsic keyword height does not resolve
-    // percentage-height descendants.
-    if (used_height <= natural_content_height)
+    // Only force a definite content box when the button's used block size exceeds its content block size, so a larger
+    // preferred or minimum size has room to center within. A content-sized box stays indefinite, so an intrinsic
+    // keyword does not resolve percentage-sized descendants.
+    if (used_block_size <= natural_content_block_size)
         return;
 
-    box_state.set_content_block_size(used_height);
+    box_state.set_content_block_size(used_block_size);
     box_state.set_has_definite_block_size(true);
 }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -864,7 +864,7 @@ CSSPixels FormattingContext::compute_table_box_inline_size_inside_table_wrapper(
     table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
-    context->run_until_width_calculation(
+    context->run_until_inline_size_calculation(
         LayoutInput { table_box_state.available_inner_space_or_constraints_from(available_space), table_constraints },
         TableFormattingContext::RowMeasurement::Skip);
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -592,20 +592,20 @@ OwnPtr<FormattingContext> FormattingContext::layout_inside(Box const& child_box,
     return independent_formatting_context;
 }
 
-CSSPixels FormattingContext::greatest_child_width(Box const& box) const
+CSSPixels FormattingContext::greatest_child_inline_size(Box const& box) const
 {
-    CSSPixels max_width = 0;
+    CSSPixels max_inline_size = 0;
     if (box.children_are_inline()) {
         for (auto& line_box : m_state.get(box).line_boxes)
-            max_width = max(max_width, line_box_physical_width(box, line_box));
+            max_inline_size = max(max_inline_size, line_box_physical_width(box, line_box));
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {
             if (!child.is_absolutely_positioned())
-                max_width = max(max_width, m_state.get(child).margin_box_inline_size());
+                max_inline_size = max(max_inline_size, m_state.get(child).margin_box_inline_size());
             return IterationDecision::Continue;
         });
     }
-    return max_width;
+    return max_inline_size;
 }
 
 CSSPixels FormattingContext::line_box_physical_width(Box const& box, LineBox const& line_box)
@@ -633,11 +633,11 @@ CSSPixels FormattingContext::line_box_physical_width(Box const& box, LineBox con
     return rightmost_fragment_x - leftmost_fragment_x;
 }
 
-FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_widths(Box const& box, ContainingBlockConstraints const& containing_block_constraints)
+FormattingContext::ShrinkToFitInlineSizeResult FormattingContext::calculate_shrink_to_fit_inline_sizes(Box const& box, ContainingBlockConstraints const& containing_block_constraints)
 {
     return {
-        .preferred_width = calculate_max_content_inline_size(box, containing_block_constraints),
-        .preferred_minimum_width = calculate_min_content_inline_size(box, containing_block_constraints),
+        .preferred_inline_size = calculate_max_content_inline_size(box, containing_block_constraints),
+        .preferred_minimum_inline_size = calculate_min_content_inline_size(box, containing_block_constraints),
     };
 }
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -819,25 +819,25 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
 
 // 17.5.2 Table width algorithms: the 'table-layout' property
 // https://www.w3.org/TR/CSS22/tables.html#width-layout
-CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
+CSSPixels FormattingContext::compute_table_box_inline_size_inside_table_wrapper(
     Box const& box,
     AvailableSpace const& available_space,
     ContainingBlockConstraints const& table_wrapper_constraints,
-    Optional<CSSPixels> table_wrapper_containing_block_width,
-    TableWrapperWidthMode table_wrapper_width_mode)
+    Optional<CSSPixels> table_wrapper_containing_block_inline_size,
+    TableWrapperInlineSizeMode table_wrapper_inline_size_mode)
 {
-    // CSS 2 says the table wrapper width is the border-edge width of the table grid box inside it.
+    // CSS 2 says the table wrapper inline size is the border-edge inline size of the table grid box inside it.
 
     auto const& computed_values = box.computed_values();
 
-    auto width_of_containing_block = table_wrapper_containing_block_width.value_or(available_space.inline_size.to_px_or_zero());
+    auto containing_block_inline_size = table_wrapper_containing_block_inline_size.value_or(available_space.inline_size.to_px_or_zero());
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
-    auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
-    auto margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
+    auto margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
+    auto margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
 
     // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
-    auto available_width = width_of_containing_block - margin_left - margin_right;
+    auto available_inline_size = containing_block_inline_size - margin_left - margin_right;
 
     Optional<Box const&> table_box;
     box.for_each_in_subtree_of_type<Box>([&](Box const& child_box) {
@@ -853,46 +853,46 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
 
     // The table wrapper is invisible to percentage resolution, so the table box gets the
     // wrapper's constraints unchanged. Callers measuring a table wrapper for grid alignment
-    // pass the grid-area width as the wrapper's percentage basis.
+    // pass the grid-area inline size as the wrapper's percentage basis.
     throwaway_state.create(box, table_wrapper_constraints.percentage_basis_inline_size, table_wrapper_constraints.percentage_basis_block_size);
     auto const& table_constraints = table_wrapper_constraints;
     auto& table_box_state = throwaway_state.create(*table_box, table_constraints.percentage_basis_inline_size, table_constraints.percentage_basis_block_size);
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;
     table_box_state.border_right = table_box_computed_values.border_right().width;
-    table_box_state.padding_left = table_box_computed_values.padding().left().to_px_or_zero(width_of_containing_block);
-    table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(width_of_containing_block);
+    table_box_state.padding_left = table_box_computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
+    table_box_state.padding_right = table_box_computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 
     auto context = make<TableFormattingContext>(throwaway_state, LayoutMode::IntrinsicSizing, *table_box, this);
     context->run_until_width_calculation(
         LayoutInput { table_box_state.available_inner_space_or_constraints_from(available_space), table_constraints },
         TableFormattingContext::RowMeasurement::Skip);
 
-    auto table_used_width = throwaway_state.get(*table_box).border_box_width();
-    if (table_wrapper_width_mode == TableWrapperWidthMode::UseTableUsedWidthIfNotAuto
+    auto table_used_inline_size = throwaway_state.get(*table_box).border_box_width();
+    if (table_wrapper_inline_size_mode == TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto
         && !table_box->computed_values().width().is_auto()) {
-        return table_used_width;
+        return table_used_inline_size;
     }
-    return available_space.inline_size.is_definite() ? min(table_used_width, available_width) : table_used_width;
+    return available_space.inline_size.is_definite() ? min(table_used_inline_size, available_inline_size) : table_used_inline_size;
 }
 
 // 17.5.3 Table height algorithms
 // https://www.w3.org/TR/CSS22/tables.html#height-layout
-CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& table_wrapper_constraints)
+CSSPixels FormattingContext::compute_table_box_block_size_inside_table_wrapper(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& table_wrapper_constraints)
 {
-    // Table wrapper height should be equal to height of table box it contains
+    // The table wrapper block size should equal the block size of the table box it contains.
 
     auto const& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
-    auto height_of_containing_block = available_space.block_size.to_px_or_zero();
+    auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
+    auto containing_block_block_size = available_space.block_size.to_px_or_zero();
 
     // If 'margin-top', or 'margin-bottom' are computed as 'auto', their used value is '0'.
-    auto margin_top = computed_values.margin().top().resolved_or_auto(width_of_containing_block).to_px_or_zero();
-    auto margin_bottom = computed_values.margin().bottom().resolved_or_auto(width_of_containing_block).to_px_or_zero();
+    auto margin_top = computed_values.margin().top().resolved_or_auto(containing_block_inline_size).to_px_or_zero();
+    auto margin_bottom = computed_values.margin().bottom().resolved_or_auto(containing_block_inline_size).to_px_or_zero();
 
     // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
-    auto available_height = height_of_containing_block - margin_top - margin_bottom;
+    auto available_block_size = containing_block_block_size - margin_top - margin_bottom;
 
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
     throwaway_state.create(box, table_wrapper_constraints.percentage_basis_inline_size, table_wrapper_constraints.percentage_basis_block_size);
@@ -911,8 +911,8 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     });
     VERIFY(table_box.has_value());
 
-    auto table_used_height = throwaway_state.get(*table_box).border_box_height();
-    return available_space.block_size.is_definite() ? min(table_used_height, available_height) : table_used_height;
+    auto table_used_block_size = throwaway_state.get(*table_box).border_box_height();
+    return available_space.block_size.is_definite() ? min(table_used_block_size, available_block_size) : table_used_block_size;
 }
 
 ContainingBlockConstraints FormattingContext::constraints_for_child_context(
@@ -1332,7 +1332,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = try_compute_width([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
-            return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, available_space, containing_block_constraints));
+            return CSS::Length::make_px(compute_table_box_inline_size_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (computed_values.width().is_auto())
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
@@ -1670,7 +1670,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
     auto used_height = try_compute_height([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
-            return CSS::Length::make_px(compute_table_box_height_inside_table_wrapper(box, available_space, containing_block_constraints));
+            return CSS::Length::make_px(compute_table_box_block_size_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_block_size(box, available_space_for_intrinsic_height, box.computed_values().height(), containing_block_constraints));

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -57,9 +57,9 @@ static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::U
         auto border_box_right = computed_values.border_right().width + box_state.padding_right;
         auto border_box_top = computed_values.border_top().width + box_state.padding_top;
         auto border_box_bottom = computed_values.border_bottom().width + box_state.padding_bottom;
-        auto border_box_width = content_inline_size + border_box_left + border_box_right;
-        auto border_box_height = border_box_width / aspect_ratio;
-        return max(border_box_height - border_box_top - border_box_bottom, 0);
+        auto border_box_inline_size = content_inline_size + border_box_left + border_box_right;
+        auto border_box_block_size = border_box_inline_size / aspect_ratio;
+        return max(border_box_block_size - border_box_top - border_box_bottom, 0);
     }
 
     return content_inline_size / aspect_ratio;
@@ -84,9 +84,9 @@ static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::Us
         auto border_box_right = computed_values.border_right().width + box_state.padding_right;
         auto border_box_top = computed_values.border_top().width + box_state.padding_top;
         auto border_box_bottom = computed_values.border_bottom().width + box_state.padding_bottom;
-        auto border_box_height = content_block_size + border_box_top + border_box_bottom;
-        auto border_box_width = border_box_height * aspect_ratio;
-        return max(border_box_width - border_box_left - border_box_right, 0);
+        auto border_box_block_size = content_block_size + border_box_top + border_box_bottom;
+        auto border_box_inline_size = border_box_block_size * aspect_ratio;
+        return max(border_box_inline_size - border_box_left - border_box_right, 0);
     }
 
     return content_block_size * aspect_ratio;
@@ -485,7 +485,7 @@ void FormattingContext::register_contained_abspos_child(Box const& child, Static
 
 CSSPixelPoint FormattingContext::aligned_static_position(StaticPositionRect const& static_position_rect, LayoutState::UsedValues const& box_state)
 {
-    return static_position_rect.aligned_position_for_box_with_size({ box_state.margin_box_width(), box_state.margin_box_height() });
+    return static_position_rect.aligned_position_for_box_with_size({ box_state.margin_box_inline_size(), box_state.margin_box_block_size() });
 }
 
 // FIXME: This is a hack. Get rid of it.
@@ -601,7 +601,7 @@ CSSPixels FormattingContext::greatest_child_width(Box const& box) const
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {
             if (!child.is_absolutely_positioned())
-                max_width = max(max_width, m_state.get(child).margin_box_width());
+                max_width = max(max_width, m_state.get(child).margin_box_inline_size());
             return IterationDecision::Continue;
         });
     }
@@ -868,7 +868,7 @@ CSSPixels FormattingContext::compute_table_box_inline_size_inside_table_wrapper(
         LayoutInput { table_box_state.available_inner_space_or_constraints_from(available_space), table_constraints },
         TableFormattingContext::RowMeasurement::Skip);
 
-    auto table_used_inline_size = throwaway_state.get(*table_box).border_box_width();
+    auto table_used_inline_size = throwaway_state.get(*table_box).border_box_inline_size();
     if (table_wrapper_inline_size_mode == TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto
         && !table_box->computed_values().width().is_auto()) {
         return table_used_inline_size;
@@ -911,7 +911,7 @@ CSSPixels FormattingContext::compute_table_box_block_size_inside_table_wrapper(B
     });
     VERIFY(table_box.has_value());
 
-    auto table_used_block_size = throwaway_state.get(*table_box).border_box_height();
+    auto table_used_block_size = throwaway_state.get(*table_box).border_box_block_size();
     return available_space.block_size.is_definite() ? min(table_used_block_size, available_block_size) : table_used_block_size;
 }
 
@@ -1789,8 +1789,8 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
         auto const is_horizontal = writing_mode == CSS::WritingMode::HorizontalTb;
         auto const inline_axis_border_box_start = fragment.inline_offset() - (is_horizontal ? child_used_values->border_box_left() : child_used_values->border_box_top());
         auto const inline_axis_border_box_extent = is_horizontal
-            ? child_used_values->border_box_width()
-            : child_used_values->border_box_height();
+            ? child_used_values->border_box_inline_size()
+            : child_used_values->border_box_block_size();
         auto const block_axis_line_height = inline_node.computed_values().line_height();
         auto const block_axis_start = [&] {
             if (fragment.style_source().computed_values().block_axis_is_reverse())
@@ -1849,7 +1849,7 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
                         child_used_values->border_left + child_used_values->padding_left,
                         child_used_values->border_top + child_used_values->padding_top,
                     };
-                    add_fragment_rect({ border_box_origin, { child_used_values->border_box_width(), child_used_values->border_box_height() } });
+                    add_fragment_rect({ border_box_origin, { child_used_values->border_box_inline_size(), child_used_values->border_box_block_size() } });
                 }
             }
             self(*child, child_offset);
@@ -2156,7 +2156,7 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             + CSSPixelPoint { containing_block_state.padding_left, containing_block_state.padding_top };
         return CSSPixelRect {
             anchor_border_box_origin,
-            { anchor_state.border_box_width(), anchor_state.border_box_height() },
+            { anchor_state.border_box_inline_size(), anchor_state.border_box_block_size() },
         };
     };
 
@@ -2296,8 +2296,8 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             return existing_value;
 
         auto containing_block_extent = is_horizontal_axis
-            ? containing_block_state.padding_box_width()
-            : containing_block_state.padding_box_height();
+            ? containing_block_state.padding_box_inline_size()
+            : containing_block_state.padding_box_block_size();
 
         AnchorInsetResolver anchor_resolver { resolve_anchor_side, note_resolved_anchor_function, box.is_absolutely_positioned(), is_from_end, is_horizontal_axis, containing_block_extent };
 
@@ -2532,7 +2532,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
 
     // Apply grid alignment for auto inset axes
     if (containing_block_info.horizontal_alignment.has_value() && computed_values.inset().left().is_auto() && computed_values.inset().right().is_auto()) {
-        auto available_space_for_alignment = containing_block_info.rect.width() - box_state.margin_box_width();
+        auto available_space_for_alignment = containing_block_info.rect.width() - box_state.margin_box_inline_size();
         switch (*containing_block_info.horizontal_alignment) {
         case Alignment::Center:
             box_state.inset_left = available_space_for_alignment / 2;
@@ -2552,7 +2552,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     }
 
     if (containing_block_info.vertical_alignment.has_value() && computed_values.inset().top().is_auto() && computed_values.inset().bottom().is_auto()) {
-        auto available_space_for_alignment = containing_block_info.rect.height() - box_state.margin_box_height();
+        auto available_space_for_alignment = containing_block_info.rect.height() - box_state.margin_box_block_size();
         switch (*containing_block_info.vertical_alignment) {
         case Alignment::Center:
             box_state.inset_top = available_space_for_alignment / 2;
@@ -3427,7 +3427,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
             return box_state.border_box_top();
         case CSS::VerticalAlign::Middle:
             // Middle: Align the vertical midpoint of the box with the baseline of the parent box plus half the x-height of the parent.
-            return box_state.margin_box_height() / 2 + CSSPixels::nearest_value_for(box.containing_block()->first_available_font().pixel_metrics().x_height / 2);
+            return box_state.margin_box_block_size() / 2 + CSSPixels::nearest_value_for(box.containing_block()->first_available_font().pixel_metrics().x_height / 2);
         case CSS::VerticalAlign::Bottom:
             // Bottom: Align the bottom of the aligned subtree with the bottom of the line box.
             return box_state.content_block_size() + box_state.margin_box_top();
@@ -3436,7 +3436,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
             return box.computed_values().font_size();
         case CSS::VerticalAlign::TextBottom:
             // TextBottom: Align the bottom of the box with the bottom of the parent's content area (see 10.6.1).
-            return box_state.margin_box_height() - CSSPixels::nearest_value_for(box.containing_block()->first_available_font().pixel_metrics().descent);
+            return box_state.margin_box_block_size() - CSSPixels::nearest_value_for(box.containing_block()->first_available_font().pixel_metrics().descent);
         default:
             break;
         }
@@ -3478,7 +3478,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
         return box_state.margin_box_top() + *content_baseline;
 
     // If the box has no baseline set, the bottom margin edge of the box is used.
-    return box_state.margin_box_height();
+    return box_state.margin_box_block_size();
 }
 
 CSSPixelRect FormattingContext::margin_box_rect(LayoutState::UsedValues const& used_values)

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -2264,8 +2264,8 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
     };
 
     auto* default_anchor_box = default_anchor_name.has_value() ? target_anchor_box(default_anchor_name.value()) : nullptr;
-    bool compensates_for_scroll_in_x = false;
-    bool compensates_for_scroll_in_y = false;
+    bool compensates_for_horizontal_scroll = false;
+    bool compensates_for_vertical_scroll = false;
 
     // https://drafts.csswg.org/css-anchor-position-1/#compensate-for-scroll
     // An absolutely positioned box abspos compensates for scroll in the horizontal or vertical axis if both of the
@@ -2295,9 +2295,9 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
             return;
 
         if (is_horizontal_axis)
-            compensates_for_scroll_in_x = true;
+            compensates_for_horizontal_scroll = true;
         else
-            compensates_for_scroll_in_y = true;
+            compensates_for_vertical_scroll = true;
     };
 
     auto resolve_inset = [&](bool contains_anchor, CSS::StyleValue const& value, CSS::LengthPercentageOrAuto const& existing_value, CSS::PropertyID property_id, bool is_from_end, bool is_horizontal_axis) -> CSS::LengthPercentageOrAuto {
@@ -2343,8 +2343,8 @@ void FormattingContext::resolve_anchor_insets(Box& box) const
         });
     });
 
-    if (compensates_for_scroll_in_x || compensates_for_scroll_in_y)
-        box.set_default_scroll_shift(default_anchor_box->make_weak_ptr(), compensates_for_scroll_in_x, compensates_for_scroll_in_y);
+    if (compensates_for_horizontal_scroll || compensates_for_vertical_scroll)
+        box.set_default_scroll_shift(default_anchor_box->make_weak_ptr(), compensates_for_horizontal_scroll, compensates_for_vertical_scroll);
 }
 
 void FormattingContext::layout_absolutely_positioned_children()

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1879,8 +1879,8 @@ static Optional<CSSPixelRect> compute_inline_containing_block_rect(InlineNode co
 }
 
 struct AbsposAxisModes {
-    AbsposAxisMode horizontal;
-    AbsposAxisMode vertical;
+    AbsposAxisMode inline_axis;
+    AbsposAxisMode block_axis;
 };
 
 // Per-axis mode: auto+auto insets -> static position, otherwise -> inset from rect.
@@ -1888,22 +1888,22 @@ static AbsposAxisModes abspos_axis_modes_from_computed_insets(CSS::ComputedValue
 {
     auto const& inset = computed_values.inset();
     return {
-        .horizontal = inset.left().is_auto() && inset.right().is_auto() ? AbsposAxisMode::StaticPosition : AbsposAxisMode::InsetFromRect,
-        .vertical = inset.top().is_auto() && inset.bottom().is_auto() ? AbsposAxisMode::StaticPosition : AbsposAxisMode::InsetFromRect,
+        .inline_axis = inset.left().is_auto() && inset.right().is_auto() ? AbsposAxisMode::StaticPosition : AbsposAxisMode::InsetFromRect,
+        .block_axis = inset.top().is_auto() && inset.bottom().is_auto() ? AbsposAxisMode::StaticPosition : AbsposAxisMode::InsetFromRect,
     };
 }
 
 AbsposContainingBlockInfo FormattingContext::resolve_abspos_containing_block_info(Box const& box)
 {
     auto const& computed_values = box.computed_values();
-    auto [horizontal_axis_mode, vertical_axis_mode] = abspos_axis_modes_from_computed_insets(computed_values);
+    auto [inline_axis_mode, block_axis_mode] = abspos_axis_modes_from_computed_insets(computed_values);
 
     // Check if there's an inline element that should be the real containing block.
     auto inline_containing_block = box.inline_containing_block_if_applicable();
     if (inline_containing_block && box.containing_block()) {
         auto rect = compute_inline_containing_block_rect(*inline_containing_block, *box.containing_block(), m_state);
         if (rect.has_value())
-            return { *rect, horizontal_axis_mode, vertical_axis_mode, {}, {} };
+            return { *rect, inline_axis_mode, block_axis_mode, {}, {} };
     }
 
     // Normal case: padding box of the actual containing block.
@@ -1915,7 +1915,7 @@ AbsposContainingBlockInfo FormattingContext::resolve_abspos_containing_block_inf
         containing_block_state.content_inline_size() + containing_block_state.padding_left + containing_block_state.padding_right,
         containing_block_state.content_block_size() + containing_block_state.padding_top + containing_block_state.padding_bottom
     };
-    return { rect, horizontal_axis_mode, vertical_axis_mode, {}, {} };
+    return { rect, inline_axis_mode, block_axis_mode, {}, {} };
 }
 
 static bool calculation_tree_contains_anchor(CSS::CalculationNode const& root)
@@ -2418,8 +2418,8 @@ bool FormattingContext::can_replay_saved_abspos_layout_inputs_after_style_change
         return false;
 
     auto axis_modes = abspos_axis_modes_from_computed_insets(box.computed_values());
-    bool uses_static_position = axis_modes.horizontal == AbsposAxisMode::StaticPosition
-        || axis_modes.vertical == AbsposAxisMode::StaticPosition;
+    bool uses_static_position = axis_modes.inline_axis == AbsposAxisMode::StaticPosition
+        || axis_modes.block_axis == AbsposAxisMode::StaticPosition;
     if (uses_static_position && inputs.static_position_rect.alignment_derives_from_own_computed_values)
         return false;
 
@@ -2441,8 +2441,8 @@ void FormattingContext::layout_absolutely_positioned_element_from_saved_inputs(L
     // computed values pin their axis modes structurally and never replay after such a change.
     if (!inputs.containing_block_info.derives_from_own_computed_values) {
         auto axis_modes = abspos_axis_modes_from_computed_insets(box.computed_values());
-        inputs.containing_block_info.horizontal_axis_mode = axis_modes.horizontal;
-        inputs.containing_block_info.vertical_axis_mode = axis_modes.vertical;
+        inputs.containing_block_info.inline_axis_mode = axis_modes.inline_axis;
+        inputs.containing_block_info.block_axis_mode = axis_modes.block_axis;
     }
 
     // Mirror how the ancestor formatting context prepares an absolutely positioned child
@@ -2528,9 +2528,9 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     }
 
     // Apply grid alignment for auto inset axes
-    if (containing_block_info.horizontal_alignment.has_value() && computed_values.inset().left().is_auto() && computed_values.inset().right().is_auto()) {
+    if (containing_block_info.inline_alignment.has_value() && computed_values.inset().left().is_auto() && computed_values.inset().right().is_auto()) {
         auto available_space_for_alignment = containing_block_info.rect.width() - box_state.margin_box_inline_size();
-        switch (*containing_block_info.horizontal_alignment) {
+        switch (*containing_block_info.inline_alignment) {
         case Alignment::Center:
             box_state.inset_left = available_space_for_alignment / 2;
             box_state.inset_right = available_space_for_alignment / 2;
@@ -2548,9 +2548,9 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
         }
     }
 
-    if (containing_block_info.vertical_alignment.has_value() && computed_values.inset().top().is_auto() && computed_values.inset().bottom().is_auto()) {
+    if (containing_block_info.block_alignment.has_value() && computed_values.inset().top().is_auto() && computed_values.inset().bottom().is_auto()) {
         auto available_space_for_alignment = containing_block_info.rect.height() - box_state.margin_box_block_size();
-        switch (*containing_block_info.vertical_alignment) {
+        switch (*containing_block_info.block_alignment) {
         case Alignment::Center:
             box_state.inset_top = available_space_for_alignment / 2;
             box_state.inset_bottom = available_space_for_alignment / 2;
@@ -2576,13 +2576,13 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     auto static_position = aligned_static_position(static_position_rect, box_state);
 
     // Horizontal axis
-    if (containing_block_info.horizontal_axis_mode == AbsposAxisMode::StaticPosition)
+    if (containing_block_info.inline_axis_mode == AbsposAxisMode::StaticPosition)
         used_offset.set_x(static_position.x());
     else
         used_offset.set_x(containing_block_info.rect.x() + box_state.inset_left);
 
     // Vertical axis
-    if (containing_block_info.vertical_axis_mode == AbsposAxisMode::StaticPosition)
+    if (containing_block_info.block_axis_mode == AbsposAxisMode::StaticPosition)
         used_offset.set_y(static_position.y());
     else
         used_offset.set_y(containing_block_info.rect.y() + box_state.inset_top);

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -685,7 +685,7 @@ LogicalSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_in
     return { input_inline_size, input_block_size };
 }
 
-Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout) const
+Optional<CSSPixels> FormattingContext::compute_automatic_block_size_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout) const
 {
     // NOTE: CSS 2.2 tells us to use the automatic block size for block formatting context roots here.
     //       That's fine as long as the box is a BFC root.
@@ -1057,12 +1057,12 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_element(Bo
         compute_inline_size_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_block_size_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints))
-        compute_height_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
+        compute_block_size_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
     else
-        compute_height_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
+        compute_block_size_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
 }
 
 CSSPixels FormattingContext::compute_inline_size_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
@@ -1236,7 +1236,7 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_non_replac
             // is 'ltr' set 'left' to the static position and apply rule number three below;
             // otherwise, set 'right' to the static position and apply rule number one below.
 
-            // NOTE: As with compute_height_for_absolutely_positioned_non_replaced_element, we actually apply these
+            // NOTE: As with compute_block_size_for_absolutely_positioned_non_replaced_element, we actually apply these
             //       steps in the opposite order since the static position may depend on the width of the box.
 
             auto content_inline_size = calculate_shrink_to_fit_inline_size();
@@ -1448,7 +1448,7 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_replaced_e
 }
 
 // https://drafts.csswg.org/css-position-3/#abs-non-replaced-height
-void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_block_size_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 5.3. The Height Of Absolutely Positioned, Non-Replaced Elements
 
@@ -1456,24 +1456,24 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // top + margin-top + border-top-width + padding-top + height + padding-bottom + border-bottom-width + margin-bottom + bottom = height of containing block
 
     // NOTE: This function is called twice: both before and after inside layout.
-    //       In the before pass, if it turns out we need the automatic height of the box, we abort these steps.
-    //       This allows the box to retain an indefinite height from the perspective of inside layout.
+    //       In the before pass, if the box needs its automatic block size, abort these steps.
+    //       This lets the box retain an indefinite block size from the perspective of inside layout.
 
-    auto apply_min_max_height_constraints = [this, &box, &available_space, &containing_block_constraints](CSS::LengthOrAuto const& unconstrained_height) -> CSS::LengthOrAuto {
-        auto const& computed_min_height = box.computed_values().min_height();
-        auto const& computed_max_height = box.computed_values().max_height();
-        auto constrained_height = unconstrained_height;
-        if (!computed_max_height.is_none()) {
-            auto inner_max_height = calculate_inner_block_size(box, available_space, computed_max_height, containing_block_constraints);
-            if (inner_max_height < constrained_height.to_px_or_zero())
-                constrained_height = CSS::Length::make_px(inner_max_height);
+    auto apply_min_max_block_size_constraints = [this, &box, &available_space, &containing_block_constraints](CSS::LengthOrAuto const& unconstrained_block_size) -> CSS::LengthOrAuto {
+        auto const& computed_min_block_size = box.computed_values().min_height();
+        auto const& computed_max_block_size = box.computed_values().max_height();
+        auto constrained_block_size = unconstrained_block_size;
+        if (!computed_max_block_size.is_none()) {
+            auto inner_max_block_size = calculate_inner_block_size(box, available_space, computed_max_block_size, containing_block_constraints);
+            if (inner_max_block_size < constrained_block_size.to_px_or_zero())
+                constrained_block_size = CSS::Length::make_px(inner_max_block_size);
         }
-        if (!computed_min_height.is_auto()) {
-            auto inner_min_height = calculate_inner_block_size(box, available_space, computed_min_height, containing_block_constraints);
-            if (inner_min_height > constrained_height.to_px_or_zero())
-                constrained_height = CSS::Length::make_px(inner_min_height);
+        if (!computed_min_block_size.is_auto()) {
+            auto inner_min_block_size = calculate_inner_block_size(box, available_space, computed_min_block_size, containing_block_constraints);
+            if (inner_min_block_size > constrained_block_size.to_px_or_zero())
+                constrained_block_size = CSS::Length::make_px(inner_min_block_size);
         }
-        return constrained_height;
+        return constrained_block_size;
     };
 
     auto margin_top = box.computed_values().margin().top();
@@ -1482,7 +1482,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto bottom = box.computed_values().inset().bottom();
 
     auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
-    auto height_of_containing_block = available_space.block_size.to_px_or_zero();
+    auto containing_block_block_size = available_space.block_size.to_px_or_zero();
 
     enum class ClampToZero {
         No,
@@ -1490,7 +1490,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     };
 
     auto& state = m_state.get(box);
-    auto try_compute_height = [&](CSS::LengthOrAuto height) -> CSS::LengthOrAuto {
+    auto try_compute_block_size = [&](CSS::LengthOrAuto block_size) -> CSS::LengthOrAuto {
         // Reset values that may have been modified by a previous call (when re-solving for min/max-height).
         margin_top = box.computed_values().margin().top();
         margin_bottom = box.computed_values().margin().bottom();
@@ -1498,16 +1498,16 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         bottom = box.computed_values().inset().bottom();
 
         auto solve_for = [&](CSS::LengthOrAuto const& length_or_auto, ClampToZero clamp_to_zero = ClampToZero::No) {
-            auto unclamped_value = height_of_containing_block
-                - top.to_px_or_zero(height_of_containing_block)
+            auto unclamped_value = containing_block_block_size
+                - top.to_px_or_zero(containing_block_block_size)
                 - margin_top.to_px_or_zero(containing_block_inline_size)
                 - box.computed_values().border_top().width
                 - state.padding_top
-                - height.to_px_or_zero()
+                - block_size.to_px_or_zero()
                 - state.padding_bottom
                 - box.computed_values().border_bottom().width
                 - margin_bottom.to_px_or_zero(containing_block_inline_size)
-                - bottom.to_px_or_zero(height_of_containing_block)
+                - bottom.to_px_or_zero(containing_block_block_size)
                 + length_or_auto.to_px_or_zero();
             if (clamp_to_zero == ClampToZero::Yes)
                 return CSS::Length::make_px(max(CSSPixels(0), unclamped_value));
@@ -1515,15 +1515,15 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         };
 
         auto solve_for_top = [&] {
-            top = solve_for(top.resolved_or_auto(height_of_containing_block));
+            top = solve_for(top.resolved_or_auto(containing_block_block_size));
         };
 
         auto solve_for_bottom = [&] {
-            bottom = solve_for(bottom.resolved_or_auto(height_of_containing_block));
+            bottom = solve_for(bottom.resolved_or_auto(containing_block_block_size));
         };
 
-        auto solve_for_height = [&] {
-            height = solve_for(height, ClampToZero::Yes);
+        auto solve_for_block_size = [&] {
+            block_size = solve_for(block_size, ClampToZero::Yes);
         };
 
         auto solve_for_margin_top = [&] {
@@ -1541,7 +1541,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         };
 
         // If all three of top, height, and bottom are auto:
-        if (top.is_auto() && height.is_auto() && bottom.is_auto()) {
+        if (top.is_auto() && block_size.is_auto() && bottom.is_auto()) {
             // First set any auto values for margin-top and margin-bottom to 0,
             if (margin_top.is_auto())
                 margin_top = CSS::Length::make_px(0);
@@ -1552,15 +1552,15 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             // and finally apply rule number three below.
 
             // NOTE: We actually perform these two steps in the opposite order,
-            //       because the static position may depend on the height of the box (due to alignment properties).
+            //       because the static position may depend on the box's block size due to alignment properties.
 
-            auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
-            if (!maybe_height.has_value())
-                return height;
-            height = CSS::Length::make_px(maybe_height.value());
+            auto maybe_block_size = compute_automatic_block_size_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
+            if (!maybe_block_size.has_value())
+                return block_size;
+            block_size = CSS::Length::make_px(maybe_block_size.value());
 
-            auto constrained_height = apply_min_max_height_constraints(height);
-            m_state.get_mutable(box).set_content_block_size(constrained_height.to_px_or_zero());
+            auto constrained_block_size = apply_min_max_block_size_constraints(block_size);
+            m_state.get_mutable(box).set_content_block_size(constrained_block_size.to_px_or_zero());
 
             auto static_position = aligned_static_position(static_position_rect, state);
             top = CSS::Length::make_px(static_position.y());
@@ -1569,7 +1569,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         }
 
         // If none of the three are auto:
-        else if (!top.is_auto() && !height.is_auto() && !bottom.is_auto()) {
+        else if (!top.is_auto() && !block_size.is_auto() && !bottom.is_auto()) {
             // If both margin-top and margin-bottom are auto,
             if (margin_top.is_auto() && margin_bottom.is_auto()) {
                 // solve the equation under the extra constraint that the two margins get equal values.
@@ -1603,19 +1603,19 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             // and pick one of the following six rules that apply.
 
             // 1. If top and height are auto and bottom is not auto,
-            if (top.is_auto() && height.is_auto() && !bottom.is_auto()) {
+            if (top.is_auto() && block_size.is_auto() && !bottom.is_auto()) {
                 // then the height is based on the Auto heights for block formatting context roots,
-                auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
-                if (!maybe_height.has_value())
-                    return height;
-                height = CSS::Length::make_px(maybe_height.value());
+                auto maybe_block_size = compute_automatic_block_size_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
+                if (!maybe_block_size.has_value())
+                    return block_size;
+                block_size = CSS::Length::make_px(maybe_block_size.value());
 
                 // and solve for top.
                 solve_for_top();
             }
 
             // 2. If top and bottom are auto and height is not auto,
-            else if (top.is_auto() && bottom.is_auto() && !height.is_auto()) {
+            else if (top.is_auto() && bottom.is_auto() && !block_size.is_auto()) {
                 // then set top to the static position,
                 top = CSS::Length::make_px(aligned_static_position(static_position_rect, state).y());
 
@@ -1624,93 +1624,91 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             }
 
             // 3. If height and bottom are auto and top is not auto,
-            else if (height.is_auto() && bottom.is_auto() && !top.is_auto()) {
+            else if (block_size.is_auto() && bottom.is_auto() && !top.is_auto()) {
                 // then the height is based on the Auto heights for block formatting context roots,
-                auto maybe_height = compute_auto_height_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
-                if (!maybe_height.has_value())
-                    return height;
-                height = CSS::Length::make_px(maybe_height.value());
+                auto maybe_block_size = compute_automatic_block_size_for_absolutely_positioned_element(box, available_space, containing_block_constraints, before_or_after_inside_layout);
+                if (!maybe_block_size.has_value())
+                    return block_size;
+                block_size = CSS::Length::make_px(maybe_block_size.value());
 
                 // and solve for bottom.
                 solve_for_bottom();
             }
 
             // 4. If top is auto, height and bottom are not auto,
-            else if (top.is_auto() && !height.is_auto() && !bottom.is_auto()) {
+            else if (top.is_auto() && !block_size.is_auto() && !bottom.is_auto()) {
                 // then solve for top.
                 solve_for_top();
             }
 
             // 5. If height is auto, top and bottom are not auto,
-            else if (height.is_auto() && !top.is_auto() && !bottom.is_auto()) {
+            else if (block_size.is_auto() && !top.is_auto() && !bottom.is_auto()) {
                 // then solve for height.
-                solve_for_height();
+                solve_for_block_size();
             }
 
             // 6. If bottom is auto, top and height are not auto,
-            else if (bottom.is_auto() && !top.is_auto() && !height.is_auto()) {
+            else if (bottom.is_auto() && !top.is_auto() && !block_size.is_auto()) {
                 // then solve for bottom.
                 solve_for_bottom();
             }
         }
 
-        return height;
+        return block_size;
     };
 
-    // Intrinsic (fit-content/min-content/max-content) heights depend on the box's own used width,
-    // which was already resolved above, not on the width of the containing block. Absolutely
-    // positioned boxes routinely have a used width narrower than their containing block (e.g. a
-    // fixed-position dialog sized to 400px inside a 1300px viewport), and measuring their content
-    // at the containing block width lets text that should wrap stay on one line, underestimating
-    // the height. Feed the box's own width to the intrinsic-height calculations.
-    auto available_space_for_intrinsic_height = available_space;
-    available_space_for_intrinsic_height.inline_size = AvailableSize::make_definite(state.content_inline_size());
+    // Intrinsic block sizes depend on the box's own used inline size, which was already resolved above, not on the
+    // inline size of the containing block. Absolutely positioned boxes routinely have a narrower used inline size
+    // than their containing block, and measuring their content at the containing block inline size can prevent text
+    // from wrapping and underestimate the block size. Feed the box's own inline size to the intrinsic calculation.
+    auto available_space_for_intrinsic_block_size = available_space;
+    available_space_for_intrinsic_block_size.inline_size = AvailableSize::make_definite(state.content_inline_size());
 
-    // Compute the height based on box type and CSS properties:
+    // Compute the block size based on box type and CSS properties:
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
-    auto used_height = try_compute_height([&] -> CSS::LengthOrAuto {
+    auto used_block_size = try_compute_block_size([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
             return CSS::Length::make_px(compute_table_box_block_size_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (should_treat_block_size_as_auto(box, available_space, containing_block_constraints))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_block_size(box, available_space_for_intrinsic_height, box.computed_values().height(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_block_size(box, available_space_for_intrinsic_block_size, box.computed_values().height(), containing_block_constraints));
     }());
 
     // If the tentative used height is greater than 'max-height', the rules above are applied again,
     // but this time using the computed value of 'max-height' as the computed value for 'height'.
-    auto const& computed_max_height = box.computed_values().max_height();
-    if (!used_height.is_auto() && !computed_max_height.is_none()) {
-        auto max_height = calculate_inner_block_size(box, available_space_for_intrinsic_height, computed_max_height, containing_block_constraints);
-        if (used_height.to_px_or_zero() > max_height)
-            used_height = try_compute_height(CSS::Length::make_px(max_height));
+    auto const& computed_max_block_size = box.computed_values().max_height();
+    if (!used_block_size.is_auto() && !computed_max_block_size.is_none()) {
+        auto max_block_size = calculate_inner_block_size(box, available_space_for_intrinsic_block_size, computed_max_block_size, containing_block_constraints);
+        if (used_block_size.to_px_or_zero() > max_block_size)
+            used_block_size = try_compute_block_size(CSS::Length::make_px(max_block_size));
     }
 
     // If the resulting height is smaller than 'min-height', the rules above are applied again,
     // but this time using the value of 'min-height' as the computed value for 'height'.
-    auto const& computed_min_height = box.computed_values().min_height();
-    if (!used_height.is_auto() && !computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_block_size(box, available_space_for_intrinsic_height, computed_min_height, containing_block_constraints);
-        if (used_height.to_px_or_zero() < min_height)
-            used_height = try_compute_height(CSS::Length::make_px(min_height));
+    auto const& computed_min_block_size = box.computed_values().min_height();
+    if (!used_block_size.is_auto() && !computed_min_block_size.is_auto()) {
+        auto min_block_size = calculate_inner_block_size(box, available_space_for_intrinsic_block_size, computed_min_block_size, containing_block_constraints);
+        if (used_block_size.to_px_or_zero() < min_block_size)
+            used_block_size = try_compute_block_size(CSS::Length::make_px(min_block_size));
     }
 
-    // For the before-inside-layout pass where height is still auto, apply min-max as a simple clamp.
-    if (used_height.is_auto())
-        used_height = apply_min_max_height_constraints(used_height);
+    // For the before-inside-layout pass where the block size is still auto, apply min-max as a simple clamp.
+    if (used_block_size.is_auto())
+        used_block_size = apply_min_max_block_size_constraints(used_block_size);
 
     // NOTE: The following is not directly part of any spec, but this is where we resolve
     //       the final used values for vertical margin/border/padding.
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.set_content_block_size(used_height.to_px_or_zero());
+    box_state.set_content_block_size(used_block_size.to_px_or_zero());
 
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
     if (computed_block_size_establishes_definite_containing_block_size(box.computed_values().height()))
         box_state.set_has_definite_block_size(true);
-    box_state.inset_top = top.to_px_or_zero(height_of_containing_block);
-    box_state.inset_bottom = bottom.to_px_or_zero(height_of_containing_block);
+    box_state.inset_top = top.to_px_or_zero(containing_block_block_size);
+    box_state.inset_bottom = bottom.to_px_or_zero(containing_block_block_size);
     box_state.margin_top = margin_top.to_px_or_zero(containing_block_inline_size);
     box_state.margin_bottom = margin_bottom.to_px_or_zero(containing_block_inline_size);
 }
@@ -2491,12 +2489,11 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
 
     compute_inline_size_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect);
 
-    // NOTE: We compute height before *and* after doing inside layout.
-    //       This is done so that inside layout can resolve percentage heights.
-    //       In some situations, e.g with non-auto top & bottom values, the height can be determined early.
-    compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect, BeforeOrAfterInsideLayout::Before);
+    // NOTE: We compute the block size before and after inside layout so percentages can resolve during child layout.
+    //       In some situations, such as non-auto top and bottom values, the block size can be determined early.
+    compute_block_size_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect, BeforeOrAfterInsideLayout::Before);
 
-    // If the box width and/or height is fixed and/or or resolved from inset properties,
+    // If either box axis is fixed or resolved from inset properties,
     // mark the size as being definite (since layout was not required to resolve it, per CSS-SIZING-3).
     auto is_non_auto = [](auto const& length_percentage) {
         return !length_percentage.is_auto();
@@ -2509,16 +2506,16 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
         box_state.set_has_definite_block_size(true);
     }
 
-    // NOTE: BFC is special, as their abspos auto height depends on performing inside layout.
-    //       For other formatting contexts, the height we've resolved early is good.
-    //       See FormattingContext::compute_auto_height_for_absolutely_positioned_element()
+    // NOTE: BFC is special, as its automatic block size depends on performing inside layout.
+    //       For other formatting contexts, the block size resolved early is sufficient.
+    //       See FormattingContext::compute_automatic_block_size_for_absolutely_positioned_element()
     //       for the special-casing of BFC roots.
     if (!creates_block_formatting_context(box)) {
-        auto height_resolved_from_aspect_ratio = computed_values.height().is_auto()
+        auto block_size_resolved_from_aspect_ratio = computed_values.height().is_auto()
             && box.has_preferred_aspect_ratio()
             && box_state.has_definite_inline_size();
         box_state.set_has_definite_inline_size(true);
-        if ((!computed_values.height().is_auto() && computed_block_size_establishes_definite_containing_block_size(computed_values.height())) || height_resolved_from_aspect_ratio)
+        if ((!computed_values.height().is_auto() && computed_block_size_establishes_definite_containing_block_size(computed_values.height())) || block_size_resolved_from_aspect_ratio)
             box_state.set_has_definite_block_size(true);
     }
 
@@ -2527,7 +2524,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, LayoutInput { box_state.available_inner_space_or_constraints_from(available_space), absolutely_positioned_constraints });
 
     if (computed_values.height().is_auto()) {
-        compute_height_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect, BeforeOrAfterInsideLayout::After);
+        compute_block_size_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect, BeforeOrAfterInsideLayout::After);
     }
 
     // Apply grid alignment for auto inset axes
@@ -2603,7 +2600,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
         independent_formatting_context->parent_context_did_dimension_child_root_box();
 }
 
-void FormattingContext::compute_height_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
+void FormattingContext::compute_block_size_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
 {
     // 10.6.5 Absolutely positioned, replaced elements
     // This situation is similar to 10.6.4, except that the element has an intrinsic height.

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -646,12 +646,12 @@ CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_w
     // 10.4 Minimum and maximum widths: 'min-width' and 'max-width'
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
 
-    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_width(box, available_space.width, box.computed_values().min_width(), containing_block_constraints);
-    auto specified_max_width = should_treat_max_width_as_none(box, available_space.width, containing_block_constraints) ? input_width : calculate_inner_width(box, available_space.width, box.computed_values().max_width(), containing_block_constraints);
+    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_width(box, available_space.inline_size, box.computed_values().min_width(), containing_block_constraints);
+    auto specified_max_width = should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints) ? input_width : calculate_inner_width(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
     auto max_width = max(min_width, specified_max_width);
 
     auto min_height = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_height(box, available_space, box.computed_values().min_height(), containing_block_constraints);
-    auto specified_max_height = should_treat_max_height_as_none(box, available_space.height, containing_block_constraints) ? input_height : calculate_inner_height(box, available_space, box.computed_values().max_height(), containing_block_constraints);
+    auto specified_max_height = should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) ? input_height : calculate_inner_height(box, available_space, box.computed_values().max_height(), containing_block_constraints);
     auto max_height = max(min_height, specified_max_height);
 
     auto const& box_state = m_state.get(box);
@@ -802,7 +802,7 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
     auto used_height = should_treat_height_as_auto(box, available_space, containing_block_constraints)
         ? natural_content_height
         : calculate_inner_height(box, available_space, computed_values.height(), containing_block_constraints);
-    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints) && !computed_values.max_height().is_auto())
+    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) && !computed_values.max_height().is_auto())
         used_height = min(used_height, calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints));
     if (!computed_values.min_height().is_auto())
         used_height = max(used_height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
@@ -830,7 +830,7 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
 
     auto const& computed_values = box.computed_values();
 
-    auto width_of_containing_block = table_wrapper_containing_block_width.value_or(available_space.width.to_px_or_zero());
+    auto width_of_containing_block = table_wrapper_containing_block_width.value_or(available_space.inline_size.to_px_or_zero());
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     auto margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
@@ -873,7 +873,7 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
         && !table_box->computed_values().width().is_auto()) {
         return table_used_width;
     }
-    return available_space.width.is_definite() ? min(table_used_width, available_width) : table_used_width;
+    return available_space.inline_size.is_definite() ? min(table_used_width, available_width) : table_used_width;
 }
 
 // 17.5.3 Table height algorithms
@@ -884,8 +884,8 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
 
     auto const& computed_values = box.computed_values();
 
-    auto width_of_containing_block = available_space.width.to_px_or_zero();
-    auto height_of_containing_block = available_space.height.to_px_or_zero();
+    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto height_of_containing_block = available_space.block_size.to_px_or_zero();
 
     // If 'margin-top', or 'margin-bottom' are computed as 'auto', their used value is '0'.
     auto margin_top = computed_values.margin().top().resolved_or_auto(width_of_containing_block).to_px_or_zero();
@@ -912,7 +912,7 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     VERIFY(table_box.has_value());
 
     auto table_used_height = throwaway_state.get(*table_box).border_box_height();
-    return available_space.height.is_definite() ? min(table_used_height, available_height) : table_used_height;
+    return available_space.block_size.is_definite() ? min(table_used_height, available_height) : table_used_height;
 }
 
 ContainingBlockConstraints FormattingContext::constraints_for_child_context(
@@ -996,9 +996,9 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
 
     CSSPixels used_width = 0;
     if (computed_width.is_auto()) {
-        used_width = computed_width.to_px(available_space.width.to_px_or_zero());
+        used_width = computed_width.to_px(available_space.inline_size.to_px_or_zero());
     } else {
-        used_width = calculate_inner_width(box, available_space.width, computed_width, containing_block_constraints);
+        used_width = calculate_inner_width(box, available_space.inline_size, computed_width, containing_block_constraints);
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width,
@@ -1024,16 +1024,16 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     // depend on the replaced element's width, then the used value of 'width' is calculated from the constraint equation used for block-level,
     // non-replaced elements in normal flow.
     if (computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && !intrinsic.has_height() && box.has_preferred_aspect_ratio()) {
-        if (!available_space.width.is_intrinsic_sizing_constraint())
-            return calculate_stretch_fit_width(box, available_space.width);
+        if (!available_space.inline_size.is_intrinsic_sizing_constraint())
+            return calculate_stretch_fit_width(box, available_space.inline_size);
 
-        switch (cyclic_percentage_intrinsic_contribution(box, box.computed_values().width(), available_space.width, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        switch (cyclic_percentage_intrinsic_contribution(box, box.computed_values().width(), available_space.inline_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return 0;
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
             break;
         case CyclicPercentageIntrinsicContribution::NotCyclic:
-            return calculate_stretch_fit_width(box, available_space.width);
+            return calculate_stretch_fit_width(box, available_space.inline_size);
         }
     }
 
@@ -1084,9 +1084,9 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
 
     // 2. If the tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
+    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
         auto const& computed_max_width = box.computed_values().max_width();
-        auto max_width = calculate_inner_width(box, available_space.width, computed_max_width, containing_block_constraints);
+        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_max_width, containing_block_constraints);
         if (used_width > max_width)
             used_width = tentative_width_for_replaced_element(box, computed_max_width, available_space, containing_block_constraints);
     }
@@ -1095,7 +1095,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     auto computed_min_width = box.computed_values().min_width();
     if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_min_width, containing_block_constraints);
+        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_min_width, containing_block_constraints);
         if (used_width < min_width)
             used_width = tentative_width_for_replaced_element(box, computed_min_width, available_space, containing_block_constraints);
     }
@@ -1161,7 +1161,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     }
     // 2. If this tentative height is greater than 'max-height', the rules above are applied again,
     //    but this time using the value of 'max-height' as the computed value for 'height'.
-    if (!should_treat_max_height_as_none(box, available_space.height, containing_block_constraints)) {
+    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
         auto const& computed_max_height = box.computed_values().max_height();
         auto max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
         if (used_height > max_height)
@@ -1182,7 +1182,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
 
 void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
-    auto width_of_containing_block = available_space.width.to_px_or_zero();
+    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
 
@@ -1335,13 +1335,13 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (computed_values.width().is_auto())
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.width, computed_values.width(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_width(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }());
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.width, containing_block_constraints)) {
-        auto max_width = calculate_inner_width(box, available_space.width, computed_values.max_width(), containing_block_constraints);
+    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width) {
             used_width = try_compute_width(CSS::Length::make_px(max_width));
         }
@@ -1350,7 +1350,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.width, computed_values.min_width(), containing_block_constraints);
+        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() < min_width) {
             used_width = try_compute_width(CSS::Length::make_px(min_width));
         }
@@ -1373,7 +1373,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     // 1. The used value of 'width' is determined as for inline replaced elements.
 
     auto width = compute_width_for_replaced_element(box, available_space, containing_block_constraints);
-    auto width_of_containing_block = available_space.width.to_px_or_zero();
+    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
     auto const border_left = computed_values.border_left().width;
@@ -1481,8 +1481,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto top = box.computed_values().inset().top();
     auto bottom = box.computed_values().inset().bottom();
 
-    auto width_of_containing_block = available_space.width.to_px_or_zero();
-    auto height_of_containing_block = available_space.height.to_px_or_zero();
+    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto height_of_containing_block = available_space.block_size.to_px_or_zero();
 
     enum class ClampToZero {
         No,
@@ -1664,7 +1664,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // at the containing block width lets text that should wrap stay on one line, underestimating
     // the height. Feed the box's own width to the intrinsic-height calculations.
     auto available_space_for_intrinsic_height = available_space;
-    available_space_for_intrinsic_height.width = AvailableSize::make_definite(state.content_width());
+    available_space_for_intrinsic_height.inline_size = AvailableSize::make_definite(state.content_width());
 
     // Compute the height based on box type and CSS properties:
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
@@ -2470,8 +2470,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
 
     auto const& computed_values = box.computed_values();
 
-    auto const containing_block_width = available_space.width.to_px_or_zero();
-    auto const containing_block_height = available_space.height.to_px_or_zero();
+    auto const containing_block_width = available_space.inline_size.to_px_or_zero();
+    auto const containing_block_height = available_space.block_size.to_px_or_zero();
     // The percentage basis of an absolutely positioned box is the padding box of its absolute
     // positioning containing block, which need not match the basis its used values were created
     // with (grid places absolutely positioned children into their grid area).
@@ -2611,7 +2611,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     // The used value of 'height' is determined as for inline replaced elements.
     auto height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
 
-    auto height_of_containing_block = available_space.height.to_px_or_zero();
+    auto height_of_containing_block = available_space.block_size.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
     auto const border_top = computed_values.border_top().width;
@@ -2753,8 +2753,8 @@ CSSPixels FormattingContext::calculate_fit_content_width(Layout::Box const& box,
 {
     // If the available space in a given axis is definite, equal to clamp(min-content size, stretch-fit size,
     // max-content size) (i.e. max(min-content size, min(max-content size, stretch-fit size))).
-    if (available_space.width.is_definite()) {
-        auto stretch_fit_width = calculate_stretch_fit_width(box, available_space.width);
+    if (available_space.inline_size.is_definite()) {
+        auto stretch_fit_width = calculate_stretch_fit_width(box, available_space.inline_size);
         auto max_content_width = calculate_max_content_width(box, containing_block_constraints);
         if (max_content_width <= stretch_fit_width)
             return max_content_width;
@@ -2762,7 +2762,7 @@ CSSPixels FormattingContext::calculate_fit_content_width(Layout::Box const& box,
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.
-    if (available_space.width.is_min_content())
+    if (available_space.inline_size.is_min_content())
         return calculate_min_content_width(box, containing_block_constraints);
 
     // Otherwise, equal to the max-content size in that axis.
@@ -2775,9 +2775,9 @@ CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box
     // If the available space in a given axis is definite,
     // equal to clamp(min-content size, stretch-fit size, max-content size)
     // (i.e. max(min-content size, min(max-content size, stretch-fit size))).
-    if (available_space.height.is_definite()) {
-        auto width = available_space.width.to_px_or_zero();
-        auto stretch_fit_height = calculate_stretch_fit_height(box, available_space.height);
+    if (available_space.block_size.is_definite()) {
+        auto width = available_space.inline_size.to_px_or_zero();
+        auto stretch_fit_height = calculate_stretch_fit_height(box, available_space.block_size);
         auto max_content_height = calculate_max_content_height(box, width, containing_block_constraints);
         if (max_content_height <= stretch_fit_height)
             return max_content_height;
@@ -2785,11 +2785,11 @@ CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.
-    if (available_space.height.is_min_content())
-        return calculate_min_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+    if (available_space.block_size.is_min_content())
+        return calculate_min_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
 
     // Otherwise, equal to the max-content size in that axis.
-    return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+    return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
 }
 
 static IntrinsicSizeCacheKey intrinsic_size_cache_key(ContainingBlockConstraints const& containing_block_constraints)
@@ -3159,13 +3159,13 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
         return calculate_fit_content_height(box, available_space, containing_block_constraints);
     }
     if (height.is_max_content()) {
-        return calculate_max_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
     if (height.is_min_content()) {
-        return calculate_min_content_height(box, available_space.width.to_px_or_zero(), containing_block_constraints);
+        return calculate_min_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
 
-    CSSPixels height_of_containing_block = available_space.height.to_px_or_zero();
+    CSSPixels height_of_containing_block = available_space.block_size.to_px_or_zero();
     // NOTE: Percentage heights are resolved against the containing block's used height,
     //       not the available space height. The containing block's height must be definite
     //       for percentage resolution to work (otherwise should_treat_height_as_auto
@@ -3173,7 +3173,7 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
     // NOTE: We only do this when available space height is indefinite. If it's definite,
     //       we trust that the caller has set it up correctly (e.g., grid/flex items get
     //       their cell/area size as available space).
-    if (height.contains_percentage() && available_space.height.is_indefinite()) {
+    if (height.contains_percentage() && available_space.block_size.is_indefinite()) {
         // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
         // NOTE: Flex/grid items resolve percentage heights against their container, not via quirk.
         bool is_flex_or_grid_item = box.parent() && (box.parent()->display().is_flex_inside() || box.parent()->display().is_grid_inside());
@@ -3243,7 +3243,7 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
     if (computed_width.contains_percentage()) {
-        switch (cyclic_percentage_intrinsic_contribution(box, computed_width, available_space.width, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        switch (cyclic_percentage_intrinsic_contribution(box, computed_width, available_space.inline_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return false;
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
@@ -3251,7 +3251,7 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
         case CyclicPercentageIntrinsicContribution::NotCyclic:
             break;
         }
-        if (available_space.width.is_indefinite())
+        if (available_space.inline_size.is_indefinite())
             return true;
     }
     // AD-HOC: If the box has a preferred aspect ratio and an intrinsic keyword for width...
@@ -3278,7 +3278,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
     if (computed_height.contains_percentage()) {
-        switch (cyclic_percentage_intrinsic_contribution(box, computed_height, available_space.height, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+        switch (cyclic_percentage_intrinsic_contribution(box, computed_height, available_space.block_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return false;
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -483,9 +483,9 @@ void FormattingContext::register_contained_abspos_child(Box const& child, Static
     m_state.register_contained_abspos_child(box_establishing_containing_formatting_context(child), child, static_position_rect);
 }
 
-CSSPixelPoint FormattingContext::aligned_static_position(StaticPositionRect const& static_position_rect, LayoutState::UsedValues const& box_state)
+LogicalOffset FormattingContext::aligned_static_offset(StaticPositionRect const& static_position_rect, LayoutState::UsedValues const& box_state)
 {
-    return static_position_rect.aligned_position_for_box_with_size({ box_state.margin_box_inline_size(), box_state.margin_box_block_size() });
+    return static_position_rect.aligned_offset_for_box_with_size({ box_state.margin_box_inline_size(), box_state.margin_box_block_size() });
 }
 
 // FIXME: This is a hack. Get rid of it.
@@ -1243,9 +1243,9 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_non_replac
             inline_size = CSS::Length::make_px(content_inline_size);
             m_state.get_mutable(box).set_content_inline_size(content_inline_size);
 
-            auto static_position = aligned_static_position(static_position_rect, box_state);
+            auto static_offset = aligned_static_offset(static_position_rect, box_state);
 
-            left = static_position.x();
+            left = static_offset.inline_offset;
             right = solve_for_right();
         }
 
@@ -1299,8 +1299,8 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_non_replac
         //    Then solve for 'left' (if 'direction is 'rtl') or 'right' (if 'direction' is 'ltr').
         else if (computed_left.is_auto() && computed_right.is_auto() && !inline_size.is_auto()) {
             // FIXME: Check direction
-            auto static_position = aligned_static_position(static_position_rect, box_state);
-            left = static_position.x();
+            auto static_offset = aligned_static_offset(static_position_rect, box_state);
+            left = static_offset.inline_offset;
             right = solve_for_right();
         }
 
@@ -1385,7 +1385,7 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_replaced_e
     auto margin_left = computed_values.margin().left();
     auto right = computed_values.inset().right();
     auto margin_right = computed_values.margin().right();
-    auto static_position = aligned_static_position(static_position_rect, box_state);
+    auto static_offset = aligned_static_offset(static_position_rect, box_state);
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
         return l.to_px_or_zero(containing_block_inline_size);
@@ -1396,7 +1396,7 @@ void FormattingContext::compute_inline_size_for_absolutely_positioned_replaced_e
     // element establishing the static-position containing block is 'ltr', set 'left' to the static
     // position; else if 'direction' is 'rtl', set 'right' to the static position.
     if (left.is_auto() && right.is_auto()) {
-        left = CSS::Length::make_px(static_position.x());
+        left = CSS::Length::make_px(static_offset.inline_offset);
     }
 
     // 3. If 'left' or 'right' are 'auto', replace any 'auto' on 'margin-left' or 'margin-right' with '0'.
@@ -1562,8 +1562,8 @@ void FormattingContext::compute_block_size_for_absolutely_positioned_non_replace
             auto constrained_block_size = apply_min_max_block_size_constraints(block_size);
             m_state.get_mutable(box).set_content_block_size(constrained_block_size.to_px_or_zero());
 
-            auto static_position = aligned_static_position(static_position_rect, state);
-            top = CSS::Length::make_px(static_position.y());
+            auto static_offset = aligned_static_offset(static_position_rect, state);
+            top = CSS::Length::make_px(static_offset.block_offset);
 
             solve_for_bottom();
         }
@@ -1617,7 +1617,7 @@ void FormattingContext::compute_block_size_for_absolutely_positioned_non_replace
             // 2. If top and bottom are auto and height is not auto,
             else if (top.is_auto() && bottom.is_auto() && !block_size.is_auto()) {
                 // then set top to the static position,
-                top = CSS::Length::make_px(aligned_static_position(static_position_rect, state).y());
+                top = CSS::Length::make_px(aligned_static_offset(static_position_rect, state).block_offset);
 
                 // then solve for bottom.
                 solve_for_bottom();
@@ -2464,28 +2464,32 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
 
     auto& box_state = m_state.get_mutable(box);
 
-    auto const available_space = AvailableSpace(AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_info.rect.width())), AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_info.rect.height())));
+    LogicalSize const containing_block_size {
+        clamp_to_max_dimension_value(containing_block_info.rect.width()),
+        clamp_to_max_dimension_value(containing_block_info.rect.height())
+    };
+    auto const available_space = AvailableSpace(AvailableSize::make_definite(containing_block_size.inline_size), AvailableSize::make_definite(containing_block_size.block_size));
 
     auto const& computed_values = box.computed_values();
 
-    auto const containing_block_width = available_space.inline_size.to_px_or_zero();
-    auto const containing_block_height = available_space.block_size.to_px_or_zero();
+    auto const containing_block_inline_size = available_space.inline_size.to_px_or_zero();
+    auto const containing_block_block_size = available_space.block_size.to_px_or_zero();
     // The percentage basis of an absolutely positioned box is the padding box of its absolute
     // positioning containing block, which need not match the basis its used values were created
     // with (grid places absolutely positioned children into their grid area).
-    ContainingBlockConstraints const absolutely_positioned_constraints { containing_block_width, containing_block_height, {} };
+    ContainingBlockConstraints const absolutely_positioned_constraints { containing_block_inline_size, containing_block_block_size, {} };
 
-    // The border computed values are not changed by the compute_height & width calculations below.
+    // The border computed values are not changed by the size calculations below.
     // The spec only adjusts and computes sizes, insets and margins.
     box_state.border_left = computed_values.border_left().width;
     box_state.border_right = computed_values.border_right().width;
     box_state.border_top = computed_values.border_top().width;
     box_state.border_bottom = computed_values.border_bottom().width;
 
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
-    box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
-    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
+    box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_inline_size);
+    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_inline_size);
 
     compute_inline_size_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect);
 
@@ -2529,17 +2533,17 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
 
     // Apply grid alignment for auto inset axes
     if (containing_block_info.inline_alignment.has_value() && computed_values.inset().left().is_auto() && computed_values.inset().right().is_auto()) {
-        auto available_space_for_alignment = containing_block_info.rect.width() - box_state.margin_box_inline_size();
+        auto available_inline_size_for_alignment = containing_block_size.inline_size - box_state.margin_box_inline_size();
         switch (*containing_block_info.inline_alignment) {
         case Alignment::Center:
-            box_state.inset_left = available_space_for_alignment / 2;
-            box_state.inset_right = available_space_for_alignment / 2;
+            box_state.inset_left = available_inline_size_for_alignment / 2;
+            box_state.inset_right = available_inline_size_for_alignment / 2;
             break;
         case Alignment::Start:
-            box_state.inset_right = available_space_for_alignment;
+            box_state.inset_right = available_inline_size_for_alignment;
             break;
         case Alignment::End:
-            box_state.inset_left = available_space_for_alignment;
+            box_state.inset_left = available_inline_size_for_alignment;
             break;
         case Alignment::Normal:
         case Alignment::Stretch:
@@ -2549,19 +2553,19 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     }
 
     if (containing_block_info.block_alignment.has_value() && computed_values.inset().top().is_auto() && computed_values.inset().bottom().is_auto()) {
-        auto available_space_for_alignment = containing_block_info.rect.height() - box_state.margin_box_block_size();
+        auto available_block_size_for_alignment = containing_block_size.block_size - box_state.margin_box_block_size();
         switch (*containing_block_info.block_alignment) {
         case Alignment::Center:
-            box_state.inset_top = available_space_for_alignment / 2;
-            box_state.inset_bottom = available_space_for_alignment / 2;
+            box_state.inset_top = available_block_size_for_alignment / 2;
+            box_state.inset_bottom = available_block_size_for_alignment / 2;
             break;
         case Alignment::Start:
         case Alignment::SelfStart:
-            box_state.inset_bottom = available_space_for_alignment;
+            box_state.inset_bottom = available_block_size_for_alignment;
             break;
         case Alignment::End:
         case Alignment::SelfEnd:
-            box_state.inset_top = available_space_for_alignment;
+            box_state.inset_top = available_block_size_for_alignment;
             break;
         case Alignment::Normal:
         case Alignment::Stretch:
@@ -2571,25 +2575,26 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
         }
     }
 
-    CSSPixelPoint used_offset;
+    LogicalOffset used_offset;
 
-    auto static_position = aligned_static_position(static_position_rect, box_state);
+    auto static_offset = aligned_static_offset(static_position_rect, box_state);
 
-    // Horizontal axis
+    // Inline axis
     if (containing_block_info.inline_axis_mode == AbsposAxisMode::StaticPosition)
-        used_offset.set_x(static_position.x());
+        used_offset.inline_offset = static_offset.inline_offset;
     else
-        used_offset.set_x(containing_block_info.rect.x() + box_state.inset_left);
+        used_offset.inline_offset = containing_block_info.rect.x() + box_state.inset_left;
 
-    // Vertical axis
+    // Block axis
     if (containing_block_info.block_axis_mode == AbsposAxisMode::StaticPosition)
-        used_offset.set_y(static_position.y());
+        used_offset.block_offset = static_offset.block_offset;
     else
-        used_offset.set_y(containing_block_info.rect.y() + box_state.inset_top);
+        used_offset.block_offset = containing_block_info.rect.y() + box_state.inset_top;
 
-    used_offset.translate_by(box_state.margin_box_left(), box_state.margin_box_top());
+    used_offset.inline_offset += box_state.margin_box_left();
+    used_offset.block_offset += box_state.margin_box_top();
 
-    place_child(box, used_offset);
+    place_child(box, { used_offset.inline_offset, used_offset.block_offset });
 
     // The inputs reach the box itself only through LayoutState::commit(), so recording them
     // into a throwaway measurement state would just be discarded work.
@@ -2620,7 +2625,7 @@ void FormattingContext::compute_block_size_for_absolutely_positioned_replaced_el
     auto margin_top = computed_values.margin().top();
     auto bottom = computed_values.inset().bottom();
     auto margin_bottom = computed_values.margin().bottom();
-    auto static_position = aligned_static_position(static_position_rect, box_state);
+    auto static_offset = aligned_static_offset(static_position_rect, box_state);
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
         return l.to_px_or_zero(containing_block_block_size);
@@ -2629,7 +2634,7 @@ void FormattingContext::compute_block_size_for_absolutely_positioned_replaced_el
     // If 'margin-top' or 'margin-bottom' is specified as 'auto' its used value is determined by the rules below.
     // 2. If both 'top' and 'bottom' have the value 'auto', replace 'top' with the element's static position.
     if (top.is_auto() && bottom.is_auto()) {
-        top = CSS::Length::make_px(static_position.y());
+        top = CSS::Length::make_px(static_offset.block_offset);
     }
 
     // 3. If 'bottom' is 'auto', replace any 'auto' on 'margin-top' or 'margin-bottom' with '0'.

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -37,13 +37,13 @@
 namespace Web::Layout {
 
 enum class SizeDimension {
-    Width,
-    Height,
+    Inline,
+    Block,
 };
 
 // NB: Intrinsic grid sizing can transfer an aspect ratio before block-axis border metrics are copied into the layout
 //     state. Border widths are already definite at computed-value time, while padding remains resolved in the state.
-static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_inline_size)
+static CSSPixels content_block_size_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_inline_size)
 {
     VERIFY(box.has_preferred_aspect_ratio());
 
@@ -65,12 +65,12 @@ static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::U
     return content_inline_size / aspect_ratio;
 }
 
-static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state)
+static CSSPixels content_block_size_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state)
 {
-    return content_height_from_aspect_ratio(box, box_state, box_state.content_inline_size());
+    return content_block_size_from_aspect_ratio(box, box_state, box_state.content_inline_size());
 }
 
-static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_block_size)
+static CSSPixels content_inline_size_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_block_size)
 {
     VERIFY(box.has_preferred_aspect_ratio());
 
@@ -94,16 +94,16 @@ static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::Us
 
 struct ReplacedMaxContentSizeConstraints {
     Optional<CSSPixels> definite_size_in_ratio_determining_axis;
-    Optional<CSSPixels> minimum_width;
-    Optional<CSSPixels> minimum_height;
+    Optional<CSSPixels> minimum_inline_size;
+    Optional<CSSPixels> minimum_block_size;
 };
 
 // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
 static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural_size(Box const& box, CSS::SizeWithAspectRatio const& natural_size, LayoutState::UsedValues const& box_state, SizeDimension dimension, ReplacedMaxContentSizeConstraints const& constraints = {})
 {
     // the intrinsic sizes of replaced elements without natural sizes are defined below:
-    auto is_width = dimension == SizeDimension::Width;
-    if (!box.is_replaced_box() || (is_width ? natural_size.has_width() : natural_size.has_height()))
+    auto is_inline_axis = dimension == SizeDimension::Inline;
+    if (!box.is_replaced_box() || (is_inline_axis ? natural_size.has_width() : natural_size.has_height()))
         return {};
 
     // SVG Integration says that a non-top-level <svg> starts with auto width/height, and that with a viewBox, missing
@@ -119,9 +119,9 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
     //  - https://drafts.csswg.org/css2/#inline-replaced-width
     //  - https://drafts.csswg.org/css2/#inline-replaced-height
     if (box.is_svg_svg_box() && natural_size.has_aspect_ratio()) {
-        if (is_width && natural_size.has_height())
+        if (is_inline_axis && natural_size.has_height())
             return natural_size.height.value() * natural_size.aspect_ratio.value();
-        if (!is_width && natural_size.has_width())
+        if (!is_inline_axis && natural_size.has_width())
             return natural_size.width.value() / natural_size.aspect_ratio.value();
     }
 
@@ -134,9 +134,9 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         // NB: This helper is only for the max-content size, which has no definite available inline size. Callers may
         //     still know a definite used size in the opposite axis when the box lacks a natural size in that axis.
         if (constraints.definite_size_in_ratio_determining_axis.has_value())
-            return is_width
-                ? content_width_from_aspect_ratio(box, box_state, constraints.definite_size_in_ratio_determining_axis.value())
-                : content_height_from_aspect_ratio(box, box_state, constraints.definite_size_in_ratio_determining_axis.value());
+            return is_inline_axis
+                ? content_inline_size_from_aspect_ratio(box, box_state, constraints.definite_size_in_ratio_determining_axis.value())
+                : content_block_size_from_aspect_ratio(box, box_state, constraints.definite_size_in_ratio_determining_axis.value());
 
         // Otherwise if the box has a <length> as its computed value for min-width or min-height, use that size and
         // calculate the other dimension using the aspect ratio; if both dimensions have a <length> minimum, choose the
@@ -145,36 +145,36 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         // NOTE: This case was previous calculated from a 300x150 default size, rather than the box’s min size. This is
         //       believed to be a better behavior, and likely to be Web-compatible, but please send feedback to the CSSWG
         //       if there are any problems.
-        Optional<CSSPixels> size_from_min_width;
-        if (constraints.minimum_width.has_value()) {
-            auto inline_size = constraints.minimum_width.value();
-            size_from_min_width = is_width ? inline_size : content_height_from_aspect_ratio(box, box_state, inline_size);
+        Optional<CSSPixels> size_from_min_inline_size;
+        if (constraints.minimum_inline_size.has_value()) {
+            auto inline_size = constraints.minimum_inline_size.value();
+            size_from_min_inline_size = is_inline_axis ? inline_size : content_block_size_from_aspect_ratio(box, box_state, inline_size);
         } else {
             auto const& min_width = box.computed_values().min_width();
             if (min_width.is_length_percentage() && !min_width.contains_percentage()) {
                 auto inline_size = min_width.to_px(0);
-                size_from_min_width = is_width ? inline_size : content_height_from_aspect_ratio(box, box_state, inline_size);
+                size_from_min_inline_size = is_inline_axis ? inline_size : content_block_size_from_aspect_ratio(box, box_state, inline_size);
             }
         }
 
-        Optional<CSSPixels> size_from_min_height;
-        if (constraints.minimum_height.has_value()) {
-            auto block_size = constraints.minimum_height.value();
-            size_from_min_height = is_width ? content_width_from_aspect_ratio(box, box_state, block_size) : block_size;
+        Optional<CSSPixels> size_from_min_block_size;
+        if (constraints.minimum_block_size.has_value()) {
+            auto block_size = constraints.minimum_block_size.value();
+            size_from_min_block_size = is_inline_axis ? content_inline_size_from_aspect_ratio(box, box_state, block_size) : block_size;
         } else {
             auto const& min_height = box.computed_values().min_height();
             if (min_height.is_length_percentage() && !min_height.contains_percentage()) {
                 auto block_size = min_height.to_px(0);
-                size_from_min_height = is_width ? content_width_from_aspect_ratio(box, box_state, block_size) : block_size;
+                size_from_min_block_size = is_inline_axis ? content_inline_size_from_aspect_ratio(box, box_state, block_size) : block_size;
             }
         }
 
-        if (size_from_min_width.has_value() && size_from_min_height.has_value())
-            return max(size_from_min_width.value(), size_from_min_height.value());
-        if (size_from_min_width.has_value())
-            return size_from_min_width.value();
-        if (size_from_min_height.has_value())
-            return size_from_min_height.value();
+        if (size_from_min_inline_size.has_value() && size_from_min_block_size.has_value())
+            return max(size_from_min_inline_size.value(), size_from_min_block_size.value());
+        if (size_from_min_inline_size.has_value())
+            return size_from_min_inline_size.value();
+        if (size_from_min_block_size.has_value())
+            return size_from_min_block_size.value();
 
         // Otherwise use an inline size matching the corresponding dimension of the initial containing block and calculate
         // the other dimension using the aspect ratio.
@@ -183,18 +183,18 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
         //       This is believed to be a better behavior, but it is not yet clear if it is Web-compatible, so please
         //       send feedback to the CSSWG if there are any problems.
         auto initial_containing_block_inline_size = box.document().viewport_rect().width();
-        return is_width ? initial_containing_block_inline_size : content_height_from_aspect_ratio(box, box_state, initial_containing_block_inline_size);
+        return is_inline_axis ? initial_containing_block_inline_size : content_block_size_from_aspect_ratio(box, box_state, initial_containing_block_inline_size);
     }
 
     // If it has no preferred aspect ratio:
     // For both the min-content size and max-content size:
     // If the box has a <length> as its computed minimum size (min-width/min-height) in that dimension, use that size.
-    auto const& min_size = is_width ? box.computed_values().min_width() : box.computed_values().min_height();
+    auto const& min_size = is_inline_axis ? box.computed_values().min_width() : box.computed_values().min_height();
     if (min_size.is_length_percentage() && !min_size.contains_percentage())
         return min_size.to_px(0);
 
     // Otherwise, use 300px for the width and/or 150px for the height as needed.
-    return is_width ? CSSPixels(300) : CSSPixels(150);
+    return is_inline_axis ? CSSPixels(300) : CSSPixels(150);
 }
 
 static bool is_text_control_input(HTML::HTMLInputElement const& input_element)
@@ -641,48 +641,48 @@ FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_
     };
 }
 
-CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+LogicalSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_inline_size, CSSPixels input_block_size, Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // 10.4 Minimum and maximum widths: 'min-width' and 'max-width'
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
 
-    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().min_width(), containing_block_constraints);
-    auto specified_max_width = should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints) ? input_width : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
-    auto max_width = max(min_width, specified_max_width);
+    auto min_inline_size = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().min_width(), containing_block_constraints);
+    auto specified_max_inline_size = should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints) ? input_inline_size : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
+    auto max_inline_size = max(min_inline_size, specified_max_inline_size);
 
-    auto min_height = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_block_size(box, available_space, box.computed_values().min_height(), containing_block_constraints);
-    auto specified_max_height = should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) ? input_height : calculate_inner_block_size(box, available_space, box.computed_values().max_height(), containing_block_constraints);
-    auto max_height = max(min_height, specified_max_height);
+    auto min_block_size = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_block_size(box, available_space, box.computed_values().min_height(), containing_block_constraints);
+    auto specified_max_block_size = should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) ? input_block_size : calculate_inner_block_size(box, available_space, box.computed_values().max_height(), containing_block_constraints);
+    auto max_block_size = max(min_block_size, specified_max_block_size);
 
     auto const& box_state = m_state.get(box);
     // These are from the "Constraint Violation" table in spec, but reordered so that each condition is
     // interpreted as mutually exclusive to any other.
-    if (input_width < min_width && input_height > max_height)
-        return { min_width, max_height };
-    if (input_width > max_width && input_height < min_height)
-        return { max_width, min_height };
+    if (input_inline_size < min_inline_size && input_block_size > max_block_size)
+        return { min_inline_size, max_block_size };
+    if (input_inline_size > max_inline_size && input_block_size < min_block_size)
+        return { max_inline_size, min_block_size };
 
-    if (input_width > 0 && input_height > 0) {
-        if (input_width > max_width && input_height > max_height && max_width / input_width <= max_height / input_height)
-            return { max_width, max(min_height, content_height_from_aspect_ratio(box, box_state, max_width)) };
-        if (input_width > max_width && input_height > max_height && max_width / input_width > max_height / input_height)
-            return { max(min_width, content_width_from_aspect_ratio(box, box_state, max_height)), max_height };
-        if (input_width < min_width && input_height < min_height && min_width / input_width <= min_height / input_height)
-            return { min(max_width, content_width_from_aspect_ratio(box, box_state, min_height)), min_height };
-        if (input_width < min_width && input_height < min_height && min_width / input_width > min_height / input_height)
-            return { min_width, min(max_height, content_height_from_aspect_ratio(box, box_state, min_width)) };
+    if (input_inline_size > 0 && input_block_size > 0) {
+        if (input_inline_size > max_inline_size && input_block_size > max_block_size && max_inline_size / input_inline_size <= max_block_size / input_block_size)
+            return { max_inline_size, max(min_block_size, content_block_size_from_aspect_ratio(box, box_state, max_inline_size)) };
+        if (input_inline_size > max_inline_size && input_block_size > max_block_size && max_inline_size / input_inline_size > max_block_size / input_block_size)
+            return { max(min_inline_size, content_inline_size_from_aspect_ratio(box, box_state, max_block_size)), max_block_size };
+        if (input_inline_size < min_inline_size && input_block_size < min_block_size && min_inline_size / input_inline_size <= min_block_size / input_block_size)
+            return { min(max_inline_size, content_inline_size_from_aspect_ratio(box, box_state, min_block_size)), min_block_size };
+        if (input_inline_size < min_inline_size && input_block_size < min_block_size && min_inline_size / input_inline_size > min_block_size / input_block_size)
+            return { min_inline_size, min(max_block_size, content_block_size_from_aspect_ratio(box, box_state, min_inline_size)) };
     }
 
-    if (input_width > max_width)
-        return { max_width, max(content_height_from_aspect_ratio(box, box_state, max_width), min_height) };
-    if (input_width < min_width)
-        return { min_width, min(content_height_from_aspect_ratio(box, box_state, min_width), max_height) };
-    if (input_height > max_height)
-        return { max(content_width_from_aspect_ratio(box, box_state, max_height), min_width), max_height };
-    if (input_height < min_height)
-        return { min(content_width_from_aspect_ratio(box, box_state, min_height), max_width), min_height };
+    if (input_inline_size > max_inline_size)
+        return { max_inline_size, max(content_block_size_from_aspect_ratio(box, box_state, max_inline_size), min_block_size) };
+    if (input_inline_size < min_inline_size)
+        return { min_inline_size, min(content_block_size_from_aspect_ratio(box, box_state, min_inline_size), max_block_size) };
+    if (input_block_size > max_block_size)
+        return { max(content_inline_size_from_aspect_ratio(box, box_state, max_block_size), min_inline_size), max_block_size };
+    if (input_block_size < min_block_size)
+        return { min(content_inline_size_from_aspect_ratio(box, box_state, min_block_size), max_inline_size), min_block_size };
 
-    return { input_width, input_height };
+    return { input_inline_size, input_block_size };
 }
 
 Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, BeforeOrAfterInsideLayout before_or_after_inside_layout) const
@@ -986,25 +986,25 @@ LayoutInput FormattingContext::layout_input_for_child_context(
 }
 
 // 10.3.2 Inline, replaced elements, https://www.w3.org/TR/CSS22/visudet.html#inline-replaced-width
-CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box, CSS::Size const& computed_width, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::tentative_inline_size_for_replaced_element(Box const& box, CSS::Size const& computed_inline_size, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // Treat percentages of indefinite containing block widths as 0 (the initial width).
-    if (computed_width.is_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
+    if (computed_inline_size.is_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
         return 0;
 
-    auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_block_size = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
-    CSSPixels used_width = 0;
-    if (computed_width.is_auto()) {
-        used_width = computed_width.to_px(available_space.inline_size.to_px_or_zero());
+    CSSPixels used_inline_size = 0;
+    if (computed_inline_size.is_auto()) {
+        used_inline_size = computed_inline_size.to_px(available_space.inline_size.to_px_or_zero());
     } else {
-        used_width = calculate_inner_inline_size(box, available_space.inline_size, computed_width, containing_block_constraints);
+        used_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_inline_size, containing_block_constraints);
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width,
     // then that intrinsic width is the used value of 'width'.
     auto intrinsic = intrinsic_size_for_replaced_sizing(box);
-    if (computed_height.is_auto() && computed_width.is_auto() && intrinsic.has_width())
+    if (computed_block_size.is_auto() && computed_inline_size.is_auto() && intrinsic.has_width())
         return intrinsic.width.value();
 
     // If 'height' and 'width' both have computed values of 'auto' and the element has no intrinsic width,
@@ -1013,17 +1013,17 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     // 'height' has some other computed value, and the element does have an intrinsic ratio; then the used value of 'width' is:
     //
     //     (used height) * (intrinsic ratio)
-    if ((computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && intrinsic.has_height() && box.has_preferred_aspect_ratio())
-        || (computed_width.is_auto() && !computed_height.is_auto() && box.has_preferred_aspect_ratio())) {
-        auto content_block_size = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
-        return content_width_from_aspect_ratio(box, m_state.get(box), content_block_size);
+    if ((computed_block_size.is_auto() && computed_inline_size.is_auto() && !intrinsic.has_width() && intrinsic.has_height() && box.has_preferred_aspect_ratio())
+        || (computed_inline_size.is_auto() && !computed_block_size.is_auto() && box.has_preferred_aspect_ratio())) {
+        auto content_block_size = compute_block_size_for_replaced_element(box, available_space, containing_block_constraints);
+        return content_inline_size_from_aspect_ratio(box, m_state.get(box), content_block_size);
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element has an intrinsic ratio but no intrinsic height or width,
     // then the used value of 'width' is undefined in CSS 2.2. However, it is suggested that, if the containing block's width does not itself
     // depend on the replaced element's width, then the used value of 'width' is calculated from the constraint equation used for block-level,
     // non-replaced elements in normal flow.
-    if (computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && !intrinsic.has_height() && box.has_preferred_aspect_ratio()) {
+    if (computed_block_size.is_auto() && computed_inline_size.is_auto() && !intrinsic.has_width() && !intrinsic.has_height() && box.has_preferred_aspect_ratio()) {
         if (!available_space.inline_size.is_intrinsic_sizing_constraint())
             return calculate_stretch_fit_inline_size(box, available_space.inline_size);
 
@@ -1038,15 +1038,15 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     }
 
     // Otherwise, if 'width' has a computed value of 'auto', and the element has an intrinsic width, then that intrinsic width is the used value of 'width'.
-    if (computed_width.is_auto() && intrinsic.has_width())
+    if (computed_inline_size.is_auto() && intrinsic.has_width())
         return intrinsic.width.value();
 
     // Otherwise, if 'width' has a computed value of 'auto', but none of the conditions above are met, then the used value of 'width' becomes 300px.
     // If 300px is too wide to fit the device, UAs should use the width of the largest rectangle that has a 2:1 ratio and fits the device instead.
-    if (computed_width.is_auto())
+    if (computed_inline_size.is_auto())
         return 300;
 
-    return used_width;
+    return used_inline_size;
 }
 
 void FormattingContext::compute_width_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
@@ -1065,47 +1065,47 @@ void FormattingContext::compute_height_for_absolutely_positioned_element(Box con
         compute_height_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect, before_or_after_inside_layout);
 }
 
-CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::compute_inline_size_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // 10.3.4 Block-level, replaced elements in normal flow...
     // 10.3.2 Inline, replaced elements
 
-    auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_inline_size = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
+    auto computed_block_size = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
-    auto used_width = tentative_width_for_replaced_element(box, computed_width, available_space, containing_block_constraints);
+    auto used_inline_size = tentative_inline_size_for_replaced_element(box, computed_inline_size, available_space, containing_block_constraints);
 
-    if (computed_width.is_auto() && computed_height.is_auto() && box.has_preferred_aspect_ratio()) {
-        CSSPixels w = used_width;
-        CSSPixels h = tentative_height_for_replaced_element(box, computed_height, available_space, containing_block_constraints);
-        used_width = solve_replaced_size_constraint(w, h, box, available_space, containing_block_constraints).width();
+    if (computed_inline_size.is_auto() && computed_block_size.is_auto() && box.has_preferred_aspect_ratio()) {
+        CSSPixels inline_size = used_inline_size;
+        CSSPixels block_size = tentative_block_size_for_replaced_element(box, computed_block_size, available_space, containing_block_constraints);
+        used_inline_size = solve_replaced_size_constraint(inline_size, block_size, box, available_space, containing_block_constraints).inline_size;
     }
 
     // 2. If the tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto const& computed_max_width = box.computed_values().max_width();
-        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_max_width, containing_block_constraints);
-        if (used_width > max_width)
-            used_width = tentative_width_for_replaced_element(box, computed_max_width, available_space, containing_block_constraints);
+        auto const& computed_max_inline_size = box.computed_values().max_width();
+        auto max_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_max_inline_size, containing_block_constraints);
+        if (used_inline_size > max_inline_size)
+            used_inline_size = tentative_inline_size_for_replaced_element(box, computed_max_inline_size, available_space, containing_block_constraints);
     }
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto computed_min_width = box.computed_values().min_width();
-    if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_min_width, containing_block_constraints);
-        if (used_width < min_width)
-            used_width = tentative_width_for_replaced_element(box, computed_min_width, available_space, containing_block_constraints);
+    auto computed_min_inline_size = box.computed_values().min_width();
+    if (!computed_min_inline_size.is_auto()) {
+        auto min_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_min_inline_size, containing_block_constraints);
+        if (used_inline_size < min_inline_size)
+            used_inline_size = tentative_inline_size_for_replaced_element(box, computed_min_inline_size, available_space, containing_block_constraints);
     }
 
-    return used_width;
+    return used_inline_size;
 }
 
 // 10.6.2 Inline replaced elements, block-level replaced elements in normal flow, 'inline-block' replaced elements in normal flow and floating replaced elements
 // https://www.w3.org/TR/CSS22/visudet.html#inline-replaced-height
-CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& box, CSS::Size const& computed_height, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::tentative_block_size_for_replaced_element(Box const& box, CSS::Size const& computed_block_size, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto intrinsic = intrinsic_size_for_replaced_sizing(box);
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
@@ -1116,68 +1116,68 @@ CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& bo
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic ratio then the used value of 'height' is:
     //
     //     (used width) / (intrinsic ratio)
-    if (computed_height.is_auto() && box.has_preferred_aspect_ratio())
-        return content_height_from_aspect_ratio(box, m_state.get(box));
+    if (computed_block_size.is_auto() && box.has_preferred_aspect_ratio())
+        return content_block_size_from_aspect_ratio(box, m_state.get(box));
 
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic height, then that intrinsic height is the used value of 'height'.
-    if (computed_height.is_auto() && intrinsic.has_height())
+    if (computed_block_size.is_auto() && intrinsic.has_height())
         return intrinsic.height.value();
 
     // Otherwise, if 'height' has a computed value of 'auto', but none of the conditions above are met,
     // then the used value of 'height' must be set to the height of the largest rectangle that has a 2:1 ratio, has a height not greater than 150px,
     // and has a width not greater than the device width.
-    if (computed_height.is_auto())
+    if (computed_block_size.is_auto())
         return 150;
 
     // FIXME: Handle cases when available_space is not definite.
-    return calculate_inner_block_size(box, available_space, computed_height, containing_block_constraints);
+    return calculate_inner_block_size(box, available_space, computed_block_size, containing_block_constraints);
 }
 
-CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::compute_block_size_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // 10.6.2 Inline replaced elements
     // 10.6.4 Block-level replaced elements in normal flow
     // 10.6.6 Floating replaced elements
     // 10.6.10 'inline-block' replaced elements in normal flow
 
-    auto computed_width = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_inline_size = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
+    auto computed_block_size = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used height is calculated (without 'min-height' and 'max-height')
-    CSSPixels used_height = tentative_height_for_replaced_element(box, computed_height, available_space, containing_block_constraints);
+    CSSPixels used_block_size = tentative_block_size_for_replaced_element(box, computed_block_size, available_space, containing_block_constraints);
 
     // However, for replaced elements with both 'width' and 'height' computed as 'auto',
     // use the algorithm under 'Minimum and maximum widths'
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
     // to find the used width and height.
-    if ((computed_width.is_auto() && computed_height.is_auto() && box.has_preferred_aspect_ratio())) {
-        // NOTE: This is a special case where calling tentative_width_for_replaced_element() would call us right back,
+    if ((computed_inline_size.is_auto() && computed_block_size.is_auto() && box.has_preferred_aspect_ratio())) {
+        // NOTE: This is a special case where calling tentative_inline_size_for_replaced_element() would call us right back,
         //       and we'd end up in an infinite loop. So we need to handle this case separately.
         if (auto intrinsic = intrinsic_size_for_replaced_sizing(box); intrinsic.has_width() || !intrinsic.has_height()) {
-            CSSPixels w = tentative_width_for_replaced_element(box, computed_width, available_space, containing_block_constraints);
-            CSSPixels h = used_height;
-            used_height = solve_replaced_size_constraint(w, h, box, available_space, containing_block_constraints).height();
+            CSSPixels inline_size = tentative_inline_size_for_replaced_element(box, computed_inline_size, available_space, containing_block_constraints);
+            CSSPixels block_size = used_block_size;
+            used_block_size = solve_replaced_size_constraint(inline_size, block_size, box, available_space, containing_block_constraints).block_size;
         }
     }
     // 2. If this tentative height is greater than 'max-height', the rules above are applied again,
     //    but this time using the value of 'max-height' as the computed value for 'height'.
     if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
-        auto const& computed_max_height = box.computed_values().max_height();
-        auto max_height = calculate_inner_block_size(box, available_space, computed_max_height, containing_block_constraints);
-        if (used_height > max_height)
-            used_height = tentative_height_for_replaced_element(box, computed_max_height, available_space, containing_block_constraints);
+        auto const& computed_max_block_size = box.computed_values().max_height();
+        auto max_block_size = calculate_inner_block_size(box, available_space, computed_max_block_size, containing_block_constraints);
+        if (used_block_size > max_block_size)
+            used_block_size = tentative_block_size_for_replaced_element(box, computed_max_block_size, available_space, containing_block_constraints);
     }
 
     // 3. If the resulting height is smaller than 'min-height', the rules above are applied again,
     //    but this time using the value of 'min-height' as the computed value for 'height'.
-    auto computed_min_height = box.computed_values().min_height();
-    if (!computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_block_size(box, available_space, computed_min_height, containing_block_constraints);
-        if (used_height < min_height)
-            used_height = tentative_height_for_replaced_element(box, computed_min_height, available_space, containing_block_constraints);
+    auto computed_min_block_size = box.computed_values().min_height();
+    if (!computed_min_block_size.is_auto()) {
+        auto min_block_size = calculate_inner_block_size(box, available_space, computed_min_block_size, containing_block_constraints);
+        if (used_block_size < min_block_size)
+            used_block_size = tentative_block_size_for_replaced_element(box, computed_min_block_size, available_space, containing_block_constraints);
     }
 
-    return used_height;
+    return used_block_size;
 }
 
 void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
@@ -1372,15 +1372,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
 
     // 1. The used value of 'width' is determined as for inline replaced elements.
 
-    auto width = compute_width_for_replaced_element(box, available_space, containing_block_constraints);
-    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto inline_size = compute_inline_size_for_replaced_element(box, available_space, containing_block_constraints);
+    auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
     auto const border_left = computed_values.border_left().width;
     auto const border_right = computed_values.border_right().width;
     auto const padding_left = box_state.padding_left;
     auto const padding_right = box_state.padding_right;
-    auto available = width_of_containing_block - width - border_left - padding_left - padding_right - border_right;
+    auto available = containing_block_inline_size - inline_size - border_left - padding_left - padding_right - border_right;
     auto left = computed_values.inset().left();
     auto margin_left = computed_values.margin().left();
     auto right = computed_values.inset().right();
@@ -1388,7 +1388,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     auto static_position = aligned_static_position(static_position_rect, box_state);
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
-        return l.to_px_or_zero(width_of_containing_block);
+        return l.to_px_or_zero(containing_block_inline_size);
     };
 
     // If 'margin-left' or 'margin-right' is specified as 'auto' its used value is determined by the rules below.
@@ -1444,7 +1444,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     box_state.inset_right = to_px(right);
     box_state.margin_left = to_px(margin_left);
     box_state.margin_right = to_px(margin_right);
-    box_state.set_content_inline_size(width);
+    box_state.set_content_inline_size(inline_size);
 }
 
 // https://drafts.csswg.org/css-position-3/#abs-non-replaced-height
@@ -2609,16 +2609,16 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     // This situation is similar to 10.6.4, except that the element has an intrinsic height.
 
     // The used value of 'height' is determined as for inline replaced elements.
-    auto height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
+    auto block_size = compute_block_size_for_replaced_element(box, available_space, containing_block_constraints);
 
-    auto height_of_containing_block = available_space.block_size.to_px_or_zero();
+    auto containing_block_block_size = available_space.block_size.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
     auto const border_top = computed_values.border_top().width;
     auto const border_bottom = computed_values.border_bottom().width;
     auto const padding_top = box_state.padding_top;
     auto const padding_bottom = box_state.padding_bottom;
-    auto available = height_of_containing_block - height - border_top - padding_top - padding_bottom - border_bottom;
+    auto available = containing_block_block_size - block_size - border_top - padding_top - padding_bottom - border_bottom;
     auto top = computed_values.inset().top();
     auto margin_top = computed_values.margin().top();
     auto bottom = computed_values.inset().bottom();
@@ -2626,7 +2626,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     auto static_position = aligned_static_position(static_position_rect, box_state);
 
     auto to_px = [&](CSS::LengthPercentageOrAuto const& l) {
-        return l.to_px_or_zero(height_of_containing_block);
+        return l.to_px_or_zero(containing_block_block_size);
     };
 
     // If 'margin-top' or 'margin-bottom' is specified as 'auto' its used value is determined by the rules below.
@@ -2667,7 +2667,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
         bottom = CSS::Length::make_px(available - to_px(top) - to_px(margin_top) - to_px(margin_bottom));
     }
 
-    box_state.set_content_block_size(height);
+    box_state.set_content_block_size(block_size);
 
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
@@ -2823,14 +2823,14 @@ CSSPixels FormattingContext::calculate_min_content_inline_size(Layout::Box const
             return calculate_inner_inline_size(box, AvailableSize::make_min_content(), min_width, zero_percentage_basis_constraints);
         }
     }
-    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
-        return transferred_width.value();
+    if (auto transferred_inline_size = calculate_transferred_inline_size_for_replaced_element(box, containing_block_constraints); transferred_inline_size.has_value())
+        return transferred_inline_size.value();
     auto auto_size = box.auto_content_box_size();
     if (auto_size.has_width())
         return auto_size.width.value();
     if (box.is_replaced_box() && !box.has_preferred_aspect_ratio()) {
-        if (auto fallback_width = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Width); fallback_width.has_value())
-            return fallback_width.value();
+        if (auto fallback_inline_size = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Inline); fallback_inline_size.has_value())
+            return fallback_inline_size.value();
     }
 
     // Boxes with no children have zero intrinsic width.
@@ -2865,7 +2865,7 @@ CSSPixels FormattingContext::calculate_min_content_inline_size(Layout::Box const
 
 // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
 // "size constraints in the opposite dimension will transfer through and can affect the auto size in the considered one"
-Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_element(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
+Optional<CSSPixels> FormattingContext::calculate_transferred_inline_size_for_replaced_element(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     if (!box.is_replaced_box() || !box.has_preferred_aspect_ratio())
         return {};
@@ -2875,8 +2875,8 @@ Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_
     if (!box.computed_values().width().is_auto())
         return {};
 
-    auto const& computed_height = box.computed_values().height();
-    if (computed_height.is_auto() || computed_height.is_intrinsic_sizing_constraint())
+    auto const& computed_block_size = box.computed_values().height();
+    if (computed_block_size.is_auto() || computed_block_size.is_intrinsic_sizing_constraint())
         return {};
 
     auto available_space = m_state.get(box).available_inner_space_or_constraints_from(
@@ -2886,14 +2886,14 @@ Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_
 
     // https://drafts.csswg.org/css2/#inline-replaced-width
     // "(used height) * (intrinsic ratio)"
-    return compute_width_for_replaced_element(box, available_space, {});
+    return compute_inline_size_for_replaced_element(box, available_space, {});
 }
 
 CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto auto_size = box.auto_content_box_size();
-    if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
-        return transferred_width.value();
+    if (auto transferred_inline_size = calculate_transferred_inline_size_for_replaced_element(box, containing_block_constraints); transferred_inline_size.has_value())
+        return transferred_inline_size.value();
     if (!auto_size.has_width()) {
         // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
         // "If the box is non-replaced, then the entire value of any max size property or preferred size property
@@ -2966,11 +2966,11 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
     auto definite_minimum_size_in_origin_axis = resolve_size_in_origin_axis(box.computed_values().min_height(), CyclicPercentageSizeProperty::MinSize);
     ReplacedMaxContentSizeConstraints constraints {
         .definite_size_in_ratio_determining_axis = definite_height,
-        .minimum_width = definite_minimum_size_in_destination_axis,
-        .minimum_height = definite_minimum_size_in_origin_axis,
+        .minimum_inline_size = definite_minimum_size_in_destination_axis,
+        .minimum_block_size = definite_minimum_size_in_origin_axis,
     };
 
-    if (auto max_content_width = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Width, constraints); max_content_width.has_value()) {
+    if (auto max_content_inline_size = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Inline, constraints); max_content_inline_size.has_value()) {
         if (!definite_height.has_value() && box.has_preferred_aspect_ratio()) {
             if (auto definite_maximum_size_in_origin_axis = resolve_size_in_origin_axis(box.computed_values().max_height(), CyclicPercentageSizeProperty::PreferredOrMaxSize); definite_maximum_size_in_origin_axis.has_value()) {
                 // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers
@@ -2978,7 +2978,7 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
                 // This transferred minimum is capped by any definite preferred or maximum size in the destination axis.
                 Optional<CSSPixels> transferred_minimum;
                 if (definite_minimum_size_in_origin_axis.has_value()) {
-                    transferred_minimum = content_width_from_aspect_ratio(box, m_state.get(box), definite_minimum_size_in_origin_axis.value());
+                    transferred_minimum = content_inline_size_from_aspect_ratio(box, m_state.get(box), definite_minimum_size_in_origin_axis.value());
 
                     auto cap_transferred_minimum = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) {
                         if (auto resolved_size = resolve_destination_width(size, size_property); resolved_size.has_value())
@@ -2991,7 +2991,7 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
                 // Then, any definite maximum size is converted and transferred from the origin to destination.
                 // This transferred maximum is floored by any definite preferred or minimum size in the destination axis
                 // as well as by the transferred minimum, if any.
-                auto transferred_maximum = content_width_from_aspect_ratio(box, m_state.get(box), definite_maximum_size_in_origin_axis.value());
+                auto transferred_maximum = content_inline_size_from_aspect_ratio(box, m_state.get(box), definite_maximum_size_in_origin_axis.value());
 
                 auto floor_transferred_maximum = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) {
                     if (auto resolved_size = resolve_destination_width(size, size_property); resolved_size.has_value())
@@ -3002,10 +3002,10 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
                 if (transferred_minimum.has_value())
                     transferred_maximum = max(transferred_maximum, transferred_minimum.value());
 
-                return min(max_content_width.value(), transferred_maximum);
+                return min(max_content_inline_size.value(), transferred_maximum);
             }
         }
-        return max_content_width.value();
+        return max_content_inline_size.value();
     }
 
     // Boxes with no children have zero intrinsic width.
@@ -3085,8 +3085,8 @@ CSSPixels FormattingContext::calculate_max_content_block_size(Layout::Box const&
 
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_height())
         return auto_size.height.value();
-    if (auto max_content_height = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), m_state.get(box), SizeDimension::Height); max_content_height.has_value())
-        return max_content_height.value();
+    if (auto max_content_block_size = max_content_size_for_replaced_element_without_natural_size(box, box.auto_content_box_size(), m_state.get(box), SizeDimension::Block); max_content_block_size.has_value())
+        return max_content_block_size.value();
 
     // Boxes with no children have zero intrinsic height.
     if (!box.has_children())
@@ -3151,7 +3151,7 @@ CSSPixels FormattingContext::calculate_inner_block_size(Box const& box, Availabl
     auto const& box_state = m_state.get(box);
 
     if (preferred_size.is_auto() && box.has_preferred_aspect_ratio())
-        return content_height_from_aspect_ratio(box, box_state);
+        return content_block_size_from_aspect_ratio(box, box_state);
 
     VERIFY(!preferred_size.is_auto());
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -743,7 +743,7 @@ CSSPixels FormattingContext::compute_automatic_block_size_for_block_formatting_c
             if (!child_box_state)
                 return IterationDecision::Continue;
 
-            CSSPixels child_box_bottom = child_box_state->content_offset().y() + child_box_state->content_block_size() + child_box_state->margin_box_bottom();
+            CSSPixels child_box_bottom = child_box_state->content_logical_offset().block_offset + child_box_state->content_block_size() + child_box_state->margin_box_bottom();
 
             if (!bottom.has_value() || child_box_bottom > bottom.value())
                 bottom = child_box_bottom;
@@ -3382,7 +3382,7 @@ void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& use
             VERIFY(line_box.fragments().size() == 1);
             auto const& block_child = as<Box>(line_box.fragments().first().layout_node());
             auto const& block_child_state = m_state.get(block_child);
-            auto child_offset_from_margin_edge = block_child_state.content_offset().y() - block_child_state.margin_box_top();
+            auto child_offset_from_margin_edge = block_child_state.content_logical_offset().block_offset - block_child_state.margin_box_top();
             return child_offset_from_margin_edge + box_baseline(block_child, baseline_set);
         };
 
@@ -3420,7 +3420,7 @@ void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& use
             auto const& child_baseline = deriving_first_baseline ? child_state->first_baseline : child_state->last_baseline;
             if (!child_baseline.has_value())
                 continue;
-            auto child_offset_from_margin_edge = child_state->content_offset().y() - child_state->margin_box_top();
+            auto child_offset_from_margin_edge = child_state->content_logical_offset().block_offset - child_state->margin_box_top();
             return child_offset_from_margin_edge + box_baseline(*child_box, baseline_set);
         }
         return {};

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -636,8 +636,8 @@ CSSPixels FormattingContext::line_box_physical_width(Box const& box, LineBox con
 FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_widths(Box const& box, ContainingBlockConstraints const& containing_block_constraints)
 {
     return {
-        .preferred_width = calculate_max_content_width(box, containing_block_constraints),
-        .preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints),
+        .preferred_width = calculate_max_content_inline_size(box, containing_block_constraints),
+        .preferred_minimum_width = calculate_min_content_inline_size(box, containing_block_constraints),
     };
 }
 
@@ -646,12 +646,12 @@ CSSPixelSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_w
     // 10.4 Minimum and maximum widths: 'min-width' and 'max-width'
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
 
-    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_width(box, available_space.inline_size, box.computed_values().min_width(), containing_block_constraints);
-    auto specified_max_width = should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints) ? input_width : calculate_inner_width(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
+    auto min_width = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().min_width(), containing_block_constraints);
+    auto specified_max_width = should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints) ? input_width : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
     auto max_width = max(min_width, specified_max_width);
 
-    auto min_height = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_height(box, available_space, box.computed_values().min_height(), containing_block_constraints);
-    auto specified_max_height = should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) ? input_height : calculate_inner_height(box, available_space, box.computed_values().max_height(), containing_block_constraints);
+    auto min_height = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_block_size(box, available_space, box.computed_values().min_height(), containing_block_constraints);
+    auto specified_max_height = should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) ? input_height : calculate_inner_block_size(box, available_space, box.computed_values().max_height(), containing_block_constraints);
     auto max_height = max(min_height, specified_max_height);
 
     auto const& box_state = m_state.get(box);
@@ -698,7 +698,7 @@ Optional<CSSPixels> FormattingContext::compute_auto_height_for_absolutely_positi
     // NOTE: For anything else, we use the fit-content height.
     //       This should eventually be replaced by the new absolute positioning model:
     //       https://www.w3.org/TR/css-position-3/#abspos-layout
-    return calculate_fit_content_height(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
+    return calculate_fit_content_block_size(box, m_state.get(box).available_inner_space_or_constraints_from(available_space), containing_block_constraints);
 }
 
 // https://www.w3.org/TR/CSS22/visudet.html#root-height
@@ -801,11 +801,11 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
 
     auto used_height = should_treat_height_as_auto(box, available_space, containing_block_constraints)
         ? natural_content_height
-        : calculate_inner_height(box, available_space, computed_values.height(), containing_block_constraints);
+        : calculate_inner_block_size(box, available_space, computed_values.height(), containing_block_constraints);
     if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) && !computed_values.max_height().is_auto())
-        used_height = min(used_height, calculate_inner_height(box, available_space, computed_values.max_height(), containing_block_constraints));
+        used_height = min(used_height, calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints));
     if (!computed_values.min_height().is_auto())
-        used_height = max(used_height, calculate_inner_height(box, available_space, computed_values.min_height(), containing_block_constraints));
+        used_height = max(used_height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
 
     // Only force a definite content box when the button is taller than its content, so a min-height or a larger height
     // has room to center within. A content-sized box stays indefinite, so an intrinsic keyword height does not resolve
@@ -998,7 +998,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     if (computed_width.is_auto()) {
         used_width = computed_width.to_px(available_space.inline_size.to_px_or_zero());
     } else {
-        used_width = calculate_inner_width(box, available_space.inline_size, computed_width, containing_block_constraints);
+        used_width = calculate_inner_inline_size(box, available_space.inline_size, computed_width, containing_block_constraints);
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has an intrinsic width,
@@ -1025,7 +1025,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     // non-replaced elements in normal flow.
     if (computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && !intrinsic.has_height() && box.has_preferred_aspect_ratio()) {
         if (!available_space.inline_size.is_intrinsic_sizing_constraint())
-            return calculate_stretch_fit_width(box, available_space.inline_size);
+            return calculate_stretch_fit_inline_size(box, available_space.inline_size);
 
         switch (cyclic_percentage_intrinsic_contribution(box, box.computed_values().width(), available_space.inline_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
@@ -1033,7 +1033,7 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
             break;
         case CyclicPercentageIntrinsicContribution::NotCyclic:
-            return calculate_stretch_fit_width(box, available_space.inline_size);
+            return calculate_stretch_fit_inline_size(box, available_space.inline_size);
         }
     }
 
@@ -1086,7 +1086,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
         auto const& computed_max_width = box.computed_values().max_width();
-        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_max_width, containing_block_constraints);
+        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_max_width, containing_block_constraints);
         if (used_width > max_width)
             used_width = tentative_width_for_replaced_element(box, computed_max_width, available_space, containing_block_constraints);
     }
@@ -1095,7 +1095,7 @@ CSSPixels FormattingContext::compute_width_for_replaced_element(Box const& box, 
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     auto computed_min_width = box.computed_values().min_width();
     if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_min_width, containing_block_constraints);
+        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_min_width, containing_block_constraints);
         if (used_width < min_width)
             used_width = tentative_width_for_replaced_element(box, computed_min_width, available_space, containing_block_constraints);
     }
@@ -1130,7 +1130,7 @@ CSSPixels FormattingContext::tentative_height_for_replaced_element(Box const& bo
         return 150;
 
     // FIXME: Handle cases when available_space is not definite.
-    return calculate_inner_height(box, available_space, computed_height, containing_block_constraints);
+    return calculate_inner_block_size(box, available_space, computed_height, containing_block_constraints);
 }
 
 CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
@@ -1163,7 +1163,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     //    but this time using the value of 'max-height' as the computed value for 'height'.
     if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
         auto const& computed_max_height = box.computed_values().max_height();
-        auto max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
+        auto max_height = calculate_inner_block_size(box, available_space, computed_max_height, containing_block_constraints);
         if (used_height > max_height)
             used_height = tentative_height_for_replaced_element(box, computed_max_height, available_space, containing_block_constraints);
     }
@@ -1172,7 +1172,7 @@ CSSPixels FormattingContext::compute_height_for_replaced_element(Box const& box,
     //    but this time using the value of 'min-height' as the computed value for 'height'.
     auto computed_min_height = box.computed_values().min_height();
     if (!computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_height(box, available_space, computed_min_height, containing_block_constraints);
+        auto min_height = calculate_inner_block_size(box, available_space, computed_min_height, containing_block_constraints);
         if (used_height < min_height)
             used_height = tentative_height_for_replaced_element(box, computed_min_height, available_space, containing_block_constraints);
     }
@@ -1218,10 +1218,10 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
         auto calculate_shrink_to_fit_width = [&] {
             auto available_width = solve_for_width().to_px(box);
-            auto preferred_width = calculate_max_content_width(box, containing_block_constraints);
+            auto preferred_width = calculate_max_content_inline_size(box, containing_block_constraints);
             if (preferred_width <= available_width)
                 return preferred_width;
-            auto preferred_minimum_width = calculate_min_content_width(box, containing_block_constraints);
+            auto preferred_minimum_width = calculate_min_content_inline_size(box, containing_block_constraints);
             return min(max(preferred_minimum_width, available_width), preferred_width);
         };
 
@@ -1335,13 +1335,13 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             return CSS::Length::make_px(compute_table_box_width_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (computed_values.width().is_auto())
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_width(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_inline_size(box, available_space.inline_size, computed_values.width(), containing_block_constraints));
     }());
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto max_width = calculate_inner_width(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
+        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width) {
             used_width = try_compute_width(CSS::Length::make_px(max_width));
         }
@@ -1350,7 +1350,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_width(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
+        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() < min_width) {
             used_width = try_compute_width(CSS::Length::make_px(min_width));
         }
@@ -1464,12 +1464,12 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         auto const& computed_max_height = box.computed_values().max_height();
         auto constrained_height = unconstrained_height;
         if (!computed_max_height.is_none()) {
-            auto inner_max_height = calculate_inner_height(box, available_space, computed_max_height, containing_block_constraints);
+            auto inner_max_height = calculate_inner_block_size(box, available_space, computed_max_height, containing_block_constraints);
             if (inner_max_height < constrained_height.to_px_or_zero())
                 constrained_height = CSS::Length::make_px(inner_max_height);
         }
         if (!computed_min_height.is_auto()) {
-            auto inner_min_height = calculate_inner_height(box, available_space, computed_min_height, containing_block_constraints);
+            auto inner_min_height = calculate_inner_block_size(box, available_space, computed_min_height, containing_block_constraints);
             if (inner_min_height > constrained_height.to_px_or_zero())
                 constrained_height = CSS::Length::make_px(inner_min_height);
         }
@@ -1673,14 +1673,14 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             return CSS::Length::make_px(compute_table_box_height_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
             return CSS::LengthOrAuto::make_auto();
-        return CSS::Length::make_px(calculate_inner_height(box, available_space_for_intrinsic_height, box.computed_values().height(), containing_block_constraints));
+        return CSS::Length::make_px(calculate_inner_block_size(box, available_space_for_intrinsic_height, box.computed_values().height(), containing_block_constraints));
     }());
 
     // If the tentative used height is greater than 'max-height', the rules above are applied again,
     // but this time using the computed value of 'max-height' as the computed value for 'height'.
     auto const& computed_max_height = box.computed_values().max_height();
     if (!used_height.is_auto() && !computed_max_height.is_none()) {
-        auto max_height = calculate_inner_height(box, available_space_for_intrinsic_height, computed_max_height, containing_block_constraints);
+        auto max_height = calculate_inner_block_size(box, available_space_for_intrinsic_height, computed_max_height, containing_block_constraints);
         if (used_height.to_px_or_zero() > max_height)
             used_height = try_compute_height(CSS::Length::make_px(max_height));
     }
@@ -1689,7 +1689,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // but this time using the value of 'min-height' as the computed value for 'height'.
     auto const& computed_min_height = box.computed_values().min_height();
     if (!used_height.is_auto() && !computed_min_height.is_auto()) {
-        auto min_height = calculate_inner_height(box, available_space_for_intrinsic_height, computed_min_height, containing_block_constraints);
+        auto min_height = calculate_inner_block_size(box, available_space_for_intrinsic_height, computed_min_height, containing_block_constraints);
         if (used_height.to_px_or_zero() < min_height)
             used_height = try_compute_height(CSS::Length::make_px(min_height));
     }
@@ -2749,60 +2749,60 @@ void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box
 }
 
 // https://drafts.csswg.org/css-sizing-3/#fit-content-size
-CSSPixels FormattingContext::calculate_fit_content_width(Layout::Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_fit_content_inline_size(Layout::Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // If the available space in a given axis is definite, equal to clamp(min-content size, stretch-fit size,
     // max-content size) (i.e. max(min-content size, min(max-content size, stretch-fit size))).
     if (available_space.inline_size.is_definite()) {
-        auto stretch_fit_width = calculate_stretch_fit_width(box, available_space.inline_size);
-        auto max_content_width = calculate_max_content_width(box, containing_block_constraints);
-        if (max_content_width <= stretch_fit_width)
-            return max_content_width;
-        return max(calculate_min_content_width(box, containing_block_constraints), stretch_fit_width);
+        auto stretch_fit_inline_size = calculate_stretch_fit_inline_size(box, available_space.inline_size);
+        auto max_content_inline_size = calculate_max_content_inline_size(box, containing_block_constraints);
+        if (max_content_inline_size <= stretch_fit_inline_size)
+            return max_content_inline_size;
+        return max(calculate_min_content_inline_size(box, containing_block_constraints), stretch_fit_inline_size);
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.
     if (available_space.inline_size.is_min_content())
-        return calculate_min_content_width(box, containing_block_constraints);
+        return calculate_min_content_inline_size(box, containing_block_constraints);
 
     // Otherwise, equal to the max-content size in that axis.
-    return calculate_max_content_width(box, containing_block_constraints);
+    return calculate_max_content_inline_size(box, containing_block_constraints);
 }
 
 // https://drafts.csswg.org/css-sizing-3/#fit-content-size
-CSSPixels FormattingContext::calculate_fit_content_height(Layout::Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_fit_content_block_size(Layout::Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // If the available space in a given axis is definite,
     // equal to clamp(min-content size, stretch-fit size, max-content size)
     // (i.e. max(min-content size, min(max-content size, stretch-fit size))).
     if (available_space.block_size.is_definite()) {
-        auto width = available_space.inline_size.to_px_or_zero();
-        auto stretch_fit_height = calculate_stretch_fit_height(box, available_space.block_size);
-        auto max_content_height = calculate_max_content_height(box, width, containing_block_constraints);
-        if (max_content_height <= stretch_fit_height)
-            return max_content_height;
-        return max(calculate_min_content_height(box, width, containing_block_constraints), stretch_fit_height);
+        auto inline_size = available_space.inline_size.to_px_or_zero();
+        auto stretch_fit_block_size = calculate_stretch_fit_block_size(box, available_space.block_size);
+        auto max_content_block_size = calculate_max_content_block_size(box, inline_size, containing_block_constraints);
+        if (max_content_block_size <= stretch_fit_block_size)
+            return max_content_block_size;
+        return max(calculate_min_content_block_size(box, inline_size, containing_block_constraints), stretch_fit_block_size);
     }
 
     // When sizing under a min-content constraint, equal to the min-content size.
     if (available_space.block_size.is_min_content())
-        return calculate_min_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+        return calculate_min_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
 
     // Otherwise, equal to the max-content size in that axis.
-    return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+    return calculate_max_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
 }
 
 static IntrinsicSizeCacheKey intrinsic_size_cache_key(ContainingBlockConstraints const& containing_block_constraints)
 {
     return {
-        .measured_at_width = {},
+        .measured_at_inline_size = {},
         .percentage_basis_inline_size = containing_block_constraints.percentage_basis_inline_size,
         .percentage_basis_block_size = containing_block_constraints.percentage_basis_block_size,
         .quirks_mode_percentage_basis_block_size = containing_block_constraints.quirks_mode_percentage_basis_block_size,
     };
 }
 
-CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_min_content_inline_size(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     if (box.is_replaced_box()) {
         // https://www.w3.org/TR/css-sizing-3/#replaced-percentage-min-contribution
@@ -2820,7 +2820,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
 
             auto zero_percentage_basis_constraints = containing_block_constraints;
             zero_percentage_basis_constraints.percentage_basis_inline_size = 0;
-            return calculate_inner_width(box, AvailableSize::make_min_content(), min_width, zero_percentage_basis_constraints);
+            return calculate_inner_inline_size(box, AvailableSize::make_min_content(), min_width, zero_percentage_basis_constraints);
         }
     }
     if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
@@ -2838,7 +2838,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
         return 0;
 
     auto cache_key = intrinsic_size_cache_key(containing_block_constraints);
-    auto& cache = box.cached_intrinsic_sizes().min_content_width;
+    auto& cache = box.cached_intrinsic_sizes().min_content_inline_size;
     if (auto cached_value = cache.get(cache_key); cached_value.has_value())
         return cached_value.value();
 
@@ -2850,17 +2850,17 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
-    auto available_width = AvailableSize::make_min_content();
-    auto available_height = box_state.has_definite_block_size()
+    auto available_inline_size = AvailableSize::make_min_content();
+    auto available_block_size = box_state.has_definite_block_size()
         ? AvailableSize::make_definite(box_state.content_block_size())
         : AvailableSize::make_indefinite();
 
-    auto available_space = AvailableSpace(available_width, available_height);
+    auto available_space = AvailableSpace(available_inline_size, available_block_size);
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto min_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
-    cache.set(cache_key, min_content_width);
-    return min_content_width;
+    auto min_content_inline_size = clamp_to_max_dimension_value(context->automatic_content_width());
+    cache.set(cache_key, min_content_inline_size);
+    return min_content_inline_size;
 }
 
 // https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes
@@ -2889,7 +2889,7 @@ Optional<CSSPixels> FormattingContext::calculate_transferred_width_for_replaced_
     return compute_width_for_replaced_element(box, available_space, {});
 }
 
-CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const& box, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto auto_size = box.auto_content_box_size();
     if (auto transferred_width = calculate_transferred_width_for_replaced_element(box, containing_block_constraints); transferred_width.has_value())
@@ -2932,12 +2932,12 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
         case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
             auto zero_percentage_basis_constraints = containing_block_constraints;
             zero_percentage_basis_constraints.percentage_basis_inline_size = 0;
-            return calculate_inner_width(box, max_content_available_width, size, zero_percentage_basis_constraints);
+            return calculate_inner_inline_size(box, max_content_available_width, size, zero_percentage_basis_constraints);
         }
         case CyclicPercentageIntrinsicContribution::NotCyclic:
             if (size.contains_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
                 return {};
-            return calculate_inner_width(box, max_content_available_width, size, containing_block_constraints);
+            return calculate_inner_inline_size(box, max_content_available_width, size, containing_block_constraints);
         }
         VERIFY_NOT_REACHED();
     };
@@ -2946,7 +2946,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
         if (!size.is_length_percentage())
             return {};
         if (!size.contains_percentage() || containing_block_constraints.percentage_basis_block_size.has_value())
-            return calculate_inner_height(box, intrinsic_available_space, size, containing_block_constraints);
+            return calculate_inner_block_size(box, intrinsic_available_space, size, containing_block_constraints);
 
         switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_width, size_property)) {
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
@@ -2954,7 +2954,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
         case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
             auto zero_percentage_basis_constraints = containing_block_constraints;
             zero_percentage_basis_constraints.percentage_basis_block_size = 0;
-            return calculate_inner_height(box, intrinsic_available_space, size, zero_percentage_basis_constraints);
+            return calculate_inner_block_size(box, intrinsic_available_space, size, zero_percentage_basis_constraints);
         }
         case CyclicPercentageIntrinsicContribution::NotCyclic:
             return {};
@@ -3013,7 +3013,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
         return 0;
 
     auto cache_key = intrinsic_size_cache_key(containing_block_constraints);
-    auto& cache = box.cached_intrinsic_sizes().max_content_width;
+    auto& cache = box.cached_intrinsic_sizes().max_content_inline_size;
     if (auto cached_value = cache.get(cache_key); cached_value.has_value())
         return cached_value.value();
 
@@ -3025,29 +3025,29 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
-    auto available_width = AvailableSize::make_max_content();
-    auto available_height = box_state.has_definite_block_size()
+    auto available_inline_size = AvailableSize::make_max_content();
+    auto available_block_size = box_state.has_definite_block_size()
         ? AvailableSize::make_definite(box_state.content_block_size())
         : AvailableSize::make_indefinite();
 
-    auto available_space = AvailableSpace(available_width, available_height);
+    auto available_space = AvailableSpace(available_inline_size, available_block_size);
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto max_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
-    cache.set(cache_key, max_content_width);
-    return max_content_width;
+    auto max_content_inline_size = clamp_to_max_dimension_value(context->automatic_content_width());
+    cache.set(cache_key, max_content_inline_size);
+    return max_content_inline_size;
 }
 
 // https://www.w3.org/TR/css-sizing-3/#min-content-block-size
-CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box, CSSPixels width, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_min_content_block_size(Layout::Box const& box, CSSPixels inline_size, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // For block containers, tables, and inline boxes, this is equivalent to the max-content block size.
     if (box.is_block_container() || box.display().is_table_inside())
-        return calculate_max_content_height(box, width, containing_block_constraints);
+        return calculate_max_content_block_size(box, inline_size, containing_block_constraints);
 
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_height()) {
         if (auto_size.has_aspect_ratio())
-            return width / auto_size.aspect_ratio.value();
+            return inline_size / auto_size.aspect_ratio.value();
         return auto_size.height.value();
     }
 
@@ -3056,8 +3056,8 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
         return 0;
 
     auto cache_key = intrinsic_size_cache_key(containing_block_constraints);
-    cache_key.measured_at_width = width;
-    auto& cache = box.cached_intrinsic_sizes().min_content_height;
+    cache_key.measured_at_inline_size = inline_size;
+    auto& cache = box.cached_intrinsic_sizes().min_content_block_size;
     if (auto cached_value = cache.get(cache_key); cached_value.has_value())
         return cached_value.value();
 
@@ -3066,22 +3066,22 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     box_state.block_size_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_block_size();
-    box_state.set_content_inline_size(width);
+    box_state.set_content_inline_size(inline_size);
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
-    auto available_space = AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content());
+    auto available_space = AvailableSpace(AvailableSize::make_definite(inline_size), AvailableSize::make_min_content());
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto min_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
-    cache.set(cache_key, min_content_height);
-    return min_content_height;
+    auto min_content_block_size = clamp_to_max_dimension_value(context->automatic_content_height());
+    cache.set(cache_key, min_content_block_size);
+    return min_content_block_size;
 }
 
-CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box, CSSPixels width, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_max_content_block_size(Layout::Box const& box, CSSPixels inline_size, ContainingBlockConstraints const& containing_block_constraints) const
 {
     if (box.has_preferred_aspect_ratio())
-        return width / *box.preferred_aspect_ratio();
+        return inline_size / *box.preferred_aspect_ratio();
 
     if (auto auto_size = box.auto_content_box_size(); auto_size.has_height())
         return auto_size.height.value();
@@ -3093,8 +3093,8 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
         return 0;
 
     auto cache_key = intrinsic_size_cache_key(containing_block_constraints);
-    cache_key.measured_at_width = width;
-    auto& cache = box.cached_intrinsic_sizes().max_content_height;
+    cache_key.measured_at_inline_size = inline_size;
+    auto& cache = box.cached_intrinsic_sizes().max_content_block_size;
     if (auto cached_value = cache.get(cache_key); cached_value.has_value())
         return cached_value.value();
 
@@ -3103,69 +3103,69 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     box_state.block_size_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_block_size();
-    box_state.set_content_inline_size(width);
+    box_state.set_content_inline_size(inline_size);
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
-    auto available_space = AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content());
+    auto available_space = AvailableSpace(AvailableSize::make_definite(inline_size), AvailableSize::make_max_content());
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto max_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
-    cache.set(cache_key, max_content_height);
-    return max_content_height;
+    auto max_content_block_size = clamp_to_max_dimension_value(context->automatic_content_height());
+    cache.set(cache_key, max_content_block_size);
+    return max_content_block_size;
 }
 
-CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, AvailableSize const& available_width, CSS::Size const& width, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_inner_inline_size(Layout::Box const& box, AvailableSize const& available_inline_size, CSS::Size const& preferred_size, ContainingBlockConstraints const& containing_block_constraints) const
 {
-    VERIFY(!width.is_auto());
+    VERIFY(!preferred_size.is_auto());
 
     auto const& box_state = m_state.get(box);
-    auto width_of_containing_block = width.contains_percentage()
-        ? containing_block_constraints.percentage_basis_inline_size.value_or(available_width.to_px_or_zero())
-        : available_width.to_px_or_zero();
-    if (width.is_fit_content()) {
-        return calculate_fit_content_width(box, AvailableSpace { available_width, AvailableSize::make_indefinite() }, containing_block_constraints);
+    auto containing_block_inline_size = preferred_size.contains_percentage()
+        ? containing_block_constraints.percentage_basis_inline_size.value_or(available_inline_size.to_px_or_zero())
+        : available_inline_size.to_px_or_zero();
+    if (preferred_size.is_fit_content()) {
+        return calculate_fit_content_inline_size(box, AvailableSpace { available_inline_size, AvailableSize::make_indefinite() }, containing_block_constraints);
     }
-    if (width.is_max_content()) {
-        return calculate_max_content_width(box, containing_block_constraints);
+    if (preferred_size.is_max_content()) {
+        return calculate_max_content_inline_size(box, containing_block_constraints);
     }
-    if (width.is_min_content()) {
-        return calculate_min_content_width(box, containing_block_constraints);
+    if (preferred_size.is_min_content()) {
+        return calculate_min_content_inline_size(box, containing_block_constraints);
     }
 
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
-        auto inner_width = width.to_px(width_of_containing_block)
+        auto inner_inline_size = preferred_size.to_px(containing_block_inline_size)
             - computed_values.border_left().width
             - box_state.padding_left
             - computed_values.border_right().width
             - box_state.padding_right;
-        return max(inner_width, 0);
+        return max(inner_inline_size, 0);
     }
 
-    return width.to_px(width_of_containing_block);
+    return preferred_size.to_px(containing_block_inline_size);
 }
 
-CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpace const& available_space, CSS::Size const& height, ContainingBlockConstraints const& containing_block_constraints) const
+CSSPixels FormattingContext::calculate_inner_block_size(Box const& box, AvailableSpace const& available_space, CSS::Size const& preferred_size, ContainingBlockConstraints const& containing_block_constraints) const
 {
     auto const& box_state = m_state.get(box);
 
-    if (height.is_auto() && box.has_preferred_aspect_ratio())
+    if (preferred_size.is_auto() && box.has_preferred_aspect_ratio())
         return content_height_from_aspect_ratio(box, box_state);
 
-    VERIFY(!height.is_auto());
+    VERIFY(!preferred_size.is_auto());
 
-    if (height.is_fit_content()) {
-        return calculate_fit_content_height(box, available_space, containing_block_constraints);
+    if (preferred_size.is_fit_content()) {
+        return calculate_fit_content_block_size(box, available_space, containing_block_constraints);
     }
-    if (height.is_max_content()) {
-        return calculate_max_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+    if (preferred_size.is_max_content()) {
+        return calculate_max_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
-    if (height.is_min_content()) {
-        return calculate_min_content_height(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
+    if (preferred_size.is_min_content()) {
+        return calculate_min_content_block_size(box, available_space.inline_size.to_px_or_zero(), containing_block_constraints);
     }
 
-    CSSPixels height_of_containing_block = available_space.block_size.to_px_or_zero();
+    CSSPixels containing_block_block_size = available_space.block_size.to_px_or_zero();
     // NOTE: Percentage heights are resolved against the containing block's used height,
     //       not the available space height. The containing block's height must be definite
     //       for percentage resolution to work (otherwise should_treat_height_as_auto
@@ -3173,44 +3173,44 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
     // NOTE: We only do this when available space height is indefinite. If it's definite,
     //       we trust that the caller has set it up correctly (e.g., grid/flex items get
     //       their cell/area size as available space).
-    if (height.contains_percentage() && available_space.block_size.is_indefinite()) {
+    if (preferred_size.contains_percentage() && available_space.block_size.is_indefinite()) {
         // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
         // NOTE: Flex/grid items resolve percentage heights against their container, not via quirk.
         bool is_flex_or_grid_item = box.parent() && (box.parent()->display().is_flex_inside() || box.parent()->display().is_grid_inside());
         auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
         bool is_in_ua_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
         if (box.document().in_quirks_mode() && !box.is_anonymous() && !is_flex_or_grid_item && !is_in_ua_shadow_tree) {
-            height_of_containing_block = containing_block_constraints.quirks_mode_percentage_basis_block_size.value_or(0);
+            containing_block_block_size = containing_block_constraints.quirks_mode_percentage_basis_block_size.value_or(0);
         } else if (containing_block_constraints.percentage_basis_block_size.has_value()) {
-            height_of_containing_block = containing_block_constraints.percentage_basis_block_size.value();
+            containing_block_block_size = containing_block_constraints.percentage_basis_block_size.value();
         }
     }
     auto& computed_values = box.computed_values();
 
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
-        auto inner_height = height.to_px(height_of_containing_block)
+        auto inner_block_size = preferred_size.to_px(containing_block_block_size)
             - computed_values.border_top().width
             - box_state.padding_top
             - computed_values.border_bottom().width
             - box_state.padding_bottom;
-        return max(inner_height, 0);
+        return max(inner_block_size, 0);
     }
 
-    return height.to_px(height_of_containing_block);
+    return preferred_size.to_px(containing_block_block_size);
 }
 
 // https://drafts.csswg.org/css-sizing-3/#stretch-fit-size
-CSSPixels FormattingContext::calculate_stretch_fit_width(Box const& box, AvailableSize const& available_width) const
+CSSPixels FormattingContext::calculate_stretch_fit_inline_size(Box const& box, AvailableSize const& available_inline_size) const
 {
     // The size a box would take if its outer size filled the available space in the given axis;
     // in other words, the stretch fit into the available space, if that is definite.
 
     // Undefined if the available space is indefinite.
-    if (!available_width.is_definite())
+    if (!available_inline_size.is_definite())
         return 0;
 
     auto const& box_state = m_state.get(box);
-    return available_width.to_px_or_zero()
+    return available_inline_size.to_px_or_zero()
         - box_state.margin_left
         - box_state.margin_right
         - box_state.padding_left
@@ -3220,13 +3220,13 @@ CSSPixels FormattingContext::calculate_stretch_fit_width(Box const& box, Availab
 }
 
 // https://drafts.csswg.org/css-sizing-3/#stretch-fit-size
-CSSPixels FormattingContext::calculate_stretch_fit_height(Box const& box, AvailableSize const& available_height) const
+CSSPixels FormattingContext::calculate_stretch_fit_block_size(Box const& box, AvailableSize const& available_block_size) const
 {
     // The size a box would take if its outer size filled the available space in the given axis;
     // in other words, the stretch fit into the available space, if that is definite.
     // Undefined if the available space is indefinite.
     auto const& box_state = m_state.get(box);
-    return available_height.to_px_or_zero()
+    return available_block_size.to_px_or_zero()
         - box_state.margin_top
         - box_state.margin_bottom
         - box_state.padding_top

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1902,18 +1902,29 @@ AbsposContainingBlockInfo FormattingContext::resolve_abspos_containing_block_inf
     auto inline_containing_block = box.inline_containing_block_if_applicable();
     if (inline_containing_block && box.containing_block()) {
         auto rect = compute_inline_containing_block_rect(*inline_containing_block, *box.containing_block(), m_state);
-        if (rect.has_value())
-            return { *rect, inline_axis_mode, block_axis_mode, {}, {} };
+        if (rect.has_value()) {
+            return {
+                {
+                    { rect->x(), rect->y() },
+                    { rect->width(), rect->height() },
+                },
+                inline_axis_mode,
+                block_axis_mode,
+                {},
+                {},
+            };
+        }
     }
 
     // Normal case: padding box of the actual containing block.
     VERIFY(box.containing_block());
     auto& containing_block_state = m_state.get(*box.containing_block());
-    CSSPixelRect rect {
-        -containing_block_state.padding_left,
-        -containing_block_state.padding_top,
-        containing_block_state.content_inline_size() + containing_block_state.padding_left + containing_block_state.padding_right,
-        containing_block_state.content_block_size() + containing_block_state.padding_top + containing_block_state.padding_bottom
+    LogicalRect rect {
+        { -containing_block_state.padding_left, -containing_block_state.padding_top },
+        {
+            containing_block_state.content_inline_size() + containing_block_state.padding_left + containing_block_state.padding_right,
+            containing_block_state.content_block_size() + containing_block_state.padding_top + containing_block_state.padding_bottom,
+        },
     };
     return { rect, inline_axis_mode, block_axis_mode, {}, {} };
 }
@@ -2389,7 +2400,9 @@ StaticPositionRect FormattingContext::resolve_static_position_relative_to_contai
             offset += m_state.get(*node).content_offset();
         return offset;
     };
-    static_position_rect.rect.translate_by(offset_relative_to_merge_point(*static_position_cb) - offset_relative_to_merge_point(*actual_containing_block));
+    auto physical_offset = offset_relative_to_merge_point(*static_position_cb) - offset_relative_to_merge_point(*actual_containing_block);
+    static_position_rect.rect.offset.inline_offset += physical_offset.x();
+    static_position_rect.rect.offset.block_offset += physical_offset.y();
     return static_position_rect;
 }
 
@@ -2465,8 +2478,8 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     auto& box_state = m_state.get_mutable(box);
 
     LogicalSize const containing_block_size {
-        clamp_to_max_dimension_value(containing_block_info.rect.width()),
-        clamp_to_max_dimension_value(containing_block_info.rect.height())
+        clamp_to_max_dimension_value(containing_block_info.rect.size.inline_size),
+        clamp_to_max_dimension_value(containing_block_info.rect.size.block_size),
     };
     auto const available_space = AvailableSpace(AvailableSize::make_definite(containing_block_size.inline_size), AvailableSize::make_definite(containing_block_size.block_size));
 
@@ -2583,13 +2596,13 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     if (containing_block_info.inline_axis_mode == AbsposAxisMode::StaticPosition)
         used_offset.inline_offset = static_offset.inline_offset;
     else
-        used_offset.inline_offset = containing_block_info.rect.x() + box_state.inset_left;
+        used_offset.inline_offset = containing_block_info.rect.offset.inline_offset + box_state.inset_left;
 
     // Block axis
     if (containing_block_info.block_axis_mode == AbsposAxisMode::StaticPosition)
         used_offset.block_offset = static_offset.block_offset;
     else
-        used_offset.block_offset = containing_block_info.rect.y() + box_state.inset_top;
+        used_offset.block_offset = containing_block_info.rect.offset.block_offset + box_state.inset_top;
 
     used_offset.inline_offset += box_state.margin_box_left();
     used_offset.block_offset += box_state.margin_box_top();

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -766,7 +766,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
 CSSPixels FormattingContext::measure_automatic_content_height(Box const& box, AvailableSpace const& inner_available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
-    throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
+    throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box, this);
     measuring_context->run(LayoutInput { inner_available_space, containing_block_constraints });
     return measuring_context->automatic_content_height();
@@ -854,9 +854,9 @@ CSSPixels FormattingContext::compute_table_box_width_inside_table_wrapper(
     // The table wrapper is invisible to percentage resolution, so the table box gets the
     // wrapper's constraints unchanged. Callers measuring a table wrapper for grid alignment
     // pass the grid-area width as the wrapper's percentage basis.
-    throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
+    throwaway_state.create(box, table_wrapper_constraints.percentage_basis_inline_size, table_wrapper_constraints.percentage_basis_block_size);
     auto const& table_constraints = table_wrapper_constraints;
-    auto& table_box_state = throwaway_state.create(*table_box, table_constraints.percentage_basis_width, table_constraints.percentage_basis_height);
+    auto& table_box_state = throwaway_state.create(*table_box, table_constraints.percentage_basis_inline_size, table_constraints.percentage_basis_block_size);
     auto const& table_box_computed_values = table_box->computed_values();
     table_box_state.border_left = table_box_computed_values.border_left().width;
     table_box_state.border_right = table_box_computed_values.border_right().width;
@@ -895,7 +895,7 @@ CSSPixels FormattingContext::compute_table_box_height_inside_table_wrapper(Box c
     auto available_height = height_of_containing_block - margin_top - margin_bottom;
 
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
-    throwaway_state.create(box, table_wrapper_constraints.percentage_basis_width, table_wrapper_constraints.percentage_basis_height);
+    throwaway_state.create(box, table_wrapper_constraints.percentage_basis_inline_size, table_wrapper_constraints.percentage_basis_block_size);
 
     auto context = create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box, this);
     VERIFY(context);
@@ -932,17 +932,17 @@ ContainingBlockConstraints FormattingContext::constraints_for_child_context(
         && containing_block_used_values.width_constraint == SizeConstraint::None
         && containing_block_used_values.height_constraint == SizeConstraint::None;
 
-    auto percentage_basis_width = containing_block_used_values.has_definite_width()
+    auto percentage_basis_inline_size = containing_block_used_values.has_definite_width()
         ? Optional<CSSPixels> { containing_block_used_values.content_width() }
-        : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_width
+        : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_inline_size
                                           : Optional<CSSPixels> {};
-    auto percentage_basis_height = containing_block_used_values.has_definite_height()
+    auto percentage_basis_block_size = containing_block_used_values.has_definite_height()
         ? Optional<CSSPixels> { containing_block_used_values.content_height() }
-        : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_height
+        : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_block_size
                                           : Optional<CSSPixels> {};
 
     // https://quirks.spec.whatwg.org/#the-percentage-height-calculation-quirk
-    auto quirks_mode_percentage_basis_height = [&]() -> Optional<CSSPixels> {
+    auto quirks_mode_percentage_basis_block_size = [&]() -> Optional<CSSPixels> {
         // 1. Let element be the nearest ancestor containing block of element, if there is one.
         //    Otherwise, return the initial containing block.
         if (containing_block.is_viewport())
@@ -967,10 +967,10 @@ ContainingBlockConstraints FormattingContext::constraints_for_child_context(
         // 5. Jump to the first step.
         // NOTE: Evaluated incrementally: in-flow auto-height block containers pass the basis they
         //       inherited from their own containing block through to their children.
-        return containing_block_constraints.quirks_mode_percentage_basis_height;
+        return containing_block_constraints.quirks_mode_percentage_basis_block_size;
     }();
 
-    return { percentage_basis_width, percentage_basis_height, quirks_mode_percentage_basis_height };
+    return { percentage_basis_inline_size, percentage_basis_block_size, quirks_mode_percentage_basis_block_size };
 }
 
 LayoutInput FormattingContext::layout_input_for_child_context(
@@ -989,7 +989,7 @@ LayoutInput FormattingContext::layout_input_for_child_context(
 CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box, CSS::Size const& computed_width, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // Treat percentages of indefinite containing block widths as 0 (the initial width).
-    if (computed_width.is_percentage() && !containing_block_constraints.percentage_basis_width.has_value())
+    if (computed_width.is_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
         return 0;
 
     auto computed_height = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
@@ -2796,9 +2796,9 @@ static IntrinsicSizeCacheKey intrinsic_size_cache_key(ContainingBlockConstraints
 {
     return {
         .measured_at_width = {},
-        .percentage_basis_width = containing_block_constraints.percentage_basis_width,
-        .percentage_basis_height = containing_block_constraints.percentage_basis_height,
-        .quirks_mode_percentage_basis_height = containing_block_constraints.quirks_mode_percentage_basis_height,
+        .percentage_basis_inline_size = containing_block_constraints.percentage_basis_inline_size,
+        .percentage_basis_block_size = containing_block_constraints.percentage_basis_block_size,
+        .quirks_mode_percentage_basis_block_size = containing_block_constraints.quirks_mode_percentage_basis_block_size,
     };
 }
 
@@ -2819,7 +2819,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
                 return 0;
 
             auto zero_percentage_basis_constraints = containing_block_constraints;
-            zero_percentage_basis_constraints.percentage_basis_width = 0;
+            zero_percentage_basis_constraints.percentage_basis_inline_size = 0;
             return calculate_inner_width(box, AvailableSize::make_min_content(), min_width, zero_percentage_basis_constraints);
         }
     }
@@ -2844,7 +2844,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
 
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
-    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     box_state.width_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_width();
 
@@ -2931,11 +2931,11 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
             return {};
         case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
             auto zero_percentage_basis_constraints = containing_block_constraints;
-            zero_percentage_basis_constraints.percentage_basis_width = 0;
+            zero_percentage_basis_constraints.percentage_basis_inline_size = 0;
             return calculate_inner_width(box, max_content_available_width, size, zero_percentage_basis_constraints);
         }
         case CyclicPercentageIntrinsicContribution::NotCyclic:
-            if (size.contains_percentage() && !containing_block_constraints.percentage_basis_width.has_value())
+            if (size.contains_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
                 return {};
             return calculate_inner_width(box, max_content_available_width, size, containing_block_constraints);
         }
@@ -2945,7 +2945,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
     auto resolve_size_in_origin_axis = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
         if (!size.is_length_percentage())
             return {};
-        if (!size.contains_percentage() || containing_block_constraints.percentage_basis_height.has_value())
+        if (!size.contains_percentage() || containing_block_constraints.percentage_basis_block_size.has_value())
             return calculate_inner_height(box, intrinsic_available_space, size, containing_block_constraints);
 
         switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_width, size_property)) {
@@ -2953,7 +2953,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
             return {};
         case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
             auto zero_percentage_basis_constraints = containing_block_constraints;
-            zero_percentage_basis_constraints.percentage_basis_height = 0;
+            zero_percentage_basis_constraints.percentage_basis_block_size = 0;
             return calculate_inner_height(box, intrinsic_available_space, size, zero_percentage_basis_constraints);
         }
         case CyclicPercentageIntrinsicContribution::NotCyclic:
@@ -3019,7 +3019,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
 
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
-    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     box_state.width_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_width();
 
@@ -3063,7 +3063,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
 
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
-    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     box_state.height_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_height();
     box_state.set_content_width(width);
@@ -3100,7 +3100,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
-    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_width, containing_block_constraints.percentage_basis_height);
+    auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     box_state.height_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_height();
     box_state.set_content_width(width);
@@ -3121,7 +3121,7 @@ CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, Avail
 
     auto const& box_state = m_state.get(box);
     auto width_of_containing_block = width.contains_percentage()
-        ? containing_block_constraints.percentage_basis_width.value_or(available_width.to_px_or_zero())
+        ? containing_block_constraints.percentage_basis_inline_size.value_or(available_width.to_px_or_zero())
         : available_width.to_px_or_zero();
     if (width.is_fit_content()) {
         return calculate_fit_content_width(box, AvailableSpace { available_width, AvailableSize::make_indefinite() }, containing_block_constraints);
@@ -3180,9 +3180,9 @@ CSSPixels FormattingContext::calculate_inner_height(Box const& box, AvailableSpa
         auto shadow_root = box.dom_node() ? box.dom_node()->containing_shadow_root() : nullptr;
         bool is_in_ua_shadow_tree = shadow_root && shadow_root->is_user_agent_internal();
         if (box.document().in_quirks_mode() && !box.is_anonymous() && !is_flex_or_grid_item && !is_in_ua_shadow_tree) {
-            height_of_containing_block = containing_block_constraints.quirks_mode_percentage_basis_height.value_or(0);
-        } else if (containing_block_constraints.percentage_basis_height.has_value()) {
-            height_of_containing_block = containing_block_constraints.percentage_basis_height.value();
+            height_of_containing_block = containing_block_constraints.quirks_mode_percentage_basis_block_size.value_or(0);
+        } else if (containing_block_constraints.percentage_basis_block_size.has_value()) {
+            height_of_containing_block = containing_block_constraints.percentage_basis_block_size.value();
         }
     }
     auto& computed_values = box.computed_values();
@@ -3313,7 +3313,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
                 return true;
             }();
             if (!percentage_height_quirk_applies) {
-                if (!containing_block_constraints.percentage_basis_height.has_value())
+                if (!containing_block_constraints.percentage_basis_block_size.has_value())
                     return true;
             }
         }
@@ -3594,7 +3594,7 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
         case CyclicPercentageIntrinsicContribution::NotCyclic:
             break;
         }
-        if (!containing_block_constraints.percentage_basis_width.has_value())
+        if (!containing_block_constraints.percentage_basis_inline_size.has_value())
             return true;
     }
     if (max_width.is_fit_content() && available_width.is_intrinsic_sizing_constraint())
@@ -3618,7 +3618,7 @@ bool FormattingContext::should_treat_max_height_as_none(Box const& box, Availabl
     if (max_height.contains_percentage()) {
         if (available_height.is_min_content())
             return false;
-        if (!containing_block_constraints.percentage_basis_height.has_value())
+        if (!containing_block_constraints.percentage_basis_block_size.has_value())
             return true;
     }
     if (max_height.is_fit_content() && available_height.is_intrinsic_sizing_constraint())

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -43,7 +43,7 @@ enum class SizeDimension {
 
 // NB: Intrinsic grid sizing can transfer an aspect ratio before block-axis border metrics are copied into the layout
 //     state. Border widths are already definite at computed-value time, while padding remains resolved in the state.
-static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_width)
+static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_inline_size)
 {
     VERIFY(box.has_preferred_aspect_ratio());
 
@@ -57,20 +57,20 @@ static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::U
         auto border_box_right = computed_values.border_right().width + box_state.padding_right;
         auto border_box_top = computed_values.border_top().width + box_state.padding_top;
         auto border_box_bottom = computed_values.border_bottom().width + box_state.padding_bottom;
-        auto border_box_width = content_width + border_box_left + border_box_right;
+        auto border_box_width = content_inline_size + border_box_left + border_box_right;
         auto border_box_height = border_box_width / aspect_ratio;
         return max(border_box_height - border_box_top - border_box_bottom, 0);
     }
 
-    return content_width / aspect_ratio;
+    return content_inline_size / aspect_ratio;
 }
 
 static CSSPixels content_height_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state)
 {
-    return content_height_from_aspect_ratio(box, box_state, box_state.content_width());
+    return content_height_from_aspect_ratio(box, box_state, box_state.content_inline_size());
 }
 
-static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_height)
+static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::UsedValues const& box_state, CSSPixels content_block_size)
 {
     VERIFY(box.has_preferred_aspect_ratio());
 
@@ -84,12 +84,12 @@ static CSSPixels content_width_from_aspect_ratio(Box const& box, LayoutState::Us
         auto border_box_right = computed_values.border_right().width + box_state.padding_right;
         auto border_box_top = computed_values.border_top().width + box_state.padding_top;
         auto border_box_bottom = computed_values.border_bottom().width + box_state.padding_bottom;
-        auto border_box_height = content_height + border_box_top + border_box_bottom;
+        auto border_box_height = content_block_size + border_box_top + border_box_bottom;
         auto border_box_width = border_box_height * aspect_ratio;
         return max(border_box_width - border_box_left - border_box_right, 0);
     }
 
-    return content_height * aspect_ratio;
+    return content_block_size * aspect_ratio;
 }
 
 struct ReplacedMaxContentSizeConstraints {
@@ -263,21 +263,21 @@ void FormattingContext::dimension_list_item_marker(ListItemMarkerBox const& mark
     auto& marker_state = m_state.get_mutable(marker);
 
     if (auto const* list_style_image = marker.list_style_image()) {
-        marker_state.set_content_width(list_style_image->natural_width(marker.document()).value_or(0));
-        marker_state.set_content_height(list_style_image->natural_height(marker.document()).value_or(0));
+        marker_state.set_content_inline_size(list_style_image->natural_width(marker.document()).value_or(0));
+        marker_state.set_content_block_size(list_style_image->natural_height(marker.document()).value_or(0));
         return;
     }
 
     auto marker_size = marker.relative_size();
-    marker_state.set_content_height(marker_size);
+    marker_state.set_content_block_size(marker_size);
 
     auto const& marker_font = marker.first_available_font();
     if (auto marker_text = marker.text(); marker_text.has_value()) {
         // FIXME: Use per-code-point fonts to measure text.
         auto text_width = marker_font.width(marker_text.value());
-        marker_state.set_content_width(CSSPixels::nearest_value_for(text_width));
+        marker_state.set_content_inline_size(CSSPixels::nearest_value_for(text_width));
     } else {
-        marker_state.set_content_width(marker_size);
+        marker_state.set_content_inline_size(marker_size);
     }
 }
 
@@ -572,10 +572,10 @@ OwnPtr<FormattingContext> FormattingContext::layout_inside(Box const& child_box,
         auto const& used_values = m_state.get(child_box);
         if (layout_mode == LayoutMode::IntrinsicSizing
             && !child_box.is_inline()
-            && used_values.width_constraint == SizeConstraint::None
-            && used_values.height_constraint == SizeConstraint::None
-            && used_values.has_definite_width()
-            && used_values.has_definite_height()) {
+            && used_values.inline_size_constraint == SizeConstraint::None
+            && used_values.block_size_constraint == SizeConstraint::None
+            && used_values.has_definite_inline_size()
+            && used_values.has_definite_block_size()) {
             return nullptr;
         }
     }
@@ -743,7 +743,7 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
             if (!child_box_state)
                 return IterationDecision::Continue;
 
-            CSSPixels child_box_bottom = child_box_state->content_offset().y() + child_box_state->content_height() + child_box_state->margin_box_bottom();
+            CSSPixels child_box_bottom = child_box_state->content_offset().y() + child_box_state->content_block_size() + child_box_state->margin_box_bottom();
 
             if (!bottom.has_value() || child_box_bottom > bottom.value())
                 bottom = child_box_bottom;
@@ -792,7 +792,7 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
         return;
 
     auto& box_state = m_state.get_mutable(box);
-    if (box_state.has_definite_height())
+    if (box_state.has_definite_block_size())
         return;
 
     auto natural_content_height = measured_content_height.value_or_lazy_evaluated([&] {
@@ -813,8 +813,8 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
     if (used_height <= natural_content_height)
         return;
 
-    box_state.set_content_height(used_height);
-    box_state.set_has_definite_height(true);
+    box_state.set_content_block_size(used_height);
+    box_state.set_has_definite_block_size(true);
 }
 
 // 17.5.2 Table width algorithms: the 'table-layout' property
@@ -929,15 +929,15 @@ ContainingBlockConstraints FormattingContext::constraints_for_child_context(
         && containing_block_box->is_anonymous()
         && !containing_block_box->display().is_table_cell()
         && !containing_block_box->has_auto_content_box_size()
-        && containing_block_used_values.width_constraint == SizeConstraint::None
-        && containing_block_used_values.height_constraint == SizeConstraint::None;
+        && containing_block_used_values.inline_size_constraint == SizeConstraint::None
+        && containing_block_used_values.block_size_constraint == SizeConstraint::None;
 
-    auto percentage_basis_inline_size = containing_block_used_values.has_definite_width()
-        ? Optional<CSSPixels> { containing_block_used_values.content_width() }
+    auto percentage_basis_inline_size = containing_block_used_values.has_definite_inline_size()
+        ? Optional<CSSPixels> { containing_block_used_values.content_inline_size() }
         : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_inline_size
                                           : Optional<CSSPixels> {};
-    auto percentage_basis_block_size = containing_block_used_values.has_definite_height()
-        ? Optional<CSSPixels> { containing_block_used_values.content_height() }
+    auto percentage_basis_block_size = containing_block_used_values.has_definite_block_size()
+        ? Optional<CSSPixels> { containing_block_used_values.content_block_size() }
         : should_forward_indefinite_basis ? containing_block_constraints.percentage_basis_block_size
                                           : Optional<CSSPixels> {};
 
@@ -946,7 +946,7 @@ ContainingBlockConstraints FormattingContext::constraints_for_child_context(
         // 1. Let element be the nearest ancestor containing block of element, if there is one.
         //    Otherwise, return the initial containing block.
         if (containing_block.is_viewport())
-            return containing_block_used_values.content_height();
+            return containing_block_used_values.content_block_size();
 
         // 2. If element has a computed value of the display property that is table-cell, then return a
         //    UA-defined value.
@@ -957,12 +957,12 @@ ContainingBlockConstraints FormattingContext::constraints_for_child_context(
 
         // 3. If element has a computed value of the height property that is not auto, then return element.
         if (!containing_block.computed_values().height().is_auto())
-            return containing_block_used_values.content_height();
+            return containing_block_used_values.content_block_size();
 
         // 4. If element has a computed value of the position property that is absolute, or if element is a
         //    not a block container or a table wrapper box, then return element.
         if (containing_block.is_absolutely_positioned() || !is<BlockContainer>(containing_block) || is<TableWrapper>(containing_block))
-            return containing_block_used_values.content_height();
+            return containing_block_used_values.content_block_size();
 
         // 5. Jump to the first step.
         // NOTE: Evaluated incrementally: in-flow auto-height block containers pass the basis they
@@ -1015,8 +1015,8 @@ CSSPixels FormattingContext::tentative_width_for_replaced_element(Box const& box
     //     (used height) * (intrinsic ratio)
     if ((computed_height.is_auto() && computed_width.is_auto() && !intrinsic.has_width() && intrinsic.has_height() && box.has_preferred_aspect_ratio())
         || (computed_width.is_auto() && !computed_height.is_auto() && box.has_preferred_aspect_ratio())) {
-        auto content_height = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
-        return content_width_from_aspect_ratio(box, m_state.get(box), content_height);
+        auto content_block_size = compute_height_for_replaced_element(box, available_space, containing_block_constraints);
+        return content_width_from_aspect_ratio(box, m_state.get(box), content_block_size);
     }
 
     // If 'height' and 'width' both have computed values of 'auto' and the element has an intrinsic ratio but no intrinsic height or width,
@@ -1239,9 +1239,9 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             // NOTE: As with compute_height_for_absolutely_positioned_non_replaced_element, we actually apply these
             //       steps in the opposite order since the static position may depend on the width of the box.
 
-            auto content_width = calculate_shrink_to_fit_width();
-            width = CSS::Length::make_px(content_width);
-            m_state.get_mutable(box).set_content_width(content_width);
+            auto content_inline_size = calculate_shrink_to_fit_width();
+            width = CSS::Length::make_px(content_inline_size);
+            m_state.get_mutable(box).set_content_inline_size(content_inline_size);
 
             auto static_position = aligned_static_position(static_position_rect, box_state);
 
@@ -1356,7 +1356,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         }
     }
 
-    box_state.set_content_width(used_width.to_px_or_zero());
+    box_state.set_content_inline_size(used_width.to_px_or_zero());
     box_state.inset_left = left;
     box_state.inset_right = right;
     box_state.margin_left = margin_left.to_px_or_zero();
@@ -1444,7 +1444,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_replaced_element
     box_state.inset_right = to_px(right);
     box_state.margin_left = to_px(margin_left);
     box_state.margin_right = to_px(margin_right);
-    box_state.set_content_width(width);
+    box_state.set_content_inline_size(width);
 }
 
 // https://drafts.csswg.org/css-position-3/#abs-non-replaced-height
@@ -1560,7 +1560,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
             height = CSS::Length::make_px(maybe_height.value());
 
             auto constrained_height = apply_min_max_height_constraints(height);
-            m_state.get_mutable(box).set_content_height(constrained_height.to_px_or_zero());
+            m_state.get_mutable(box).set_content_block_size(constrained_height.to_px_or_zero());
 
             auto static_position = aligned_static_position(static_position_rect, state);
             top = CSS::Length::make_px(static_position.y());
@@ -1664,7 +1664,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // at the containing block width lets text that should wrap stay on one line, underestimating
     // the height. Feed the box's own width to the intrinsic-height calculations.
     auto available_space_for_intrinsic_height = available_space;
-    available_space_for_intrinsic_height.inline_size = AvailableSize::make_definite(state.content_width());
+    available_space_for_intrinsic_height.inline_size = AvailableSize::make_definite(state.content_inline_size());
 
     // Compute the height based on box type and CSS properties:
     // https://www.w3.org/TR/css-sizing-3/#box-sizing
@@ -1702,13 +1702,13 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     //       the final used values for vertical margin/border/padding.
 
     auto& box_state = m_state.get_mutable(box);
-    box_state.set_content_height(used_height.to_px_or_zero());
+    box_state.set_content_block_size(used_height.to_px_or_zero());
 
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
     if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
-        box_state.set_has_definite_height(true);
+        box_state.set_has_definite_block_size(true);
     box_state.inset_top = top.to_px_or_zero(height_of_containing_block);
     box_state.inset_bottom = bottom.to_px_or_zero(height_of_containing_block);
     box_state.margin_top = margin_top.to_px_or_zero(width_of_containing_block);
@@ -1914,8 +1914,8 @@ AbsposContainingBlockInfo FormattingContext::resolve_abspos_containing_block_inf
     CSSPixelRect rect {
         -containing_block_state.padding_left,
         -containing_block_state.padding_top,
-        containing_block_state.content_width() + containing_block_state.padding_left + containing_block_state.padding_right,
-        containing_block_state.content_height() + containing_block_state.padding_top + containing_block_state.padding_bottom
+        containing_block_state.content_inline_size() + containing_block_state.padding_left + containing_block_state.padding_right,
+        containing_block_state.content_block_size() + containing_block_state.padding_top + containing_block_state.padding_bottom
     };
     return { rect, horizontal_axis_mode, vertical_axis_mode, {}, {} };
 }
@@ -2502,11 +2502,11 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
         return !length_percentage.is_auto();
     };
     if (is_non_auto(computed_values.inset().left()) && is_non_auto(computed_values.inset().right())) {
-        box_state.set_has_definite_width(true);
+        box_state.set_has_definite_inline_size(true);
     }
     if (is_non_auto(computed_values.inset().top()) && is_non_auto(computed_values.inset().bottom())
         && (computed_values.height().is_auto() || computed_height_establishes_definite_containing_block_height(computed_values.height()))) {
-        box_state.set_has_definite_height(true);
+        box_state.set_has_definite_block_size(true);
     }
 
     // NOTE: BFC is special, as their abspos auto height depends on performing inside layout.
@@ -2516,10 +2516,10 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     if (!creates_block_formatting_context(box)) {
         auto height_resolved_from_aspect_ratio = computed_values.height().is_auto()
             && box.has_preferred_aspect_ratio()
-            && box_state.has_definite_width();
-        box_state.set_has_definite_width(true);
+            && box_state.has_definite_inline_size();
+        box_state.set_has_definite_inline_size(true);
         if ((!computed_values.height().is_auto() && computed_height_establishes_definite_containing_block_height(computed_values.height())) || height_resolved_from_aspect_ratio)
-            box_state.set_has_definite_height(true);
+            box_state.set_has_definite_block_size(true);
     }
 
     make_button_content_box_definite(box, available_space, absolutely_positioned_constraints);
@@ -2667,13 +2667,13 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
         bottom = CSS::Length::make_px(available - to_px(top) - to_px(margin_top) - to_px(margin_bottom));
     }
 
-    box_state.set_content_height(height);
+    box_state.set_content_block_size(height);
 
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
     if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
-        box_state.set_has_definite_height(true);
+        box_state.set_has_definite_block_size(true);
     box_state.inset_top = to_px(top);
     box_state.inset_bottom = to_px(bottom);
     box_state.margin_top = to_px(margin_top);
@@ -2737,7 +2737,7 @@ void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box
             auto containing_block = box.containing_block();
             while (containing_block && containing_block->is_anonymous() && !containing_block->display().is_table_cell())
                 containing_block = containing_block->containing_block();
-            if (containing_block && !m_state.get(*containing_block).has_definite_height())
+            if (containing_block && !m_state.get(*containing_block).has_definite_block_size())
                 return CSS::LengthPercentageOrAuto::make_auto();
         }
         return value;
@@ -2845,14 +2845,14 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box,
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
-    box_state.width_constraint = SizeConstraint::MinContent;
-    box_state.set_indefinite_content_width();
+    box_state.inline_size_constraint = SizeConstraint::MinContent;
+    box_state.set_indefinite_content_inline_size();
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
     auto available_width = AvailableSize::make_min_content();
-    auto available_height = box_state.has_definite_height()
-        ? AvailableSize::make_definite(box_state.content_height())
+    auto available_height = box_state.has_definite_block_size()
+        ? AvailableSize::make_definite(box_state.content_block_size())
         : AvailableSize::make_indefinite();
 
     auto available_space = AvailableSpace(available_width, available_height);
@@ -2915,8 +2915,8 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
 
     Optional<CSSPixels> definite_height;
     if (box.is_replaced_box() && !auto_size.has_height()) {
-        if (auto const& box_state = m_state.get(box); box_state.has_definite_height())
-            definite_height = box_state.content_height();
+        if (auto const& box_state = m_state.get(box); box_state.has_definite_block_size())
+            definite_height = box_state.content_block_size();
     }
 
     auto max_content_available_width = AvailableSize::make_max_content();
@@ -3020,14 +3020,14 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box,
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
-    box_state.width_constraint = SizeConstraint::MaxContent;
-    box_state.set_indefinite_content_width();
+    box_state.inline_size_constraint = SizeConstraint::MaxContent;
+    box_state.set_indefinite_content_inline_size();
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
     auto available_width = AvailableSize::make_max_content();
-    auto available_height = box_state.has_definite_height()
-        ? AvailableSize::make_definite(box_state.content_height())
+    auto available_height = box_state.has_definite_block_size()
+        ? AvailableSize::make_definite(box_state.content_block_size())
         : AvailableSize::make_indefinite();
 
     auto available_space = AvailableSpace(available_width, available_height);
@@ -3064,9 +3064,9 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
-    box_state.height_constraint = SizeConstraint::MinContent;
-    box_state.set_indefinite_content_height();
-    box_state.set_content_width(width);
+    box_state.block_size_constraint = SizeConstraint::MinContent;
+    box_state.set_indefinite_content_block_size();
+    box_state.set_content_inline_size(width);
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
@@ -3101,9 +3101,9 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
 
     auto& box_state = throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
-    box_state.height_constraint = SizeConstraint::MaxContent;
-    box_state.set_indefinite_content_height();
-    box_state.set_content_width(width);
+    box_state.block_size_constraint = SizeConstraint::MaxContent;
+    box_state.set_indefinite_content_block_size();
+    box_state.set_content_inline_size(width);
 
     auto context = create_independent_formatting_context(throwaway_state, LayoutMode::IntrinsicSizing, box, const_cast<FormattingContext*>(this));
 
@@ -3260,7 +3260,7 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
         if (!box.auto_content_box_size().has_height())
             return true;
         // If the box has definite height, we can resolve the width through the aspect ratio.
-        if (m_state.get(box).has_definite_height())
+        if (m_state.get(box).has_definite_block_size())
             return true;
     }
     return false;
@@ -3271,7 +3271,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
     auto computed_height = box.computed_values().height();
     if (computed_height.is_auto()) {
         auto const& box_state = m_state.get(box);
-        if (box_state.has_definite_width() && box.has_preferred_aspect_ratio())
+        if (box_state.has_definite_inline_size() && box.has_preferred_aspect_ratio())
             return false;
         return true;
     }
@@ -3325,7 +3325,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
         if (!box.auto_content_box_size().has_width())
             return true;
         // If the box has definite width, we can resolve the height through the aspect ratio.
-        if (m_state.get(box).has_definite_width())
+        if (m_state.get(box).has_definite_inline_size())
             return true;
     }
     return false;
@@ -3430,7 +3430,7 @@ CSSPixels FormattingContext::box_baseline(Box const& box, BaselineSet baseline_s
             return box_state.margin_box_height() / 2 + CSSPixels::nearest_value_for(box.containing_block()->first_available_font().pixel_metrics().x_height / 2);
         case CSS::VerticalAlign::Bottom:
             // Bottom: Align the bottom of the aligned subtree with the bottom of the line box.
-            return box_state.content_height() + box_state.margin_box_top();
+            return box_state.content_block_size() + box_state.margin_box_top();
         case CSS::VerticalAlign::TextTop:
             // TextTop: Align the top of the box with the top of the parent's content area (see 10.6.1).
             return box.computed_values().font_size();
@@ -3489,8 +3489,8 @@ CSSPixelRect FormattingContext::margin_box_rect(LayoutState::UsedValues const& u
             -max(used_values.margin_box_top(), 0),
         },
         {
-            max(used_values.margin_box_left(), 0) + used_values.content_width() + max(used_values.margin_box_right(), 0),
-            max(used_values.margin_box_top(), 0) + used_values.content_height() + max(used_values.margin_box_bottom(), 0),
+            max(used_values.margin_box_left(), 0) + used_values.content_inline_size() + max(used_values.margin_box_right(), 0),
+            max(used_values.margin_box_top(), 0) + used_values.content_block_size() + max(used_values.margin_box_bottom(), 0),
         },
     };
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -150,9 +150,9 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
             auto inline_size = constraints.minimum_inline_size.value();
             size_from_min_inline_size = is_inline_axis ? inline_size : content_block_size_from_aspect_ratio(box, box_state, inline_size);
         } else {
-            auto const& min_width = box.computed_values().min_width();
-            if (min_width.is_length_percentage() && !min_width.contains_percentage()) {
-                auto inline_size = min_width.to_px(0);
+            auto const& min_inline_size = box.computed_values().min_width();
+            if (min_inline_size.is_length_percentage() && !min_inline_size.contains_percentage()) {
+                auto inline_size = min_inline_size.to_px(0);
                 size_from_min_inline_size = is_inline_axis ? inline_size : content_block_size_from_aspect_ratio(box, box_state, inline_size);
             }
         }
@@ -162,9 +162,9 @@ static Optional<CSSPixels> max_content_size_for_replaced_element_without_natural
             auto block_size = constraints.minimum_block_size.value();
             size_from_min_block_size = is_inline_axis ? content_inline_size_from_aspect_ratio(box, box_state, block_size) : block_size;
         } else {
-            auto const& min_height = box.computed_values().min_height();
-            if (min_height.is_length_percentage() && !min_height.contains_percentage()) {
-                auto block_size = min_height.to_px(0);
+            auto const& min_block_size = box.computed_values().min_height();
+            if (min_block_size.is_length_percentage() && !min_block_size.contains_percentage()) {
+                auto block_size = min_block_size.to_px(0);
                 size_from_min_block_size = is_inline_axis ? content_inline_size_from_aspect_ratio(box, box_state, block_size) : block_size;
             }
         }
@@ -274,8 +274,8 @@ void FormattingContext::dimension_list_item_marker(ListItemMarkerBox const& mark
     auto const& marker_font = marker.first_available_font();
     if (auto marker_text = marker.text(); marker_text.has_value()) {
         // FIXME: Use per-code-point fonts to measure text.
-        auto text_width = marker_font.width(marker_text.value());
-        marker_state.set_content_inline_size(CSSPixels::nearest_value_for(text_width));
+        auto text_inline_size = marker_font.width(marker_text.value());
+        marker_state.set_content_inline_size(CSSPixels::nearest_value_for(text_inline_size));
     } else {
         marker_state.set_content_inline_size(marker_size);
     }
@@ -616,21 +616,21 @@ CSSPixels FormattingContext::line_box_physical_horizontal_extent(Box const& box,
     if (box.computed_values().writing_mode() == CSS::WritingMode::HorizontalTb)
         return line_box.inline_length();
 
-    CSSPixels leftmost_fragment_x = 0;
-    CSSPixels rightmost_fragment_x = 0;
+    CSSPixels leftmost_physical_horizontal_offset = 0;
+    CSSPixels rightmost_physical_horizontal_offset = 0;
     bool saw_fragment = false;
     for (auto const& fragment : line_box.fragments()) {
-        auto fragment_left = fragment.offset().x();
-        auto fragment_right = fragment_left + fragment.physical_horizontal_extent();
-        leftmost_fragment_x = saw_fragment ? min(leftmost_fragment_x, fragment_left) : fragment_left;
-        rightmost_fragment_x = saw_fragment ? max(rightmost_fragment_x, fragment_right) : fragment_right;
+        auto fragment_physical_left = fragment.offset().x();
+        auto fragment_physical_right = fragment_physical_left + fragment.physical_horizontal_extent();
+        leftmost_physical_horizontal_offset = saw_fragment ? min(leftmost_physical_horizontal_offset, fragment_physical_left) : fragment_physical_left;
+        rightmost_physical_horizontal_offset = saw_fragment ? max(rightmost_physical_horizontal_offset, fragment_physical_right) : fragment_physical_right;
         saw_fragment = true;
     }
 
     if (!saw_fragment)
         return 0;
 
-    return rightmost_fragment_x - leftmost_fragment_x;
+    return rightmost_physical_horizontal_offset - leftmost_physical_horizontal_offset;
 }
 
 FormattingContext::ShrinkToFitInlineSizeResult FormattingContext::calculate_shrink_to_fit_inline_sizes(Box const& box, ContainingBlockConstraints const& containing_block_constraints)
@@ -2816,13 +2816,13 @@ CSSPixels FormattingContext::calculate_min_content_inline_size(Layout::Box const
         //        such percentage against zero—transferred through the preferred aspect ratio.
         // Note: The min-content contribution is, as always, also floored by the minimum size in its own axis.
         if (box.computed_values().width().contains_percentage() || box.computed_values().max_width().contains_percentage()) {
-            auto const& min_width = box.computed_values().min_width();
-            if (!min_width.is_length_percentage())
+            auto const& min_inline_size = box.computed_values().min_width();
+            if (!min_inline_size.is_length_percentage())
                 return 0;
 
             auto zero_percentage_basis_constraints = containing_block_constraints;
             zero_percentage_basis_constraints.percentage_basis_inline_size = 0;
-            return calculate_inner_inline_size(box, AvailableSize::make_min_content(), min_width, zero_percentage_basis_constraints);
+            return calculate_inner_inline_size(box, AvailableSize::make_min_content(), min_inline_size, zero_percentage_basis_constraints);
         }
     }
     if (auto transferred_inline_size = calculate_transferred_inline_size_for_replaced_element(box, containing_block_constraints); transferred_inline_size.has_value())
@@ -2835,7 +2835,7 @@ CSSPixels FormattingContext::calculate_min_content_inline_size(Layout::Box const
             return fallback_inline_size.value();
     }
 
-    // Boxes with no children have zero intrinsic width.
+    // Boxes with no children have zero intrinsic inline size.
     if (!box.has_children())
         return 0;
 
@@ -2915,42 +2915,42 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
     if (auto_size.has_width())
         return auto_size.width.value();
 
-    Optional<CSSPixels> definite_height;
+    Optional<CSSPixels> definite_block_size;
     if (box.is_replaced_box() && !auto_size.has_height()) {
         if (auto const& box_state = m_state.get(box); box_state.has_definite_block_size())
-            definite_height = box_state.content_block_size();
+            definite_block_size = box_state.content_block_size();
     }
 
-    auto max_content_available_width = AvailableSize::make_max_content();
-    auto intrinsic_available_space = AvailableSpace(max_content_available_width, AvailableSize::make_indefinite());
+    auto max_content_available_inline_size = AvailableSize::make_max_content();
+    auto intrinsic_available_space = AvailableSpace(max_content_available_inline_size, AvailableSize::make_indefinite());
 
-    auto resolve_destination_width = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
+    auto resolve_destination_inline_size = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
         if (!size.is_length_percentage())
             return {};
 
-        switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_width, size_property)) {
+        switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_inline_size, size_property)) {
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
             return {};
         case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
             auto zero_percentage_basis_constraints = containing_block_constraints;
             zero_percentage_basis_constraints.percentage_basis_inline_size = 0;
-            return calculate_inner_inline_size(box, max_content_available_width, size, zero_percentage_basis_constraints);
+            return calculate_inner_inline_size(box, max_content_available_inline_size, size, zero_percentage_basis_constraints);
         }
         case CyclicPercentageIntrinsicContribution::NotCyclic:
             if (size.contains_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
                 return {};
-            return calculate_inner_inline_size(box, max_content_available_width, size, containing_block_constraints);
+            return calculate_inner_inline_size(box, max_content_available_inline_size, size, containing_block_constraints);
         }
         VERIFY_NOT_REACHED();
     };
 
-    auto resolve_size_in_origin_axis = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
+    auto resolve_block_size = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) -> Optional<CSSPixels> {
         if (!size.is_length_percentage())
             return {};
         if (!size.contains_percentage() || containing_block_constraints.percentage_basis_block_size.has_value())
             return calculate_inner_block_size(box, intrinsic_available_space, size, containing_block_constraints);
 
-        switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_width, size_property)) {
+        switch (cyclic_percentage_intrinsic_contribution(box, size, max_content_available_inline_size, size_property)) {
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
             return {};
         case CyclicPercentageIntrinsicContribution::ResolveAsZero: {
@@ -2964,26 +2964,26 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
         VERIFY_NOT_REACHED();
     };
 
-    auto definite_minimum_size_in_destination_axis = resolve_destination_width(box.computed_values().min_width(), CyclicPercentageSizeProperty::MinSize);
-    auto definite_minimum_size_in_origin_axis = resolve_size_in_origin_axis(box.computed_values().min_height(), CyclicPercentageSizeProperty::MinSize);
+    auto definite_minimum_inline_size = resolve_destination_inline_size(box.computed_values().min_width(), CyclicPercentageSizeProperty::MinSize);
+    auto definite_minimum_block_size = resolve_block_size(box.computed_values().min_height(), CyclicPercentageSizeProperty::MinSize);
     ReplacedMaxContentSizeConstraints constraints {
-        .definite_size_in_ratio_determining_axis = definite_height,
-        .minimum_inline_size = definite_minimum_size_in_destination_axis,
-        .minimum_block_size = definite_minimum_size_in_origin_axis,
+        .definite_size_in_ratio_determining_axis = definite_block_size,
+        .minimum_inline_size = definite_minimum_inline_size,
+        .minimum_block_size = definite_minimum_block_size,
     };
 
     if (auto max_content_inline_size = max_content_size_for_replaced_element_without_natural_size(box, auto_size, m_state.get(box), SizeDimension::Inline, constraints); max_content_inline_size.has_value()) {
-        if (!definite_height.has_value() && box.has_preferred_aspect_ratio()) {
-            if (auto definite_maximum_size_in_origin_axis = resolve_size_in_origin_axis(box.computed_values().max_height(), CyclicPercentageSizeProperty::PreferredOrMaxSize); definite_maximum_size_in_origin_axis.has_value()) {
+        if (!definite_block_size.has_value() && box.has_preferred_aspect_ratio()) {
+            if (auto definite_maximum_block_size = resolve_block_size(box.computed_values().max_height(), CyclicPercentageSizeProperty::PreferredOrMaxSize); definite_maximum_block_size.has_value()) {
                 // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-size-transfers
                 // First, any definite minimum size is converted and transferred from the origin to destination axis.
                 // This transferred minimum is capped by any definite preferred or maximum size in the destination axis.
                 Optional<CSSPixels> transferred_minimum;
-                if (definite_minimum_size_in_origin_axis.has_value()) {
-                    transferred_minimum = content_inline_size_from_aspect_ratio(box, m_state.get(box), definite_minimum_size_in_origin_axis.value());
+                if (definite_minimum_block_size.has_value()) {
+                    transferred_minimum = content_inline_size_from_aspect_ratio(box, m_state.get(box), definite_minimum_block_size.value());
 
                     auto cap_transferred_minimum = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) {
-                        if (auto resolved_size = resolve_destination_width(size, size_property); resolved_size.has_value())
+                        if (auto resolved_size = resolve_destination_inline_size(size, size_property); resolved_size.has_value())
                             transferred_minimum = min(transferred_minimum.value(), resolved_size.value());
                     };
                     cap_transferred_minimum(box.computed_values().width(), CyclicPercentageSizeProperty::PreferredOrMaxSize);
@@ -2993,10 +2993,10 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
                 // Then, any definite maximum size is converted and transferred from the origin to destination.
                 // This transferred maximum is floored by any definite preferred or minimum size in the destination axis
                 // as well as by the transferred minimum, if any.
-                auto transferred_maximum = content_inline_size_from_aspect_ratio(box, m_state.get(box), definite_maximum_size_in_origin_axis.value());
+                auto transferred_maximum = content_inline_size_from_aspect_ratio(box, m_state.get(box), definite_maximum_block_size.value());
 
                 auto floor_transferred_maximum = [&](CSS::Size const& size, CyclicPercentageSizeProperty size_property) {
-                    if (auto resolved_size = resolve_destination_width(size, size_property); resolved_size.has_value())
+                    if (auto resolved_size = resolve_destination_inline_size(size, size_property); resolved_size.has_value())
                         transferred_maximum = max(transferred_maximum, resolved_size.value());
                 };
                 floor_transferred_maximum(box.computed_values().width(), CyclicPercentageSizeProperty::PreferredOrMaxSize);
@@ -3010,7 +3010,7 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
         return max_content_inline_size.value();
     }
 
-    // Boxes with no children have zero intrinsic width.
+    // Boxes with no children have zero intrinsic inline size.
     if (!box.has_children())
         return 0;
 

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -494,8 +494,8 @@ struct ReplacedFormattingContext : public FormattingContext {
         : FormattingContext(Type::InternalReplaced, layout_mode, state, box)
     {
     }
-    virtual CSSPixels automatic_content_width() const override { return 0; }
-    virtual CSSPixels automatic_content_height() const override { return 0; }
+    virtual CSSPixels automatic_content_inline_size() const override { return 0; }
+    virtual CSSPixels automatic_content_block_size() const override { return 0; }
     virtual void run(LayoutInput const&) override { }
 };
 
@@ -505,8 +505,8 @@ struct DummyFormattingContext : public FormattingContext {
         : FormattingContext(Type::InternalDummy, layout_mode, state, box)
     {
     }
-    virtual CSSPixels automatic_content_width() const override { return 0; }
-    virtual CSSPixels automatic_content_height() const override { return 0; }
+    virtual CSSPixels automatic_content_inline_size() const override { return 0; }
+    virtual CSSPixels automatic_content_block_size() const override { return 0; }
     virtual void run(LayoutInput const&) override { }
 };
 
@@ -763,13 +763,13 @@ CSSPixels FormattingContext::compute_auto_height_for_block_formatting_context_ro
     return max(CSSPixels(0.0f), bottom.value_or(0) - top.value_or(0));
 }
 
-CSSPixels FormattingContext::measure_automatic_content_height(Box const& box, AvailableSpace const& inner_available_space, ContainingBlockConstraints const& containing_block_constraints)
+CSSPixels FormattingContext::measure_automatic_content_block_size(Box const& box, AvailableSpace const& inner_available_space, ContainingBlockConstraints const& containing_block_constraints)
 {
     LayoutState throwaway_state(box, LayoutState::Purpose::Measurement);
     throwaway_state.create(box, containing_block_constraints.percentage_basis_inline_size, containing_block_constraints.percentage_basis_block_size);
     auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, box, this);
     measuring_context->run(LayoutInput { inner_available_space, containing_block_constraints });
-    return measuring_context->automatic_content_height();
+    return measuring_context->automatic_content_block_size();
 }
 
 void FormattingContext::make_button_content_box_definite(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, Optional<CSSPixels> measured_content_height)
@@ -796,7 +796,7 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
         return;
 
     auto natural_content_height = measured_content_height.value_or_lazy_evaluated([&] {
-        return measure_automatic_content_height(box, box_state.available_inner_space_or_constraints_from(available_space), containing_block_constraints);
+        return measure_automatic_content_block_size(box, box_state.available_inner_space_or_constraints_from(available_space), containing_block_constraints);
     });
 
     auto used_height = should_treat_height_as_auto(box, available_space, containing_block_constraints)
@@ -2405,8 +2405,8 @@ public:
     {
     }
 
-    virtual CSSPixels automatic_content_width() const override { VERIFY_NOT_REACHED(); }
-    virtual CSSPixels automatic_content_height() const override { VERIFY_NOT_REACHED(); }
+    virtual CSSPixels automatic_content_inline_size() const override { VERIFY_NOT_REACHED(); }
+    virtual CSSPixels automatic_content_block_size() const override { VERIFY_NOT_REACHED(); }
     virtual void run(LayoutInput const&) override { VERIFY_NOT_REACHED(); }
 };
 
@@ -2858,7 +2858,7 @@ CSSPixels FormattingContext::calculate_min_content_inline_size(Layout::Box const
     auto available_space = AvailableSpace(available_inline_size, available_block_size);
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto min_content_inline_size = clamp_to_max_dimension_value(context->automatic_content_width());
+    auto min_content_inline_size = clamp_to_max_dimension_value(context->automatic_content_inline_size());
     cache.set(cache_key, min_content_inline_size);
     return min_content_inline_size;
 }
@@ -3033,7 +3033,7 @@ CSSPixels FormattingContext::calculate_max_content_inline_size(Layout::Box const
     auto available_space = AvailableSpace(available_inline_size, available_block_size);
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto max_content_inline_size = clamp_to_max_dimension_value(context->automatic_content_width());
+    auto max_content_inline_size = clamp_to_max_dimension_value(context->automatic_content_inline_size());
     cache.set(cache_key, max_content_inline_size);
     return max_content_inline_size;
 }
@@ -3073,7 +3073,7 @@ CSSPixels FormattingContext::calculate_min_content_block_size(Layout::Box const&
     auto available_space = AvailableSpace(AvailableSize::make_definite(inline_size), AvailableSize::make_min_content());
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto min_content_block_size = clamp_to_max_dimension_value(context->automatic_content_height());
+    auto min_content_block_size = clamp_to_max_dimension_value(context->automatic_content_block_size());
     cache.set(cache_key, min_content_block_size);
     return min_content_block_size;
 }
@@ -3110,7 +3110,7 @@ CSSPixels FormattingContext::calculate_max_content_block_size(Layout::Box const&
     auto available_space = AvailableSpace(AvailableSize::make_definite(inline_size), AvailableSize::make_max_content());
     context->run(LayoutInput { available_space, containing_block_constraints });
 
-    auto max_content_block_size = clamp_to_max_dimension_value(context->automatic_content_height());
+    auto max_content_block_size = clamp_to_max_dimension_value(context->automatic_content_block_size());
     cache.set(cache_key, max_content_block_size);
     return max_content_block_size;
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1049,12 +1049,12 @@ CSSPixels FormattingContext::tentative_inline_size_for_replaced_element(Box cons
     return used_inline_size;
 }
 
-void FormattingContext::compute_width_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
+void FormattingContext::compute_inline_size_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
     if (box_is_sized_as_replaced_element(box, available_space, containing_block_constraints))
-        compute_width_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
+        compute_inline_size_for_absolutely_positioned_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
     else
-        compute_width_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
+        compute_inline_size_for_absolutely_positioned_non_replaced_element(box, available_space, containing_block_constraints, static_position_rect);
 }
 
 void FormattingContext::compute_height_for_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect, BeforeOrAfterInsideLayout before_or_after_inside_layout)
@@ -1180,9 +1180,9 @@ CSSPixels FormattingContext::compute_block_size_for_replaced_element(Box const& 
     return used_block_size;
 }
 
-void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
+void FormattingContext::compute_inline_size_for_absolutely_positioned_non_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
-    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
     auto const& computed_values = box.computed_values();
     auto& box_state = m_state.get_mutable(box);
 
@@ -1195,38 +1195,38 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
     auto computed_left = computed_values.inset().left();
     auto computed_right = computed_values.inset().right();
-    auto left = computed_values.inset().left().to_px_or_zero(width_of_containing_block);
-    auto right = computed_values.inset().right().to_px_or_zero(width_of_containing_block);
+    auto left = computed_values.inset().left().to_px_or_zero(containing_block_inline_size);
+    auto right = computed_values.inset().right().to_px_or_zero(containing_block_inline_size);
 
-    auto try_compute_width = [&](CSS::LengthOrAuto const& a_width) {
-        margin_left = computed_values.margin().left().resolved_or_auto(width_of_containing_block);
-        margin_right = computed_values.margin().right().resolved_or_auto(width_of_containing_block);
+    auto try_compute_inline_size = [&](CSS::LengthOrAuto const& input_inline_size) {
+        margin_left = computed_values.margin().left().resolved_or_auto(containing_block_inline_size);
+        margin_right = computed_values.margin().right().resolved_or_auto(containing_block_inline_size);
 
-        auto width = a_width;
+        auto inline_size = input_inline_size;
 
         auto solve_for_left = [&] {
-            return width_of_containing_block - margin_left.to_px_or_zero() - border_left - padding_left - width.to_px_or_zero() - padding_right - border_right - margin_right.to_px_or_zero() - right;
+            return containing_block_inline_size - margin_left.to_px_or_zero() - border_left - padding_left - inline_size.to_px_or_zero() - padding_right - border_right - margin_right.to_px_or_zero() - right;
         };
 
-        auto solve_for_width = [&] {
-            return CSS::Length::make_px(max(CSSPixels(0), width_of_containing_block - left - margin_left.to_px_or_zero() - border_left - padding_left - padding_right - border_right - margin_right.to_px_or_zero() - right));
+        auto solve_for_inline_size = [&] {
+            return CSS::Length::make_px(max(CSSPixels(0), containing_block_inline_size - left - margin_left.to_px_or_zero() - border_left - padding_left - padding_right - border_right - margin_right.to_px_or_zero() - right));
         };
 
         auto solve_for_right = [&] {
-            return width_of_containing_block - left - margin_left.to_px_or_zero() - border_left - padding_left - width.to_px_or_zero() - padding_right - border_right - margin_right.to_px_or_zero();
+            return containing_block_inline_size - left - margin_left.to_px_or_zero() - border_left - padding_left - inline_size.to_px_or_zero() - padding_right - border_right - margin_right.to_px_or_zero();
         };
 
-        auto calculate_shrink_to_fit_width = [&] {
-            auto available_width = solve_for_width().to_px(box);
-            auto preferred_width = calculate_max_content_inline_size(box, containing_block_constraints);
-            if (preferred_width <= available_width)
-                return preferred_width;
-            auto preferred_minimum_width = calculate_min_content_inline_size(box, containing_block_constraints);
-            return min(max(preferred_minimum_width, available_width), preferred_width);
+        auto calculate_shrink_to_fit_inline_size = [&] {
+            auto available_inline_size = solve_for_inline_size().to_px(box);
+            auto preferred_inline_size = calculate_max_content_inline_size(box, containing_block_constraints);
+            if (preferred_inline_size <= available_inline_size)
+                return preferred_inline_size;
+            auto preferred_minimum_inline_size = calculate_min_content_inline_size(box, containing_block_constraints);
+            return min(max(preferred_minimum_inline_size, available_inline_size), preferred_inline_size);
         };
 
         // If all three of 'left', 'width', and 'right' are 'auto':
-        if (computed_left.is_auto() && width.is_auto() && computed_right.is_auto()) {
+        if (computed_left.is_auto() && inline_size.is_auto() && computed_right.is_auto()) {
             // First set any 'auto' values for 'margin-left' and 'margin-right' to 0.
             if (margin_left.is_auto())
                 margin_left = CSS::Length::make_px(0);
@@ -1239,8 +1239,8 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             // NOTE: As with compute_height_for_absolutely_positioned_non_replaced_element, we actually apply these
             //       steps in the opposite order since the static position may depend on the width of the box.
 
-            auto content_inline_size = calculate_shrink_to_fit_width();
-            width = CSS::Length::make_px(content_inline_size);
+            auto content_inline_size = calculate_shrink_to_fit_inline_size();
+            inline_size = CSS::Length::make_px(content_inline_size);
             m_state.get_mutable(box).set_content_inline_size(content_inline_size);
 
             auto static_position = aligned_static_position(static_position_rect, box_state);
@@ -1250,25 +1250,25 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         }
 
         // If none of the three is auto:
-        if (!computed_left.is_auto() && !width.is_auto() && !computed_right.is_auto()) {
+        if (!computed_left.is_auto() && !inline_size.is_auto() && !computed_right.is_auto()) {
             // If both margin-left and margin-right are auto,
             // solve the equation under the extra constraint that the two margins get equal values
             // FIXME: unless this would make them negative, in which case when direction of the containing block is ltr (rtl), set margin-left (margin-right) to 0 and solve for margin-right (margin-left).
-            auto size_available_for_margins = width_of_containing_block - border_left - padding_left - width.to_px_or_zero() - padding_right - border_right - left - right;
+            auto inline_size_available_for_margins = containing_block_inline_size - border_left - padding_left - inline_size.to_px_or_zero() - padding_right - border_right - left - right;
             if (margin_left.is_auto() && margin_right.is_auto()) {
-                margin_left = CSS::Length::make_px(size_available_for_margins / 2);
-                margin_right = CSS::Length::make_px(size_available_for_margins / 2);
-                return width;
+                margin_left = CSS::Length::make_px(inline_size_available_for_margins / 2);
+                margin_right = CSS::Length::make_px(inline_size_available_for_margins / 2);
+                return inline_size;
             }
 
             // If one of margin-left or margin-right is auto, solve the equation for that value.
             if (margin_left.is_auto()) {
-                margin_left = CSS::Length::make_px(size_available_for_margins);
-                return width;
+                margin_left = CSS::Length::make_px(inline_size_available_for_margins);
+                return inline_size;
             }
             if (margin_right.is_auto()) {
-                margin_right = CSS::Length::make_px(size_available_for_margins);
-                return width;
+                margin_right = CSS::Length::make_px(inline_size_available_for_margins);
+                return inline_size;
             }
             // If the values are over-constrained, ignore the value for left
             // (in case the direction property of the containing block is rtl)
@@ -1277,7 +1277,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
             // NOTE: At this point we *are* over-constrained since none of margin-left, left, width, right, or margin-right are auto.
             // FIXME: Check direction.
             right = solve_for_right();
-            return width;
+            return inline_size;
         }
 
         if (margin_left.is_auto())
@@ -1287,8 +1287,8 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
         // 1. 'left' and 'width' are 'auto' and 'right' is not 'auto',
         //    then the width is shrink-to-fit. Then solve for 'left'
-        if (computed_left.is_auto() && width.is_auto() && !computed_right.is_auto()) {
-            width = CSS::Length::make_px(calculate_shrink_to_fit_width());
+        if (computed_left.is_auto() && inline_size.is_auto() && !computed_right.is_auto()) {
+            inline_size = CSS::Length::make_px(calculate_shrink_to_fit_inline_size());
             left = solve_for_left();
         }
 
@@ -1297,7 +1297,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         //    the static-position containing block is 'ltr' set 'left'
         //    to the static position, otherwise set 'right' to the static position.
         //    Then solve for 'left' (if 'direction is 'rtl') or 'right' (if 'direction' is 'ltr').
-        else if (computed_left.is_auto() && computed_right.is_auto() && !width.is_auto()) {
+        else if (computed_left.is_auto() && computed_right.is_auto() && !inline_size.is_auto()) {
             // FIXME: Check direction
             auto static_position = aligned_static_position(static_position_rect, box_state);
             left = static_position.x();
@@ -1306,31 +1306,31 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
         // 3. 'width' and 'right' are 'auto' and 'left' is not 'auto',
         //    then the width is shrink-to-fit. Then solve for 'right'
-        else if (width.is_auto() && computed_right.is_auto() && !computed_left.is_auto()) {
-            width = CSS::Length::make_px(calculate_shrink_to_fit_width());
+        else if (inline_size.is_auto() && computed_right.is_auto() && !computed_left.is_auto()) {
+            inline_size = CSS::Length::make_px(calculate_shrink_to_fit_inline_size());
             right = solve_for_right();
         }
 
         // 4. 'left' is 'auto', 'width' and 'right' are not 'auto', then solve for 'left'
-        else if (computed_left.is_auto() && !width.is_auto() && !computed_right.is_auto()) {
+        else if (computed_left.is_auto() && !inline_size.is_auto() && !computed_right.is_auto()) {
             left = solve_for_left();
         }
 
         // 5. 'width' is 'auto', 'left' and 'right' are not 'auto', then solve for 'width'
-        else if (width.is_auto() && !computed_left.is_auto() && !computed_right.is_auto()) {
-            width = solve_for_width();
+        else if (inline_size.is_auto() && !computed_left.is_auto() && !computed_right.is_auto()) {
+            inline_size = solve_for_inline_size();
         }
 
         // 6. 'right' is 'auto', 'left' and 'width' are not 'auto', then solve for 'right'
-        else if (computed_right.is_auto() && !computed_left.is_auto() && !width.is_auto()) {
+        else if (computed_right.is_auto() && !computed_left.is_auto() && !inline_size.is_auto()) {
             right = solve_for_right();
         }
 
-        return width;
+        return inline_size;
     };
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
-    auto used_width = try_compute_width([&] -> CSS::LengthOrAuto {
+    auto used_inline_size = try_compute_inline_size([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
             return CSS::Length::make_px(compute_table_box_inline_size_inside_table_wrapper(box, available_space, containing_block_constraints));
         if (computed_values.width().is_auto())
@@ -1341,22 +1341,22 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
     if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
-        auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
-        if (used_width.to_px_or_zero() > max_width) {
-            used_width = try_compute_width(CSS::Length::make_px(max_width));
+        auto max_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
+        if (used_inline_size.to_px_or_zero() > max_inline_size) {
+            used_inline_size = try_compute_inline_size(CSS::Length::make_px(max_inline_size));
         }
     }
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
     if (!computed_values.min_width().is_auto()) {
-        auto min_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
-        if (used_width.to_px_or_zero() < min_width) {
-            used_width = try_compute_width(CSS::Length::make_px(min_width));
+        auto min_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_values.min_width(), containing_block_constraints);
+        if (used_inline_size.to_px_or_zero() < min_inline_size) {
+            used_inline_size = try_compute_inline_size(CSS::Length::make_px(min_inline_size));
         }
     }
 
-    box_state.set_content_inline_size(used_width.to_px_or_zero());
+    box_state.set_content_inline_size(used_inline_size.to_px_or_zero());
     box_state.inset_left = left;
     box_state.inset_right = right;
     box_state.margin_left = margin_left.to_px_or_zero();
@@ -1364,7 +1364,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 }
 
 // https://drafts.csswg.org/css2/#abs-replaced-width
-void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
+void FormattingContext::compute_inline_size_for_absolutely_positioned_replaced_element(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints, StaticPositionRect const& static_position_rect)
 {
     // 10.3.8 Absolutely positioned, replaced elements
     // In this case, section 10.3.7 applies up through and including the constraint equation,
@@ -1481,7 +1481,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto top = box.computed_values().inset().top();
     auto bottom = box.computed_values().inset().bottom();
 
-    auto width_of_containing_block = available_space.inline_size.to_px_or_zero();
+    auto containing_block_inline_size = available_space.inline_size.to_px_or_zero();
     auto height_of_containing_block = available_space.block_size.to_px_or_zero();
 
     enum class ClampToZero {
@@ -1500,13 +1500,13 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         auto solve_for = [&](CSS::LengthOrAuto const& length_or_auto, ClampToZero clamp_to_zero = ClampToZero::No) {
             auto unclamped_value = height_of_containing_block
                 - top.to_px_or_zero(height_of_containing_block)
-                - margin_top.to_px_or_zero(width_of_containing_block)
+                - margin_top.to_px_or_zero(containing_block_inline_size)
                 - box.computed_values().border_top().width
                 - state.padding_top
                 - height.to_px_or_zero()
                 - state.padding_bottom
                 - box.computed_values().border_bottom().width
-                - margin_bottom.to_px_or_zero(width_of_containing_block)
+                - margin_bottom.to_px_or_zero(containing_block_inline_size)
                 - bottom.to_px_or_zero(height_of_containing_block)
                 + length_or_auto.to_px_or_zero();
             if (clamp_to_zero == ClampToZero::Yes)
@@ -1527,15 +1527,15 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         };
 
         auto solve_for_margin_top = [&] {
-            margin_top = solve_for(margin_top.resolved_or_auto(width_of_containing_block));
+            margin_top = solve_for(margin_top.resolved_or_auto(containing_block_inline_size));
         };
 
         auto solve_for_margin_bottom = [&] {
-            margin_bottom = solve_for(margin_bottom.resolved_or_auto(width_of_containing_block));
+            margin_bottom = solve_for(margin_bottom.resolved_or_auto(containing_block_inline_size));
         };
 
         auto solve_for_margin_top_and_margin_bottom = [&] {
-            auto remainder = solve_for(CSS::Length::make_px(margin_top.to_px_or_zero(width_of_containing_block) + margin_bottom.to_px_or_zero(width_of_containing_block))).to_px(box);
+            auto remainder = solve_for(CSS::Length::make_px(margin_top.to_px_or_zero(containing_block_inline_size) + margin_bottom.to_px_or_zero(containing_block_inline_size))).to_px(box);
             margin_top = CSS::Length::make_px(remainder / 2);
             margin_bottom = CSS::Length::make_px(remainder / 2);
         };
@@ -1711,8 +1711,8 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
         box_state.set_has_definite_block_size(true);
     box_state.inset_top = top.to_px_or_zero(height_of_containing_block);
     box_state.inset_bottom = bottom.to_px_or_zero(height_of_containing_block);
-    box_state.margin_top = margin_top.to_px_or_zero(width_of_containing_block);
-    box_state.margin_bottom = margin_bottom.to_px_or_zero(width_of_containing_block);
+    box_state.margin_top = margin_top.to_px_or_zero(containing_block_inline_size);
+    box_state.margin_bottom = margin_bottom.to_px_or_zero(containing_block_inline_size);
 }
 
 // FIXME: Containing block handling for absolutely positioned elements needs architectural improvements.
@@ -2489,7 +2489,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
     box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
     box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
 
-    compute_width_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect);
+    compute_inline_size_for_absolutely_positioned_element(box, available_space, absolutely_positioned_constraints, static_position_rect);
 
     // NOTE: We compute height before *and* after doing inside layout.
     //       This is done so that inside layout can resolve percentage heights.

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -597,7 +597,7 @@ CSSPixels FormattingContext::greatest_child_inline_size(Box const& box) const
     CSSPixels max_inline_size = 0;
     if (box.children_are_inline()) {
         for (auto& line_box : m_state.get(box).line_boxes)
-            max_inline_size = max(max_inline_size, line_box_physical_width(box, line_box));
+            max_inline_size = max(max_inline_size, line_box_physical_horizontal_extent(box, line_box));
     } else {
         box.for_each_child_of_type<Box>([&](Box const& child) {
             if (!child.is_absolutely_positioned())
@@ -608,20 +608,20 @@ CSSPixels FormattingContext::greatest_child_inline_size(Box const& box) const
     return max_inline_size;
 }
 
-CSSPixels FormattingContext::line_box_physical_width(Box const& box, LineBox const& line_box)
+CSSPixels FormattingContext::line_box_physical_horizontal_extent(Box const& box, LineBox const& line_box)
 {
     if (line_box.has_block_level_box())
         return line_box.inline_length();
 
     if (box.computed_values().writing_mode() == CSS::WritingMode::HorizontalTb)
-        return line_box.width();
+        return line_box.inline_length();
 
     CSSPixels leftmost_fragment_x = 0;
     CSSPixels rightmost_fragment_x = 0;
     bool saw_fragment = false;
     for (auto const& fragment : line_box.fragments()) {
         auto fragment_left = fragment.offset().x();
-        auto fragment_right = fragment_left + fragment.width();
+        auto fragment_right = fragment_left + fragment.physical_horizontal_extent();
         leftmost_fragment_x = saw_fragment ? min(leftmost_fragment_x, fragment_left) : fragment_left;
         rightmost_fragment_x = saw_fragment ? max(rightmost_fragment_x, fragment_right) : fragment_right;
         saw_fragment = true;
@@ -714,11 +714,11 @@ CSSPixels FormattingContext::compute_automatic_block_size_for_block_formatting_c
         auto const& line_boxes = m_state.get(root).line_boxes;
         top = 0;
         if (!line_boxes.is_empty()) {
-            bottom = line_boxes.last().bottom();
+            bottom = line_boxes.last().physical_vertical_end();
             // A trailing interrupting block's bottom margin cannot collapse out of a BFC root,
             // so it contributes to the root's automatic block size. The line box bottom excludes it.
             if (line_boxes.last().has_block_level_box())
-                bottom = max(CSSPixels(0), bottom.value() + line_boxes.last().block_level_box_bottom_margin());
+                bottom = max(CSSPixels(0), bottom.value() + line_boxes.last().block_level_box_block_end_margin());
         }
     } else {
         // If it has block-level children, the block size is the distance between
@@ -3362,8 +3362,8 @@ void FormattingContext::compute_and_store_baselines(LayoutState::UsedValues& use
     if (!used_values.line_boxes.is_empty()) {
         auto baseline_for_line_box = [&](LineBox const& line_box, BaselineSet baseline_set) -> CSSPixels {
             if (!line_box.has_block_level_box()) {
-                auto line_box_top = line_box.bottom() - line_box.block_length();
-                return line_box_top + line_box.baseline();
+                auto line_box_block_start = line_box.physical_vertical_end() - line_box.block_length();
+                return line_box_block_start + line_box.baseline();
             }
 
             VERIFY(line_box.fragments().size() == 1);

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -288,12 +288,12 @@ CSSPixels FormattingContext::distance_between_marker_and_list_item(ListItemMarke
     return CSSPixels::nearest_value_for(.5f * marker.first_available_font().pixel_size());
 }
 
-bool FormattingContext::computed_height_establishes_definite_containing_block_height(CSS::Size const& computed_height)
+bool FormattingContext::computed_block_size_establishes_definite_containing_block_size(CSS::Size const& computed_block_size)
 {
-    // A resolved used height is not always a definite containing block height.
+    // A resolved used block size is not always a definite containing block size.
     // Intrinsic sizing keywords like fit-content still depend on child layout,
-    // so percentage-height descendants must continue to treat them as indefinite.
-    return !computed_height.is_intrinsic_sizing_constraint();
+    // so percentage-sized descendants must continue to treat it as indefinite.
+    return !computed_block_size.is_intrinsic_sizing_constraint();
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
@@ -647,11 +647,11 @@ LogicalSize FormattingContext::solve_replaced_size_constraint(CSSPixels input_in
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-widths
 
     auto min_inline_size = box.computed_values().min_width().is_auto() ? 0 : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().min_width(), containing_block_constraints);
-    auto specified_max_inline_size = should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints) ? input_inline_size : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
+    auto specified_max_inline_size = should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints) ? input_inline_size : calculate_inner_inline_size(box, available_space.inline_size, box.computed_values().max_width(), containing_block_constraints);
     auto max_inline_size = max(min_inline_size, specified_max_inline_size);
 
     auto min_block_size = box.computed_values().min_height().is_auto() ? 0 : calculate_inner_block_size(box, available_space, box.computed_values().min_height(), containing_block_constraints);
-    auto specified_max_block_size = should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) ? input_block_size : calculate_inner_block_size(box, available_space, box.computed_values().max_height(), containing_block_constraints);
+    auto specified_max_block_size = should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints) ? input_block_size : calculate_inner_block_size(box, available_space, box.computed_values().max_height(), containing_block_constraints);
     auto max_block_size = max(min_block_size, specified_max_block_size);
 
     auto const& box_state = m_state.get(box);
@@ -799,10 +799,10 @@ void FormattingContext::make_button_content_box_definite(Box const& box, Availab
         return measure_automatic_content_block_size(box, box_state.available_inner_space_or_constraints_from(available_space), containing_block_constraints);
     });
 
-    auto used_height = should_treat_height_as_auto(box, available_space, containing_block_constraints)
+    auto used_height = should_treat_block_size_as_auto(box, available_space, containing_block_constraints)
         ? natural_content_height
         : calculate_inner_block_size(box, available_space, computed_values.height(), containing_block_constraints);
-    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints) && !computed_values.max_height().is_auto())
+    if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints) && !computed_values.max_height().is_auto())
         used_height = min(used_height, calculate_inner_block_size(box, available_space, computed_values.max_height(), containing_block_constraints));
     if (!computed_values.min_height().is_auto())
         used_height = max(used_height, calculate_inner_block_size(box, available_space, computed_values.min_height(), containing_block_constraints));
@@ -992,7 +992,7 @@ CSSPixels FormattingContext::tentative_inline_size_for_replaced_element(Box cons
     if (computed_inline_size.is_percentage() && !containing_block_constraints.percentage_basis_inline_size.has_value())
         return 0;
 
-    auto computed_block_size = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_block_size = should_treat_block_size_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     CSSPixels used_inline_size = 0;
     if (computed_inline_size.is_auto()) {
@@ -1070,8 +1070,8 @@ CSSPixels FormattingContext::compute_inline_size_for_replaced_element(Box const&
     // 10.3.4 Block-level, replaced elements in normal flow...
     // 10.3.2 Inline, replaced elements
 
-    auto computed_inline_size = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_block_size = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_inline_size = should_treat_inline_size_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
+    auto computed_block_size = should_treat_block_size_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_inline_size = tentative_inline_size_for_replaced_element(box, computed_inline_size, available_space, containing_block_constraints);
@@ -1084,7 +1084,7 @@ CSSPixels FormattingContext::compute_inline_size_for_replaced_element(Box const&
 
     // 2. If the tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+    if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
         auto const& computed_max_inline_size = box.computed_values().max_width();
         auto max_inline_size = calculate_inner_inline_size(box, available_space.inline_size, computed_max_inline_size, containing_block_constraints);
         if (used_inline_size > max_inline_size)
@@ -1110,7 +1110,7 @@ CSSPixels FormattingContext::tentative_block_size_for_replaced_element(Box const
     auto intrinsic = intrinsic_size_for_replaced_sizing(box);
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
-    if (should_treat_width_as_auto(box, available_space) && should_treat_height_as_auto(box, available_space, containing_block_constraints) && intrinsic.has_height())
+    if (should_treat_inline_size_as_auto(box, available_space) && should_treat_block_size_as_auto(box, available_space, containing_block_constraints) && intrinsic.has_height())
         return intrinsic.height.value();
 
     // Otherwise, if 'height' has a computed value of 'auto', and the element has an intrinsic ratio then the used value of 'height' is:
@@ -1140,8 +1140,8 @@ CSSPixels FormattingContext::compute_block_size_for_replaced_element(Box const& 
     // 10.6.6 Floating replaced elements
     // 10.6.10 'inline-block' replaced elements in normal flow
 
-    auto computed_inline_size = should_treat_width_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
-    auto computed_block_size = should_treat_height_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
+    auto computed_inline_size = should_treat_inline_size_as_auto(box, available_space) ? CSS::Size::make_auto() : box.computed_values().width();
+    auto computed_block_size = should_treat_block_size_as_auto(box, available_space, containing_block_constraints) ? CSS::Size::make_auto() : box.computed_values().height();
 
     // 1. The tentative used height is calculated (without 'min-height' and 'max-height')
     CSSPixels used_block_size = tentative_block_size_for_replaced_element(box, computed_block_size, available_space, containing_block_constraints);
@@ -1161,7 +1161,7 @@ CSSPixels FormattingContext::compute_block_size_for_replaced_element(Box const& 
     }
     // 2. If this tentative height is greater than 'max-height', the rules above are applied again,
     //    but this time using the value of 'max-height' as the computed value for 'height'.
-    if (!should_treat_max_height_as_none(box, available_space.block_size, containing_block_constraints)) {
+    if (!should_treat_max_block_size_as_none(box, available_space.block_size, containing_block_constraints)) {
         auto const& computed_max_block_size = box.computed_values().max_height();
         auto max_block_size = calculate_inner_block_size(box, available_space, computed_max_block_size, containing_block_constraints);
         if (used_block_size > max_block_size)
@@ -1340,7 +1340,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    if (!should_treat_max_width_as_none(box, available_space.inline_size, containing_block_constraints)) {
+    if (!should_treat_max_inline_size_as_none(box, available_space.inline_size, containing_block_constraints)) {
         auto max_width = calculate_inner_inline_size(box, available_space.inline_size, computed_values.max_width(), containing_block_constraints);
         if (used_width.to_px_or_zero() > max_width) {
             used_width = try_compute_width(CSS::Length::make_px(max_width));
@@ -1671,7 +1671,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto used_height = try_compute_height([&] -> CSS::LengthOrAuto {
         if (is<TableWrapper>(box))
             return CSS::Length::make_px(compute_table_box_block_size_inside_table_wrapper(box, available_space, containing_block_constraints));
-        if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
+        if (should_treat_block_size_as_auto(box, available_space, containing_block_constraints))
             return CSS::LengthOrAuto::make_auto();
         return CSS::Length::make_px(calculate_inner_block_size(box, available_space_for_intrinsic_height, box.computed_values().height(), containing_block_constraints));
     }());
@@ -1707,7 +1707,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
-    if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
+    if (computed_block_size_establishes_definite_containing_block_size(box.computed_values().height()))
         box_state.set_has_definite_block_size(true);
     box_state.inset_top = top.to_px_or_zero(height_of_containing_block);
     box_state.inset_bottom = bottom.to_px_or_zero(height_of_containing_block);
@@ -2505,7 +2505,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
         box_state.set_has_definite_inline_size(true);
     }
     if (is_non_auto(computed_values.inset().top()) && is_non_auto(computed_values.inset().bottom())
-        && (computed_values.height().is_auto() || computed_height_establishes_definite_containing_block_height(computed_values.height()))) {
+        && (computed_values.height().is_auto() || computed_block_size_establishes_definite_containing_block_size(computed_values.height()))) {
         box_state.set_has_definite_block_size(true);
     }
 
@@ -2518,7 +2518,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box, AbsposLay
             && box.has_preferred_aspect_ratio()
             && box_state.has_definite_inline_size();
         box_state.set_has_definite_inline_size(true);
-        if ((!computed_values.height().is_auto() && computed_height_establishes_definite_containing_block_height(computed_values.height())) || height_resolved_from_aspect_ratio)
+        if ((!computed_values.height().is_auto() && computed_block_size_establishes_definite_containing_block_size(computed_values.height())) || height_resolved_from_aspect_ratio)
             box_state.set_has_definite_block_size(true);
     }
 
@@ -2672,7 +2672,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
     // do not set calculated insets or margins on the first pass, there will be a second pass
     if (box.computed_values().height().is_auto() && before_or_after_inside_layout == BeforeOrAfterInsideLayout::Before)
         return;
-    if (computed_height_establishes_definite_containing_block_height(box.computed_values().height()))
+    if (computed_block_size_establishes_definite_containing_block_size(box.computed_values().height()))
         box_state.set_has_definite_block_size(true);
     box_state.inset_top = to_px(top);
     box_state.inset_bottom = to_px(bottom);
@@ -2881,7 +2881,7 @@ Optional<CSSPixels> FormattingContext::calculate_transferred_inline_size_for_rep
 
     auto available_space = m_state.get(box).available_inner_space_or_constraints_from(
         AvailableSpace(AvailableSize::make_max_content(), AvailableSize::make_indefinite()));
-    if (should_treat_height_as_auto(box, available_space, containing_block_constraints))
+    if (should_treat_block_size_as_auto(box, available_space, containing_block_constraints))
         return {};
 
     // https://drafts.csswg.org/css2/#inline-replaced-width
@@ -3168,7 +3168,7 @@ CSSPixels FormattingContext::calculate_inner_block_size(Box const& box, Availabl
     CSSPixels containing_block_block_size = available_space.block_size.to_px_or_zero();
     // NOTE: Percentage heights are resolved against the containing block's used height,
     //       not the available space height. The containing block's height must be definite
-    //       for percentage resolution to work (otherwise should_treat_height_as_auto
+    //       for percentage resolution to work (otherwise should_treat_block_size_as_auto
     //       should have returned true and we wouldn't be here).
     // NOTE: We only do this when available space height is indefinite. If it's definite,
     //       we trust that the caller has set it up correctly (e.g., grid/flex items get
@@ -3235,15 +3235,15 @@ CSSPixels FormattingContext::calculate_stretch_fit_block_size(Box const& box, Av
         - box_state.border_bottom;
 }
 
-bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpace const& available_space) const
+bool FormattingContext::should_treat_inline_size_as_auto(Box const& box, AvailableSpace const& available_space) const
 {
-    auto const& computed_width = box.computed_values().width();
-    if (computed_width.is_auto())
+    auto const& computed_inline_size = box.computed_values().width();
+    if (computed_inline_size.is_auto())
         return true;
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
-    if (computed_width.contains_percentage()) {
-        switch (cyclic_percentage_intrinsic_contribution(box, computed_width, available_space.inline_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+    if (computed_inline_size.contains_percentage()) {
+        switch (cyclic_percentage_intrinsic_contribution(box, computed_inline_size, available_space.inline_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return false;
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
@@ -3255,7 +3255,7 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
             return true;
     }
     // AD-HOC: If the box has a preferred aspect ratio and an intrinsic keyword for width...
-    if (box.has_preferred_aspect_ratio() && computed_width.is_intrinsic_sizing_constraint()) {
+    if (box.has_preferred_aspect_ratio() && computed_inline_size.is_intrinsic_sizing_constraint()) {
         // If the box has no natural height to resolve the aspect ratio, we treat the width as auto.
         if (!box.auto_content_box_size().has_height())
             return true;
@@ -3266,10 +3266,10 @@ bool FormattingContext::should_treat_width_as_auto(Box const& box, AvailableSpac
     return false;
 }
 
-bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
+bool FormattingContext::should_treat_block_size_as_auto(Box const& box, AvailableSpace const& available_space, ContainingBlockConstraints const& containing_block_constraints) const
 {
-    auto computed_height = box.computed_values().height();
-    if (computed_height.is_auto()) {
+    auto computed_block_size = box.computed_values().height();
+    if (computed_block_size.is_auto()) {
         auto const& box_state = m_state.get(box);
         if (box_state.has_definite_inline_size() && box.has_preferred_aspect_ratio())
             return false;
@@ -3277,8 +3277,8 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
     }
 
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
-    if (computed_height.contains_percentage()) {
-        switch (cyclic_percentage_intrinsic_contribution(box, computed_height, available_space.block_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+    if (computed_block_size.contains_percentage()) {
+        switch (cyclic_percentage_intrinsic_contribution(box, computed_block_size, available_space.block_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return false;
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
@@ -3295,7 +3295,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
         // height. The quirk applies to DOM elements only (not anonymous boxes), and excludes
         // table-related display types.
         if (!box.is_absolutely_positioned()) {
-            auto percentage_height_quirk_applies = [&] {
+            auto percentage_block_size_quirk_applies = [&] {
                 if (!box.document().in_quirks_mode() || box.is_anonymous())
                     return false;
                 if (box.display().is_table_inside())
@@ -3312,7 +3312,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
                 }
                 return true;
             }();
-            if (!percentage_height_quirk_applies) {
+            if (!percentage_block_size_quirk_applies) {
                 if (!containing_block_constraints.percentage_basis_block_size.has_value())
                     return true;
             }
@@ -3320,7 +3320,7 @@ bool FormattingContext::should_treat_height_as_auto(Box const& box, AvailableSpa
     }
 
     // AD-HOC: If the box has a preferred aspect ratio and an intrinsic keyword for height...
-    if (box.has_preferred_aspect_ratio() && computed_height.is_intrinsic_sizing_constraint()) {
+    if (box.has_preferred_aspect_ratio() && computed_block_size.is_intrinsic_sizing_constraint()) {
         // If the box has no natural width to resolve the aspect ratio, we treat the height as auto.
         if (!box.auto_content_box_size().has_width())
             return true;
@@ -3565,8 +3565,8 @@ bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, Availab
         //         size it as a normal box to match other browsers.
 
         auto auto_size = box.auto_content_box_size();
-        if (should_treat_width_as_auto(box, available_space)
-            && should_treat_height_as_auto(box, available_space, containing_block_constraints)
+        if (should_treat_inline_size_as_auto(box, available_space)
+            && should_treat_block_size_as_auto(box, available_space, containing_block_constraints)
             && !auto_size.has_width()
             && !auto_size.has_height()) {
             return false;
@@ -3577,16 +3577,16 @@ bool FormattingContext::box_is_sized_as_replaced_element(Box const& box, Availab
     return false;
 }
 
-bool FormattingContext::should_treat_max_width_as_none(Box const& box, AvailableSize const& available_width, ContainingBlockConstraints const& containing_block_constraints) const
+bool FormattingContext::should_treat_max_inline_size_as_none(Box const& box, AvailableSize const& available_inline_size, ContainingBlockConstraints const& containing_block_constraints) const
 {
-    auto const& max_width = box.computed_values().max_width();
-    if (max_width.is_none())
+    auto const& max_inline_size = box.computed_values().max_width();
+    if (max_inline_size.is_none())
         return true;
-    if (available_width.is_max_content() && max_width.is_max_content())
+    if (available_inline_size.is_max_content() && max_inline_size.is_max_content())
         return true;
     // https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-contribution
-    if (max_width.contains_percentage()) {
-        switch (cyclic_percentage_intrinsic_contribution(box, max_width, available_width, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
+    if (max_inline_size.contains_percentage()) {
+        switch (cyclic_percentage_intrinsic_contribution(box, max_inline_size, available_inline_size, CyclicPercentageSizeProperty::PreferredOrMaxSize)) {
         case CyclicPercentageIntrinsicContribution::ResolveAsZero:
             return false;
         case CyclicPercentageIntrinsicContribution::TreatAsInitialValue:
@@ -3597,35 +3597,35 @@ bool FormattingContext::should_treat_max_width_as_none(Box const& box, Available
         if (!containing_block_constraints.percentage_basis_inline_size.has_value())
             return true;
     }
-    if (max_width.is_fit_content() && available_width.is_intrinsic_sizing_constraint())
+    if (max_inline_size.is_fit_content() && available_inline_size.is_intrinsic_sizing_constraint())
         return true;
-    if (max_width.is_max_content() && available_width.is_max_content())
+    if (max_inline_size.is_max_content() && available_inline_size.is_max_content())
         return true;
-    if (max_width.is_min_content() && available_width.is_min_content())
+    if (max_inline_size.is_min_content() && available_inline_size.is_min_content())
         return true;
     return false;
 }
 
-bool FormattingContext::should_treat_max_height_as_none(Box const& box, AvailableSize const& available_height, ContainingBlockConstraints const& containing_block_constraints) const
+bool FormattingContext::should_treat_max_block_size_as_none(Box const& box, AvailableSize const& available_block_size, ContainingBlockConstraints const& containing_block_constraints) const
 {
     // https://www.w3.org/TR/CSS22/visudet.html#min-max-heights
     // If the height of the containing block is not specified explicitly (i.e., it depends on content height),
     // and this element is not absolutely positioned, the percentage value is treated as '0' (for 'min-height')
     // or 'none' (for 'max-height').
-    auto const& max_height = box.computed_values().max_height();
-    if (max_height.is_none())
+    auto const& max_block_size = box.computed_values().max_height();
+    if (max_block_size.is_none())
         return true;
-    if (max_height.contains_percentage()) {
-        if (available_height.is_min_content())
+    if (max_block_size.contains_percentage()) {
+        if (available_block_size.is_min_content())
             return false;
         if (!containing_block_constraints.percentage_basis_block_size.has_value())
             return true;
     }
-    if (max_height.is_fit_content() && available_height.is_intrinsic_sizing_constraint())
+    if (max_block_size.is_fit_content() && available_block_size.is_intrinsic_sizing_constraint())
         return true;
-    if (max_height.is_max_content() && available_height.is_max_content())
+    if (max_block_size.is_max_content() && available_block_size.is_max_content())
         return true;
-    if (max_height.is_min_content() && available_height.is_min_content())
+    if (max_block_size.is_min_content() && available_block_size.is_min_content())
         return true;
     return false;
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -181,14 +181,14 @@ protected:
     void dimension_list_item_marker(ListItemMarkerBox const&);
     [[nodiscard]] static CSSPixels distance_between_marker_and_list_item(ListItemMarkerBox const&);
 
-    [[nodiscard]] static bool computed_height_establishes_definite_containing_block_height(CSS::Size const&);
+    [[nodiscard]] static bool computed_block_size_establishes_definite_containing_block_size(CSS::Size const&);
     [[nodiscard]] Optional<CSSPixels> calculate_transferred_inline_size_for_replaced_element(Layout::Box const&, ContainingBlockConstraints const&) const;
 
-    [[nodiscard]] bool should_treat_width_as_auto(Box const&, AvailableSpace const&) const;
-    [[nodiscard]] bool should_treat_height_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    [[nodiscard]] bool should_treat_inline_size_as_auto(Box const&, AvailableSpace const&) const;
+    [[nodiscard]] bool should_treat_block_size_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
-    [[nodiscard]] bool should_treat_max_width_as_none(Box const&, AvailableSize const&, ContainingBlockConstraints const&) const;
-    [[nodiscard]] bool should_treat_max_height_as_none(Box const&, AvailableSize const&, ContainingBlockConstraints const&) const;
+    [[nodiscard]] bool should_treat_max_inline_size_as_none(Box const&, AvailableSize const&, ContainingBlockConstraints const&) const;
+    [[nodiscard]] bool should_treat_max_block_size_as_none(Box const&, AvailableSize const&, ContainingBlockConstraints const&) const;
 
     [[nodiscard]] bool box_is_sized_as_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -12,6 +12,7 @@
 #include <LibWeb/Layout/AvailableSpace.h>
 #include <LibWeb/Layout/LayoutInput.h>
 #include <LibWeb/Layout/LayoutState.h>
+#include <LibWeb/Layout/LogicalGeometry.h>
 
 namespace Web::Layout {
 
@@ -111,8 +112,8 @@ public:
         TableWrapperInlineSizeMode = TableWrapperInlineSizeMode::ClampToAvailableInlineSize);
     CSSPixels compute_table_box_block_size_inside_table_wrapper(Box const&, AvailableSpace const&, ContainingBlockConstraints const& table_wrapper_constraints);
 
-    CSSPixels compute_width_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
-    CSSPixels compute_height_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels compute_inline_size_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels compute_block_size_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
     static OwnPtr<FormattingContext> create_independent_formatting_context_if_needed(LayoutState&, LayoutMode, Box const& child_box, FormattingContext* parent);
     static NonnullOwnPtr<FormattingContext> create_independent_formatting_context(LayoutState&, LayoutMode, Box const& child_box, FormattingContext* parent);
@@ -181,7 +182,7 @@ protected:
     [[nodiscard]] static CSSPixels distance_between_marker_and_list_item(ListItemMarkerBox const&);
 
     [[nodiscard]] static bool computed_height_establishes_definite_containing_block_height(CSS::Size const&);
-    [[nodiscard]] Optional<CSSPixels> calculate_transferred_width_for_replaced_element(Layout::Box const&, ContainingBlockConstraints const&) const;
+    [[nodiscard]] Optional<CSSPixels> calculate_transferred_inline_size_for_replaced_element(Layout::Box const&, ContainingBlockConstraints const&) const;
 
     [[nodiscard]] bool should_treat_width_as_auto(Box const&, AvailableSpace const&) const;
     [[nodiscard]] bool should_treat_height_as_auto(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
@@ -216,15 +217,15 @@ protected:
         CSSPixels preferred_minimum_width { 0 };
     };
 
-    CSSPixels tentative_width_for_replaced_element(Box const&, CSS::Size const& computed_width, AvailableSpace const&, ContainingBlockConstraints const&) const;
-    CSSPixels tentative_height_for_replaced_element(Box const&, CSS::Size const& computed_height, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels tentative_inline_size_for_replaced_element(Box const&, CSS::Size const& computed_inline_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels tentative_block_size_for_replaced_element(Box const&, CSS::Size const& computed_block_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
     CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
     static CSSPixels line_box_physical_width(Box const&, LineBox const&);
 
     CSSPixels measure_automatic_content_block_size(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
     void make_button_content_box_definite(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, Optional<CSSPixels> measured_content_height = {});
 
-    [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    [[nodiscard]] LogicalSize solve_replaced_size_constraint(CSSPixels input_inline_size, CSSPixels input_block_size, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&, ContainingBlockConstraints const&);
 

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -235,7 +235,7 @@ protected:
 
     void register_contained_abspos_child(Box const& child, StaticPositionRect const&);
     [[nodiscard]] StaticPositionRect resolve_static_position_relative_to_containing_block(Box const&, StaticPositionRect) const;
-    [[nodiscard]] static CSSPixelPoint aligned_static_position(StaticPositionRect const&, LayoutState::UsedValues const&);
+    [[nodiscard]] static LogicalOffset aligned_static_offset(StaticPositionRect const&, LayoutState::UsedValues const&);
     void layout_absolutely_positioned_children();
     void layout_absolutely_positioned_children(Box const&);
     virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -248,11 +248,11 @@ protected:
         Before,
         After,
     };
-    void compute_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
-    void compute_height_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
+    void compute_block_size_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
+    void compute_block_size_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
+    void compute_block_size_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&, BeforeOrAfterInsideLayout);
 
-    [[nodiscard]] Optional<CSSPixels> compute_auto_height_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout) const;
+    [[nodiscard]] Optional<CSSPixels> compute_automatic_block_size_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, BeforeOrAfterInsideLayout) const;
 
     Type m_type {};
     LayoutMode m_layout_mode;

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -84,9 +84,9 @@ public:
 
     virtual void run(LayoutInput const&) = 0;
 
-    // These functions return the automatic content dimensions of the context's root box.
-    virtual CSSPixels automatic_content_width() const = 0;
-    virtual CSSPixels automatic_content_height() const = 0;
+    // These functions return the automatic content sizes of the context's root box.
+    virtual CSSPixels automatic_content_inline_size() const = 0;
+    virtual CSSPixels automatic_content_block_size() const = 0;
 
     Box const& context_box() const { return m_context_box; }
 
@@ -221,7 +221,7 @@ protected:
     CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
     static CSSPixels line_box_physical_width(Box const&, LineBox const&);
 
-    CSSPixels measure_automatic_content_height(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
+    CSSPixels measure_automatic_content_block_size(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
     void make_button_content_box_definite(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, Optional<CSSPixels> measured_content_height = {});
 
     [[nodiscard]] CSSPixelSize solve_replaced_size_constraint(CSSPixels input_width, CSSPixels input_height, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -219,11 +219,11 @@ protected:
 
     CSSPixels tentative_inline_size_for_replaced_element(Box const&, CSS::Size const& computed_inline_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
     CSSPixels tentative_block_size_for_replaced_element(Box const&, CSS::Size const& computed_block_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
-    CSSPixels compute_auto_height_for_block_formatting_context_root(Box const&) const;
+    CSSPixels compute_automatic_block_size_for_block_formatting_context_root(Box const&) const;
     static CSSPixels line_box_physical_width(Box const&, LineBox const&);
 
     CSSPixels measure_automatic_content_block_size(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
-    void make_button_content_box_definite(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, Optional<CSSPixels> measured_content_height = {});
+    void make_button_content_box_definite(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, Optional<CSSPixels> measured_content_block_size = {});
 
     [[nodiscard]] LogicalSize solve_replaced_size_constraint(CSSPixels input_inline_size, CSSPixels input_block_size, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -220,7 +220,7 @@ protected:
     CSSPixels tentative_inline_size_for_replaced_element(Box const&, CSS::Size const& computed_inline_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
     CSSPixels tentative_block_size_for_replaced_element(Box const&, CSS::Size const& computed_block_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
     CSSPixels compute_automatic_block_size_for_block_formatting_context_root(Box const&) const;
-    static CSSPixels line_box_physical_width(Box const&, LineBox const&);
+    static CSSPixels line_box_physical_horizontal_extent(Box const&, LineBox const&);
 
     CSSPixels measure_automatic_content_block_size(Box const&, AvailableSpace const& inner_available_space, ContainingBlockConstraints const&);
     void make_button_content_box_definite(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, Optional<CSSPixels> measured_content_block_size = {});

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -145,16 +145,16 @@ public:
 
     void place_child(Box const& child, CSSPixelPoint content_offset);
 
-    CSSPixels calculate_min_content_width(Layout::Box const&, ContainingBlockConstraints const&) const;
-    CSSPixels calculate_max_content_width(Layout::Box const&, ContainingBlockConstraints const&) const;
-    CSSPixels calculate_min_content_height(Layout::Box const&, CSSPixels width, ContainingBlockConstraints const&) const;
-    CSSPixels calculate_max_content_height(Layout::Box const&, CSSPixels width, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_min_content_inline_size(Layout::Box const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_max_content_inline_size(Layout::Box const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_min_content_block_size(Layout::Box const&, CSSPixels inline_size, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_max_content_block_size(Layout::Box const&, CSSPixels inline_size, ContainingBlockConstraints const&) const;
 
-    CSSPixels calculate_fit_content_height(Layout::Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
-    CSSPixels calculate_fit_content_width(Layout::Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_fit_content_block_size(Layout::Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_fit_content_inline_size(Layout::Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
-    CSSPixels calculate_inner_width(Layout::Box const&, AvailableSize const&, CSS::Size const& width, ContainingBlockConstraints const&) const;
-    [[nodiscard]] CSSPixels calculate_inner_height(Box const&, AvailableSpace const&, CSS::Size const& height, ContainingBlockConstraints const&) const;
+    CSSPixels calculate_inner_inline_size(Layout::Box const&, AvailableSize const&, CSS::Size const& preferred_size, ContainingBlockConstraints const&) const;
+    [[nodiscard]] CSSPixels calculate_inner_block_size(Box const&, AvailableSpace const&, CSS::Size const& preferred_size, ContainingBlockConstraints const&) const;
 
     virtual CSSPixels greatest_child_width(Box const&) const;
 
@@ -167,8 +167,8 @@ public:
     [[nodiscard]] CSSPixels box_baseline(Box const&, BaselineSet) const;
     void compute_and_store_baselines(LayoutState::UsedValues&) const;
 
-    [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
-    [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;
+    [[nodiscard]] CSSPixels calculate_stretch_fit_inline_size(Box const&, AvailableSize const&) const;
+    [[nodiscard]] CSSPixels calculate_stretch_fit_block_size(Box const&, AvailableSize const&) const;
 
     bool can_skip_is_anonymous_text_run(Box&);
 

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -23,9 +23,9 @@ template<typename T>
     return ::max(min, ::min(value, max));
 }
 
-enum class TableWrapperWidthMode {
-    ClampToAvailableWidth,
-    UseTableUsedWidthIfNotAuto,
+enum class TableWrapperInlineSizeMode {
+    ClampToAvailableInlineSize,
+    UseTableUsedInlineSizeIfNotAuto,
 };
 
 class FormattingContext {
@@ -105,11 +105,11 @@ public:
 
     static bool creates_block_formatting_context(Box const&);
 
-    CSSPixels compute_table_box_width_inside_table_wrapper(Box const&, AvailableSpace const&,
+    CSSPixels compute_table_box_inline_size_inside_table_wrapper(Box const&, AvailableSpace const&,
         ContainingBlockConstraints const& table_wrapper_constraints,
-        Optional<CSSPixels> table_wrapper_containing_block_width = {},
-        TableWrapperWidthMode = TableWrapperWidthMode::ClampToAvailableWidth);
-    CSSPixels compute_table_box_height_inside_table_wrapper(Box const&, AvailableSpace const&, ContainingBlockConstraints const& table_wrapper_constraints);
+        Optional<CSSPixels> table_wrapper_containing_block_inline_size = {},
+        TableWrapperInlineSizeMode = TableWrapperInlineSizeMode::ClampToAvailableInlineSize);
+    CSSPixels compute_table_box_block_size_inside_table_wrapper(Box const&, AvailableSpace const&, ContainingBlockConstraints const& table_wrapper_constraints);
 
     CSSPixels compute_width_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
     CSSPixels compute_height_for_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -240,9 +240,9 @@ protected:
     void layout_absolutely_positioned_children(Box const&);
     virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&);
     void resolve_anchor_insets(Box&) const;
-    void compute_width_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
-    void compute_width_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
-    void compute_width_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
+    void compute_inline_size_for_absolutely_positioned_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
+    void compute_inline_size_for_absolutely_positioned_non_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
+    void compute_inline_size_for_absolutely_positioned_replaced_element(Box const&, AvailableSpace const&, ContainingBlockConstraints const&, StaticPositionRect const&);
 
     enum class BeforeOrAfterInsideLayout {
         Before,

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -157,7 +157,7 @@ public:
     CSSPixels calculate_inner_inline_size(Layout::Box const&, AvailableSize const&, CSS::Size const& preferred_size, ContainingBlockConstraints const&) const;
     [[nodiscard]] CSSPixels calculate_inner_block_size(Box const&, AvailableSpace const&, CSS::Size const& preferred_size, ContainingBlockConstraints const&) const;
 
-    virtual CSSPixels greatest_child_width(Box const&) const;
+    virtual CSSPixels greatest_child_inline_size(Box const&) const;
 
     [[nodiscard]] static CSSPixelRect margin_box_rect(LayoutState::UsedValues const&);
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
@@ -212,9 +212,9 @@ protected:
         CSSPixels right { 0 };
     };
 
-    struct ShrinkToFitResult {
-        CSSPixels preferred_width { 0 };
-        CSSPixels preferred_minimum_width { 0 };
+    struct ShrinkToFitInlineSizeResult {
+        CSSPixels preferred_inline_size { 0 };
+        CSSPixels preferred_minimum_inline_size { 0 };
     };
 
     CSSPixels tentative_inline_size_for_replaced_element(Box const&, CSS::Size const& computed_inline_size, AvailableSpace const&, ContainingBlockConstraints const&) const;
@@ -227,7 +227,7 @@ protected:
 
     [[nodiscard]] LogicalSize solve_replaced_size_constraint(CSSPixels input_inline_size, CSSPixels input_block_size, Box const&, AvailableSpace const&, ContainingBlockConstraints const&) const;
 
-    ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&, ContainingBlockConstraints const&);
+    ShrinkToFitInlineSizeResult calculate_shrink_to_fit_inline_sizes(Box const&, ContainingBlockConstraints const&);
 
     void layout_absolutely_positioned_element(Box&, AbsposLayoutInputs const&);
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -394,8 +394,8 @@ void GridFormattingContext::for_each_subgrid_item_contributing_to_track_sizing(G
     GridFormattingContext subgrid_context(m_state, LayoutMode::IntrinsicSizing, subgrid.box, this);
     subgrid_context.m_available_space = *m_available_space;
     subgrid_context.m_layout_input.emplace(*subgrid_context.m_available_space, track_sizing_constraints_for_items());
-    if (dimension == GridDimension::Row && subgrid.used_values.has_definite_width())
-        subgrid_context.m_available_space->inline_size = AvailableSize::make_definite(subgrid.used_values.content_width());
+    if (dimension == GridDimension::Row && subgrid.used_values.has_definite_inline_size())
+        subgrid_context.m_available_space->inline_size = AvailableSize::make_definite(subgrid.used_values.content_inline_size());
     subgrid_context.init_grid_lines(GridDimension::Column);
     subgrid_context.init_grid_lines(GridDimension::Row);
     subgrid_context.build_grid_areas();
@@ -2389,7 +2389,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
                 CSSPixels fit_content_size;
                 if (dimension == GridDimension::Column) {
                     fit_content_size = calculate_fit_content_width(item.box, available_space, grid_area_constraints);
-                } else if (preferred_size.is_auto() && item.box.has_preferred_aspect_ratio() && *item.box.preferred_aspect_ratio() != 0 && item.used_values.has_definite_width()) {
+                } else if (preferred_size.is_auto() && item.box.has_preferred_aspect_ratio() && *item.box.preferred_aspect_ratio() != 0 && item.used_values.has_definite_inline_size()) {
                     // NB: When the item has a preferred aspect ratio and a definite width, resolve the
                     //     height through the aspect ratio instead of using fit-content sizing, which would
                     //     incorrectly use the available width (grid area width) instead of the item's width.
@@ -2425,11 +2425,11 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
         if (dimension == GridDimension::Column) {
             item.used_values.margin_left = used_alignment.margin_start;
             item.used_values.margin_right = used_alignment.margin_end;
-            item.used_values.set_content_width(used_alignment.size);
+            item.used_values.set_content_inline_size(used_alignment.size);
         } else {
             item.used_values.margin_top = used_alignment.margin_start;
             item.used_values.margin_bottom = used_alignment.margin_end;
-            item.used_values.set_content_height(used_alignment.size);
+            item.used_values.set_content_block_size(used_alignment.size);
         }
     }
 }
@@ -2636,14 +2636,14 @@ void GridFormattingContext::save_grid_layout_data()
 CSSPixels GridFormattingContext::grid_container_size_for_track_alignment(GridDimension dimension) const
 {
     if (dimension == GridDimension::Column)
-        return m_grid_container_used_values.content_width();
+        return m_grid_container_used_values.content_inline_size();
     if (m_use_row_track_alignment_grid_container_height) {
         if (!grid_container().computed_values().min_height().is_auto())
-            return max(m_row_track_alignment_grid_container_height, m_grid_container_used_values.content_height());
+            return max(m_row_track_alignment_grid_container_height, m_grid_container_used_values.content_block_size());
         return m_row_track_alignment_grid_container_height;
     }
-    if (m_grid_container_used_values.has_definite_height())
-        return m_grid_container_used_values.content_height();
+    if (m_grid_container_used_values.has_definite_block_size())
+        return m_grid_container_used_values.content_block_size();
     return m_row_track_alignment_grid_container_height;
 }
 
@@ -2921,9 +2921,9 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             grid_area_size.set_width(non_cyclic_containing_block_width_for_table_wrapper(grid_item, grid_area_size.width()));
             table_wrapper_grid_area_size = grid_area_size;
         }
-        auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_width()), AvailableSize::make_definite(grid_item.used_values.content_height()));
-        grid_item.used_values.set_has_definite_width(true);
-        grid_item.used_values.set_has_definite_height(true);
+        auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_inline_size()), AvailableSize::make_definite(grid_item.used_values.content_block_size()));
+        grid_item.used_values.set_has_definite_inline_size(true);
+        grid_item.used_values.set_has_definite_block_size(true);
         auto child_constraints = [&] {
             auto constraints = grid_area_constraints_for_item(grid_item);
             // Table wrappers pass their constraints through to the table box, so hand them the
@@ -3143,7 +3143,7 @@ void GridFormattingContext::determine_intrinsic_size_of_grid_container(Available
         for (auto& track : m_grid_rows_and_gaps) {
             grid_container_height += track.base_size;
         }
-        m_grid_container_used_values.set_content_height(grid_container_height);
+        m_grid_container_used_values.set_content_block_size(grid_container_height);
     }
 
     if (available_space.inline_size.is_intrinsic_sizing_constraint()) {
@@ -3151,13 +3151,13 @@ void GridFormattingContext::determine_intrinsic_size_of_grid_container(Available
         for (auto& track : m_grid_columns_and_gaps) {
             grid_container_width += track.base_size;
         }
-        m_grid_container_used_values.set_content_width(grid_container_width);
+        m_grid_container_used_values.set_content_inline_size(grid_container_width);
     }
 }
 
 CSSPixels GridFormattingContext::automatic_content_width() const
 {
-    return m_grid_container_used_values.content_width();
+    return m_grid_container_used_values.content_inline_size();
 }
 
 CSSPixels GridFormattingContext::automatic_content_height() const
@@ -3640,7 +3640,7 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
 
     item.used_values.margin_left = margin_start;
     item.used_values.margin_right = margin_end;
-    item.used_values.set_content_width(table_wrapper_width);
+    item.used_values.set_content_inline_size(table_wrapper_width);
 }
 
 CSSPixels GridFormattingContext::non_cyclic_containing_block_width_for_table_wrapper(GridItem const& item, CSSPixels containing_block_width) const
@@ -3657,10 +3657,10 @@ CSSPixels GridFormattingContext::non_cyclic_containing_block_width_for_table_wra
         return containing_block_width;
     }
 
-    if (!m_grid_container_used_values.has_definite_width())
+    if (!m_grid_container_used_values.has_definite_inline_size())
         return containing_block_width;
 
-    auto const available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(m_grid_container_used_values.content_width()));
+    auto const available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(m_grid_container_used_values.content_inline_size()));
     bool spans_intrinsic_column_track = false;
     for_each_spanned_track_by_item(item, GridDimension::Column, [&](GridTrack const& track) {
         if (track.is_gap)
@@ -3678,11 +3678,11 @@ CSSPixels GridFormattingContext::non_cyclic_containing_block_width_for_table_wra
     for (auto const& track : m_grid_columns_and_gaps)
         total_column_width += track.base_size;
 
-    if (total_column_width <= m_grid_container_used_values.content_width())
+    if (total_column_width <= m_grid_container_used_values.content_inline_size())
         return containing_block_width;
 
     auto non_spanned_column_width = max(CSSPixels(0), total_column_width - containing_block_width);
-    auto non_cyclic_containing_block_width = max(CSSPixels(0), m_grid_container_used_values.content_width() - non_spanned_column_width);
+    auto non_cyclic_containing_block_width = max(CSSPixels(0), m_grid_container_used_values.content_inline_size() - non_spanned_column_width);
     return min(containing_block_width, non_cyclic_containing_block_width);
 }
 
@@ -3856,7 +3856,7 @@ Optional<CSSPixels> GridFormattingContext::specified_size_suggestion(GridItem co
     if (!item.box.is_replaced_box() && item.preferred_size(dimension).contains_percentage())
         return {};
 
-    auto has_definite_preferred_size = dimension == GridDimension::Column ? item.used_values.has_definite_width() : item.used_values.has_definite_height();
+    auto has_definite_preferred_size = dimension == GridDimension::Column ? item.used_values.has_definite_inline_size() : item.used_values.has_definite_block_size();
     if (has_definite_preferred_size) {
         // FIXME: consider margins, padding and borders because it is outer size.
         auto containing_block_size = containing_block_size_for_item(item, dimension);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2376,15 +2376,15 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             } else if (dimension == GridDimension::Column && is<TableWrapper>(item.box)) {
                 // CSS Grid lays out each grid item into its grid-area containing block before alignment. For
                 // display:table, the anonymous table wrapper is the grid item, while table layout computes the inner
-                // table's border-box width, so resolve the wrapper width with the same grid-area basis used later.
-                auto table_wrapper_containing_block_width = non_cyclic_containing_block_width_for_table_wrapper(item, containing_block_size);
+                // table's border-box inline size, so resolve the wrapper with the same grid-area basis used later.
+                auto table_wrapper_containing_block_inline_size = non_cyclic_containing_block_inline_size_for_table_wrapper(item, containing_block_size);
                 auto table_wrapper_constraints = container_derived_constraints();
-                table_wrapper_constraints.percentage_basis_inline_size = table_wrapper_containing_block_width;
-                auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
-                    item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
+                table_wrapper_constraints.percentage_basis_inline_size = table_wrapper_containing_block_inline_size;
+                auto table_wrapper_inline_size = compute_table_box_inline_size_inside_table_wrapper(
+                    item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_inline_size, TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto);
                 if (table_box_inside_table_wrapper(item).computed_values().width().is_auto())
-                    table_wrapper_width = max(table_wrapper_width, calculate_min_content_inline_size(item.box, table_wrapper_constraints));
-                used_alignment = try_compute_size(table_wrapper_width, CSS::Size::make_px(table_wrapper_width), table_wrapper_containing_block_width);
+                    table_wrapper_inline_size = max(table_wrapper_inline_size, calculate_min_content_inline_size(item.box, table_wrapper_constraints));
+                used_alignment = try_compute_size(table_wrapper_inline_size, CSS::Size::make_px(table_wrapper_inline_size), table_wrapper_containing_block_inline_size);
             } else if (preferred_size.is_auto() || preferred_size.is_fit_content()) {
                 CSSPixels fit_content_size;
                 if (dimension == GridDimension::Column) {
@@ -2914,11 +2914,11 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
         auto const grid_area_rect = get_grid_area_rect(grid_item);
         Optional<CSSPixelSize> table_wrapper_grid_area_size;
         if (is<TableWrapper>(grid_item.box)) {
-            // Track spacing can expand the final grid area after the earlier width pass. Recompute the wrapper width
+            // Track spacing can expand the final grid area after the earlier inline-size pass. Recompute the wrapper
             // against that final area so the real table layout resolves percentages against the grid area.
-            resolve_table_wrapper_grid_item_width(grid_item, grid_area_rect.width());
+            resolve_table_wrapper_grid_item_inline_size(grid_item, grid_area_rect.width());
             auto grid_area_size = grid_area_rect.size();
-            grid_area_size.set_width(non_cyclic_containing_block_width_for_table_wrapper(grid_item, grid_area_size.width()));
+            grid_area_size.set_width(non_cyclic_containing_block_inline_size_for_table_wrapper(grid_item, grid_area_size.width()));
             table_wrapper_grid_area_size = grid_area_size;
         }
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_inline_size()), AvailableSize::make_definite(grid_item.used_values.content_block_size()));
@@ -3546,65 +3546,65 @@ Box const& GridFormattingContext::table_box_inside_table_wrapper(GridItem const&
     return *table_box;
 }
 
-void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item, CSSPixels containing_block_width)
+void GridFormattingContext::resolve_table_wrapper_grid_item_inline_size(GridItem& item, CSSPixels containing_block_inline_size)
 {
     VERIFY(is<TableWrapper>(item.box));
 
-    auto table_wrapper_containing_block_width = non_cyclic_containing_block_width_for_table_wrapper(item, containing_block_width);
+    auto table_wrapper_containing_block_inline_size = non_cyclic_containing_block_inline_size_for_table_wrapper(item, containing_block_inline_size);
     auto available_space = AvailableSpace {
-        AvailableSize::make_definite(clamp_to_max_dimension_value(table_wrapper_containing_block_width)),
+        AvailableSize::make_definite(clamp_to_max_dimension_value(table_wrapper_containing_block_inline_size)),
         AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)))
     };
     auto table_wrapper_constraints = container_derived_constraints();
-    table_wrapper_constraints.percentage_basis_inline_size = table_wrapper_containing_block_width;
-    auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
-        item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
+    table_wrapper_constraints.percentage_basis_inline_size = table_wrapper_containing_block_inline_size;
+    auto table_wrapper_inline_size = compute_table_box_inline_size_inside_table_wrapper(
+        item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_inline_size, TableWrapperInlineSizeMode::UseTableUsedInlineSizeIfNotAuto);
     auto const& table_box = table_box_inside_table_wrapper(item);
-    auto const& preferred_width = item.preferred_size(GridDimension::Column);
-    if (!preferred_width.is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_inline_size(item.box, available_space.inline_size, preferred_width, grid_area_constraints_for_item(item)));
+    auto const& preferred_inline_size = item.preferred_size(GridDimension::Column);
+    if (!preferred_inline_size.is_auto())
+        table_wrapper_inline_size = max(table_wrapper_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, preferred_inline_size, grid_area_constraints_for_item(item)));
     if (table_box.computed_values().width().is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_min_content_inline_size(item.box, table_wrapper_constraints));
+        table_wrapper_inline_size = max(table_wrapper_inline_size, calculate_min_content_inline_size(item.box, table_wrapper_constraints));
     auto alignment = alignment_for_item(item.box, GridDimension::Column);
     if (table_box.computed_values().width().is_auto()
         && (alignment == Alignment::Normal || alignment == Alignment::Stretch)
         && !item.margin_start(GridDimension::Column).is_auto()
         && !item.margin_end(GridDimension::Column).is_auto()) {
-        // Stretching the wrapper also stretches the auto-width table inside it, so the stretched
-        // width has to respect the max-width of both the wrapper and the table box.
-        auto stretched_width = table_wrapper_containing_block_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
+        // Stretching the wrapper also stretches the auto-width table inside it, so the stretched inline size has to
+        // respect the max-width of both the wrapper and the table box.
+        auto stretched_inline_size = table_wrapper_containing_block_inline_size - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
         if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
-            stretched_width = min(stretched_width, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+            stretched_inline_size = min(stretched_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
         if (!should_treat_max_width_as_none(table_box, available_space.inline_size, grid_area_constraints_for_item(item))) {
-            auto const& table_max_width = table_box.computed_values().max_width();
-            if (table_max_width.is_length_percentage()) {
+            auto const& table_max_inline_size = table_box.computed_values().max_width();
+            if (table_max_inline_size.is_length_percentage()) {
                 auto const& table_box_computed_values = table_box.computed_values();
-                auto table_max_border_box_width = table_max_width.to_px(table_wrapper_containing_block_width);
+                auto table_max_border_box_inline_size = table_max_inline_size.to_px(table_wrapper_containing_block_inline_size);
                 if (table_box_computed_values.box_sizing() == CSS::BoxSizing::ContentBox) {
-                    table_max_border_box_width += table_box_computed_values.border_left().width
-                        + table_box_computed_values.padding().left().to_px_or_zero(table_wrapper_containing_block_width)
-                        + table_box_computed_values.padding().right().to_px_or_zero(table_wrapper_containing_block_width)
+                    table_max_border_box_inline_size += table_box_computed_values.border_left().width
+                        + table_box_computed_values.padding().left().to_px_or_zero(table_wrapper_containing_block_inline_size)
+                        + table_box_computed_values.padding().right().to_px_or_zero(table_wrapper_containing_block_inline_size)
                         + table_box_computed_values.border_right().width;
                 }
-                stretched_width = min(stretched_width, table_max_border_box_width);
+                stretched_inline_size = min(stretched_inline_size, table_max_border_box_inline_size);
             } else {
-                stretched_width = min(stretched_width, table_wrapper_width);
+                stretched_inline_size = min(stretched_inline_size, table_wrapper_inline_size);
             }
         }
-        table_wrapper_width = max(table_wrapper_width, stretched_width);
+        table_wrapper_inline_size = max(table_wrapper_inline_size, stretched_inline_size);
     }
     if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
-        table_wrapper_width = min(table_wrapper_width, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        table_wrapper_inline_size = min(table_wrapper_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
     if (!item.minimum_size(GridDimension::Column).is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_inline_size(item.box, available_space.inline_size, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        table_wrapper_inline_size = max(table_wrapper_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
 
     auto const& computed_values = item.box.computed_values();
-    item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(table_wrapper_containing_block_width);
-    item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(table_wrapper_containing_block_width);
+    item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(table_wrapper_containing_block_inline_size);
+    item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(table_wrapper_containing_block_inline_size);
 
     auto margin_start = item.used_margin_start(GridDimension::Column);
     auto margin_end = item.used_margin_end(GridDimension::Column);
-    auto free_space_left_for_margins = table_wrapper_containing_block_width - table_wrapper_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
+    auto free_space_left_for_margins = table_wrapper_containing_block_inline_size - table_wrapper_inline_size - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
     bool start_is_auto = item.margin_start(GridDimension::Column).is_auto();
     bool end_is_auto = item.margin_end(GridDimension::Column).is_auto();
     auto absorbed_margin_space = max(CSSPixels(0), free_space_left_for_margins);
@@ -3618,7 +3618,7 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
     }
 
     if (!(start_is_auto || end_is_auto) || free_space_left_for_margins <= 0) {
-        auto free_space_left_for_alignment = table_wrapper_containing_block_width - table_wrapper_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
+        auto free_space_left_for_alignment = table_wrapper_containing_block_inline_size - table_wrapper_inline_size - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
         switch (alignment) {
         case Alignment::Center:
             margin_start += free_space_left_for_alignment / 2;
@@ -3640,10 +3640,10 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
 
     item.used_values.margin_left = margin_start;
     item.used_values.margin_right = margin_end;
-    item.used_values.set_content_inline_size(table_wrapper_width);
+    item.used_values.set_content_inline_size(table_wrapper_inline_size);
 }
 
-CSSPixels GridFormattingContext::non_cyclic_containing_block_width_for_table_wrapper(GridItem const& item, CSSPixels containing_block_width) const
+CSSPixels GridFormattingContext::non_cyclic_containing_block_inline_size_for_table_wrapper(GridItem const& item, CSSPixels containing_block_inline_size) const
 {
     auto const& table_box = table_box_inside_table_wrapper(item);
     auto const& table_box_computed_values = table_box.computed_values();
@@ -3654,36 +3654,36 @@ CSSPixels GridFormattingContext::non_cyclic_containing_block_width_for_table_wra
         && !table_box_computed_values.width().contains_percentage()
         && !table_box_computed_values.min_width().contains_percentage()
         && !table_box_computed_values.max_width().contains_percentage()) {
-        return containing_block_width;
+        return containing_block_inline_size;
     }
 
     if (!m_grid_container_used_values.has_definite_inline_size())
-        return containing_block_width;
+        return containing_block_inline_size;
 
-    auto const available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(m_grid_container_used_values.content_inline_size()));
+    auto const available_inline_size = AvailableSize::make_definite(clamp_to_max_dimension_value(m_grid_container_used_values.content_inline_size()));
     bool spans_intrinsic_column_track = false;
     for_each_spanned_track_by_item(item, GridDimension::Column, [&](GridTrack const& track) {
         if (track.is_gap)
             return;
-        if (track.min_track_sizing_function.is_intrinsic(available_width) || track.max_track_sizing_function.is_intrinsic(available_width))
+        if (track.min_track_sizing_function.is_intrinsic(available_inline_size) || track.max_track_sizing_function.is_intrinsic(available_inline_size))
             spans_intrinsic_column_track = true;
     });
     if (!spans_intrinsic_column_track)
-        return containing_block_width;
+        return containing_block_inline_size;
 
     // CSS Grid breaks cyclic percentage dependencies during intrinsic track sizing. Percentage table width/min/max
     // constraints can contribute to intrinsic column tracks, so do not feed that contribution back into the table
     // wrapper containing block when resolving the final table width or margins.
-    CSSPixels total_column_width = 0;
+    CSSPixels total_column_inline_size = 0;
     for (auto const& track : m_grid_columns_and_gaps)
-        total_column_width += track.base_size;
+        total_column_inline_size += track.base_size;
 
-    if (total_column_width <= m_grid_container_used_values.content_inline_size())
-        return containing_block_width;
+    if (total_column_inline_size <= m_grid_container_used_values.content_inline_size())
+        return containing_block_inline_size;
 
-    auto non_spanned_column_width = max(CSSPixels(0), total_column_width - containing_block_width);
-    auto non_cyclic_containing_block_width = max(CSSPixels(0), m_grid_container_used_values.content_inline_size() - non_spanned_column_width);
-    return min(containing_block_width, non_cyclic_containing_block_width);
+    auto non_spanned_column_inline_size = max(CSSPixels(0), total_column_inline_size - containing_block_inline_size);
+    auto non_cyclic_containing_block_inline_size = max(CSSPixels(0), m_grid_container_used_values.content_inline_size() - non_spanned_column_inline_size);
+    return min(containing_block_inline_size, non_cyclic_containing_block_inline_size);
 }
 
 CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem const& item, GridDimension dimension) const
@@ -3998,16 +3998,16 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
             return calculate_max_content_contribution(item, dimension);
         CSSPixels inner_minimum_size;
         if (dimension == GridDimension::Column) {
-            auto available_width = item.available_space().inline_size;
+            auto available_inline_size = item.available_space().inline_size;
             // Percentage minimum sizes on a table wrapper resolve against the same non-cyclic
-            // width that the wrapper's own width resolution uses.
+            // inline size that the wrapper's own inline-size resolution uses.
             if (is<TableWrapper>(item.box) && minimum_size.contains_percentage()) {
-                auto containing_block_width = non_cyclic_containing_block_width_for_table_wrapper(
+                auto containing_block_inline_size = non_cyclic_containing_block_inline_size_for_table_wrapper(
                     item,
                     containing_block_size_for_item(item, GridDimension::Column));
-                available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_width));
+                available_inline_size = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_inline_size));
             }
-            inner_minimum_size = calculate_inner_inline_size(item.box, available_width, minimum_size, track_sizing_constraints_for_items());
+            inner_minimum_size = calculate_inner_inline_size(item.box, available_inline_size, minimum_size, track_sizing_constraints_for_items());
         } else {
             inner_minimum_size = calculate_inner_block_size(item.box, item.available_space(), minimum_size, track_sizing_constraints_for_items());
         }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2147,12 +2147,12 @@ CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_r
     auto const& computed_values = grid_container().computed_values();
 
     if (!should_treat_max_height_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
-        auto max_height = calculate_inner_height(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
+        auto max_height = calculate_inner_block_size(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
         height = min(height, max_height);
     }
 
     if (!computed_values.min_height().is_auto())
-        height = max(height, calculate_inner_height(grid_container(), *m_available_space, computed_values.min_height(), m_layout_input->containing_block_constraints));
+        height = max(height, calculate_inner_block_size(grid_container(), *m_available_space, computed_values.min_height(), m_layout_input->containing_block_constraints));
 
     return height;
 }
@@ -2323,8 +2323,8 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
 
         auto calculate_inner_size = [this, &item, dimension, available_space, grid_area_constraints](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return calculate_inner_width(item.box, available_space.inline_size, size, grid_area_constraints);
-            return calculate_inner_height(item.box, available_space, size, grid_area_constraints);
+                return calculate_inner_inline_size(item.box, available_space.inline_size, size, grid_area_constraints);
+            return calculate_inner_block_size(item.box, available_space, size, grid_area_constraints);
         };
 
         auto tentative_size_for_replaced_element = [this, &item, dimension, available_space, grid_area_constraints](CSS::Size const& size) {
@@ -2358,7 +2358,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
         } else {
             // OPTIMIZATION: For auto-sized items with stretch/normal alignment and no auto margins, the item stretches
             //               to fill the containing block. We can compute this directly without the expensive
-            //               calculate_fit_content_width/height calls that trigger intrinsic sizing.
+            //               calculate_fit_content_inline_size/height calls that trigger intrinsic sizing.
             // NB: Final grid item alignment works with the resolved grid area size. Percentage preferred sizes
             //     must resolve against that definite area instead of being reclassified as auto from the outer
             //     grid container's own definiteness.
@@ -2383,19 +2383,19 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
                 auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
                     item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
                 if (table_box_inside_table_wrapper(item).computed_values().width().is_auto())
-                    table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box, table_wrapper_constraints));
+                    table_wrapper_width = max(table_wrapper_width, calculate_min_content_inline_size(item.box, table_wrapper_constraints));
                 used_alignment = try_compute_size(table_wrapper_width, CSS::Size::make_px(table_wrapper_width), table_wrapper_containing_block_width);
             } else if (preferred_size.is_auto() || preferred_size.is_fit_content()) {
                 CSSPixels fit_content_size;
                 if (dimension == GridDimension::Column) {
-                    fit_content_size = calculate_fit_content_width(item.box, available_space, grid_area_constraints);
+                    fit_content_size = calculate_fit_content_inline_size(item.box, available_space, grid_area_constraints);
                 } else if (preferred_size.is_auto() && item.box.has_preferred_aspect_ratio() && *item.box.preferred_aspect_ratio() != 0 && item.used_values.has_definite_inline_size()) {
                     // NB: When the item has a preferred aspect ratio and a definite width, resolve the
                     //     height through the aspect ratio instead of using fit-content sizing, which would
                     //     incorrectly use the available width (grid area width) instead of the item's width.
-                    fit_content_size = calculate_inner_height(item.box, available_space, CSS::Size::make_auto(), grid_area_constraints);
+                    fit_content_size = calculate_inner_block_size(item.box, available_space, CSS::Size::make_auto(), grid_area_constraints);
                 } else {
-                    fit_content_size = calculate_fit_content_height(item.box, available_space, grid_area_constraints);
+                    fit_content_size = calculate_fit_content_block_size(item.box, available_space, grid_area_constraints);
                 }
                 used_alignment = try_compute_size(fit_content_size, preferred_size);
             } else {
@@ -3485,8 +3485,8 @@ CSSPixels GridFormattingContext::calculate_grid_container_maximum_size(GridDimen
 {
     auto const& computed_values = grid_container().computed_values();
     if (dimension == GridDimension::Column)
-        return calculate_inner_width(grid_container(), m_available_space->inline_size, computed_values.max_width(), m_layout_input->containing_block_constraints);
-    return calculate_inner_height(grid_container(), m_available_space.value(), computed_values.max_height(), m_layout_input->containing_block_constraints);
+        return calculate_inner_inline_size(grid_container(), m_available_space->inline_size, computed_values.max_width(), m_layout_input->containing_block_constraints);
+    return calculate_inner_block_size(grid_container(), m_available_space.value(), computed_values.max_height(), m_layout_input->containing_block_constraints);
 }
 
 bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_contribution(GridItem const& item, GridDimension dimension) const
@@ -3510,17 +3510,17 @@ bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_co
 CSSPixels GridFormattingContext::calculate_min_content_size(GridItem const& item, GridDimension dimension) const
 {
     if (dimension == GridDimension::Column) {
-        return calculate_min_content_width(item.box, container_derived_constraints());
+        return calculate_min_content_inline_size(item.box, container_derived_constraints());
     }
-    return calculate_min_content_height(item.box, item.available_space().inline_size.to_px_or_zero(), container_derived_constraints());
+    return calculate_min_content_block_size(item.box, item.available_space().inline_size.to_px_or_zero(), container_derived_constraints());
 }
 
 CSSPixels GridFormattingContext::calculate_max_content_size(GridItem const& item, GridDimension dimension) const
 {
     if (dimension == GridDimension::Column) {
-        return calculate_max_content_width(item.box, container_derived_constraints());
+        return calculate_max_content_inline_size(item.box, container_derived_constraints());
     }
-    return calculate_max_content_height(item.box, item.available_space().inline_size.to_px_or_zero(), container_derived_constraints());
+    return calculate_max_content_block_size(item.box, item.available_space().inline_size.to_px_or_zero(), container_derived_constraints());
 }
 
 CSSPixels GridFormattingContext::containing_block_size_for_item(GridItem const& item, GridDimension dimension) const
@@ -3562,9 +3562,9 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
     auto const& table_box = table_box_inside_table_wrapper(item);
     auto const& preferred_width = item.preferred_size(GridDimension::Column);
     if (!preferred_width.is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.inline_size, preferred_width, grid_area_constraints_for_item(item)));
+        table_wrapper_width = max(table_wrapper_width, calculate_inner_inline_size(item.box, available_space.inline_size, preferred_width, grid_area_constraints_for_item(item)));
     if (table_box.computed_values().width().is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box, table_wrapper_constraints));
+        table_wrapper_width = max(table_wrapper_width, calculate_min_content_inline_size(item.box, table_wrapper_constraints));
     auto alignment = alignment_for_item(item.box, GridDimension::Column);
     if (table_box.computed_values().width().is_auto()
         && (alignment == Alignment::Normal || alignment == Alignment::Stretch)
@@ -3574,7 +3574,7 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         // width has to respect the max-width of both the wrapper and the table box.
         auto stretched_width = table_wrapper_containing_block_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
         if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
-            stretched_width = min(stretched_width, calculate_inner_width(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+            stretched_width = min(stretched_width, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
         if (!should_treat_max_width_as_none(table_box, available_space.inline_size, grid_area_constraints_for_item(item))) {
             auto const& table_max_width = table_box.computed_values().max_width();
             if (table_max_width.is_length_percentage()) {
@@ -3594,9 +3594,9 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         table_wrapper_width = max(table_wrapper_width, stretched_width);
     }
     if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
-        table_wrapper_width = min(table_wrapper_width, calculate_inner_width(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        table_wrapper_width = min(table_wrapper_width, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
     if (!item.minimum_size(GridDimension::Column).is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.inline_size, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        table_wrapper_width = max(table_wrapper_width, calculate_inner_inline_size(item.box, available_space.inline_size, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
 
     auto const& computed_values = item.box.computed_values();
     item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(table_wrapper_containing_block_width);
@@ -3711,10 +3711,10 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
 
     auto preferred_size = item.preferred_size(dimension);
     if (dimension == GridDimension::Column) {
-        auto width = calculate_inner_width(item.box, m_available_space->inline_size, preferred_size, track_sizing_constraints_for_items());
+        auto width = calculate_inner_inline_size(item.box, m_available_space->inline_size, preferred_size, track_sizing_constraints_for_items());
         return min(item.add_margin_box_sizes(width, dimension), maximum_size);
     }
-    auto height = calculate_inner_height(item.box, *m_available_space, preferred_size, track_sizing_constraints_for_items());
+    auto height = calculate_inner_block_size(item.box, *m_available_space, preferred_size, track_sizing_constraints_for_items());
     return min(item.add_margin_box_sizes(height, dimension), maximum_size);
 }
 
@@ -3730,7 +3730,7 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
 
     auto preferred_size = item.preferred_size(dimension);
     if (should_treat_preferred_size_as_auto || preferred_size.is_fit_content()) {
-        auto fit_content_size = dimension == GridDimension::Column ? calculate_fit_content_width(item.box, available_space_for_item, container_derived_constraints()) : calculate_fit_content_height(item.box, available_space_for_item, container_derived_constraints());
+        auto fit_content_size = dimension == GridDimension::Column ? calculate_fit_content_inline_size(item.box, available_space_for_item, container_derived_constraints()) : calculate_fit_content_block_size(item.box, available_space_for_item, container_derived_constraints());
         auto result = item.add_margin_box_sizes(fit_content_size, dimension);
         return min(result, maximum_size);
     }
@@ -3740,9 +3740,9 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
         if (dimension == GridDimension::Row) {
             auto available_height = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)));
             AvailableSpace item_available_space { available_width, available_height };
-            return calculate_inner_height(item.box, item_available_space, preferred_size, track_sizing_constraints_for_items());
+            return calculate_inner_block_size(item.box, item_available_space, preferred_size, track_sizing_constraints_for_items());
         }
-        return calculate_inner_width(item.box, available_width, preferred_size, track_sizing_constraints_for_items());
+        return calculate_inner_inline_size(item.box, available_width, preferred_size, track_sizing_constraints_for_items());
     };
 
     auto result = item.add_margin_box_sizes(resolve_size(), dimension);
@@ -4007,9 +4007,9 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
                     containing_block_size_for_item(item, GridDimension::Column));
                 available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_width));
             }
-            inner_minimum_size = calculate_inner_width(item.box, available_width, minimum_size, track_sizing_constraints_for_items());
+            inner_minimum_size = calculate_inner_inline_size(item.box, available_width, minimum_size, track_sizing_constraints_for_items());
         } else {
-            inner_minimum_size = calculate_inner_height(item.box, item.available_space(), minimum_size, track_sizing_constraints_for_items());
+            inner_minimum_size = calculate_inner_block_size(item.box, item.available_space(), minimum_size, track_sizing_constraints_for_items());
         }
         return item.add_margin_box_sizes(inner_minimum_size, dimension);
     }

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -3100,10 +3100,7 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
         return rect;
     }();
 
-    containing_block_info.rect = CSSPixelRect {
-        { grid_area.offset.inline_offset, grid_area.offset.block_offset },
-        { grid_area.size.inline_size, grid_area.size.block_size }
-    };
+    containing_block_info.rect = grid_area;
     containing_block_info.inline_alignment = alignment_for_item(box, GridDimension::Column);
     containing_block_info.block_alignment = alignment_for_item(box, GridDimension::Row);
     containing_block_info.derives_from_own_computed_values = true;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2136,14 +2136,14 @@ void GridFormattingContext::determine_grid_container_height()
     CSSPixels total_y = 0;
     for (auto& grid_row : m_grid_rows_and_gaps)
         total_y += grid_row.base_size;
-    m_automatic_content_height = total_y;
+    m_automatic_content_block_size = total_y;
     m_row_track_alignment_grid_container_height = total_y;
     m_use_row_track_alignment_grid_container_height = false;
 }
 
 CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_row_layout() const
 {
-    auto height = m_automatic_content_height;
+    auto height = m_automatic_content_block_size;
     auto const& computed_values = grid_container().computed_values();
 
     if (!should_treat_max_height_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
@@ -2889,13 +2889,13 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     determine_grid_container_height();
 
-    auto intrinsic_grid_container_height = m_automatic_content_height;
+    auto intrinsic_grid_container_height = m_automatic_content_block_size;
     if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_indefinite()) {
         auto resolved_grid_container_height = resolve_used_grid_container_height_for_second_row_layout();
         rerun_row_track_sizing_using_grid_container_height(resolved_grid_container_height);
         m_row_track_alignment_grid_container_height = resolved_grid_container_height;
         m_use_row_track_alignment_grid_container_height = true;
-        m_automatic_content_height = intrinsic_grid_container_height;
+        m_automatic_content_block_size = intrinsic_grid_container_height;
     } else if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_definite() && should_treat_height_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
         m_row_track_alignment_grid_container_height = m_available_space->block_size.to_px_or_zero();
         m_use_row_track_alignment_grid_container_height = true;
@@ -3155,14 +3155,14 @@ void GridFormattingContext::determine_intrinsic_size_of_grid_container(Available
     }
 }
 
-CSSPixels GridFormattingContext::automatic_content_width() const
+CSSPixels GridFormattingContext::automatic_content_inline_size() const
 {
     return m_grid_container_used_values.content_inline_size();
 }
 
-CSSPixels GridFormattingContext::automatic_content_height() const
+CSSPixels GridFormattingContext::automatic_content_block_size() const
 {
-    return m_automatic_content_height;
+    return m_automatic_content_block_size;
 }
 
 bool GridFormattingContext::is_auto_positioned_track(CSS::GridTrackPlacement const& grid_track_start, CSS::GridTrackPlacement const& grid_track_end) const

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1742,7 +1742,7 @@ void GridFormattingContext::maximize_tracks(GridDimension dimension)
     auto const& computed_values = grid_container().computed_values();
     auto should_treat_grid_container_maximum_size_as_none = [&] {
         if (dimension == GridDimension::Column)
-            return should_treat_max_width_as_none(grid_container(), available_size, m_layout_input->containing_block_constraints);
+            return should_treat_max_inline_size_as_none(grid_container(), available_size, m_layout_input->containing_block_constraints);
         return !computed_values.max_height().is_auto();
     }();
 
@@ -2146,7 +2146,7 @@ CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_r
     auto height = m_automatic_content_block_size;
     auto const& computed_values = grid_container().computed_values();
 
-    if (!should_treat_max_height_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
+    if (!should_treat_max_block_size_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
         auto max_height = calculate_inner_block_size(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
         height = min(height, max_height);
     }
@@ -2404,7 +2404,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             }
         }
 
-        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints) : should_treat_max_height_as_none(item.box, available_space.block_size, grid_area_constraints);
+        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_inline_size_as_none(item.box, available_space.inline_size, grid_area_constraints) : should_treat_max_block_size_as_none(item.box, available_space.block_size, grid_area_constraints);
         if (!should_treat_maximum_size_as_none) {
             auto const& maximum_size = item.maximum_size(dimension);
             auto max_size_px = calculate_inner_size(maximum_size);
@@ -2896,7 +2896,7 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
         m_row_track_alignment_grid_container_height = resolved_grid_container_height;
         m_use_row_track_alignment_grid_container_height = true;
         m_automatic_content_block_size = intrinsic_grid_container_height;
-    } else if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_definite() && should_treat_height_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
+    } else if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_definite() && should_treat_block_size_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
         m_row_track_alignment_grid_container_height = m_available_space->block_size.to_px_or_zero();
         m_use_row_track_alignment_grid_container_height = true;
     }
@@ -3477,8 +3477,8 @@ int GridItem::gap_adjusted_column() const
 bool GridFormattingContext::should_treat_grid_container_maximum_size_as_none(GridDimension dimension) const
 {
     if (dimension == GridDimension::Column)
-        return should_treat_max_width_as_none(grid_container(), m_available_space->inline_size, m_layout_input->containing_block_constraints);
-    return should_treat_max_height_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints);
+        return should_treat_max_inline_size_as_none(grid_container(), m_available_space->inline_size, m_layout_input->containing_block_constraints);
+    return should_treat_max_block_size_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints);
 }
 
 CSSPixels GridFormattingContext::calculate_grid_container_maximum_size(GridDimension dimension) const
@@ -3494,8 +3494,8 @@ bool GridFormattingContext::should_treat_preferred_size_as_auto_for_intrinsic_co
     auto available_space_for_item = item.available_space();
     auto should_treat_preferred_size_as_auto = [&] {
         if (dimension == GridDimension::Column)
-            return should_treat_width_as_auto(item.box, available_space_for_item);
-        return should_treat_height_as_auto(item.box, available_space_for_item, track_sizing_constraints_for_items());
+            return should_treat_inline_size_as_auto(item.box, available_space_for_item);
+        return should_treat_block_size_as_auto(item.box, available_space_for_item, track_sizing_constraints_for_items());
     }();
     if (should_treat_preferred_size_as_auto)
         return true;
@@ -3573,9 +3573,9 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_inline_size(GridItem
         // Stretching the wrapper also stretches the auto-width table inside it, so the stretched inline size has to
         // respect the max-width of both the wrapper and the table box.
         auto stretched_inline_size = table_wrapper_containing_block_inline_size - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
-        if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
+        if (!should_treat_max_inline_size_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
             stretched_inline_size = min(stretched_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
-        if (!should_treat_max_width_as_none(table_box, available_space.inline_size, grid_area_constraints_for_item(item))) {
+        if (!should_treat_max_inline_size_as_none(table_box, available_space.inline_size, grid_area_constraints_for_item(item))) {
             auto const& table_max_inline_size = table_box.computed_values().max_width();
             if (table_max_inline_size.is_length_percentage()) {
                 auto const& table_box_computed_values = table_box.computed_values();
@@ -3593,7 +3593,7 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_inline_size(GridItem
         }
         table_wrapper_inline_size = max(table_wrapper_inline_size, stretched_inline_size);
     }
-    if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
+    if (!should_treat_max_inline_size_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
         table_wrapper_inline_size = min(table_wrapper_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
     if (!item.minimum_size(GridDimension::Column).is_auto())
         table_wrapper_inline_size = max(table_wrapper_inline_size, calculate_inner_inline_size(item.box, available_space.inline_size, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1751,12 +1751,12 @@ void GridFormattingContext::maximize_tracks(GridDimension dimension)
         if (grid_container_inner_size > maximum_size) {
             for (size_t i = 0; i < tracks.size(); i++)
                 tracks[i].base_size = saved_base_sizes[i];
-            auto available_space_with_max_width = *m_available_space;
+            auto available_space_with_maximum_size = *m_available_space;
             if (dimension == GridDimension::Column)
-                available_space_with_max_width.inline_size = AvailableSize::make_definite(maximum_size);
+                available_space_with_maximum_size.inline_size = AvailableSize::make_definite(maximum_size);
             else
-                available_space_with_max_width.block_size = AvailableSize::make_definite(maximum_size);
-            maximize_tracks_using_available_size(available_space_with_max_width, dimension);
+                available_space_with_maximum_size.block_size = AvailableSize::make_definite(maximum_size);
+            maximize_tracks_using_available_size(available_space_with_maximum_size, dimension);
         }
     }
 }
@@ -2131,35 +2131,35 @@ void GridFormattingContext::place_grid_items()
     }
 }
 
-void GridFormattingContext::determine_grid_container_height()
+void GridFormattingContext::determine_grid_container_block_size()
 {
-    CSSPixels total_y = 0;
+    CSSPixels total_block_size = 0;
     for (auto& grid_row : m_grid_rows_and_gaps)
-        total_y += grid_row.base_size;
-    m_automatic_content_block_size = total_y;
-    m_row_track_alignment_grid_container_height = total_y;
-    m_use_row_track_alignment_grid_container_height = false;
+        total_block_size += grid_row.base_size;
+    m_automatic_content_block_size = total_block_size;
+    m_row_track_alignment_grid_container_block_size = total_block_size;
+    m_use_row_track_alignment_grid_container_block_size = false;
 }
 
-CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_row_layout() const
+CSSPixels GridFormattingContext::resolve_used_grid_container_block_size_for_second_row_layout() const
 {
-    auto height = m_automatic_content_block_size;
+    auto block_size = m_automatic_content_block_size;
     auto const& computed_values = grid_container().computed_values();
 
     if (!should_treat_max_block_size_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
-        auto max_height = calculate_inner_block_size(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
-        height = min(height, max_height);
+        auto max_block_size = calculate_inner_block_size(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
+        block_size = min(block_size, max_block_size);
     }
 
     if (!computed_values.min_height().is_auto())
-        height = max(height, calculate_inner_block_size(grid_container(), *m_available_space, computed_values.min_height(), m_layout_input->containing_block_constraints));
+        block_size = max(block_size, calculate_inner_block_size(grid_container(), *m_available_space, computed_values.min_height(), m_layout_input->containing_block_constraints));
 
-    return height;
+    return block_size;
 }
 
-void GridFormattingContext::rerun_row_track_sizing_using_grid_container_height(CSSPixels grid_container_height)
+void GridFormattingContext::rerun_row_track_sizing_using_grid_container_block_size(CSSPixels grid_container_block_size)
 {
-    m_available_space->block_size = AvailableSize::make_definite(grid_container_height);
+    m_available_space->block_size = AvailableSize::make_definite(grid_container_block_size);
     initialize_gap_tracks(GridDimension::Row, m_available_space->block_size);
 
     resolve_items_box_metrics(GridDimension::Row);
@@ -2637,14 +2637,14 @@ CSSPixels GridFormattingContext::grid_container_size_for_track_alignment(GridDim
 {
     if (dimension == GridDimension::Column)
         return m_grid_container_used_values.content_inline_size();
-    if (m_use_row_track_alignment_grid_container_height) {
+    if (m_use_row_track_alignment_grid_container_block_size) {
         if (!grid_container().computed_values().min_height().is_auto())
-            return max(m_row_track_alignment_grid_container_height, m_grid_container_used_values.content_block_size());
-        return m_row_track_alignment_grid_container_height;
+            return max(m_row_track_alignment_grid_container_block_size, m_grid_container_used_values.content_block_size());
+        return m_row_track_alignment_grid_container_block_size;
     }
     if (m_grid_container_used_values.has_definite_block_size())
         return m_grid_container_used_values.content_block_size();
-    return m_row_track_alignment_grid_container_height;
+    return m_row_track_alignment_grid_container_block_size;
 }
 
 void GridFormattingContext::resolve_items_box_metrics(GridDimension dimension)
@@ -2652,24 +2652,24 @@ void GridFormattingContext::resolve_items_box_metrics(GridDimension dimension)
     for (auto& item : m_grid_items) {
         auto& computed_values = item.box.computed_values();
 
-        CSSPixels containing_block_width = containing_block_size_for_item(item, GridDimension::Column);
+        CSSPixels containing_block_inline_size = containing_block_size_for_item(item, GridDimension::Column);
         if (dimension == GridDimension::Column) {
-            item.used_values.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
-            item.used_values.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
+            item.used_values.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
+            item.used_values.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
 
-            item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_width);
-            item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_width);
+            item.used_values.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
+            item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
 
             item.used_values.border_right = computed_values.border_right().width;
             item.used_values.border_left = computed_values.border_left().width;
 
             apply_subgrid_gap_extra_margins(item, dimension, m_available_space->inline_size);
         } else {
-            item.used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
-            item.used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
+            item.used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_inline_size);
+            item.used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_inline_size);
 
-            item.used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_width);
-            item.used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_width);
+            item.used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_inline_size);
+            item.used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_inline_size);
 
             item.used_values.border_top = computed_values.border_top().width;
             item.used_values.border_bottom = computed_values.border_bottom().width;
@@ -2790,16 +2790,16 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         // Instead of auto-placement, an auto value for a grid-placement property contributes a special line to the placement whose position
         // is that of the corresponding padding edge of the grid container (the padding edge of the scrollable area, if the grid container
         // overflows). These lines become the first and last lines (0th and -0th) of the augmented grid used for positioning absolutely-positioned items.
-        CSSPixels height = 0;
+        CSSPixels block_size = 0;
         if (m_available_space->block_size.is_definite()) {
-            height = m_available_space->block_size.to_px_or_zero();
+            block_size = m_available_space->block_size.to_px_or_zero();
         } else {
             for (auto const& row_track : m_grid_rows_and_gaps)
-                height += row_track.base_size;
+                block_size += row_track.base_size;
         }
-        height += m_grid_container_used_values.padding_top + m_grid_container_used_values.padding_bottom;
+        block_size += m_grid_container_used_values.padding_top + m_grid_container_used_values.padding_bottom;
 
-        area_rect.set_height(height);
+        area_rect.set_height(block_size);
         area_rect.set_y(-m_grid_container_used_values.padding_top);
     }
 
@@ -2810,16 +2810,16 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
             place_into_track(GridDimension::Column);
         }
     } else {
-        CSSPixels width = 0;
+        CSSPixels inline_size = 0;
         if (m_available_space->inline_size.is_definite()) {
-            width = m_available_space->inline_size.to_px_or_zero();
+            inline_size = m_available_space->inline_size.to_px_or_zero();
         } else {
             for (auto const& col_track : m_grid_columns_and_gaps)
-                width += col_track.base_size;
+                inline_size += col_track.base_size;
         }
-        width += m_grid_container_used_values.padding_left + m_grid_container_used_values.padding_right;
+        inline_size += m_grid_container_used_values.padding_left + m_grid_container_used_values.padding_right;
 
-        area_rect.set_width(width);
+        area_rect.set_width(inline_size);
         area_rect.set_x(-m_grid_container_used_values.padding_left);
     }
 
@@ -2887,18 +2887,18 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     resolve_grid_item_sizes(GridDimension::Row);
 
-    determine_grid_container_height();
+    determine_grid_container_block_size();
 
-    auto intrinsic_grid_container_height = m_automatic_content_block_size;
+    auto intrinsic_grid_container_block_size = m_automatic_content_block_size;
     if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_indefinite()) {
-        auto resolved_grid_container_height = resolve_used_grid_container_height_for_second_row_layout();
-        rerun_row_track_sizing_using_grid_container_height(resolved_grid_container_height);
-        m_row_track_alignment_grid_container_height = resolved_grid_container_height;
-        m_use_row_track_alignment_grid_container_height = true;
-        m_automatic_content_block_size = intrinsic_grid_container_height;
+        auto resolved_grid_container_block_size = resolve_used_grid_container_block_size_for_second_row_layout();
+        rerun_row_track_sizing_using_grid_container_block_size(resolved_grid_container_block_size);
+        m_row_track_alignment_grid_container_block_size = resolved_grid_container_block_size;
+        m_use_row_track_alignment_grid_container_block_size = true;
+        m_automatic_content_block_size = intrinsic_grid_container_block_size;
     } else if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_definite() && should_treat_block_size_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
-        m_row_track_alignment_grid_container_height = m_available_space->block_size.to_px_or_zero();
-        m_use_row_track_alignment_grid_container_height = true;
+        m_row_track_alignment_grid_container_block_size = m_available_space->block_size.to_px_or_zero();
+        m_use_row_track_alignment_grid_container_block_size = true;
     }
 
     resolve_track_spacing(GridDimension::Column);
@@ -3139,19 +3139,19 @@ void GridFormattingContext::determine_intrinsic_size_of_grid_container(Available
     // (including gutters) in the appropriate axis, when the grid is sized under a max-content constraint (min-content constraint).
 
     if (available_space.block_size.is_intrinsic_sizing_constraint()) {
-        CSSPixels grid_container_height = 0;
+        CSSPixels grid_container_block_size = 0;
         for (auto& track : m_grid_rows_and_gaps) {
-            grid_container_height += track.base_size;
+            grid_container_block_size += track.base_size;
         }
-        m_grid_container_used_values.set_content_block_size(grid_container_height);
+        m_grid_container_used_values.set_content_block_size(grid_container_block_size);
     }
 
     if (available_space.inline_size.is_intrinsic_sizing_constraint()) {
-        CSSPixels grid_container_width = 0;
+        CSSPixels grid_container_inline_size = 0;
         for (auto& track : m_grid_columns_and_gaps) {
-            grid_container_width += track.base_size;
+            grid_container_inline_size += track.base_size;
         }
-        m_grid_container_used_values.set_content_inline_size(grid_container_width);
+        m_grid_container_used_values.set_content_inline_size(grid_container_inline_size);
     }
 }
 
@@ -3711,11 +3711,11 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
 
     auto preferred_size = item.preferred_size(dimension);
     if (dimension == GridDimension::Column) {
-        auto width = calculate_inner_inline_size(item.box, m_available_space->inline_size, preferred_size, track_sizing_constraints_for_items());
-        return min(item.add_margin_box_sizes(width, dimension), maximum_size);
+        auto inline_size = calculate_inner_inline_size(item.box, m_available_space->inline_size, preferred_size, track_sizing_constraints_for_items());
+        return min(item.add_margin_box_sizes(inline_size, dimension), maximum_size);
     }
-    auto height = calculate_inner_block_size(item.box, *m_available_space, preferred_size, track_sizing_constraints_for_items());
-    return min(item.add_margin_box_sizes(height, dimension), maximum_size);
+    auto block_size = calculate_inner_block_size(item.box, *m_available_space, preferred_size, track_sizing_constraints_for_items());
+    return min(item.add_margin_box_sizes(block_size, dimension), maximum_size);
 }
 
 CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem const& item, GridDimension dimension) const
@@ -3736,13 +3736,13 @@ CSSPixels GridFormattingContext::calculate_max_content_contribution(GridItem con
     }
 
     auto resolve_size = [&] {
-        auto available_width = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Column)));
+        auto available_inline_size = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Column)));
         if (dimension == GridDimension::Row) {
-            auto available_height = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)));
-            AvailableSpace item_available_space { available_width, available_height };
+            auto available_block_size = AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)));
+            AvailableSpace item_available_space { available_inline_size, available_block_size };
             return calculate_inner_block_size(item.box, item_available_space, preferred_size, track_sizing_constraints_for_items());
         }
-        return calculate_inner_inline_size(item.box, available_width, preferred_size, track_sizing_constraints_for_items());
+        return calculate_inner_inline_size(item.box, available_inline_size, preferred_size, track_sizing_constraints_for_items());
     };
 
     auto result = item.add_margin_box_sizes(resolve_size(), dimension);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2329,8 +2329,8 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
 
         auto tentative_size_for_replaced_element = [this, &item, dimension, available_space, grid_area_constraints](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return tentative_width_for_replaced_element(item.box, size, available_space, grid_area_constraints);
-            return tentative_height_for_replaced_element(item.box, size, available_space, grid_area_constraints);
+                return tentative_inline_size_for_replaced_element(item.box, size, available_space, grid_area_constraints);
+            return tentative_block_size_for_replaced_element(item.box, size, available_space, grid_area_constraints);
         };
 
         ItemAlignment used_alignment;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2701,9 +2701,9 @@ void GridFormattingContext::collapse_auto_fit_tracks_if_needed(GridDimension dim
     }
 }
 
-CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item) const
+LogicalRect GridFormattingContext::get_grid_area(GridItem const& grid_item) const
 {
-    CSSPixelRect area_rect;
+    LogicalRect area;
 
     auto place_into_track = [&](GridDimension dimension) {
         auto const& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
@@ -2754,11 +2754,11 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
 
         if (dimension == GridDimension::Column) {
-            area_rect.set_x(start_offset);
-            area_rect.set_width(end_offset - start_offset);
+            area.offset.inline_offset = start_offset;
+            area.size.inline_size = end_offset - start_offset;
         } else {
-            area_rect.set_y(start_offset);
-            area_rect.set_height(end_offset - start_offset);
+            area.offset.block_offset = start_offset;
+            area.size.block_size = end_offset - start_offset;
         }
     };
 
@@ -2771,11 +2771,11 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
         CSSPixels size = dimension == GridDimension::Column ? m_grid_container_used_values.padding_right : m_grid_container_used_values.padding_bottom;
         if (dimension == GridDimension::Column) {
-            area_rect.set_x(offset);
-            area_rect.set_width(size);
+            area.offset.inline_offset = offset;
+            area.size.inline_size = size;
         } else {
-            area_rect.set_y(offset);
-            area_rect.set_height(size);
+            area.offset.block_offset = offset;
+            area.size.block_size = size;
         }
     };
 
@@ -2799,8 +2799,8 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
         block_size += m_grid_container_used_values.padding_top + m_grid_container_used_values.padding_bottom;
 
-        area_rect.set_height(block_size);
-        area_rect.set_y(-m_grid_container_used_values.padding_top);
+        area.size.block_size = block_size;
+        area.offset.block_offset = -m_grid_container_used_values.padding_top;
     }
 
     if (grid_item.column.has_value()) {
@@ -2819,11 +2819,11 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
         inline_size += m_grid_container_used_values.padding_left + m_grid_container_used_values.padding_right;
 
-        area_rect.set_width(inline_size);
-        area_rect.set_x(-m_grid_container_used_values.padding_left);
+        area.size.inline_size = inline_size;
+        area.offset.inline_offset = -m_grid_container_used_values.padding_left;
     }
 
-    return area_rect;
+    return area;
 }
 
 void GridFormattingContext::run(LayoutInput const& layout_input)
@@ -2911,14 +2911,14 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
     }
 
     for (auto& grid_item : m_grid_items) {
-        auto const grid_area_rect = get_grid_area_rect(grid_item);
-        Optional<CSSPixelSize> table_wrapper_grid_area_size;
+        auto const grid_area = get_grid_area(grid_item);
+        Optional<LogicalSize> table_wrapper_grid_area_size;
         if (is<TableWrapper>(grid_item.box)) {
             // Track spacing can expand the final grid area after the earlier inline-size pass. Recompute the wrapper
             // against that final area so the real table layout resolves percentages against the grid area.
-            resolve_table_wrapper_grid_item_inline_size(grid_item, grid_area_rect.width());
-            auto grid_area_size = grid_area_rect.size();
-            grid_area_size.set_width(non_cyclic_containing_block_inline_size_for_table_wrapper(grid_item, grid_area_size.width()));
+            resolve_table_wrapper_grid_item_inline_size(grid_item, grid_area.size.inline_size);
+            auto grid_area_size = grid_area.size;
+            grid_area_size.inline_size = non_cyclic_containing_block_inline_size_for_table_wrapper(grid_item, grid_area_size.inline_size);
             table_wrapper_grid_area_size = grid_area_size;
         }
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item.used_values.content_inline_size()), AvailableSize::make_definite(grid_item.used_values.content_block_size()));
@@ -2929,16 +2929,19 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             // Table wrappers pass their constraints through to the table box, so hand them the
             // grid area in both axes for the table's percentage resolution.
             if (table_wrapper_grid_area_size.has_value()) {
-                constraints.percentage_basis_inline_size = table_wrapper_grid_area_size->width();
-                constraints.percentage_basis_block_size = table_wrapper_grid_area_size->height();
+                constraints.percentage_basis_inline_size = table_wrapper_grid_area_size->inline_size;
+                constraints.percentage_basis_block_size = table_wrapper_grid_area_size->block_size;
             }
             return constraints;
         }();
         auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, LayoutInput { available_space_for_children, child_constraints });
 
-        CSSPixelPoint grid_item_content_offset = grid_area_rect.top_left() + CSSPixelPoint { grid_item.used_values.margin_box_left(), grid_item.used_values.margin_box_top() };
+        CSSPixelPoint grid_item_content_offset {
+            grid_area.offset.inline_offset + grid_item.used_values.margin_box_left(),
+            grid_area.offset.block_offset + grid_item.used_values.margin_box_top()
+        };
         place_child(grid_item.box, grid_item_content_offset);
-        compute_inset(grid_item.box, grid_area_rect.size());
+        compute_inset(grid_item.box, { grid_area.size.inline_size, grid_area.size.block_size });
 
         if (independent_formatting_context)
             independent_formatting_context->parent_context_did_dimension_child_root_box();
@@ -3006,7 +3009,7 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
     auto& abspos_box_state = m_state.get_mutable(box);
     auto containing_block_info = FormattingContext::resolve_abspos_containing_block_info(box);
 
-    auto grid_area_rect = [&] -> CSSPixelRect {
+    auto grid_area = [&] -> LogicalRect {
         auto const& computed_values = box.computed_values();
         GridItem item { box, abspos_box_state, {}, {}, {}, {} };
         auto row_placement_position = resolve_grid_position(box, GridDimension::Row);
@@ -3020,7 +3023,7 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
             item.column_span = column_placement_position.span;
         }
 
-        auto rect = get_grid_area_rect(item);
+        auto rect = get_grid_area(item);
 
         auto explicit_line_position = [&](GridDimension dimension, int line_index) {
             auto const& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
@@ -3083,11 +3086,11 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
                 : explicit_line_position(dimension, placement_position.end);
 
             if (dimension == GridDimension::Column) {
-                rect.set_x(start_offset);
-                rect.set_width(end_offset - start_offset);
+                rect.offset.inline_offset = start_offset;
+                rect.size.inline_size = end_offset - start_offset;
             } else {
-                rect.set_y(start_offset);
-                rect.set_height(end_offset - start_offset);
+                rect.offset.block_offset = start_offset;
+                rect.size.block_size = end_offset - start_offset;
             }
         };
 
@@ -3097,7 +3100,10 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
         return rect;
     }();
 
-    containing_block_info.rect = grid_area_rect;
+    containing_block_info.rect = CSSPixelRect {
+        { grid_area.offset.inline_offset, grid_area.offset.block_offset },
+        { grid_area.size.inline_size, grid_area.size.block_size }
+    };
     containing_block_info.inline_alignment = alignment_for_item(box, GridDimension::Column);
     containing_block_info.block_alignment = alignment_for_item(box, GridDimension::Row);
     containing_block_info.derives_from_own_computed_values = true;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -3098,8 +3098,8 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
     }();
 
     containing_block_info.rect = grid_area_rect;
-    containing_block_info.horizontal_alignment = alignment_for_item(box, GridDimension::Column);
-    containing_block_info.vertical_alignment = alignment_for_item(box, GridDimension::Row);
+    containing_block_info.inline_alignment = alignment_for_item(box, GridDimension::Column);
+    containing_block_info.block_alignment = alignment_for_item(box, GridDimension::Row);
     containing_block_info.derives_from_own_computed_values = true;
 
     // An absolutely positioned child of a grid container gets its static
@@ -3107,8 +3107,8 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
     // inside grid items still use the generic static-position behavior from
     // their in-flow ancestor.
     if (box.static_position_containing_block() == &grid_container()) {
-        containing_block_info.horizontal_axis_mode = AbsposAxisMode::InsetFromRect;
-        containing_block_info.vertical_axis_mode = AbsposAxisMode::InsetFromRect;
+        containing_block_info.inline_axis_mode = AbsposAxisMode::InsetFromRect;
+        containing_block_info.block_axis_mode = AbsposAxisMode::InsetFromRect;
     }
 
     return containing_block_info;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -248,13 +248,13 @@ GridFormattingContext::~GridFormattingContext() = default;
 
 ContainingBlockConstraints GridFormattingContext::grid_area_constraints_for_item(GridItem const& item) const
 {
-    return { containing_block_size_for_item(item, GridDimension::Column), {}, item_quirks_mode_percentage_basis_height() };
+    return { containing_block_size_for_item(item, GridDimension::Column), {}, item_quirks_mode_percentage_basis_block_size() };
 }
 
 // During track sizing the grid area is not known yet, so items have no percentage basis.
 ContainingBlockConstraints GridFormattingContext::track_sizing_constraints_for_items() const
 {
-    return { {}, {}, item_quirks_mode_percentage_basis_height() };
+    return { {}, {}, item_quirks_mode_percentage_basis_block_size() };
 }
 
 // Intrinsic contributions during track sizing measure items against the grid container's own content box, since the
@@ -264,9 +264,9 @@ ContainingBlockConstraints GridFormattingContext::container_derived_constraints(
     return constraints_for_child_context(m_grid_container_used_values, m_layout_input->containing_block_constraints);
 }
 
-Optional<CSSPixels> GridFormattingContext::item_quirks_mode_percentage_basis_height() const
+Optional<CSSPixels> GridFormattingContext::item_quirks_mode_percentage_basis_block_size() const
 {
-    return constraints_for_child_context(m_grid_container_used_values, m_layout_input->containing_block_constraints).quirks_mode_percentage_basis_height;
+    return constraints_for_child_context(m_grid_container_used_values, m_layout_input->containing_block_constraints).quirks_mode_percentage_basis_block_size;
 }
 
 static size_t count_subgrid_line_name_lists_from_index(CSS::GridTrackSizeList const& list, size_t start_index)
@@ -2248,7 +2248,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
         // A grid item is sized within the containing block defined by its grid area.
         auto grid_area_constraints = grid_area_constraints_for_item(item);
         if (dimension == GridDimension::Row)
-            grid_area_constraints.percentage_basis_height = containing_block_size;
+            grid_area_constraints.percentage_basis_block_size = containing_block_size;
 
         auto const& preferred_size = item.preferred_size(dimension);
 
@@ -2379,7 +2379,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
                 // table's border-box width, so resolve the wrapper width with the same grid-area basis used later.
                 auto table_wrapper_containing_block_width = non_cyclic_containing_block_width_for_table_wrapper(item, containing_block_size);
                 auto table_wrapper_constraints = container_derived_constraints();
-                table_wrapper_constraints.percentage_basis_width = table_wrapper_containing_block_width;
+                table_wrapper_constraints.percentage_basis_inline_size = table_wrapper_containing_block_width;
                 auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
                     item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
                 if (table_box_inside_table_wrapper(item).computed_values().width().is_auto())
@@ -2929,8 +2929,8 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
             // Table wrappers pass their constraints through to the table box, so hand them the
             // grid area in both axes for the table's percentage resolution.
             if (table_wrapper_grid_area_size.has_value()) {
-                constraints.percentage_basis_width = table_wrapper_grid_area_size->width();
-                constraints.percentage_basis_height = table_wrapper_grid_area_size->height();
+                constraints.percentage_basis_inline_size = table_wrapper_grid_area_size->width();
+                constraints.percentage_basis_block_size = table_wrapper_grid_area_size->height();
             }
             return constraints;
         }();
@@ -3556,7 +3556,7 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         AvailableSize::make_definite(clamp_to_max_dimension_value(containing_block_size_for_item(item, GridDimension::Row)))
     };
     auto table_wrapper_constraints = container_derived_constraints();
-    table_wrapper_constraints.percentage_basis_width = table_wrapper_containing_block_width;
+    table_wrapper_constraints.percentage_basis_inline_size = table_wrapper_containing_block_width;
     auto table_wrapper_width = compute_table_box_width_inside_table_wrapper(
         item.box, available_space, table_wrapper_constraints, table_wrapper_containing_block_width, TableWrapperWidthMode::UseTableUsedWidthIfNotAuto);
     auto const& table_box = table_box_inside_table_wrapper(item);

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -395,7 +395,7 @@ void GridFormattingContext::for_each_subgrid_item_contributing_to_track_sizing(G
     subgrid_context.m_available_space = *m_available_space;
     subgrid_context.m_layout_input.emplace(*subgrid_context.m_available_space, track_sizing_constraints_for_items());
     if (dimension == GridDimension::Row && subgrid.used_values.has_definite_width())
-        subgrid_context.m_available_space->width = AvailableSize::make_definite(subgrid.used_values.content_width());
+        subgrid_context.m_available_space->inline_size = AvailableSize::make_definite(subgrid.used_values.content_width());
     subgrid_context.init_grid_lines(GridDimension::Column);
     subgrid_context.init_grid_lines(GridDimension::Row);
     subgrid_context.build_grid_areas();
@@ -577,7 +577,7 @@ bool GridFormattingContext::has_gaps(GridDimension dimension) const
 CSSPixels GridFormattingContext::resolve_definite_track_size(CSS::GridSize const& grid_size, AvailableSpace const& available_space) const
 {
     VERIFY(grid_size.is_definite());
-    return grid_size.css_size().to_px(available_space.width.to_px_or_zero());
+    return grid_size.css_size().to_px(available_space.inline_size.to_px_or_zero());
 }
 
 int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimension dimension, CSS::ExplicitGridTrack const& repeated_track)
@@ -625,7 +625,7 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
         size_of_repeated_tracks += max(track_size, CSSPixels(1));
     }
 
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
     auto const& gap = dimension == GridDimension::Column ? grid_computed_values.column_gap() : grid_computed_values.row_gap();
     auto gap_px = gap_to_px(gap, available_size.to_px_or_zero());
     auto size_of_repeated_tracks_with_gap = size_of_repeated_tracks + repeat_track_list.size() * gap_px;
@@ -1192,8 +1192,8 @@ void GridFormattingContext::initialize_gap_tracks(GridDimension dimension, Avail
 
 void GridFormattingContext::initialize_gap_tracks(AvailableSpace const& available_space)
 {
-    initialize_gap_tracks(GridDimension::Column, available_space.width);
-    initialize_gap_tracks(GridDimension::Row, available_space.height);
+    initialize_gap_tracks(GridDimension::Column, available_space.inline_size);
+    initialize_gap_tracks(GridDimension::Row, available_space.block_size);
 }
 
 void GridFormattingContext::initialize_track_sizes(GridDimension dimension)
@@ -1203,7 +1203,7 @@ void GridFormattingContext::initialize_track_sizes(GridDimension dimension)
     // Initialize each track’s base size and growth limit.
 
     auto& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
-    auto& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
     if (dimension == GridDimension::Column)
         m_has_flexible_column_tracks = false;
@@ -1301,7 +1301,7 @@ void GridFormattingContext::resolve_intrinsic_track_sizes(GridDimension dimensio
 template<typename Match>
 void GridFormattingContext::distribute_extra_space_across_spanned_tracks_base_size(GridDimension dimension, CSSPixels item_size_contribution, SpaceDistributionPhase phase, Vector<GridTrack&>& spanned_tracks, Match matcher)
 {
-    auto& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
     Vector<GridTrack&> affected_tracks;
     for (auto& track : spanned_tracks) {
@@ -1469,7 +1469,7 @@ void GridFormattingContext::distribute_extra_space_across_spanned_tracks_growth_
 
 void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossing_content_sized_tracks(GridDimension dimension, size_t span)
 {
-    auto& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
     auto& tracks = dimension == GridDimension::Column ? m_grid_columns : m_grid_rows;
     for_each_item_contributing_to_track_sizing(dimension, [&](GridItem const& item) {
         auto const item_span = item.span(dimension);
@@ -1590,7 +1590,7 @@ void GridFormattingContext::increase_sizes_to_accommodate_spanning_items_crossin
     // https://www.w3.org/TR/css-grid-1/#algo-spanning-flex-items
     // 11.5.4. Increase sizes to accommodate spanning items crossing flexible tracks
 
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
     auto dominated_by_available_size = [&](GridTrack const& track) {
         // NB: This step repeats the content-sized track step, but only distributes space to flexible tracks.
@@ -1738,7 +1738,7 @@ void GridFormattingContext::maximize_tracks(GridDimension dimension)
     CSSPixels grid_container_inner_size = 0;
     for (auto& track : tracks)
         grid_container_inner_size += track.base_size;
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
     auto const& computed_values = grid_container().computed_values();
     auto should_treat_grid_container_maximum_size_as_none = [&] {
         if (dimension == GridDimension::Column)
@@ -1753,9 +1753,9 @@ void GridFormattingContext::maximize_tracks(GridDimension dimension)
                 tracks[i].base_size = saved_base_sizes[i];
             auto available_space_with_max_width = *m_available_space;
             if (dimension == GridDimension::Column)
-                available_space_with_max_width.width = AvailableSize::make_definite(maximum_size);
+                available_space_with_max_width.inline_size = AvailableSize::make_definite(maximum_size);
             else
-                available_space_with_max_width.height = AvailableSize::make_definite(maximum_size);
+                available_space_with_max_width.block_size = AvailableSize::make_definite(maximum_size);
             maximize_tracks_using_available_size(available_space_with_max_width, dimension);
         }
     }
@@ -1770,7 +1770,7 @@ void GridFormattingContext::expand_flexible_tracks(GridDimension dimension)
 
     auto& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
     auto& tracks = dimension == GridDimension::Column ? m_grid_columns : m_grid_rows;
-    auto& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
     // FIXME: This should ideally take a Span, as that is more idomatic, but Span does not yet support holding references
     auto find_the_size_of_an_fr = [&](Vector<GridTrack&> const& tracks, CSSPixels space_to_fill) -> CSSPixelFraction {
         // https://www.w3.org/TR/css-grid-2/#algo-find-fr-size
@@ -1899,7 +1899,7 @@ void GridFormattingContext::stretch_auto_tracks(GridDimension dimension)
         return;
 
     auto& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
-    auto& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
     auto count_of_auto_max_sizing_tracks = 0;
     for (auto& track : tracks_and_gaps) {
@@ -2146,7 +2146,7 @@ CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_r
     auto height = m_automatic_content_height;
     auto const& computed_values = grid_container().computed_values();
 
-    if (!should_treat_max_height_as_none(grid_container(), m_available_space->height, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
+    if (!should_treat_max_height_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints) && !computed_values.max_height().is_auto()) {
         auto max_height = calculate_inner_height(grid_container(), *m_available_space, computed_values.max_height(), m_layout_input->containing_block_constraints);
         height = min(height, max_height);
     }
@@ -2159,8 +2159,8 @@ CSSPixels GridFormattingContext::resolve_used_grid_container_height_for_second_r
 
 void GridFormattingContext::rerun_row_track_sizing_using_grid_container_height(CSSPixels grid_container_height)
 {
-    m_available_space->height = AvailableSize::make_definite(grid_container_height);
-    initialize_gap_tracks(GridDimension::Row, m_available_space->height);
+    m_available_space->block_size = AvailableSize::make_definite(grid_container_height);
+    initialize_gap_tracks(GridDimension::Row, m_available_space->block_size);
 
     resolve_items_box_metrics(GridDimension::Row);
     run_track_sizing(GridDimension::Row);
@@ -2323,7 +2323,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
 
         auto calculate_inner_size = [this, &item, dimension, available_space, grid_area_constraints](CSS::Size const& size) {
             if (dimension == GridDimension::Column)
-                return calculate_inner_width(item.box, available_space.width, size, grid_area_constraints);
+                return calculate_inner_width(item.box, available_space.inline_size, size, grid_area_constraints);
             return calculate_inner_height(item.box, available_space, size, grid_area_constraints);
         };
 
@@ -2404,7 +2404,7 @@ void GridFormattingContext::resolve_grid_item_sizes(GridDimension dimension)
             }
         }
 
-        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints) : should_treat_max_height_as_none(item.box, available_space.height, grid_area_constraints);
+        bool should_treat_maximum_size_as_none = dimension == GridDimension::Column ? should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints) : should_treat_max_height_as_none(item.box, available_space.block_size, grid_area_constraints);
         if (!should_treat_maximum_size_as_none) {
             auto const& maximum_size = item.maximum_size(dimension);
             auto max_size_px = calculate_inner_size(maximum_size);
@@ -2663,7 +2663,7 @@ void GridFormattingContext::resolve_items_box_metrics(GridDimension dimension)
             item.used_values.border_right = computed_values.border_right().width;
             item.used_values.border_left = computed_values.border_left().width;
 
-            apply_subgrid_gap_extra_margins(item, dimension, m_available_space->width);
+            apply_subgrid_gap_extra_margins(item, dimension, m_available_space->inline_size);
         } else {
             item.used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
             item.used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
@@ -2674,7 +2674,7 @@ void GridFormattingContext::resolve_items_box_metrics(GridDimension dimension)
             item.used_values.border_top = computed_values.border_top().width;
             item.used_values.border_bottom = computed_values.border_bottom().width;
 
-            apply_subgrid_gap_extra_margins(item, dimension, m_available_space->height);
+            apply_subgrid_gap_extra_margins(item, dimension, m_available_space->block_size);
         }
     }
 }
@@ -2791,8 +2791,8 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         // is that of the corresponding padding edge of the grid container (the padding edge of the scrollable area, if the grid container
         // overflows). These lines become the first and last lines (0th and -0th) of the augmented grid used for positioning absolutely-positioned items.
         CSSPixels height = 0;
-        if (m_available_space->height.is_definite()) {
-            height = m_available_space->height.to_px_or_zero();
+        if (m_available_space->block_size.is_definite()) {
+            height = m_available_space->block_size.to_px_or_zero();
         } else {
             for (auto const& row_track : m_grid_rows_and_gaps)
                 height += row_track.base_size;
@@ -2811,8 +2811,8 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
         }
     } else {
         CSSPixels width = 0;
-        if (m_available_space->width.is_definite()) {
-            width = m_available_space->width.to_px_or_zero();
+        if (m_available_space->inline_size.is_definite()) {
+            width = m_available_space->inline_size.to_px_or_zero();
         } else {
             for (auto const& col_track : m_grid_columns_and_gaps)
                 width += col_track.base_size;
@@ -2835,8 +2835,8 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
     //               However, an inline-level container must still lay out its items, since the
     //               parent inline formatting context derives the fragment's baseline from them.
     if (m_layout_mode == LayoutMode::IntrinsicSizing
-        && !available_space.width.is_intrinsic_sizing_constraint()
-        && !available_space.height.is_intrinsic_sizing_constraint()
+        && !available_space.inline_size.is_intrinsic_sizing_constraint()
+        && !available_space.block_size.is_intrinsic_sizing_constraint()
         && !grid_container().display().is_inline_outside()) {
         return;
     }
@@ -2890,14 +2890,14 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
     determine_grid_container_height();
 
     auto intrinsic_grid_container_height = m_automatic_content_height;
-    if (m_layout_mode == LayoutMode::Normal && m_available_space->height.is_indefinite()) {
+    if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_indefinite()) {
         auto resolved_grid_container_height = resolve_used_grid_container_height_for_second_row_layout();
         rerun_row_track_sizing_using_grid_container_height(resolved_grid_container_height);
         m_row_track_alignment_grid_container_height = resolved_grid_container_height;
         m_use_row_track_alignment_grid_container_height = true;
         m_automatic_content_height = intrinsic_grid_container_height;
-    } else if (m_layout_mode == LayoutMode::Normal && m_available_space->height.is_definite() && should_treat_height_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
-        m_row_track_alignment_grid_container_height = m_available_space->height.to_px_or_zero();
+    } else if (m_layout_mode == LayoutMode::Normal && m_available_space->block_size.is_definite() && should_treat_height_as_auto(grid_container(), available_space, m_layout_input->containing_block_constraints)) {
+        m_row_track_alignment_grid_container_height = m_available_space->block_size.to_px_or_zero();
         m_use_row_track_alignment_grid_container_height = true;
     }
 
@@ -2905,7 +2905,7 @@ void GridFormattingContext::run(LayoutInput const& layout_input)
 
     resolve_track_spacing(GridDimension::Row);
 
-    if (available_space.width.is_intrinsic_sizing_constraint() || available_space.height.is_intrinsic_sizing_constraint()) {
+    if (available_space.inline_size.is_intrinsic_sizing_constraint() || available_space.block_size.is_intrinsic_sizing_constraint()) {
         determine_intrinsic_size_of_grid_container(available_space);
         return;
     }
@@ -3024,7 +3024,7 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
 
         auto explicit_line_position = [&](GridDimension dimension, int line_index) {
             auto const& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
-            auto const& grid_container_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+            auto const& grid_container_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
             CSSPixels offset = 0;
             auto sum_of_base_sizes_including_gaps = CSSPixels(0);
@@ -3053,7 +3053,7 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
         };
 
         auto augmented_grid_padding_edge = [&](GridDimension dimension, bool is_start_line) {
-            auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+            auto const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
             auto padding_start = dimension == GridDimension::Column ? m_grid_container_used_values.padding_left : m_grid_container_used_values.padding_top;
             auto padding_end = dimension == GridDimension::Column ? m_grid_container_used_values.padding_right : m_grid_container_used_values.padding_bottom;
             auto const& tracks_and_gaps = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
@@ -3138,7 +3138,7 @@ void GridFormattingContext::determine_intrinsic_size_of_grid_container(Available
     // The max-content size (min-content size) of a grid container is the sum of the grid container’s track sizes
     // (including gutters) in the appropriate axis, when the grid is sized under a max-content constraint (min-content constraint).
 
-    if (available_space.height.is_intrinsic_sizing_constraint()) {
+    if (available_space.block_size.is_intrinsic_sizing_constraint()) {
         CSSPixels grid_container_height = 0;
         for (auto& track : m_grid_rows_and_gaps) {
             grid_container_height += track.base_size;
@@ -3146,7 +3146,7 @@ void GridFormattingContext::determine_intrinsic_size_of_grid_container(Available
         m_grid_container_used_values.set_content_height(grid_container_height);
     }
 
-    if (available_space.width.is_intrinsic_sizing_constraint()) {
+    if (available_space.inline_size.is_intrinsic_sizing_constraint()) {
         CSSPixels grid_container_width = 0;
         for (auto& track : m_grid_columns_and_gaps) {
             grid_container_width += track.base_size;
@@ -3176,7 +3176,7 @@ AvailableSize GridFormattingContext::get_free_space(AvailableSpace const& availa
     // free space: Equal to the available grid space minus the sum of the base sizes of all the grid
     // tracks (including gutters), floored at zero. If available grid space is indefinite, the free
     // space is indefinite as well.
-    auto& available_size = dimension == GridDimension::Column ? available_space.width : available_space.height;
+    auto& available_size = dimension == GridDimension::Column ? available_space.inline_size : available_space.block_size;
     auto& tracks = dimension == GridDimension::Column ? m_grid_columns_and_gaps : m_grid_rows_and_gaps;
     if (available_size.is_definite()) {
         CSSPixels sum_base_sizes = 0;
@@ -3477,15 +3477,15 @@ int GridItem::gap_adjusted_column() const
 bool GridFormattingContext::should_treat_grid_container_maximum_size_as_none(GridDimension dimension) const
 {
     if (dimension == GridDimension::Column)
-        return should_treat_max_width_as_none(grid_container(), m_available_space->width, m_layout_input->containing_block_constraints);
-    return should_treat_max_height_as_none(grid_container(), m_available_space->height, m_layout_input->containing_block_constraints);
+        return should_treat_max_width_as_none(grid_container(), m_available_space->inline_size, m_layout_input->containing_block_constraints);
+    return should_treat_max_height_as_none(grid_container(), m_available_space->block_size, m_layout_input->containing_block_constraints);
 }
 
 CSSPixels GridFormattingContext::calculate_grid_container_maximum_size(GridDimension dimension) const
 {
     auto const& computed_values = grid_container().computed_values();
     if (dimension == GridDimension::Column)
-        return calculate_inner_width(grid_container(), m_available_space->width, computed_values.max_width(), m_layout_input->containing_block_constraints);
+        return calculate_inner_width(grid_container(), m_available_space->inline_size, computed_values.max_width(), m_layout_input->containing_block_constraints);
     return calculate_inner_height(grid_container(), m_available_space.value(), computed_values.max_height(), m_layout_input->containing_block_constraints);
 }
 
@@ -3512,7 +3512,7 @@ CSSPixels GridFormattingContext::calculate_min_content_size(GridItem const& item
     if (dimension == GridDimension::Column) {
         return calculate_min_content_width(item.box, container_derived_constraints());
     }
-    return calculate_min_content_height(item.box, item.available_space().width.to_px_or_zero(), container_derived_constraints());
+    return calculate_min_content_height(item.box, item.available_space().inline_size.to_px_or_zero(), container_derived_constraints());
 }
 
 CSSPixels GridFormattingContext::calculate_max_content_size(GridItem const& item, GridDimension dimension) const
@@ -3520,7 +3520,7 @@ CSSPixels GridFormattingContext::calculate_max_content_size(GridItem const& item
     if (dimension == GridDimension::Column) {
         return calculate_max_content_width(item.box, container_derived_constraints());
     }
-    return calculate_max_content_height(item.box, item.available_space().width.to_px_or_zero(), container_derived_constraints());
+    return calculate_max_content_height(item.box, item.available_space().inline_size.to_px_or_zero(), container_derived_constraints());
 }
 
 CSSPixels GridFormattingContext::containing_block_size_for_item(GridItem const& item, GridDimension dimension) const
@@ -3562,7 +3562,7 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
     auto const& table_box = table_box_inside_table_wrapper(item);
     auto const& preferred_width = item.preferred_size(GridDimension::Column);
     if (!preferred_width.is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, preferred_width, grid_area_constraints_for_item(item)));
+        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.inline_size, preferred_width, grid_area_constraints_for_item(item)));
     if (table_box.computed_values().width().is_auto())
         table_wrapper_width = max(table_wrapper_width, calculate_min_content_width(item.box, table_wrapper_constraints));
     auto alignment = alignment_for_item(item.box, GridDimension::Column);
@@ -3573,9 +3573,9 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         // Stretching the wrapper also stretches the auto-width table inside it, so the stretched
         // width has to respect the max-width of both the wrapper and the table box.
         auto stretched_width = table_wrapper_containing_block_width - item.used_margin_box_start(GridDimension::Column) - item.used_margin_box_end(GridDimension::Column);
-        if (!should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)))
-            stretched_width = min(stretched_width, calculate_inner_width(item.box, available_space.width, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
-        if (!should_treat_max_width_as_none(table_box, available_space.width, grid_area_constraints_for_item(item))) {
+        if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
+            stretched_width = min(stretched_width, calculate_inner_width(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        if (!should_treat_max_width_as_none(table_box, available_space.inline_size, grid_area_constraints_for_item(item))) {
             auto const& table_max_width = table_box.computed_values().max_width();
             if (table_max_width.is_length_percentage()) {
                 auto const& table_box_computed_values = table_box.computed_values();
@@ -3593,10 +3593,10 @@ void GridFormattingContext::resolve_table_wrapper_grid_item_width(GridItem& item
         }
         table_wrapper_width = max(table_wrapper_width, stretched_width);
     }
-    if (!should_treat_max_width_as_none(item.box, available_space.width, grid_area_constraints_for_item(item)))
-        table_wrapper_width = min(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+    if (!should_treat_max_width_as_none(item.box, available_space.inline_size, grid_area_constraints_for_item(item)))
+        table_wrapper_width = min(table_wrapper_width, calculate_inner_width(item.box, available_space.inline_size, item.maximum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
     if (!item.minimum_size(GridDimension::Column).is_auto())
-        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.width, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
+        table_wrapper_width = max(table_wrapper_width, calculate_inner_width(item.box, available_space.inline_size, item.minimum_size(GridDimension::Column), grid_area_constraints_for_item(item)));
 
     auto const& computed_values = item.box.computed_values();
     item.used_values.margin_left = computed_values.margin().left().to_px_or_zero(table_wrapper_containing_block_width);
@@ -3711,7 +3711,7 @@ CSSPixels GridFormattingContext::calculate_min_content_contribution(GridItem con
 
     auto preferred_size = item.preferred_size(dimension);
     if (dimension == GridDimension::Column) {
-        auto width = calculate_inner_width(item.box, m_available_space->width, preferred_size, track_sizing_constraints_for_items());
+        auto width = calculate_inner_width(item.box, m_available_space->inline_size, preferred_size, track_sizing_constraints_for_items());
         return min(item.add_margin_box_sizes(width, dimension), maximum_size);
     }
     auto height = calculate_inner_height(item.box, *m_available_space, preferred_size, track_sizing_constraints_for_items());
@@ -3758,7 +3758,7 @@ Optional<CSSPixels> GridFormattingContext::calculate_fixed_max_track_size_limit(
     //
     // https://drafts.csswg.org/css-grid-2#algo-terms
     // In all cases, treat auto and fit-content() as max-content, except where specified otherwise for fit-content().
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
     CSSPixels result = 0;
     bool saw_track = false;
@@ -3911,7 +3911,7 @@ CSSPixels GridFormattingContext::content_based_minimum_size(GridItem const& item
     // plus any intervening fixed gutters.
     // FIXME: Account for intervening fixed gutters.
     auto const& tracks = dimension == GridDimension::Column ? m_grid_columns : m_grid_rows;
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    auto const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
     auto item_track_index = item.raw_position(dimension);
     auto item_track_span = item.span(dimension);
     bool spans_only_tracks_with_limited_max_track_sizing_function = true;
@@ -3922,7 +3922,7 @@ CSSPixels GridFormattingContext::content_based_minimum_size(GridItem const& item
             spans_only_tracks_with_limited_max_track_sizing_function = false;
             break;
         }
-        sum_of_max_sizing_functions += track.max_track_sizing_function.css_size().to_px(m_available_space->width.to_px_or_zero());
+        sum_of_max_sizing_functions += track.max_track_sizing_function.css_size().to_px(m_available_space->inline_size.to_px_or_zero());
     }
     if (spans_only_tracks_with_limited_max_track_sizing_function) {
         result = min(result, sum_of_max_sizing_functions);
@@ -3958,7 +3958,7 @@ CSSPixels GridFormattingContext::automatic_minimum_size(GridItem const& item, Gr
     auto item_track_index = item.raw_position(dimension);
     auto item_track_span = item.span(dimension);
 
-    AvailableSize const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
+    AvailableSize const& available_size = dimension == GridDimension::Column ? m_available_space->inline_size : m_available_space->block_size;
 
     bool spans_auto_tracks = false;
     bool spans_flexible_tracks = false;
@@ -3998,7 +3998,7 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
             return calculate_max_content_contribution(item, dimension);
         CSSPixels inner_minimum_size;
         if (dimension == GridDimension::Column) {
-            auto available_width = item.available_space().width;
+            auto available_width = item.available_space().inline_size;
             // Percentage minimum sizes on a table wrapper resolve against the same non-cyclic
             // width that the wrapper's own width resolution uses.
             if (is<TableWrapper>(item.box) && minimum_size.contains_percentage()) {

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -402,7 +402,7 @@ private:
     void resolve_table_wrapper_grid_item_inline_size(GridItem&, CSSPixels containing_block_inline_size);
     CSSPixels non_cyclic_containing_block_inline_size_for_table_wrapper(GridItem const&, CSSPixels containing_block_inline_size) const;
 
-    CSSPixelRect get_grid_area_rect(GridItem const&) const;
+    LogicalRect get_grid_area(GridItem const&) const;
 
     CSSPixels content_size_suggestion(GridItem const&, GridDimension) const;
     Optional<CSSPixels> specified_size_suggestion(GridItem const&, GridDimension) const;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -167,8 +167,8 @@ public:
     virtual bool inhibits_floating() const override { return true; }
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_width() const override;
-    virtual CSSPixels automatic_content_height() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
 
     Box const& grid_container() const { return context_box(); }
 
@@ -177,7 +177,7 @@ private:
 
     void resolve_items_box_metrics(GridDimension dimension);
 
-    CSSPixels m_automatic_content_height { 0 };
+    CSSPixels m_automatic_content_block_size { 0 };
     CSSPixels m_row_track_alignment_grid_container_height { 0 };
     bool m_use_row_track_alignment_grid_container_height { false };
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -113,9 +113,9 @@ struct GridItem {
 
     AvailableSpace available_space() const
     {
-        auto available_width = used_values.has_definite_inline_size() ? AvailableSize::make_definite(used_values.content_inline_size()) : AvailableSize::make_indefinite();
-        auto available_height = used_values.has_definite_block_size() ? AvailableSize::make_definite(used_values.content_block_size()) : AvailableSize::make_indefinite();
-        return { available_width, available_height };
+        auto available_inline_size = used_values.has_definite_inline_size() ? AvailableSize::make_definite(used_values.content_inline_size()) : AvailableSize::make_indefinite();
+        auto available_block_size = used_values.has_definite_block_size() ? AvailableSize::make_definite(used_values.content_block_size()) : AvailableSize::make_indefinite();
+        return { available_inline_size, available_block_size };
     }
 };
 
@@ -178,8 +178,8 @@ private:
     void resolve_items_box_metrics(GridDimension dimension);
 
     CSSPixels m_automatic_content_block_size { 0 };
-    CSSPixels m_row_track_alignment_grid_container_height { 0 };
-    bool m_use_row_track_alignment_grid_container_height { false };
+    CSSPixels m_row_track_alignment_grid_container_block_size { 0 };
+    bool m_use_row_track_alignment_grid_container_block_size { false };
 
     bool is_auto_positioned_track(CSS::GridTrackPlacement const&, CSS::GridTrackPlacement const&) const;
 
@@ -312,9 +312,9 @@ private:
 
     LayoutState::UsedValues& m_grid_container_used_values;
 
-    void determine_grid_container_height();
-    CSSPixels resolve_used_grid_container_height_for_second_row_layout() const;
-    void rerun_row_track_sizing_using_grid_container_height(CSSPixels);
+    void determine_grid_container_block_size();
+    CSSPixels resolve_used_grid_container_block_size_for_second_row_layout() const;
+    void rerun_row_track_sizing_using_grid_container_block_size(CSSPixels);
     void determine_intrinsic_size_of_grid_container(AvailableSpace const& available_space);
 
     virtual AbsposContainingBlockInfo resolve_abspos_containing_block_info(Box const&) override;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -399,8 +399,8 @@ private:
 
     CSSPixels containing_block_size_for_item(GridItem const&, GridDimension) const;
     Box const& table_box_inside_table_wrapper(GridItem const&) const;
-    void resolve_table_wrapper_grid_item_width(GridItem&, CSSPixels containing_block_width);
-    CSSPixels non_cyclic_containing_block_width_for_table_wrapper(GridItem const&, CSSPixels containing_block_width) const;
+    void resolve_table_wrapper_grid_item_inline_size(GridItem&, CSSPixels containing_block_inline_size);
+    CSSPixels non_cyclic_containing_block_inline_size_for_table_wrapper(GridItem const&, CSSPixels containing_block_inline_size) const;
 
     CSSPixelRect get_grid_area_rect(GridItem const&) const;
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -308,7 +308,7 @@ private:
     ContainingBlockConstraints grid_area_constraints_for_item(GridItem const&) const;
     ContainingBlockConstraints track_sizing_constraints_for_items() const;
     ContainingBlockConstraints container_derived_constraints() const;
-    Optional<CSSPixels> item_quirks_mode_percentage_basis_height() const;
+    Optional<CSSPixels> item_quirks_mode_percentage_basis_block_size() const;
 
     LayoutState::UsedValues& m_grid_container_used_values;
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -113,8 +113,8 @@ struct GridItem {
 
     AvailableSpace available_space() const
     {
-        auto available_width = used_values.has_definite_width() ? AvailableSize::make_definite(used_values.content_width()) : AvailableSize::make_indefinite();
-        auto available_height = used_values.has_definite_height() ? AvailableSize::make_definite(used_values.content_height()) : AvailableSize::make_indefinite();
+        auto available_width = used_values.has_definite_inline_size() ? AvailableSize::make_definite(used_values.content_inline_size()) : AvailableSize::make_indefinite();
+        auto available_height = used_values.has_definite_block_size() ? AvailableSize::make_definite(used_values.content_block_size()) : AvailableSize::make_indefinite();
         return { available_width, available_height };
     }
 };

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -419,25 +419,25 @@ void InlineFormattingContext::compute_inline_box_pieces()
 
 void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode layout_mode)
 {
-    auto width_of_containing_block = m_available_space->inline_size.to_px_or_zero();
+    auto containing_block_inline_size = m_available_space->inline_size.to_px_or_zero();
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    box_state.margin_left = computed_values.margin().left().to_px_or_zero(width_of_containing_block);
+    box_state.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
     box_state.border_left = computed_values.border_left().width;
-    box_state.padding_left = computed_values.padding().left().to_px_or_zero(width_of_containing_block);
+    box_state.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
 
-    box_state.margin_right = computed_values.margin().right().to_px_or_zero(width_of_containing_block);
+    box_state.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
     box_state.border_right = computed_values.border_right().width;
-    box_state.padding_right = computed_values.padding().right().to_px_or_zero(width_of_containing_block);
+    box_state.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 
-    box_state.margin_top = computed_values.margin().top().to_px_or_zero(width_of_containing_block);
+    box_state.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_inline_size);
     box_state.border_top = computed_values.border_top().width;
-    box_state.padding_top = computed_values.padding().top().to_px_or_zero(width_of_containing_block);
+    box_state.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_inline_size);
 
-    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(width_of_containing_block);
+    box_state.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_inline_size);
     box_state.border_bottom = computed_values.border_bottom().width;
-    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(width_of_containing_block);
+    box_state.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_inline_size);
 
     if (auto const* marker = as_if<ListItemMarkerBox>(box)) {
         dimension_list_item_marker(*marker);
@@ -457,10 +457,10 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
         // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
         // The axis in which the preferred size calculation depends on this aspect ratio is called the ratio-dependent
         // axis, and the resulting size is definite if its input sizes are also definite
-        auto const height_is_automatic = computed_values.height().is_auto() || should_treat_block_size_as_auto(box, *m_available_space, box_constraints);
-        auto const height_resolved_from_aspect_ratio = box_state.has_definite_inline_size() && box.has_preferred_aspect_ratio() && height_is_automatic;
+        auto const block_size_is_automatic = computed_values.height().is_auto() || should_treat_block_size_as_auto(box, *m_available_space, box_constraints);
+        auto const block_size_resolved_from_aspect_ratio = box_state.has_definite_inline_size() && box.has_preferred_aspect_ratio() && block_size_is_automatic;
 
-        if (height_resolved_from_aspect_ratio)
+        if (block_size_resolved_from_aspect_ratio)
             box_state.set_has_definite_block_size(true);
 
         auto child_layout_input = m_layout_input->for_child_formatting_context(box_state.available_inner_space_or_constraints_from(*m_available_space));
@@ -477,11 +477,11 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
         return;
     }
 
-    auto const& width_value = box.computed_values().width();
-    CSSPixels unconstrained_width = 0;
+    auto const& computed_inline_size = box.computed_values().width();
+    CSSPixels unconstrained_inline_size = 0;
     if (should_treat_inline_size_as_auto(box, *m_available_space)) {
         if (m_available_space->inline_size.is_definite()) {
-            auto available_width = m_available_space->inline_size.to_px_or_zero()
+            auto available_inline_size = m_available_space->inline_size.to_px_or_zero()
                 - box_state.margin_left
                 - box_state.border_left
                 - box_state.padding_left
@@ -489,46 +489,46 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
                 - box_state.border_right
                 - box_state.margin_right;
 
-            auto preferred_width = calculate_max_content_inline_size(box, box_constraints);
-            if (preferred_width <= available_width) {
-                unconstrained_width = preferred_width;
+            auto preferred_inline_size = calculate_max_content_inline_size(box, box_constraints);
+            if (preferred_inline_size <= available_inline_size) {
+                unconstrained_inline_size = preferred_inline_size;
             } else {
-                auto preferred_minimum_width = calculate_min_content_inline_size(box, box_constraints);
-                unconstrained_width = min(max(preferred_minimum_width, available_width), preferred_width);
+                auto preferred_minimum_inline_size = calculate_min_content_inline_size(box, box_constraints);
+                unconstrained_inline_size = min(max(preferred_minimum_inline_size, available_inline_size), preferred_inline_size);
             }
         } else if (m_available_space->inline_size.is_min_content()) {
-            unconstrained_width = calculate_min_content_inline_size(box, box_constraints);
+            unconstrained_inline_size = calculate_min_content_inline_size(box, box_constraints);
         } else {
-            unconstrained_width = calculate_max_content_inline_size(box, box_constraints);
+            unconstrained_inline_size = calculate_max_content_inline_size(box, box_constraints);
         }
     } else {
-        if (width_value.contains_percentage() && !m_available_space->inline_size.is_definite()) {
+        if (computed_inline_size.contains_percentage() && !m_available_space->inline_size.is_definite()) {
             // NOTE: We can't resolve percentages yet. We'll have to wait until after inner layout.
         } else {
-            auto inner_width = calculate_inner_inline_size(box, m_available_space->inline_size, width_value, box_constraints);
-            unconstrained_width = inner_width;
+            auto inner_inline_size = calculate_inner_inline_size(box, m_available_space->inline_size, computed_inline_size, box_constraints);
+            unconstrained_inline_size = inner_inline_size;
         }
     }
 
-    CSSPixels width = unconstrained_width;
+    CSSPixels inline_size = unconstrained_inline_size;
     if (!should_treat_max_inline_size_as_none(box, m_available_space->inline_size, box_constraints)) {
-        auto max_width = calculate_inner_inline_size(box, m_available_space->inline_size, box.computed_values().max_width(), box_constraints);
-        width = min(width, max_width);
+        auto max_inline_size = calculate_inner_inline_size(box, m_available_space->inline_size, box.computed_values().max_width(), box_constraints);
+        inline_size = min(inline_size, max_inline_size);
     }
 
-    auto computed_min_width = box.computed_values().min_width();
-    if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_inline_size(box, m_available_space->inline_size, computed_min_width, box_constraints);
-        width = max(width, min_width);
+    auto computed_min_inline_size = box.computed_values().min_width();
+    if (!computed_min_inline_size.is_auto()) {
+        auto min_inline_size = calculate_inner_inline_size(box, m_available_space->inline_size, computed_min_inline_size, box_constraints);
+        inline_size = max(inline_size, min_inline_size);
     }
 
-    box_state.set_content_inline_size(width);
+    box_state.set_content_inline_size(inline_size);
 
-    parent().resolve_used_block_size_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
+    parent().resolve_used_block_size_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(inline_size), AvailableSize::make_indefinite()), box_constraints);
 
-    // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
+    // NOTE: Flex containers with an automatic block size are treated as max-content, so resolve it early.
     if (box.display().is_flex_inside())
-        parent().resolve_used_block_size_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
+        parent().resolve_used_block_size_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(inline_size), AvailableSize::make_indefinite()), box_constraints);
 
     make_button_content_box_definite(box, *m_available_space, box_constraints);
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -96,7 +96,7 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     //       This ensures that any floated boxes are taken into account.
     auto provisional_containing_block_position_in_root = m_layout_input->content_box_position_in_bfc_root->translated(
         0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
-    m_automatic_content_inline_size = parent().greatest_child_width_in_rect(
+    m_automatic_content_inline_size = parent().greatest_child_inline_size_in_rect(
         containing_block(), { provisional_containing_block_position_in_root, m_containing_block_used_values.content_size() });
     m_automatic_content_block_size = content_block_size;
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -63,14 +63,14 @@ AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels block_
     return AvailableSize::make_definite(m_available_space->inline_size.to_px_or_zero() - intrusions.left - intrusions.right);
 }
 
-CSSPixels InlineFormattingContext::automatic_content_width() const
+CSSPixels InlineFormattingContext::automatic_content_inline_size() const
 {
-    return m_automatic_content_width;
+    return m_automatic_content_inline_size;
 }
 
-CSSPixels InlineFormattingContext::automatic_content_height() const
+CSSPixels InlineFormattingContext::automatic_content_block_size() const
 {
-    return m_automatic_content_height;
+    return m_automatic_content_block_size;
 }
 
 void InlineFormattingContext::run(LayoutInput const& layout_input)
@@ -92,13 +92,13 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
             content_block_size += line_box.height();
     }
 
-    // NOTE: We ask the parent BFC to calculate the automatic content width of this IFC.
+    // NOTE: We ask the parent BFC to calculate the automatic content inline size of this IFC.
     //       This ensures that any floated boxes are taken into account.
     auto provisional_containing_block_position_in_root = m_layout_input->content_box_position_in_bfc_root->translated(
         0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
-    m_automatic_content_width = parent().greatest_child_width_in_rect(
+    m_automatic_content_inline_size = parent().greatest_child_width_in_rect(
         containing_block(), { provisional_containing_block_position_in_root, m_containing_block_used_values.content_size() });
-    m_automatic_content_height = content_block_size;
+    m_automatic_content_block_size = content_block_size;
 
     compute_and_store_baselines(m_containing_block_used_values);
 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -84,12 +84,12 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     compute_inline_box_pieces();
 
     auto const& line_boxes = m_containing_block_used_values.line_boxes;
-    CSSPixels content_height = 0;
+    CSSPixels content_block_size = 0;
     if (any_of(line_boxes, [](auto& line_box) { return line_box.has_block_level_box(); })) {
-        content_height = line_boxes.last().bottom();
+        content_block_size = line_boxes.last().bottom();
     } else {
         for (auto& line_box : line_boxes)
-            content_height += line_box.height();
+            content_block_size += line_box.height();
     }
 
     // NOTE: We ask the parent BFC to calculate the automatic content width of this IFC.
@@ -98,7 +98,7 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
         0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
     m_automatic_content_width = parent().greatest_child_width_in_rect(
         containing_block(), { provisional_containing_block_position_in_root, m_containing_block_used_values.content_size() });
-    m_automatic_content_height = content_height;
+    m_automatic_content_height = content_block_size;
 
     compute_and_store_baselines(m_containing_block_used_values);
 }
@@ -451,17 +451,17 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     auto const& box_constraints = m_layout_input->containing_block_constraints;
     if (box_is_sized_as_replaced_element(box, *m_available_space, box_constraints)) {
-        box_state.set_content_width(compute_width_for_replaced_element(box, *m_available_space, box_constraints));
-        box_state.set_content_height(compute_height_for_replaced_element(box, *m_available_space, box_constraints));
+        box_state.set_content_inline_size(compute_width_for_replaced_element(box, *m_available_space, box_constraints));
+        box_state.set_content_block_size(compute_height_for_replaced_element(box, *m_available_space, box_constraints));
 
         // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
         // The axis in which the preferred size calculation depends on this aspect ratio is called the ratio-dependent
         // axis, and the resulting size is definite if its input sizes are also definite
         auto const height_is_automatic = computed_values.height().is_auto() || should_treat_height_as_auto(box, *m_available_space, box_constraints);
-        auto const height_resolved_from_aspect_ratio = box_state.has_definite_width() && box.has_preferred_aspect_ratio() && height_is_automatic;
+        auto const height_resolved_from_aspect_ratio = box_state.has_definite_inline_size() && box.has_preferred_aspect_ratio() && height_is_automatic;
 
         if (height_resolved_from_aspect_ratio)
-            box_state.set_has_definite_height(true);
+            box_state.set_has_definite_block_size(true);
 
         auto child_layout_input = m_layout_input->for_child_formatting_context(box_state.available_inner_space_or_constraints_from(*m_available_space));
         auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
@@ -522,7 +522,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
         width = max(width, min_width);
     }
 
-    box_state.set_content_width(width);
+    box_state.set_content_inline_size(width);
 
     parent().resolve_used_height_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -904,7 +904,7 @@ void InlineFormattingContext::generate_line_boxes()
                         static_position_rect.rect = { marker.offset(), { 0, 0 } };
                     }
                     if (direction == CSS::Direction::Rtl)
-                        static_position_rect.horizontal_alignment = StaticPositionRect::Alignment::End;
+                        static_position_rect.inline_alignment = StaticPositionRect::Alignment::End;
                     found_static_position_marker = true;
                     break;
                 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -48,18 +48,18 @@ FormattingContext::SpaceUsedByFloats InlineFormattingContext::intrusion_by_float
     return parent().intrusion_by_floats_into_rect({ containing_block_position_in_root_now, m_containing_block_used_values.content_size() }, block_start, block_end);
 }
 
-CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_height) const
+CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_block_size) const
 {
-    auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_height);
+    auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_block_size);
     return intrusions.left;
 }
 
-AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels block_offset, CSSPixels line_height) const
+AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels block_offset, CSSPixels line_block_size) const
 {
     if (!m_available_space->inline_size.is_definite())
         return m_available_space->inline_size;
 
-    auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_height);
+    auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_block_size);
     return AvailableSize::make_definite(m_available_space->inline_size.to_px_or_zero() - intrusions.left - intrusions.right);
 }
 
@@ -564,20 +564,20 @@ void InlineFormattingContext::apply_justification_to_fragments(CSS::TextJustify 
     if (is_last_line || line_box.m_has_forced_break)
         return;
 
-    CSSPixels excess_horizontal_space = line_box.original_available_width().to_px_or_zero() - line_box.inline_length();
-    CSSPixels excess_horizontal_space_including_whitespace = excess_horizontal_space;
+    CSSPixels excess_inline_space = line_box.original_available_inline_size().to_px_or_zero() - line_box.inline_length();
+    CSSPixels excess_inline_space_including_whitespace = excess_inline_space;
     size_t whitespace_count = 0;
     for (auto& fragment : line_box.fragments()) {
         if (fragment.is_justifiable_whitespace()) {
             ++whitespace_count;
-            excess_horizontal_space_including_whitespace += fragment.inline_length();
+            excess_inline_space_including_whitespace += fragment.inline_length();
         }
     }
 
-    CSSPixels justified_space_width = whitespace_count > 0 ? (excess_horizontal_space_including_whitespace / whitespace_count) : 0;
+    CSSPixels justified_space_inline_size = whitespace_count > 0 ? (excess_inline_space_including_whitespace / whitespace_count) : 0;
 
     // This is the amount that each fragment will be offset by. If a whitespace
-    // fragment is shorter than the justified space width, it increases to push
+    // fragment is shorter than the justified space inline size, it increases to push
     // subsequent fragments, and decreases to pull them back otherwise.
     CSSPixels running_diff = 0;
     for (size_t i = 0; i < line_box.fragments().size(); ++i) {
@@ -585,14 +585,14 @@ void InlineFormattingContext::apply_justification_to_fragments(CSS::TextJustify 
         fragment.set_inline_offset(fragment.inline_offset() + running_diff);
 
         if (fragment.is_justifiable_whitespace()
-            && fragment.inline_length() != justified_space_width) {
-            auto diff = justified_space_width - fragment.inline_length();
+            && fragment.inline_length() != justified_space_inline_size) {
+            auto diff = justified_space_inline_size - fragment.inline_length();
             running_diff += diff;
             for (auto& marker : line_box.static_position_markers()) {
                 if (marker.inline_offset > fragment.inline_offset())
                     marker.inline_offset += diff;
             }
-            fragment.set_inline_length(justified_space_width);
+            fragment.set_inline_length(justified_space_inline_size);
         }
     }
 }
@@ -620,12 +620,12 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
     constexpr u32 ellipsis_codepoint = 0x2026;
 
     for (auto& line_box : line_boxes) {
-        // NB: Use the line box's original available width rather than the IFC's available space, since the line's
-        //     usable width may be reduced by float intrusions.
-        if (!line_box.original_available_width().is_definite())
+        // NB: Use the line box's original available inline size rather than the IFC's available space, since the
+        //     usable inline size may be reduced by float intrusions.
+        if (!line_box.original_available_inline_size().is_definite())
             continue;
-        auto available_width = line_box.original_available_width().to_px_or_zero();
-        if (line_box.inline_length() <= available_width)
+        auto available_inline_size = line_box.original_available_inline_size().to_px_or_zero();
+        if (line_box.inline_length() <= available_inline_size)
             continue;
 
         auto& fragments = line_box.fragments();
@@ -641,7 +641,7 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
             auto fragment_start = fragment.inline_offset();
             auto fragment_end = fragment_start + fragment.inline_length();
 
-            if (fragment_end <= available_width) {
+            if (fragment_end <= available_inline_size) {
                 line_has_visible_content = true;
                 continue;
             }
@@ -652,42 +652,42 @@ void InlineFormattingContext::apply_text_overflow_ellipsis(Vector<LineBox>& line
                 continue;
 
             auto& font = fragment.glyph_run()->font();
-            auto ellipsis_width = font.glyph_width(ellipsis_codepoint);
-            auto available_in_fragment = (available_width - fragment_start).to_float();
-            auto max_text_width = available_in_fragment - ellipsis_width;
+            auto ellipsis_inline_size = font.glyph_width(ellipsis_codepoint);
+            auto available_in_fragment = (available_inline_size - fragment_start).to_float();
+            auto max_text_inline_size = available_in_fragment - ellipsis_inline_size;
 
             auto& glyphs = fragment.glyph_run()->glyphs();
             size_t keep_count = 0;
             float last_kept_end = 0.f;
-            float y_position = 0.f;
+            float glyph_block_offset = 0.f;
 
             // https://drafts.csswg.org/css-overflow-4/#auto-ellipsis
             // The first character or atomic inline-level element on a line must be clipped rather than ellipsed.
             for (auto const& glyph : glyphs) {
                 auto glyph_end = glyph.position.x() + glyph.glyph_width;
-                if (glyph_end > max_text_width && (keep_count > 0 || line_has_visible_content))
+                if (glyph_end > max_text_inline_size && (keep_count > 0 || line_has_visible_content))
                     break;
                 keep_count++;
                 last_kept_end = glyph_end;
-                y_position = glyph.position.y();
+                glyph_block_offset = glyph.position.y();
             }
 
             if (keep_count < glyphs.size())
                 glyphs.remove(keep_count, glyphs.size() - keep_count);
 
             glyphs.append(Gfx::DrawGlyph {
-                .position = { last_kept_end, y_position },
+                .position = { last_kept_end, glyph_block_offset },
                 .length_in_code_units = AK::UnicodeUtils::code_unit_length_for_code_point(ellipsis_codepoint),
-                .glyph_width = ellipsis_width,
+                .glyph_width = ellipsis_inline_size,
                 .glyph_id = font.glyph_id_for_code_point(ellipsis_codepoint),
             });
 
-            fragment.set_inline_length(CSSPixels::nearest_value_for(last_kept_end + ellipsis_width));
+            fragment.set_inline_length(CSSPixels::nearest_value_for(last_kept_end + ellipsis_inline_size));
 
             for (size_t j = i + 1; j < fragments.size(); ++j)
                 fragments[j].set_fully_truncated(true);
 
-            line_box.m_inline_length = available_width;
+            line_box.m_inline_length = available_inline_size;
             line_box.clamp_static_position_markers_to_inline_length();
             break;
         }
@@ -704,8 +704,8 @@ void InlineFormattingContext::generate_line_boxes()
 
     InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, *m_layout_input, m_layout_mode);
     m_fragmented_inlines_in_pre_order = iterator.take_visited_fragmented_inlines();
-    auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
-    LineBuilder line_builder(*this, m_state, m_containing_block_used_values, containing_block_width, direction, writing_mode);
+    auto containing_block_inline_size = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
+    LineBuilder line_builder(*this, m_state, m_containing_block_used_values, containing_block_inline_size, direction, writing_mode);
 
     // NOTE: When we ignore collapsible whitespace chunks at the start of a line,
     //       we have to remember how much start margin, border and padding that chunk had
@@ -725,10 +725,10 @@ void InlineFormattingContext::generate_line_boxes()
         // Ignore collapsible whitespace chunks at the start of line, and if the last fragment already ends in whitespace.
         if (item.is_collapsible_whitespace && (line_boxes.is_empty() || line_boxes.last().is_empty_or_ends_in_whitespace() || line_boxes.last().has_block_level_box())) {
             if (item.style_source().computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
-                auto next_width = iterator.next_non_whitespace_sequence_width();
-                if (next_width > 0) {
+                auto next_inline_size = iterator.next_non_whitespace_sequence_inline_size();
+                if (next_inline_size > 0) {
                     line_builder.prepare_to_append_inline_content();
-                    line_builder.break_if_needed(next_width);
+                    line_builder.break_if_needed(next_inline_size);
                 }
             }
             leading_margin_from_collapsible_whitespace += item.margin_start;
@@ -761,7 +761,7 @@ void InlineFormattingContext::generate_line_boxes()
             line_builder.prepare_to_append_inline_content();
             compute_inset(box, content_box_rect(m_containing_block_used_values).size());
             if (containing_block().computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
-                auto minimum_space_needed_on_line = item.border_box_width();
+                auto minimum_space_needed_on_line = item.border_box_inline_size();
                 if (item.margin_start < 0)
                     minimum_space_needed_on_line += item.margin_start;
                 if (item.margin_end < 0)
@@ -803,7 +803,7 @@ void InlineFormattingContext::generate_line_boxes()
                 (void)parent().clear_floating_boxes(as<NodeWithStyle>(*item.node), *this, m_layout_input->content_box_position_in_bfc_root.value());
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
-                line_builder.set_unbreakable_run_width_interrupted_by_float(iterator.next_non_whitespace_sequence_width());
+                line_builder.set_unbreakable_run_inline_size_interrupted_by_float(iterator.next_non_whitespace_sequence_inline_size());
                 parent().layout_floating_box(*box, containing_block(), *m_layout_input, 0, &line_builder);
             }
             break;
@@ -814,21 +814,21 @@ void InlineFormattingContext::generate_line_boxes()
 
             if (text_node.parent()->computed_values().text_wrap_mode() == CSS::TextWrapMode::Wrap) {
                 bool is_whitespace = false;
-                CSSPixels next_width = 0;
+                CSSPixels next_inline_size = 0;
                 // If we're in a whitespace-collapsing context, we can simply check the flag.
                 if (item.is_collapsible_whitespace) {
                     is_whitespace = true;
-                    next_width = iterator.next_non_whitespace_sequence_width();
+                    next_inline_size = iterator.next_non_whitespace_sequence_inline_size();
                 } else {
                     // In whitespace-preserving contexts (white-space: pre*), we have to check manually.
                     auto view = text_node.text_for_rendering().substring_view(item.offset_in_node, item.length_in_node);
                     is_whitespace = view.is_ascii_whitespace();
                     if (is_whitespace)
-                        next_width = iterator.next_non_whitespace_sequence_width();
+                        next_inline_size = iterator.next_non_whitespace_sequence_inline_size();
                 }
 
                 // If whitespace caused us to break, don't put it on the next line.
-                if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width)) {
+                if (is_whitespace && next_inline_size > 0 && line_builder.break_if_needed(item.border_box_inline_size() + next_inline_size)) {
                     // Record that the previous line has trailing whitespace for text selection.
                     line_builder.set_trailing_whitespace_on_previous_line();
                     break;
@@ -838,7 +838,7 @@ void InlineFormattingContext::generate_line_boxes()
                 // If a shortened line box is too small to contain any content, then the line box is shifted downward
                 // (and its width recomputed) until either some content fits or there are no more floats present.
                 if (!is_whitespace && (item.can_break_before || line_boxes.last().is_empty()))
-                    line_builder.break_if_needed(item.border_box_width());
+                    line_builder.break_if_needed(item.border_box_inline_size());
             }
             line_builder.append_text_chunk(
                 text_node,
@@ -848,7 +848,7 @@ void InlineFormattingContext::generate_line_boxes()
                 item.padding_end + item.border_end,
                 item.margin_start,
                 item.margin_end,
-                item.width,
+                item.inline_size,
                 text_node.parent()->computed_values().line_height(),
                 move(item.glyph_run));
             break;
@@ -898,8 +898,8 @@ void InlineFormattingContext::generate_line_boxes()
 
                     if (box->display_before_box_type_transformation().is_block_outside()) {
                         auto block_position = marker.preceded_by_in_flow_content ? line_box.bottom() : marker.offset().y();
-                        auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
-                        static_position_rect.rect = { { 0, block_position }, { containing_block_width, 0 } };
+                        auto containing_block_inline_size = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
+                        static_position_rect.rect = { { 0, block_position }, { containing_block_inline_size, 0 } };
                     } else {
                         static_position_rect.rect = { marker.offset(), { 0, 0 } };
                     }
@@ -925,13 +925,13 @@ bool InlineFormattingContext::any_floats_intrude_in_block_range(CSSPixels block_
     return intrusions.left > 0 || intrusions.right > 0;
 }
 
-bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_height) const
+bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_block_size) const
 {
     // FIXME: Respect inline direction.
 
     if (!m_available_space->inline_size.is_definite())
         return true;
-    return available_space_for_line(block_offset, line_height).to_px_or_zero() > 0;
+    return available_space_for_line(block_offset, line_block_size).to_px_or_zero() > 0;
 }
 
 Optional<CSSPixels> InlineFormattingContext::next_float_band_block_start_after(CSSPixels block_offset) const

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -489,36 +489,36 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
                 - box_state.border_right
                 - box_state.margin_right;
 
-            auto preferred_width = calculate_max_content_width(box, box_constraints);
+            auto preferred_width = calculate_max_content_inline_size(box, box_constraints);
             if (preferred_width <= available_width) {
                 unconstrained_width = preferred_width;
             } else {
-                auto preferred_minimum_width = calculate_min_content_width(box, box_constraints);
+                auto preferred_minimum_width = calculate_min_content_inline_size(box, box_constraints);
                 unconstrained_width = min(max(preferred_minimum_width, available_width), preferred_width);
             }
         } else if (m_available_space->inline_size.is_min_content()) {
-            unconstrained_width = calculate_min_content_width(box, box_constraints);
+            unconstrained_width = calculate_min_content_inline_size(box, box_constraints);
         } else {
-            unconstrained_width = calculate_max_content_width(box, box_constraints);
+            unconstrained_width = calculate_max_content_inline_size(box, box_constraints);
         }
     } else {
         if (width_value.contains_percentage() && !m_available_space->inline_size.is_definite()) {
             // NOTE: We can't resolve percentages yet. We'll have to wait until after inner layout.
         } else {
-            auto inner_width = calculate_inner_width(box, m_available_space->inline_size, width_value, box_constraints);
+            auto inner_width = calculate_inner_inline_size(box, m_available_space->inline_size, width_value, box_constraints);
             unconstrained_width = inner_width;
         }
     }
 
     CSSPixels width = unconstrained_width;
     if (!should_treat_max_width_as_none(box, m_available_space->inline_size, box_constraints)) {
-        auto max_width = calculate_inner_width(box, m_available_space->inline_size, box.computed_values().max_width(), box_constraints);
+        auto max_width = calculate_inner_inline_size(box, m_available_space->inline_size, box.computed_values().max_width(), box_constraints);
         width = min(width, max_width);
     }
 
     auto computed_min_width = box.computed_values().min_width();
     if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, m_available_space->inline_size, computed_min_width, box_constraints);
+        auto min_width = calculate_inner_inline_size(box, m_available_space->inline_size, computed_min_width, box_constraints);
         width = max(width, min_width);
     }
 

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -901,7 +901,11 @@ void InlineFormattingContext::generate_line_boxes()
                         auto containing_block_inline_size = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
                         static_position_rect.rect = { { 0, block_position }, { containing_block_inline_size, 0 } };
                     } else {
-                        static_position_rect.rect = { marker.offset(), { 0, 0 } };
+                        auto physical_marker_offset = marker.offset();
+                        static_position_rect.rect = {
+                            { physical_marker_offset.x(), physical_marker_offset.y() },
+                            { 0, 0 },
+                        };
                     }
                     if (direction == CSS::Direction::Rtl)
                         static_position_rect.inline_alignment = StaticPositionRect::Alignment::End;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -524,11 +524,11 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     box_state.set_content_inline_size(width);
 
-    parent().resolve_used_height_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
+    parent().resolve_used_block_size_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
 
     // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
     if (box.display().is_flex_inside())
-        parent().resolve_used_height_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
+        parent().resolve_used_block_size_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()), box_constraints);
 
     make_button_content_box_definite(box, *m_available_space, box_constraints);
 
@@ -537,9 +537,9 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     if (should_treat_block_size_as_auto(box, *m_available_space, box_constraints)) {
         // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
-        parent().resolve_used_height_if_treated_as_auto(box, *m_available_space, box_constraints);
+        parent().resolve_used_block_size_if_treated_as_auto(box, *m_available_space, box_constraints);
     } else {
-        parent().resolve_used_height_if_not_treated_as_auto(box, *m_available_space, box_constraints);
+        parent().resolve_used_block_size_if_not_treated_as_auto(box, *m_available_space, box_constraints);
     }
 
     if (independent_formatting_context)

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -704,7 +704,7 @@ void InlineFormattingContext::generate_line_boxes()
 
     InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, *m_layout_input, m_layout_mode);
     m_fragmented_inlines_in_pre_order = iterator.take_visited_fragmented_inlines();
-    auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_width.value_or(0);
+    auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
     LineBuilder line_builder(*this, m_state, m_containing_block_used_values, containing_block_width, direction, writing_mode);
 
     // NOTE: When we ignore collapsible whitespace chunks at the start of a line,
@@ -799,7 +799,7 @@ void InlineFormattingContext::generate_line_boxes()
             if (auto* box = as_if<Box>(*item.node)) {
                 line_builder.commit_pending_margin_before_float();
                 if (!is<ListItemMarkerBox>(*box))
-                    m_state.create(*box, m_layout_input->containing_block_constraints.percentage_basis_width, m_layout_input->containing_block_constraints.percentage_basis_height);
+                    m_state.create(*box, m_layout_input->containing_block_constraints.percentage_basis_inline_size, m_layout_input->containing_block_constraints.percentage_basis_block_size);
                 (void)parent().clear_floating_boxes(as<NodeWithStyle>(*item.node), *this, m_layout_input->content_box_position_in_bfc_root.value());
                 // Even if this introduces clearance, we do NOT reset the margin state, because that is clearance
                 // between floats and does not contribute to the height of the Inline Formatting Context.
@@ -898,7 +898,7 @@ void InlineFormattingContext::generate_line_boxes()
 
                     if (box->display_before_box_type_transformation().is_block_outside()) {
                         auto block_position = marker.preceded_by_in_flow_content ? line_box.bottom() : marker.offset().y();
-                        auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_width.value_or(0);
+                        auto containing_block_width = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
                         static_position_rect.rect = { { 0, block_position }, { containing_block_width, 0 } };
                     } else {
                         static_position_rect.rect = { marker.offset(), { 0, 0 } };

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -44,7 +44,7 @@ BlockFormattingContext const& InlineFormattingContext::parent() const
 
 FormattingContext::SpaceUsedByFloats InlineFormattingContext::intrusion_by_floats_into_containing_block(CSSPixels block_start, CSSPixels block_end) const
 {
-    auto containing_block_position_in_root_now = m_layout_input->content_box_position_in_bfc_root->translated(0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
+    auto containing_block_position_in_root_now = m_layout_input->content_box_position_in_bfc_root->translated(0, parent().block_offset_adjustment_from_pending_ancestor_block_start_margins(containing_block()));
     return parent().intrusion_by_floats_into_rect({ containing_block_position_in_root_now, m_containing_block_used_values.content_size() }, block_start, block_end);
 }
 
@@ -95,7 +95,7 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     // NOTE: We ask the parent BFC to calculate the automatic content inline size of this IFC.
     //       This ensures that any floated boxes are taken into account.
     auto provisional_containing_block_position_in_root = m_layout_input->content_box_position_in_bfc_root->translated(
-        0, parent().y_adjustment_from_pending_ancestor_top_margins(containing_block()));
+        0, parent().block_offset_adjustment_from_pending_ancestor_block_start_margins(containing_block()));
     m_automatic_content_inline_size = parent().greatest_child_inline_size_in_rect(
         containing_block(), { provisional_containing_block_position_in_root, m_containing_block_used_values.content_size() });
     m_automatic_content_block_size = content_block_size;
@@ -750,7 +750,7 @@ void InlineFormattingContext::generate_line_boxes()
             if (item.node) {
                 auto introduce_clearance = parent().clear_floating_boxes(as<NodeWithStyle>(*item.node), *this, m_layout_input->content_box_position_in_bfc_root.value());
                 if (introduce_clearance == BlockFormattingContext::DidIntroduceClearance::Yes) {
-                    line_builder.did_introduce_clearance(vertical_float_clearance());
+                    line_builder.did_introduce_clearance(block_axis_float_clearance());
                     parent().reset_margin_state();
                 }
             }
@@ -936,21 +936,21 @@ bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_o
 
 Optional<CSSPixels> InlineFormattingContext::next_float_band_block_start_after(CSSPixels block_offset) const
 {
-    auto containing_block_y_in_root_now = m_layout_input->content_box_position_in_bfc_root->y() + parent().y_adjustment_from_pending_ancestor_top_margins(containing_block());
-    auto next_band_start = parent().next_float_band_block_start_after(containing_block_y_in_root_now + block_offset);
+    auto containing_block_block_offset_in_root_now = m_layout_input->content_box_position_in_bfc_root->y() + parent().block_offset_adjustment_from_pending_ancestor_block_start_margins(containing_block());
+    auto next_band_start = parent().next_float_band_block_start_after(containing_block_block_offset_in_root_now + block_offset);
     if (!next_band_start.has_value())
         return {};
-    return next_band_start.value() - containing_block_y_in_root_now;
+    return next_band_start.value() - containing_block_block_offset_in_root_now;
 }
 
-CSSPixels InlineFormattingContext::vertical_float_clearance() const
+CSSPixels InlineFormattingContext::block_axis_float_clearance() const
 {
-    return m_vertical_float_clearance;
+    return m_block_axis_float_clearance;
 }
 
-void InlineFormattingContext::set_vertical_float_clearance(CSSPixels vertical_float_clearance)
+void InlineFormattingContext::set_block_axis_float_clearance(CSSPixels block_axis_float_clearance)
 {
-    m_vertical_float_clearance = vertical_float_clearance;
+    m_block_axis_float_clearance = block_axis_float_clearance;
 }
 
 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -451,8 +451,8 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     auto const& box_constraints = m_layout_input->containing_block_constraints;
     if (box_is_sized_as_replaced_element(box, *m_available_space, box_constraints)) {
-        box_state.set_content_inline_size(compute_width_for_replaced_element(box, *m_available_space, box_constraints));
-        box_state.set_content_block_size(compute_height_for_replaced_element(box, *m_available_space, box_constraints));
+        box_state.set_content_inline_size(compute_inline_size_for_replaced_element(box, *m_available_space, box_constraints));
+        box_state.set_content_block_size(compute_block_size_for_replaced_element(box, *m_available_space, box_constraints));
 
         // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
         // The axis in which the preferred size calculation depends on this aspect ratio is called the ratio-dependent

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -86,10 +86,10 @@ void InlineFormattingContext::run(LayoutInput const& layout_input)
     auto const& line_boxes = m_containing_block_used_values.line_boxes;
     CSSPixels content_block_size = 0;
     if (any_of(line_boxes, [](auto& line_box) { return line_box.has_block_level_box(); })) {
-        content_block_size = line_boxes.last().bottom();
+        content_block_size = line_boxes.last().physical_vertical_end();
     } else {
         for (auto& line_box : line_boxes)
-            content_block_size += line_box.height();
+            content_block_size += line_box.physical_vertical_extent();
     }
 
     // NOTE: We ask the parent BFC to calculate the automatic content inline size of this IFC.
@@ -897,7 +897,7 @@ void InlineFormattingContext::generate_line_boxes()
                         continue;
 
                     if (box->display_before_box_type_transformation().is_block_outside()) {
-                        auto block_position = marker.preceded_by_in_flow_content ? line_box.bottom() : marker.offset().y();
+                        auto block_position = marker.preceded_by_in_flow_content ? line_box.physical_vertical_end() : marker.offset().y();
                         auto containing_block_inline_size = m_layout_input->containing_block_constraints.percentage_basis_inline_size.value_or(0);
                         static_position_rect.rect = { { 0, block_position }, { containing_block_inline_size, 0 } };
                     } else {

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -56,11 +56,11 @@ CSSPixels InlineFormattingContext::leftmost_inline_offset_at(CSSPixels block_off
 
 AvailableSize InlineFormattingContext::available_space_for_line(CSSPixels block_offset, CSSPixels line_height) const
 {
-    if (!m_available_space->width.is_definite())
-        return m_available_space->width;
+    if (!m_available_space->inline_size.is_definite())
+        return m_available_space->inline_size;
 
     auto intrusions = intrusion_by_floats_into_containing_block(block_offset, block_offset + line_height);
-    return AvailableSize::make_definite(m_available_space->width.to_px_or_zero() - intrusions.left - intrusions.right);
+    return AvailableSize::make_definite(m_available_space->inline_size.to_px_or_zero() - intrusions.left - intrusions.right);
 }
 
 CSSPixels InlineFormattingContext::automatic_content_width() const
@@ -419,7 +419,7 @@ void InlineFormattingContext::compute_inline_box_pieces()
 
 void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode layout_mode)
 {
-    auto width_of_containing_block = m_available_space->width.to_px_or_zero();
+    auto width_of_containing_block = m_available_space->inline_size.to_px_or_zero();
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
@@ -480,8 +480,8 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     auto const& width_value = box.computed_values().width();
     CSSPixels unconstrained_width = 0;
     if (should_treat_width_as_auto(box, *m_available_space)) {
-        if (m_available_space->width.is_definite()) {
-            auto available_width = m_available_space->width.to_px_or_zero()
+        if (m_available_space->inline_size.is_definite()) {
+            auto available_width = m_available_space->inline_size.to_px_or_zero()
                 - box_state.margin_left
                 - box_state.border_left
                 - box_state.padding_left
@@ -496,29 +496,29 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
                 auto preferred_minimum_width = calculate_min_content_width(box, box_constraints);
                 unconstrained_width = min(max(preferred_minimum_width, available_width), preferred_width);
             }
-        } else if (m_available_space->width.is_min_content()) {
+        } else if (m_available_space->inline_size.is_min_content()) {
             unconstrained_width = calculate_min_content_width(box, box_constraints);
         } else {
             unconstrained_width = calculate_max_content_width(box, box_constraints);
         }
     } else {
-        if (width_value.contains_percentage() && !m_available_space->width.is_definite()) {
+        if (width_value.contains_percentage() && !m_available_space->inline_size.is_definite()) {
             // NOTE: We can't resolve percentages yet. We'll have to wait until after inner layout.
         } else {
-            auto inner_width = calculate_inner_width(box, m_available_space->width, width_value, box_constraints);
+            auto inner_width = calculate_inner_width(box, m_available_space->inline_size, width_value, box_constraints);
             unconstrained_width = inner_width;
         }
     }
 
     CSSPixels width = unconstrained_width;
-    if (!should_treat_max_width_as_none(box, m_available_space->width, box_constraints)) {
-        auto max_width = calculate_inner_width(box, m_available_space->width, box.computed_values().max_width(), box_constraints);
+    if (!should_treat_max_width_as_none(box, m_available_space->inline_size, box_constraints)) {
+        auto max_width = calculate_inner_width(box, m_available_space->inline_size, box.computed_values().max_width(), box_constraints);
         width = min(width, max_width);
     }
 
     auto computed_min_width = box.computed_values().min_width();
     if (!computed_min_width.is_auto()) {
-        auto min_width = calculate_inner_width(box, m_available_space->width, computed_min_width, box_constraints);
+        auto min_width = calculate_inner_width(box, m_available_space->inline_size, computed_min_width, box_constraints);
         width = max(width, min_width);
     }
 
@@ -929,7 +929,7 @@ bool InlineFormattingContext::can_fit_new_line_at_block_offset(CSSPixels block_o
 {
     // FIXME: Respect inline direction.
 
-    if (!m_available_space->width.is_definite())
+    if (!m_available_space->inline_size.is_definite())
         return true;
     return available_space_for_line(block_offset, line_height).to_px_or_zero() > 0;
 }

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -457,7 +457,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
         // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
         // The axis in which the preferred size calculation depends on this aspect ratio is called the ratio-dependent
         // axis, and the resulting size is definite if its input sizes are also definite
-        auto const height_is_automatic = computed_values.height().is_auto() || should_treat_height_as_auto(box, *m_available_space, box_constraints);
+        auto const height_is_automatic = computed_values.height().is_auto() || should_treat_block_size_as_auto(box, *m_available_space, box_constraints);
         auto const height_resolved_from_aspect_ratio = box_state.has_definite_inline_size() && box.has_preferred_aspect_ratio() && height_is_automatic;
 
         if (height_resolved_from_aspect_ratio)
@@ -479,7 +479,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
 
     auto const& width_value = box.computed_values().width();
     CSSPixels unconstrained_width = 0;
-    if (should_treat_width_as_auto(box, *m_available_space)) {
+    if (should_treat_inline_size_as_auto(box, *m_available_space)) {
         if (m_available_space->inline_size.is_definite()) {
             auto available_width = m_available_space->inline_size.to_px_or_zero()
                 - box_state.margin_left
@@ -511,7 +511,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     }
 
     CSSPixels width = unconstrained_width;
-    if (!should_treat_max_width_as_none(box, m_available_space->inline_size, box_constraints)) {
+    if (!should_treat_max_inline_size_as_none(box, m_available_space->inline_size, box_constraints)) {
         auto max_width = calculate_inner_inline_size(box, m_available_space->inline_size, box.computed_values().max_width(), box_constraints);
         width = min(width, max_width);
     }
@@ -535,7 +535,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     auto child_layout_input = m_layout_input->for_child_formatting_context(box_state.available_inner_space_or_constraints_from(*m_available_space));
     auto independent_formatting_context = layout_inside(box, layout_mode, child_layout_input);
 
-    if (should_treat_height_as_auto(box, *m_available_space, box_constraints)) {
+    if (should_treat_block_size_as_auto(box, *m_available_space, box_constraints)) {
         // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
         parent().resolve_used_height_if_treated_as_auto(box, *m_available_space, box_constraints);
     } else {

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -25,8 +25,8 @@ public:
     BlockContainer const& containing_block() const { return static_cast<BlockContainer const&>(context_box()); }
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_height() const override;
-    virtual CSSPixels automatic_content_width() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
 
     void dimension_box_on_line(Box const&, LayoutMode);
 
@@ -54,8 +54,8 @@ private:
 
     Vector<NodeWithStyleAndBoxModelMetrics const*> m_fragmented_inlines_in_pre_order;
 
-    CSSPixels m_automatic_content_width { 0 };
-    CSSPixels m_automatic_content_height { 0 };
+    CSSPixels m_automatic_content_inline_size { 0 };
+    CSSPixels m_automatic_content_block_size { 0 };
 
     CSSPixels m_vertical_float_clearance { 0 };
 };

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -30,10 +30,10 @@ public:
 
     void dimension_box_on_line(Box const&, LayoutMode);
 
-    CSSPixels leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_height) const;
-    AvailableSize available_space_for_line(CSSPixels block_offset, CSSPixels line_height) const;
+    CSSPixels leftmost_inline_offset_at(CSSPixels block_offset, CSSPixels line_block_size) const;
+    AvailableSize available_space_for_line(CSSPixels block_offset, CSSPixels line_block_size) const;
     bool any_floats_intrude_in_block_range(CSSPixels block_start, CSSPixels block_end) const;
-    bool can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_height) const;
+    bool can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_block_size) const;
     Optional<CSSPixels> next_float_band_block_start_after(CSSPixels block_offset) const;
 
     CSSPixels vertical_float_clearance() const;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -36,8 +36,8 @@ public:
     bool can_fit_new_line_at_block_offset(CSSPixels block_offset, CSSPixels line_block_size) const;
     Optional<CSSPixels> next_float_band_block_start_after(CSSPixels block_offset) const;
 
-    CSSPixels vertical_float_clearance() const;
-    void set_vertical_float_clearance(CSSPixels);
+    CSSPixels block_axis_float_clearance() const;
+    void set_block_axis_float_clearance(CSSPixels);
 
 private:
     void generate_line_boxes();
@@ -57,7 +57,7 @@ private:
     CSSPixels m_automatic_content_inline_size { 0 };
     CSSPixels m_automatic_content_block_size { 0 };
 
-    CSSPixels m_vertical_float_clearance { 0 };
+    CSSPixels m_block_axis_float_clearance { 0 };
 };
 
 }

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -66,11 +66,11 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
 
     auto& used_values = is<ListItemMarkerBox>(node)
         ? m_layout_state.get_mutable(node)
-        : m_layout_state.create(node, m_layout_input.containing_block_constraints.percentage_basis_width, m_layout_input.containing_block_constraints.percentage_basis_height);
+        : m_layout_state.create(node, m_layout_input.containing_block_constraints.percentage_basis_inline_size, m_layout_input.containing_block_constraints.percentage_basis_block_size);
 
     auto const& computed_values = node.computed_values();
 
-    auto containing_block_width = m_layout_input.containing_block_constraints.percentage_basis_width.value_or(0);
+    auto containing_block_width = m_layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
 
     used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_width);
     used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_width);
@@ -441,7 +441,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         if (is<ListItemMarkerBox>(box)
             || (!m_box_model_node_stack.is_empty() && m_box_model_node_stack.last() == &box))
             return m_layout_state.get_mutable(box);
-        return m_layout_state.create(box, m_layout_input.containing_block_constraints.percentage_basis_width, m_layout_input.containing_block_constraints.percentage_basis_height);
+        return m_layout_state.create(box, m_layout_input.containing_block_constraints.percentage_basis_inline_size, m_layout_input.containing_block_constraints.percentage_basis_block_size);
     }();
     m_inline_formatting_context.dimension_box_on_line(box, m_layout_mode);
 

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -450,7 +450,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         .node = &box,
         .offset_in_node = 0,
         .length_in_node = 0,
-        .width = box_state.content_width(),
+        .width = box_state.content_inline_size(),
         .padding_start = box_state.padding_left,
         .padding_end = box_state.padding_right,
         .border_start = box_state.border_left,

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -42,12 +42,12 @@ void InlineLevelIterator::generate_all_items()
         if (!item.has_value())
             break;
 
-        // Track accumulated width for tab calculations.
+        // Track accumulated inline size for tab calculations.
         // Reset on forced breaks since tabs measure from line start.
         if (item->type == Item::Type::ForcedBreak || item->type == Item::Type::BlockLevelBox) {
-            m_accumulated_width_for_tabs = 0;
+            m_accumulated_inline_size_for_tabs = 0;
         } else {
-            m_accumulated_width_for_tabs += item->border_box_width();
+            m_accumulated_inline_size_for_tabs += item->border_box_inline_size();
         }
 
         m_items.append(item.release_value());
@@ -70,23 +70,23 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
 
     auto const& computed_values = node.computed_values();
 
-    auto containing_block_width = m_layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
+    auto containing_block_inline_size = m_layout_input.containing_block_constraints.percentage_basis_inline_size.value_or(0);
 
-    used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_width);
-    used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_width);
+    used_values.margin_top = computed_values.margin().top().to_px_or_zero(containing_block_inline_size);
+    used_values.margin_bottom = computed_values.margin().bottom().to_px_or_zero(containing_block_inline_size);
 
-    used_values.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_width);
+    used_values.margin_left = computed_values.margin().left().to_px_or_zero(containing_block_inline_size);
     used_values.border_left = computed_values.border_left().width;
-    used_values.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
+    used_values.padding_left = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
 
-    used_values.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_width);
+    used_values.margin_right = computed_values.margin().right().to_px_or_zero(containing_block_inline_size);
     used_values.border_right = computed_values.border_right().width;
-    used_values.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
+    used_values.padding_right = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 
     used_values.border_top = computed_values.border_top().width;
     used_values.border_bottom = computed_values.border_bottom().width;
-    used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_width);
-    used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_width);
+    used_values.padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_inline_size);
+    used_values.padding_top = computed_values.padding().top().to_px_or_zero(containing_block_inline_size);
 
     m_extra_leading_metrics->margin += used_values.margin_left;
     m_extra_leading_metrics->border += used_values.border_left;
@@ -185,9 +185,9 @@ Optional<InlineLevelIterator::Item&> InlineLevelIterator::next()
     return m_items[m_next_item_index++];
 }
 
-CSSPixels InlineLevelIterator::next_non_whitespace_sequence_width()
+CSSPixels InlineLevelIterator::next_non_whitespace_sequence_inline_size()
 {
-    CSSPixels next_width = 0;
+    CSSPixels next_inline_size = 0;
     for (size_t i = m_next_item_index; i < m_items.size(); ++i) {
         auto const& next_item = m_items[i];
         if (next_item.type == InlineLevelIterator::Item::Type::ForcedBreak || next_item.type == InlineLevelIterator::Item::Type::BlockLevelBox)
@@ -202,9 +202,9 @@ CSSPixels InlineLevelIterator::next_non_whitespace_sequence_width()
             if (next_view.is_ascii_whitespace())
                 break;
         }
-        next_width += next_item.border_box_width();
+        next_inline_size += next_item.border_box_inline_size();
     }
-    return next_width;
+    return next_inline_size;
 }
 
 Gfx::GlyphRun::TextType InlineLevelIterator::resolve_text_direction_from_context()
@@ -316,14 +316,14 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         // FIXME: We should apply word spacing to all word-separator characters not just breaking tabs
         auto word_spacing = text_node->parent()->computed_values().word_spacing();
 
-        auto x = 0.0f;
+        auto inline_offset = 0.0f;
         if (chunk.has_breaking_tab) {
-            // Use the accumulated width we've been tracking during pre-generation.
+            // Use the accumulated inline size we've been tracking during pre-generation.
             // This accounts for items that would appear before this tab on the same line.
-            CSSPixels accumulated_width = m_accumulated_width_for_tabs;
+            CSSPixels accumulated_inline_size = m_accumulated_inline_size_for_tabs;
 
             // https://drafts.csswg.org/css-text/#tab-size-property
-            auto tab_width = text_node->parent()->computed_values().tab_size().visit(
+            auto tab_inline_size = text_node->parent()->computed_values().tab_size().visit(
                 [&](CSSPixels const& css_pixels) -> CSSPixels {
                     return css_pixels;
                 },
@@ -332,13 +332,14 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
                 });
 
             // https://drafts.csswg.org/css-text/#white-space-phase-2
-            // if fragments have added to the width, calculate the net distance to the next tab stop, otherwise the shift will just be the tab width
-            auto tab_stop_dist = accumulated_width > 0 ? (ceil((accumulated_width / tab_width)) * tab_width) - accumulated_width : tab_width;
-            auto ch_width = chunk.font->glyph_width('0');
+            // If fragments have added to the inline size, calculate the net distance to the next tab stop;
+            // otherwise, the shift will just be the tab inline size.
+            auto tab_stop_dist = accumulated_inline_size > 0 ? (ceil((accumulated_inline_size / tab_inline_size)) * tab_inline_size) - accumulated_inline_size : tab_inline_size;
+            auto character_inline_size = chunk.font->glyph_width('0');
 
             // If this distance is less than 0.5ch, then the subsequent tab stop is used instead
-            if (tab_stop_dist < ch_width * 0.5)
-                tab_stop_dist += tab_width;
+            if (tab_stop_dist < character_inline_size * 0.5)
+                tab_stop_dist += tab_inline_size;
 
             // account for consecutive tabs
             auto num_of_tabs = 0;
@@ -351,12 +352,12 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
 
             // remove tabs, we don't want to render them when we shape the text
             chunk.view = chunk.view.substring_view(num_of_tabs);
-            x = tab_stop_dist.to_float();
+            inline_offset = tab_stop_dist.to_float();
         }
 
-        auto glyph_run = Gfx::shape_text({ x, 0 }, letter_spacing.to_float(), chunk.view, chunk.font, text_type);
+        auto glyph_run = Gfx::shape_text({ inline_offset, 0 }, letter_spacing.to_float(), chunk.view, chunk.font, text_type);
 
-        CSSPixels chunk_width = CSSPixels::nearest_value_for(glyph_run->width() + x);
+        CSSPixels chunk_inline_size = CSSPixels::nearest_value_for(glyph_run->width() + inline_offset);
 
         // NOTE: We never consider `content: ""` to be collapsible whitespace.
         bool is_generated_empty_string = is_empty_editable || (text_node->is_generated_for_pseudo_element() && chunk.length == 0);
@@ -368,7 +369,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
             .glyph_run = move(glyph_run),
             .offset_in_node = chunk.start,
             .length_in_node = chunk.length,
-            .width = chunk_width,
+            .inline_size = chunk_inline_size,
             .is_collapsible_whitespace = collapse_whitespace && chunk.is_all_whitespace && !is_generated_empty_string,
             .can_break_before = m_previous_chunk_can_break_after,
         };
@@ -450,7 +451,7 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::generate_next_item()
         .node = &box,
         .offset_in_node = 0,
         .length_in_node = 0,
-        .width = box_state.content_inline_size(),
+        .inline_size = box_state.content_inline_size(),
         .padding_start = box_state.padding_left,
         .padding_end = box_state.padding_right,
         .border_start = box_state.border_left,

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -15,7 +15,7 @@
 namespace Web::Layout {
 
 // This class iterates over all the inline-level objects within an inline formatting context.
-// By repeatedly calling next() with the remaining available width on the current line,
+// By repeatedly calling next() with the remaining available inline size on the current line,
 // it returns an "Item" representing the next piece of inline-level content to be placed on the line.
 class InlineLevelIterator {
     AK_MAKE_NONCOPYABLE(InlineLevelIterator);
@@ -36,7 +36,7 @@ public:
         RefPtr<Gfx::GlyphRun> glyph_run {};
         size_t offset_in_node { 0 };
         size_t length_in_node { 0 };
-        CSSPixels width { 0.0f };
+        CSSPixels inline_size { 0.0f };
         CSSPixels padding_start { 0.0f };
         CSSPixels padding_end { 0.0f };
         CSSPixels border_start { 0.0f };
@@ -49,9 +49,9 @@ public:
         // hasn't attached to any fragment yet. Only set for AbsolutelyPositionedElement items.
         bool preceded_by_unattached_inline_start_edges { false };
 
-        CSSPixels border_box_width() const
+        CSSPixels border_box_inline_size() const
         {
-            return border_start + padding_start + width + padding_end + border_end;
+            return border_start + padding_start + inline_size + padding_end + border_end;
         }
 
         NodeWithStyle const& style_source() const
@@ -66,7 +66,7 @@ public:
     InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutInput const&, LayoutMode);
 
     Optional<Item&> next();
-    CSSPixels next_non_whitespace_sequence_width();
+    CSSPixels next_non_whitespace_sequence_inline_size();
 
     Vector<NodeWithStyleAndBoxModelMetrics const*> take_visited_fragmented_inlines() { return move(m_visited_fragmented_inlines); }
 
@@ -122,8 +122,8 @@ private:
     Vector<Item> m_items;
     size_t m_next_item_index { 0 };
 
-    // Accumulated width tracking for tab calculations during pre-generation.
-    CSSPixels m_accumulated_width_for_tabs { 0 };
+    // Accumulated inline-size tracking for tab calculations during pre-generation.
+    CSSPixels m_accumulated_inline_size_for_tabs { 0 };
 
     bool m_previous_chunk_can_break_after { false };
 };

--- a/Libraries/LibWeb/Layout/LayoutInput.h
+++ b/Libraries/LibWeb/Layout/LayoutInput.h
@@ -13,9 +13,9 @@
 namespace Web::Layout {
 
 struct ContainingBlockConstraints {
-    Optional<CSSPixels> percentage_basis_width;
-    Optional<CSSPixels> percentage_basis_height;
-    Optional<CSSPixels> quirks_mode_percentage_basis_height;
+    Optional<CSSPixels> percentage_basis_inline_size;
+    Optional<CSSPixels> percentage_basis_block_size;
+    Optional<CSSPixels> quirks_mode_percentage_basis_block_size;
 };
 
 struct LayoutInput {

--- a/Libraries/LibWeb/Layout/LayoutInput.h
+++ b/Libraries/LibWeb/Layout/LayoutInput.h
@@ -19,11 +19,11 @@ struct ContainingBlockConstraints {
 };
 
 struct LayoutInput {
-    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {}, Optional<CSSPixelPoint> new_content_box_position_in_bfc_root = {}, Optional<CSSPixels> new_table_grid_min_border_box_height = {})
+    explicit LayoutInput(AvailableSpace new_available_space, ContainingBlockConstraints new_containing_block_constraints = {}, Optional<CSSPixelPoint> new_content_box_position_in_bfc_root = {}, Optional<CSSPixels> new_table_grid_min_border_box_block_size = {})
         : available_space(move(new_available_space))
         , containing_block_constraints(move(new_containing_block_constraints))
         , content_box_position_in_bfc_root(new_content_box_position_in_bfc_root)
-        , table_grid_min_border_box_height(new_table_grid_min_border_box_height)
+        , table_grid_min_border_box_block_size(new_table_grid_min_border_box_block_size)
     {
     }
 
@@ -34,19 +34,19 @@ struct LayoutInput {
 
     [[nodiscard]] LayoutInput with_content_box_position_in_bfc_root(Optional<CSSPixelPoint> position) const
     {
-        return LayoutInput { available_space, containing_block_constraints, position, table_grid_min_border_box_height };
+        return LayoutInput { available_space, containing_block_constraints, position, table_grid_min_border_box_block_size };
     }
 
-    [[nodiscard]] LayoutInput with_table_grid_min_border_box_height(CSSPixels height) const
+    [[nodiscard]] LayoutInput with_table_grid_min_border_box_block_size(CSSPixels block_size) const
     {
-        return LayoutInput { available_space, containing_block_constraints, content_box_position_in_bfc_root, height };
+        return LayoutInput { available_space, containing_block_constraints, content_box_position_in_bfc_root, block_size };
     }
 
     AvailableSpace const available_space;
     ContainingBlockConstraints const containing_block_constraints;
 
     Optional<CSSPixelPoint> const content_box_position_in_bfc_root;
-    Optional<CSSPixels> const table_grid_min_border_box_height;
+    Optional<CSSPixels> const table_grid_min_border_box_block_size;
 };
 
 }

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -88,7 +88,7 @@ LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
     return *used_values;
 }
 
-LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height)
+LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_inline_size, Optional<CSSPixels> percentage_basis_block_size)
 {
     auto index = node.layout_index();
     if (m_used_values_store.get(index)) {
@@ -99,7 +99,7 @@ LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional
     VERIFY(!m_subtree_root || m_subtree_root == &node || m_subtree_root->is_inclusive_ancestor_of(node));
 
     auto& used_values = m_used_values_store.allocate(index);
-    used_values.set_node(node, percentage_basis_width, percentage_basis_height);
+    used_values.set_node(node, percentage_basis_inline_size, percentage_basis_block_size);
 
     if (auto const* list_item_box = as_if<ListItemBox>(node); list_item_box && list_item_box->marker()) {
         auto const& marker = *list_item_box->marker();
@@ -496,7 +496,7 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
     return *this;
 }
 
-void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height)
+void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_inline_size, Optional<CSSPixels> percentage_basis_block_size)
 {
     m_node = &node;
 
@@ -512,7 +512,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
     auto const& computed_values = node.computed_values();
 
     auto containing_block_size_for_axis = [&](bool width) {
-        return width ? percentage_basis_width.value_or(0) : percentage_basis_height.value_or(0);
+        return width ? percentage_basis_inline_size.value_or(0) : percentage_basis_block_size.value_or(0);
     };
 
     auto adjust_for_box_sizing = [&](CSSPixels unadjusted_pixels, CSS::Size const& computed_size, bool width) -> CSSPixels {
@@ -525,14 +525,14 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
 
         if (width) {
             border_and_padding = computed_values.border_left().width
-                + computed_values.padding().left().to_px_or_zero(percentage_basis_width.value_or(0))
+                + computed_values.padding().left().to_px_or_zero(percentage_basis_inline_size.value_or(0))
                 + computed_values.border_right().width
-                + computed_values.padding().right().to_px_or_zero(percentage_basis_width.value_or(0));
+                + computed_values.padding().right().to_px_or_zero(percentage_basis_inline_size.value_or(0));
         } else {
             border_and_padding = computed_values.border_top().width
-                + computed_values.padding().top().to_px_or_zero(percentage_basis_width.value_or(0))
+                + computed_values.padding().top().to_px_or_zero(percentage_basis_inline_size.value_or(0))
                 + computed_values.border_bottom().width
-                + computed_values.padding().bottom().to_px_or_zero(percentage_basis_width.value_or(0));
+                + computed_values.padding().bottom().to_px_or_zero(percentage_basis_inline_size.value_or(0));
         }
 
         return unadjusted_pixels - border_and_padding;
@@ -545,7 +545,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
         // a size of the initial containing block,
         // or a <percentage> or other formula (such as the “stretch-fit” sizing of non-replaced blocks [CSS2]) that is resolved solely against definite sizes.
 
-        auto containing_block_has_definite_size = width ? percentage_basis_width.has_value() : percentage_basis_height.has_value();
+        auto containing_block_has_definite_size = width ? percentage_basis_inline_size.has_value() : percentage_basis_block_size.has_value();
 
         if (size.is_auto()) {
             // NOTE: The width of a non-flex-item block is considered definite if it's auto and the containing block has definite width.

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -106,8 +106,8 @@ LayoutState::UsedValues& LayoutState::create(NodeWithStyle const& node, Optional
         if (!m_used_values_store.get(marker.layout_index())) {
             auto& marker_used_values = m_used_values_store.allocate(marker.layout_index());
             marker_used_values.set_node(marker,
-                used_values.has_definite_width() ? Optional<CSSPixels> { used_values.content_width() } : Optional<CSSPixels> {},
-                used_values.has_definite_height() ? Optional<CSSPixels> { used_values.content_height() } : Optional<CSSPixels> {});
+                used_values.has_definite_inline_size() ? Optional<CSSPixels> { used_values.content_inline_size() } : Optional<CSSPixels> {},
+                used_values.has_definite_block_size() ? Optional<CSSPixels> { used_values.content_block_size() } : Optional<CSSPixels> {});
         }
     }
 
@@ -307,7 +307,7 @@ RefPtr<Painting::Paintable> LayoutState::commit_used_values_to_paintable(UsedVal
 
     transfer_box_model_metrics(paintable->box_model(), used_values);
 
-    paintable->set_content_size(used_values.content_width(), used_values.content_height());
+    paintable->set_content_size(used_values.content_inline_size(), used_values.content_block_size());
     if (used_values.override_borders_data().has_value())
         paintable->set_override_borders_data(used_values.override_borders_data().value());
     if (used_values.table_cell_coordinates().has_value())
@@ -328,7 +328,7 @@ RefPtr<Painting::Paintable> LayoutState::commit_used_values_to_paintable(UsedVal
             }
 
             lines.append({
-                .rect = rect_for_line_box(line_box, used_values.content_width()),
+                .rect = rect_for_line_box(line_box, used_values.content_inline_size()),
                 .fragment_count = static_cast<u32>(paintable_with_lines->fragments().size() - first_fragment_index),
             });
         }
@@ -457,8 +457,8 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
         return *this;
 
     m_content_offset = other.m_content_offset;
-    width_constraint = other.width_constraint;
-    height_constraint = other.height_constraint;
+    inline_size_constraint = other.inline_size_constraint;
+    block_size_constraint = other.block_size_constraint;
     margin_left = other.margin_left;
     margin_right = other.margin_right;
     margin_top = other.margin_top;
@@ -483,10 +483,10 @@ LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& ot
 
     m_node = other.m_node;
     m_cumulative_offset = other.m_cumulative_offset;
-    m_content_width = other.m_content_width;
-    m_content_height = other.m_content_height;
-    m_has_definite_width = other.m_has_definite_width;
-    m_has_definite_height = other.m_has_definite_height;
+    m_content_inline_size = other.m_content_inline_size;
+    m_content_block_size = other.m_content_block_size;
+    m_has_definite_inline_size = other.m_has_definite_inline_size;
+    m_has_definite_block_size = other.m_has_definite_block_size;
     m_materialized_from_paintable = other.m_materialized_from_paintable;
     if (other.m_rare)
         m_rare = make<RareData>(*other.m_rare);
@@ -507,7 +507,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
     //
     //       There are additional cases where CSS considers values to be definite. We model all of
     //       those by having our engine consider sizes to be definite *once they are assigned to
-    //       the UsedValues by calling set_content_width() or set_content_height().
+    //       the UsedValues by calling set_content_inline_size() or set_content_block_size().
 
     auto const& computed_values = node.computed_values();
 
@@ -604,21 +604,21 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
     CSSPixels max_height = 0;
     bool has_definite_max_height = is_definite_size(computed_values.max_height(), max_height, false);
 
-    m_has_definite_width = is_definite_size(computed_values.width(), m_content_width, true);
-    m_has_definite_height = is_definite_size(computed_values.height(), m_content_height, false);
+    m_has_definite_inline_size = is_definite_size(computed_values.width(), m_content_inline_size, true);
+    m_has_definite_block_size = is_definite_size(computed_values.height(), m_content_block_size, false);
 
-    if (m_has_definite_width) {
+    if (m_has_definite_inline_size) {
         if (has_definite_min_width)
-            m_content_width = clamp_to_max_dimension_value(max(min_width, m_content_width));
+            m_content_inline_size = clamp_to_max_dimension_value(max(min_width, m_content_inline_size));
         if (has_definite_max_width)
-            m_content_width = clamp_to_max_dimension_value(min(max_width, m_content_width));
+            m_content_inline_size = clamp_to_max_dimension_value(min(max_width, m_content_inline_size));
     }
 
-    if (m_has_definite_height) {
+    if (m_has_definite_block_size) {
         if (has_definite_min_height)
-            m_content_height = clamp_to_max_dimension_value(max(min_height, m_content_height));
+            m_content_block_size = clamp_to_max_dimension_value(max(min_height, m_content_block_size));
         if (has_definite_max_height)
-            m_content_height = clamp_to_max_dimension_value(min(max_height, m_content_height));
+            m_content_block_size = clamp_to_max_dimension_value(min(max_height, m_content_block_size));
     }
 }
 
@@ -628,10 +628,10 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::Paintable con
 
     auto const& box_model = paintable.box_model();
 
-    set_content_width(paintable.content_width());
-    set_content_height(paintable.content_height());
-    m_has_definite_width = true;
-    m_has_definite_height = true;
+    set_content_inline_size(paintable.content_width());
+    set_content_block_size(paintable.content_height());
+    m_has_definite_inline_size = true;
+    m_has_definite_block_size = true;
 
     m_content_offset = paintable.offset();
     m_cumulative_offset = paintable.absolute_rect().location();
@@ -664,7 +664,7 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::Paintable con
         set_computed_svg_transforms(svg_svg_paintable->computed_transforms());
 }
 
-void LayoutState::UsedValues::set_content_width(CSSPixels width)
+void LayoutState::UsedValues::set_content_inline_size(CSSPixels width)
 {
     VERIFY(!is_placed());
     if (width < 0) {
@@ -672,13 +672,13 @@ void LayoutState::UsedValues::set_content_width(CSSPixels width)
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative width for {}: {}", m_node->debug_description(), width);
         width = 0;
     }
-    m_content_width = clamp_to_max_dimension_value(width);
+    m_content_inline_size = clamp_to_max_dimension_value(width);
     // FIXME: We should not do this! Definiteness of widths should be determined early,
     //        and not changed later (except for some special cases in flex layout..)
-    m_has_definite_width = true;
+    m_has_definite_inline_size = true;
 }
 
-void LayoutState::UsedValues::set_content_height(CSSPixels height)
+void LayoutState::UsedValues::set_content_block_size(CSSPixels height)
 {
     VERIFY(!is_placed());
     if (height < 0) {
@@ -686,35 +686,35 @@ void LayoutState::UsedValues::set_content_height(CSSPixels height)
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative height for {}: {}", m_node->debug_description(), height);
         height = 0;
     }
-    m_content_height = clamp_to_max_dimension_value(height);
+    m_content_block_size = clamp_to_max_dimension_value(height);
 }
 
-AvailableSize LayoutState::UsedValues::available_width_inside() const
+AvailableSize LayoutState::UsedValues::available_inline_size_inside() const
 {
-    if (width_constraint == SizeConstraint::MinContent)
+    if (inline_size_constraint == SizeConstraint::MinContent)
         return AvailableSize::make_min_content();
-    if (width_constraint == SizeConstraint::MaxContent)
+    if (inline_size_constraint == SizeConstraint::MaxContent)
         return AvailableSize::make_max_content();
-    if (has_definite_width())
-        return AvailableSize::make_definite(m_content_width);
+    if (has_definite_inline_size())
+        return AvailableSize::make_definite(m_content_inline_size);
     return AvailableSize::make_indefinite();
 }
 
-AvailableSize LayoutState::UsedValues::available_height_inside() const
+AvailableSize LayoutState::UsedValues::available_block_size_inside() const
 {
-    if (height_constraint == SizeConstraint::MinContent)
+    if (block_size_constraint == SizeConstraint::MinContent)
         return AvailableSize::make_min_content();
-    if (height_constraint == SizeConstraint::MaxContent)
+    if (block_size_constraint == SizeConstraint::MaxContent)
         return AvailableSize::make_max_content();
-    if (has_definite_height())
-        return AvailableSize::make_definite(m_content_height);
+    if (has_definite_block_size())
+        return AvailableSize::make_definite(m_content_block_size);
     return AvailableSize::make_indefinite();
 }
 
 AvailableSpace LayoutState::UsedValues::available_inner_space_or_constraints_from(AvailableSpace const& outer_space) const
 {
-    auto inner_width = available_width_inside();
-    auto inner_height = available_height_inside();
+    auto inner_width = available_inline_size_inside();
+    auto inner_height = available_block_size_inside();
 
     if (inner_width.is_indefinite() && outer_space.inline_size.is_intrinsic_sizing_constraint())
         inner_width = outer_space.inline_size;
@@ -723,14 +723,14 @@ AvailableSpace LayoutState::UsedValues::available_inner_space_or_constraints_fro
     return AvailableSpace(inner_width, inner_height);
 }
 
-void LayoutState::UsedValues::set_indefinite_content_width()
+void LayoutState::UsedValues::set_indefinite_content_inline_size()
 {
-    m_has_definite_width = false;
+    m_has_definite_inline_size = false;
 }
 
-void LayoutState::UsedValues::set_indefinite_content_height()
+void LayoutState::UsedValues::set_indefinite_content_block_size()
 {
-    m_has_definite_height = false;
+    m_has_definite_block_size = false;
 }
 
 void LayoutState::register_contained_abspos_child(Box const& target, Box const& child, StaticPositionRect const& static_position_rect)

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -716,10 +716,10 @@ AvailableSpace LayoutState::UsedValues::available_inner_space_or_constraints_fro
     auto inner_width = available_width_inside();
     auto inner_height = available_height_inside();
 
-    if (inner_width.is_indefinite() && outer_space.width.is_intrinsic_sizing_constraint())
-        inner_width = outer_space.width;
-    if (inner_height.is_indefinite() && outer_space.height.is_intrinsic_sizing_constraint())
-        inner_height = outer_space.height;
+    if (inner_width.is_indefinite() && outer_space.inline_size.is_intrinsic_sizing_constraint())
+        inner_width = outer_space.inline_size;
+    if (inner_height.is_indefinite() && outer_space.block_size.is_intrinsic_sizing_constraint())
+        inner_height = outer_space.block_size;
     return AvailableSpace(inner_width, inner_height);
 }
 

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -49,17 +49,17 @@ static CSSPixelRect united_fragment_rect_for_line_box(LineBox const& line_box)
 
     auto writing_mode = line_box.fragments().first().writing_mode();
     if (writing_mode == CSS::WritingMode::HorizontalTb) {
-        rect.set_y(line_box.bottom() - line_box.height());
-        rect.set_height(line_box.height());
+        rect.set_y(line_box.physical_vertical_end() - line_box.physical_vertical_extent());
+        rect.set_height(line_box.physical_vertical_extent());
     }
 
     return rect;
 }
 
-static CSSPixelRect rect_for_line_box(LineBox const& line_box, CSSPixels containing_block_content_width)
+static CSSPixelRect rect_for_line_box(LineBox const& line_box, CSSPixels containing_block_content_inline_size)
 {
     if (line_box.fragments().is_empty())
-        return { 0, line_box.bottom() - line_box.height(), containing_block_content_width, line_box.height() };
+        return { 0, line_box.physical_vertical_end() - line_box.physical_vertical_extent(), containing_block_content_inline_size, line_box.physical_vertical_extent() };
     return united_fragment_rect_for_line_box(line_box);
 }
 

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -500,7 +500,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
 {
     m_node = &node;
 
-    // NOTE: In the code below, we decide if `node` has definite width and/or height.
+    // NOTE: In the code below, we decide if `node` has definite inline and/or block size.
     //       This attempts to cover all the *general* cases where CSS considers sizes to be definite.
     //       If `node` has definite values for min/max-width or min/max-height and a definite
     //       preferred size in the same axis, we clamp the preferred size here as well.
@@ -511,11 +511,11 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
 
     auto const& computed_values = node.computed_values();
 
-    auto containing_block_size_for_axis = [&](bool width) {
-        return width ? percentage_basis_inline_size.value_or(0) : percentage_basis_block_size.value_or(0);
+    auto containing_block_size_for_axis = [&](LogicalAxis axis) {
+        return axis == LogicalAxis::Inline ? percentage_basis_inline_size.value_or(0) : percentage_basis_block_size.value_or(0);
     };
 
-    auto adjust_for_box_sizing = [&](CSSPixels unadjusted_pixels, CSS::Size const& computed_size, bool width) -> CSSPixels {
+    auto adjust_for_box_sizing = [&](CSSPixels unadjusted_pixels, CSS::Size const& computed_size, LogicalAxis axis) -> CSSPixels {
         // box-sizing: content-box and/or automatic size don't require any adjustment.
         if (computed_values.box_sizing() == CSS::BoxSizing::ContentBox || computed_size.is_auto())
             return unadjusted_pixels;
@@ -523,7 +523,7 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
         // box-sizing: border-box requires us to subtract the relevant border and padding from the size.
         CSSPixels border_and_padding;
 
-        if (width) {
+        if (axis == LogicalAxis::Inline) {
             border_and_padding = computed_values.border_left().width
                 + computed_values.padding().left().to_px_or_zero(percentage_basis_inline_size.value_or(0))
                 + computed_values.border_right().width
@@ -538,21 +538,21 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
         return unadjusted_pixels - border_and_padding;
     };
 
-    auto is_definite_size = [&](CSS::Size const& size, CSSPixels& resolved_definite_size, bool width) {
+    auto is_definite_size = [&](CSS::Size const& size, CSSPixels& resolved_definite_size, LogicalAxis axis) {
         // A size that can be determined without performing layout; that is,
         // a <length>,
         // a measure of text (without consideration of line-wrapping),
         // a size of the initial containing block,
         // or a <percentage> or other formula (such as the “stretch-fit” sizing of non-replaced blocks [CSS2]) that is resolved solely against definite sizes.
 
-        auto containing_block_has_definite_size = width ? percentage_basis_inline_size.has_value() : percentage_basis_block_size.has_value();
+        auto containing_block_has_definite_size = axis == LogicalAxis::Inline ? percentage_basis_inline_size.has_value() : percentage_basis_block_size.has_value();
 
         if (size.is_auto()) {
-            // NOTE: The width of a non-flex-item block is considered definite if it's auto and the containing block has definite width.
+            // NOTE: The inline size of a non-flex-item block is considered definite if it is auto and the containing block has a definite inline size.
             //       This models the "stretch-fit" case from the css-sizing-3 definition of definite sizes quoted above.
-            //       It explicitly only covers non-replaced blocks; the automatic width of a replaced box is
+            //       It explicitly only covers non-replaced blocks; the automatic inline size of a replaced box is
             //       content-based and thus not definite before layout.
-            if (width
+            if (axis == LogicalAxis::Inline
                 && !node.is_replaced_box()
                 && !node.is_floating()
                 && !node.is_absolutely_positioned()
@@ -562,9 +562,9 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
                 && (node.parent()->display().is_flow_root_inside()
                     || node.parent()->display().is_flow_inside())) {
                 if (containing_block_has_definite_size) {
-                    CSSPixels available_width = containing_block_size_for_axis(true);
+                    CSSPixels available_inline_size = containing_block_size_for_axis(LogicalAxis::Inline);
                     resolved_definite_size = clamp_to_max_dimension_value(
-                        available_width
+                        available_inline_size
                         - margin_left
                         - margin_right
                         - padding_left
@@ -582,43 +582,43 @@ void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPi
             if (size.contains_percentage()) {
                 if (!containing_block_has_definite_size)
                     return false;
-                auto containing_block_size_as_length = containing_block_size_for_axis(width);
-                resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(containing_block_size_as_length), size, width));
+                auto containing_block_size_as_length = containing_block_size_for_axis(axis);
+                resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(containing_block_size_as_length), size, axis));
                 return true;
             }
 
-            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(CSSPixels { 0 }), size, width));
+            resolved_definite_size = clamp_to_max_dimension_value(adjust_for_box_sizing(size.to_px(CSSPixels { 0 }), size, axis));
             return true;
         }
 
         return false;
     };
 
-    CSSPixels min_width = 0;
-    bool has_definite_min_width = is_definite_size(computed_values.min_width(), min_width, true);
-    CSSPixels max_width = 0;
-    bool has_definite_max_width = is_definite_size(computed_values.max_width(), max_width, true);
+    CSSPixels min_inline_size = 0;
+    bool has_definite_min_inline_size = is_definite_size(computed_values.min_width(), min_inline_size, LogicalAxis::Inline);
+    CSSPixels max_inline_size = 0;
+    bool has_definite_max_inline_size = is_definite_size(computed_values.max_width(), max_inline_size, LogicalAxis::Inline);
 
-    CSSPixels min_height = 0;
-    bool has_definite_min_height = is_definite_size(computed_values.min_height(), min_height, false);
-    CSSPixels max_height = 0;
-    bool has_definite_max_height = is_definite_size(computed_values.max_height(), max_height, false);
+    CSSPixels min_block_size = 0;
+    bool has_definite_min_block_size = is_definite_size(computed_values.min_height(), min_block_size, LogicalAxis::Block);
+    CSSPixels max_block_size = 0;
+    bool has_definite_max_block_size = is_definite_size(computed_values.max_height(), max_block_size, LogicalAxis::Block);
 
-    m_has_definite_inline_size = is_definite_size(computed_values.width(), m_content_inline_size, true);
-    m_has_definite_block_size = is_definite_size(computed_values.height(), m_content_block_size, false);
+    m_has_definite_inline_size = is_definite_size(computed_values.width(), m_content_inline_size, LogicalAxis::Inline);
+    m_has_definite_block_size = is_definite_size(computed_values.height(), m_content_block_size, LogicalAxis::Block);
 
     if (m_has_definite_inline_size) {
-        if (has_definite_min_width)
-            m_content_inline_size = clamp_to_max_dimension_value(max(min_width, m_content_inline_size));
-        if (has_definite_max_width)
-            m_content_inline_size = clamp_to_max_dimension_value(min(max_width, m_content_inline_size));
+        if (has_definite_min_inline_size)
+            m_content_inline_size = clamp_to_max_dimension_value(max(min_inline_size, m_content_inline_size));
+        if (has_definite_max_inline_size)
+            m_content_inline_size = clamp_to_max_dimension_value(min(max_inline_size, m_content_inline_size));
     }
 
     if (m_has_definite_block_size) {
-        if (has_definite_min_height)
-            m_content_block_size = clamp_to_max_dimension_value(max(min_height, m_content_block_size));
-        if (has_definite_max_height)
-            m_content_block_size = clamp_to_max_dimension_value(min(max_height, m_content_block_size));
+        if (has_definite_min_block_size)
+            m_content_block_size = clamp_to_max_dimension_value(max(min_block_size, m_content_block_size));
+        if (has_definite_max_block_size)
+            m_content_block_size = clamp_to_max_dimension_value(min(max_block_size, m_content_block_size));
     }
 }
 
@@ -664,29 +664,29 @@ void LayoutState::UsedValues::materialize_from_paintable(Painting::Paintable con
         set_computed_svg_transforms(svg_svg_paintable->computed_transforms());
 }
 
-void LayoutState::UsedValues::set_content_inline_size(CSSPixels width)
+void LayoutState::UsedValues::set_content_inline_size(CSSPixels inline_size)
 {
     VERIFY(!is_placed());
-    if (width < 0) {
-        // Negative widths are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
-        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative width for {}: {}", m_node->debug_description(), width);
-        width = 0;
+    if (inline_size < 0) {
+        // Negative inline sizes are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
+        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative inline size for {}: {}", m_node->debug_description(), inline_size);
+        inline_size = 0;
     }
-    m_content_inline_size = clamp_to_max_dimension_value(width);
-    // FIXME: We should not do this! Definiteness of widths should be determined early,
+    m_content_inline_size = clamp_to_max_dimension_value(inline_size);
+    // FIXME: We should not do this! Definiteness of inline sizes should be determined early,
     //        and not changed later (except for some special cases in flex layout..)
     m_has_definite_inline_size = true;
 }
 
-void LayoutState::UsedValues::set_content_block_size(CSSPixels height)
+void LayoutState::UsedValues::set_content_block_size(CSSPixels block_size)
 {
     VERIFY(!is_placed());
-    if (height < 0) {
-        // Negative heights are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
-        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative height for {}: {}", m_node->debug_description(), height);
-        height = 0;
+    if (block_size < 0) {
+        // Negative block sizes are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
+        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Layout calculated a negative block size for {}: {}", m_node->debug_description(), block_size);
+        block_size = 0;
     }
-    m_content_block_size = clamp_to_max_dimension_value(height);
+    m_content_block_size = clamp_to_max_dimension_value(block_size);
 }
 
 AvailableSize LayoutState::UsedValues::available_inline_size_inside() const
@@ -713,14 +713,14 @@ AvailableSize LayoutState::UsedValues::available_block_size_inside() const
 
 AvailableSpace LayoutState::UsedValues::available_inner_space_or_constraints_from(AvailableSpace const& outer_space) const
 {
-    auto inner_width = available_inline_size_inside();
-    auto inner_height = available_block_size_inside();
+    auto inner_inline_size = available_inline_size_inside();
+    auto inner_block_size = available_block_size_inside();
 
-    if (inner_width.is_indefinite() && outer_space.inline_size.is_intrinsic_sizing_constraint())
-        inner_width = outer_space.inline_size;
-    if (inner_height.is_indefinite() && outer_space.block_size.is_intrinsic_sizing_constraint())
-        inner_height = outer_space.block_size;
-    return AvailableSpace(inner_width, inner_height);
+    if (inner_inline_size.is_indefinite() && outer_space.inline_size.is_intrinsic_sizing_constraint())
+        inner_inline_size = outer_space.inline_size;
+    if (inner_block_size.is_indefinite() && outer_space.block_size.is_intrinsic_sizing_constraint())
+        inner_block_size = outer_space.block_size;
+    return AvailableSpace(inner_inline_size, inner_block_size);
 }
 
 void LayoutState::UsedValues::set_indefinite_content_inline_size()

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -116,7 +116,7 @@ struct LayoutState {
 
         NodeWithStyle const& node() const { return *m_node; }
         NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
-        void set_node(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_width = {}, Optional<CSSPixels> percentage_basis_height = {});
+        void set_node(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_inline_size = {}, Optional<CSSPixels> percentage_basis_block_size = {});
 
         CSSPixels content_width() const { return m_content_width; }
         CSSPixels content_height() const { return m_content_height; }
@@ -383,7 +383,7 @@ struct LayoutState {
     UsedValues& get_mutable(NodeWithStyle const&);
     UsedValues const& get(NodeWithStyle const&) const;
 
-    UsedValues& create(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_width, Optional<CSSPixels> percentage_basis_height);
+    UsedValues& create(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_inline_size, Optional<CSSPixels> percentage_basis_block_size);
 
     UsedValues& populate_from_paintable(NodeWithStyle const&, Painting::Paintable const&);
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -118,21 +118,21 @@ struct LayoutState {
         NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
         void set_node(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_inline_size = {}, Optional<CSSPixels> percentage_basis_block_size = {});
 
-        CSSPixels content_width() const { return m_content_width; }
-        CSSPixels content_height() const { return m_content_height; }
-        void set_content_width(CSSPixels);
-        void set_content_height(CSSPixels);
+        CSSPixels content_inline_size() const { return m_content_inline_size; }
+        CSSPixels content_block_size() const { return m_content_block_size; }
+        void set_content_inline_size(CSSPixels);
+        void set_content_block_size(CSSPixels);
 
-        CSSPixelSize content_size() const { return { content_width(), content_height() }; }
+        CSSPixelSize content_size() const { return { content_inline_size(), content_block_size() }; }
 
-        void set_indefinite_content_width();
-        void set_indefinite_content_height();
+        void set_indefinite_content_inline_size();
+        void set_indefinite_content_block_size();
 
-        void set_has_definite_width(bool has_definite_width) { m_has_definite_width = has_definite_width; }
-        void set_has_definite_height(bool has_definite_height) { m_has_definite_height = has_definite_height; }
+        void set_has_definite_inline_size(bool has_definite_inline_size) { m_has_definite_inline_size = has_definite_inline_size; }
+        void set_has_definite_block_size(bool has_definite_block_size) { m_has_definite_block_size = has_definite_block_size; }
 
-        bool has_definite_width() const { return m_has_definite_width && width_constraint == SizeConstraint::None; }
-        bool has_definite_height() const { return m_has_definite_height && height_constraint == SizeConstraint::None; }
+        bool has_definite_inline_size() const { return m_has_definite_inline_size && inline_size_constraint == SizeConstraint::None; }
+        bool has_definite_block_size() const { return m_has_definite_block_size && block_size_constraint == SizeConstraint::None; }
 
         // Returns the available space for content inside this layout box.
         // If the space in an axis is indefinite, and the outer space is an intrinsic sizing constraint,
@@ -146,8 +146,8 @@ struct LayoutState {
 
         bool is_placed() const { return m_content_offset.has_value(); }
 
-        SizeConstraint width_constraint { SizeConstraint::None };
-        SizeConstraint height_constraint { SizeConstraint::None };
+        SizeConstraint inline_size_constraint { SizeConstraint::None };
+        SizeConstraint block_size_constraint { SizeConstraint::None };
 
         CSSPixels margin_left { 0 };
         CSSPixels margin_right { 0 };
@@ -185,19 +185,19 @@ struct LayoutState {
         CSSPixels margin_box_top() const { return margin_top + border_top_collapsed() + padding_top; }
         CSSPixels margin_box_bottom() const { return margin_bottom + border_bottom_collapsed() + padding_bottom; }
 
-        CSSPixels margin_box_width() const { return margin_box_left() + content_width() + margin_box_right(); }
-        CSSPixels margin_box_height() const { return margin_box_top() + content_height() + margin_box_bottom(); }
+        CSSPixels margin_box_width() const { return margin_box_left() + content_inline_size() + margin_box_right(); }
+        CSSPixels margin_box_height() const { return margin_box_top() + content_block_size() + margin_box_bottom(); }
 
         CSSPixels border_box_left() const { return border_left_collapsed() + padding_left; }
         CSSPixels border_box_right() const { return border_right_collapsed() + padding_right; }
         CSSPixels border_box_top() const { return border_top_collapsed() + padding_top; }
         CSSPixels border_box_bottom() const { return border_bottom_collapsed() + padding_bottom; }
 
-        CSSPixels border_box_width() const { return border_box_left() + content_width() + border_box_right(); }
-        CSSPixels border_box_height() const { return border_box_top() + content_height() + border_box_bottom(); }
+        CSSPixels border_box_width() const { return border_box_left() + content_inline_size() + border_box_right(); }
+        CSSPixels border_box_height() const { return border_box_top() + content_block_size() + border_box_bottom(); }
 
-        CSSPixels padding_box_width() const { return padding_left + content_width() + padding_right; }
-        CSSPixels padding_box_height() const { return padding_top + content_height() + padding_bottom; }
+        CSSPixels padding_box_width() const { return padding_left + content_inline_size() + padding_right; }
+        CSSPixels padding_box_height() const { return padding_top + content_block_size() + padding_bottom; }
 
         Optional<LineBoxFragmentCoordinate> containing_line_box_fragment;
 
@@ -294,8 +294,8 @@ struct LayoutState {
             m_content_offset = content_offset;
         }
 
-        AvailableSize available_width_inside() const;
-        AvailableSize available_height_inside() const;
+        AvailableSize available_inline_size_inside() const;
+        AvailableSize available_block_size_inside() const;
 
         bool use_collapsing_borders_model() const { return m_rare && m_rare->override_borders_data.has_value(); }
         // Implement the collapsing border model https://www.w3.org/TR/CSS22/tables.html#collapsing-borders.
@@ -346,11 +346,11 @@ struct LayoutState {
         Layout::NodeWithStyle const* m_node { nullptr };
         Optional<CSSPixelPoint> m_cumulative_offset;
 
-        CSSPixels m_content_width { 0 };
-        CSSPixels m_content_height { 0 };
+        CSSPixels m_content_inline_size { 0 };
+        CSSPixels m_content_block_size { 0 };
 
-        bool m_has_definite_width { false };
-        bool m_has_definite_height { false };
+        bool m_has_definite_inline_size { false };
+        bool m_has_definite_block_size { false };
         bool m_materialized_from_paintable { false };
 
         Optional<CSSPixelPoint> m_content_offset;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -143,6 +143,11 @@ struct LayoutState {
         bool is_materialized_from_paintable() const { return m_materialized_from_paintable; }
 
         CSSPixelPoint content_offset() const { return m_content_offset.value_or({}); }
+        LogicalOffset content_logical_offset() const
+        {
+            auto offset = content_offset();
+            return { offset.x(), offset.y() };
+        }
 
         bool is_placed() const { return m_content_offset.has_value(); }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -185,19 +185,19 @@ struct LayoutState {
         CSSPixels margin_box_top() const { return margin_top + border_top_collapsed() + padding_top; }
         CSSPixels margin_box_bottom() const { return margin_bottom + border_bottom_collapsed() + padding_bottom; }
 
-        CSSPixels margin_box_width() const { return margin_box_left() + content_inline_size() + margin_box_right(); }
-        CSSPixels margin_box_height() const { return margin_box_top() + content_block_size() + margin_box_bottom(); }
+        CSSPixels margin_box_inline_size() const { return margin_box_left() + content_inline_size() + margin_box_right(); }
+        CSSPixels margin_box_block_size() const { return margin_box_top() + content_block_size() + margin_box_bottom(); }
 
         CSSPixels border_box_left() const { return border_left_collapsed() + padding_left; }
         CSSPixels border_box_right() const { return border_right_collapsed() + padding_right; }
         CSSPixels border_box_top() const { return border_top_collapsed() + padding_top; }
         CSSPixels border_box_bottom() const { return border_bottom_collapsed() + padding_bottom; }
 
-        CSSPixels border_box_width() const { return border_box_left() + content_inline_size() + border_box_right(); }
-        CSSPixels border_box_height() const { return border_box_top() + content_block_size() + border_box_bottom(); }
+        CSSPixels border_box_inline_size() const { return border_box_left() + content_inline_size() + border_box_right(); }
+        CSSPixels border_box_block_size() const { return border_box_top() + content_block_size() + border_box_bottom(); }
 
-        CSSPixels padding_box_width() const { return padding_left + content_inline_size() + padding_right; }
-        CSSPixels padding_box_height() const { return padding_top + content_block_size() + padding_bottom; }
+        CSSPixels padding_box_inline_size() const { return padding_left + content_inline_size() + padding_right; }
+        CSSPixels padding_box_block_size() const { return padding_top + content_block_size() + padding_bottom; }
 
         Optional<LineBoxFragmentCoordinate> containing_line_box_fragment;
 

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -38,8 +38,8 @@ CSSPixels LineBox::bottom() const
 }
 
 void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size,
-    CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width,
-    CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run)
+    CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size,
+    CSSPixels content_block_size, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run)
 {
     auto const* layout_node_with_style = as_if<NodeWithStyle>(layout_node);
     auto const& style_source = layout_node_with_style ? *layout_node_with_style : *layout_node.parent();
@@ -51,15 +51,15 @@ void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length,
         // The fragment we're adding is from the last Layout::Node on the line.
         // Expand the last fragment instead of adding a new one with the same Layout::Node.
         m_fragments.last().m_length_in_code_units += length;
-        m_fragments.last().append_glyph_run(glyph_run, content_width);
+        m_fragments.last().append_glyph_run(glyph_run, content_inline_size);
     } else {
         CSSPixels inline_offset = leading_margin + leading_size + m_inline_length;
         CSSPixels block_offset = 0;
-        m_fragments.append(LineBoxFragment { layout_node, start, length, inline_offset, block_offset, content_width,
-            content_height, border_box_top, m_direction, m_writing_mode, move(glyph_run) });
+        m_fragments.append(LineBoxFragment { layout_node, start, length, inline_offset, block_offset, content_inline_size,
+            content_block_size, border_box_top, m_direction, m_writing_mode, move(glyph_run) });
     }
-    m_inline_length += leading_margin + leading_size + content_width + trailing_size + trailing_margin;
-    m_block_length = max(m_block_length, content_height + border_box_top + border_box_bottom);
+    m_inline_length += leading_margin + leading_size + content_inline_size + trailing_size + trailing_margin;
+    m_block_length = max(m_block_length, content_block_size + border_box_top + border_box_bottom);
 }
 
 void LineBox::add_static_position_marker(Box const& box, bool preceded_by_inline_box_start_edges)

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -16,30 +16,30 @@
 
 namespace Web::Layout {
 
-CSSPixels LineBox::width() const
+CSSPixels LineBox::physical_horizontal_extent() const
 {
     if (m_writing_mode != CSS::WritingMode::HorizontalTb)
         return m_block_length;
     return m_inline_length;
 }
 
-CSSPixels LineBox::height() const
+CSSPixels LineBox::physical_vertical_extent() const
 {
     if (m_writing_mode != CSS::WritingMode::HorizontalTb)
         return m_inline_length;
     return m_block_length;
 }
 
-CSSPixels LineBox::bottom() const
+CSSPixels LineBox::physical_vertical_end() const
 {
     if (m_writing_mode != CSS::WritingMode::HorizontalTb)
         return m_inline_length;
-    return m_bottom;
+    return m_block_end;
 }
 
 void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size,
     CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size,
-    CSSPixels content_block_size, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run)
+    CSSPixels content_block_size, CSSPixels border_box_block_start, CSSPixels border_box_block_end, RefPtr<Gfx::GlyphRun> glyph_run)
 {
     auto const* layout_node_with_style = as_if<NodeWithStyle>(layout_node);
     auto const& style_source = layout_node_with_style ? *layout_node_with_style : *layout_node.parent();
@@ -56,16 +56,16 @@ void LineBox::add_fragment(Node const& layout_node, size_t start, size_t length,
         CSSPixels inline_offset = leading_margin + leading_size + m_inline_length;
         CSSPixels block_offset = 0;
         m_fragments.append(LineBoxFragment { layout_node, start, length, inline_offset, block_offset, content_inline_size,
-            content_block_size, border_box_top, m_direction, m_writing_mode, move(glyph_run) });
+            content_block_size, border_box_block_start, m_direction, m_writing_mode, move(glyph_run) });
     }
     m_inline_length += leading_margin + leading_size + content_inline_size + trailing_size + trailing_margin;
-    m_block_length = max(m_block_length, content_block_size + border_box_top + border_box_bottom);
+    m_block_length = max(m_block_length, content_block_size + border_box_block_start + border_box_block_end);
 }
 
 void LineBox::add_static_position_marker(Box const& box, bool preceded_by_inline_box_start_edges)
 {
     // Inline box start edges count like content here: a line box holding an inline element with
-    // non-zero margin, border or padding is not a zero-height line box (CSS 2 § 9.4.2), so a
+    // non-zero margin, border or padding is not a zero-block-size line box (CSS 2 § 9.4.2), so a
     // block-level abspos after such an edge belongs below this line, not at its top.
     m_static_position_markers.append(StaticPositionMarker {
         .box = &box,

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -92,27 +92,27 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
         return white_space_collapse == CSS::WhiteSpaceCollapse::Collapse || white_space_collapse == CSS::WhiteSpaceCollapse::PreserveBreaks;
     };
 
-    CSSPixels whitespace_width = 0;
-    CSSPixels trailing_whitespace_width = 0;
+    CSSPixels whitespace_inline_size = 0;
+    CSSPixels trailing_whitespace_inline_size = 0;
     LineBoxFragment* last_fragment = nullptr;
     size_t fragment_index = m_fragments.size();
     for (;;) {
         if (fragment_index == 0)
-            return whitespace_width;
+            return whitespace_inline_size;
 
         last_fragment = &m_fragments[--fragment_index];
         if (auto const* dom_node = last_fragment->layout_node().dom_node()) {
             auto cursor_position = dom_node->document().cursor_position();
             if (cursor_position && cursor_position->node() == dom_node)
-                return whitespace_width;
+                return whitespace_inline_size;
         }
         if (!should_trim(last_fragment))
-            return whitespace_width;
+            return whitespace_inline_size;
         if (!last_fragment->is_justifiable_whitespace())
             break;
 
-        whitespace_width += last_fragment->inline_length();
-        trailing_whitespace_width += last_fragment->inline_length();
+        whitespace_inline_size += last_fragment->inline_length();
+        trailing_whitespace_inline_size += last_fragment->inline_length();
         if (should_remove == RemoveTrailingWhitespace::Yes) {
             m_inline_length -= last_fragment->inline_length();
             m_fragments.remove(fragment_index);
@@ -123,9 +123,9 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
     auto last_text = last_fragment->text();
     if (last_text.is_empty()) {
         // No text to trim, but we may have removed whitespace-only fragments.
-        if (should_remove == RemoveTrailingWhitespace::Yes && trailing_whitespace_width > 0)
+        if (should_remove == RemoveTrailingWhitespace::Yes && trailing_whitespace_inline_size > 0)
             last_fragment->set_has_trailing_whitespace(true);
-        return whitespace_width;
+        return whitespace_inline_size;
     }
 
     // Trim trailing whitespace characters from the last fragment.
@@ -136,13 +136,13 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
             break;
 
         auto const& font = last_fragment->glyph_run() ? last_fragment->glyph_run()->font() : last_fragment->layout_node().first_available_font();
-        CSSPixels last_character_width = CSSPixels(font.glyph_width(last_character)) + last_fragment->style_source().computed_values().letter_spacing();
-        whitespace_width += last_character_width;
-        trailing_whitespace_width += last_character_width;
+        CSSPixels last_character_inline_size = CSSPixels(font.glyph_width(last_character)) + last_fragment->style_source().computed_values().letter_spacing();
+        whitespace_inline_size += last_character_inline_size;
+        trailing_whitespace_inline_size += last_character_inline_size;
         if (should_remove == RemoveTrailingWhitespace::Yes) {
             --last_fragment->m_length_in_code_units;
-            last_fragment->set_inline_length(last_fragment->inline_length() - last_character_width);
-            m_inline_length -= last_character_width;
+            last_fragment->set_inline_length(last_fragment->inline_length() - last_character_inline_size);
+            m_inline_length -= last_character_inline_size;
             clamp_static_position_markers_to_inline_length();
         }
     }
@@ -150,14 +150,14 @@ CSSPixels LineBox::calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespac
     // Track trimmed whitespace for selection purposes, but don't overwrite a value
     // that was already set during line breaking (for wrapped lines).
     if (should_remove == RemoveTrailingWhitespace::Yes
-        && (trailing_whitespace_width > 0 || !last_fragment->has_trailing_whitespace())) {
-        last_fragment->set_has_trailing_whitespace(trailing_whitespace_width > 0);
+        && (trailing_whitespace_inline_size > 0 || !last_fragment->has_trailing_whitespace())) {
+        last_fragment->set_has_trailing_whitespace(trailing_whitespace_inline_size > 0);
     }
 
-    return whitespace_width;
+    return whitespace_inline_size;
 }
 
-CSSPixels LineBox::get_trailing_whitespace_width() const
+CSSPixels LineBox::trailing_whitespace_inline_size() const
 {
     return const_cast<LineBox&>(*this).calculate_or_trim_trailing_whitespace(RemoveTrailingWhitespace::No);
 }

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -44,7 +44,7 @@ public:
     CSSPixels block_length() const { return m_block_length; }
     CSSPixels baseline() const { return m_baseline; }
 
-    void add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run = {});
+    void add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size, CSSPixels content_block_size, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run = {});
     void add_static_position_marker(Box const&, bool preceded_by_inline_box_start_edges);
 
     Vector<LineBoxFragment> const& fragments() const { return m_fragments; }

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -52,7 +52,7 @@ public:
     Vector<StaticPositionMarker> const& static_position_markers() const { return m_static_position_markers; }
     Vector<StaticPositionMarker>& static_position_markers() { return m_static_position_markers; }
 
-    CSSPixels get_trailing_whitespace_width() const;
+    CSSPixels trailing_whitespace_inline_size() const;
     void trim_trailing_whitespace();
     void clamp_static_position_markers_to_inline_length();
 
@@ -62,7 +62,7 @@ public:
     bool has_block_level_box() const { return m_has_block_level_box; }
     CSSPixels block_level_box_bottom_margin() const { return m_block_level_box_bottom_margin; }
 
-    AvailableSize original_available_width() const { return m_original_available_width; }
+    AvailableSize original_available_inline_size() const { return m_original_available_inline_size; }
 
 private:
     friend class BlockContainer;
@@ -88,8 +88,9 @@ private:
     CSS::Direction m_direction { CSS::Direction::Ltr };
     CSS::WritingMode m_writing_mode { CSS::WritingMode::HorizontalTb };
 
-    // The amount of available width that was originally available when creating this line box. Used for text justification.
-    AvailableSize m_original_available_width { AvailableSize::make_indefinite() };
+    // The amount of available inline size that was originally available when creating this line box.
+    // Used for text justification.
+    AvailableSize m_original_available_inline_size { AvailableSize::make_indefinite() };
 
     bool m_has_break { false };
     bool m_has_forced_break { false };

--- a/Libraries/LibWeb/Layout/LineBox.h
+++ b/Libraries/LibWeb/Layout/LineBox.h
@@ -36,15 +36,14 @@ public:
     {
     }
 
-    CSSPixels width() const;
-    CSSPixels height() const;
-    CSSPixels bottom() const;
-
     CSSPixels inline_length() const { return m_inline_length; }
     CSSPixels block_length() const { return m_block_length; }
+    CSSPixels physical_horizontal_extent() const;
+    CSSPixels physical_vertical_extent() const;
+    CSSPixels physical_vertical_end() const;
     CSSPixels baseline() const { return m_baseline; }
 
-    void add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size, CSSPixels content_block_size, CSSPixels border_box_top, CSSPixels border_box_bottom, RefPtr<Gfx::GlyphRun> glyph_run = {});
+    void add_fragment(Node const& layout_node, size_t start, size_t length, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size, CSSPixels content_block_size, CSSPixels border_box_block_start, CSSPixels border_box_block_end, RefPtr<Gfx::GlyphRun> glyph_run = {});
     void add_static_position_marker(Box const&, bool preceded_by_inline_box_start_edges);
 
     Vector<LineBoxFragment> const& fragments() const { return m_fragments; }
@@ -60,7 +59,7 @@ public:
     bool is_empty() const { return m_fragments.is_empty() && !m_has_break; }
     bool has_forced_break() const { return m_has_forced_break; }
     bool has_block_level_box() const { return m_has_block_level_box; }
-    CSSPixels block_level_box_bottom_margin() const { return m_block_level_box_bottom_margin; }
+    CSSPixels block_level_box_block_end_margin() const { return m_block_level_box_block_end_margin; }
 
     AvailableSize original_available_inline_size() const { return m_original_available_inline_size; }
 
@@ -80,11 +79,11 @@ private:
     Vector<StaticPositionMarker> m_static_position_markers;
     CSSPixels m_inline_length { 0 };
     CSSPixels m_block_length { 0 };
-    CSSPixels m_bottom { 0 };
+    CSSPixels m_block_end { 0 };
     CSSPixels m_baseline { 0 };
     // For a line box holding an interrupting block-level box: the block's pending (collapsed) bottom margin,
-    // which is not included in m_bottom. Needed to size BFC roots whose last line is such a line.
-    CSSPixels m_block_level_box_bottom_margin { 0 };
+    // which is not included in m_block_end. Needed to size BFC roots whose last line is such a line.
+    CSSPixels m_block_level_box_block_end_margin { 0 };
     CSS::Direction m_direction { CSS::Direction::Ltr };
     CSS::WritingMode m_writing_mode { CSS::WritingMode::HorizontalTb };
 

--- a/Libraries/LibWeb/Layout/LineBoxFragment.cpp
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.cpp
@@ -14,7 +14,7 @@ namespace Web::Layout {
 
 LineBoxFragment::LineBoxFragment(Node const& layout_node, size_t start, size_t length_in_code_units,
     CSSPixels inline_offset, CSSPixels block_offset, CSSPixels inline_length, CSSPixels block_length,
-    CSSPixels border_box_top, CSS::Direction direction, CSS::WritingMode writing_mode, RefPtr<Gfx::GlyphRun> glyph_run)
+    CSSPixels border_box_block_start, CSS::Direction direction, CSS::WritingMode writing_mode, RefPtr<Gfx::GlyphRun> glyph_run)
     : m_layout_node(layout_node)
     , m_start(start)
     , m_length_in_code_units(length_in_code_units)
@@ -22,7 +22,7 @@ LineBoxFragment::LineBoxFragment(Node const& layout_node, size_t start, size_t l
     , m_block_offset(block_offset)
     , m_inline_length(inline_length)
     , m_block_length(block_length)
-    , m_border_box_top(border_box_top)
+    , m_border_box_block_start(border_box_block_start)
     , m_direction(direction)
     , m_writing_mode(writing_mode)
     , m_glyph_run(move(glyph_run))
@@ -95,19 +95,19 @@ CSS::Direction LineBoxFragment::resolve_glyph_run_direction(Gfx::GlyphRun::TextT
     }
 }
 
-void LineBoxFragment::append_glyph_run(RefPtr<Gfx::GlyphRun> const& glyph_run, CSSPixels run_width)
+void LineBoxFragment::append_glyph_run(RefPtr<Gfx::GlyphRun> const& glyph_run, CSSPixels run_inline_size)
 {
     switch (m_direction) {
     case CSS::Direction::Ltr:
-        append_glyph_run_ltr(glyph_run, run_width);
+        append_glyph_run_ltr(glyph_run, run_inline_size);
         break;
     case CSS::Direction::Rtl:
-        append_glyph_run_rtl(glyph_run, run_width);
+        append_glyph_run_rtl(glyph_run, run_inline_size);
         break;
     }
 }
 
-void LineBoxFragment::append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const& glyph_run, CSSPixels run_width)
+void LineBoxFragment::append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const& glyph_run, CSSPixels run_inline_size)
 {
     auto run_direction = resolve_glyph_run_direction(glyph_run->text_type());
     auto inline_offset = m_inline_length.to_float();
@@ -132,7 +132,7 @@ void LineBoxFragment::append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const& glyph_ru
     case CSS::Direction::Rtl:
         for (auto& glyph : m_glyph_run->glyphs()) {
             if (glyph.position.x() >= m_insert_position)
-                glyph.position.translate_by(run_width.to_float(), 0);
+                glyph.position.translate_by(run_inline_size.to_float(), 0);
         }
         for (auto const& glyph : glyph_run->glyphs()) {
             auto translated = glyph;
@@ -142,13 +142,13 @@ void LineBoxFragment::append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const& glyph_ru
         break;
     }
 
-    m_inline_length += run_width;
+    m_inline_length += run_inline_size;
 }
 
-void LineBoxFragment::append_glyph_run_rtl(RefPtr<Gfx::GlyphRun> const& glyph_run, CSSPixels run_width)
+void LineBoxFragment::append_glyph_run_rtl(RefPtr<Gfx::GlyphRun> const& glyph_run, CSSPixels run_inline_size)
 {
     auto run_direction = resolve_glyph_run_direction(glyph_run->text_type());
-    auto run_offset = run_width.to_float();
+    auto run_offset = run_inline_size.to_float();
 
     if (m_current_insert_direction != run_direction) {
         if (run_direction == CSS::Direction::Ltr)
@@ -183,8 +183,8 @@ void LineBoxFragment::append_glyph_run_rtl(RefPtr<Gfx::GlyphRun> const& glyph_ru
         break;
     }
 
-    m_inline_length += run_width;
-    m_insert_position += run_width.to_float();
+    m_inline_length += run_inline_size;
+    m_insert_position += run_inline_size.to_float();
 }
 
 }

--- a/Libraries/LibWeb/Layout/LineBoxFragment.h
+++ b/Libraries/LibWeb/Layout/LineBoxFragment.h
@@ -20,7 +20,7 @@ class LineBoxFragment {
     friend class LineBox;
 
 public:
-    LineBoxFragment(Node const& layout_node, size_t start, size_t length, CSSPixels inline_offset, CSSPixels block_offset, CSSPixels inline_length, CSSPixels block_length, CSSPixels border_box_top, CSS::Direction, CSS::WritingMode, RefPtr<Gfx::GlyphRun>);
+    LineBoxFragment(Node const& layout_node, size_t start, size_t length, CSSPixels inline_offset, CSSPixels block_offset, CSSPixels inline_length, CSSPixels block_length, CSSPixels border_box_block_start, CSS::Direction, CSS::WritingMode, RefPtr<Gfx::GlyphRun>);
 
     Node const& layout_node() const
     {
@@ -37,19 +37,19 @@ public:
     void set_inline_offset(CSSPixels inline_offset) { m_inline_offset = inline_offset; }
     void set_block_offset(CSSPixels block_offset) { m_block_offset = block_offset; }
 
-    // The baseline of a fragment is the number of pixels from the top to the text baseline.
-    void set_baseline(CSSPixels y) { m_baseline = y; }
+    // The baseline of a fragment is the distance from its block-start edge to the text baseline.
+    void set_baseline(CSSPixels block_offset) { m_baseline = block_offset; }
     CSSPixels baseline() const { return m_baseline; }
 
     CSSPixelSize size() const;
-    CSSPixels width() const { return size().width(); }
-    CSSPixels height() const { return size().height(); }
+    CSSPixels physical_horizontal_extent() const { return m_writing_mode != CSS::WritingMode::HorizontalTb ? m_block_length : m_inline_length; }
+    CSSPixels physical_vertical_extent() const { return m_writing_mode != CSS::WritingMode::HorizontalTb ? m_inline_length : m_block_length; }
     CSSPixels inline_length() const { return m_inline_length; }
     CSSPixels block_length() const { return m_block_length; }
     void set_inline_length(CSSPixels inline_length) { m_inline_length = inline_length; }
     void set_block_length(CSSPixels block_length) { m_block_length = block_length; }
 
-    CSSPixels border_box_top() const { return m_border_box_top; }
+    CSSPixels border_box_block_start() const { return m_border_box_block_start; }
 
     bool ends_in_whitespace() const;
     bool is_justifiable_whitespace() const;
@@ -59,7 +59,7 @@ public:
 
     RefPtr<Gfx::GlyphRun> glyph_run() const { return m_glyph_run; }
     CSS::WritingMode writing_mode() const { return m_writing_mode; }
-    void append_glyph_run(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_width);
+    void append_glyph_run(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_inline_size);
 
     bool has_trailing_whitespace() const { return m_has_trailing_whitespace; }
     void set_has_trailing_whitespace(bool value) { m_has_trailing_whitespace = value; }
@@ -69,8 +69,8 @@ public:
 
 private:
     CSS::Direction resolve_glyph_run_direction(Gfx::GlyphRun::TextType) const;
-    void append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_width);
-    void append_glyph_run_rtl(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_width);
+    void append_glyph_run_ltr(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_inline_size);
+    void append_glyph_run_rtl(RefPtr<Gfx::GlyphRun> const&, CSSPixels run_inline_size);
 
     WeakPtr<Node const> m_layout_node;
     size_t m_start { 0 };
@@ -79,7 +79,7 @@ private:
     CSSPixels m_block_offset;
     CSSPixels m_inline_length;
     CSSPixels m_block_length;
-    CSSPixels m_border_box_top { 0 };
+    CSSPixels m_border_box_block_start { 0 };
     CSSPixels m_baseline { 0 };
     CSS::Direction m_direction { CSS::Direction::Ltr };
     CSS::WritingMode m_writing_mode { CSS::WritingMode::HorizontalTb };

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -101,7 +101,7 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
     auto& line_box = ensure_last_line_box();
     line_box.add_fragment(box, 0, 0, leading_size, trailing_size, leading_margin, trailing_margin,
         box_state.content_inline_size(), box_state.content_block_size(), box_state.border_box_top(), box_state.border_box_bottom());
-    m_max_block_size_on_current_line = max(m_max_block_size_on_current_line, box_state.margin_box_height());
+    m_max_block_size_on_current_line = max(m_max_block_size_on_current_line, box_state.margin_box_block_size());
 
     box_state.containing_line_box_fragment = {};
 
@@ -193,7 +193,7 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
 
     line_box.m_fragments.append(LineBoxFragment { box, 0, 0, inline_offset, block_offset,
         inline_length, block_length, box_state.border_box_top(), m_direction, m_writing_mode, {} });
-    line_box.m_inline_length = is_horizontal ? box_state.margin_box_width() : box_state.margin_box_height();
+    line_box.m_inline_length = is_horizontal ? box_state.margin_box_inline_size() : box_state.margin_box_block_size();
     line_box.m_block_length = 0;
     line_box.m_bottom = block_bottom;
     line_box.m_baseline = 0;
@@ -226,7 +226,7 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
 CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
 {
     auto const& box_state = m_layout_state.get(box);
-    CSSPixels const inline_size = box_state.margin_box_width();
+    CSSPixels const inline_size = box_state.margin_box_inline_size();
 
     CSSPixels candidate_block_offset = m_current_block_offset;
 

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::Layout {
 
-LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_state, LayoutState::UsedValues& containing_block_used_values, CSSPixels containing_block_width, CSS::Direction direction, CSS::WritingMode writing_mode)
+LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_state, LayoutState::UsedValues& containing_block_used_values, CSSPixels containing_block_inline_size, CSS::Direction direction, CSS::WritingMode writing_mode)
     : m_context(context)
     , m_layout_state(layout_state)
     , m_containing_block_used_values(containing_block_used_values)
@@ -19,13 +19,13 @@ LineBuilder::LineBuilder(InlineFormattingContext& context, LayoutState& layout_s
     , m_writing_mode(writing_mode)
 {
     auto text_indent = m_context.containing_block().computed_values().text_indent();
-    m_text_indent = text_indent.length_percentage.to_px(containing_block_width);
+    m_text_indent = text_indent.length_percentage.to_px(containing_block_inline_size);
     m_text_indent_each_line = text_indent.each_line;
     m_text_indent_hanging = text_indent.hanging;
     begin_new_line(false);
 }
 
-void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_item_width)
+void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_item_inline_size)
 {
     // FIXME: Respect inline direction.
 
@@ -37,40 +37,40 @@ void LineBuilder::break_line(ForcedBreak forced_break, Optional<CSSPixels> next_
     update_last_line();
 
     size_t break_count = 0;
-    bool floats_intrude_at_current_y = false;
+    bool floats_intrude_at_current_block_offset = false;
     do {
         m_containing_block_used_values.line_boxes.append(LineBox(m_direction, m_writing_mode));
         begin_new_line(true, break_count == 0, forced_break);
         break_count++;
-        auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
-        floats_intrude_at_current_y = m_context.any_floats_intrude_in_block_range(m_current_block_offset, m_current_block_offset + current_line_height);
-    } while (floats_intrude_at_current_y
+        auto current_line_block_size = max(m_max_block_size_on_current_line, m_context.containing_block().computed_values().line_height());
+        floats_intrude_at_current_block_offset = m_context.any_floats_intrude_in_block_range(m_current_block_offset, m_current_block_offset + current_line_block_size);
+    } while (floats_intrude_at_current_block_offset
         && (!m_context.can_fit_new_line_at_block_offset(m_current_block_offset, m_context.containing_block().computed_values().line_height())
-            || (next_item_width.value_or(0) > m_available_width_for_current_line)));
+            || (next_item_inline_size.value_or(0) > m_available_inline_size_for_current_line)));
 }
 
-void LineBuilder::begin_new_line(bool increment_y, bool is_first_break_in_sequence, ForcedBreak forced_break)
+void LineBuilder::begin_new_line(bool advance_block_offset, bool is_first_break_in_sequence, ForcedBreak forced_break)
 {
-    if (increment_y) {
+    if (advance_block_offset) {
         if (is_first_break_in_sequence) {
             // First break is simple, just go to the start of the next line.
             if (m_should_advance_to_last_line_box_bottom && m_containing_block_used_values.line_boxes.size() > 1)
                 m_current_block_offset = m_containing_block_used_values.line_boxes[m_containing_block_used_values.line_boxes.size() - 2].bottom();
             else
-                m_current_block_offset += max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
+                m_current_block_offset += max(m_max_block_size_on_current_line, m_context.containing_block().computed_values().line_height());
         } else {
             // We're doing more than one break in a row.
             // This means we're trying to squeeze past intruding floats.
             if (auto next_band_start = m_context.next_float_band_block_start_after(m_current_block_offset); next_band_start.has_value())
                 m_current_block_offset = next_band_start.value();
             else
-                m_current_block_offset += max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
+                m_current_block_offset += max(m_max_block_size_on_current_line, m_context.containing_block().computed_values().line_height());
         }
     }
     recalculate_available_space();
     auto& line_box = ensure_last_line_box();
-    line_box.m_original_available_width = m_available_width_for_current_line;
-    m_max_height_on_current_line = 0;
+    line_box.m_original_available_inline_size = m_available_inline_size_for_current_line;
+    m_max_block_size_on_current_line = 0;
     m_last_line_needs_update = true;
     m_should_advance_to_last_line_box_bottom = false;
 
@@ -101,7 +101,7 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
     auto& line_box = ensure_last_line_box();
     line_box.add_fragment(box, 0, 0, leading_size, trailing_size, leading_margin, trailing_margin,
         box_state.content_inline_size(), box_state.content_block_size(), box_state.border_box_top(), box_state.border_box_bottom());
-    m_max_height_on_current_line = max(m_max_height_on_current_line, box_state.margin_box_height());
+    m_max_block_size_on_current_line = max(m_max_block_size_on_current_line, box_state.margin_box_height());
 
     box_state.containing_line_box_fragment = {};
 
@@ -124,7 +124,7 @@ void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_
     line_box.add_fragment(text_node, offset_in_node, length_in_node, leading_size, trailing_size, leading_margin,
         trailing_margin, content_inline_size, content_block_size, 0, 0, move(glyph_run));
 
-    m_max_height_on_current_line = max(m_max_height_on_current_line, line_box.block_length());
+    m_max_block_size_on_current_line = max(m_max_block_size_on_current_line, line_box.block_length());
 }
 
 void LineBuilder::append_static_position_marker(Box const& box, bool preceded_by_inline_box_start_edges)
@@ -215,7 +215,7 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
 
     m_pending_margin_follows_block_level_box = true;
     m_current_block_offset = block_bottom;
-    m_max_height_on_current_line = 0;
+    m_max_block_size_on_current_line = 0;
     m_last_line_needs_update = false;
     m_should_advance_to_last_line_box_bottom = false;
 
@@ -226,33 +226,33 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
 CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
 {
     auto const& box_state = m_layout_state.get(box);
-    CSSPixels const width = box_state.margin_box_width();
+    CSSPixels const inline_size = box_state.margin_box_width();
 
     CSSPixels candidate_block_offset = m_current_block_offset;
 
-    // Determine the current line width and subtract trailing whitespace, since those have not yet been removed while
+    // Determine the current line inline size and subtract trailing whitespace, since those have not yet been removed while
     // placing floating boxes.
     auto const& current_line = ensure_last_line_box();
-    auto current_line_width = current_line.width() - current_line.get_trailing_whitespace_width();
+    auto current_line_inline_size = current_line.width() - current_line.trailing_whitespace_inline_size();
 
     // A float interrupting an unbreakable run cannot let the remainder of the run overflow across it;
     // the remainder must also fit beside the float for the float to stay on this line.
-    auto width_needed_beside_float = current_line_width;
+    auto inline_size_needed_beside_float = current_line_inline_size;
     if (!current_line.is_empty_or_ends_in_whitespace())
-        width_needed_beside_float += m_unbreakable_run_width_interrupted_by_float;
-    m_unbreakable_run_width_interrupted_by_float = 0;
+        inline_size_needed_beside_float += m_unbreakable_run_inline_size_interrupted_by_float;
+    m_unbreakable_run_inline_size_interrupted_by_float = 0;
 
     // If there's already inline content on the current line, check if the new float can fit
     // alongside the content. If not, place it on the next line.
-    if (current_line_width > 0 && (width_needed_beside_float + width) > m_available_width_for_current_line)
+    if (current_line_inline_size > 0 && (inline_size_needed_beside_float + inline_size) > m_available_inline_size_for_current_line)
         candidate_block_offset += current_line.height();
 
     return max(candidate_block_offset, m_context.vertical_float_clearance());
 }
 
-bool LineBuilder::should_break(CSSPixels next_item_width)
+bool LineBuilder::should_break(CSSPixels next_item_inline_size)
 {
-    if (m_available_width_for_current_line.is_max_content())
+    if (m_available_inline_size_for_current_line.is_max_content())
         return false;
 
     auto const& line_boxes = m_containing_block_used_values.line_boxes;
@@ -263,8 +263,8 @@ bool LineBuilder::should_break(CSSPixels next_item_width)
         if (!m_context.any_floats_intrude_in_block_range(m_current_block_offset, m_current_block_offset + line_height))
             return false;
     }
-    auto current_line_width = ensure_last_line_box().width();
-    return (current_line_width + next_item_width) > m_available_width_for_current_line;
+    auto current_line_inline_size = ensure_last_line_box().width();
+    return (current_line_inline_size + next_item_inline_size) > m_available_inline_size_for_current_line;
 }
 
 void LineBuilder::update_last_line()
@@ -290,16 +290,16 @@ void LineBuilder::update_last_line()
     auto text_align = m_context.containing_block().computed_values().text_align();
     auto direction = m_context.containing_block().computed_values().direction();
 
-    auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
-    CSSPixels start_inline_offset = m_context.leftmost_inline_offset_at(m_current_block_offset, current_line_height);
+    auto current_line_block_size = max(m_max_block_size_on_current_line, m_context.containing_block().computed_values().line_height());
+    CSSPixels start_inline_offset = m_context.leftmost_inline_offset_at(m_current_block_offset, current_line_block_size);
     CSSPixels inline_offset = start_inline_offset;
     CSSPixels block_offset = 0;
 
     // FIXME: Respect inline direction.
-    CSSPixels excess_inline_space = m_available_width_for_current_line.to_px_or_zero() - line_box.inline_length();
+    CSSPixels excess_inline_space = m_available_inline_size_for_current_line.to_px_or_zero() - line_box.inline_length();
 
     if (m_writing_mode != CSS::WritingMode::HorizontalTb) {
-        block_offset = m_available_width_for_current_line.to_px_or_zero() - line_box.block_length();
+        block_offset = m_available_inline_size_for_current_line.to_px_or_zero() - line_box.block_length();
     }
 
     // If (after justification, if any) the inline contents of a line box are too long to fit within it,
@@ -561,10 +561,10 @@ void LineBuilder::remove_last_line_if_empty()
 
 void LineBuilder::recalculate_available_space()
 {
-    auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
-    m_available_width_for_current_line = m_context.available_space_for_line(m_current_block_offset, current_line_height);
+    auto current_line_block_size = max(m_max_block_size_on_current_line, m_context.containing_block().computed_values().line_height());
+    m_available_inline_size_for_current_line = m_context.available_space_for_line(m_current_block_offset, current_line_block_size);
     if (!m_containing_block_used_values.line_boxes.is_empty())
-        m_containing_block_used_values.line_boxes.last().m_original_available_width = m_available_width_for_current_line;
+        m_containing_block_used_values.line_boxes.last().m_original_available_inline_size = m_available_inline_size_for_current_line;
 }
 
 void LineBuilder::did_introduce_clearance(CSSPixels clearance)

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -54,8 +54,8 @@ void LineBuilder::begin_new_line(bool advance_block_offset, bool is_first_break_
     if (advance_block_offset) {
         if (is_first_break_in_sequence) {
             // First break is simple, just go to the start of the next line.
-            if (m_should_advance_to_last_line_box_bottom && m_containing_block_used_values.line_boxes.size() > 1)
-                m_current_block_offset = m_containing_block_used_values.line_boxes[m_containing_block_used_values.line_boxes.size() - 2].bottom();
+            if (m_should_advance_to_last_line_box_block_end && m_containing_block_used_values.line_boxes.size() > 1)
+                m_current_block_offset = m_containing_block_used_values.line_boxes[m_containing_block_used_values.line_boxes.size() - 2].physical_vertical_end();
             else
                 m_current_block_offset += max(m_max_block_size_on_current_line, m_context.containing_block().computed_values().line_height());
         } else {
@@ -72,7 +72,7 @@ void LineBuilder::begin_new_line(bool advance_block_offset, bool is_first_break_
     line_box.m_original_available_inline_size = m_available_inline_size_for_current_line;
     m_max_block_size_on_current_line = 0;
     m_last_line_needs_update = true;
-    m_should_advance_to_last_line_box_bottom = false;
+    m_should_advance_to_last_line_box_block_end = false;
 
     bool should_indent = m_containing_block_used_values.line_boxes.size() <= 1
         || (m_text_indent_each_line && forced_break == ForcedBreak::Yes);
@@ -178,7 +178,7 @@ void LineBuilder::finish_current_line_before_block_level_box()
     begin_new_line(true);
 }
 
-void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom, CSSPixels block_bottom_margin)
+void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_end, CSSPixels block_end_margin)
 {
     auto& box_state = m_layout_state.get_mutable(box);
     auto& line_box = ensure_last_line_box();
@@ -195,10 +195,10 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
         inline_length, block_length, box_state.border_box_top(), m_direction, m_writing_mode, {} });
     line_box.m_inline_length = is_horizontal ? box_state.margin_box_inline_size() : box_state.margin_box_block_size();
     line_box.m_block_length = 0;
-    line_box.m_bottom = block_bottom;
+    line_box.m_block_end = block_end;
     line_box.m_baseline = 0;
     line_box.m_has_block_level_box = true;
-    line_box.m_block_level_box_bottom_margin = block_bottom_margin;
+    line_box.m_block_level_box_block_end_margin = block_end_margin;
     line_box.m_has_break = true;
     // The interrupting block also ends the inline flow after itself; any content that follows starts on a fresh line.
     line_box.m_has_forced_break = true;
@@ -214,10 +214,10 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
         marker.block_offset += m_current_block_offset;
 
     m_pending_margin_follows_block_level_box = true;
-    m_current_block_offset = block_bottom;
+    m_current_block_offset = block_end;
     m_max_block_size_on_current_line = 0;
     m_last_line_needs_update = false;
-    m_should_advance_to_last_line_box_bottom = false;
+    m_should_advance_to_last_line_box_block_end = false;
 
     m_containing_block_used_values.line_boxes.append(LineBox(m_direction, m_writing_mode));
     begin_new_line(false);
@@ -233,7 +233,7 @@ CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
     // Determine the current line inline size and subtract trailing whitespace, since those have not yet been removed while
     // placing floating boxes.
     auto const& current_line = ensure_last_line_box();
-    auto current_line_inline_size = current_line.width() - current_line.trailing_whitespace_inline_size();
+    auto current_line_inline_size = current_line.physical_horizontal_extent() - current_line.trailing_whitespace_inline_size();
 
     // A float interrupting an unbreakable run cannot let the remainder of the run overflow across it;
     // the remainder must also fit beside the float for the float to stay on this line.
@@ -245,7 +245,7 @@ CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
     // If there's already inline content on the current line, check if the new float can fit
     // alongside the content. If not, place it on the next line.
     if (current_line_inline_size > 0 && (inline_size_needed_beside_float + inline_size) > m_available_inline_size_for_current_line)
-        candidate_block_offset += current_line.height();
+        candidate_block_offset += current_line.physical_vertical_extent();
 
     return max(candidate_block_offset, m_context.vertical_float_clearance());
 }
@@ -263,7 +263,7 @@ bool LineBuilder::should_break(CSSPixels next_item_inline_size)
         if (!m_context.any_floats_intrude_in_block_range(m_current_block_offset, m_current_block_offset + line_height))
             return false;
     }
-    auto current_line_inline_size = ensure_last_line_box().width();
+    auto current_line_inline_size = ensure_last_line_box().physical_horizontal_extent();
     return (current_line_inline_size + next_item_inline_size) > m_available_inline_size_for_current_line;
 }
 
@@ -280,7 +280,7 @@ void LineBuilder::update_last_line()
     auto& line_box = line_boxes.last();
 
     if (line_box.has_block_level_box()) {
-        m_should_advance_to_last_line_box_bottom = false;
+        m_should_advance_to_last_line_box_block_end = false;
         return;
     }
 
@@ -335,8 +335,8 @@ void LineBuilder::update_last_line()
     }
 
     auto baseline_for_font = [](Gfx::FontPixelMetrics const& font_metrics, CSSPixels line_height) {
-        auto const typographic_height = CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent);
-        auto const half_leading = (line_height - typographic_height) / 2;
+        auto const typographic_block_size = CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent);
+        auto const half_leading = (line_height - typographic_block_size) / 2;
         return CSSPixels::nearest_value_for(font_metrics.ascent) + half_leading;
     };
 
@@ -384,26 +384,26 @@ void LineBuilder::update_last_line()
         return line_box_baseline;
     }();
 
-    // Start with the "strut", an imaginary zero-width box at the start of each line box.
+    // Start with the "strut", an imaginary zero-inline-size box at the start of each line box.
     auto const strut_line_height = m_context.containing_block().computed_values().line_height();
-    auto strut_top = m_current_block_offset;
-    auto strut_bottom = should_align_strut_to_line_box_baseline
+    auto strut_block_start = m_current_block_offset;
+    auto strut_block_end = should_align_strut_to_line_box_baseline
         ? m_current_block_offset + line_box_baseline + (strut_line_height - strut_baseline)
         : m_current_block_offset + strut_line_height;
 
-    CSSPixels uppermost_box_top = strut_top;
-    CSSPixels lowermost_box_bottom = strut_bottom;
+    CSSPixels earliest_box_block_start = strut_block_start;
+    CSSPixels latest_box_block_end = strut_block_end;
 
     struct VerticalAlignMetrics {
         CSSPixels baseline { 0 };
-        CSSPixels height { 0 };
-        CSSPixels effective_box_top_offset { 0 };
-        CSSPixels effective_box_bottom_offset { 0 };
+        CSSPixels block_size { 0 };
+        CSSPixels effective_box_block_start_offset { 0 };
+        CSSPixels effective_box_block_end_offset { 0 };
         CSSPixels line_height { 0 };
     };
 
     auto block_offset_value_for_alignment = [&](Variant<CSS::VerticalAlign, CSS::LengthPercentage> const& vertical_align, VerticalAlignMetrics const& metrics) -> CSSPixels {
-        auto alphabetic_baseline = m_current_block_offset + line_box_baseline - metrics.baseline + metrics.effective_box_top_offset;
+        auto alphabetic_baseline = m_current_block_offset + line_box_baseline - metrics.baseline + metrics.effective_box_block_start_offset;
 
         if (auto const* length_percentage = vertical_align.get_pointer<CSS::LengthPercentage>())
             return alphabetic_baseline - length_percentage->to_px(metrics.line_height);
@@ -412,13 +412,13 @@ void LineBuilder::update_last_line()
         case CSS::VerticalAlign::Baseline:
             return alphabetic_baseline;
         case CSS::VerticalAlign::Top:
-            return m_current_block_offset + metrics.effective_box_top_offset;
+            return m_current_block_offset + metrics.effective_box_block_start_offset;
         case CSS::VerticalAlign::Middle: {
             // Align the vertical midpoint of the box with the baseline of the parent box
             // plus half the x-height of the parent.
             // FIXME: Per CSS2 §10.8.1 this should use the parent inline box's x-height, not the containing block's.
             auto const x_height = CSSPixels::nearest_value_for(m_context.containing_block().first_available_font().pixel_metrics().x_height);
-            return m_current_block_offset + line_box_baseline + ((metrics.effective_box_top_offset - metrics.effective_box_bottom_offset - x_height - metrics.height) / 2);
+            return m_current_block_offset + line_box_baseline + ((metrics.effective_box_block_start_offset - metrics.effective_box_block_end_offset - x_height - metrics.block_size) / 2);
         }
         case CSS::VerticalAlign::Sub:
             // https://drafts.csswg.org/css-inline/#valdef-baseline-shift-sub
@@ -446,9 +446,9 @@ void LineBuilder::update_last_line()
         auto const& used_values = m_layout_state.get(inline_box);
         return VerticalAlignMetrics {
             .baseline = baseline_for_font(inline_box.first_available_font().pixel_metrics(), line_height),
-            .height = line_height,
-            .effective_box_top_offset = used_values.border_box_top(),
-            .effective_box_bottom_offset = used_values.border_box_bottom(),
+            .block_size = line_height,
+            .effective_box_block_start_offset = used_values.border_box_top(),
+            .effective_box_block_end_offset = used_values.border_box_bottom(),
             .line_height = line_height,
         };
     };
@@ -458,15 +458,15 @@ void LineBuilder::update_last_line()
 
         VerticalAlignMetrics fragment_metrics {
             .baseline = fragment.baseline(),
-            .height = fragment.height(),
-            .effective_box_top_offset = fragment.border_box_top(),
-            .effective_box_bottom_offset = fragment.border_box_top(),
+            .block_size = fragment.physical_vertical_extent(),
+            .effective_box_block_start_offset = fragment.border_box_block_start(),
+            .effective_box_block_end_offset = fragment.border_box_block_start(),
             .line_height = fragment.style_source().computed_values().line_height(),
         };
         if (fragment.is_atomic_inline()) {
             auto const& fragment_box_state = m_layout_state.get(static_cast<Box const&>(fragment.layout_node()));
-            fragment_metrics.effective_box_top_offset = fragment_box_state.margin_box_top();
-            fragment_metrics.effective_box_bottom_offset = fragment_box_state.margin_box_bottom();
+            fragment_metrics.effective_box_block_start_offset = fragment_box_state.margin_box_top();
+            fragment_metrics.effective_box_block_end_offset = fragment_box_state.margin_box_bottom();
         }
 
         // Position the fragment according to the vertical-align of its own styled inline element.
@@ -501,38 +501,38 @@ void LineBuilder::update_last_line()
         fragment.set_inline_offset(new_fragment_inline_offset);
         fragment.set_block_offset(floor(new_fragment_block_offset) + block_offset);
 
-        CSSPixels top_of_inline_box = 0;
-        CSSPixels bottom_of_inline_box = 0;
+        CSSPixels inline_box_block_start = 0;
+        CSSPixels inline_box_block_end = 0;
         {
             // FIXME: Support inline-table elements.
             if (fragment.is_atomic_inline()) {
                 auto const& fragment_box_state = m_layout_state.get(static_cast<Box const&>(fragment.layout_node()));
-                top_of_inline_box = (fragment.block_offset() - fragment_box_state.margin_box_top());
-                bottom_of_inline_box = (fragment.block_offset() + fragment_box_state.content_block_size() + fragment_box_state.margin_box_bottom());
+                inline_box_block_start = (fragment.block_offset() - fragment_box_state.margin_box_top());
+                inline_box_block_end = (fragment.block_offset() + fragment_box_state.content_block_size() + fragment_box_state.margin_box_bottom());
             } else {
                 auto font_metrics = fragment.layout_node().first_available_font().pixel_metrics();
-                auto typographic_height = CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent);
-                auto leading = fragment.style_source().computed_values().line_height() - typographic_height;
+                auto typographic_block_size = CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent);
+                auto leading = fragment.style_source().computed_values().line_height() - typographic_block_size;
                 auto half_leading = leading / 2;
-                top_of_inline_box = (fragment.block_offset() + fragment.baseline() - CSSPixels::nearest_value_for(font_metrics.ascent) - half_leading);
-                bottom_of_inline_box = (fragment.block_offset() + fragment.baseline() + CSSPixels::nearest_value_for(font_metrics.descent) + half_leading);
+                inline_box_block_start = (fragment.block_offset() + fragment.baseline() - CSSPixels::nearest_value_for(font_metrics.ascent) - half_leading);
+                inline_box_block_end = (fragment.block_offset() + fragment.baseline() + CSSPixels::nearest_value_for(font_metrics.descent) + half_leading);
             }
             if (auto const* length_percentage = fragment.style_source().computed_values().vertical_align().get_pointer<CSS::LengthPercentage>()) {
-                bottom_of_inline_box += length_percentage->to_px(fragment.style_source().computed_values().line_height());
+                inline_box_block_end += length_percentage->to_px(fragment.style_source().computed_values().line_height());
             }
         }
 
-        uppermost_box_top = min(uppermost_box_top, top_of_inline_box);
-        lowermost_box_bottom = max(lowermost_box_bottom, bottom_of_inline_box);
+        earliest_box_block_start = min(earliest_box_block_start, inline_box_block_start);
+        latest_box_block_end = max(latest_box_block_end, inline_box_block_end);
 
         // FIXME: Also anchor text fragment boxes to the font baseline in vertical writing modes.
         if (fragment.layout_node().is_text_node() && m_writing_mode == CSS::WritingMode::HorizontalTb) {
             auto const& font_metrics = fragment.layout_node().first_available_font().pixel_metrics();
-            auto const font_box_height = CSS::ComputedProperties::normal_line_height(font_metrics);
-            auto const font_baseline = baseline_for_font(font_metrics, font_box_height);
+            auto const font_box_block_size = CSS::ComputedProperties::normal_line_height(font_metrics);
+            auto const font_baseline = baseline_for_font(font_metrics, font_box_block_size);
             fragment.set_block_offset(fragment.block_offset() + fragment.baseline() - font_baseline);
             fragment.set_baseline(font_baseline);
-            fragment.set_block_length(font_box_height);
+            fragment.set_block_length(font_box_block_size);
         }
     }
 
@@ -541,17 +541,17 @@ void LineBuilder::update_last_line()
         marker.block_offset += block_offset + m_current_block_offset;
     }
 
-    // 3. The line box height is the distance between the uppermost box top and the lowermost box bottom.
-    line_box.m_block_length = lowermost_box_bottom - uppermost_box_top;
-    m_should_advance_to_last_line_box_bottom = should_align_strut_to_line_box_baseline;
+    // 3. The line box block size is the distance between the earliest box block start and latest box block end.
+    line_box.m_block_length = latest_box_block_end - earliest_box_block_start;
+    m_should_advance_to_last_line_box_block_end = should_align_strut_to_line_box_baseline;
 
-    line_box.m_bottom = m_current_block_offset + line_box.m_block_length;
+    line_box.m_block_end = m_current_block_offset + line_box.m_block_length;
     line_box.m_baseline = line_box_baseline;
 }
 
 void LineBuilder::remove_last_line_if_empty()
 {
-    // If there's an empty line box at the bottom, just remove it instead of giving it height.
+    // If there is an empty line box at the block end, remove it instead of giving it block size.
     auto& line_boxes = m_containing_block_used_values.line_boxes;
     if (!line_boxes.is_empty() && line_boxes.last().is_empty()) {
         line_boxes.take_last();
@@ -573,12 +573,12 @@ void LineBuilder::did_introduce_clearance(CSSPixels clearance)
     if (clearance <= m_current_block_offset)
         return;
 
-    // Increase the height of the previous line box so it matches the clearance, because the element's height is first
-    // determined by the bottom of the last line box (after trimming empty/whitespace boxes).
+    // Increase the block end of the previous line box so it matches the clearance, because the element's block size is
+    // first determined by the block end of the last line box (after trimming empty/whitespace boxes).
     auto& line_boxes = m_containing_block_used_values.line_boxes;
     if (line_boxes.size() > 1) {
         auto& previous_line_box = line_boxes[line_boxes.size() - 2];
-        previous_line_box.m_bottom = clearance;
+        previous_line_box.m_block_end = clearance;
     }
 
     // The current line box will start directly after any cleared floats.

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -100,7 +100,7 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
     auto& box_state = m_layout_state.get_mutable(box);
     auto& line_box = ensure_last_line_box();
     line_box.add_fragment(box, 0, 0, leading_size, trailing_size, leading_margin, trailing_margin,
-        box_state.content_width(), box_state.content_height(), box_state.border_box_top(), box_state.border_box_bottom());
+        box_state.content_inline_size(), box_state.content_block_size(), box_state.border_box_top(), box_state.border_box_bottom());
     m_max_height_on_current_line = max(m_max_height_on_current_line, box_state.margin_box_height());
 
     box_state.containing_line_box_fragment = {};
@@ -116,13 +116,13 @@ void LineBuilder::append_box(Box const& box, CSSPixels leading_size, CSSPixels t
     }
 }
 
-void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun> glyph_run)
+void LineBuilder::append_text_chunk(TextNode const& text_node, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size, CSSPixels content_block_size, RefPtr<Gfx::GlyphRun> glyph_run)
 {
     prepare_to_append_inline_content();
 
     auto& line_box = ensure_last_line_box();
     line_box.add_fragment(text_node, offset_in_node, length_in_node, leading_size, trailing_size, leading_margin,
-        trailing_margin, content_width, content_height, 0, 0, move(glyph_run));
+        trailing_margin, content_inline_size, content_block_size, 0, 0, move(glyph_run));
 
     m_max_height_on_current_line = max(m_max_height_on_current_line, line_box.block_length());
 }
@@ -188,8 +188,8 @@ void LineBuilder::append_block_level_box(Box const& box, CSSPixels block_bottom,
     auto is_horizontal = m_writing_mode == CSS::WritingMode::HorizontalTb;
     auto inline_offset = is_horizontal ? box_state.content_offset().x() : box_state.content_offset().y();
     auto block_offset = is_horizontal ? box_state.content_offset().y() : box_state.content_offset().x();
-    auto inline_length = is_horizontal ? box_state.content_width() : box_state.content_height();
-    auto block_length = is_horizontal ? box_state.content_height() : box_state.content_width();
+    auto inline_length = is_horizontal ? box_state.content_inline_size() : box_state.content_block_size();
+    auto block_length = is_horizontal ? box_state.content_block_size() : box_state.content_inline_size();
 
     line_box.m_fragments.append(LineBoxFragment { box, 0, 0, inline_offset, block_offset,
         inline_length, block_length, box_state.border_box_top(), m_direction, m_writing_mode, {} });
@@ -508,7 +508,7 @@ void LineBuilder::update_last_line()
             if (fragment.is_atomic_inline()) {
                 auto const& fragment_box_state = m_layout_state.get(static_cast<Box const&>(fragment.layout_node()));
                 top_of_inline_box = (fragment.block_offset() - fragment_box_state.margin_box_top());
-                bottom_of_inline_box = (fragment.block_offset() + fragment_box_state.content_height() + fragment_box_state.margin_box_bottom());
+                bottom_of_inline_box = (fragment.block_offset() + fragment_box_state.content_block_size() + fragment_box_state.margin_box_bottom());
             } else {
                 auto font_metrics = fragment.layout_node().first_available_font().pixel_metrics();
                 auto typographic_height = CSSPixels::nearest_value_for(font_metrics.ascent + font_metrics.descent);

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -247,7 +247,7 @@ CSSPixels LineBuilder::ceiling_for_float_to_be_inserted_here(Box const& box)
     if (current_line_inline_size > 0 && (inline_size_needed_beside_float + inline_size) > m_available_inline_size_for_current_line)
         candidate_block_offset += current_line.physical_vertical_extent();
 
-    return max(candidate_block_offset, m_context.vertical_float_clearance());
+    return max(candidate_block_offset, m_context.block_axis_float_clearance());
 }
 
 bool LineBuilder::should_break(CSSPixels next_item_inline_size)

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -29,7 +29,7 @@ public:
     void prepare_to_append_inline_content();
     void commit_pending_margin_before_float();
     void finish_current_line_before_block_level_box();
-    void append_block_level_box(Box const&, CSSPixels block_bottom, CSSPixels block_bottom_margin);
+    void append_block_level_box(Box const&, CSSPixels block_end, CSSPixels block_end_margin);
 
     // Returns whether a line break occurred.
     bool break_if_needed(CSSPixels next_item_inline_size)
@@ -76,7 +76,7 @@ private:
     CSS::WritingMode m_writing_mode { CSS::WritingMode::HorizontalTb };
 
     bool m_last_line_needs_update { false };
-    bool m_should_advance_to_last_line_box_bottom { false };
+    bool m_should_advance_to_last_line_box_block_end { false };
     bool m_current_line_committed_pending_margin { false };
     bool m_pending_margin_follows_block_level_box { false };
 };

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -15,14 +15,14 @@ class LineBuilder {
     AK_MAKE_NONMOVABLE(LineBuilder);
 
 public:
-    LineBuilder(InlineFormattingContext&, LayoutState&, LayoutState::UsedValues& containing_block_used_values, CSSPixels containing_block_width, CSS::Direction, CSS::WritingMode);
+    LineBuilder(InlineFormattingContext&, LayoutState&, LayoutState::UsedValues& containing_block_used_values, CSSPixels containing_block_inline_size, CSS::Direction, CSS::WritingMode);
 
     enum class ForcedBreak {
         No,
         Yes,
     };
 
-    void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
+    void break_line(ForcedBreak, Optional<CSSPixels> next_item_inline_size = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
     void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size, CSSPixels content_block_size, RefPtr<Gfx::GlyphRun>);
     void append_static_position_marker(Box const&, bool preceded_by_inline_box_start_edges);
@@ -32,10 +32,10 @@ public:
     void append_block_level_box(Box const&, CSSPixels block_bottom, CSSPixels block_bottom_margin);
 
     // Returns whether a line break occurred.
-    bool break_if_needed(CSSPixels next_item_width)
+    bool break_if_needed(CSSPixels next_item_inline_size)
     {
-        if (should_break(next_item_width)) {
-            break_line(LineBuilder::ForcedBreak::No, next_item_width);
+        if (should_break(next_item_inline_size)) {
+            break_line(LineBuilder::ForcedBreak::No, next_item_inline_size);
             return true;
         }
         return false;
@@ -51,24 +51,24 @@ public:
 
     void recalculate_available_space();
     CSSPixels ceiling_for_float_to_be_inserted_here(Box const&);
-    void set_unbreakable_run_width_interrupted_by_float(CSSPixels width) { m_unbreakable_run_width_interrupted_by_float = width; }
+    void set_unbreakable_run_inline_size_interrupted_by_float(CSSPixels inline_size) { m_unbreakable_run_inline_size_interrupted_by_float = inline_size; }
 
     void did_introduce_clearance(CSSPixels);
 
 private:
-    void begin_new_line(bool increment_y, bool is_first_break_in_sequence = true, ForcedBreak = ForcedBreak::No);
+    void begin_new_line(bool advance_block_offset, bool is_first_break_in_sequence = true, ForcedBreak = ForcedBreak::No);
 
-    bool should_break(CSSPixels next_item_width);
+    bool should_break(CSSPixels next_item_inline_size);
 
     LineBox& ensure_last_line_box();
 
     InlineFormattingContext& m_context;
     LayoutState& m_layout_state;
     LayoutState::UsedValues& m_containing_block_used_values;
-    AvailableSize m_available_width_for_current_line { AvailableSize::make_indefinite() };
+    AvailableSize m_available_inline_size_for_current_line { AvailableSize::make_indefinite() };
     CSSPixels m_current_block_offset { 0 };
-    CSSPixels m_max_height_on_current_line { 0 };
-    CSSPixels m_unbreakable_run_width_interrupted_by_float { 0 };
+    CSSPixels m_max_block_size_on_current_line { 0 };
+    CSSPixels m_unbreakable_run_inline_size_interrupted_by_float { 0 };
     CSSPixels m_text_indent { 0 };
     bool m_text_indent_hanging : 1 { false };
     bool m_text_indent_each_line : 1 { false };

--- a/Libraries/LibWeb/Layout/LineBuilder.h
+++ b/Libraries/LibWeb/Layout/LineBuilder.h
@@ -24,7 +24,7 @@ public:
 
     void break_line(ForcedBreak, Optional<CSSPixels> next_item_width = {});
     void append_box(Box const&, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin);
-    void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_width, CSSPixels content_height, RefPtr<Gfx::GlyphRun>);
+    void append_text_chunk(TextNode const&, size_t offset_in_node, size_t length_in_node, CSSPixels leading_size, CSSPixels trailing_size, CSSPixels leading_margin, CSSPixels trailing_margin, CSSPixels content_inline_size, CSSPixels content_block_size, RefPtr<Gfx::GlyphRun>);
     void append_static_position_marker(Box const&, bool preceded_by_inline_box_start_edges);
     void prepare_to_append_inline_content();
     void commit_pending_margin_before_float();

--- a/Libraries/LibWeb/Layout/LogicalGeometry.h
+++ b/Libraries/LibWeb/Layout/LogicalGeometry.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::Layout {
+
+enum class LogicalAxis {
+    Inline,
+    Block,
+};
+
+struct LogicalSize {
+    CSSPixels inline_size {};
+    CSSPixels block_size {};
+
+    bool operator==(LogicalSize const&) const = default;
+};
+
+struct LogicalOffset {
+    CSSPixels inline_offset {};
+    CSSPixels block_offset {};
+
+    bool operator==(LogicalOffset const&) const = default;
+};
+
+struct LogicalRect {
+    LogicalOffset offset {};
+    LogicalSize size {};
+
+    bool operator==(LogicalRect const&) const = default;
+};
+
+}

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -18,24 +18,24 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
 {
     auto const& available_space = layout_input.available_space;
     auto& root_state = m_state.get_mutable(context_box());
-    auto content_width = root_state.content_width();
+    auto content_inline_size = root_state.content_inline_size();
 
     // Mark the replaced element as having definite dimensions when the parent FC has
     // computed them from intrinsic size, so children with percentage sizes can resolve.
     auto natural_size = context_box().natural_size();
     if (natural_size.has_width())
-        root_state.set_has_definite_width(true);
+        root_state.set_has_definite_inline_size(true);
     if (natural_size.has_height())
-        root_state.set_has_definite_height(true);
+        root_state.set_has_definite_block_size(true);
 
     // For height, use the parent-set content height if it's been resolved (e.g. explicit height
     // or intrinsic height), otherwise use the available space from the parent formatting context.
-    auto child_available_height = root_state.has_definite_height()
-        ? AvailableSize::make_definite(root_state.content_height())
+    auto child_available_height = root_state.has_definite_block_size()
+        ? AvailableSize::make_definite(root_state.content_block_size())
         : available_space.block_size;
 
     auto child_available_space = AvailableSpace(
-        AvailableSize::make_definite(content_width),
+        AvailableSize::make_definite(content_inline_size),
         child_available_height);
 
     // The TreeBuilder wraps shadow DOM children in an anonymous BlockContainer.
@@ -46,15 +46,15 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
 
     auto wrapper_constraints = constraints_for_child_context(root_state, layout_input.containing_block_constraints);
     auto& wrapper_state = m_state.create(*wrapper, wrapper_constraints.percentage_basis_inline_size, wrapper_constraints.percentage_basis_block_size);
-    wrapper_state.set_content_width(content_width);
+    wrapper_state.set_content_inline_size(content_inline_size);
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
     bfc->run(LayoutInput { child_available_space, wrapper_constraints });
 
-    m_automatic_content_width = content_width;
+    m_automatic_content_width = content_inline_size;
     m_automatic_content_height = bfc->automatic_content_height();
 
-    wrapper_state.set_content_height(m_automatic_content_height);
+    wrapper_state.set_content_block_size(m_automatic_content_height);
 
     place_child(*wrapper, { 0, 0 });
 

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -28,15 +28,15 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     if (natural_size.has_height())
         root_state.set_has_definite_block_size(true);
 
-    // For height, use the parent-set content height if it's been resolved (e.g. explicit height
-    // or intrinsic height), otherwise use the available space from the parent formatting context.
-    auto child_available_height = root_state.has_definite_block_size()
+    // For the block axis, use the parent-set content block size if it has been resolved (e.g. an
+    // explicit or intrinsic block size); otherwise use the parent formatting context's space.
+    auto child_available_block_size = root_state.has_definite_block_size()
         ? AvailableSize::make_definite(root_state.content_block_size())
         : available_space.block_size;
 
     auto child_available_space = AvailableSpace(
         AvailableSize::make_definite(content_inline_size),
-        child_available_height);
+        child_available_block_size);
 
     // The TreeBuilder wraps shadow DOM children in an anonymous BlockContainer.
     // Delegate layout to a BFC for that wrapper.

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -45,7 +45,7 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
         return;
 
     auto wrapper_constraints = constraints_for_child_context(root_state, layout_input.containing_block_constraints);
-    auto& wrapper_state = m_state.create(*wrapper, wrapper_constraints.percentage_basis_width, wrapper_constraints.percentage_basis_height);
+    auto& wrapper_state = m_state.create(*wrapper, wrapper_constraints.percentage_basis_inline_size, wrapper_constraints.percentage_basis_block_size);
     wrapper_state.set_content_width(content_width);
 
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -32,7 +32,7 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     // or intrinsic height), otherwise use the available space from the parent formatting context.
     auto child_available_height = root_state.has_definite_height()
         ? AvailableSize::make_definite(root_state.content_height())
-        : available_space.height;
+        : available_space.block_size;
 
     auto child_available_space = AvailableSpace(
         AvailableSize::make_definite(content_width),

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.cpp
@@ -51,24 +51,24 @@ void ReplacedWithChildrenFormattingContext::run(LayoutInput const& layout_input)
     auto bfc = make<BlockFormattingContext>(m_state, m_layout_mode, *wrapper, this);
     bfc->run(LayoutInput { child_available_space, wrapper_constraints });
 
-    m_automatic_content_width = content_inline_size;
-    m_automatic_content_height = bfc->automatic_content_height();
+    m_automatic_content_inline_size = content_inline_size;
+    m_automatic_content_block_size = bfc->automatic_content_block_size();
 
-    wrapper_state.set_content_block_size(m_automatic_content_height);
+    wrapper_state.set_content_block_size(m_automatic_content_block_size);
 
     place_child(*wrapper, { 0, 0 });
 
     bfc->parent_context_did_dimension_child_root_box();
 }
 
-CSSPixels ReplacedWithChildrenFormattingContext::automatic_content_width() const
+CSSPixels ReplacedWithChildrenFormattingContext::automatic_content_inline_size() const
 {
-    return m_automatic_content_width;
+    return m_automatic_content_inline_size;
 }
 
-CSSPixels ReplacedWithChildrenFormattingContext::automatic_content_height() const
+CSSPixels ReplacedWithChildrenFormattingContext::automatic_content_block_size() const
 {
-    return m_automatic_content_height;
+    return m_automatic_content_block_size;
 }
 
 void ReplacedWithChildrenFormattingContext::parent_context_did_dimension_child_root_box()

--- a/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.h
+++ b/Libraries/LibWeb/Layout/ReplacedWithChildrenFormattingContext.h
@@ -15,13 +15,13 @@ public:
     explicit ReplacedWithChildrenFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent);
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_width() const override;
-    virtual CSSPixels automatic_content_height() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
     virtual void parent_context_did_dimension_child_root_box() override;
 
 private:
-    CSSPixels m_automatic_content_width { 0 };
-    CSSPixels m_automatic_content_height { 0 };
+    CSSPixels m_automatic_content_inline_size { 0 };
+    CSSPixels m_automatic_content_block_size { 0 };
 };
 
 }

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -321,12 +321,12 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         auto& child_state = m_state.create(child, {}, {});
         CSSPixelRect rect {
             {
-                child.computed_values().x().to_px(m_available_space->width.to_px_or_zero()),
-                child.computed_values().y().to_px(m_available_space->height.to_px_or_zero()),
+                child.computed_values().x().to_px(m_available_space->inline_size.to_px_or_zero()),
+                child.computed_values().y().to_px(m_available_space->block_size.to_px_or_zero()),
             },
             {
-                child.computed_values().width().to_px(m_available_space->width.to_px_or_zero()),
-                child.computed_values().height().to_px(m_available_space->height.to_px_or_zero()),
+                child.computed_values().width().to_px(m_available_space->inline_size.to_px_or_zero()),
+                child.computed_values().height().to_px(m_available_space->block_size.to_px_or_zero()),
             }
         };
         auto svg_transform = parent_svg_transform;

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -297,7 +297,7 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
     }();
 
     m_available_space = available_space;
-    m_quirks_mode_percentage_basis_height = layout_input.containing_block_constraints.quirks_mode_percentage_basis_height;
+    m_quirks_mode_percentage_basis_block_size = layout_input.containing_block_constraints.quirks_mode_percentage_basis_block_size;
     m_viewport_size = { viewport_width, viewport_height };
 
     auto svg_transform_for_children = m_parent_svg_transform.value_or(Gfx::AffineTransform {});
@@ -338,7 +338,7 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         child_state.set_content_height(transformed_rect.height());
 
         auto child_available_space = AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height()));
-        bfc.run(LayoutInput { child_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
+        bfc.run(LayoutInput { child_available_space, { {}, {}, m_quirks_mode_percentage_basis_block_size } });
 
         // Masks and clips may use this offset for objectBoundingBox units.
         place_child(child, transformed_rect.location());
@@ -409,7 +409,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
     if (has_own_view_box)
         place_child(viewport, content_offset);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform, parent_svg_transform);
-    nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
+    nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_block_size } });
     if (!has_own_view_box) {
         Gfx::FloatRect nested_viewport_rect_in_parent_user_space {
             { nested_viewport_x.to_float(), nested_viewport_y.to_float() },
@@ -645,7 +645,7 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform, Gfx::AffineTransform {});
     layout_state.set_has_definite_width(true);
     layout_state.set_has_definite_height(true);
-    nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_height } });
+    nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_block_size } });
 
     Gfx::FloatRect box_rect_in_parent_user_space { {}, { float(layout_state.content_width()), float(layout_state.content_height()) } };
     auto mapped_box_rect = parent_viewbox_transform.map(box_rect_in_parent_user_space);

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -48,12 +48,12 @@ SVGFormattingContext::SVGFormattingContext(LayoutState& state, LayoutMode layout
 
 SVGFormattingContext::~SVGFormattingContext() = default;
 
-CSSPixels SVGFormattingContext::automatic_content_width() const
+CSSPixels SVGFormattingContext::automatic_content_inline_size() const
 {
     return 0;
 }
 
-CSSPixels SVGFormattingContext::automatic_content_height() const
+CSSPixels SVGFormattingContext::automatic_content_block_size() const
 {
     return 0;
 }

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -97,7 +97,7 @@ static ViewBoxTransform scale_and_align_viewbox_content(SVG::PreserveAspectRatio
     }
 
     // Handle X alignment:
-    if (svg_box_state.has_definite_width()) {
+    if (svg_box_state.has_definite_inline_size()) {
         switch (preserve_aspect_ratio.align) {
         case SVG::PreserveAspectRatio::Align::xMinYMin:
         case SVG::PreserveAspectRatio::Align::xMinYMid:
@@ -115,20 +115,20 @@ static ViewBoxTransform scale_and_align_viewbox_content(SVG::PreserveAspectRatio
         case SVG::PreserveAspectRatio::Align::xMidYMid:
         case SVG::PreserveAspectRatio::Align::xMidYMax:
             // Align the midpoint X value of the element's ‘viewBox’ with the midpoint X value of the SVG viewport.
-            viewbox_transform.offset.translate_by((svg_box_state.content_width() - CSSPixels::nearest_value_for(view_box.width * viewbox_transform.scale_factor_x)) / 2, 0);
+            viewbox_transform.offset.translate_by((svg_box_state.content_inline_size() - CSSPixels::nearest_value_for(view_box.width * viewbox_transform.scale_factor_x)) / 2, 0);
             break;
         case SVG::PreserveAspectRatio::Align::xMaxYMin:
         case SVG::PreserveAspectRatio::Align::xMaxYMid:
         case SVG::PreserveAspectRatio::Align::xMaxYMax:
             // Align the <min-x>+<width> of the element's ‘viewBox’ with the maximum X value of the SVG viewport.
-            viewbox_transform.offset.translate_by((svg_box_state.content_width() - CSSPixels::nearest_value_for(view_box.width * viewbox_transform.scale_factor_x)), 0);
+            viewbox_transform.offset.translate_by((svg_box_state.content_inline_size() - CSSPixels::nearest_value_for(view_box.width * viewbox_transform.scale_factor_x)), 0);
             break;
         default:
             VERIFY_NOT_REACHED();
         }
     }
 
-    if (svg_box_state.has_definite_width()) {
+    if (svg_box_state.has_definite_inline_size()) {
         switch (preserve_aspect_ratio.align) {
         case SVG::PreserveAspectRatio::Align::xMinYMin:
         case SVG::PreserveAspectRatio::Align::xMidYMin:
@@ -146,13 +146,13 @@ static ViewBoxTransform scale_and_align_viewbox_content(SVG::PreserveAspectRatio
         case SVG::PreserveAspectRatio::Align::xMidYMid:
         case SVG::PreserveAspectRatio::Align::xMaxYMid:
             // Align the midpoint Y value of the element's ‘viewBox’ with the midpoint Y value of the SVG viewport.
-            viewbox_transform.offset.translate_by(0, (svg_box_state.content_height() - CSSPixels::nearest_value_for(view_box.height * viewbox_transform.scale_factor_y)) / 2);
+            viewbox_transform.offset.translate_by(0, (svg_box_state.content_block_size() - CSSPixels::nearest_value_for(view_box.height * viewbox_transform.scale_factor_y)) / 2);
             break;
         case SVG::PreserveAspectRatio::Align::xMinYMax:
         case SVG::PreserveAspectRatio::Align::xMidYMax:
         case SVG::PreserveAspectRatio::Align::xMaxYMax:
             // Align the <min-y>+<height> of the element's ‘viewBox’ with the maximum Y value of the SVG viewport.
-            viewbox_transform.offset.translate_by(0, (svg_box_state.content_height() - CSSPixels::nearest_value_for(view_box.height * viewbox_transform.scale_factor_y)));
+            viewbox_transform.offset.translate_by(0, (svg_box_state.content_block_size() - CSSPixels::nearest_value_for(view_box.height * viewbox_transform.scale_factor_y)));
             break;
         default:
             VERIFY_NOT_REACHED();
@@ -209,16 +209,16 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
 
         // NOTE: If a height had not been provided by the svg element, it was set to the height of the container
         if (svg_box_state.node().computed_values().width().is_length())
-            svg_box_state.set_content_width(svg_box_state.node().computed_values().width().length().to_px(svg_box_state.node()));
+            svg_box_state.set_content_inline_size(svg_box_state.node().computed_values().width().length().to_px(svg_box_state.node()));
         if (svg_box_state.node().computed_values().height().is_length())
-            svg_box_state.set_content_height(svg_box_state.node().computed_values().height().length().to_px(svg_box_state.node()));
+            svg_box_state.set_content_block_size(svg_box_state.node().computed_values().height().length().to_px(svg_box_state.node()));
         // FIXME: In SVG 2, length can also be a percentage. We'll need to support that.
     }
 
     // NOTE: We consider all SVG root elements to have definite size in both axes.
     //       I'm not sure if this is good or bad, but our viewport transform logic depends on it.
-    svg_box_state.set_has_definite_width(true);
-    svg_box_state.set_has_definite_height(true);
+    svg_box_state.set_has_definite_inline_size(true);
+    svg_box_state.set_has_definite_block_size(true);
 
     auto* dom_node = context_box().dom_node();
     VERIFY(dom_node);
@@ -250,12 +250,12 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
     if (active_view_box.has_value()) {
         // FIXME: This should allow just one of width or height to be specified.
         // E.g. We should be able to layout <svg width="100%"> where height is unspecified/auto.
-        if (!svg_box_state.has_definite_width() || !svg_box_state.has_definite_height()) {
+        if (!svg_box_state.has_definite_inline_size() || !svg_box_state.has_definite_block_size()) {
             dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Attempting to layout indefinitely sized SVG with a viewbox -- this likely won't work!");
         }
 
-        auto scale_width = svg_box_state.has_definite_width() ? svg_box_state.content_width() / active_view_box->width : 1;
-        auto scale_height = svg_box_state.has_definite_height() ? svg_box_state.content_height() / active_view_box->height : 1;
+        auto scale_width = svg_box_state.has_definite_inline_size() ? svg_box_state.content_inline_size() / active_view_box->width : 1;
+        auto scale_height = svg_box_state.has_definite_block_size() ? svg_box_state.content_block_size() / active_view_box->height : 1;
 
         // The initial value for preserveAspectRatio is xMidYMid meet.
         SVG::PreserveAspectRatio preserve_aspect_ratio {};
@@ -281,8 +281,8 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
     auto viewport_width = [&] {
         if (active_view_box.has_value())
             return CSSPixels::nearest_value_for(active_view_box->width);
-        if (svg_box_state.has_definite_width())
-            return svg_box_state.content_width();
+        if (svg_box_state.has_definite_inline_size())
+            return svg_box_state.content_inline_size();
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Failed to resolve width of SVG viewport!");
         return CSSPixels {};
     }();
@@ -290,8 +290,8 @@ void SVGFormattingContext::run(LayoutInput const& layout_input)
     auto viewport_height = [&] {
         if (active_view_box.has_value())
             return CSSPixels::nearest_value_for(active_view_box->height);
-        if (svg_box_state.has_definite_height())
-            return svg_box_state.content_height();
+        if (svg_box_state.has_definite_block_size())
+            return svg_box_state.content_block_size();
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Failed to resolve height of SVG viewport!");
         return CSSPixels {};
     }();
@@ -334,10 +334,10 @@ void SVGFormattingContext::layout_svg_element(Box const& child, LayoutInput cons
         child_state.set_computed_svg_transforms(Painting::SVGGraphicsPaintable::ComputedTransforms(m_current_viewbox_transform, svg_transform));
         auto to_css_pixels_transform = Gfx::AffineTransform {}.multiply(m_current_viewbox_transform).multiply(svg_transform);
         auto transformed_rect = to_css_pixels_transform.map(rect.to_type<float>()).to_type<CSSPixels>();
-        child_state.set_content_width(transformed_rect.width());
-        child_state.set_content_height(transformed_rect.height());
+        child_state.set_content_inline_size(transformed_rect.width());
+        child_state.set_content_block_size(transformed_rect.height());
 
-        auto child_available_space = AvailableSpace(AvailableSize::make_definite(child_state.content_width()), AvailableSize::make_definite(child_state.content_height()));
+        auto child_available_space = AvailableSpace(AvailableSize::make_definite(child_state.content_inline_size()), AvailableSize::make_definite(child_state.content_block_size()));
         bfc.run(LayoutInput { child_available_space, { {}, {}, m_quirks_mode_percentage_basis_block_size } });
 
         // Masks and clips may use this offset for objectBoundingBox units.
@@ -383,8 +383,8 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
     }
 
     CSSPixelPoint content_offset { nested_viewport_x, nested_viewport_y };
-    auto content_width = nested_viewport_width;
-    auto content_height = nested_viewport_height;
+    auto content_inline_size = nested_viewport_width;
+    auto content_block_size = nested_viewport_height;
     auto parent_viewbox_transform = m_current_viewbox_transform;
 
     auto* svg_element = as_if<SVG::SVGSVGElement>(*viewport.dom_node());
@@ -397,15 +397,15 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
         };
         auto mapped_rect = m_current_viewbox_transform.map(nested_rect);
         content_offset = mapped_rect.location().to_type<CSSPixels>();
-        content_width = CSSPixels(mapped_rect.width());
-        content_height = CSSPixels(mapped_rect.height());
+        content_inline_size = CSSPixels(mapped_rect.width());
+        content_block_size = CSSPixels(mapped_rect.height());
         parent_viewbox_transform = {};
     }
 
-    nested_viewport_state.set_content_width(content_width);
-    nested_viewport_state.set_content_height(content_height);
-    nested_viewport_state.set_has_definite_width(true);
-    nested_viewport_state.set_has_definite_height(true);
+    nested_viewport_state.set_content_inline_size(content_inline_size);
+    nested_viewport_state.set_content_block_size(content_block_size);
+    nested_viewport_state.set_has_definite_inline_size(true);
+    nested_viewport_state.set_has_definite_block_size(true);
     if (has_own_view_box)
         place_child(viewport, content_offset);
     SVGFormattingContext nested_context(m_state, m_layout_mode, viewport, this, parent_viewbox_transform, parent_svg_transform);
@@ -416,8 +416,8 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport, Gfx::Affi
             { nested_viewport_width.to_float(), nested_viewport_height.to_float() }
         };
         auto mapped_nested_viewport_rect = m_current_viewbox_transform.map(nested_viewport_rect_in_parent_user_space);
-        nested_viewport_state.set_content_width(CSSPixels(mapped_nested_viewport_rect.width()));
-        nested_viewport_state.set_content_height(CSSPixels(mapped_nested_viewport_rect.height()));
+        nested_viewport_state.set_content_inline_size(CSSPixels(mapped_nested_viewport_rect.width()));
+        nested_viewport_state.set_content_block_size(CSSPixels(mapped_nested_viewport_rect.height()));
         place_child(viewport, mapped_nested_viewport_rect.location().to_type<CSSPixels>());
     }
 }
@@ -546,11 +546,11 @@ void SVGFormattingContext::layout_path_like_element(SVGGraphicsBox const& graphi
     // Stroke increases the path's size by stroke_width/2 per side.
     CSSPixels stroke_width = CSSPixels::nearest_value_for(graphics_box.dom_node().visible_stroke_width() * m_current_viewbox_transform.x_scale());
     transformed_bounding_box.inflate(stroke_width, stroke_width);
-    graphics_box_state.set_content_width(transformed_bounding_box.width());
-    graphics_box_state.set_content_height(transformed_bounding_box.height());
+    graphics_box_state.set_content_inline_size(transformed_bounding_box.width());
+    graphics_box_state.set_content_block_size(transformed_bounding_box.height());
     place_child(graphics_box, transformed_bounding_box.top_left());
-    graphics_box_state.set_has_definite_width(true);
-    graphics_box_state.set_has_definite_height(true);
+    graphics_box_state.set_has_definite_inline_size(true);
+    graphics_box_state.set_has_definite_block_size(true);
     graphics_box_state.set_computed_svg_path(move(path));
 }
 
@@ -595,11 +595,11 @@ void SVGFormattingContext::layout_image_element(SVGImageBox const& image_box)
                                        .multiply(box_state.computed_svg_transforms()->svg_transform());
     auto bounding_box = to_css_pixels_transform.map(image_box.dom_node().bounding_box(m_viewport_size)).to_type<CSSPixels>();
 
-    box_state.set_content_width(bounding_box.width());
-    box_state.set_content_height(bounding_box.height());
+    box_state.set_content_inline_size(bounding_box.width());
+    box_state.set_content_block_size(bounding_box.height());
     place_child(image_box, bounding_box.top_left());
-    box_state.set_has_definite_width(true);
-    box_state.set_has_definite_height(true);
+    box_state.set_has_definite_inline_size(true);
+    box_state.set_has_definite_block_size(true);
 }
 
 void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
@@ -621,36 +621,36 @@ void SVGFormattingContext::layout_mask_or_clip(SVGBox const& mask_or_clip)
     if (pattern_box && pattern_box->dom_node().view_box().has_value()) {
         auto const& pattern = pattern_box->dom_node();
         if (pattern.pattern_units() == SVG::SVGUnits::UserSpaceOnUse) {
-            layout_state.set_content_width(CSSPixels::nearest_value_for(pattern.pattern_width().resolve_relative_to(m_viewport_size.width().to_float())));
-            layout_state.set_content_height(CSSPixels::nearest_value_for(pattern.pattern_height().resolve_relative_to(m_viewport_size.height().to_float())));
+            layout_state.set_content_inline_size(CSSPixels::nearest_value_for(pattern.pattern_width().resolve_relative_to(m_viewport_size.width().to_float())));
+            layout_state.set_content_block_size(CSSPixels::nearest_value_for(pattern.pattern_height().resolve_relative_to(m_viewport_size.height().to_float())));
         } else {
             auto& parent_node_state = m_state.get(*mask_or_clip.parent());
-            layout_state.set_content_width(CSSPixels::nearest_value_for(pattern.pattern_width().value() * parent_node_state.content_width().to_double()));
-            layout_state.set_content_height(CSSPixels::nearest_value_for(pattern.pattern_height().value() * parent_node_state.content_height().to_double()));
+            layout_state.set_content_inline_size(CSSPixels::nearest_value_for(pattern.pattern_width().value() * parent_node_state.content_inline_size().to_double()));
+            layout_state.set_content_block_size(CSSPixels::nearest_value_for(pattern.pattern_height().value() * parent_node_state.content_block_size().to_double()));
             parent_viewbox_transform = Gfx::AffineTransform {}.translate(parent_node_state.content_offset().to_type<float>());
         }
     } else if (content_units == SVG::SVGUnits::ObjectBoundingBox) {
         auto& parent_node_state = m_state.get(*mask_or_clip.parent());
-        layout_state.set_content_width(parent_node_state.content_width());
-        layout_state.set_content_height(parent_node_state.content_height());
+        layout_state.set_content_inline_size(parent_node_state.content_inline_size());
+        layout_state.set_content_block_size(parent_node_state.content_block_size());
         // https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute
         parent_viewbox_transform = Gfx::AffineTransform {}.translate(parent_node_state.content_offset().to_type<float>());
         if (pattern_box)
-            parent_viewbox_transform.scale(parent_node_state.content_width().to_float(), parent_node_state.content_height().to_float());
+            parent_viewbox_transform.scale(parent_node_state.content_inline_size().to_float(), parent_node_state.content_block_size().to_float());
     } else {
-        layout_state.set_content_width(m_viewport_size.width());
-        layout_state.set_content_height(m_viewport_size.height());
+        layout_state.set_content_inline_size(m_viewport_size.width());
+        layout_state.set_content_block_size(m_viewport_size.height());
     }
     // Pretend masks/clips are a viewport so we can scale the contents depending on the `contentUnits`.
     SVGFormattingContext nested_context(m_state, m_layout_mode, mask_or_clip, this, parent_viewbox_transform, Gfx::AffineTransform {});
-    layout_state.set_has_definite_width(true);
-    layout_state.set_has_definite_height(true);
+    layout_state.set_has_definite_inline_size(true);
+    layout_state.set_has_definite_block_size(true);
     nested_context.run(LayoutInput { *m_available_space, { {}, {}, m_quirks_mode_percentage_basis_block_size } });
 
-    Gfx::FloatRect box_rect_in_parent_user_space { {}, { float(layout_state.content_width()), float(layout_state.content_height()) } };
+    Gfx::FloatRect box_rect_in_parent_user_space { {}, { float(layout_state.content_inline_size()), float(layout_state.content_block_size()) } };
     auto mapped_box_rect = parent_viewbox_transform.map(box_rect_in_parent_user_space);
-    layout_state.set_content_width(CSSPixels(mapped_box_rect.width()));
-    layout_state.set_content_height(CSSPixels(mapped_box_rect.height()));
+    layout_state.set_content_inline_size(CSSPixels(mapped_box_rect.width()));
+    layout_state.set_content_block_size(CSSPixels(mapped_box_rect.height()));
     place_child(mask_or_clip, mapped_box_rect.location().to_type<CSSPixels>());
 }
 
@@ -665,14 +665,14 @@ void SVGFormattingContext::layout_container_element(SVGBox const& container, Lay
         layout_svg_element(child, layout_input, container_svg_transform);
         auto& child_state = m_state.get(child);
         bounding_box.add_point(child_state.content_offset());
-        bounding_box.add_point(child_state.content_offset().translated(child_state.content_width(), child_state.content_height()));
+        bounding_box.add_point(child_state.content_offset().translated(child_state.content_inline_size(), child_state.content_block_size()));
         return IterationDecision::Continue;
     });
-    box_state.set_content_width(bounding_box.width());
-    box_state.set_content_height(bounding_box.height());
+    box_state.set_content_inline_size(bounding_box.width());
+    box_state.set_content_block_size(bounding_box.height());
     place_child(container, { bounding_box.x(), bounding_box.y() });
-    box_state.set_has_definite_width(true);
-    box_state.set_has_definite_height(true);
+    box_state.set_has_definite_inline_size(true);
+    box_state.set_has_definite_block_size(true);
 }
 
 }

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -21,8 +21,8 @@ public:
     ~SVGFormattingContext();
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_width() const override;
-    virtual CSSPixels automatic_content_height() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
 
 private:
     void layout_svg_element(Box const&, LayoutInput const&, Gfx::AffineTransform const& parent_svg_transform);

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.h
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.h
@@ -40,7 +40,7 @@ private:
     Optional<Gfx::AffineTransform> m_parent_svg_transform {};
 
     Optional<AvailableSpace> m_available_space {};
-    Optional<CSSPixels> m_quirks_mode_percentage_basis_height {};
+    Optional<CSSPixels> m_quirks_mode_percentage_basis_block_size {};
     Gfx::AffineTransform m_current_viewbox_transform {};
     CSSPixelSize m_viewport_size {};
     Gfx::FloatPoint m_current_text_position {};

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -33,8 +33,8 @@ ContainedBoxesMap collect_scrollable_overflow_contained_boxes(Node const& root, 
 }
 
 struct PhysicalOverflowDirections {
-    bool x_positive { true };
-    bool y_positive { true };
+    bool horizontal_axis_is_positive { true };
+    bool vertical_axis_is_positive { true };
 };
 
 struct AxisDirection {
@@ -92,8 +92,8 @@ static PhysicalOverflowDirections physical_overflow_directions(Box const& box)
     auto horizontal_axis = axes.get<0>();
     auto vertical_axis = axes.get<1>();
     return {
-        .x_positive = !horizontal_axis.is_reverse,
-        .y_positive = !vertical_axis.is_reverse,
+        .horizontal_axis_is_positive = !horizontal_axis.is_reverse,
+        .vertical_axis_is_positive = !vertical_axis.is_reverse,
     };
 }
 
@@ -125,19 +125,19 @@ static CSSPixelRect padding_inflated_scrollable_overflow(Box const& box, CSSPixe
     auto right = in_flow_and_floated_content_bounds.right();
     auto bottom = in_flow_and_floated_content_bounds.bottom();
 
-    auto in_flow_bounds_overflow_content_box_in_x_axis = left < content_box.left() || right > content_box.right();
-    if (in_flow_bounds_overflow_content_box_in_x_axis) {
-        if (overflow_directions.x_positive && right > content_box.right())
+    auto in_flow_bounds_overflow_content_box_in_horizontal_axis = left < content_box.left() || right > content_box.right();
+    if (in_flow_bounds_overflow_content_box_in_horizontal_axis) {
+        if (overflow_directions.horizontal_axis_is_positive && right > content_box.right())
             right += padding.right;
-        else if (!overflow_directions.x_positive)
+        else if (!overflow_directions.horizontal_axis_is_positive)
             left = min(left, padding_box.left()) - padding.left;
     }
 
-    auto in_flow_bounds_overflow_content_box_in_y_axis = top < content_box.top() || bottom > content_box.bottom();
-    if (in_flow_bounds_overflow_content_box_in_y_axis) {
-        if (overflow_directions.y_positive && bottom > content_box.bottom())
+    auto in_flow_bounds_overflow_content_box_in_vertical_axis = top < content_box.top() || bottom > content_box.bottom();
+    if (in_flow_bounds_overflow_content_box_in_vertical_axis) {
+        if (overflow_directions.vertical_axis_is_positive && bottom > content_box.bottom())
             bottom += padding.bottom;
-        else if (!overflow_directions.y_positive)
+        else if (!overflow_directions.vertical_axis_is_positive)
             top = min(top, padding_box.top()) - padding.top;
     }
 
@@ -218,13 +218,13 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
             auto child_border_box = apply_css_transform_to_overflow_rect(child, untransformed_child_border_box);
 
             // NOTE: Only boxes that are not wholly in the unreachable scrollable overflow region contribute.
-            auto wholly_in_unreachable_x = overflow_directions.x_positive
+            auto wholly_in_unreachable_horizontal_axis = overflow_directions.horizontal_axis_is_positive
                 ? child_border_box.right() < paintable_absolute_padding_box.x()
                 : child_border_box.x() > paintable_absolute_padding_box.right();
-            auto wholly_in_unreachable_y = overflow_directions.y_positive
+            auto wholly_in_unreachable_vertical_axis = overflow_directions.vertical_axis_is_positive
                 ? child_border_box.bottom() < paintable_absolute_padding_box.y()
                 : child_border_box.y() > paintable_absolute_padding_box.bottom();
-            if (wholly_in_unreachable_x || wholly_in_unreachable_y)
+            if (wholly_in_unreachable_horizontal_axis || wholly_in_unreachable_vertical_axis)
                 continue;
 
             // Border boxes with zero area do not affect the scrollable overflow area.
@@ -281,10 +281,10 @@ CSSPixelRect measure_scrollable_overflow(Box const& box, ContainedBoxesMap const
     // Unless otherwise adjusted (e.g. by content alignment [css-align-3]), the area beyond the scroll origin in either
     // axis is considered the unreachable scrollable overflow region: content rendered here is not accessible to the
     // reader, see § 2.2 Scrollable Overflow.
-    auto left = overflow_directions.x_positive ? max(scrollable_overflow_rect.x(), paintable_absolute_padding_box.x()) : scrollable_overflow_rect.x();
-    auto top = overflow_directions.y_positive ? max(scrollable_overflow_rect.y(), paintable_absolute_padding_box.y()) : scrollable_overflow_rect.y();
-    auto right = overflow_directions.x_positive ? scrollable_overflow_rect.right() : min(scrollable_overflow_rect.right(), paintable_absolute_padding_box.right());
-    auto bottom = overflow_directions.y_positive ? scrollable_overflow_rect.bottom() : min(scrollable_overflow_rect.bottom(), paintable_absolute_padding_box.bottom());
+    auto left = overflow_directions.horizontal_axis_is_positive ? max(scrollable_overflow_rect.x(), paintable_absolute_padding_box.x()) : scrollable_overflow_rect.x();
+    auto top = overflow_directions.vertical_axis_is_positive ? max(scrollable_overflow_rect.y(), paintable_absolute_padding_box.y()) : scrollable_overflow_rect.y();
+    auto right = overflow_directions.horizontal_axis_is_positive ? scrollable_overflow_rect.right() : min(scrollable_overflow_rect.right(), paintable_absolute_padding_box.right());
+    auto bottom = overflow_directions.vertical_axis_is_positive ? scrollable_overflow_rect.bottom() : min(scrollable_overflow_rect.bottom(), paintable_absolute_padding_box.bottom());
     if (left != scrollable_overflow_rect.x() || top != scrollable_overflow_rect.y() || right != scrollable_overflow_rect.right() || bottom != scrollable_overflow_rect.bottom()) {
         scrollable_overflow_rect = {
             left,

--- a/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
+++ b/Libraries/LibWeb/Layout/ScrollableOverflow.cpp
@@ -37,7 +37,7 @@ struct PhysicalOverflowDirections {
     bool y_positive { true };
 };
 
-struct LogicalAxis {
+struct AxisDirection {
     bool is_horizontal { false };
     bool is_reverse { false };
 };
@@ -59,11 +59,11 @@ static bool node_is_in_focused_text_control(DOM::Node const& node)
 static PhysicalOverflowDirections physical_overflow_directions(Box const& box)
 {
     auto const& computed_values = box.computed_values();
-    LogicalAxis inline_axis {
+    AxisDirection inline_axis {
         .is_horizontal = inline_axis_is_horizontal(computed_values.writing_mode()),
         .is_reverse = computed_values.inline_axis_is_reverse(),
     };
-    LogicalAxis block_axis {
+    AxisDirection block_axis {
         .is_horizontal = !inline_axis.is_horizontal,
         .is_reverse = computed_values.block_axis_is_reverse(),
     };

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -551,7 +551,7 @@ void TableFormattingContext::compute_table_inline_size()
     CSSPixels table_wrapper_containing_block_inline_size = m_table_constraints.percentage_basis_inline_size.value_or(0);
 
     // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
-    auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
+    auto undistributable_space = (m_columns.size() + 1) * border_spacing_inline();
 
     // The row/column-grid inline-size minimum (GRIDMIN) is the sum of the min-content inline size
     // of all the columns plus cell spacing or borders.
@@ -756,10 +756,10 @@ void TableFormattingContext::distribute_inline_size_to_columns()
 {
     // Implements https://www.w3.org/TR/css-tables-3/#width-distribution-algorithm
 
-    // The total horizontal border spacing is defined for each table:
-    // - For tables laid out in separated-borders mode containing at least one column, the horizontal component of the computed value of the border-spacing property times one plus the number of columns in the table
+    // The total inline-axis border spacing is defined for each table:
+    // - For tables laid out in separated-borders mode containing at least one column, the inline-axis component of the computed value of the border-spacing property times one plus the number of columns in the table
     // - Otherwise, 0
-    auto total_inline_border_spacing = m_columns.is_empty() ? 0 : (m_columns.size() + 1) * border_spacing_horizontal();
+    auto total_inline_border_spacing = m_columns.is_empty() ? 0 : (m_columns.size() + 1) * border_spacing_inline();
 
     // The assignable table inline size is its used inline size minus the inline-axis border spacing.
     CSSPixels const available_inline_size = m_state.get(table_box()).content_inline_size() - total_inline_border_spacing;
@@ -1063,9 +1063,9 @@ void TableFormattingContext::compute_table_block_size()
         // Compute cell inline size as specified by https://www.w3.org/TR/css-tables-3/#bounding-box-assignment:
         // The position of any table cell, track, or track group is defined by the sums of its spanned columns and rows:
         // - the inline/block sizes of all spanned visible columns/rows
-        // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
+        // - the inline/block border spacing times the amount of spanned visible columns/rows minus one
         // FIXME: Account for visibility.
-        cell_state.set_content_inline_size(span_inline_size - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        cell_state.set_content_inline_size(span_inline_size - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_inline());
         Optional<CSSPixels> measured_baseline;
         if (cell_block_size_depends_on_table_block_size(cell.box)) {
             // This cell's final inside layout happens in the second pass below; measure its
@@ -1190,7 +1190,7 @@ void TableFormattingContext::compute_table_block_size()
         if (!row.is_collapsed)
             row.reference_block_size = max(row.reference_block_size, cell_used_block_size);
 
-        cell_state.set_content_inline_size(span_inline_size - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        cell_state.set_content_inline_size(span_inline_size - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_inline());
         // The first pass only measured this cell in a throwaway state; this is its one and
         // only inside layout in the committing state.
         if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
@@ -1265,15 +1265,15 @@ void TableFormattingContext::distribute_block_size_to_rows()
     }
 
     // Add undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
-    m_table_block_size += (number_of_visible_rows + 1) * border_spacing_vertical();
+    m_table_block_size += (number_of_visible_rows + 1) * border_spacing_block();
 }
 
 void TableFormattingContext::position_row_boxes()
 {
     auto const& table_state = m_state.get(table_box());
 
-    CSSPixels row_block_offset = m_pending_table_box_content_offset_in_wrapper.block_offset + border_spacing_vertical();
-    CSSPixels row_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
+    CSSPixels row_block_offset = m_pending_table_box_content_offset_in_wrapper.block_offset + border_spacing_block();
+    CSSPixels row_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_inline();
     for (size_t row_index = 0; row_index < m_rows.size(); row_index++) {
         auto& row = m_rows[row_index];
         auto& row_state = m_state.get_mutable(row.box);
@@ -1282,17 +1282,17 @@ void TableFormattingContext::position_row_boxes()
             row_inline_size += column.used_inline_size;
         }
         if (m_columns.size() >= 2)
-            row_inline_size += (m_columns.size() - 1) * border_spacing_horizontal();
+            row_inline_size += (m_columns.size() - 1) * border_spacing_inline();
 
         row_state.set_content_block_size(row.final_block_size);
         row_state.set_content_inline_size(row_inline_size);
         place_child(row.box, { row_inline_offset, row_block_offset });
         if (!row.is_collapsed)
-            row_block_offset += row_state.content_block_size() + border_spacing_vertical();
+            row_block_offset += row_state.content_block_size() + border_spacing_block();
     }
 
-    CSSPixels row_group_block_offset = m_pending_table_box_content_offset_in_wrapper.block_offset + border_spacing_vertical();
-    CSSPixels row_group_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
+    CSSPixels row_group_block_offset = m_pending_table_box_content_offset_in_wrapper.block_offset + border_spacing_block();
+    CSSPixels row_group_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_inline();
     TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
         CSSPixels row_group_block_size = 0;
         CSSPixels row_group_inline_size = 0;
@@ -1307,13 +1307,13 @@ void TableFormattingContext::position_row_boxes()
             num_rows += 1;
         });
         if (num_rows >= 2)
-            row_group_block_size += (num_rows - 1) * border_spacing_vertical();
+            row_group_block_size += (num_rows - 1) * border_spacing_block();
 
         row_group_box_state.set_content_block_size(row_group_block_size);
         row_group_box_state.set_content_inline_size(row_group_inline_size);
         place_child(row_group_box, { row_group_inline_offset, row_group_block_offset });
 
-        row_group_block_offset += row_group_block_size + (num_rows > 0 ? border_spacing_vertical() : 0);
+        row_group_block_offset += row_group_block_size + (num_rows > 0 ? border_spacing_block() : 0);
     });
 
     auto total_content_block_size = max(row_block_offset, row_group_block_offset) - m_pending_table_box_content_offset_in_wrapper.block_offset - table_state.padding_top;
@@ -1396,7 +1396,7 @@ void TableFormattingContext::position_cell_boxes()
         // - the padding-left/padding-top and border-left-width/border-top-width of the table
         // FIXME: Account for visibility.
         auto cell_offset = row_state.content_offset().translated(
-            cell_state.border_box_left() + m_columns[cell.column_index].inline_offset + cell.column_index * border_spacing_horizontal(),
+            cell_state.border_box_left() + m_columns[cell.column_index].inline_offset + cell.column_index * border_spacing_inline(),
             cell_state.border_box_top());
         place_child(cell.box, cell_offset);
     }
@@ -1408,8 +1408,8 @@ bool TableFormattingContext::use_fixed_mode_layout() const
     // A table-root is said to be laid out in fixed mode whenever the computed value of the table-layout property is equal to fixed, and the
     // specified width of the table root is either a <length-percentage>, min-content or fit-content. When the specified width is not one of
     // those values, or if the computed value of the table-layout property is auto, then the table-root is said to be laid out in auto mode.
-    auto const& width = table_box().computed_values().width();
-    return table_box().computed_values().table_layout() == CSS::TableLayout::Fixed && (width.is_length() || width.is_percentage() || width.is_min_content() || width.is_fit_content());
+    auto const& inline_size = table_box().computed_values().width();
+    return table_box().computed_values().table_layout() == CSS::TableLayout::Fixed && (inline_size.is_length() || inline_size.is_percentage() || inline_size.is_min_content() || inline_size.is_fit_content());
 }
 
 static unsigned line_style_score(CSS::LineStyle line_style)
@@ -1689,9 +1689,9 @@ CSSPixels TableFormattingContext::compute_row_content_block_size(Cell const& cel
     // Compute cell block size as specified by https://www.w3.org/TR/css-tables-3/#bounding-box-assignment:
     // The logical size is the sum of:
     // - the inline/block sizes of all spanned visible columns/rows
-    // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
+    // - the inline/block border spacing times the amount of spanned visible columns/rows minus one
     // FIXME: Account for visibility.
-    span_block_size += (cell.row_span - 1) * border_spacing_vertical();
+    span_block_size += (cell.row_span - 1) * border_spacing_block();
     return span_block_size;
 }
 
@@ -2013,16 +2013,16 @@ void TableFormattingContext::initialize_intrinsic_percentages_from_cells()
 template<>
 CSSPixels TableFormattingContext::border_spacing<TableFormattingContext::Row>()
 {
-    return border_spacing_vertical();
+    return border_spacing_block();
 }
 
 template<>
 CSSPixels TableFormattingContext::border_spacing<TableFormattingContext::Column>()
 {
-    return border_spacing_horizontal();
+    return border_spacing_inline();
 }
 
-CSSPixels TableFormattingContext::border_spacing_horizontal() const
+CSSPixels TableFormattingContext::border_spacing_inline() const
 {
     auto const& computed_values = table_box().computed_values();
     // When a table is laid out in collapsed-borders mode, the border-spacing of the table-root is ignored (as if it was set to 0px):
@@ -2032,7 +2032,7 @@ CSSPixels TableFormattingContext::border_spacing_horizontal() const
     return computed_values.border_spacing_horizontal();
 }
 
-CSSPixels TableFormattingContext::border_spacing_vertical() const
+CSSPixels TableFormattingContext::border_spacing_block() const
 {
     auto const& computed_values = table_box().computed_values();
     // When a table is laid out in collapsed-borders mode, the border-spacing of the table-root is ignored (as if it was set to 0px):

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1281,8 +1281,8 @@ void TableFormattingContext::position_row_boxes()
 
     CSSPixels row_top_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
     CSSPixels row_left_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
-    for (size_t y = 0; y < m_rows.size(); y++) {
-        auto& row = m_rows[y];
+    for (size_t row_index = 0; row_index < m_rows.size(); row_index++) {
+        auto& row = m_rows[row_index];
         auto& row_state = m_state.get_mutable(row.box);
         CSSPixels row_width = 0;
         for (auto& column : m_columns) {

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -129,40 +129,40 @@ void TableFormattingContext::compute_constrainedness()
 void TableFormattingContext::compute_cell_measures(RowMeasurement row_measurement)
 {
     // Implements https://www.w3.org/TR/css-tables-3/#computing-cell-measures.
-    auto containing_block_width = m_table_constraints.percentage_basis_inline_size.value_or(0);
-    auto containing_block_height = m_table_constraints.percentage_basis_block_size.value_or(0);
+    auto containing_block_inline_size = m_table_constraints.percentage_basis_inline_size.value_or(0);
+    auto containing_block_block_size = m_table_constraints.percentage_basis_block_size.value_or(0);
 
     compute_constrainedness();
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
-        CSSPixels padding_top = computed_values.padding().top().to_px_or_zero(containing_block_height);
-        CSSPixels padding_bottom = computed_values.padding().bottom().to_px_or_zero(containing_block_height);
-        CSSPixels padding_left = computed_values.padding().left().to_px_or_zero(containing_block_width);
-        CSSPixels padding_right = computed_values.padding().right().to_px_or_zero(containing_block_width);
+        CSSPixels padding_block_start = computed_values.padding().top().to_px_or_zero(containing_block_block_size);
+        CSSPixels padding_block_end = computed_values.padding().bottom().to_px_or_zero(containing_block_block_size);
+        CSSPixels padding_inline_start = computed_values.padding().left().to_px_or_zero(containing_block_inline_size);
+        CSSPixels padding_inline_end = computed_values.padding().right().to_px_or_zero(containing_block_inline_size);
 
         auto const& cell_state = m_state.get(cell.box);
         auto use_collapsing_borders_model = cell_state.override_borders_data().has_value();
         // Implement the collapsing border model https://www.w3.org/TR/CSS22/tables.html#collapsing-borders.
-        CSSPixels border_top = use_collapsing_borders_model ? round(cell_state.border_top / 2) : computed_values.border_top().width;
-        CSSPixels border_bottom = use_collapsing_borders_model ? round(cell_state.border_bottom / 2) : computed_values.border_bottom().width;
-        CSSPixels border_left = use_collapsing_borders_model ? round(cell_state.border_left / 2) : computed_values.border_left().width;
-        CSSPixels border_right = use_collapsing_borders_model ? round(cell_state.border_right / 2) : computed_values.border_right().width;
+        CSSPixels border_block_start = use_collapsing_borders_model ? round(cell_state.border_top / 2) : computed_values.border_top().width;
+        CSSPixels border_block_end = use_collapsing_borders_model ? round(cell_state.border_bottom / 2) : computed_values.border_bottom().width;
+        CSSPixels border_inline_start = use_collapsing_borders_model ? round(cell_state.border_left / 2) : computed_values.border_left().width;
+        CSSPixels border_inline_end = use_collapsing_borders_model ? round(cell_state.border_right / 2) : computed_values.border_right().width;
 
-        auto cell_intrinsic_width_offsets = padding_left + padding_right + border_left + border_right;
+        auto cell_intrinsic_inline_size_offsets = padding_inline_start + padding_inline_end + border_inline_start + border_inline_end;
 
-        auto min_width = computed_values.min_width().to_px(containing_block_width);
-        auto width = computed_values.width().is_length() ? computed_values.width().to_px(containing_block_width) : 0;
-        auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(containing_block_width) : CSSPixels::max();
+        auto min_inline_size = computed_values.min_width().to_px(containing_block_inline_size);
+        auto inline_size = computed_values.width().is_length() ? computed_values.width().to_px(containing_block_inline_size) : 0;
+        auto max_inline_size = computed_values.max_width().is_length() ? computed_values.max_width().to_px(containing_block_inline_size) : CSSPixels::max();
 
         if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
-            min_width -= cell_intrinsic_width_offsets;
-            width -= cell_intrinsic_width_offsets;
-            max_width -= cell_intrinsic_width_offsets;
+            min_inline_size -= cell_intrinsic_inline_size_offsets;
+            inline_size -= cell_intrinsic_inline_size_offsets;
+            max_inline_size -= cell_intrinsic_inline_size_offsets;
         }
 
-        CSSPixels min_content_width;
-        CSSPixels max_content_width;
+        CSSPixels min_content_inline_size;
+        CSSPixels max_content_inline_size;
 
         // https://drafts.csswg.org/css-tables-3/#computing-column-measures
         // For the purpose of measuring a column when laid out in fixed mode [...] the min-content and max-content width
@@ -170,44 +170,44 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
         // resolved based on the table width (if it is definite, otherwise use 0).
         if (use_fixed_mode_layout()) {
             if (computed_values.width().is_length_percentage()) {
-                min_content_width = width;
-                max_content_width = width;
+                min_content_inline_size = inline_size;
+                max_content_inline_size = inline_size;
             }
         } else {
-            min_content_width = calculate_min_content_inline_size(cell.box, m_participant_constraints);
-            max_content_width = calculate_max_content_inline_size(cell.box, m_participant_constraints);
+            min_content_inline_size = calculate_min_content_inline_size(cell.box, m_participant_constraints);
+            max_content_inline_size = calculate_max_content_inline_size(cell.box, m_participant_constraints);
         }
 
-        // The outer min-content width of a table-cell is max(min-width, min-content width) adjusted by the cell intrinsic offsets.
-        cell.outer_min_width = max(min_width, min_content_width) + cell_intrinsic_width_offsets;
+        // The outer min-content inline size of a table cell is its minimum inline size adjusted by the cell intrinsic offsets.
+        cell.outer_min_inline_size = max(min_inline_size, min_content_inline_size) + cell_intrinsic_inline_size_offsets;
 
         if (row_measurement == RowMeasurement::Include) {
-            auto min_content_height = calculate_min_content_block_size(cell.box, max_content_width, m_participant_constraints);
-            auto max_content_height = calculate_max_content_block_size(cell.box, min_content_width, m_participant_constraints);
+            auto min_content_block_size = calculate_min_content_block_size(cell.box, max_content_inline_size, m_participant_constraints);
+            auto max_content_block_size = calculate_max_content_block_size(cell.box, min_content_inline_size, m_participant_constraints);
 
-            // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
-            auto min_height = computed_values.min_height().to_px(containing_block_height);
-            auto cell_intrinsic_height_offsets = padding_top + padding_bottom + border_top + border_bottom;
-            cell.outer_min_height = max(min_height, min_content_height) + cell_intrinsic_height_offsets;
+            // The outer min-content block size of a table cell is its minimum block size adjusted by the cell intrinsic offsets.
+            auto min_block_size = computed_values.min_height().to_px(containing_block_block_size);
+            auto cell_intrinsic_block_size_offsets = padding_block_start + padding_block_end + border_block_start + border_block_end;
+            cell.outer_min_block_size = max(min_block_size, min_content_block_size) + cell_intrinsic_block_size_offsets;
 
             // The tables specification isn't explicit on how to use the height and max-height CSS properties in the outer max-content formulas.
             // However, during this early phase we don't have enough information to resolve percentage sizes yet and the formulas for outer sizes
             // in the specification give enough clues to pick defaults in a way that makes sense.
-            auto height = computed_values.height().is_length() ? computed_values.height().to_px(containing_block_height) : 0;
-            auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(containing_block_height) : CSSPixels::max();
+            auto block_size = computed_values.height().is_length() ? computed_values.height().to_px(containing_block_block_size) : 0;
+            auto max_block_size = computed_values.max_height().is_length() ? computed_values.max_height().to_px(containing_block_block_size) : CSSPixels::max();
             if (m_rows[cell.row_index].is_constrained) {
                 // The outer max-content height of a table-cell in a constrained row is
                 // max(min-height, height, min-content height, min(max-height, height)) adjusted by the cell intrinsic offsets.
                 // NB: min(max-height, height) doesn't have any effect here, we can simplify the expression to max(min-height, height, min-content height).
-                cell.outer_max_height = max(min_height, max(height, min_content_height)) + cell_intrinsic_height_offsets;
+                cell.outer_max_block_size = max(min_block_size, max(block_size, min_content_block_size)) + cell_intrinsic_block_size_offsets;
             } else {
                 // The outer max-content height of a table-cell in a non-constrained row is
                 // max(min-height, height, min-content height, min(max-height, max-content height)) adjusted by the cell intrinsic offsets.
-                cell.outer_max_height = max(min_height, max(height, max(min_content_height, min(max_height, max_content_height)))) + cell_intrinsic_height_offsets;
+                cell.outer_max_block_size = max(min_block_size, max(block_size, max(min_content_block_size, min(max_block_size, max_content_block_size)))) + cell_intrinsic_block_size_offsets;
             }
         }
 
-        // See the explanation for height and max_height above.
+        // See the explanation for block_size and max_block_size above.
         if (m_columns[cell.column_index].is_constrained) {
             // The outer max-content width of a table-cell in a constrained column is
             // max(min-width, width, min-content width, min(max-width, width)) adjusted by the cell intrinsic offsets.
@@ -215,11 +215,11 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
             // AD-HOC: The formula defined by the spec doesn't respect max-width. We use a different formula that
             //         matches the behavior that is expected by WPT and is implemented by other browsers.
             // FIXME: Open a spec issue about this.
-            cell.outer_max_width = max(min_width, min(max_width, max(width, min_content_width))) + cell_intrinsic_width_offsets;
+            cell.outer_max_inline_size = max(min_inline_size, min(max_inline_size, max(inline_size, min_content_inline_size))) + cell_intrinsic_inline_size_offsets;
         } else {
             // The outer max-content width of a table-cell in a non-constrained column is
             // max(min-width, width, min-content width, min(max-width, max-content width)) adjusted by the cell intrinsic offsets.
-            cell.outer_max_width = max(min_width, max(width, max(min_content_width, min(max_width, max_content_width)))) + cell_intrinsic_width_offsets;
+            cell.outer_max_inline_size = max(min_inline_size, max(inline_size, max(min_content_inline_size, min(max_inline_size, max_content_inline_size)))) + cell_intrinsic_inline_size_offsets;
         }
     }
 }
@@ -272,13 +272,13 @@ void TableFormattingContext::initialize_table_measures<TableFormattingContext::R
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
         if (cell.row_span == 1) {
-            auto specified_height = computed_values.height().to_px(containing_block_height);
+            auto specified_block_size = computed_values.height().to_px(containing_block_height);
             // https://www.w3.org/TR/css-tables-3/#row-layout makes specified cell height part of the initialization formula for row table measures:
             // This is done by running the same algorithm as the column measurement, with the span=1 value being initialized (for min-content) with
             // the largest of the resulting height of the previous row layout, the height specified on the corresponding table-row (if any), and
             // the largest height specified on cells that span this row only (the algorithm starts by considering cells of span 2 on top of that assignment).
-            m_rows[cell.row_index].min_size = max(m_rows[cell.row_index].min_size, max(cell.outer_min_height, specified_height));
-            m_rows[cell.row_index].max_size = max(m_rows[cell.row_index].max_size, cell.outer_max_height);
+            m_rows[cell.row_index].min_size = max(m_rows[cell.row_index].min_size, max(cell.outer_min_block_size, specified_block_size));
+            m_rows[cell.row_index].max_size = max(m_rows[cell.row_index].max_size, cell.outer_max_block_size);
         }
     }
 }
@@ -291,8 +291,8 @@ void TableFormattingContext::initialize_table_measures<TableFormattingContext::C
     // https://www.w3.org/TR/css-tables-3/#max-content-width-of-a-column-based-on-cells-of-span-up-to-1
     for (auto& cell : m_cells) {
         if (cell.column_span == 1 && (cell.row_index == 0 || !use_fixed_mode_layout())) {
-            m_columns[cell.column_index].min_size = max(m_columns[cell.column_index].min_size, cell.outer_min_width);
-            m_columns[cell.column_index].max_size = max(m_columns[cell.column_index].max_size, cell.outer_max_width);
+            m_columns[cell.column_index].min_size = max(m_columns[cell.column_index].min_size, cell.outer_min_inline_size);
+            m_columns[cell.column_index].max_size = max(m_columns[cell.column_index].max_size, cell.outer_max_inline_size);
         }
     }
 }
@@ -620,7 +620,7 @@ void TableFormattingContext::compute_table_width()
                 if (cell_width.is_percentage()) {
                     CSSPixels adjusted_used_width = undistributable_space;
                     if (cell_width.percentage().value() != 0)
-                        adjusted_used_width += CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_width));
+                        adjusted_used_width += CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_inline_size));
 
                     if (width_of_table_containing_block.is_definite())
                         used_width = min(max(used_width, adjusted_used_width), width_of_table_containing_block.to_px_or_zero());
@@ -1083,11 +1083,11 @@ void TableFormattingContext::compute_table_height()
         }
         if (m_needs_fixed_mode_row_measurement) {
             auto const& computed_values = cell.box.computed_values();
-            auto min_height = computed_values.min_height().to_px(height_of_containing_block);
-            auto cell_intrinsic_height_offsets = cell_state.border_box_top() + cell_state.border_box_bottom();
-            auto measured_outer_height = max(cell_state.border_box_block_size(), min_height + cell_intrinsic_height_offsets);
-            cell.outer_min_height = measured_outer_height;
-            cell.outer_max_height = measured_outer_height;
+            auto min_block_size = computed_values.min_height().to_px(height_of_containing_block);
+            auto cell_intrinsic_block_size_offsets = cell_state.border_box_top() + cell_state.border_box_bottom();
+            auto measured_outer_block_size = max(cell_state.border_box_block_size(), min_block_size + cell_intrinsic_block_size_offsets);
+            cell.outer_min_block_size = measured_outer_block_size;
+            cell.outer_max_block_size = measured_outer_block_size;
         }
 
         // https://drafts.csswg.org/css2/#height-layout
@@ -1907,25 +1907,25 @@ size_t TableFormattingContext::cell_index<TableFormattingContext::Column>(TableF
 template<>
 CSSPixels TableFormattingContext::cell_min_size<TableFormattingContext::Row>(TableFormattingContext::Cell const& cell)
 {
-    return cell.outer_min_height;
+    return cell.outer_min_block_size;
 }
 
 template<>
 CSSPixels TableFormattingContext::cell_min_size<TableFormattingContext::Column>(TableFormattingContext::Cell const& cell)
 {
-    return cell.outer_min_width;
+    return cell.outer_min_inline_size;
 }
 
 template<>
 CSSPixels TableFormattingContext::cell_max_size<TableFormattingContext::Row>(TableFormattingContext::Cell const& cell)
 {
-    return cell.outer_max_height;
+    return cell.outer_max_block_size;
 }
 
 template<>
 CSSPixels TableFormattingContext::cell_max_size<TableFormattingContext::Column>(TableFormattingContext::Cell const& cell)
 {
-    return cell.outer_max_width;
+    return cell.outer_max_inline_size;
 }
 
 template<>

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -53,7 +53,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             auto* block_context = as_if<BlockFormattingContext>(caption_context.ptr());
             CSSPixelPoint caption_offset;
             if (block_context) {
-                auto available_width = caption_available_space.width.to_px_or_zero();
+                auto available_width = caption_available_space.inline_size.to_px_or_zero();
                 block_context->resolve_vertical_box_model_metrics(child_box, available_width);
                 CSSPixelPoint caption_position_in_block_context {};
                 block_context->compute_width(child_box, caption_available_space, caption_constraints, caption_position_in_block_context);
@@ -544,7 +544,7 @@ void TableFormattingContext::compute_table_width()
 
     auto& computed_values = table_box().computed_values();
 
-    auto width_of_table_containing_block = m_available_space->width;
+    auto width_of_table_containing_block = m_available_space->inline_size;
 
     // Percentages on 'width' and 'height' on the table are relative to the table wrapper box's containing block,
     // not the table wrapper box itself.
@@ -601,9 +601,9 @@ void TableFormattingContext::compute_table_width()
         // NOTE: In normal layout the available width already is the wrapper's used width, which the
         //       parent context resolved with shrink-to-fit; filling it keeps the table and its
         //       wrapper consistent without reading the wrapper's state from here.
-        if (m_available_space->width.is_min_content())
+        if (m_available_space->inline_size.is_min_content())
             used_width = grid_min;
-        else if (m_available_space->width.is_max_content())
+        else if (m_available_space->inline_size.is_max_content())
             used_width = grid_max;
         else if (width_of_table_containing_block.is_definite() && m_layout_mode == LayoutMode::Normal)
             used_width = max(width_of_table_containing_block.to_px_or_zero(), used_min_width);
@@ -614,7 +614,7 @@ void TableFormattingContext::compute_table_width()
         // https://www.w3.org/TR/CSS22/tables.html#auto-table-layout
         // A percentage value for a column width is relative to the table width. If the table has 'width: auto',
         // a percentage represents a constraint on the column's width, which a UA should try to satisfy.
-        if (!m_available_space->width.is_intrinsic_sizing_constraint()) {
+        if (!m_available_space->inline_size.is_intrinsic_sizing_constraint()) {
             for (auto& cell : m_cells) {
                 auto const& cell_width = cell.box.computed_values().width();
                 if (cell_width.is_percentage()) {
@@ -637,11 +637,11 @@ void TableFormattingContext::compute_table_width()
         // of resolved-table-width, and the used min-width of the table.
         CSSPixels resolved_table_width = resolve_width_constraint_to_content_box(computed_values.width());
         used_width = max(resolved_table_width, used_min_width);
-        if (!should_treat_max_width_as_none(table_box(), m_available_space->width, m_table_constraints))
+        if (!should_treat_max_width_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
             used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     }
 
-    if (!should_treat_max_width_as_none(table_box(), m_available_space->width, m_table_constraints))
+    if (!should_treat_max_width_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
         used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     used_width = max(used_width, used_min_width);
 
@@ -1821,14 +1821,14 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
 
     run_until_width_calculation(layout_input);
 
-    if (available_space.width.is_intrinsic_sizing_constraint() && !available_space.height.is_intrinsic_sizing_constraint()) {
+    if (available_space.inline_size.is_intrinsic_sizing_constraint() && !available_space.block_size.is_intrinsic_sizing_constraint()) {
         return;
     }
 
     auto const& table_state = m_state.get(table_box());
     auto caption_available_space = AvailableSpace(
         AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_width())),
-        available_space.height);
+        available_space.block_size);
 
     auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -492,7 +492,7 @@ CSSPixels TableFormattingContext::compute_capmin()
     // The caption width minimum (CAPMIN) is the largest of the table captions min-content contribution:
     // https://drafts.csswg.org/css-tables-3/#computing-the-table-width
     CSSPixels capmin = 0;
-    auto width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_inline_size.value_or(0);
+    auto table_wrapper_containing_block_inline_size = m_table_constraints.percentage_basis_inline_size.value_or(0);
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
         auto const* child_box = as_if<Box>(*child);
         if (!child_box || !child_box->display().is_table_caption()) {
@@ -500,10 +500,10 @@ CSSPixels TableFormattingContext::compute_capmin()
         }
         auto const& computed_values = child_box->computed_values();
 
-        auto margin_left = computed_values.margin().left().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero();
-        auto margin_right = computed_values.margin().right().resolved_or_auto(width_of_table_wrapper_containing_block).to_px_or_zero();
-        auto padding_left = computed_values.padding().left().to_px_or_zero(width_of_table_wrapper_containing_block);
-        auto padding_right = computed_values.padding().right().to_px_or_zero(width_of_table_wrapper_containing_block);
+        auto margin_left = computed_values.margin().left().resolved_or_auto(table_wrapper_containing_block_inline_size).to_px_or_zero();
+        auto margin_right = computed_values.margin().right().resolved_or_auto(table_wrapper_containing_block_inline_size).to_px_or_zero();
+        auto padding_left = computed_values.padding().left().to_px_or_zero(table_wrapper_containing_block_inline_size);
+        auto padding_right = computed_values.padding().right().to_px_or_zero(table_wrapper_containing_block_inline_size);
         auto outer_size_for_inner_size = [&](CSSPixels inner_size) {
             return inner_size
                 + margin_left
@@ -516,8 +516,8 @@ CSSPixels TableFormattingContext::compute_capmin()
 
         auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_inline_size(*child_box, m_participant_constraints));
         if (!computed_values.width().is_auto() && !computed_values.width().contains_percentage()) {
-            auto preferred_inner_width = calculate_inner_inline_size(*child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width(), m_participant_constraints);
-            caption_min_content_contribution = max(caption_min_content_contribution, outer_size_for_inner_size(preferred_inner_width));
+            auto preferred_inner_inline_size = calculate_inner_inline_size(*child_box, AvailableSize::make_definite(table_wrapper_containing_block_inline_size), computed_values.width(), m_participant_constraints);
+            caption_min_content_contribution = max(caption_min_content_contribution, outer_size_for_inner_size(preferred_inner_inline_size));
         }
 
         capmin = max(caption_min_content_contribution, capmin);
@@ -548,7 +548,7 @@ void TableFormattingContext::compute_table_width()
 
     // Percentages on 'width' and 'height' on the table are relative to the table wrapper box's containing block,
     // not the table wrapper box itself.
-    CSSPixels width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_inline_size.value_or(0);
+    CSSPixels table_wrapper_containing_block_inline_size = m_table_constraints.percentage_basis_inline_size.value_or(0);
 
     // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
     auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
@@ -575,14 +575,14 @@ void TableFormattingContext::compute_table_width()
         if (inline_size_constraint.is_max_content())
             return grid_max;
         if (inline_size_constraint.is_fit_content()) {
-            auto fit_content_limit = width_of_table_wrapper_containing_block;
+            auto fit_content_limit = table_wrapper_containing_block_inline_size;
             if (auto const& fit_content_available_space = inline_size_constraint.fit_content_available_space(); fit_content_available_space.has_value())
-                fit_content_limit = fit_content_available_space->to_px(width_of_table_wrapper_containing_block);
+                fit_content_limit = fit_content_available_space->to_px(table_wrapper_containing_block_inline_size);
             return min(grid_max, max(grid_min, fit_content_limit));
         }
         // CSS Sizing says box-sizing:border-box applies length/percentage width/min-width/max-width constraints to
         // the border box. The table width algorithm compares content widths, so convert them before comparing.
-        auto resolved_width = inline_size_constraint.to_px(width_of_table_wrapper_containing_block);
+        auto resolved_width = inline_size_constraint.to_px(table_wrapper_containing_block_inline_size);
         if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox)
             resolved_width -= table_box_state.border_box_left() + table_box_state.border_box_right();
         return max(CSSPixels(0), resolved_width);
@@ -1128,10 +1128,10 @@ void TableFormattingContext::compute_table_height()
 
     m_table_height = sum_rows_height;
 
-    if (m_min_border_box_height_from_flex_item.has_value()) {
+    if (m_min_border_box_block_size_from_flex_item.has_value()) {
         auto const& table_state = m_state.get(table_box());
-        auto min_content_height = *m_min_border_box_height_from_flex_item - table_state.border_box_top() - table_state.border_box_bottom();
-        m_table_height = max(m_table_height, min_content_height);
+        auto min_content_block_size = *m_min_border_box_block_size_from_flex_item - table_state.border_box_top() - table_state.border_box_bottom();
+        m_table_height = max(m_table_height, min_content_block_size);
     }
 
     if (!table_box().computed_values().height().is_auto()) {
@@ -1817,7 +1817,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     auto const& available_space = layout_input.available_space;
     FORMATTING_CONTEXT_TRACE();
     m_available_space = available_space;
-    m_min_border_box_height_from_flex_item = layout_input.table_grid_min_border_box_height;
+    m_min_border_box_block_size_from_flex_item = layout_input.table_grid_min_border_box_block_size;
 
     run_until_width_calculation(layout_input);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -250,29 +250,29 @@ void TableFormattingContext::compute_outer_content_sizes()
 
 void TableFormattingContext::initialize_row_content_sizes()
 {
-    auto containing_block_height = m_table_constraints.percentage_basis_block_size.value_or(0);
+    auto containing_block_block_size = m_table_constraints.percentage_basis_block_size.value_or(0);
 
     for (auto& row : m_rows) {
         auto const& computed_values = row.box.computed_values();
-        auto min_height = computed_values.min_height().to_px(containing_block_height);
-        auto max_height = computed_values.max_height().is_length() ? computed_values.max_height().to_px(containing_block_height) : CSSPixels::max();
-        auto height = computed_values.height().to_px(containing_block_height);
-        // The outer min-content height of a table-row or table-row-group is max(min-height, height).
-        row.min_size = max(min_height, height);
-        // The outer max-content height of a table-row or table-row-group is max(min-height, min(max-height, height)).
-        row.max_size = max(min_height, min(max_height, height));
+        auto min_block_size = computed_values.min_height().to_px(containing_block_block_size);
+        auto max_block_size = computed_values.max_height().is_length() ? computed_values.max_height().to_px(containing_block_block_size) : CSSPixels::max();
+        auto block_size = computed_values.height().to_px(containing_block_block_size);
+        // The outer min-content block size of a table row or row group is max(min-block-size, block-size).
+        row.min_size = max(min_block_size, block_size);
+        // The outer max-content block size is max(min-block-size, min(max-block-size, block-size)).
+        row.max_size = max(min_block_size, min(max_block_size, block_size));
     }
 }
 
 template<>
 void TableFormattingContext::initialize_table_measures<TableFormattingContext::Row>()
 {
-    auto containing_block_height = m_table_constraints.percentage_basis_block_size.value_or(0);
+    auto containing_block_block_size = m_table_constraints.percentage_basis_block_size.value_or(0);
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
         if (cell.row_span == 1) {
-            auto specified_block_size = computed_values.height().to_px(containing_block_height);
+            auto specified_block_size = computed_values.height().to_px(containing_block_block_size);
             // https://www.w3.org/TR/css-tables-3/#row-layout makes specified cell height part of the initialization formula for row table measures:
             // This is done by running the same algorithm as the column measurement, with the span=1 value being initialized (for min-content) with
             // the largest of the resulting height of the previous row layout, the height specified on the corresponding table-row (if any), and
@@ -978,7 +978,7 @@ bool TableFormattingContext::can_skip_row_intrinsic_measurement() const
     return true;
 }
 
-static bool cell_height_depends_on_table_height(Box const& cell_box)
+static bool cell_block_size_depends_on_table_block_size(Box const& cell_box)
 {
     return cell_box.computed_values().height().is_percentage();
 }
@@ -1013,19 +1013,19 @@ Optional<TableFormattingContext::MeasuredCellContent> TableFormattingContext::me
     };
 }
 
-void TableFormattingContext::compute_table_height()
+void TableFormattingContext::compute_table_block_size()
 {
-    // First pass of row height calculation:
+    // First pass of row block-size calculation:
     for (auto& row : m_rows) {
         if (row.is_collapsed) {
-            row.base_height = 0;
+            row.base_block_size = 0;
             continue;
         }
-        auto row_computed_height = row.box.computed_values().height();
-        if (row_computed_height.is_length()) {
-            // NOTE: A <length> height resolves without a percentage basis.
-            auto row_used_height = row_computed_height.to_px(0);
-            row.base_height = max(row.base_height, row_used_height);
+        auto row_computed_block_size = row.box.computed_values().height();
+        if (row_computed_block_size.is_length()) {
+            // NOTE: A <length> block size resolves without a percentage basis.
+            auto row_used_block_size = row_computed_block_size.to_px(0);
+            row.base_block_size = max(row.base_block_size, row_used_block_size);
         }
     }
 
@@ -1034,17 +1034,17 @@ void TableFormattingContext::compute_table_height()
         auto& row = m_rows[cell.row_index];
         auto& cell_state = m_state.get_mutable(cell.box);
 
-        CSSPixels span_width = 0;
+        CSSPixels span_inline_size = 0;
         for (size_t i = 0; i < cell.column_span; ++i)
-            span_width += m_columns[cell.column_index + i].used_width;
+            span_inline_size += m_columns[cell.column_index + i].used_width;
 
-        auto width_of_containing_block = m_participant_constraints.percentage_basis_inline_size.value_or(0);
-        auto height_of_containing_block = m_participant_constraints.percentage_basis_block_size.value_or(0);
+        auto containing_block_inline_size = m_participant_constraints.percentage_basis_inline_size.value_or(0);
+        auto containing_block_block_size = m_participant_constraints.percentage_basis_block_size.value_or(0);
 
-        cell_state.padding_top = cell.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
-        cell_state.padding_bottom = cell.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
-        cell_state.padding_left = cell.box.computed_values().padding().left().to_px_or_zero(width_of_containing_block);
-        cell_state.padding_right = cell.box.computed_values().padding().right().to_px_or_zero(width_of_containing_block);
+        cell_state.padding_top = cell.box.computed_values().padding().top().to_px_or_zero(containing_block_inline_size);
+        cell_state.padding_bottom = cell.box.computed_values().padding().bottom().to_px_or_zero(containing_block_inline_size);
+        cell_state.padding_left = cell.box.computed_values().padding().left().to_px_or_zero(containing_block_inline_size);
+        cell_state.padding_right = cell.box.computed_values().padding().right().to_px_or_zero(containing_block_inline_size);
 
         if (table_box().computed_values().border_collapse() == CSS::BorderCollapse::Separate) {
             cell_state.border_top = cell.box.computed_values().border_top().width;
@@ -1054,23 +1054,23 @@ void TableFormattingContext::compute_table_height()
         }
 
         if (!row.is_collapsed) {
-            auto cell_computed_height = cell.box.computed_values().height();
-            if (cell_computed_height.is_length()) {
-                auto cell_used_height = cell_computed_height.to_px(height_of_containing_block);
-                cell_state.set_content_block_size(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
+            auto cell_computed_block_size = cell.box.computed_values().height();
+            if (cell_computed_block_size.is_length()) {
+                auto cell_used_block_size = cell_computed_block_size.to_px(containing_block_block_size);
+                cell_state.set_content_block_size(cell_used_block_size - cell_state.border_box_top() - cell_state.border_box_bottom());
 
-                row.base_height = max(row.base_height, cell_used_height);
+                row.base_block_size = max(row.base_block_size, cell_used_block_size);
             }
         }
 
-        // Compute cell width as specified by https://www.w3.org/TR/css-tables-3/#bounding-box-assignment:
-        // The position of any table-cell, table-track, or table-track-group box within the table is defined as the rectangle whose width/height is the sum of:
-        // - the widths/heights of all spanned visible columns/rows
+        // Compute cell inline size as specified by https://www.w3.org/TR/css-tables-3/#bounding-box-assignment:
+        // The position of any table cell, track, or track group is defined by the sums of its spanned columns and rows:
+        // - the inline/block sizes of all spanned visible columns/rows
         // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
         // FIXME: Account for visibility.
-        cell_state.set_content_inline_size(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        cell_state.set_content_inline_size(span_inline_size - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
         Optional<CSSPixels> measured_baseline;
-        if (cell_height_depends_on_table_height(cell.box)) {
+        if (cell_block_size_depends_on_table_block_size(cell.box)) {
             // This cell's final inside layout happens in the second pass below; measure its
             // content in a throwaway state instead of laying out the committing state twice.
             if (auto measured = measure_cell_content(cell.box, cell_state, cell_state.available_inner_space_or_constraints_from(*m_available_space)); measured.has_value()) {
@@ -1083,7 +1083,7 @@ void TableFormattingContext::compute_table_height()
         }
         if (m_needs_fixed_mode_row_measurement) {
             auto const& computed_values = cell.box.computed_values();
-            auto min_block_size = computed_values.min_height().to_px(height_of_containing_block);
+            auto min_block_size = computed_values.min_height().to_px(containing_block_block_size);
             auto cell_intrinsic_block_size_offsets = cell_state.border_box_top() + cell_state.border_box_bottom();
             auto measured_outer_block_size = max(cell_state.border_box_block_size(), min_block_size + cell_intrinsic_block_size_offsets);
             cell.outer_min_block_size = measured_outer_block_size;
@@ -1097,17 +1097,17 @@ void TableFormattingContext::compute_table_height()
 
         // Implements https://www.w3.org/TR/css-tables-3/#computing-the-table-height
 
-        // The minimum height of a row is the maximum of:
-        // - the computed height (if definite, percentages being considered 0px) of its corresponding table-row (if nay)
-        // - the computed height of each cell spanning the current row exclusively (if definite, percentages being treated as 0px), and
-        // - the minimum height (ROWMIN) required by the cells spanning the row.
+        // The minimum block size of a row is the maximum of:
+        // - the computed block size (if definite, percentages being considered 0px) of its corresponding table row,
+        // - the computed block size of each cell spanning the current row exclusively (if definite, percentages being treated as 0px), and
+        // - the minimum block size (ROWMIN) required by the cells spanning the row.
         // Note that we've already applied the first rule at the top of the method.
         if (!row.is_collapsed) {
             if (cell.row_span == 1) {
-                row.base_height = max(row.base_height, cell_state.border_box_block_size());
+                row.base_block_size = max(row.base_block_size, cell_state.border_box_block_size());
             }
             if (!m_needs_fixed_mode_row_measurement)
-                row.base_height = max(row.base_height, m_rows[cell.row_index].min_size);
+                row.base_block_size = max(row.base_block_size, m_rows[cell.row_index].min_size);
             row.baseline = max(row.baseline, cell.baseline);
         }
     }
@@ -1117,84 +1117,83 @@ void TableFormattingContext::compute_table_height()
         compute_table_measures<Row>();
         for (auto& row : m_rows) {
             if (!row.is_collapsed)
-                row.base_height = max(row.base_height, row.min_size);
+                row.base_block_size = max(row.base_block_size, row.min_size);
         }
     }
 
-    CSSPixels sum_rows_height = 0;
+    CSSPixels sum_base_block_sizes = 0;
     for (auto& row : m_rows) {
-        sum_rows_height += row.base_height;
+        sum_base_block_sizes += row.base_block_size;
     }
 
-    m_table_height = sum_rows_height;
+    m_table_block_size = sum_base_block_sizes;
 
     if (m_min_border_box_block_size_from_flex_item.has_value()) {
         auto const& table_state = m_state.get(table_box());
         auto min_content_block_size = *m_min_border_box_block_size_from_flex_item - table_state.border_box_top() - table_state.border_box_bottom();
-        m_table_height = max(m_table_height, min_content_block_size);
+        m_table_block_size = max(m_table_block_size, min_content_block_size);
     }
 
     if (!table_box().computed_values().height().is_auto()) {
-        // If the table has a height property with a value other than auto, it is treated as a minimum height for the
-        // table grid, and will eventually be distributed to the height of the rows if their collective minimum height
-        // ends up smaller than this number.
-        CSSPixels height_of_table_containing_block = m_table_constraints.percentage_basis_block_size.value_or(0);
-        auto specified_table_height = table_box().computed_values().height().to_px(height_of_table_containing_block);
+        // If the table has a `height` property other than auto, it is treated as a minimum block size for the
+        // table grid, and will eventually be distributed to the rows if their collective minimum block size is smaller.
+        CSSPixels table_containing_block_block_size = m_table_constraints.percentage_basis_block_size.value_or(0);
+        auto specified_table_block_size = table_box().computed_values().height().to_px(table_containing_block_block_size);
         if (table_box().computed_values().box_sizing() == CSS::BoxSizing::BorderBox) {
             auto const& table_state = m_state.get(table_box());
-            specified_table_height -= table_state.border_box_top() + table_state.border_box_bottom();
+            specified_table_block_size -= table_state.border_box_top() + table_state.border_box_bottom();
         }
-        m_table_height = max(m_table_height, specified_table_height);
+        m_table_block_size = max(m_table_block_size, specified_table_block_size);
     }
 
     for (auto& row : m_rows) {
         // Reference size is the largest of
-        // - its initial base height and
-        // - its new base height (the one evaluated during the second layout pass, where percentages used in
-        //   rowgroups/rows/cells' specified heights were resolved according to the table height, instead of
+        // - its initial base block size and
+        // - its new base block size (the one evaluated during the second layout pass, where percentages used in
+        //   row groups, rows, and cells were resolved according to the table block size, instead of
         //   being ignored as 0px).
 
         // Assign reference size to base size. Later, the reference size might change to a larger value during
         // the second pass of rows layout.
-        row.reference_height = row.base_height;
+        row.reference_block_size = row.base_block_size;
     }
 
-    // Second pass of rows height calculation:
-    // At this point, percentage row height can be resolved because the final table height is calculated.
+    // Second pass of row block-size calculation:
+    // At this point, percentage row block sizes can be resolved because the final table block size is calculated.
     for (auto& row : m_rows) {
         if (row.is_collapsed) {
-            row.reference_height = 0;
+            row.reference_block_size = 0;
             continue;
         }
-        auto row_computed_height = row.box.computed_values().height();
-        if (row_computed_height.is_percentage()) {
-            auto row_used_height = row_computed_height.to_px(m_table_height);
-            row.reference_height = max(row.reference_height, row_used_height);
+        auto row_computed_block_size = row.box.computed_values().height();
+        if (row_computed_block_size.is_percentage()) {
+            auto row_used_block_size = row_computed_block_size.to_px(m_table_block_size);
+            row.reference_block_size = max(row.reference_block_size, row_used_block_size);
         } else {
             continue;
         }
     }
 
     // Second pass cells layout:
-    // At this point, percentage cell height can be resolved because the final table height is calculated.
+    // At this point, percentage cell block sizes can be resolved because the final table block size is calculated.
     for (auto& cell : m_cells) {
         auto& row = m_rows[cell.row_index];
         auto& cell_state = m_state.get_mutable(cell.box);
 
-        CSSPixels span_width = 0;
+        CSSPixels span_inline_size = 0;
         for (size_t i = 0; i < cell.column_span; ++i)
-            span_width += m_columns[cell.column_index + i].used_width;
+            span_inline_size += m_columns[cell.column_index + i].used_width;
 
-        if (!cell_height_depends_on_table_height(cell.box))
+        if (!cell_block_size_depends_on_table_block_size(cell.box))
             continue;
 
-        auto cell_used_height = cell.box.computed_values().height().to_px(m_table_height);
-        cell_state.set_content_block_size(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
+        auto cell_used_block_size = cell.box.computed_values().height().to_px(m_table_block_size);
+        cell_state.set_content_block_size(cell_used_block_size - cell_state.border_box_top() - cell_state.border_box_bottom());
 
         if (!row.is_collapsed)
-            row.reference_height = max(row.reference_height, cell_used_height);
+            row.reference_block_size = max(row.reference_block_size, cell_used_block_size);
 
-        cell_state.set_content_inline_size(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        cell_state.set_content_inline_size(span_inline_size - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
         // The first pass only measured this cell in a throwaway state; this is its one and
         // only inside layout in the committing state.
         if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
@@ -1204,127 +1203,124 @@ void TableFormattingContext::compute_table_height()
         cell.baseline = box_baseline(cell.box, BaselineSet::First);
 
         if (!row.is_collapsed) {
-            row.reference_height = max(row.reference_height, cell_state.border_box_block_size());
+            row.reference_block_size = max(row.reference_block_size, cell_state.border_box_block_size());
             row.baseline = max(row.baseline, cell.baseline);
         }
     }
 }
 
-void TableFormattingContext::distribute_height_to_rows()
+void TableFormattingContext::distribute_block_size_to_rows()
 {
-    CSSPixels sum_reference_height = 0;
+    CSSPixels sum_reference_block_sizes = 0;
     size_t number_of_visible_rows = 0;
     for (auto& row : m_rows) {
-        sum_reference_height += row.reference_height;
+        sum_reference_block_sizes += row.reference_block_size;
         if (!row.is_collapsed)
             ++number_of_visible_rows;
     }
 
-    if (sum_reference_height == 0)
+    if (sum_reference_block_sizes == 0)
         return;
 
-    Vector<Row&> rows_with_auto_height;
+    Vector<Row&> rows_with_auto_block_size;
     for (auto& row : m_rows) {
         if (row.box.computed_values().height().is_auto() && !row.is_collapsed) {
-            rows_with_auto_height.append(row);
+            rows_with_auto_block_size.append(row);
         }
     }
 
-    if (m_table_height <= sum_reference_height) {
-        // If the table height is equal or smaller than sum of reference sizes, the final height assigned to each row
-        // will be the weighted mean of the base and the reference size that yields the correct total height.
+    if (m_table_block_size <= sum_reference_block_sizes) {
+        // If the table block size is no larger than the sum of reference sizes, each final row block size is the
+        // weighted mean of the base and reference sizes that yields the correct total block size.
 
         for (auto& row : m_rows) {
             if (row.is_collapsed) {
-                row.final_height = 0;
+                row.final_block_size = 0;
                 continue;
             }
-            auto weight = row.reference_height / static_cast<double>(sum_reference_height);
-            auto final_height = m_table_height * weight;
-            row.final_height = CSSPixels::nearest_value_for(final_height);
+            auto weight = row.reference_block_size / static_cast<double>(sum_reference_block_sizes);
+            auto final_block_size = m_table_block_size * weight;
+            row.final_block_size = CSSPixels::nearest_value_for(final_block_size);
         }
-    } else if (rows_with_auto_height.size() > 0) {
-        // Else, if the table owns any “auto-height” row (a row whose size is only determined by its content size and
-        // none of the specified heights), each non-auto-height row receives its reference height and auto-height rows
-        // receive their reference size plus some increment which is equal to the height missing to amount to the
-        // specified table height divided by the amount of such rows.
+    } else if (rows_with_auto_block_size.size() > 0) {
+        // Else, if the table owns any auto-block-size row, each non-auto row receives its reference block size and
+        // auto rows receive their reference size plus an equal share of the missing table block size.
 
         for (auto& row : m_rows) {
-            row.final_height = row.reference_height;
+            row.final_block_size = row.reference_block_size;
         }
 
-        auto auto_height_rows_increment = (m_table_height - sum_reference_height) / rows_with_auto_height.size();
-        for (auto& row : rows_with_auto_height) {
-            row.final_height += auto_height_rows_increment;
+        auto auto_block_size_rows_increment = (m_table_block_size - sum_reference_block_sizes) / rows_with_auto_block_size.size();
+        for (auto& row : rows_with_auto_block_size) {
+            row.final_block_size += auto_block_size_rows_increment;
         }
     } else {
-        // Else, all rows receive their reference size plus some increment which is equal to the height missing to
-        // amount to the specified table height divided by the amount of rows.
+        // Else, all rows receive their reference size plus an equal share of the missing table block size.
 
-        auto increment = (m_table_height - sum_reference_height) / number_of_visible_rows;
+        auto increment = (m_table_block_size - sum_reference_block_sizes) / number_of_visible_rows;
         for (auto& row : m_rows) {
             if (row.is_collapsed) {
-                row.final_height = 0;
+                row.final_block_size = 0;
                 continue;
             }
-            row.final_height = row.reference_height + increment;
+            row.final_block_size = row.reference_block_size + increment;
         }
     }
 
     // Add undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
-    m_table_height += (number_of_visible_rows + 1) * border_spacing_vertical();
+    m_table_block_size += (number_of_visible_rows + 1) * border_spacing_vertical();
 }
 
 void TableFormattingContext::position_row_boxes()
 {
     auto const& table_state = m_state.get(table_box());
 
-    CSSPixels row_top_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
-    CSSPixels row_left_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
+    CSSPixels row_block_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
+    CSSPixels row_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
     for (size_t row_index = 0; row_index < m_rows.size(); row_index++) {
         auto& row = m_rows[row_index];
         auto& row_state = m_state.get_mutable(row.box);
-        CSSPixels row_width = 0;
+        CSSPixels row_inline_size = 0;
         for (auto& column : m_columns) {
-            row_width += column.used_width;
+            row_inline_size += column.used_width;
         }
         if (m_columns.size() >= 2)
-            row_width += (m_columns.size() - 1) * border_spacing_horizontal();
+            row_inline_size += (m_columns.size() - 1) * border_spacing_horizontal();
 
-        row_state.set_content_block_size(row.final_height);
-        row_state.set_content_inline_size(row_width);
-        place_child(row.box, { row_left_offset, row_top_offset });
+        row_state.set_content_block_size(row.final_block_size);
+        row_state.set_content_inline_size(row_inline_size);
+        place_child(row.box, { row_inline_offset, row_block_offset });
         if (!row.is_collapsed)
-            row_top_offset += row_state.content_block_size() + border_spacing_vertical();
+            row_block_offset += row_state.content_block_size() + border_spacing_vertical();
     }
 
-    CSSPixels row_group_top_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
-    CSSPixels row_group_left_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
+    CSSPixels row_group_block_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
+    CSSPixels row_group_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
     TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
-        CSSPixels row_group_height = 0;
-        CSSPixels row_group_width = 0;
+        CSSPixels row_group_block_size = 0;
+        CSSPixels row_group_inline_size = 0;
 
         auto& row_group_box_state = m_state.get_mutable(row_group_box);
 
         int num_rows = 0;
         TableGrid::for_each_child_box_matching(row_group_box, TableGrid::is_table_row, [&](auto& row) {
             auto const& row_state = m_state.get(row);
-            row_group_height += row_state.border_box_block_size();
-            row_group_width = max(row_group_width, row_state.border_box_inline_size());
+            row_group_block_size += row_state.border_box_block_size();
+            row_group_inline_size = max(row_group_inline_size, row_state.border_box_inline_size());
             num_rows += 1;
         });
         if (num_rows >= 2)
-            row_group_height += (num_rows - 1) * border_spacing_vertical();
+            row_group_block_size += (num_rows - 1) * border_spacing_vertical();
 
-        row_group_box_state.set_content_block_size(row_group_height);
-        row_group_box_state.set_content_inline_size(row_group_width);
-        place_child(row_group_box, { row_group_left_offset, row_group_top_offset });
+        row_group_box_state.set_content_block_size(row_group_block_size);
+        row_group_box_state.set_content_inline_size(row_group_inline_size);
+        place_child(row_group_box, { row_group_inline_offset, row_group_block_offset });
 
-        row_group_top_offset += row_group_height + (num_rows > 0 ? border_spacing_vertical() : 0);
+        row_group_block_offset += row_group_block_size + (num_rows > 0 ? border_spacing_vertical() : 0);
     });
 
-    auto total_content_height = max(row_top_offset, row_group_top_offset) - m_pending_table_box_content_offset_in_wrapper.y() - table_state.padding_top;
-    m_table_height = max(total_content_height, m_table_height);
+    auto total_content_block_size = max(row_block_offset, row_group_block_offset) - m_pending_table_box_content_offset_in_wrapper.y() - table_state.padding_top;
+    m_table_block_size = max(total_content_block_size, m_table_block_size);
 }
 
 void TableFormattingContext::position_cell_boxes()
@@ -1354,31 +1350,31 @@ void TableFormattingContext::position_cell_boxes()
     for (auto& cell : m_cells) {
         auto& cell_state = m_state.get_mutable(cell.box);
         auto& row_state = m_state.get(m_rows[cell.row_index].box);
-        auto const row_content_height = compute_row_content_height(cell);
+        auto const row_content_block_size = compute_row_content_block_size(cell);
         auto const& vertical_align = cell.box.computed_values().vertical_align();
         // The following image shows various alignment lines of a row:
         // https://www.w3.org/TR/css-tables-3/images/cell-align-explainer.png
         // https://drafts.csswg.org/css2/#height-layout
         // In the context of tables, values for vertical-align have the following meanings:
         if (cell_is_anonymous_wrapper_for_flex_or_grid(cell)) {
-            cell_state.padding_bottom += row_content_height - cell_state.border_box_block_size();
+            cell_state.padding_bottom += row_content_block_size - cell_state.border_box_block_size();
         } else if (vertical_align.has<CSS::VerticalAlign>()) {
             switch (vertical_align.get<CSS::VerticalAlign>()) {
             // The center of the cell is aligned with the center of the rows it spans.
             case CSS::VerticalAlign::Middle: {
-                auto const height_diff = row_content_height - cell_state.border_box_block_size();
-                cell_state.padding_top += height_diff / 2;
-                cell_state.padding_bottom += height_diff / 2;
+                auto const block_size_difference = row_content_block_size - cell_state.border_box_block_size();
+                cell_state.padding_top += block_size_difference / 2;
+                cell_state.padding_bottom += block_size_difference / 2;
                 break;
             }
             // The top of the cell box is aligned with the top of the first row it spans.
             case CSS::VerticalAlign::Top: {
-                cell_state.padding_bottom += row_content_height - cell_state.border_box_block_size();
+                cell_state.padding_bottom += row_content_block_size - cell_state.border_box_block_size();
                 break;
             }
             // The bottom of the cell box is aligned with the bottom of the last row it spans.
             case CSS::VerticalAlign::Bottom: {
-                cell_state.padding_top += row_content_height - cell_state.border_box_block_size();
+                cell_state.padding_top += row_content_block_size - cell_state.border_box_block_size();
                 break;
             }
             // These values do not apply to cells; the cell is aligned at the baseline instead.
@@ -1389,7 +1385,7 @@ void TableFormattingContext::position_cell_boxes()
             // The baseline of the cell is put at the same height as the baseline of the first of the rows it spans.
             case CSS::VerticalAlign::Baseline: {
                 cell_state.padding_top += m_rows[cell.row_index].baseline - cell.baseline;
-                cell_state.padding_bottom += row_content_height - cell_state.border_box_block_size();
+                cell_state.padding_bottom += row_content_block_size - cell_state.border_box_block_size();
                 break;
             }
             default:
@@ -1668,38 +1664,38 @@ void TableFormattingContext::border_conflict_resolution()
     }
 }
 
-CSSPixels TableFormattingContext::compute_row_content_height(Cell const& cell) const
+CSSPixels TableFormattingContext::compute_row_content_block_size(Cell const& cell) const
 {
     auto& row_state = m_state.get(m_rows[cell.row_index].box);
     if (cell.row_span == 1) {
         return row_state.content_block_size();
     }
-    // The height of a cell is the sum of all spanned rows, as described in
+    // The block size of a cell is the sum of all spanned rows, as described in
     // https://www.w3.org/TR/css-tables-3/#bounding-box-assignment
 
     // When the row span is greater than 1, the borders of inner rows within the span have to be
-    // included in the content height of the spanning cell. First top and final bottom borders are
+    // included in the content block size of the spanning cell. First top and final bottom borders are
     // excluded to be consistent with the handling of row span 1 case above, which uses the content
-    // height (no top and bottom borders) of the row.
-    CSSPixels span_height = 0;
+    // block size (no top and bottom borders) of the row.
+    CSSPixels span_block_size = 0;
     for (size_t i = 0; i < cell.row_span; ++i) {
         auto const& row_state = m_state.get(m_rows[cell.row_index + i].box);
         if (i == 0) {
-            span_height += row_state.content_block_size() + row_state.border_box_bottom();
+            span_block_size += row_state.content_block_size() + row_state.border_box_bottom();
         } else if (i == cell.row_span - 1) {
-            span_height += row_state.border_box_top() + row_state.content_block_size();
+            span_block_size += row_state.border_box_top() + row_state.content_block_size();
         } else {
-            span_height += row_state.border_box_block_size();
+            span_block_size += row_state.border_box_block_size();
         }
     }
 
-    // Compute cell height as specified by https://www.w3.org/TR/css-tables-3/#bounding-box-assignment:
-    // width/height is the sum of:
-    // - the widths/heights of all spanned visible columns/rows
+    // Compute cell block size as specified by https://www.w3.org/TR/css-tables-3/#bounding-box-assignment:
+    // The logical size is the sum of:
+    // - the inline/block sizes of all spanned visible columns/rows
     // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
     // FIXME: Account for visibility.
-    span_height += (cell.row_span - 1) * border_spacing_vertical();
-    return span_height;
+    span_block_size += (cell.row_span - 1) * border_spacing_vertical();
+    return span_block_size;
 }
 
 void TableFormattingContext::finish_grid_initialization(TableGrid const& table_grid)
@@ -1741,8 +1737,8 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
 
     // The containing block of every internal table box and caption is the table wrapper;
     // the table's own input carries the wrapper's constraints, and participant percentages
-    // resolve against those. Percentage heights of participants only resolve once the table
-    // itself has a non-auto height.
+    // resolve against those. Percentage block sizes of participants only resolve once the table
+    // itself has a non-auto block size.
     m_table_constraints = layout_input.containing_block_constraints;
     m_participant_constraints = ContainingBlockConstraints {
         m_table_constraints.percentage_basis_inline_size,
@@ -1755,8 +1751,8 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
 
     auto effective_row_measurement = row_measurement;
     m_needs_fixed_mode_row_measurement = false;
-    // OPTIMIZATION: Row intrinsic measurements are only needed when row height constraints or rowspans can affect
-    //               the later row height distribution. Simple tables get their actual row heights from cell layout.
+    // OPTIMIZATION: Row intrinsic measurements are only needed when row block-size constraints or row spans can affect
+    //               the later row distribution. Simple tables get their actual row block sizes from cell layout.
     if (effective_row_measurement == RowMeasurement::Include && can_skip_row_intrinsic_measurement())
         effective_row_measurement = RowMeasurement::Skip;
     if (effective_row_measurement == RowMeasurement::Include && use_fixed_mode_layout()) {
@@ -1765,7 +1761,7 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
         // of cells is considered zero.
         //
         // https://drafts.csswg.org/css-tables-3/#ROWMIN
-        // ROWMIN is defined as the sum of the minimum height of the rows after a first row layout pass.
+        // ROWMIN is defined as the sum of the minimum block sizes of the rows after a first row layout pass.
         // NB: So defer fixed-mode row measurement until after columns have their used widths.
         effective_row_measurement = RowMeasurement::Skip;
         m_needs_fixed_mode_row_measurement = true;
@@ -1778,11 +1774,11 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
 
     if (effective_row_measurement == RowMeasurement::Include) {
         // https://www.w3.org/TR/css-tables-3/#row-layout
-        // Since during row layout the specified heights of cells in the row were ignored and cells that were spanning more than one rows
-        // have not been sized correctly, their height will need to be eventually distributed to the set of rows they spanned. This is done
+        // Since specified cell block sizes were ignored during row layout and cells spanning multiple rows were not
+        // sized correctly, their block size must eventually be distributed to the rows they span. This is done
         // by running the same algorithm as the column measurement, with the span=1 value being initialized (for min-content) with the largest
-        // of the resulting height of the previous row layout, the height specified on the corresponding table-row (if any), and the largest
-        // height specified on cells that span this row only (the algorithm starts by considering cells of span 2 on top of that assignment).
+        // of the resulting block size of the previous row layout, the size specified on the corresponding table row,
+        // and the largest block size specified on cells that span only this row.
         compute_table_measures<Row>();
     }
 
@@ -1830,14 +1826,14 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
         AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_inline_size())),
         available_space.block_size);
 
-    auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
+    auto captions_block_size = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
 
     // Distribute the width of the table among columns.
     distribute_width_to_columns();
 
-    compute_table_height();
+    compute_table_block_size();
 
-    distribute_height_to_rows();
+    distribute_block_size_to_rows();
 
     position_row_boxes();
     position_cell_boxes();
@@ -1845,14 +1841,14 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     for (auto& cell : m_cells)
         layout_absolutely_positioned_children(cell.box);
 
-    m_state.get_mutable(table_box()).set_content_block_size(m_table_height);
+    m_state.get_mutable(table_box()).set_content_block_size(m_table_block_size);
 
-    total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space);
+    captions_block_size += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space);
 
     // Table captions are positioned between the table margins and its borders (outside the grid box borders) as described in
     // https://www.w3.org/TR/css-tables-3/#bounding-box-assignment
     // A visual representation of this model can be found at https://www.w3.org/TR/css-tables-3/images/table_container.png
-    m_state.get_mutable(table_box()).margin_bottom += total_captions_height;
+    m_state.get_mutable(table_box()).margin_bottom += captions_block_size;
 
     // Derive baselines for the table internals bottom-up (rows, then row groups, then the table box)
     // now that all offsets are final, so the table exports its baseline to outside consumers
@@ -1867,7 +1863,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     });
     compute_and_store_baselines(m_state.get_mutable(table_box()));
 
-    m_automatic_content_block_size = m_table_height;
+    m_automatic_content_block_size = m_table_block_size;
 }
 
 CSSPixels TableFormattingContext::automatic_content_inline_size() const
@@ -1933,9 +1929,9 @@ double TableFormattingContext::cell_percentage_contribution<TableFormattingConte
 {
     // Definition of percentage contribution: https://www.w3.org/TR/css-tables-3/#percentage-contribution
     auto const& computed_values = cell.box.computed_values();
-    auto max_height_percentage = computed_values.max_height().is_percentage() ? computed_values.max_height().percentage().value() : static_cast<double>(INFINITY);
-    auto height_percentage = computed_values.height().is_percentage() ? computed_values.height().percentage().value() : 0;
-    return min(height_percentage, max_height_percentage);
+    auto max_block_size_percentage = computed_values.max_height().is_percentage() ? computed_values.max_height().percentage().value() : static_cast<double>(INFINITY);
+    auto block_size_percentage = computed_values.height().is_percentage() ? computed_values.height().percentage().value() : 0;
+    return min(block_size_percentage, max_block_size_percentage);
 }
 
 template<>
@@ -1966,10 +1962,10 @@ void TableFormattingContext::initialize_intrinsic_percentages_from_rows_or_colum
     for (auto& row : m_rows) {
         auto const& computed_values = row.box.computed_values();
         // Definition of percentage contribution: https://www.w3.org/TR/css-tables-3/#percentage-contribution
-        auto max_height_percentage = computed_values.max_height().is_percentage() ? computed_values.max_height().percentage().value() : static_cast<double>(INFINITY);
-        auto height_percentage = computed_values.height().is_percentage() ? computed_values.height().percentage().value() : 0;
+        auto max_block_size_percentage = computed_values.max_height().is_percentage() ? computed_values.max_height().percentage().value() : static_cast<double>(INFINITY);
+        auto block_size_percentage = computed_values.height().is_percentage() ? computed_values.height().percentage().value() : 0;
         row.has_intrinsic_percentage = computed_values.max_height().is_percentage() || computed_values.height().is_percentage();
-        row.intrinsic_percentage = min(height_percentage, max_height_percentage);
+        row.intrinsic_percentage = min(block_size_percentage, max_block_size_percentage);
     }
 }
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -226,19 +226,19 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
 
 void TableFormattingContext::compute_outer_content_sizes()
 {
-    auto containing_block_width = m_table_constraints.percentage_basis_inline_size.value_or(0);
+    auto containing_block_inline_size = m_table_constraints.percentage_basis_inline_size.value_or(0);
 
     size_t column_index = 0;
     TableGrid::for_each_child_box_matching(table_box(), is_table_column_group, [&](auto& column_group_box) {
         TableGrid::for_each_child_box_matching(column_group_box, is_table_column, [&](auto& column_box) {
             auto const& computed_values = column_box.computed_values();
-            auto min_width = computed_values.min_width().to_px(containing_block_width);
-            auto max_width = computed_values.max_width().is_length() ? computed_values.max_width().to_px(containing_block_width) : CSSPixels::max();
-            auto width = computed_values.width().to_px(containing_block_width);
-            // The outer min-content width of a table-column or table-column-group is max(min-width, width).
-            m_columns[column_index].min_size = max(min_width, width);
-            // The outer max-content width of a table-column or table-column-group is max(min-width, min(max-width, width)).
-            m_columns[column_index].max_size = max(min_width, min(max_width, width));
+            auto min_inline_size = computed_values.min_width().to_px(containing_block_inline_size);
+            auto max_inline_size = computed_values.max_width().is_length() ? computed_values.max_width().to_px(containing_block_inline_size) : CSSPixels::max();
+            auto inline_size = computed_values.width().to_px(containing_block_inline_size);
+            // The outer min-content inline size of a table-column or table-column-group is max(min-width, width).
+            m_columns[column_index].min_size = max(min_inline_size, inline_size);
+            // The outer max-content inline size of a table-column or table-column-group is max(min-width, min(max-width, width)).
+            m_columns[column_index].max_size = max(min_inline_size, min(max_inline_size, inline_size));
             auto const& col_node = static_cast<HTML::HTMLElement const&>(*column_box.dom_node());
             unsigned span = col_node.get_attribute_value(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             column_index += span;
@@ -332,12 +332,12 @@ void TableFormattingContext::compute_intrinsic_percentage(size_t max_cell_span)
             }
             // Compute the sum of the non-spanning max-content sizes of all rows / columns spanned by the cell that have an intrinsic percentage
             // size of the row / column based on cells of span up to N-1 equal to 0%, to be used in step 3 of the cell contribution algorithm.
-            CSSPixels width_sum_of_columns_with_zero_intrinsic_percentage = 0;
-            size_t number_of_columns_with_zero_intrinsic_percentage = 0;
+            CSSPixels size_sum_of_tracks_with_zero_intrinsic_percentage = 0;
+            size_t number_of_tracks_with_zero_intrinsic_percentage = 0;
             for (auto rc_index = cell_start_rc_index; rc_index < cell_end_rc_index; rc_index++) {
                 if (rows_or_columns[rc_index].intrinsic_percentage == 0) {
-                    width_sum_of_columns_with_zero_intrinsic_percentage += rows_or_columns[rc_index].max_size;
-                    ++number_of_columns_with_zero_intrinsic_percentage;
+                    size_sum_of_tracks_with_zero_intrinsic_percentage += rows_or_columns[rc_index].max_size;
+                    ++number_of_tracks_with_zero_intrinsic_percentage;
                 }
             }
             for (size_t rc_index = cell_start_rc_index; rc_index < cell_end_rc_index; rc_index++) {
@@ -354,12 +354,12 @@ void TableFormattingContext::compute_intrinsic_percentage(size_t max_cell_span)
                 // 3. Multiply by the ratio of the column’s non-spanning max-content width to the sum of the non-spanning max-content widths of all
                 //    columns spanned by the cell that have an intrinsic percentage width of the column based on cells of span up to N-1 equal to 0%.
                 CSSPixels adjusted_cell_contribution;
-                if (width_sum_of_columns_with_zero_intrinsic_percentage != 0) {
-                    adjusted_cell_contribution = cell_contribution.scaled(rows_or_columns[rc_index].max_size / static_cast<double>(width_sum_of_columns_with_zero_intrinsic_percentage));
+                if (size_sum_of_tracks_with_zero_intrinsic_percentage != 0) {
+                    adjusted_cell_contribution = cell_contribution.scaled(rows_or_columns[rc_index].max_size / static_cast<double>(size_sum_of_tracks_with_zero_intrinsic_percentage));
                 } else {
                     // However, if this ratio is undefined because the denominator is zero, instead use the 1 divided by the number of columns
                     // spanned by the cell that have an intrinsic percentage width of the column based on cells of span up to N-1 equal to zero.
-                    adjusted_cell_contribution = cell_contribution * 1 / number_of_columns_with_zero_intrinsic_percentage;
+                    adjusted_cell_contribution = cell_contribution * 1 / number_of_tracks_with_zero_intrinsic_percentage;
                 }
                 intrinsic_percentage_contribution_by_index[rc_index] = max(static_cast<double>(adjusted_cell_contribution), intrinsic_percentage_contribution_by_index[rc_index]);
             }
@@ -525,18 +525,18 @@ CSSPixels TableFormattingContext::compute_capmin()
     return capmin;
 }
 
-static bool width_is_auto_or_indefinite_percentage(CSS::Size const& width, bool containing_block_has_definite_width)
+static bool inline_size_is_auto_or_indefinite_percentage(CSS::Size const& inline_size, bool containing_block_has_definite_inline_size)
 {
-    if (width.is_auto())
+    if (inline_size.is_auto())
         return true;
-    if (width.contains_percentage()) {
-        if (!containing_block_has_definite_width)
+    if (inline_size.contains_percentage()) {
+        if (!containing_block_has_definite_inline_size)
             return true;
     }
     return false;
 }
 
-void TableFormattingContext::compute_table_width()
+void TableFormattingContext::compute_table_inline_size()
 {
     // https://drafts.csswg.org/css-tables-3/#computing-the-table-width
 
@@ -544,7 +544,7 @@ void TableFormattingContext::compute_table_width()
 
     auto& computed_values = table_box().computed_values();
 
-    auto width_of_table_containing_block = m_available_space->inline_size;
+    auto table_containing_block_inline_size = m_available_space->inline_size;
 
     // Percentages on 'width' and 'height' on the table are relative to the table wrapper box's containing block,
     // not the table wrapper box itself.
@@ -553,99 +553,98 @@ void TableFormattingContext::compute_table_width()
     // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
     auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
 
-    // The row/column-grid width minimum (GRIDMIN) width is the sum of the min-content width
+    // The row/column-grid inline-size minimum (GRIDMIN) is the sum of the min-content inline size
     // of all the columns plus cell spacing or borders.
-    CSSPixels grid_min = 0;
+    CSSPixels grid_min_inline_size = 0;
     for (auto& column : m_columns) {
-        grid_min += column.min_size;
+        grid_min_inline_size += column.min_size;
     }
-    grid_min += undistributable_space;
+    grid_min_inline_size += undistributable_space;
 
-    // The row/column-grid width maximum (GRIDMAX) width is the sum of the max-content width
+    // The row/column-grid inline-size maximum (GRIDMAX) is the sum of the max-content inline size
     // of all the columns plus cell spacing or borders.
-    CSSPixels grid_max = 0;
+    CSSPixels grid_max_inline_size = 0;
     for (auto& column : m_columns) {
-        grid_max += column.max_size;
+        grid_max_inline_size += column.max_size;
     }
-    grid_max += undistributable_space;
+    grid_max_inline_size += undistributable_space;
 
-    auto resolve_width_constraint_to_content_box = [&](auto const& inline_size_constraint) {
+    auto resolve_inline_size_constraint_to_content_box = [&](auto const& inline_size_constraint) {
         if (inline_size_constraint.is_min_content())
-            return grid_min;
+            return grid_min_inline_size;
         if (inline_size_constraint.is_max_content())
-            return grid_max;
+            return grid_max_inline_size;
         if (inline_size_constraint.is_fit_content()) {
             auto fit_content_limit = table_wrapper_containing_block_inline_size;
             if (auto const& fit_content_available_space = inline_size_constraint.fit_content_available_space(); fit_content_available_space.has_value())
                 fit_content_limit = fit_content_available_space->to_px(table_wrapper_containing_block_inline_size);
-            return min(grid_max, max(grid_min, fit_content_limit));
+            return min(grid_max_inline_size, max(grid_min_inline_size, fit_content_limit));
         }
         // CSS Sizing says box-sizing:border-box applies length/percentage width/min-width/max-width constraints to
-        // the border box. The table width algorithm compares content widths, so convert them before comparing.
-        auto resolved_width = inline_size_constraint.to_px(table_wrapper_containing_block_inline_size);
+        // the border box. The table inline-size algorithm compares content inline sizes, so convert them before comparing.
+        auto resolved_inline_size = inline_size_constraint.to_px(table_wrapper_containing_block_inline_size);
         if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox)
-            resolved_width -= table_box_state.border_box_left() + table_box_state.border_box_right();
-        return max(CSSPixels(0), resolved_width);
+            resolved_inline_size -= table_box_state.border_box_left() + table_box_state.border_box_right();
+        return max(CSSPixels(0), resolved_inline_size);
     };
 
-    // The used min-width of a table is the greater of the resolved min-width, CAPMIN, and GRIDMIN.
-    auto used_min_width = max(grid_min, compute_capmin());
+    // The used minimum inline size of a table is the greater of the resolved min-width, CAPMIN, and GRIDMIN.
+    auto used_min_inline_size = max(grid_min_inline_size, compute_capmin());
     if (!computed_values.min_width().is_auto()) {
-        used_min_width = max(used_min_width, resolve_width_constraint_to_content_box(computed_values.min_width()));
+        used_min_inline_size = max(used_min_inline_size, resolve_inline_size_constraint_to_content_box(computed_values.min_width()));
     }
 
-    CSSPixels used_width;
-    if (width_is_auto_or_indefinite_percentage(computed_values.width(), m_table_constraints.percentage_basis_inline_size.has_value())) {
-        // If the table-root has 'width: auto', the used width is the greater of
-        // min(GRIDMAX, the table’s containing block width), the used min-width of the table.
-        // NOTE: In normal layout the available width already is the wrapper's used width, which the
+    CSSPixels used_inline_size;
+    if (inline_size_is_auto_or_indefinite_percentage(computed_values.width(), m_table_constraints.percentage_basis_inline_size.has_value())) {
+        // If the table-root has 'width: auto', the used inline size is the greater of
+        // min(GRIDMAX, the table’s containing block inline size), the used minimum inline size of the table.
+        // NOTE: In normal layout the available inline size already is the wrapper's used inline size, which the
         //       parent context resolved with shrink-to-fit; filling it keeps the table and its
         //       wrapper consistent without reading the wrapper's state from here.
         if (m_available_space->inline_size.is_min_content())
-            used_width = grid_min;
+            used_inline_size = grid_min_inline_size;
         else if (m_available_space->inline_size.is_max_content())
-            used_width = grid_max;
-        else if (width_of_table_containing_block.is_definite() && m_layout_mode == LayoutMode::Normal)
-            used_width = max(width_of_table_containing_block.to_px_or_zero(), used_min_width);
-        else if (width_of_table_containing_block.is_definite())
-            used_width = max(min(grid_max, width_of_table_containing_block.to_px_or_zero()), used_min_width);
+            used_inline_size = grid_max_inline_size;
+        else if (table_containing_block_inline_size.is_definite() && m_layout_mode == LayoutMode::Normal)
+            used_inline_size = max(table_containing_block_inline_size.to_px_or_zero(), used_min_inline_size);
+        else if (table_containing_block_inline_size.is_definite())
+            used_inline_size = max(min(grid_max_inline_size, table_containing_block_inline_size.to_px_or_zero()), used_min_inline_size);
         else
-            used_width = max(grid_max, used_min_width);
+            used_inline_size = max(grid_max_inline_size, used_min_inline_size);
         // https://www.w3.org/TR/CSS22/tables.html#auto-table-layout
-        // A percentage value for a column width is relative to the table width. If the table has 'width: auto',
-        // a percentage represents a constraint on the column's width, which a UA should try to satisfy.
+        // A percentage value for a column inline size is relative to the table inline size. If the table has
+        // 'width: auto', a percentage represents a constraint on the column's inline size, which a UA should try to satisfy.
         if (!m_available_space->inline_size.is_intrinsic_sizing_constraint()) {
             for (auto& cell : m_cells) {
-                auto const& cell_width = cell.box.computed_values().width();
-                if (cell_width.is_percentage()) {
-                    CSSPixels adjusted_used_width = undistributable_space;
-                    if (cell_width.percentage().value() != 0)
-                        adjusted_used_width += CSSPixels::nearest_value_for(ceil(100 / cell_width.percentage().value() * cell.outer_max_inline_size));
+                auto const& cell_inline_size = cell.box.computed_values().width();
+                if (cell_inline_size.is_percentage()) {
+                    CSSPixels adjusted_used_inline_size = undistributable_space;
+                    if (cell_inline_size.percentage().value() != 0)
+                        adjusted_used_inline_size += CSSPixels::nearest_value_for(ceil(100 / cell_inline_size.percentage().value() * cell.outer_max_inline_size));
 
-                    if (width_of_table_containing_block.is_definite())
-                        used_width = min(max(used_width, adjusted_used_width), width_of_table_containing_block.to_px_or_zero());
+                    if (table_containing_block_inline_size.is_definite())
+                        used_inline_size = min(max(used_inline_size, adjusted_used_inline_size), table_containing_block_inline_size.to_px_or_zero());
                     else
-                        used_width = max(used_width, adjusted_used_width);
+                        used_inline_size = max(used_inline_size, adjusted_used_inline_size);
                 }
             }
         }
     } else if (computed_values.width().is_max_content()) {
-        used_width = grid_max;
+        used_inline_size = grid_max_inline_size;
     } else {
-        // If the table-root’s width property has a computed value (resolving to
-        // resolved-table-width) other than auto, the used width is the greater
-        // of resolved-table-width, and the used min-width of the table.
-        CSSPixels resolved_table_width = resolve_width_constraint_to_content_box(computed_values.width());
-        used_width = max(resolved_table_width, used_min_width);
+        // If the table-root’s width property has a computed value (resolving to the table inline size) other than auto,
+        // the used inline size is the greater of the resolved table inline size and the used minimum inline size.
+        CSSPixels resolved_table_inline_size = resolve_inline_size_constraint_to_content_box(computed_values.width());
+        used_inline_size = max(resolved_table_inline_size, used_min_inline_size);
         if (!should_treat_max_inline_size_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
-            used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
+            used_inline_size = min(used_inline_size, resolve_inline_size_constraint_to_content_box(computed_values.max_width()));
     }
 
     if (!should_treat_max_inline_size_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
-        used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
-    used_width = max(used_width, used_min_width);
+        used_inline_size = min(used_inline_size, resolve_inline_size_constraint_to_content_box(computed_values.max_width()));
+    used_inline_size = max(used_inline_size, used_min_inline_size);
 
-    table_box_state.set_content_inline_size(used_width);
+    table_box_state.set_content_inline_size(used_inline_size);
 }
 
 CSSPixels TableFormattingContext::compute_columns_total_used_inline_size() const
@@ -1725,7 +1724,7 @@ void TableFormattingContext::seed_table_participant_used_values(ContainingBlockC
     }
 }
 
-void TableFormattingContext::run_until_width_calculation(LayoutInput const& layout_input, RowMeasurement row_measurement)
+void TableFormattingContext::run_until_inline_size_calculation(LayoutInput const& layout_input, RowMeasurement row_measurement)
 {
     auto const& available_space = layout_input.available_space;
     m_available_space = available_space;
@@ -1780,8 +1779,8 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
         compute_table_measures<Row>();
     }
 
-    // Compute the width of the table.
-    compute_table_width();
+    // Compute the inline size of the table.
+    compute_table_inline_size();
 }
 
 void TableFormattingContext::parent_context_did_dimension_child_root_box()
@@ -1813,7 +1812,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     m_available_space = available_space;
     m_min_border_box_block_size_from_flex_item = layout_input.table_grid_min_border_box_block_size;
 
-    run_until_width_calculation(layout_input);
+    run_until_inline_size_calculation(layout_input);
 
     if (available_space.inline_size.is_intrinsic_sizing_constraint() && !available_space.block_size.is_intrinsic_sizing_constraint()) {
         return;
@@ -1826,7 +1825,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
 
     auto captions_block_size = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
 
-    // Distribute the width of the table among columns.
+    // Distribute the inline size of the table among columns.
     distribute_inline_size_to_columns();
 
     compute_table_block_size();
@@ -1937,9 +1936,9 @@ double TableFormattingContext::cell_percentage_contribution<TableFormattingConte
 {
     // Definition of percentage contribution: https://www.w3.org/TR/css-tables-3/#percentage-contribution
     auto const& computed_values = cell.box.computed_values();
-    auto max_width_percentage = computed_values.max_width().is_percentage() ? computed_values.max_width().percentage().value() : static_cast<double>(INFINITY);
-    auto width_percentage = computed_values.width().is_percentage() ? computed_values.width().percentage().value() : 0;
-    return min(width_percentage, max_width_percentage);
+    auto max_inline_size_percentage = computed_values.max_width().is_percentage() ? computed_values.max_width().percentage().value() : static_cast<double>(INFINITY);
+    auto inline_size_percentage = computed_values.width().is_percentage() ? computed_values.width().percentage().value() : 0;
+    return min(inline_size_percentage, max_inline_size_percentage);
 }
 
 template<>
@@ -1975,10 +1974,10 @@ void TableFormattingContext::initialize_intrinsic_percentages_from_rows_or_colum
         TableGrid::for_each_child_box_matching(column_group_box, is_table_column, [&](auto& column_box) {
             auto const& computed_values = column_box.computed_values();
             // Definition of percentage contribution: https://www.w3.org/TR/css-tables-3/#percentage-contribution
-            auto max_width_percentage = computed_values.max_width().is_percentage() ? computed_values.max_width().percentage().value() : static_cast<double>(INFINITY);
-            auto width_percentage = computed_values.width().is_percentage() ? computed_values.width().percentage().value() : 0;
+            auto max_inline_size_percentage = computed_values.max_width().is_percentage() ? computed_values.max_width().percentage().value() : static_cast<double>(INFINITY);
+            auto inline_size_percentage = computed_values.width().is_percentage() ? computed_values.width().percentage().value() : 0;
             m_columns[column_index].has_intrinsic_percentage = computed_values.max_width().is_percentage() || computed_values.width().is_percentage();
-            m_columns[column_index].intrinsic_percentage = min(width_percentage, max_width_percentage);
+            m_columns[column_index].intrinsic_percentage = min(inline_size_percentage, max_inline_size_percentage);
             auto const& col_node = static_cast<HTML::HTMLElement const&>(*column_box.dom_node());
             unsigned span = col_node.get_attribute_value(HTML::AttributeNames::span).to_number<unsigned>().value_or(1);
             column_index += span;

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -69,7 +69,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
 
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
-                if (should_treat_height_as_auto(child_box, caption_available_space, m_participant_constraints)) {
+                if (should_treat_block_size_as_auto(child_box, caption_available_space, m_participant_constraints)) {
                     auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_block_size();
                     caption_state.set_content_block_size(height);
                 }
@@ -637,11 +637,11 @@ void TableFormattingContext::compute_table_width()
         // of resolved-table-width, and the used min-width of the table.
         CSSPixels resolved_table_width = resolve_width_constraint_to_content_box(computed_values.width());
         used_width = max(resolved_table_width, used_min_width);
-        if (!should_treat_max_width_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
+        if (!should_treat_max_inline_size_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
             used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     }
 
-    if (!should_treat_max_width_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
+    if (!should_treat_max_inline_size_as_none(table_box(), m_available_space->inline_size, m_table_constraints))
         used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     used_width = max(used_width, used_min_width);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -53,10 +53,10 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             auto* block_context = as_if<BlockFormattingContext>(caption_context.ptr());
             CSSPixelPoint caption_offset;
             if (block_context) {
-                auto available_width = caption_available_space.inline_size.to_px_or_zero();
-                block_context->resolve_vertical_box_model_metrics(child_box, available_width);
+                auto available_inline_size = caption_available_space.inline_size.to_px_or_zero();
+                block_context->resolve_vertical_box_model_metrics(child_box, available_inline_size);
                 CSSPixelPoint caption_position_in_block_context {};
-                block_context->compute_width(child_box, caption_available_space, caption_constraints, caption_position_in_block_context);
+                block_context->compute_inline_size(child_box, caption_available_space, caption_constraints, caption_position_in_block_context);
                 inner_available_space = m_state.get(child_box).available_inner_space_or_constraints_from(caption_available_space);
 
                 auto const& caption_state = m_state.get(child_box);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -35,7 +35,7 @@ static inline bool is_table_column(Box const& box)
 
 CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, AvailableSpace const& caption_available_space)
 {
-    CSSPixels caption_height = 0;
+    CSSPixels captions_block_size = 0;
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
         auto const* child_box_ptr = as_if<Box>(*child);
         if (!child_box_ptr || !child_box_ptr->display().is_table_caption() || child_box_ptr->computed_values().caption_side() != phase) {
@@ -51,7 +51,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
         if (auto caption_context = create_independent_formatting_context_if_needed(m_state, m_layout_mode, child_box, this)) {
             auto inner_available_space = caption_available_space;
             auto* block_context = as_if<BlockFormattingContext>(caption_context.ptr());
-            CSSPixelPoint caption_offset;
+            LogicalOffset caption_offset;
             if (block_context) {
                 auto available_inline_size = caption_available_space.inline_size.to_px_or_zero();
                 block_context->resolve_vertical_box_model_metrics(child_box, available_inline_size);
@@ -62,7 +62,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 auto const& caption_state = m_state.get(child_box);
                 caption_offset = { caption_state.border_box_left(), 0 };
                 if (phase == CSS::CaptionSide::Bottom)
-                    caption_offset.set_y(m_state.get(table_box()).margin_box_block_size() + caption_state.margin_box_top());
+                    caption_offset.block_offset = m_state.get(table_box()).margin_box_block_size() + caption_state.margin_box_top();
             }
 
             caption_context->run(LayoutInput { inner_available_space, caption_constraints });
@@ -70,23 +70,23 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
                 if (should_treat_block_size_as_auto(child_box, caption_available_space, m_participant_constraints)) {
-                    auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_block_size();
-                    caption_state.set_content_block_size(height);
+                    auto content_block_size = child_box.has_size_containment() ? 0 : caption_context->automatic_content_block_size();
+                    caption_state.set_content_block_size(content_block_size);
                 }
-                place_child(child_box, caption_offset);
+                place_child(child_box, { caption_offset.inline_offset, caption_offset.block_offset });
                 caption_was_placed = true;
             }
         }
 
         auto const& caption_state = m_state.get(child_box);
         if (phase == CSS::CaptionSide::Top) {
-            m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_block_size() + caption_state.margin_box_bottom());
+            m_pending_table_box_content_offset_in_wrapper.block_offset = caption_state.content_block_size() + caption_state.margin_box_bottom();
         } else if (!caption_was_placed) {
             place_child(child_box, { caption_state.border_box_left(), m_state.get(table_box()).margin_box_block_size() + caption_state.margin_box_top() });
         }
-        caption_height += caption_state.margin_box_block_size();
+        captions_block_size += caption_state.margin_box_block_size();
     }
-    return caption_height;
+    return captions_block_size;
 }
 
 void TableFormattingContext::compute_constrainedness()
@@ -1272,7 +1272,7 @@ void TableFormattingContext::position_row_boxes()
 {
     auto const& table_state = m_state.get(table_box());
 
-    CSSPixels row_block_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
+    CSSPixels row_block_offset = m_pending_table_box_content_offset_in_wrapper.block_offset + border_spacing_vertical();
     CSSPixels row_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
     for (size_t row_index = 0; row_index < m_rows.size(); row_index++) {
         auto& row = m_rows[row_index];
@@ -1291,7 +1291,7 @@ void TableFormattingContext::position_row_boxes()
             row_block_offset += row_state.content_block_size() + border_spacing_vertical();
     }
 
-    CSSPixels row_group_block_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
+    CSSPixels row_group_block_offset = m_pending_table_box_content_offset_in_wrapper.block_offset + border_spacing_vertical();
     CSSPixels row_group_inline_offset = table_state.border_left + table_state.padding_left + border_spacing_horizontal();
     TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
         CSSPixels row_group_block_size = 0;
@@ -1316,7 +1316,7 @@ void TableFormattingContext::position_row_boxes()
         row_group_block_offset += row_group_block_size + (num_rows > 0 ? border_spacing_vertical() : 0);
     });
 
-    auto total_content_block_size = max(row_block_offset, row_group_block_offset) - m_pending_table_box_content_offset_in_wrapper.y() - table_state.padding_top;
+    auto total_content_block_size = max(row_block_offset, row_group_block_offset) - m_pending_table_box_content_offset_in_wrapper.block_offset - table_state.padding_top;
     m_table_block_size = max(total_content_block_size, m_table_block_size);
 }
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -62,7 +62,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 auto const& caption_state = m_state.get(child_box);
                 caption_offset = { caption_state.border_box_left(), 0 };
                 if (phase == CSS::CaptionSide::Bottom)
-                    caption_offset.set_y(m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top());
+                    caption_offset.set_y(m_state.get(table_box()).margin_box_block_size() + caption_state.margin_box_top());
             }
 
             caption_context->run(LayoutInput { inner_available_space, caption_constraints });
@@ -82,9 +82,9 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
         if (phase == CSS::CaptionSide::Top) {
             m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_block_size() + caption_state.margin_box_bottom());
         } else if (!caption_was_placed) {
-            place_child(child_box, { caption_state.border_box_left(), m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top() });
+            place_child(child_box, { caption_state.border_box_left(), m_state.get(table_box()).margin_box_block_size() + caption_state.margin_box_top() });
         }
-        caption_height += caption_state.margin_box_height();
+        caption_height += caption_state.margin_box_block_size();
     }
     return caption_height;
 }
@@ -1085,7 +1085,7 @@ void TableFormattingContext::compute_table_height()
             auto const& computed_values = cell.box.computed_values();
             auto min_height = computed_values.min_height().to_px(height_of_containing_block);
             auto cell_intrinsic_height_offsets = cell_state.border_box_top() + cell_state.border_box_bottom();
-            auto measured_outer_height = max(cell_state.border_box_height(), min_height + cell_intrinsic_height_offsets);
+            auto measured_outer_height = max(cell_state.border_box_block_size(), min_height + cell_intrinsic_height_offsets);
             cell.outer_min_height = measured_outer_height;
             cell.outer_max_height = measured_outer_height;
         }
@@ -1104,7 +1104,7 @@ void TableFormattingContext::compute_table_height()
         // Note that we've already applied the first rule at the top of the method.
         if (!row.is_collapsed) {
             if (cell.row_span == 1) {
-                row.base_height = max(row.base_height, cell_state.border_box_height());
+                row.base_height = max(row.base_height, cell_state.border_box_block_size());
             }
             if (!m_needs_fixed_mode_row_measurement)
                 row.base_height = max(row.base_height, m_rows[cell.row_index].min_size);
@@ -1204,7 +1204,7 @@ void TableFormattingContext::compute_table_height()
         cell.baseline = box_baseline(cell.box, BaselineSet::First);
 
         if (!row.is_collapsed) {
-            row.reference_height = max(row.reference_height, cell_state.border_box_height());
+            row.reference_height = max(row.reference_height, cell_state.border_box_block_size());
             row.baseline = max(row.baseline, cell.baseline);
         }
     }
@@ -1309,8 +1309,8 @@ void TableFormattingContext::position_row_boxes()
         int num_rows = 0;
         TableGrid::for_each_child_box_matching(row_group_box, TableGrid::is_table_row, [&](auto& row) {
             auto const& row_state = m_state.get(row);
-            row_group_height += row_state.border_box_height();
-            row_group_width = max(row_group_width, row_state.border_box_width());
+            row_group_height += row_state.border_box_block_size();
+            row_group_width = max(row_group_width, row_state.border_box_inline_size());
             num_rows += 1;
         });
         if (num_rows >= 2)
@@ -1361,24 +1361,24 @@ void TableFormattingContext::position_cell_boxes()
         // https://drafts.csswg.org/css2/#height-layout
         // In the context of tables, values for vertical-align have the following meanings:
         if (cell_is_anonymous_wrapper_for_flex_or_grid(cell)) {
-            cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
+            cell_state.padding_bottom += row_content_height - cell_state.border_box_block_size();
         } else if (vertical_align.has<CSS::VerticalAlign>()) {
             switch (vertical_align.get<CSS::VerticalAlign>()) {
             // The center of the cell is aligned with the center of the rows it spans.
             case CSS::VerticalAlign::Middle: {
-                auto const height_diff = row_content_height - cell_state.border_box_height();
+                auto const height_diff = row_content_height - cell_state.border_box_block_size();
                 cell_state.padding_top += height_diff / 2;
                 cell_state.padding_bottom += height_diff / 2;
                 break;
             }
             // The top of the cell box is aligned with the top of the first row it spans.
             case CSS::VerticalAlign::Top: {
-                cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
+                cell_state.padding_bottom += row_content_height - cell_state.border_box_block_size();
                 break;
             }
             // The bottom of the cell box is aligned with the bottom of the last row it spans.
             case CSS::VerticalAlign::Bottom: {
-                cell_state.padding_top += row_content_height - cell_state.border_box_height();
+                cell_state.padding_top += row_content_height - cell_state.border_box_block_size();
                 break;
             }
             // These values do not apply to cells; the cell is aligned at the baseline instead.
@@ -1389,7 +1389,7 @@ void TableFormattingContext::position_cell_boxes()
             // The baseline of the cell is put at the same height as the baseline of the first of the rows it spans.
             case CSS::VerticalAlign::Baseline: {
                 cell_state.padding_top += m_rows[cell.row_index].baseline - cell.baseline;
-                cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
+                cell_state.padding_bottom += row_content_height - cell_state.border_box_block_size();
                 break;
             }
             default:
@@ -1689,7 +1689,7 @@ CSSPixels TableFormattingContext::compute_row_content_height(Cell const& cell) c
         } else if (i == cell.row_span - 1) {
             span_height += row_state.border_box_top() + row_state.content_block_size();
         } else {
-            span_height += row_state.border_box_height();
+            span_height += row_state.border_box_block_size();
         }
     }
 
@@ -1827,7 +1827,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
 
     auto const& table_state = m_state.get(table_box());
     auto caption_available_space = AvailableSpace(
-        AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_width())),
+        AvailableSize::make_definite(clamp_to_max_dimension_value(table_state.border_box_inline_size())),
         available_space.block_size);
 
     auto total_captions_height = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -174,16 +174,16 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
                 max_content_width = width;
             }
         } else {
-            min_content_width = calculate_min_content_width(cell.box, m_participant_constraints);
-            max_content_width = calculate_max_content_width(cell.box, m_participant_constraints);
+            min_content_width = calculate_min_content_inline_size(cell.box, m_participant_constraints);
+            max_content_width = calculate_max_content_inline_size(cell.box, m_participant_constraints);
         }
 
         // The outer min-content width of a table-cell is max(min-width, min-content width) adjusted by the cell intrinsic offsets.
         cell.outer_min_width = max(min_width, min_content_width) + cell_intrinsic_width_offsets;
 
         if (row_measurement == RowMeasurement::Include) {
-            auto min_content_height = calculate_min_content_height(cell.box, max_content_width, m_participant_constraints);
-            auto max_content_height = calculate_max_content_height(cell.box, min_content_width, m_participant_constraints);
+            auto min_content_height = calculate_min_content_block_size(cell.box, max_content_width, m_participant_constraints);
+            auto max_content_height = calculate_max_content_block_size(cell.box, min_content_width, m_participant_constraints);
 
             // The outer min-content height of a table-cell is max(min-height, min-content height) adjusted by the cell intrinsic offsets.
             auto min_height = computed_values.min_height().to_px(containing_block_height);
@@ -514,9 +514,9 @@ CSSPixels TableFormattingContext::compute_capmin()
                 + margin_right;
         };
 
-        auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_width(*child_box, m_participant_constraints));
+        auto caption_min_content_contribution = outer_size_for_inner_size(calculate_min_content_inline_size(*child_box, m_participant_constraints));
         if (!computed_values.width().is_auto() && !computed_values.width().contains_percentage()) {
-            auto preferred_inner_width = calculate_inner_width(*child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width(), m_participant_constraints);
+            auto preferred_inner_width = calculate_inner_inline_size(*child_box, AvailableSize::make_definite(width_of_table_wrapper_containing_block), computed_values.width(), m_participant_constraints);
             caption_min_content_contribution = max(caption_min_content_contribution, outer_size_for_inner_size(preferred_inner_width));
         }
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -71,7 +71,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
                 auto& caption_state = m_state.get_mutable(child_box);
                 if (should_treat_height_as_auto(child_box, caption_available_space, m_participant_constraints)) {
                     auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_height();
-                    caption_state.set_content_height(height);
+                    caption_state.set_content_block_size(height);
                 }
                 place_child(child_box, caption_offset);
                 caption_was_placed = true;
@@ -80,7 +80,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
 
         auto const& caption_state = m_state.get(child_box);
         if (phase == CSS::CaptionSide::Top) {
-            m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_height() + caption_state.margin_box_bottom());
+            m_pending_table_box_content_offset_in_wrapper.set_y(caption_state.content_block_size() + caption_state.margin_box_bottom());
         } else if (!caption_was_placed) {
             place_child(child_box, { caption_state.border_box_left(), m_state.get(table_box()).margin_box_height() + caption_state.margin_box_top() });
         }
@@ -569,20 +569,20 @@ void TableFormattingContext::compute_table_width()
     }
     grid_max += undistributable_space;
 
-    auto resolve_width_constraint_to_content_box = [&](auto const& width_constraint) {
-        if (width_constraint.is_min_content())
+    auto resolve_width_constraint_to_content_box = [&](auto const& inline_size_constraint) {
+        if (inline_size_constraint.is_min_content())
             return grid_min;
-        if (width_constraint.is_max_content())
+        if (inline_size_constraint.is_max_content())
             return grid_max;
-        if (width_constraint.is_fit_content()) {
+        if (inline_size_constraint.is_fit_content()) {
             auto fit_content_limit = width_of_table_wrapper_containing_block;
-            if (auto const& fit_content_available_space = width_constraint.fit_content_available_space(); fit_content_available_space.has_value())
+            if (auto const& fit_content_available_space = inline_size_constraint.fit_content_available_space(); fit_content_available_space.has_value())
                 fit_content_limit = fit_content_available_space->to_px(width_of_table_wrapper_containing_block);
             return min(grid_max, max(grid_min, fit_content_limit));
         }
         // CSS Sizing says box-sizing:border-box applies length/percentage width/min-width/max-width constraints to
         // the border box. The table width algorithm compares content widths, so convert them before comparing.
-        auto resolved_width = width_constraint.to_px(width_of_table_wrapper_containing_block);
+        auto resolved_width = inline_size_constraint.to_px(width_of_table_wrapper_containing_block);
         if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox)
             resolved_width -= table_box_state.border_box_left() + table_box_state.border_box_right();
         return max(CSSPixels(0), resolved_width);
@@ -645,7 +645,7 @@ void TableFormattingContext::compute_table_width()
         used_width = min(used_width, resolve_width_constraint_to_content_box(computed_values.max_width()));
     used_width = max(used_width, used_min_width);
 
-    table_box_state.set_content_width(used_width);
+    table_box_state.set_content_inline_size(used_width);
 }
 
 CSSPixels TableFormattingContext::compute_columns_total_used_width() const
@@ -764,7 +764,7 @@ void TableFormattingContext::distribute_width_to_columns()
 
     // The assignable table width is the used width of the table minus the total horizontal border spacing (if any).
     // This is the width that we will be able to allocate to the columns.
-    CSSPixels const available_width = m_state.get(table_box()).content_width() - total_horizontal_border_spacing;
+    CSSPixels const available_width = m_state.get(table_box()).content_inline_size() - total_horizontal_border_spacing;
 
     Vector<CSSPixels> candidate_widths;
     candidate_widths.resize(m_columns.size());
@@ -987,10 +987,10 @@ Optional<TableFormattingContext::MeasuredCellContent> TableFormattingContext::me
 {
     if (m_layout_mode == LayoutMode::IntrinsicSizing
         && !cell_box.is_inline()
-        && cell_used_values.width_constraint == SizeConstraint::None
-        && cell_used_values.height_constraint == SizeConstraint::None
-        && cell_used_values.has_definite_width()
-        && cell_used_values.has_definite_height()) {
+        && cell_used_values.inline_size_constraint == SizeConstraint::None
+        && cell_used_values.block_size_constraint == SizeConstraint::None
+        && cell_used_values.has_definite_inline_size()
+        && cell_used_values.has_definite_block_size()) {
         return {};
     }
     if (!cell_box.can_have_children())
@@ -1005,10 +1005,10 @@ Optional<TableFormattingContext::MeasuredCellContent> TableFormattingContext::me
         return {};
     measuring_context->run(LayoutInput { inner_available_space });
 
-    auto content_height = measuring_context->automatic_content_height();
-    throwaway_cell_used_values.set_content_height(content_height);
+    auto content_block_size = measuring_context->automatic_content_height();
+    throwaway_cell_used_values.set_content_block_size(content_block_size);
     return MeasuredCellContent {
-        .content_height = content_height,
+        .content_block_size = content_block_size,
         .first_baseline = measuring_context->box_baseline(cell_box, BaselineSet::First),
     };
 }
@@ -1057,7 +1057,7 @@ void TableFormattingContext::compute_table_height()
             auto cell_computed_height = cell.box.computed_values().height();
             if (cell_computed_height.is_length()) {
                 auto cell_used_height = cell_computed_height.to_px(height_of_containing_block);
-                cell_state.set_content_height(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
+                cell_state.set_content_block_size(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
 
                 row.base_height = max(row.base_height, cell_used_height);
             }
@@ -1068,17 +1068,17 @@ void TableFormattingContext::compute_table_height()
         // - the widths/heights of all spanned visible columns/rows
         // - the horizontal/vertical border-spacing times the amount of spanned visible columns/rows minus one
         // FIXME: Account for visibility.
-        cell_state.set_content_width(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        cell_state.set_content_inline_size(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
         Optional<CSSPixels> measured_baseline;
         if (cell_height_depends_on_table_height(cell.box)) {
             // This cell's final inside layout happens in the second pass below; measure its
             // content in a throwaway state instead of laying out the committing state twice.
             if (auto measured = measure_cell_content(cell.box, cell_state, cell_state.available_inner_space_or_constraints_from(*m_available_space)); measured.has_value()) {
-                cell_state.set_content_height(measured->content_height);
+                cell_state.set_content_block_size(measured->content_block_size);
                 measured_baseline = measured->first_baseline;
             }
         } else if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
-            cell_state.set_content_height(independent_formatting_context->automatic_content_height());
+            cell_state.set_content_block_size(independent_formatting_context->automatic_content_height());
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }
         if (m_needs_fixed_mode_row_measurement) {
@@ -1189,12 +1189,12 @@ void TableFormattingContext::compute_table_height()
             continue;
 
         auto cell_used_height = cell.box.computed_values().height().to_px(m_table_height);
-        cell_state.set_content_height(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
+        cell_state.set_content_block_size(cell_used_height - cell_state.border_box_top() - cell_state.border_box_bottom());
 
         if (!row.is_collapsed)
             row.reference_height = max(row.reference_height, cell_used_height);
 
-        cell_state.set_content_width(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
+        cell_state.set_content_inline_size(span_width - cell_state.border_box_left() - cell_state.border_box_right() + (cell.column_span - 1) * border_spacing_horizontal());
         // The first pass only measured this cell in a throwaway state; this is its one and
         // only inside layout in the committing state.
         if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
@@ -1291,11 +1291,11 @@ void TableFormattingContext::position_row_boxes()
         if (m_columns.size() >= 2)
             row_width += (m_columns.size() - 1) * border_spacing_horizontal();
 
-        row_state.set_content_height(row.final_height);
-        row_state.set_content_width(row_width);
+        row_state.set_content_block_size(row.final_height);
+        row_state.set_content_inline_size(row_width);
         place_child(row.box, { row_left_offset, row_top_offset });
         if (!row.is_collapsed)
-            row_top_offset += row_state.content_height() + border_spacing_vertical();
+            row_top_offset += row_state.content_block_size() + border_spacing_vertical();
     }
 
     CSSPixels row_group_top_offset = m_pending_table_box_content_offset_in_wrapper.y() + border_spacing_vertical();
@@ -1316,8 +1316,8 @@ void TableFormattingContext::position_row_boxes()
         if (num_rows >= 2)
             row_group_height += (num_rows - 1) * border_spacing_vertical();
 
-        row_group_box_state.set_content_height(row_group_height);
-        row_group_box_state.set_content_width(row_group_width);
+        row_group_box_state.set_content_block_size(row_group_height);
+        row_group_box_state.set_content_inline_size(row_group_width);
         place_child(row_group_box, { row_group_left_offset, row_group_top_offset });
 
         row_group_top_offset += row_group_height + (num_rows > 0 ? border_spacing_vertical() : 0);
@@ -1672,7 +1672,7 @@ CSSPixels TableFormattingContext::compute_row_content_height(Cell const& cell) c
 {
     auto& row_state = m_state.get(m_rows[cell.row_index].box);
     if (cell.row_span == 1) {
-        return row_state.content_height();
+        return row_state.content_block_size();
     }
     // The height of a cell is the sum of all spanned rows, as described in
     // https://www.w3.org/TR/css-tables-3/#bounding-box-assignment
@@ -1685,9 +1685,9 @@ CSSPixels TableFormattingContext::compute_row_content_height(Cell const& cell) c
     for (size_t i = 0; i < cell.row_span; ++i) {
         auto const& row_state = m_state.get(m_rows[cell.row_index + i].box);
         if (i == 0) {
-            span_height += row_state.content_height() + row_state.border_box_bottom();
+            span_height += row_state.content_block_size() + row_state.border_box_bottom();
         } else if (i == cell.row_span - 1) {
-            span_height += row_state.border_box_top() + row_state.content_height();
+            span_height += row_state.border_box_top() + row_state.content_block_size();
         } else {
             span_height += row_state.border_box_height();
         }
@@ -1845,7 +1845,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     for (auto& cell : m_cells)
         layout_absolutely_positioned_children(cell.box);
 
-    m_state.get_mutable(table_box()).set_content_height(m_table_height);
+    m_state.get_mutable(table_box()).set_content_block_size(m_table_height);
 
     total_captions_height += run_caption_layout(CSS::CaptionSide::Bottom, caption_available_space);
 
@@ -1872,7 +1872,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
 
 CSSPixels TableFormattingContext::automatic_content_width() const
 {
-    return m_state.get(table_box()).content_width();
+    return m_state.get(table_box()).content_inline_size();
 }
 
 CSSPixels TableFormattingContext::automatic_content_height() const

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -648,71 +648,71 @@ void TableFormattingContext::compute_table_width()
     table_box_state.set_content_inline_size(used_width);
 }
 
-CSSPixels TableFormattingContext::compute_columns_total_used_width() const
+CSSPixels TableFormattingContext::compute_columns_total_used_inline_size() const
 {
-    CSSPixels total_used_width = 0;
+    CSSPixels total_used_inline_size = 0;
     for (auto& column : m_columns) {
-        total_used_width += column.used_width;
+        total_used_inline_size += column.used_inline_size;
     }
-    return total_used_width;
+    return total_used_inline_size;
 }
 
-static CSSPixels compute_columns_total_candidate_width(Vector<CSSPixels> const& candidate_widths)
+static CSSPixels compute_columns_total_candidate_inline_size(Vector<CSSPixels> const& candidate_inline_sizes)
 {
-    CSSPixels total_candidate_width = 0;
-    for (auto width : candidate_widths) {
-        total_candidate_width += width;
+    CSSPixels total_candidate_inline_size = 0;
+    for (auto inline_size : candidate_inline_sizes) {
+        total_candidate_inline_size += inline_size;
     }
-    return total_candidate_width;
+    return total_candidate_inline_size;
 }
 
-void TableFormattingContext::commit_candidate_column_widths(Vector<CSSPixels> const& candidate_widths)
+void TableFormattingContext::commit_candidate_column_inline_sizes(Vector<CSSPixels> const& candidate_inline_sizes)
 {
-    VERIFY(candidate_widths.size() == m_columns.size());
+    VERIFY(candidate_inline_sizes.size() == m_columns.size());
     for (size_t i = 0; i < m_columns.size(); ++i) {
-        m_columns[i].used_width = candidate_widths[i];
+        m_columns[i].used_inline_size = candidate_inline_sizes[i];
     }
 }
 
-void TableFormattingContext::assign_columns_width_linear_combination(Vector<CSSPixels> const& candidate_widths, CSSPixels available_width)
+void TableFormattingContext::assign_columns_inline_size_linear_combination(Vector<CSSPixels> const& candidate_inline_sizes, CSSPixels available_inline_size)
 {
-    auto columns_total_candidate_width = compute_columns_total_candidate_width(candidate_widths);
-    auto columns_total_used_width = compute_columns_total_used_width();
-    if (columns_total_candidate_width == columns_total_used_width) {
+    auto columns_total_candidate_inline_size = compute_columns_total_candidate_inline_size(candidate_inline_sizes);
+    auto columns_total_used_inline_size = compute_columns_total_used_inline_size();
+    if (columns_total_candidate_inline_size == columns_total_used_inline_size) {
         return;
     }
-    auto candidate_weight = (available_width - columns_total_used_width) / static_cast<double>(columns_total_candidate_width - columns_total_used_width);
+    auto candidate_weight = (available_inline_size - columns_total_used_inline_size) / static_cast<double>(columns_total_candidate_inline_size - columns_total_used_inline_size);
     for (size_t i = 0; i < m_columns.size(); ++i) {
         auto& column = m_columns[i];
-        column.used_width = CSSPixels::nearest_value_for(candidate_weight * candidate_widths[i] + (1 - candidate_weight) * column.used_width);
+        column.used_inline_size = CSSPixels::nearest_value_for(candidate_weight * candidate_inline_sizes[i] + (1 - candidate_weight) * column.used_inline_size);
     }
 }
 
-template<class ColumnFilter, class BaseWidthGetter>
-bool TableFormattingContext::distribute_excess_width_proportionally_to_base_width(CSSPixels excess_width, ColumnFilter column_filter, BaseWidthGetter base_width_getter)
+template<class ColumnFilter, class BaseInlineSizeGetter>
+bool TableFormattingContext::distribute_excess_inline_size_proportionally_to_base_inline_size(CSSPixels excess_inline_size, ColumnFilter column_filter, BaseInlineSizeGetter base_inline_size_getter)
 {
     bool found_matching_columns = false;
-    CSSPixels total_base_width = 0;
+    CSSPixels total_base_inline_size = 0;
     for (auto const& column : m_columns) {
         if (column_filter(column)) {
-            total_base_width += base_width_getter(column);
+            total_base_inline_size += base_inline_size_getter(column);
             found_matching_columns = true;
         }
     }
     if (!found_matching_columns) {
         return false;
     }
-    VERIFY(total_base_width > 0);
+    VERIFY(total_base_inline_size > 0);
     for (auto& column : m_columns) {
         if (column_filter(column)) {
-            column.used_width += CSSPixels::nearest_value_for(excess_width * base_width_getter(column) / static_cast<double>(total_base_width));
+            column.used_inline_size += CSSPixels::nearest_value_for(excess_inline_size * base_inline_size_getter(column) / static_cast<double>(total_base_inline_size));
         }
     }
     return true;
 }
 
 template<class ColumnFilter>
-bool TableFormattingContext::distribute_excess_width_equally(CSSPixels excess_width, ColumnFilter column_filter)
+bool TableFormattingContext::distribute_excess_inline_size_equally(CSSPixels excess_inline_size, ColumnFilter column_filter)
 {
     size_t matching_column_count = 0;
     for (auto const& column : m_columns) {
@@ -725,21 +725,21 @@ bool TableFormattingContext::distribute_excess_width_equally(CSSPixels excess_wi
     }
     for (auto& column : m_columns) {
         if (column_filter(column)) {
-            column.used_width += excess_width / matching_column_count;
+            column.used_inline_size += excess_inline_size / matching_column_count;
         }
     }
     return matching_column_count;
 }
 
 template<class ColumnFilter>
-bool TableFormattingContext::distribute_excess_width_by_intrinsic_percentage(CSSPixels excess_width, ColumnFilter column_filter)
+bool TableFormattingContext::distribute_excess_inline_size_by_intrinsic_percentage(CSSPixels excess_inline_size, ColumnFilter column_filter)
 {
     bool found_matching_columns = false;
-    double total_percentage_width = 0;
+    double total_intrinsic_percentage = 0;
     for (auto const& column : m_columns) {
         if (column_filter(column)) {
             found_matching_columns = true;
-            total_percentage_width += column.intrinsic_percentage;
+            total_intrinsic_percentage += column.intrinsic_percentage;
         }
     }
     if (!found_matching_columns) {
@@ -747,29 +747,28 @@ bool TableFormattingContext::distribute_excess_width_by_intrinsic_percentage(CSS
     }
     for (auto& column : m_columns) {
         if (column_filter(column)) {
-            column.used_width += CSSPixels::nearest_value_for(excess_width * column.intrinsic_percentage / total_percentage_width);
+            column.used_inline_size += CSSPixels::nearest_value_for(excess_inline_size * column.intrinsic_percentage / total_intrinsic_percentage);
         }
     }
     return true;
 }
 
-void TableFormattingContext::distribute_width_to_columns()
+void TableFormattingContext::distribute_inline_size_to_columns()
 {
     // Implements https://www.w3.org/TR/css-tables-3/#width-distribution-algorithm
 
     // The total horizontal border spacing is defined for each table:
     // - For tables laid out in separated-borders mode containing at least one column, the horizontal component of the computed value of the border-spacing property times one plus the number of columns in the table
     // - Otherwise, 0
-    auto total_horizontal_border_spacing = m_columns.is_empty() ? 0 : (m_columns.size() + 1) * border_spacing_horizontal();
+    auto total_inline_border_spacing = m_columns.is_empty() ? 0 : (m_columns.size() + 1) * border_spacing_horizontal();
 
-    // The assignable table width is the used width of the table minus the total horizontal border spacing (if any).
-    // This is the width that we will be able to allocate to the columns.
-    CSSPixels const available_width = m_state.get(table_box()).content_inline_size() - total_horizontal_border_spacing;
+    // The assignable table inline size is its used inline size minus the inline-axis border spacing.
+    CSSPixels const available_inline_size = m_state.get(table_box()).content_inline_size() - total_inline_border_spacing;
 
-    Vector<CSSPixels> candidate_widths;
-    candidate_widths.resize(m_columns.size());
+    Vector<CSSPixels> candidate_inline_sizes;
+    candidate_inline_sizes.resize(m_columns.size());
 
-    // 1. The min-content sizing-guess is the set of column width assignments where each column is assigned its min-content width.
+    // 1. The min-content sizing guess assigns every column its min-content inline size.
     for (size_t i = 0; i < m_columns.size(); ++i) {
         auto& column = m_columns[i];
         // In fixed mode, the min-content width of percent-columns and auto-columns is considered to be zero:
@@ -777,8 +776,8 @@ void TableFormattingContext::distribute_width_to_columns()
         if (use_fixed_mode_layout() && !column.is_constrained) {
             continue;
         }
-        column.used_width = column.min_size;
-        candidate_widths[i] = column.min_size;
+        column.used_inline_size = column.min_size;
+        candidate_inline_sizes[i] = column.min_size;
     }
 
     // 2. The min-content-percentage sizing-guess is the set of column width assignments where:
@@ -789,17 +788,17 @@ void TableFormattingContext::distribute_width_to_columns()
     for (size_t i = 0; i < m_columns.size(); ++i) {
         auto& column = m_columns[i];
         if (column.has_intrinsic_percentage) {
-            candidate_widths[i] = max(column.min_size, CSSPixels::nearest_value_for(column.intrinsic_percentage / 100 * available_width));
+            candidate_inline_sizes[i] = max(column.min_size, CSSPixels::nearest_value_for(column.intrinsic_percentage / 100 * available_inline_size));
         }
     }
 
-    // If the assignable table width is less than or equal to the max-content sizing-guess, the used widths of the columns must be the
-    // linear combination (with weights adding to 1) of the two consecutive sizing-guesses whose width sums bound the available width.
-    if (available_width < compute_columns_total_candidate_width(candidate_widths)) {
-        assign_columns_width_linear_combination(candidate_widths, available_width);
+    // If the assignable inline size is no larger than the max-content sizing guess, use the linear combination
+    // of the consecutive sizing guesses whose sums bound the available inline size.
+    if (available_inline_size < compute_columns_total_candidate_inline_size(candidate_inline_sizes)) {
+        assign_columns_inline_size_linear_combination(candidate_inline_sizes, available_inline_size);
         return;
     } else {
-        commit_candidate_column_widths(candidate_widths);
+        commit_candidate_column_inline_sizes(candidate_inline_sizes);
     }
 
     // 3. The min-content-specified sizing-guess is the set of column width assignments where:
@@ -811,15 +810,15 @@ void TableFormattingContext::distribute_width_to_columns()
     for (size_t i = 0; i < m_columns.size(); ++i) {
         auto& column = m_columns[i];
         if (column.is_constrained) {
-            candidate_widths[i] = column.max_size;
+            candidate_inline_sizes[i] = column.max_size;
         }
     }
 
-    if (available_width < compute_columns_total_candidate_width(candidate_widths)) {
-        assign_columns_width_linear_combination(candidate_widths, available_width);
+    if (available_inline_size < compute_columns_total_candidate_inline_size(candidate_inline_sizes)) {
+        assign_columns_inline_size_linear_combination(candidate_inline_sizes, available_inline_size);
         return;
     } else {
-        commit_candidate_column_widths(candidate_widths);
+        commit_candidate_column_inline_sizes(candidate_inline_sizes);
     }
 
     // 4. The max-content sizing-guess is the set of column width assignments where:
@@ -830,123 +829,122 @@ void TableFormattingContext::distribute_width_to_columns()
     for (size_t i = 0; i < m_columns.size(); ++i) {
         auto& column = m_columns[i];
         if (!column.has_intrinsic_percentage) {
-            candidate_widths[i] = column.max_size;
+            candidate_inline_sizes[i] = column.max_size;
         }
     }
 
-    if (available_width < compute_columns_total_candidate_width(candidate_widths)) {
-        assign_columns_width_linear_combination(candidate_widths, available_width);
+    if (available_inline_size < compute_columns_total_candidate_inline_size(candidate_inline_sizes)) {
+        assign_columns_inline_size_linear_combination(candidate_inline_sizes, available_inline_size);
         return;
     } else {
-        commit_candidate_column_widths(candidate_widths);
+        commit_candidate_column_inline_sizes(candidate_inline_sizes);
     }
 
-    // Otherwise, the used widths of the columns are the result of starting from the max-content sizing-guess and distributing
-    // the excess width to the columns of the table according to the rules for distributing excess width to columns (for used width).
-    distribute_excess_width_to_columns(available_width);
+    // Otherwise, start from the max-content sizing guess and distribute the excess inline size to the columns.
+    distribute_excess_inline_size_to_columns(available_inline_size);
 }
 
-void TableFormattingContext::distribute_excess_width_to_columns(CSSPixels available_width)
+void TableFormattingContext::distribute_excess_inline_size_to_columns(CSSPixels available_inline_size)
 {
     // Implements https://www.w3.org/TR/css-tables-3/#distributing-width-to-columns
-    auto columns_total_used_width = compute_columns_total_used_width();
-    if (columns_total_used_width >= available_width) {
+    auto columns_total_used_inline_size = compute_columns_total_used_inline_size();
+    if (columns_total_used_inline_size >= available_inline_size) {
         return;
     }
-    auto excess_width = available_width - columns_total_used_width;
-    if (excess_width == 0) {
+    auto excess_inline_size = available_inline_size - columns_total_used_inline_size;
+    if (excess_inline_size == 0) {
         return;
     }
 
     if (use_fixed_mode_layout()) {
-        distribute_excess_width_to_columns_fixed_mode(excess_width);
+        distribute_excess_inline_size_to_columns_fixed_mode(excess_inline_size);
         return;
     }
 
     // 1. If there are non-constrained columns that have originating cells with intrinsic percentage width of 0% and with nonzero
     //    max-content width (aka the columns allowed to grow by this rule), the distributed widths of the columns allowed to grow
     //    by this rule are increased in proportion to max-content width so the total increase adds to the excess width.
-    if (distribute_excess_width_proportionally_to_base_width(
-            excess_width,
+    if (distribute_excess_inline_size_proportionally_to_base_inline_size(
+            excess_inline_size,
             [](auto const& column) {
                 return !column.is_constrained && column.has_originating_cells && column.intrinsic_percentage == 0 && column.max_size > 0;
             },
             [](auto const& column) { return column.max_size; })) {
-        excess_width = available_width - compute_columns_total_used_width();
+        excess_inline_size = available_inline_size - compute_columns_total_used_inline_size();
     }
-    if (excess_width == 0) {
+    if (excess_inline_size == 0) {
         return;
     }
     // 2. Otherwise, if there are non-constrained columns that have originating cells with intrinsic percentage width of 0% (aka the columns
     //    allowed to grow by this rule, which thanks to the previous rule must have zero max-content width), the distributed widths of the
     //    columns allowed to grow by this rule are increased by equal amounts so the total increase adds to the excess width.
-    if (distribute_excess_width_equally(excess_width,
+    if (distribute_excess_inline_size_equally(excess_inline_size,
             [](auto const& column) {
                 return !column.is_constrained && column.has_originating_cells && column.intrinsic_percentage == 0;
             })) {
-        excess_width = available_width - compute_columns_total_used_width();
+        excess_inline_size = available_inline_size - compute_columns_total_used_inline_size();
     }
-    if (excess_width == 0) {
+    if (excess_inline_size == 0) {
         return;
     }
     // 3. Otherwise, if there are constrained columns with intrinsic percentage width of 0% and with nonzero max-content width
     //    (aka the columns allowed to grow by this rule, which, due to other rules, must have originating cells), the distributed widths of the
     //    columns allowed to grow by this rule are increased in proportion to max-content width so the total increase adds to the excess width.
-    if (distribute_excess_width_proportionally_to_base_width(
-            excess_width,
+    if (distribute_excess_inline_size_proportionally_to_base_inline_size(
+            excess_inline_size,
             [](auto const& column) {
                 return column.is_constrained && column.intrinsic_percentage == 0 && column.max_size > 0;
             },
             [](auto const& column) { return column.max_size; })) {
-        excess_width = available_width - compute_columns_total_used_width();
+        excess_inline_size = available_inline_size - compute_columns_total_used_inline_size();
     }
-    if (excess_width == 0) {
+    if (excess_inline_size == 0) {
         return;
     }
     // 4. Otherwise, if there are columns with intrinsic percentage width greater than 0% (aka the columns allowed to grow by this rule,
     //    which, due to other rules, must have originating cells), the distributed widths of the columns allowed to grow by this rule are
     //    increased in proportion to intrinsic percentage width so the total increase adds to the excess width.
-    if (distribute_excess_width_by_intrinsic_percentage(excess_width, [](auto const& column) {
+    if (distribute_excess_inline_size_by_intrinsic_percentage(excess_inline_size, [](auto const& column) {
             return column.intrinsic_percentage > 0;
         })) {
-        excess_width = available_width - compute_columns_total_used_width();
+        excess_inline_size = available_inline_size - compute_columns_total_used_inline_size();
     }
-    if (excess_width == 0) {
+    if (excess_inline_size == 0) {
         return;
     }
     // 5. Otherwise, if there is any such column, the distributed widths of all columns that have originating cells are increased by equal amounts
     //    so the total increase adds to the excess width.
-    if (distribute_excess_width_equally(
-            excess_width,
+    if (distribute_excess_inline_size_equally(
+            excess_inline_size,
             [](auto const& column) { return column.has_originating_cells; })) {
-        excess_width = available_width - compute_columns_total_used_width();
+        excess_inline_size = available_inline_size - compute_columns_total_used_inline_size();
     }
-    if (excess_width == 0) {
+    if (excess_inline_size == 0) {
         return;
     }
     // 6. Otherwise, the distributed widths of all columns are increased by equal amounts so the total increase adds to the excess width.
-    distribute_excess_width_equally(excess_width, [](auto const&) { return true; });
+    distribute_excess_inline_size_equally(excess_inline_size, [](auto const&) { return true; });
 }
 
-void TableFormattingContext::distribute_excess_width_to_columns_fixed_mode(CSSPixels excess_width)
+void TableFormattingContext::distribute_excess_inline_size_to_columns_fixed_mode(CSSPixels excess_inline_size)
 {
     // Implements the fixed mode for https://www.w3.org/TR/css-tables-3/#distributing-width-to-columns.
 
-    // If there are any columns with no width specified, the excess width is distributed in equally to such columns
-    if (distribute_excess_width_equally(excess_width, [](auto const& column) { return !column.is_constrained && !column.has_intrinsic_percentage; })) {
+    // If any columns have no specified inline size, distribute the excess inline size equally to them.
+    if (distribute_excess_inline_size_equally(excess_inline_size, [](auto const& column) { return !column.is_constrained && !column.has_intrinsic_percentage; })) {
         return;
     }
-    // otherwise, if there are columns with non-zero length widths from the base assignment, the excess width is distributed proportionally to width among those columns
-    if (distribute_excess_width_proportionally_to_base_width(
-            excess_width, [](auto const& column) { return column.used_width > 0; }, [](auto const& column) { return column.used_width; })) {
+    // Otherwise, distribute proportionally among columns with non-zero length sizes from the base assignment.
+    if (distribute_excess_inline_size_proportionally_to_base_inline_size(
+            excess_inline_size, [](auto const& column) { return column.used_inline_size > 0; }, [](auto const& column) { return column.used_inline_size; })) {
         return;
     }
-    // otherwise, if there are columns with non-zero percentage widths from the base assignment, the excess width is distributed proportionally to percentage width among those columns
-    if (distribute_excess_width_by_intrinsic_percentage(excess_width, [](auto const& column) { return column.intrinsic_percentage > 0; })) {
+    // Otherwise, distribute proportionally among columns with non-zero percentage sizes from the base assignment.
+    if (distribute_excess_inline_size_by_intrinsic_percentage(excess_inline_size, [](auto const& column) { return column.intrinsic_percentage > 0; })) {
         return;
     }
-    // otherwise, the excess width is distributed equally to the zero-sized columns
-    distribute_excess_width_equally(excess_width, [](auto const& column) { return column.used_width == 0; });
+    // Otherwise, distribute the excess inline size equally to the zero-sized columns.
+    distribute_excess_inline_size_equally(excess_inline_size, [](auto const& column) { return column.used_inline_size == 0; });
 }
 
 bool TableFormattingContext::can_skip_row_intrinsic_measurement() const
@@ -1036,7 +1034,7 @@ void TableFormattingContext::compute_table_block_size()
 
         CSSPixels span_inline_size = 0;
         for (size_t i = 0; i < cell.column_span; ++i)
-            span_inline_size += m_columns[cell.column_index + i].used_width;
+            span_inline_size += m_columns[cell.column_index + i].used_inline_size;
 
         auto containing_block_inline_size = m_participant_constraints.percentage_basis_inline_size.value_or(0);
         auto containing_block_block_size = m_participant_constraints.percentage_basis_block_size.value_or(0);
@@ -1182,7 +1180,7 @@ void TableFormattingContext::compute_table_block_size()
 
         CSSPixels span_inline_size = 0;
         for (size_t i = 0; i < cell.column_span; ++i)
-            span_inline_size += m_columns[cell.column_index + i].used_width;
+            span_inline_size += m_columns[cell.column_index + i].used_inline_size;
 
         if (!cell_block_size_depends_on_table_block_size(cell.box))
             continue;
@@ -1282,7 +1280,7 @@ void TableFormattingContext::position_row_boxes()
         auto& row_state = m_state.get_mutable(row.box);
         CSSPixels row_inline_size = 0;
         for (auto& column : m_columns) {
-            row_inline_size += column.used_width;
+            row_inline_size += column.used_inline_size;
         }
         if (m_columns.size() >= 2)
             row_inline_size += (m_columns.size() - 1) * border_spacing_horizontal();
@@ -1325,10 +1323,10 @@ void TableFormattingContext::position_row_boxes()
 
 void TableFormattingContext::position_cell_boxes()
 {
-    CSSPixels left_column_offset = 0;
+    CSSPixels column_inline_offset = 0;
     for (auto& column : m_columns) {
-        column.left_offset = left_column_offset;
-        left_column_offset += column.used_width;
+        column.inline_offset = column_inline_offset;
+        column_inline_offset += column.used_inline_size;
     }
 
     // When a table cell is an anonymous wrapper around a flex or grid container (e.g., a <td> with display:flex is
@@ -1399,7 +1397,7 @@ void TableFormattingContext::position_cell_boxes()
         // - the padding-left/padding-top and border-left-width/border-top-width of the table
         // FIXME: Account for visibility.
         auto cell_offset = row_state.content_offset().translated(
-            cell_state.border_box_left() + m_columns[cell.column_index].left_offset + cell.column_index * border_spacing_horizontal(),
+            cell_state.border_box_left() + m_columns[cell.column_index].inline_offset + cell.column_index * border_spacing_horizontal(),
             cell_state.border_box_top());
         place_child(cell.box, cell_offset);
     }
@@ -1829,7 +1827,7 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     auto captions_block_size = run_caption_layout(CSS::CaptionSide::Top, caption_available_space);
 
     // Distribute the width of the table among columns.
-    distribute_width_to_columns();
+    distribute_inline_size_to_columns();
 
     compute_table_block_size();
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -70,7 +70,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase, Ava
             if (block_context) {
                 auto& caption_state = m_state.get_mutable(child_box);
                 if (should_treat_height_as_auto(child_box, caption_available_space, m_participant_constraints)) {
-                    auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_height();
+                    auto height = child_box.has_size_containment() ? 0 : caption_context->automatic_content_block_size();
                     caption_state.set_content_block_size(height);
                 }
                 place_child(child_box, caption_offset);
@@ -1005,7 +1005,7 @@ Optional<TableFormattingContext::MeasuredCellContent> TableFormattingContext::me
         return {};
     measuring_context->run(LayoutInput { inner_available_space });
 
-    auto content_block_size = measuring_context->automatic_content_height();
+    auto content_block_size = measuring_context->automatic_content_block_size();
     throwaway_cell_used_values.set_content_block_size(content_block_size);
     return MeasuredCellContent {
         .content_block_size = content_block_size,
@@ -1078,7 +1078,7 @@ void TableFormattingContext::compute_table_height()
                 measured_baseline = measured->first_baseline;
             }
         } else if (auto independent_formatting_context = layout_inside(cell.box, m_layout_mode, LayoutInput { cell_state.available_inner_space_or_constraints_from(*m_available_space) })) {
-            cell_state.set_content_block_size(independent_formatting_context->automatic_content_height());
+            cell_state.set_content_block_size(independent_formatting_context->automatic_content_block_size());
             independent_formatting_context->parent_context_did_dimension_child_root_box();
         }
         if (m_needs_fixed_mode_row_measurement) {
@@ -1867,17 +1867,17 @@ void TableFormattingContext::run(LayoutInput const& layout_input)
     });
     compute_and_store_baselines(m_state.get_mutable(table_box()));
 
-    m_automatic_content_height = m_table_height;
+    m_automatic_content_block_size = m_table_height;
 }
 
-CSSPixels TableFormattingContext::automatic_content_width() const
+CSSPixels TableFormattingContext::automatic_content_inline_size() const
 {
     return m_state.get(table_box()).content_inline_size();
 }
 
-CSSPixels TableFormattingContext::automatic_content_height() const
+CSSPixels TableFormattingContext::automatic_content_block_size() const
 {
-    return m_automatic_content_height;
+    return m_automatic_content_block_size;
 }
 
 template<>

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -129,8 +129,8 @@ void TableFormattingContext::compute_constrainedness()
 void TableFormattingContext::compute_cell_measures(RowMeasurement row_measurement)
 {
     // Implements https://www.w3.org/TR/css-tables-3/#computing-cell-measures.
-    auto containing_block_width = m_table_constraints.percentage_basis_width.value_or(0);
-    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
+    auto containing_block_width = m_table_constraints.percentage_basis_inline_size.value_or(0);
+    auto containing_block_height = m_table_constraints.percentage_basis_block_size.value_or(0);
 
     compute_constrainedness();
 
@@ -226,7 +226,7 @@ void TableFormattingContext::compute_cell_measures(RowMeasurement row_measuremen
 
 void TableFormattingContext::compute_outer_content_sizes()
 {
-    auto containing_block_width = m_table_constraints.percentage_basis_width.value_or(0);
+    auto containing_block_width = m_table_constraints.percentage_basis_inline_size.value_or(0);
 
     size_t column_index = 0;
     TableGrid::for_each_child_box_matching(table_box(), is_table_column_group, [&](auto& column_group_box) {
@@ -250,7 +250,7 @@ void TableFormattingContext::compute_outer_content_sizes()
 
 void TableFormattingContext::initialize_row_content_sizes()
 {
-    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
+    auto containing_block_height = m_table_constraints.percentage_basis_block_size.value_or(0);
 
     for (auto& row : m_rows) {
         auto const& computed_values = row.box.computed_values();
@@ -267,7 +267,7 @@ void TableFormattingContext::initialize_row_content_sizes()
 template<>
 void TableFormattingContext::initialize_table_measures<TableFormattingContext::Row>()
 {
-    auto containing_block_height = m_table_constraints.percentage_basis_height.value_or(0);
+    auto containing_block_height = m_table_constraints.percentage_basis_block_size.value_or(0);
 
     for (auto& cell : m_cells) {
         auto const& computed_values = cell.box.computed_values();
@@ -492,7 +492,7 @@ CSSPixels TableFormattingContext::compute_capmin()
     // The caption width minimum (CAPMIN) is the largest of the table captions min-content contribution:
     // https://drafts.csswg.org/css-tables-3/#computing-the-table-width
     CSSPixels capmin = 0;
-    auto width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_width.value_or(0);
+    auto width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_inline_size.value_or(0);
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
         auto const* child_box = as_if<Box>(*child);
         if (!child_box || !child_box->display().is_table_caption()) {
@@ -548,7 +548,7 @@ void TableFormattingContext::compute_table_width()
 
     // Percentages on 'width' and 'height' on the table are relative to the table wrapper box's containing block,
     // not the table wrapper box itself.
-    CSSPixels width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_width.value_or(0);
+    CSSPixels width_of_table_wrapper_containing_block = m_table_constraints.percentage_basis_inline_size.value_or(0);
 
     // Compute undistributable space due to border spacing: https://www.w3.org/TR/css-tables-3/#computing-undistributable-space.
     auto undistributable_space = (m_columns.size() + 1) * border_spacing_horizontal();
@@ -595,7 +595,7 @@ void TableFormattingContext::compute_table_width()
     }
 
     CSSPixels used_width;
-    if (width_is_auto_or_indefinite_percentage(computed_values.width(), m_table_constraints.percentage_basis_width.has_value())) {
+    if (width_is_auto_or_indefinite_percentage(computed_values.width(), m_table_constraints.percentage_basis_inline_size.has_value())) {
         // If the table-root has 'width: auto', the used width is the greater of
         // min(GRIDMAX, the table’s containing block width), the used min-width of the table.
         // NOTE: In normal layout the available width already is the wrapper's used width, which the
@@ -1038,8 +1038,8 @@ void TableFormattingContext::compute_table_height()
         for (size_t i = 0; i < cell.column_span; ++i)
             span_width += m_columns[cell.column_index + i].used_width;
 
-        auto width_of_containing_block = m_participant_constraints.percentage_basis_width.value_or(0);
-        auto height_of_containing_block = m_participant_constraints.percentage_basis_height.value_or(0);
+        auto width_of_containing_block = m_participant_constraints.percentage_basis_inline_size.value_or(0);
+        auto height_of_containing_block = m_participant_constraints.percentage_basis_block_size.value_or(0);
 
         cell_state.padding_top = cell.box.computed_values().padding().top().to_px_or_zero(width_of_containing_block);
         cell_state.padding_bottom = cell.box.computed_values().padding().bottom().to_px_or_zero(width_of_containing_block);
@@ -1138,7 +1138,7 @@ void TableFormattingContext::compute_table_height()
         // If the table has a height property with a value other than auto, it is treated as a minimum height for the
         // table grid, and will eventually be distributed to the height of the rows if their collective minimum height
         // ends up smaller than this number.
-        CSSPixels height_of_table_containing_block = m_table_constraints.percentage_basis_height.value_or(0);
+        CSSPixels height_of_table_containing_block = m_table_constraints.percentage_basis_block_size.value_or(0);
         auto specified_table_height = table_box().computed_values().height().to_px(height_of_table_containing_block);
         if (table_box().computed_values().box_sizing() == CSS::BoxSizing::BorderBox) {
             auto const& table_state = m_state.get(table_box());
@@ -1714,12 +1714,12 @@ void TableFormattingContext::seed_table_participant_used_values(ContainingBlockC
     auto const& participant_percentage_basis = participant_constraints;
 
     TableGrid::for_each_child_box_matching(table_box(), TableGrid::is_table_row_group, [&](auto& row_group_box) {
-        m_state.create(row_group_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+        m_state.create(row_group_box, participant_percentage_basis.percentage_basis_inline_size, participant_percentage_basis.percentage_basis_block_size);
     });
     for (auto& row : m_rows)
-        m_state.create(row.box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+        m_state.create(row.box, participant_percentage_basis.percentage_basis_inline_size, participant_percentage_basis.percentage_basis_block_size);
     for (auto& cell : m_cells)
-        m_state.create(cell.box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+        m_state.create(cell.box, participant_percentage_basis.percentage_basis_inline_size, participant_percentage_basis.percentage_basis_block_size);
 
     for (auto child = table_box().first_child(); child; child = child->next_sibling()) {
         auto* child_box = as_if<Box>(*child);
@@ -1727,7 +1727,7 @@ void TableFormattingContext::seed_table_participant_used_values(ContainingBlockC
             continue;
 
         if (child_box->display().is_table_caption())
-            m_state.create(*child_box, participant_percentage_basis.percentage_basis_width, participant_percentage_basis.percentage_basis_height);
+            m_state.create(*child_box, participant_percentage_basis.percentage_basis_inline_size, participant_percentage_basis.percentage_basis_block_size);
     }
 }
 
@@ -1745,9 +1745,9 @@ void TableFormattingContext::run_until_width_calculation(LayoutInput const& layo
     // itself has a non-auto height.
     m_table_constraints = layout_input.containing_block_constraints;
     m_participant_constraints = ContainingBlockConstraints {
-        m_table_constraints.percentage_basis_width,
-        table_box().computed_values().height().is_auto() ? Optional<CSSPixels> {} : m_table_constraints.percentage_basis_height,
-        m_table_constraints.quirks_mode_percentage_basis_height,
+        m_table_constraints.percentage_basis_inline_size,
+        table_box().computed_values().height().is_auto() ? Optional<CSSPixels> {} : m_table_constraints.percentage_basis_block_size,
+        m_table_constraints.quirks_mode_percentage_basis_block_size,
     };
     seed_table_participant_used_values(m_participant_constraints);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -27,7 +27,7 @@ public:
     explicit TableFormattingContext(LayoutState&, LayoutMode, Box const&, FormattingContext* parent);
     ~TableFormattingContext();
 
-    void run_until_width_calculation(LayoutInput const&, RowMeasurement = RowMeasurement::Include);
+    void run_until_inline_size_calculation(LayoutInput const&, RowMeasurement = RowMeasurement::Include);
 
     virtual void run(LayoutInput const&) override;
     virtual CSSPixels automatic_content_inline_size() const override;
@@ -61,7 +61,7 @@ private:
     void compute_table_measures();
     template<class RowOrColumn>
     void compute_intrinsic_percentage(size_t max_cell_span);
-    void compute_table_width();
+    void compute_table_inline_size();
     void distribute_inline_size_to_columns();
     void distribute_excess_inline_size_to_columns(CSSPixels available_inline_size);
     void distribute_excess_inline_size_to_columns_fixed_mode(CSSPixels excess_inline_size);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -95,7 +95,7 @@ private:
     CSSPixels m_table_height { 0 };
     CSSPixels m_automatic_content_block_size { 0 };
     CSSPixelPoint m_pending_table_box_content_offset_in_wrapper {};
-    Optional<CSSPixels> m_min_border_box_height_from_flex_item;
+    Optional<CSSPixels> m_min_border_box_block_size_from_flex_item;
 
     Optional<AvailableSpace> m_available_space;
     bool m_needs_fixed_mode_row_measurement { false };

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -71,8 +71,8 @@ private:
     void position_row_boxes();
     void position_cell_boxes();
     void border_conflict_resolution();
-    CSSPixels border_spacing_horizontal() const;
-    CSSPixels border_spacing_vertical() const;
+    CSSPixels border_spacing_inline() const;
+    CSSPixels border_spacing_block() const;
     void finish_grid_initialization(TableGrid const&);
     void seed_table_participant_used_values(ContainingBlockConstraints const&);
 

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -62,9 +62,9 @@ private:
     template<class RowOrColumn>
     void compute_intrinsic_percentage(size_t max_cell_span);
     void compute_table_width();
-    void distribute_width_to_columns();
-    void distribute_excess_width_to_columns(CSSPixels available_width);
-    void distribute_excess_width_to_columns_fixed_mode(CSSPixels excess_width);
+    void distribute_inline_size_to_columns();
+    void distribute_excess_inline_size_to_columns(CSSPixels available_inline_size);
+    void distribute_excess_inline_size_to_columns_fixed_mode(CSSPixels excess_inline_size);
     bool can_skip_row_intrinsic_measurement() const;
     void compute_table_block_size();
     void distribute_block_size_to_rows();
@@ -76,16 +76,16 @@ private:
     void finish_grid_initialization(TableGrid const&);
     void seed_table_participant_used_values(ContainingBlockConstraints const&);
 
-    CSSPixels compute_columns_total_used_width() const;
-    void commit_candidate_column_widths(Vector<CSSPixels> const& candidate_widths);
-    void assign_columns_width_linear_combination(Vector<CSSPixels> const& candidate_widths, CSSPixels available_width);
+    CSSPixels compute_columns_total_used_inline_size() const;
+    void commit_candidate_column_inline_sizes(Vector<CSSPixels> const& candidate_inline_sizes);
+    void assign_columns_inline_size_linear_combination(Vector<CSSPixels> const& candidate_inline_sizes, CSSPixels available_inline_size);
 
-    template<class ColumnFilter, class BaseWidthGetter>
-    bool distribute_excess_width_proportionally_to_base_width(CSSPixels excess_width, ColumnFilter column_filter, BaseWidthGetter base_width_getter);
+    template<class ColumnFilter, class BaseInlineSizeGetter>
+    bool distribute_excess_inline_size_proportionally_to_base_inline_size(CSSPixels excess_inline_size, ColumnFilter column_filter, BaseInlineSizeGetter base_inline_size_getter);
     template<class ColumnFilter>
-    bool distribute_excess_width_equally(CSSPixels excess_width, ColumnFilter column_filter);
+    bool distribute_excess_inline_size_equally(CSSPixels excess_inline_size, ColumnFilter column_filter);
     template<class ColumnFilter>
-    bool distribute_excess_width_by_intrinsic_percentage(CSSPixels excess_width, ColumnFilter column_filter);
+    bool distribute_excess_inline_size_by_intrinsic_percentage(CSSPixels excess_inline_size, ColumnFilter column_filter);
 
     bool use_fixed_mode_layout() const;
 
@@ -101,10 +101,10 @@ private:
     bool m_needs_fixed_mode_row_measurement { false };
 
     struct Column {
-        CSSPixels left_offset { 0 };
+        CSSPixels inline_offset { 0 };
         CSSPixels min_size { 0 };
         CSSPixels max_size { 0 };
-        CSSPixels used_width { 0 };
+        CSSPixels used_inline_size { 0 };
         bool has_intrinsic_percentage { false };
         double intrinsic_percentage { 0 };
         // Store whether the column is constrained: https://www.w3.org/TR/css-tables-3/#constrainedness

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -35,8 +35,8 @@ public:
 
     Box const& table_box() const { return context_box(); }
 
-    void set_pending_table_box_content_offset_in_wrapper(CSSPixelPoint offset) { m_pending_table_box_content_offset_in_wrapper = offset; }
-    CSSPixelPoint pending_table_box_content_offset_in_wrapper() const { return m_pending_table_box_content_offset_in_wrapper; }
+    void set_pending_table_box_content_offset_in_wrapper(LogicalOffset offset) { m_pending_table_box_content_offset_in_wrapper = offset; }
+    LogicalOffset pending_table_box_content_offset_in_wrapper() const { return m_pending_table_box_content_offset_in_wrapper; }
 
     static bool border_is_less_specific(CSS::BorderData const& a, CSS::BorderData const& b);
 
@@ -94,7 +94,7 @@ private:
 
     CSSPixels m_table_block_size { 0 };
     CSSPixels m_automatic_content_block_size { 0 };
-    CSSPixelPoint m_pending_table_box_content_offset_in_wrapper {};
+    LogicalOffset m_pending_table_box_content_offset_in_wrapper {};
     Optional<CSSPixels> m_min_border_box_block_size_from_flex_item;
 
     Optional<AvailableSpace> m_available_space;

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -66,8 +66,8 @@ private:
     void distribute_excess_width_to_columns(CSSPixels available_width);
     void distribute_excess_width_to_columns_fixed_mode(CSSPixels excess_width);
     bool can_skip_row_intrinsic_measurement() const;
-    void compute_table_height();
-    void distribute_height_to_rows();
+    void compute_table_block_size();
+    void distribute_block_size_to_rows();
     void position_row_boxes();
     void position_cell_boxes();
     void border_conflict_resolution();
@@ -92,7 +92,7 @@ private:
     ContainingBlockConstraints m_table_constraints;
     ContainingBlockConstraints m_participant_constraints;
 
-    CSSPixels m_table_height { 0 };
+    CSSPixels m_table_block_size { 0 };
     CSSPixels m_automatic_content_block_size { 0 };
     CSSPixelPoint m_pending_table_box_content_offset_in_wrapper {};
     Optional<CSSPixels> m_min_border_box_block_size_from_flex_item;
@@ -148,7 +148,7 @@ private:
     template<class RowOrColumn>
     Vector<RowOrColumn>& table_rows_or_columns();
 
-    CSSPixels compute_row_content_height(Cell const& cell) const;
+    CSSPixels compute_row_content_block_size(Cell const& cell) const;
 
     Vector<Cell> m_cells;
     Vector<Column> m_columns;

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -44,7 +44,7 @@ public:
 
 private:
     struct MeasuredCellContent {
-        CSSPixels content_height;
+        CSSPixels content_block_size;
         CSSPixels first_baseline;
     };
     Optional<MeasuredCellContent> measure_cell_content(Box const&, LayoutState::UsedValues const&, AvailableSpace const& inner_available_space);

--- a/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -30,8 +30,8 @@ public:
     void run_until_width_calculation(LayoutInput const&, RowMeasurement = RowMeasurement::Include);
 
     virtual void run(LayoutInput const&) override;
-    virtual CSSPixels automatic_content_width() const override;
-    virtual CSSPixels automatic_content_height() const override;
+    virtual CSSPixels automatic_content_inline_size() const override;
+    virtual CSSPixels automatic_content_block_size() const override;
 
     Box const& table_box() const { return context_box(); }
 
@@ -93,7 +93,7 @@ private:
     ContainingBlockConstraints m_participant_constraints;
 
     CSSPixels m_table_height { 0 };
-    CSSPixels m_automatic_content_height { 0 };
+    CSSPixels m_automatic_content_block_size { 0 };
     CSSPixelPoint m_pending_table_box_content_offset_in_wrapper {};
     Optional<CSSPixels> m_min_border_box_height_from_flex_item;
 

--- a/Libraries/LibWeb/Layout/TableGrid.cpp
+++ b/Libraries/LibWeb/Layout/TableGrid.cpp
@@ -15,20 +15,20 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
     // Implements https://html.spec.whatwg.org/multipage/tables.html#forming-a-table
     TableGrid table_grid;
 
-    size_t x_width = 0;
-    size_t y_height = 0;
-    size_t y_current = 0;
-    size_t max_cell_x = 0;
-    size_t max_cell_y = 0;
+    size_t column_count = 0;
+    size_t row_count = 0;
+    size_t current_row = 0;
+    size_t maximum_cell_column_index = 0;
+    size_t maximum_cell_row_index = 0;
 
     // Implements https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
-    auto process_row = [&table_grid, &cells, &rows, &x_width, &y_height, &y_current, &max_cell_x, &max_cell_y](Box const& row, Optional<Box&> row_group = {}) {
-        // 1. If yheight is equal to ycurrent, then increase yheight by 1. (ycurrent is never greater than yheight.)
-        if (y_height == y_current)
-            y_height++;
+    auto process_row = [&table_grid, &cells, &rows, &column_count, &row_count, &current_row, &maximum_cell_column_index, &maximum_cell_row_index](Box const& row, Optional<Box&> row_group = {}) {
+        // 1. If the row count equals the current row, increase the row count by 1.
+        if (row_count == current_row)
+            row_count++;
 
-        // 2. Let xcurrent be 0.
-        size_t x_current = 0;
+        // 2. Let the current column be 0.
+        size_t current_column = 0;
 
         // FIXME: 3. Run the algorithm for growing downward-growing cells.
 
@@ -45,14 +45,14 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
 
             auto& current_cell = const_cast<Box&>(*child_box);
 
-            // 6. Cells: While x_current is less than x_width and the slot with coordinate (x_current, y_current)
-            //    already has a cell assigned to it, increase x_current by 1.
-            while (x_current < x_width && table_grid.m_occupancy_grid.contains(GridPosition { x_current, y_current }))
-                x_current++;
+            // 6. Cells: While the current column is within the grid and its slot in the current row
+            //    already has a cell assigned to it, increase the current column by 1.
+            while (current_column < column_count && table_grid.m_occupancy_grid.contains(GridPosition { current_column, current_row }))
+                current_column++;
 
-            // 7. If xcurrent is equal to xwidth, increase xwidth by 1. (xcurrent is never greater than xwidth.)
-            if (x_current == x_width)
-                x_width++;
+            // 7. If the current column equals the column count, increase the column count by 1.
+            if (current_column == column_count)
+                column_count++;
 
             // NB: Steps 8 and 9 are implemented in HTMLTableCellElement.col_span() and HTMLTableCellElement.row_spam() respectively.
             size_t colspan = 1;
@@ -71,16 +71,16 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
                 rowspan = 1;
             }
 
-            // 12. If xwidth < xcurrent+colspan, then let xwidth be xcurrent+colspan.
-            if (x_width < x_current + colspan)
-                x_width = x_current + colspan;
+            // 12. Extend the column count to include the cell's column span.
+            if (column_count < current_column + colspan)
+                column_count = current_column + colspan;
 
-            // 13. If yheight < ycurrent+rowspan, then let yheight be ycurrent+rowspan.
-            if (y_height < y_current + rowspan)
-                y_height = y_current + rowspan;
+            // 13. Extend the row count to include the cell's row span.
+            if (row_count < current_row + rowspan)
+                row_count = current_row + rowspan;
 
-            // 14. Let the slots with coordinates (x, y) such that xcurrent ≤ x < xcurrent+colspan and
-            //     ycurrent ≤ y < ycurrent+rowspan be covered by a new cell c, anchored at (xcurrent, ycurrent),
+            // 14. Let the slots within the cell's column and row spans be covered by a new cell,
+            //     anchored at the current column and row,
             //     which has width colspan and height rowspan, corresponding to the current cell element.
             //     If the current cell element is a th element, let this new cell c be a header cell;
             //     otherwise, let it be a data cell.
@@ -89,20 +89,20 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
             //     If any of the slots involved already had a cell covering them, then this is a table model error.
             //     Those slots now have two cells overlapping.
             // NB: We don't distinguish between header and data cells here.
-            for (size_t y = y_current; y < y_current + rowspan; y++)
-                for (size_t x = x_current; x < x_current + colspan; x++)
-                    table_grid.m_occupancy_grid.set(GridPosition { x, y }, true);
-            cells.append(Cell { current_cell, x_current, y_current, colspan, rowspan });
-            max_cell_x = max(x_current, max_cell_x);
-            max_cell_y = max(y_current, max_cell_y);
+            for (size_t row_index = current_row; row_index < current_row + rowspan; row_index++)
+                for (size_t column_index = current_column; column_index < current_column + colspan; column_index++)
+                    table_grid.m_occupancy_grid.set(GridPosition { column_index, row_index }, true);
+            cells.append(Cell { current_cell, current_column, current_row, colspan, rowspan });
+            maximum_cell_column_index = max(current_column, maximum_cell_column_index);
+            maximum_cell_row_index = max(current_row, maximum_cell_row_index);
 
-            // 15. If cell grows downward is true, then add the tuple {c, xcurrent, colspan} to the list of downward-growing cells.
+            // 15. If cell grows downward is true, add the cell, current column, and column span to the list of downward-growing cells.
             if (cell_grows_downward) {
                 // FIXME: Add the tuple.
             }
 
-            // 16. Increase xcurrent by colspan.
-            x_current += colspan;
+            // 16. Increase the current column by the column span.
+            current_column += colspan;
 
             // NB: Step 17 is handled below, outside of this loop.
 
@@ -112,13 +112,13 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
         }
 
         // 17. If current cell is the last td or th element child in the tr element being processed, then increase
-        //    ycurrent by 1, abort this set of steps, and return to the algorithm above.
+        //    the current row by 1, abort this set of steps, and return to the algorithm above.
         rows.append(Row {
             .box = row,
             .is_collapsed = row.computed_values().visibility() == CSS::Visibility::Collapse
                 || (row_group.has_value() && row_group->computed_values().visibility() == CSS::Visibility::Collapse),
         });
-        y_current++;
+        current_row++;
     };
 
     auto process_col_group = [&](auto& col_group) {
@@ -127,7 +127,7 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
                 u32 span = 1;
                 if (auto const* col_element = as_if<HTML::HTMLTableColElement>(descendant_box.dom_node()))
                     span = col_element->span();
-                x_width += span;
+                column_count += span;
             }
             return TraversalDecision::Continue;
         });
@@ -152,7 +152,7 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
         return IterationDecision::Continue;
     });
 
-    table_grid.m_column_count = x_width;
+    table_grid.m_column_count = column_count;
 
     for (auto& cell : cells) {
         // Clip spans to the end of the table.

--- a/Libraries/LibWeb/Layout/TableGrid.h
+++ b/Libraries/LibWeb/Layout/TableGrid.h
@@ -14,8 +14,8 @@ namespace Web::Layout {
 class TableGrid {
 public:
     struct GridPosition {
-        size_t x;
-        size_t y;
+        size_t column_index;
+        size_t row_index;
         inline bool operator==(GridPosition const&) const = default;
     };
 
@@ -109,7 +109,7 @@ template<>
 struct Traits<Web::Layout::TableGrid::GridPosition> : public DefaultTraits<Web::Layout::TableGrid::GridPosition> {
     static unsigned hash(Web::Layout::TableGrid::GridPosition const& key)
     {
-        return pair_int_hash(key.x, key.y);
+        return pair_int_hash(key.column_index, key.row_index);
     }
 };
 

--- a/Libraries/LibWeb/Layout/TableGrid.h
+++ b/Libraries/LibWeb/Layout/TableGrid.h
@@ -41,10 +41,10 @@ public:
         size_t column_span;
         size_t row_span;
         CSSPixels baseline { 0 };
-        CSSPixels outer_min_width { 0 };
-        CSSPixels outer_max_width { 0 };
-        CSSPixels outer_min_height { 0 };
-        CSSPixels outer_max_height { 0 };
+        CSSPixels outer_min_inline_size { 0 };
+        CSSPixels outer_max_inline_size { 0 };
+        CSSPixels outer_min_block_size { 0 };
+        CSSPixels outer_max_block_size { 0 };
     };
 
     // Calculate and return the grid and also rows and cells as output parameters.

--- a/Libraries/LibWeb/Layout/TableGrid.h
+++ b/Libraries/LibWeb/Layout/TableGrid.h
@@ -21,9 +21,9 @@ public:
 
     struct Row {
         Box const& box;
-        CSSPixels base_height { 0 };
-        CSSPixels reference_height { 0 };
-        CSSPixels final_height { 0 };
+        CSSPixels base_block_size { 0 };
+        CSSPixels reference_block_size { 0 };
+        CSSPixels final_block_size { 0 };
         CSSPixels baseline { 0 };
         CSSPixels min_size { 0 };
         CSSPixels max_size { 0 };

--- a/Libraries/LibWeb/Layout/TextAreaBox.cpp
+++ b/Libraries/LibWeb/Layout/TextAreaBox.cpp
@@ -15,13 +15,13 @@ TextAreaBox::TextAreaBox(DOM::Document& document, GC::Ptr<DOM::Element> element,
 
 CSS::SizeWithAspectRatio TextAreaBox::compute_auto_content_box_size() const
 {
-    auto width = CSS::Length(dom_node().cols(), CSS::LengthUnit::Ch).to_px(*this);
-    auto height = CSS::Length(dom_node().rows(), CSS::LengthUnit::Lh).to_px(*this);
+    auto inline_size = CSS::Length(dom_node().cols(), CSS::LengthUnit::Ch).to_px(*this);
+    auto block_size = CSS::Length(dom_node().rows(), CSS::LengthUnit::Lh).to_px(*this);
 
     if (this->computed_values().writing_mode() != CSS::WritingMode::HorizontalTb)
-        swap(width, height);
+        return { block_size, inline_size, {} };
 
-    return { width, height, {} };
+    return { inline_size, block_size, {} };
 }
 
 }

--- a/Libraries/LibWeb/Layout/TextInputBox.cpp
+++ b/Libraries/LibWeb/Layout/TextInputBox.cpp
@@ -32,16 +32,16 @@ CSS::SizeWithAspectRatio TextInputBox::default_preferred_size_for_text_control(H
     // FIXME: Implement the specified "converting a character width to pixels" algorithm. The size attribute should
     //        also only affect the text entry types (text, search, tel, url, email, password). The other types using
     //        this box are domain-specific widgets that should ignore it.
-    auto width = CSS::Length(input_element.size(), CSS::LengthUnit::Ch).to_px(box);
+    auto inline_size = CSS::Length(input_element.size(), CSS::LengthUnit::Ch).to_px(box);
 
     // FIXME: HTML does not yet detail the primitive appearance of text inputs. Use one line for the default preferred
     //        block size, matching the native appearance described by HTML and the behavior of other engines.
-    auto height = box.computed_values().line_height();
+    auto block_size = box.computed_values().line_height();
 
     if (box.computed_values().writing_mode() != CSS::WritingMode::HorizontalTb)
-        swap(width, height);
+        return { block_size, inline_size, {} };
 
-    return { width, height, {} };
+    return { inline_size, block_size, {} };
 }
 
 }

--- a/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -23,15 +23,7 @@ namespace Web::MimeSniff {
 
 static bool equals_ignoring_ascii_case(Utf16View string, StringView ascii_string)
 {
-    if (string.length_in_code_units() != ascii_string.length())
-        return false;
-
-    for (size_t i = 0; i < string.length_in_code_units(); ++i) {
-        if (AK::to_ascii_lowercase(string.code_unit_at(i)) != AK::to_ascii_lowercase(ascii_string[i]))
-            return false;
-    }
-
-    return true;
+    return string.equals_ignoring_ascii_case(ascii_string);
 }
 
 static void append_utf8_as_utf16(Utf16StringBuilder& builder, StringView string)

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -390,8 +390,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         //     below it compensates in. The visited set and depth cap guard against malformed anchor chains.
         if (auto const* box = as_if<Layout::Box>(&layout_node)) {
             auto const& scroll_state = viewport_paintable.scroll_state();
-            bool compensate_x = true;
-            bool compensate_y = true;
+            bool compensate_horizontal_scroll = true;
+            bool compensate_vertical_scroll = true;
             Vector<Layout::Box const*, 8> visited;
             constexpr size_t max_anchor_chain_depth = 32;
             while (box && !visited.contains_slow(box) && visited.size() < max_anchor_chain_depth) {
@@ -403,15 +403,15 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 if (!box_paintable || !anchor_paintable)
                     break;
                 visited.append(box);
-                compensate_x = compensate_x && box->compensates_for_scroll_in_x();
-                compensate_y = compensate_y && box->compensates_for_scroll_in_y();
+                compensate_horizontal_scroll = compensate_horizontal_scroll && box->compensates_for_horizontal_scroll();
+                compensate_vertical_scroll = compensate_vertical_scroll && box->compensates_for_vertical_scroll();
                 auto anchor_frame = anchor_paintable->enclosing_scroll_frame_index();
                 auto base_frame = box_paintable->enclosing_scroll_frame_index();
                 auto shared_frame = scroll_frame_common_ancestor(scroll_state, anchor_frame, base_frame);
                 for (auto frame = anchor_frame; frame.value() && frame != shared_frame; frame = scroll_state.frame_at(frame).parent_index())
-                    own_state = append_node(own_state, AnchorScrollShift { frame, false, compensate_x, compensate_y });
+                    own_state = append_node(own_state, AnchorScrollShift { frame, false, compensate_horizontal_scroll, compensate_vertical_scroll });
                 for (auto frame = base_frame; frame.value() && frame != shared_frame; frame = scroll_state.frame_at(frame).parent_index())
-                    own_state = append_node(own_state, AnchorScrollShift { frame, true, compensate_x, compensate_y });
+                    own_state = append_node(own_state, AnchorScrollShift { frame, true, compensate_horizontal_scroll, compensate_vertical_scroll });
                 box = anchor_box;
             }
         }
@@ -865,9 +865,9 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
 Gfx::FloatPoint AnchorScrollShift::masked_offset(ScrollStateSnapshot const& scroll_state) const
 {
     auto offset = scroll_state.device_offset_for_index(scroll_frame_index);
-    if (!compensate_x)
+    if (!compensate_horizontal_scroll)
         offset.set_x(0);
-    if (!compensate_y)
+    if (!compensate_vertical_scroll)
         offset.set_y(0);
     return negate ? -offset : offset;
 }
@@ -929,8 +929,8 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
         [&](AnchorScrollShift const& shift) {
             builder.appendff("anchor_scroll_shift(frame_id={}{}{}{})", shift.scroll_frame_index.value(),
                 shift.negate ? ", negate"sv : ""sv,
-                shift.compensate_x ? ""sv : ", no-x"sv,
-                shift.compensate_y ? ""sv : ", no-y"sv);
+                shift.compensate_horizontal_scroll ? ""sv : ", no-x"sv,
+                shift.compensate_vertical_scroll ? ""sv : ", no-y"sv);
         });
 }
 
@@ -1062,8 +1062,8 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::AnchorScrollShift const& d
 {
     TRY(encoder.encode(data.scroll_frame_index));
     TRY(encoder.encode(data.negate));
-    TRY(encoder.encode(data.compensate_x));
-    TRY(encoder.encode(data.compensate_y));
+    TRY(encoder.encode(data.compensate_horizontal_scroll));
+    TRY(encoder.encode(data.compensate_vertical_scroll));
     return {};
 }
 
@@ -1073,8 +1073,8 @@ ErrorOr<Web::Painting::AnchorScrollShift> decode(Decoder& decoder)
     return Web::Painting::AnchorScrollShift {
         .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
         .negate = TRY(decoder.decode<bool>()),
-        .compensate_x = TRY(decoder.decode<bool>()),
-        .compensate_y = TRY(decoder.decode<bool>()),
+        .compensate_horizontal_scroll = TRY(decoder.decode<bool>()),
+        .compensate_vertical_scroll = TRY(decoder.decode<bool>()),
     };
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -94,8 +94,8 @@ struct ScrollCompensation {
 struct AnchorScrollShift {
     ScrollFrameIndex scroll_frame_index;
     bool negate { false };
-    bool compensate_x { true };
-    bool compensate_y { true };
+    bool compensate_horizontal_scroll { true };
+    bool compensate_vertical_scroll { true };
 
     Gfx::FloatPoint masked_offset(ScrollStateSnapshot const&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -156,8 +156,8 @@ static bool visual_context_data_is_equal(VisualContextData const& a, VisualConte
             return other
                 && data.scroll_frame_index == other->scroll_frame_index
                 && data.negate == other->negate
-                && data.compensate_x == other->compensate_x
-                && data.compensate_y == other->compensate_y;
+                && data.compensate_horizontal_scroll == other->compensate_horizontal_scroll
+                && data.compensate_vertical_scroll == other->compensate_vertical_scroll;
         });
 }
 


### PR DESCRIPTION
CSS layout algorithms are generally defined in terms of inline and block axes because their physical direction depends on the element's writing mode. Our layout code instead used `width`, `height`, `x`, and `y` for many values that were already writing-mode-relative.

That terminology forces readers to translate between the specification and the implementation and makes it difficult to tell whether a value is logical or physical from its name alone. It also makes axis mix-ups easier when implementing or reviewing behavior for vertical writing modes.

Use inline and block terminology throughout layout so the code follows the same coordinate system as the specifications. Physical boundaries, such as scrolling and painting, use explicit horizontal and vertical names. This makes conversions between logical and physical geometry visible instead of leaving them implicit in generic `x` and `y` values.