### PR TITLE
LibWebView+UI/Qt: Notify Qt when input-method state changes

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1259,6 +1259,9 @@ Optional<Web::DevicePixelRect> ViewImplementation::get_input_caret_rect()
 void ViewImplementation::set_input_method_state(Badge<WebContentClient>, InputMethodState state)
 {
     m_input_method_state = move(state);
+
+    if (on_input_method_state_change)
+        on_input_method_state_change();
 }
 
 void ViewImplementation::retrieved_clipboard_entries(u64 request_id, ReadonlySpan<Web::Clipboard::SystemClipboardItem> items)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -333,6 +333,7 @@ public:
     Function<void(DictionaryLookup const&, Gfx::IntPoint)> on_request_dictionary_lookup;
     Function<void(Optional<Gfx::Bitmap const&>)> on_favicon_change;
     Function<void(Gfx::Cursor const&)> on_cursor_change;
+    Function<void()> on_input_method_state_change;
     Function<void(Gfx::IntPoint, ByteString const&)> on_request_tooltip_override;
     Function<void()> on_stop_tooltip_override;
     Function<void(ByteString const&)> on_enter_tooltip_area;

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -26,6 +26,13 @@ if (NOT WIN32)
     if (APPLE)
         target_compile_definitions(TestAutocomplete PRIVATE LADYBIRD_BINARY_PATH="$<TARGET_FILE_DIR:ladybird>")
     endif()
+
+    add_executable(TestInputMethodState TestInputMethodState.cpp)
+    add_dependencies(TestInputMethodState ladybird_build_resource_files ${ladybird_helper_processes})
+    target_link_libraries(TestInputMethodState PRIVATE AK LibCore LibDiff LibFileSystem LibGfx LibImageDecoders LibImageDecoderClient LibIPC LibJS LibMain LibRequests LibURL LibWeb LibWebView)
+    if (APPLE)
+        target_compile_definitions(TestInputMethodState PRIVATE LADYBIRD_BINARY_PATH="$<TARGET_FILE_DIR:ladybird>")
+    endif()
 endif()
 
 if (BUILD_TESTING AND NOT WIN32)
@@ -37,4 +44,7 @@ if (BUILD_TESTING AND NOT WIN32)
 
     add_test(NAME TestAutocomplete COMMAND $<TARGET_FILE:TestAutocomplete>)
     set_tests_properties(TestAutocomplete PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})
+
+    add_test(NAME TestInputMethodState COMMAND $<TARGET_FILE:TestInputMethodState>)
+    set_tests_properties(TestInputMethodState PROPERTIES TIMEOUT 60 ENVIRONMENT LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR})
 endif()

