### PR TITLE
LibWeb: Apply clip-path and mask to SVG image elements

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -921,6 +921,7 @@ set(SOURCES
     Painting/SVGClipPaintable.cpp
     Painting/SVGForeignObjectPaintable.cpp
     Painting/SVGGraphicsPaintable.cpp
+    Painting/SVGImagePaintable.cpp
     Painting/SVGMaskable.cpp
     Painting/SVGMaskPaintable.cpp
     Painting/SVGPaintable.cpp

--- a/Libraries/LibWeb/Layout/SVGImageBox.cpp
+++ b/Libraries/LibWeb/Layout/SVGImageBox.cpp
@@ -5,9 +5,7 @@
  */
 
 #include <LibWeb/Layout/SVGImageBox.h>
-#include <LibWeb/Painting/ImagePaintable.h>
-#include <LibWeb/Painting/SVGGraphicsPaintable.h>
-#include <LibWeb/Painting/StackingContext.h>
+#include <LibWeb/Painting/SVGImagePaintable.h>
 
 namespace Web::Layout {
 
@@ -18,7 +16,7 @@ SVGImageBox::SVGImageBox(DOM::Document& document, SVG::SVGGraphicsElement& eleme
 
 RefPtr<Painting::Paintable> SVGImageBox::create_paintable() const
 {
-    return Painting::ImagePaintable::create(*this);
+    return Painting::SVGImagePaintable::create(*this);
 }
 
 }

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -60,25 +60,18 @@ static void paint_alt_text(DisplayListRecordingContext& context, Layout::Node co
     draw_line();
 }
 
-NonnullRefPtr<ImagePaintable> ImagePaintable::create(Layout::SVGImageBox const& layout_box)
-{
-    return adopt_ref(*new ImagePaintable(layout_box, layout_box.dom_node(), false, Utf16String {}, true));
-}
-
 NonnullRefPtr<ImagePaintable> ImagePaintable::create(Layout::ImageBox const& layout_box)
 {
     Utf16String alt;
     if (auto element = layout_box.dom_node())
         alt = element->get_attribute_value(HTML::AttributeNames::alt);
-    return adopt_ref(*new ImagePaintable(layout_box, layout_box.image_provider(), layout_box.renders_as_alt_text(), move(alt), false));
+    return adopt_ref(*new ImagePaintable(layout_box, layout_box.image_provider(), move(alt)));
 }
 
-ImagePaintable::ImagePaintable(Layout::Box const& layout_box, Layout::ImageProvider const& image_provider, bool renders_as_alt_text, Utf16String alt_text, bool is_svg_image)
+ImagePaintable::ImagePaintable(Layout::Box const& layout_box, Layout::ImageProvider const& image_provider, Utf16String alt_text)
     : Paintable(layout_box)
-    , m_renders_as_alt_text(renders_as_alt_text)
     , m_alt_text(move(alt_text))
     , m_image_provider(image_provider)
-    , m_is_svg_image(is_svg_image)
 {
 }
 
@@ -86,12 +79,9 @@ void ImagePaintable::reset_for_relayout()
 {
     Paintable::reset_for_relayout();
 
-    if (!m_is_svg_image) {
-        m_renders_as_alt_text = m_image_provider.renders_as_alt_text();
-        if (auto const* image_box = as_if<Layout::ImageBox>(layout_node())) {
-            if (auto element = image_box->dom_node())
-                m_alt_text = element->get_attribute_value(HTML::AttributeNames::alt);
-        }
+    if (auto const* image_box = as_if<Layout::ImageBox>(layout_node())) {
+        if (auto element = image_box->dom_node())
+            m_alt_text = element->get_attribute_value(HTML::AttributeNames::alt);
     }
 }
 
@@ -105,8 +95,7 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
     if (phase == PaintPhase::Foreground) {
         auto image_rect = absolute_rect();
         auto image_rect_device_pixels = context.rounded_device_rect(image_rect);
-        auto renders_as_alt_text = m_is_svg_image ? m_renders_as_alt_text : m_image_provider.renders_as_alt_text();
-        if (renders_as_alt_text) {
+        if (m_image_provider.renders_as_alt_text()) {
             if (!m_alt_text.is_empty()) {
                 auto enclosing_rect = context.enclosing_device_rect(image_rect).to_type<int>();
                 context.display_list_recorder().save();
@@ -119,7 +108,7 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
             auto image_int_rect_device_pixels = image_rect_device_pixels.to_type<int>();
 
             // https://drafts.csswg.org/css-images/#the-object-fit
-            auto object_fit = m_is_svg_image ? CSS::ObjectFit::Contain : computed_values().object_fit();
+            auto object_fit = computed_values().object_fit();
 
             auto intrinsic_size = m_image_provider.intrinsic_size().value_or(image_rect.size());
 

--- a/Libraries/LibWeb/Painting/ImagePaintable.h
+++ b/Libraries/LibWeb/Painting/ImagePaintable.h
@@ -8,7 +8,6 @@
 
 #include <AK/Utf16String.h>
 #include <LibWeb/Layout/ImageBox.h>
-#include <LibWeb/Layout/SVGImageBox.h>
 #include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Painting {
@@ -16,21 +15,17 @@ namespace Web::Painting {
 class ImagePaintable final : public Paintable {
 public:
     static NonnullRefPtr<ImagePaintable> create(Layout::ImageBox const& layout_box);
-    static NonnullRefPtr<ImagePaintable> create(Layout::SVGImageBox const& layout_box);
     virtual StringView class_name() const override { return "ImagePaintable"sv; }
 
     virtual void paint(DisplayListRecordingContext&, PaintPhase) const override;
     virtual void reset_for_relayout() override;
 
 private:
-    ImagePaintable(Layout::Box const& layout_box, Layout::ImageProvider const& image_provider, bool renders_as_alt_text, Utf16String alt_text, bool is_svg_image);
+    ImagePaintable(Layout::Box const& layout_box, Layout::ImageProvider const& image_provider, Utf16String alt_text);
 
-    bool m_renders_as_alt_text { false };
     Utf16String m_alt_text;
 
     Layout::ImageProvider const& m_image_provider;
-
-    bool m_is_svg_image { false };
 };
 
 }

--- a/Libraries/LibWeb/Painting/SVGImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGImagePaintable.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/DecodedImageData.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/ReplacedElementCommon.h>
+#include <LibWeb/Painting/SVGImagePaintable.h>
+#include <LibWeb/SVG/SVGImageElement.h>
+
+namespace Web::Painting {
+
+NonnullRefPtr<SVGImagePaintable> SVGImagePaintable::create(Layout::SVGImageBox const& layout_box)
+{
+    return adopt_ref(*new SVGImagePaintable(layout_box));
+}
+
+SVGImagePaintable::SVGImagePaintable(Layout::SVGImageBox const& layout_box)
+    : SVGGraphicsPaintable(layout_box)
+{
+}
+
+Layout::SVGImageBox const& SVGImagePaintable::layout_box() const
+{
+    return static_cast<Layout::SVGImageBox const&>(layout_node());
+}
+
+void SVGImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phase) const
+{
+    // NB: An image has no geometry, so it contributes nothing to a clipping path.
+    if (context.draw_svg_geometry_for_clip_path())
+        return;
+
+    if (!is_visible())
+        return;
+
+    SVGGraphicsPaintable::paint(context, phase);
+
+    if (phase != PaintPhase::Foreground)
+        return;
+
+    auto decoded_image_data = layout_box().dom_node().decoded_image_data();
+    if (!decoded_image_data)
+        return;
+
+    auto image_rect = absolute_rect();
+    auto intrinsic_size = layout_box().dom_node().intrinsic_size().value_or(image_rect.size());
+    // FIXME: Respect the preserveAspectRatio attribute instead of assuming its default value.
+    auto draw_rect = get_replaced_box_painting_area(*this, context, CSS::ObjectFit::Contain, intrinsic_size);
+    if (draw_rect.is_empty())
+        return;
+
+    // https://svgwg.org/svg2-draft/embedded.html#ImageElement
+    // The user agent stylesheet sets the value of the overflow property on ‘image’ element to hidden. Unless
+    // over-ridden by the author, images will therefore be clipped to the positioning rectangle defined by the
+    // geometry properties.
+    auto positioning_rectangle = context.rounded_device_rect(image_rect).to_type<int>();
+    bool overflow_is_visible = computed_values().overflow_x() == CSS::Overflow::Visible
+        && computed_values().overflow_y() == CSS::Overflow::Visible;
+    bool draw_rect_needs_clip = !overflow_is_visible && !positioning_rectangle.contains(draw_rect);
+    if (draw_rect_needs_clip) {
+        context.display_list_recorder().save();
+        context.display_list_recorder().add_clip_rect(positioning_rectangle);
+    }
+
+    decoded_image_data->paint(context, draw_rect, computed_values().image_rendering());
+
+    if (draw_rect_needs_clip)
+        context.display_list_recorder().restore();
+}
+
+}

--- a/Libraries/LibWeb/Painting/SVGImagePaintable.h
+++ b/Libraries/LibWeb/Painting/SVGImagePaintable.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Layout/SVGImageBox.h>
+#include <LibWeb/Painting/SVGGraphicsPaintable.h>
+
+namespace Web::Painting {
+
+class SVGImagePaintable final : public SVGGraphicsPaintable {
+public:
+    static NonnullRefPtr<SVGImagePaintable> create(Layout::SVGImageBox const&);
+    virtual StringView class_name() const override { return "SVGImagePaintable"sv; }
+
+    virtual void paint(DisplayListRecordingContext&, PaintPhase) const override;
+
+    Layout::SVGImageBox const& layout_box() const;
+
+private:
+    SVGImagePaintable(Layout::SVGImageBox const&);
+};
+
+}

--- a/Tests/LibWeb/Ref/expected/svg/image-clip-path-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/image-clip-path-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+    <rect width="100" height="100" fill="green"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg/image-mask-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg/image-mask-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<svg width="100" height="100">
+    <rect width="100" height="100" fill="green"></rect>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/image-clip-path.html
+++ b/Tests/LibWeb/Ref/input/svg/image-clip-path.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/image-clip-path-ref.html" />
+<svg width="100" height="100">
+    <clipPath id="top-half">
+        <rect width="100" height="50"></rect>
+    </clipPath>
+    <rect width="100" height="100" fill="red"></rect>
+    <image href="../../data/50x50-green.svg" width="100" height="100" clip-path="url(#top-half)"></image>
+    <rect y="50" width="100" height="50" fill="green"></rect>
+    <image href="../../data/50x50-red.svg" y="50" width="100" height="50" clip-path="url(#top-half)"></image>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg/image-mask.html
+++ b/Tests/LibWeb/Ref/input/svg/image-mask.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/svg/image-mask-ref.html" />
+<svg width="100" height="100">
+    <mask id="top-half">
+        <rect width="100" height="50" fill="white"></rect>
+    </mask>
+    <rect width="100" height="100" fill="red"></rect>
+    <image href="../../data/50x50-green.svg" width="100" height="100" mask="url(#top-half)"></image>
+    <rect y="50" width="100" height="50" fill="green"></rect>
+    <image href="../../data/50x50-red.svg" y="50" width="100" height="50" mask="url(#top-half)"></image>
+</svg>


### PR DESCRIPTION
Previously, SVG image elements created the same paintable as HTML image elements, which does not participate in the SVG masking machinery. A clip path or mask referenced by an image element was laid out but never applied when painting.

Give SVG image elements a dedicated paintable that inherits mask and clip handling from `SVGGraphicsPaintable`. An image inside a clipPath element now contributes nothing to the clipping path geometry instead of painting its pixels into the clip mask.

SVG images are now excluded from selection highlighting and border-radius clipping. This matches the behavior of other engines.

This change makes the speedometer SVG on https://speedtest.net render correctly:

Before:

<img width="323" height="402" alt="image" src="https://github.com/user-attachments/assets/5b58f7c8-ba5c-477e-98c0-ea780b4129e8" />


After:

<img width="323" height="402" alt="image" src="https://github.com/user-attachments/assets/e89cac2d-77ab-4daf-8385-60cf589b5413" />