### PR TITLE
UI/Qt: Preserve page cursor when showing link hover label

### DIFF
--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -721,6 +721,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     view().on_link_hover = [this](auto const& url) {
         m_hover_label->setText(qstring_from_ak_string(url.to_byte_string()));
         update_hover_label();
+        m_hover_label->setCursor(view().cursor());
         m_hover_label->show();
     };
 


### PR DESCRIPTION
Since https://github.com/LadybirdBrowser/ladybird/commit/60d9088b6af7be497600944c771d1973facb2577 the link hover label is a top-level popup widget so that it stacks above the Vulkan presentation window. On Wayland a single mouse cursor is shared by all of an application's windows, and Qt applies a top-level widget's cursor to it whenever that widget is shown, whether or not the pointer is over the widget. Showing the label therefore replaced the hand cursor set for the hovered link with the label's default arrow, so hovering a link no longer changed the cursor.

Set the label's cursor to the page's current cursor before showing it, so that displaying the label leaves the page cursor intact.