--- a/Tests/LibWebView/TestInputMethodState.cpp
+++ b/Tests/LibWebView/TestInputMethodState.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <AK/Random.h>
+#include <AK/ScopeGuard.h>
+#include <AK/String.h>
+#include <AK/Utf16String.h>
+#include <LibCore/Directory.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/StandardPaths.h>
+#include <LibFileSystem/FileSystem.h>
+#include <LibGfx/SystemTheme.h>
+#include <LibMain/Main.h>
+#include <LibWebView/Application.h>
+#include <LibWebView/HeadlessWebView.h>
+#include <LibWebView/Utilities.h>
+#include <stdlib.h>
+
+namespace {
+
+class TestApplication : public WebView::Application {
+    WEB_VIEW_APPLICATION(TestApplication)
+
+public:
+    explicit TestApplication(Optional<ByteString> ladybird_binary_path)
+        : WebView::Application(move(ladybird_binary_path))
+    {
+    }
+
+    virtual void create_platform_options(WebView::BrowserOptions& browser_options, WebView::RequestServerOptions&, WebView::WebContentOptions& web_content_options) override
+    {
+        browser_options.headless_mode = WebView::HeadlessMode::Test;
+        browser_options.disable_sql_database = WebView::DisableSQLDatabase::Yes;
+        web_content_options.is_test_mode = WebView::IsTestMode::Yes;
+    }
+
+    virtual bool should_coordinate_browser_process() const override { return false; }
+};
+
+}
+
+// WebContent pushes fresh IME state (caret, cursoranchor positions, surrounding text) to the UI on every editing step,
+// and platform IMEs compose against the UI-side copy of that state. The UI view must be notified of every push (not
+// just the first) so it can invalidate whatever the platform IME has cached: The Qt port answers inputMethodQuery()
+// from input_method_state(). And without an updateMicroFocus() nudge per push, the macOS IME composes against the stale
+// 1st-keystroke state and drops everything after the first committed character. See #9712: on_input_method_state_change
+// must fire for each state push, after the new state is already readable through input_method_state().
+
+ErrorOr<int> ladybird_main(Main::Arguments arguments)
+{
+    auto test_config_directory = ByteString::formatted("{}/Ladybird-TestInputMethodState-{}", Core::StandardPaths::tempfile_directory(), generate_random_uuid());
+    TRY(Core::Directory::create(test_config_directory, Core::Directory::CreateDirectories::Yes));
+    auto cleanup_test_config_directory = ScopeGuard([&] {
+        MUST(FileSystem::remove(test_config_directory, FileSystem::RecursionMode::Allowed));
+    });
+    VERIFY(setenv("XDG_CONFIG_HOME", test_config_directory.characters(), 1) == 0);
+
+#if defined(LADYBIRD_BINARY_PATH)
+    auto app = TRY(TestApplication::create(arguments, LADYBIRD_BINARY_PATH));
+#else
+    auto app = TRY(TestApplication::create(arguments, OptionalNone {}));
+#endif
+
+    auto theme_path = LexicalPath::join(WebView::s_ladybird_resource_root, "themes"sv, "Default.ini"sv);
+    auto theme = TRY(Gfx::load_system_theme(theme_path.string()));
+
+    auto view = WebView::HeadlessWebView::create(move(theme), { 800, 600 });
+
+    size_t loads_finished = 0;
+    view->on_load_finish = [&](auto const&) { ++loads_finished; };
+
+    // Wait out the initial about:blank load; navigating before it completes would drop the navigation.
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 1; });
+
+    view->load_html("<!DOCTYPE html><input>"sv);
+    Core::EventLoop::current().spin_until([&]() { return loads_finished >= 2; });
+
+    // Runs synchronously inside WebContent's handler, so it is ordered before the commits below.
+    view->run_javascript("document.querySelector('input').focus()"_string);
+
+    size_t state_changes = 0;
+    WebView::ViewImplementation::InputMethodState observed_state;
+    view->on_input_method_state_change = [&]() {
+        ++state_changes;
+        // The new state must already be stored when the notification fires: The notified view re-queries the state from
+        // inside the callback. Qt's updateMicroFocus() makes the platform IME call inputMethodQuery(), which answers
+        // from input_method_state().
+        observed_state = view->input_method_state();
+    };
+
+    // Each committed character round-trips through WebContent, which pushes a fresh input-method state.
+    view->commit_text_from_input_method("あ"_utf16);
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 1; });
+    VERIFY(observed_state.is_enabled);
+    VERIFY(observed_state.cursor_position == 1);
+    VERIFY(observed_state.text_before_cursor == "あ"_utf16);
+    VERIFY(observed_state.text_after_cursor.is_empty());
+
+    // Composing past the first character depends on the UI being notified for the SECOND push as well (#9712).
+    view->commit_text_from_input_method("い"_utf16);
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 2; });
+    VERIFY(observed_state.cursor_position == 2);
+    VERIFY(observed_state.text_before_cursor == "あい"_utf16);
+
+    // The disabled transition must be pushed and notified too, so the platform IME is turned off for the view.
+    view->run_javascript("document.querySelector('input').blur()"_string);
+    view->commit_text_from_input_method("x"_utf16);
+    Core::EventLoop::current().spin_until([&]() { return state_changes >= 3; });
+    VERIFY(!observed_state.is_enabled);
+    VERIFY(observed_state.text_before_cursor.is_empty());
+
+    outln("PASS: every input-method state change notified the view");
+    return 0;
+}

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -86,6 +86,14 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     m_client_state.page_index = page_index;
 
     setAttribute(Qt::WA_InputMethodEnabled, true);
+
+    // Push-based IME state (ViewImplementation::set_input_method_state) must nudge Qt to re-query inputMethodQuery().
+    // Without that, the platform IME keeps the stale first-keystroke caret and surrounding text — and composition stops
+    // after one character.
+    on_input_method_state_change = [this] {
+        updateMicroFocus();
+    };
+
     setMouseTracking(true);
     setAcceptDrops(true);
 


### PR DESCRIPTION
**Problem:** When using the Qt port, typing into web content with an IME loses everything after first character.

**Cause:** We recompute the IME state (caret rectangle, cursor and anchor positions, surrounding text) and push it to the UI on every change, and Qt’s `inputMethodQuery()` answers from that state. But nothing told Qt the state had changed. So it kept serving the platform IME the values cached from the first keystroke (cursor at zero, empty surrounding text). After the first commit, the IME document model no longer matched — and further composition was silently dropped.

**Fix:** Give `ViewImplementation` a callback fired if `set_input_method_state` stores a new state. The Qt view wires it to `QWidget::updateMicroFocus()`, which invalidates Qt’s IME cache and forces a fresh `inputMethodQuery()` round. So, the platform IME sees the updated caret and surrounding text after each step — and composition continues past the first character. Fixes https://github.com/LadybirdBrowser/ladybird/issues/9712.
