### PR TITLE
LibSandbox: Gracefully deny access()-family filesystem probes

### DIFF
--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -701,9 +701,13 @@ static char const* syscall_name(long syscall_number)
 
 #undef CASE_SYSCALL_NAME
 
+static char s_process_name[16] = "unknown";
+
 static void handle_sigsys(int, siginfo_t* info, void* context)
 {
-    write_string("Sandbox violation: disallowed syscall ");
+    write_string("Sandbox violation in ");
+    write_string(s_process_name);
+    write_string(": disallowed syscall ");
     write_string(syscall_name(info->si_syscall));
     write_string(" (");
     write_unsigned(static_cast<u64>(info->si_syscall));
@@ -757,6 +761,8 @@ static ErrorOr<void> install_sigsys_handler()
         return Error::from_syscall("sigemptyset"sv, errno);
     if (sigaction(SIGSYS, &action, nullptr) < 0)
         return Error::from_syscall("sigaction(SIGSYS)"sv, errno);
+
+    (void)prctl(PR_GET_NAME, s_process_name, 0ul, 0ul, 0ul);
     return {};
 }
 

--- a/Libraries/LibSandbox/Seccomp.cpp
+++ b/Libraries/LibSandbox/Seccomp.cpp
@@ -808,6 +808,18 @@ void SeccompPolicy::deny_readonly_filesystem_probes()
     append(SECCOMP_ERRNO(EACCES));
     append(SECCOMP_LOAD_SYSCALL_NR);
 #endif
+#ifdef __NR_access
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_access, 0, 1));
+    append(SECCOMP_ERRNO(EACCES));
+#endif
+#ifdef __NR_faccessat
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_faccessat, 0, 1));
+    append(SECCOMP_ERRNO(EACCES));
+#endif
+#ifdef __NR_faccessat2
+    append(BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_faccessat2, 0, 1));
+    append(SECCOMP_ERRNO(EACCES));
+#endif
 }
 
 void SeccompPolicy::allow_readonly_file_opens()


### PR DESCRIPTION
**Problem:** Crash with `Sandbox violation: disallowed syscall access (21)`

**Cause:** The `ImageDecoder` process installs a seccomp filter that denies read-only filesystem probes, but that denial only rewrites `open` and `openat` to `EACCES`. A library that calls `access()` during startup matches no allow rule, and falls through to the default kill.

**Fix:** Deny `access`, `faccessat`, and `faccessat2` with `EACCES` as well. So, a probe fails gracefully, instead of killing the process — matching how `open` and `openat` are already handled. Fixes: https://github.com/LadybirdBrowser/ladybird/issues/10601.
