### PR TITLE
LibCore: Create POSIX shared memory atomically with a random name

### DIFF
--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -8,7 +8,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Atomic.h>
 #include <AK/ByteString.h>
+#include <AK/Random.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Vector.h>
@@ -195,25 +197,27 @@ ErrorOr<int> anon_create([[maybe_unused]] size_t size, [[maybe_unused]] int opti
 #elif defined(SHM_ANON)
     fd = shm_open(SHM_ANON, O_RDWR | O_CREAT | options, 0600);
 #elif defined(AK_OS_BSD_GENERIC) || defined(AK_OS_HAIKU)
-    static size_t shared_memory_id = 0;
-
-    auto name = ByteString::formatted("/shm-{}-{}", getpid(), shared_memory_id++);
+    // Create the shared memory object under an unpredictable, single-use name, and unlink it immediately — so only the
+    // returned fd keeps it alive. Use O_EXCL to ensure that if the name already exists, the open fails.
+    static Atomic<u32> shared_memory_id = 0;
+    auto name = ByteString::formatted("/shm-{:016x}-{:08x}", get_random<u64>(), shared_memory_id++);
     // Passing O_CLOEXEC to shm_open in the oflag argument isn't POSIX-compliant and is known to be rejected
     // in macOS 26.4+. So we filter it out here, and instead set FD_CLOEXEC via fcntl after opening.
-    fd = shm_open(name.characters(), O_RDWR | O_CREAT | (options & ~O_CLOEXEC), 0600);
+    fd = shm_open(name.characters(), O_RDWR | O_CREAT | O_EXCL | (options & ~O_CLOEXEC), 0600);
 
-    if (shm_unlink(name.characters()) == -1) {
-        auto saved_errno = errno;
-        if (fd >= 0)
-            TRY(close(fd));
-        return Error::from_errno(saved_errno);
-    }
-
-    if (fd >= 0 && (options & O_CLOEXEC)) {
-        if (::fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+    if (fd >= 0) {
+        if (shm_unlink(name.characters()) == -1) {
             auto saved_errno = errno;
             TRY(close(fd));
             return Error::from_errno(saved_errno);
+        }
+
+        if (options & O_CLOEXEC) {
+            if (::fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+                auto saved_errno = errno;
+                TRY(close(fd));
+                return Error::from_errno(saved_errno);
+            }
         }
     }
 #endif

--- a/Tests/LibCore/TestLibCoreAnonymousBuffer.cpp
+++ b/Tests/LibCore/TestLibCoreAnonymousBuffer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/Vector.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/System.h>
 #include <LibTest/TestCase.h>
@@ -18,6 +19,20 @@ TEST_CASE(create_with_size)
     EXPECT_EQ(buffer.size(), 1024u);
     EXPECT_NE(buffer.data<void>(), nullptr);
     EXPECT_EQ(buffer.bytes().size(), 1024u);
+}
+
+TEST_CASE(create_with_size_produces_independent_buffers)
+{
+    Vector<Core::AnonymousBuffer> buffers;
+    for (u8 i = 0; i < 64; ++i) {
+        auto buffer = MUST(Core::AnonymousBuffer::create_with_size(64));
+        EXPECT(buffer.is_valid());
+        *buffer.data<u8>() = i;
+        buffers.append(move(buffer));
+    }
+
+    for (u8 i = 0; i < 64; ++i)
+        EXPECT_EQ(*buffers[i].data<u8>(), i);
 }
 
 TEST_CASE(default_constructed_is_invalid)


### PR DESCRIPTION
**Problem:** On macOS and other platforms where `Core::AnonymousBuffer` is backed by a named POSIX shared-memory object, `anon_create` opened the object with `O_CREAT` but no `O_EXCL` — under a predictable name made from the process ID and a counter starting at zero. A local process running as the same user can pre-create the same name; the victim then opens that object instead of a fresh one, and the immediate `shm_unlink` only strips the name — leaving the attacker with a descriptor to the very memory the victim goes on to use as its buffer (a CWE-377 exploit).

**Cause:** `shm_open` without `O_EXCL` adopts a pre-existing object rather than failing, and the name had no unpredictable component — so that left it possible for an attacker to guess the name and squat it ahead of time.

**Fix:** Create the object with `O_EXCL` under a single-use name — so creation is atomic, and the name can’t be predicted. And if the name does somehow already exist, we now fail closed instead of adopting it.

CodeRabbit found this during review at https://github.com/LadybirdBrowser/ladybird/pull/10524#discussion_r3612730385.
