### PR TITLE
Merge the scroll frame tree into AVC tree

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -914,7 +914,7 @@ set(SOURCES
     Painting/ResolvedCSSFilter.cpp
     Painting/ResizeHandle.cpp
     Painting/Scrollbar.cpp
-    Painting/ScrollFrame.cpp
+    Painting/ScrollNodeState.cpp
     Painting/ScrollState.cpp
     Painting/ShadowPainting.cpp
     Painting/StackingContext.cpp

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -114,7 +114,7 @@ Optional<AsyncScrollNodeID> AsyncScrollTree::scrollable_ancestor_for_node(AsyncS
     return {};
 }
 
-Gfx::FloatPoint AsyncScrollTree::cumulative_device_sticky_offset_for_frame(Painting::VisualContextIndex scroll_node_index, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
+Gfx::FloatPoint AsyncScrollTree::cumulative_device_sticky_offset_for_node(Painting::VisualContextIndex scroll_node_index, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
 {
     Gfx::FloatPoint offset;
     for (auto index = scroll_node_index; index.value();) {
@@ -167,7 +167,7 @@ void AsyncScrollTree::update_sticky_offsets(Painting::ScrollStateSnapshot& scrol
         if (!sticky_area.nearest_scrolling_ancestor_index.value())
             continue;
 
-        auto parent_sticky_offset = cumulative_device_sticky_offset_for_frame(sticky_area.parent_scroll_node_index, scroll_state_snapshot);
+        auto parent_sticky_offset = cumulative_device_sticky_offset_for_node(sticky_area.parent_scroll_node_index, scroll_state_snapshot);
 
         auto sticky_position_in_ancestor = sticky_area.position_relative_to_scroll_ancestor.translated(parent_sticky_offset);
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.cpp
@@ -55,10 +55,10 @@ AsyncScrollNode const* AsyncScrollTree::scroll_node_for_stable_id(AsyncScrollNod
     return nullptr;
 }
 
-AsyncStickyArea const* AsyncScrollTree::sticky_area_for_scroll_frame_index(Painting::ScrollFrameIndex scroll_frame_index) const
+AsyncStickyArea const* AsyncScrollTree::sticky_area_for_scroll_node_index(Painting::VisualContextIndex scroll_node_index) const
 {
     for (auto const& sticky_area : m_sticky_areas) {
-        if (sticky_area.scroll_frame_index == scroll_frame_index)
+        if (sticky_area.scroll_node_index == scroll_node_index)
             return &sticky_area;
     }
     return nullptr;
@@ -73,7 +73,7 @@ Gfx::FloatPoint AsyncScrollTree::clamp_scroll_offset_to_node(AsyncScrollNode con
 
 Gfx::FloatPoint AsyncScrollTree::scroll_offset_for_node(AsyncScrollNode const& node, Painting::ScrollStateSnapshot const& scroll_state_snapshot)
 {
-    auto device_offset = scroll_state_snapshot.device_offset_for_index(node.node_id.scroll_frame_index);
+    auto device_offset = scroll_state_snapshot.device_offset_for_index(node.node_id.scroll_node_index);
     return { -device_offset.x(), -device_offset.y() };
 }
 
@@ -114,15 +114,15 @@ Optional<AsyncScrollNodeID> AsyncScrollTree::scrollable_ancestor_for_node(AsyncS
     return {};
 }
 
-Gfx::FloatPoint AsyncScrollTree::cumulative_device_sticky_offset_for_frame(Painting::ScrollFrameIndex scroll_frame_index, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
+Gfx::FloatPoint AsyncScrollTree::cumulative_device_sticky_offset_for_frame(Painting::VisualContextIndex scroll_node_index, Painting::ScrollStateSnapshot const& scroll_state_snapshot) const
 {
     Gfx::FloatPoint offset;
-    for (auto index = scroll_frame_index; index.value();) {
-        auto const* sticky_area = sticky_area_for_scroll_frame_index(index);
+    for (auto index = scroll_node_index; index.value();) {
+        auto const* sticky_area = sticky_area_for_scroll_node_index(index);
         if (!sticky_area)
             break;
         offset.translate_by(scroll_state_snapshot.device_offset_for_index(index));
-        index = sticky_area->parent_scroll_frame_index;
+        index = sticky_area->parent_scroll_node_index;
     }
     return offset;
 }
@@ -137,18 +137,18 @@ Gfx::FloatPoint AsyncScrollTree::apply_scroll_delta_to_node(AsyncScrollNode cons
     auto new_scroll_offset = clamp_scroll_offset_to_node(node, old_scroll_offset.translated(wheel_scrollable_delta));
     if (new_scroll_offset == old_scroll_offset) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll node {} did not move for delta {},{} (offset={},{} max={},{})",
-            node.node_id.scroll_frame_index.value(), delta.x(), delta.y(), old_scroll_offset.x(), old_scroll_offset.y(), node.max_scroll_offset.x(), node.max_scroll_offset.y());
+            node.node_id.scroll_node_index.value(), delta.x(), delta.y(), old_scroll_offset.x(), old_scroll_offset.y(), node.max_scroll_offset.x(), node.max_scroll_offset.y());
         return delta;
     }
 
-    scroll_state_snapshot.set_device_offset_for_index(node.node_id.scroll_frame_index, { -new_scroll_offset.x(), -new_scroll_offset.y() });
+    scroll_state_snapshot.set_device_offset_for_index(node.node_id.scroll_node_index, { -new_scroll_offset.x(), -new_scroll_offset.y() });
 
     Gfx::FloatPoint consumed_delta {
         new_scroll_offset.x() - old_scroll_offset.x(),
         new_scroll_offset.y() - old_scroll_offset.y()
     };
     dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Async scroll node {} moved from {},{} to {},{} (consumed={},{} remaining={},{})",
-        node.node_id.scroll_frame_index.value(),
+        node.node_id.scroll_node_index.value(),
         old_scroll_offset.x(), old_scroll_offset.y(),
         new_scroll_offset.x(), new_scroll_offset.y(),
         consumed_delta.x(), consumed_delta.y(),
@@ -167,7 +167,7 @@ void AsyncScrollTree::update_sticky_offsets(Painting::ScrollStateSnapshot& scrol
         if (!sticky_area.nearest_scrolling_ancestor_index.value())
             continue;
 
-        auto parent_sticky_offset = cumulative_device_sticky_offset_for_frame(sticky_area.parent_scroll_frame_index, scroll_state_snapshot);
+        auto parent_sticky_offset = cumulative_device_sticky_offset_for_frame(sticky_area.parent_scroll_node_index, scroll_state_snapshot);
 
         auto sticky_position_in_ancestor = sticky_area.position_relative_to_scroll_ancestor.translated(parent_sticky_offset);
 
@@ -203,7 +203,7 @@ void AsyncScrollTree::update_sticky_offsets(Painting::ScrollStateSnapshot& scrol
                 sticky_offset.set_x(max(scrollport_rect.right() - sticky_area.border_box_size.width() - *sticky_area.inset_right, min_offset_within_containing_block.x()) - sticky_position_in_ancestor.x());
         }
 
-        scroll_state_snapshot.set_device_offset_for_index(sticky_area.scroll_frame_index, sticky_offset);
+        scroll_state_snapshot.set_device_offset_for_index(sticky_area.scroll_node_index, sticky_offset);
     }
 }
 
@@ -402,7 +402,7 @@ Optional<Gfx::FloatPoint> AsyncScrollTree::set_scroll_offset(AsyncScrollNodeID n
         return {};
 
     auto new_scroll_offset = clamp_scroll_offset_to_node(*node, scroll_offset);
-    scroll_state_snapshot.set_device_offset_for_index(node->node_id.scroll_frame_index, { -new_scroll_offset.x(), -new_scroll_offset.y() });
+    scroll_state_snapshot.set_device_offset_for_index(node->node_id.scroll_node_index, { -new_scroll_offset.x(), -new_scroll_offset.y() });
     update_sticky_offsets(scroll_state_snapshot);
     return new_scroll_offset;
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -75,7 +75,7 @@ private:
     AsyncScrollNode const* scroll_node_for_stable_id(AsyncScrollNodeStableID) const;
     AsyncStickyArea const* sticky_area_for_scroll_node_index(Painting::VisualContextIndex) const;
     Optional<AsyncScrollNodeID> scrollable_ancestor_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint delta) const;
-    Gfx::FloatPoint cumulative_device_sticky_offset_for_frame(Painting::VisualContextIndex, Painting::ScrollStateSnapshot const&) const;
+    Gfx::FloatPoint cumulative_device_sticky_offset_for_node(Painting::VisualContextIndex, Painting::ScrollStateSnapshot const&) const;
     Gfx::FloatPoint apply_scroll_delta_to_node(AsyncScrollNode const&, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
     void update_sticky_offsets(Painting::ScrollStateSnapshot&) const;
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollTree.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollTree.h
@@ -73,9 +73,9 @@ private:
     AsyncScrollNode const* scroll_node_for_id(AsyncScrollNodeID) const;
     WheelHitTestResult hit_test_result_for_scroll_node(AsyncScrollNodeID, Gfx::FloatPoint delta) const;
     AsyncScrollNode const* scroll_node_for_stable_id(AsyncScrollNodeStableID) const;
-    AsyncStickyArea const* sticky_area_for_scroll_frame_index(Painting::ScrollFrameIndex) const;
+    AsyncStickyArea const* sticky_area_for_scroll_node_index(Painting::VisualContextIndex) const;
     Optional<AsyncScrollNodeID> scrollable_ancestor_for_node(AsyncScrollNodeID, Painting::ScrollStateSnapshot const&, Gfx::FloatPoint delta) const;
-    Gfx::FloatPoint cumulative_device_sticky_offset_for_frame(Painting::ScrollFrameIndex, Painting::ScrollStateSnapshot const&) const;
+    Gfx::FloatPoint cumulative_device_sticky_offset_for_frame(Painting::VisualContextIndex, Painting::ScrollStateSnapshot const&) const;
     Gfx::FloatPoint apply_scroll_delta_to_node(AsyncScrollNode const&, Gfx::FloatPoint delta, Painting::ScrollStateSnapshot&);
     void update_sticky_offsets(Painting::ScrollStateSnapshot&) const;
 

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -12,9 +12,9 @@
 
 namespace Web::Compositor {
 
-static AsyncScrollNodeID scroll_node_id_for(UniqueNodeID document_id, Painting::ScrollFrameIndex scroll_frame_index)
+static AsyncScrollNodeID scroll_node_id_for(UniqueNodeID document_id, Painting::VisualContextIndex scroll_node_index)
 {
-    return { .document_id = document_id, .scroll_frame_index = scroll_frame_index };
+    return { .document_id = document_id, .scroll_node_index = scroll_node_index };
 }
 
 static AsyncScrollNodeKind async_scroll_node_kind_for(Painting::CompositorScrollNodeKind kind)
@@ -42,8 +42,8 @@ static AsyncScrollNodeStableID stable_scroll_node_id_for(UniqueNodeID scrollable
 AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const& display_list)
 {
     AsyncScrollingState async_scrolling_state;
-    Vector<Painting::ScrollFrameIndex> parent_scroll_frame_indices;
-    Vector<Painting::ScrollFrameIndex> wheel_hit_test_target_scroll_frame_indices;
+    Vector<Painting::VisualContextIndex> parent_scroll_frame_indices;
+    Vector<Painting::VisualContextIndex> wheel_hit_test_target_scroll_frame_indices;
     Vector<UniqueNodeID> wheel_hit_test_target_document_ids;
 
     if (auto const& metadata = display_list.async_scrolling_metadata(); metadata.has_value()) {
@@ -61,7 +61,7 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
                 .corner_radii = corner_radii,
                 .target_node_id = {},
             });
-            wheel_hit_test_target_scroll_frame_indices.append(command.target_scroll_frame_index);
+            wheel_hit_test_target_scroll_frame_indices.append(command.target_scroll_node_index);
             wheel_hit_test_target_document_ids.append(command.document_id);
         };
 
@@ -79,8 +79,8 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
             auto command = Painting::read_display_list_command_payload<Painting::CompositorStickyArea>(payload);
             async_scrolling_state.sticky_areas.append({
                 .document_id = command.document_id,
-                .scroll_frame_index = command.scroll_frame_index,
-                .parent_scroll_frame_index = command.parent_scroll_frame_index,
+                .scroll_node_index = command.scroll_node_index,
+                .parent_scroll_node_index = command.parent_scroll_node_index,
                 .nearest_scrolling_ancestor_index = command.nearest_scrolling_ancestor_index,
                 .position_relative_to_scroll_ancestor = command.position_relative_to_scroll_ancestor,
                 .border_box_size = command.border_box_size,
@@ -97,17 +97,16 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
         case Painting::DisplayListCommandType::CompositorScrollNode: {
             auto command = Painting::read_display_list_command_payload<Painting::CompositorScrollNode>(payload);
             async_scrolling_state.scroll_nodes.append({
-                .node_id = scroll_node_id_for(command.document_id, command.scroll_frame_index),
+                .node_id = scroll_node_id_for(command.document_id, command.scroll_node_index),
                 .stable_node_id = stable_scroll_node_id_for(command.scrollable_node_id, command.scroll_node_kind, command.pseudo_element_type),
                 .parent_node_id = {},
-                .hit_test_visual_context_index = header.context_index,
                 .scrollport_rect = command.scrollport_rect,
                 .max_scroll_offset = command.max_scroll_offset,
                 .is_viewport = command.is_viewport,
                 .can_be_wheel_scrolled_horizontally = command.can_be_wheel_scrolled_horizontally,
                 .can_be_wheel_scrolled_vertically = command.can_be_wheel_scrolled_vertically,
             });
-            parent_scroll_frame_indices.append(command.parent_scroll_frame_index);
+            parent_scroll_frame_indices.append(command.parent_scroll_node_index);
             break;
         }
         case Painting::DisplayListCommandType::CompositorWheelHitTestTarget: {
@@ -131,8 +130,8 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
         case Painting::DisplayListCommandType::CompositorViewportScrollbar: {
             auto command = Painting::read_display_list_command_payload<Painting::CompositorViewportScrollbar>(payload);
             async_scrolling_state.viewport_scrollbars.append({
-                .scroll_node_id = scroll_node_id_for(command.document_id, command.scroll_frame_index),
-                .scroll_frame_index = command.scroll_frame_index,
+                .scroll_node_id = scroll_node_id_for(command.document_id, command.scroll_node_index),
+                .scroll_node_index = command.scroll_node_index,
                 .gutter_rect = command.gutter_rect,
                 .thumb_rect = command.thumb_rect,
                 .expanded_gutter_rect = command.expanded_gutter_rect,
@@ -153,17 +152,17 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
 
     VERIFY(parent_scroll_frame_indices.size() == async_scrolling_state.scroll_nodes.size());
     for (size_t i = 0; i < async_scrolling_state.scroll_nodes.size(); ++i) {
-        auto parent_scroll_frame_index = parent_scroll_frame_indices[i];
-        if (parent_scroll_frame_index.value())
-            async_scrolling_state.scroll_nodes[i].parent_node_id = scroll_node_id_for(async_scrolling_state.scroll_nodes[i].node_id.document_id, parent_scroll_frame_index);
+        auto parent_scroll_node_index = parent_scroll_frame_indices[i];
+        if (parent_scroll_node_index.value())
+            async_scrolling_state.scroll_nodes[i].parent_node_id = scroll_node_id_for(async_scrolling_state.scroll_nodes[i].node_id.document_id, parent_scroll_node_index);
     }
 
     VERIFY(wheel_hit_test_target_scroll_frame_indices.size() == async_scrolling_state.wheel_hit_test_targets.size());
     VERIFY(wheel_hit_test_target_document_ids.size() == async_scrolling_state.wheel_hit_test_targets.size());
     for (size_t i = 0; i < async_scrolling_state.wheel_hit_test_targets.size(); ++i) {
-        auto target_scroll_frame_index = wheel_hit_test_target_scroll_frame_indices[i];
-        if (target_scroll_frame_index.value())
-            async_scrolling_state.wheel_hit_test_targets[i].target_node_id = scroll_node_id_for(wheel_hit_test_target_document_ids[i], target_scroll_frame_index);
+        auto target_scroll_node_index = wheel_hit_test_target_scroll_frame_indices[i];
+        if (target_scroll_node_index.value())
+            async_scrolling_state.wheel_hit_test_targets[i].target_node_id = scroll_node_id_for(wheel_hit_test_target_document_ids[i], target_scroll_node_index);
     }
     return async_scrolling_state;
 }

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.cpp
@@ -42,8 +42,8 @@ static AsyncScrollNodeStableID stable_scroll_node_id_for(UniqueNodeID scrollable
 AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayList const& display_list)
 {
     AsyncScrollingState async_scrolling_state;
-    Vector<Painting::VisualContextIndex> parent_scroll_frame_indices;
-    Vector<Painting::VisualContextIndex> wheel_hit_test_target_scroll_frame_indices;
+    Vector<Painting::VisualContextIndex> parent_scroll_node_indices;
+    Vector<Painting::VisualContextIndex> wheel_hit_test_target_scroll_node_indices;
     Vector<UniqueNodeID> wheel_hit_test_target_document_ids;
 
     if (auto const& metadata = display_list.async_scrolling_metadata(); metadata.has_value()) {
@@ -61,7 +61,7 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
                 .corner_radii = corner_radii,
                 .target_node_id = {},
             });
-            wheel_hit_test_target_scroll_frame_indices.append(command.target_scroll_node_index);
+            wheel_hit_test_target_scroll_node_indices.append(command.target_scroll_node_index);
             wheel_hit_test_target_document_ids.append(command.document_id);
         };
 
@@ -106,7 +106,7 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
                 .can_be_wheel_scrolled_horizontally = command.can_be_wheel_scrolled_horizontally,
                 .can_be_wheel_scrolled_vertically = command.can_be_wheel_scrolled_vertically,
             });
-            parent_scroll_frame_indices.append(command.parent_scroll_node_index);
+            parent_scroll_node_indices.append(command.parent_scroll_node_index);
             break;
         }
         case Painting::DisplayListCommandType::CompositorWheelHitTestTarget: {
@@ -150,17 +150,17 @@ AsyncScrollingState async_scrolling_state_from_display_list(Painting::DisplayLis
         }
     });
 
-    VERIFY(parent_scroll_frame_indices.size() == async_scrolling_state.scroll_nodes.size());
+    VERIFY(parent_scroll_node_indices.size() == async_scrolling_state.scroll_nodes.size());
     for (size_t i = 0; i < async_scrolling_state.scroll_nodes.size(); ++i) {
-        auto parent_scroll_node_index = parent_scroll_frame_indices[i];
+        auto parent_scroll_node_index = parent_scroll_node_indices[i];
         if (parent_scroll_node_index.value())
             async_scrolling_state.scroll_nodes[i].parent_node_id = scroll_node_id_for(async_scrolling_state.scroll_nodes[i].node_id.document_id, parent_scroll_node_index);
     }
 
-    VERIFY(wheel_hit_test_target_scroll_frame_indices.size() == async_scrolling_state.wheel_hit_test_targets.size());
+    VERIFY(wheel_hit_test_target_scroll_node_indices.size() == async_scrolling_state.wheel_hit_test_targets.size());
     VERIFY(wheel_hit_test_target_document_ids.size() == async_scrolling_state.wheel_hit_test_targets.size());
     for (size_t i = 0; i < async_scrolling_state.wheel_hit_test_targets.size(); ++i) {
-        auto target_scroll_node_index = wheel_hit_test_target_scroll_frame_indices[i];
+        auto target_scroll_node_index = wheel_hit_test_target_scroll_node_indices[i];
         if (target_scroll_node_index.value())
             async_scrolling_state.wheel_hit_test_targets[i].target_node_id = scroll_node_id_for(wheel_hit_test_target_document_ids[i], target_scroll_node_index);
     }

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -18,13 +18,13 @@
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
-#include <LibWeb/Painting/ScrollFrame.h>
+#include <LibWeb/Painting/ScrollNodeState.h>
 
 namespace Web::Compositor {
 
 using AsyncScrollOperationID = u64;
 
-// Stable identifier for a scroll frame in a document; the frame index alone is not unique across nested documents.
+// Stable identifier for a scroll node in a document; the node index alone is not unique across nested documents.
 struct AsyncScrollNodeID {
     UniqueNodeID document_id;
     Painting::VisualContextIndex scroll_node_index;
@@ -65,7 +65,7 @@ struct AsyncScrollNode {
     bool can_be_wheel_scrolled_vertically { false };
 };
 
-// Sticky elements are represented as scroll frames whose offset is derived from ancestor scroll offsets. Keep only
+// Sticky elements are represented as scroll nodes whose offset is derived from ancestor scroll offsets. Keep only
 // the precomputed geometry needed to replay that calculation on the compositor thread after an async scroll mutation.
 struct AsyncStickyArea {
     UniqueNodeID document_id;

--- a/Libraries/LibWeb/Compositor/AsyncScrollingState.h
+++ b/Libraries/LibWeb/Compositor/AsyncScrollingState.h
@@ -27,7 +27,7 @@ using AsyncScrollOperationID = u64;
 // Stable identifier for a scroll frame in a document; the frame index alone is not unique across nested documents.
 struct AsyncScrollNodeID {
     UniqueNodeID document_id;
-    Painting::ScrollFrameIndex scroll_frame_index;
+    Painting::VisualContextIndex scroll_node_index;
 
     bool operator==(AsyncScrollNodeID const&) const = default;
 };
@@ -53,13 +53,11 @@ struct AsyncScrollOffset {
     Gfx::FloatPoint unadopted_scroll_delta;
 };
 
-// One scrollable area from the paint snapshot. Non-viewport scrollports are stored in hit_test_visual_context_index
-// coordinates and transformed to viewport coordinates when the compositor rebuilds wheel targets.
+// One scrollable area from the paint snapshot.
 struct AsyncScrollNode {
     AsyncScrollNodeID node_id;
     AsyncScrollNodeStableID stable_node_id;
     Optional<AsyncScrollNodeID> parent_node_id;
-    Painting::VisualContextIndex hit_test_visual_context_index;
     Gfx::IntRect scrollport_rect;
     Gfx::FloatPoint max_scroll_offset;
     bool is_viewport { false };
@@ -71,9 +69,9 @@ struct AsyncScrollNode {
 // the precomputed geometry needed to replay that calculation on the compositor thread after an async scroll mutation.
 struct AsyncStickyArea {
     UniqueNodeID document_id;
-    Painting::ScrollFrameIndex scroll_frame_index;
-    Painting::ScrollFrameIndex parent_scroll_frame_index;
-    Painting::ScrollFrameIndex nearest_scrolling_ancestor_index;
+    Painting::VisualContextIndex scroll_node_index;
+    Painting::VisualContextIndex parent_scroll_node_index;
+    Painting::VisualContextIndex nearest_scrolling_ancestor_index;
     Gfx::FloatPoint position_relative_to_scroll_ancestor;
     Gfx::FloatSize border_box_size;
     Gfx::FloatSize scrollport_size;
@@ -106,7 +104,7 @@ struct MainThreadWheelEventRegion {
 
 struct ViewportScrollbar {
     AsyncScrollNodeID scroll_node_id;
-    Painting::ScrollFrameIndex scroll_frame_index;
+    Painting::VisualContextIndex scroll_node_index;
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
     Gfx::IntRect expanded_gutter_rect;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2522,7 +2522,7 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
         // which changes without a flip; the constraints capture the scroll ancestor's scrollable
         // overflow size though, so they have to be refreshed. When a full visual context rebuild is
         // already pending it recaptures constraints anyway, and skipping the refresh then also avoids
-        // touching scroll frames whose paintables a subtree relayout may have replaced.
+        // touching scroll nodes whose paintables a subtree relayout may have replaced.
         unsafe_paintable()->refresh_sticky_constraints();
     }
     set_needs_to_record_display_list();
@@ -2554,7 +2554,7 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
         }
     }
 
-    // Scroll frames are (re)created by the visual context tree build above, so scroll offsets and
+    // Scroll nodes are (re)created by the visual context tree build above, so scroll offsets and
     // the snapshot must be derived only after structure work is done.
     if (auto paintable = this->unsafe_paintable())
         paintable->refresh_scroll_state();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1816,7 +1816,7 @@ void Document::after_layout_commit(LayoutTreeChanged layout_tree_changed)
         m_scrollable_overflow_contained_boxes_from_last_layout = Layout::collect_scrollable_overflow_contained_boxes(*m_layout_root);
     update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates::HandledByAfterLayoutCommit);
 
-    rebuild_sticky_insets_and_reassign_scroll_frames();
+    set_needs_accumulated_visual_contexts_update(true);
 
     // Selection state lives on paintable fragments, which the commit has rebuilt.
     if (auto range = get_selection()->range())
@@ -2419,13 +2419,6 @@ static void rebuild_sticky_insets(Layout::Node const& root)
     });
 }
 
-void Document::rebuild_sticky_insets_and_reassign_scroll_frames()
-{
-    rebuild_sticky_insets(*m_layout_root);
-    unsafe_paintable()->reassign_scroll_frames();
-    set_needs_accumulated_visual_contexts_update(true);
-}
-
 void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpdates derived_structure_updates)
 {
     // For every box that will be re-measured, the overflow data it had before, so the diff below
@@ -2523,11 +2516,13 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
         return;
 
     if (any_has_scrollable_overflow_flipped) {
-        rebuild_sticky_insets_and_reassign_scroll_frames();
-    } else {
+        set_needs_accumulated_visual_contexts_update(true);
+    } else if (!m_needs_accumulated_visual_contexts_update) {
         // Sticky insets only depend on scrollport geometry and which ancestor is scrollable, neither of
         // which changes without a flip; the constraints capture the scroll ancestor's scrollable
-        // overflow size though, so they have to be refreshed.
+        // overflow size though, so they have to be refreshed. When a full visual context rebuild is
+        // already pending it recaptures constraints anyway, and skipping the refresh then also avoids
+        // touching scroll frames whose paintables a subtree relayout may have replaced.
         unsafe_paintable()->refresh_sticky_constraints();
     }
     set_needs_to_record_display_list();
@@ -2537,14 +2532,12 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
 void Document::update_paint_and_hit_testing_properties_if_needed()
 {
     // NB: Called during paint property resolution.
-    if (auto paintable = this->unsafe_paintable()) {
-        paintable->refresh_scroll_state();
-    }
-
     if (m_needs_accumulated_visual_contexts_update) {
         m_needs_accumulated_visual_contexts_update = false;
         m_paintable_boxes_needing_visual_context_value_update.clear_with_capacity();
         if (auto paintable = this->unsafe_paintable()) {
+            if (m_layout_root)
+                rebuild_sticky_insets(*m_layout_root);
             paintable->assign_accumulated_visual_contexts();
         }
     } else if (!m_paintable_boxes_needing_visual_context_value_update.is_empty()) {
@@ -2560,6 +2553,11 @@ void Document::update_paint_and_hit_testing_properties_if_needed()
             }
         }
     }
+
+    // Scroll frames are (re)created by the visual context tree build above, so scroll offsets and
+    // the snapshot must be derived only after structure work is done.
+    if (auto paintable = this->unsafe_paintable())
+        paintable->refresh_scroll_state();
 }
 
 void Document::set_normal_link_color(Color color)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1349,7 +1349,6 @@ private:
         Yes,
     };
     void after_layout_commit(LayoutTreeChanged);
-    void rebuild_sticky_insets_and_reassign_scroll_frames();
 
     void run_unloading_cleanup_steps();
 

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -405,7 +405,7 @@ int HTMLImageElement::x() const
     // to the element and its ancestors, or zero if there is no box.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementX);
     // Scroll frames are created together with the visual context tree at the lazy resolution point,
-    // so resolve it before reading the enclosing scroll frame below.
+    // so resolve it before reading the enclosing scroll node below.
     const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     auto paintable_box = this->paintable_box();
@@ -427,7 +427,7 @@ int HTMLImageElement::y() const
     // to the element and its ancestors, or zero if there is no box.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementY);
     // Scroll frames are created together with the visual context tree at the lazy resolution point,
-    // so resolve it before reading the enclosing scroll frame below.
+    // so resolve it before reading the enclosing scroll node below.
     const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     auto paintable_box = this->paintable_box();

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -413,8 +413,8 @@ int HTMLImageElement::x() const
         return 0;
 
     CSSPixels scroll_offset_x = 0;
-    if (auto idx = paintable_box->enclosing_scroll_frame_index(); idx.value())
-        scroll_offset_x = paintable_box->document().paintable()->scroll_state().cumulative_offset(idx).x();
+    if (auto idx = paintable_box->enclosing_scroll_node_index(); idx.value())
+        scroll_offset_x = paintable_box->document().paintable()->cumulative_scroll_offset_for_node(idx).x();
 
     return (paintable_box->absolute_border_box_rect().x() - scroll_offset_x).to_int();
 }
@@ -435,8 +435,8 @@ int HTMLImageElement::y() const
         return 0;
 
     CSSPixels scroll_offset_y = 0;
-    if (auto idx = paintable_box->enclosing_scroll_frame_index(); idx.value())
-        scroll_offset_y = paintable_box->document().paintable()->scroll_state().cumulative_offset(idx).y();
+    if (auto idx = paintable_box->enclosing_scroll_node_index(); idx.value())
+        scroll_offset_y = paintable_box->document().paintable()->cumulative_scroll_offset_for_node(idx).y();
 
     return (paintable_box->absolute_border_box_rect().y() - scroll_offset_y).to_int();
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -404,6 +404,9 @@ int HTMLImageElement::x() const
     // associated with the element, relative to the initial containing block origin, ignoring any transforms that apply
     // to the element and its ancestors, or zero if there is no box.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementX);
+    // Scroll frames are created together with the visual context tree at the lazy resolution point,
+    // so resolve it before reading the enclosing scroll frame below.
+    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     auto paintable_box = this->paintable_box();
     if (!paintable_box)
@@ -423,6 +426,9 @@ int HTMLImageElement::y() const
     // associated with the element, relative to the initial containing block origin, ignoring any transforms that apply
     // to the element and its ancestors, or zero if there is no box.
     const_cast<DOM::Document&>(document()).update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::HTMLImageElementY);
+    // Scroll frames are created together with the visual context tree at the lazy resolution point,
+    // so resolve it before reading the enclosing scroll frame below.
+    const_cast<DOM::Document&>(document()).update_paint_and_hit_testing_properties_if_needed();
 
     auto paintable_box = this->paintable_box();
     if (!paintable_box)

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1068,9 +1068,9 @@ JS::Object* Internals::async_scrolling_state()
         auto const& scroll_node = state.scroll_nodes[i];
         auto node = JS::Object::create(realm(), nullptr);
         node->define_direct_property("documentID"_utf16_fly_string, JS::Value(static_cast<double>(scroll_node.node_id.document_id.value())), JS::default_attributes);
-        node->define_direct_property("scrollFrameIndex"_utf16_fly_string, JS::Value(scroll_node.node_id.scroll_node_index.value()), JS::default_attributes);
+        node->define_direct_property("scrollNodeIndex"_utf16_fly_string, JS::Value(scroll_node.node_id.scroll_node_index.value()), JS::default_attributes);
         node->define_direct_property("parentDocumentID"_utf16_fly_string, JS::Value(scroll_node.parent_node_id.has_value() ? static_cast<double>(scroll_node.parent_node_id->document_id.value()) : 0), JS::default_attributes);
-        node->define_direct_property("parentScrollFrameIndex"_utf16_fly_string, JS::Value(scroll_node.parent_node_id.has_value() ? scroll_node.parent_node_id->scroll_node_index.value() : 0), JS::default_attributes);
+        node->define_direct_property("parentScrollNodeIndex"_utf16_fly_string, JS::Value(scroll_node.parent_node_id.has_value() ? scroll_node.parent_node_id->scroll_node_index.value() : 0), JS::default_attributes);
         node->define_direct_property("isViewport"_utf16_fly_string, JS::Value(scroll_node.is_viewport), JS::default_attributes);
         MUST(scroll_nodes->create_data_property_or_throw(i, node));
     }
@@ -1080,8 +1080,8 @@ JS::Object* Internals::async_scrolling_state()
         auto const& sticky_area = state.sticky_areas[i];
         auto area = JS::Object::create(realm(), nullptr);
         area->define_direct_property("documentID"_utf16_fly_string, JS::Value(static_cast<double>(sticky_area.document_id.value())), JS::default_attributes);
-        area->define_direct_property("scrollFrameIndex"_utf16_fly_string, JS::Value(sticky_area.scroll_node_index.value()), JS::default_attributes);
-        area->define_direct_property("parentScrollFrameIndex"_utf16_fly_string, JS::Value(sticky_area.parent_scroll_node_index.value()), JS::default_attributes);
+        area->define_direct_property("scrollNodeIndex"_utf16_fly_string, JS::Value(sticky_area.scroll_node_index.value()), JS::default_attributes);
+        area->define_direct_property("parentScrollNodeIndex"_utf16_fly_string, JS::Value(sticky_area.parent_scroll_node_index.value()), JS::default_attributes);
         area->define_direct_property("nearestScrollingAncestorIndex"_utf16_fly_string, JS::Value(sticky_area.nearest_scrolling_ancestor_index.value()), JS::default_attributes);
         area->define_direct_property("hasTopInset"_utf16_fly_string, JS::Value(sticky_area.inset_top.has_value()), JS::default_attributes);
         area->define_direct_property("hasRightInset"_utf16_fly_string, JS::Value(sticky_area.inset_right.has_value()), JS::default_attributes);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1068,9 +1068,9 @@ JS::Object* Internals::async_scrolling_state()
         auto const& scroll_node = state.scroll_nodes[i];
         auto node = JS::Object::create(realm(), nullptr);
         node->define_direct_property("documentID"_utf16_fly_string, JS::Value(static_cast<double>(scroll_node.node_id.document_id.value())), JS::default_attributes);
-        node->define_direct_property("scrollFrameIndex"_utf16_fly_string, JS::Value(scroll_node.node_id.scroll_frame_index.value()), JS::default_attributes);
+        node->define_direct_property("scrollFrameIndex"_utf16_fly_string, JS::Value(scroll_node.node_id.scroll_node_index.value()), JS::default_attributes);
         node->define_direct_property("parentDocumentID"_utf16_fly_string, JS::Value(scroll_node.parent_node_id.has_value() ? static_cast<double>(scroll_node.parent_node_id->document_id.value()) : 0), JS::default_attributes);
-        node->define_direct_property("parentScrollFrameIndex"_utf16_fly_string, JS::Value(scroll_node.parent_node_id.has_value() ? scroll_node.parent_node_id->scroll_frame_index.value() : 0), JS::default_attributes);
+        node->define_direct_property("parentScrollFrameIndex"_utf16_fly_string, JS::Value(scroll_node.parent_node_id.has_value() ? scroll_node.parent_node_id->scroll_node_index.value() : 0), JS::default_attributes);
         node->define_direct_property("isViewport"_utf16_fly_string, JS::Value(scroll_node.is_viewport), JS::default_attributes);
         MUST(scroll_nodes->create_data_property_or_throw(i, node));
     }
@@ -1080,8 +1080,8 @@ JS::Object* Internals::async_scrolling_state()
         auto const& sticky_area = state.sticky_areas[i];
         auto area = JS::Object::create(realm(), nullptr);
         area->define_direct_property("documentID"_utf16_fly_string, JS::Value(static_cast<double>(sticky_area.document_id.value())), JS::default_attributes);
-        area->define_direct_property("scrollFrameIndex"_utf16_fly_string, JS::Value(sticky_area.scroll_frame_index.value()), JS::default_attributes);
-        area->define_direct_property("parentScrollFrameIndex"_utf16_fly_string, JS::Value(sticky_area.parent_scroll_frame_index.value()), JS::default_attributes);
+        area->define_direct_property("scrollFrameIndex"_utf16_fly_string, JS::Value(sticky_area.scroll_node_index.value()), JS::default_attributes);
+        area->define_direct_property("parentScrollFrameIndex"_utf16_fly_string, JS::Value(sticky_area.parent_scroll_node_index.value()), JS::default_attributes);
         area->define_direct_property("nearestScrollingAncestorIndex"_utf16_fly_string, JS::Value(sticky_area.nearest_scrolling_ancestor_index.value()), JS::default_attributes);
         area->define_direct_property("hasTopInset"_utf16_fly_string, JS::Value(sticky_area.inset_top.has_value()), JS::default_attributes);
         area->define_direct_property("hasRightInset"_utf16_fly_string, JS::Value(sticky_area.inset_right.has_value()), JS::default_attributes);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -42,15 +42,15 @@ bool ClipData::contains(DevicePixelPoint point) const
 
 static Atomic<u64> s_next_accumulated_visual_context_tree_version { 1 };
 
-static ScrollStateSlot scroll_frame_common_ancestor(ScrollState const& scroll_state, ScrollStateSlot a_slot, ScrollStateSlot b_slot)
+static ScrollStateSlot common_ancestor_slot_along_scroll_parent_chain(ScrollState const& scroll_state, ScrollStateSlot a_slot, ScrollStateSlot b_slot)
 {
     Vector<ScrollStateSlot, 8> a_slot_and_ancestors;
-    for (auto slot = a_slot;; slot = scroll_state.frame_at_slot(slot).parent_slot()) {
+    for (auto slot = a_slot;; slot = scroll_state.state_at_slot(slot).parent_slot()) {
         a_slot_and_ancestors.append(slot);
         if (slot == NO_SCROLL_STATE_SLOT)
             break;
     }
-    for (auto slot = b_slot;; slot = scroll_state.frame_at_slot(slot).parent_slot()) {
+    for (auto slot = b_slot;; slot = scroll_state.state_at_slot(slot).parent_slot()) {
         if (a_slot_and_ancestors.contains_slow(slot))
             return slot;
         if (slot == NO_SCROLL_STATE_SLOT)
@@ -354,7 +354,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
     viewport_paintable.set_enclosing_scroll_node_index({});
     auto viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { .is_sticky = false });
-    viewport_paintable.register_scroll_frame(visual_context_tree, viewport_state_for_descendants, viewport_paintable, {});
+    viewport_paintable.register_scroll_node(visual_context_tree, viewport_state_for_descendants, viewport_paintable, {});
     viewport_paintable.set_own_scroll_node_index(viewport_state_for_descendants);
     viewport_paintable.set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);
     viewport_paintable.set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
@@ -418,12 +418,12 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 visited.append(box);
                 compensate_horizontal_scroll = compensate_horizontal_scroll && box->compensates_for_horizontal_scroll();
                 compensate_vertical_scroll = compensate_vertical_scroll && box->compensates_for_vertical_scroll();
-                auto anchor_frame_slot = visual_context_tree.scroll_state_slot_for_node(anchor_paintable->enclosing_scroll_node_index());
-                auto base_frame_slot = visual_context_tree.scroll_state_slot_for_node(box_paintable->enclosing_scroll_node_index());
-                auto shared_frame_slot = scroll_frame_common_ancestor(scroll_state, anchor_frame_slot, base_frame_slot);
-                for (auto slot = anchor_frame_slot; slot != NO_SCROLL_STATE_SLOT && slot != shared_frame_slot; slot = scroll_state.frame_at_slot(slot).parent_slot())
+                auto anchor_scroll_slot = visual_context_tree.scroll_state_slot_for_node(anchor_paintable->enclosing_scroll_node_index());
+                auto base_scroll_slot = visual_context_tree.scroll_state_slot_for_node(box_paintable->enclosing_scroll_node_index());
+                auto shared_scroll_slot = common_ancestor_slot_along_scroll_parent_chain(scroll_state, anchor_scroll_slot, base_scroll_slot);
+                for (auto slot = anchor_scroll_slot; slot != NO_SCROLL_STATE_SLOT && slot != shared_scroll_slot; slot = scroll_state.state_at_slot(slot).parent_slot())
                     own_state = append_node(own_state, AnchorScrollShift { scroll_state.node_index_for_slot(slot), false, compensate_horizontal_scroll, compensate_vertical_scroll });
-                for (auto slot = base_frame_slot; slot != NO_SCROLL_STATE_SLOT && slot != shared_frame_slot; slot = scroll_state.frame_at_slot(slot).parent_slot())
+                for (auto slot = base_scroll_slot; slot != NO_SCROLL_STATE_SLOT && slot != shared_scroll_slot; slot = scroll_state.state_at_slot(slot).parent_slot())
                     own_state = append_node(own_state, AnchorScrollShift { scroll_state.node_index_for_slot(slot), true, compensate_horizontal_scroll, compensate_vertical_scroll });
                 box = anchor_box;
             }
@@ -445,7 +445,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         if (creates_sticky_scroll_node) {
             sticky_scroll_node_index = append_node(own_state, ScrollData { .is_sticky = true });
             own_state = sticky_scroll_node_index;
-            viewport_paintable.register_sticky_frame(visual_context_tree, sticky_scroll_node_index, paintable_box, nearest_ancestor_scroll_node_index);
+            viewport_paintable.register_sticky_node(visual_context_tree, sticky_scroll_node_index, paintable_box, nearest_ancestor_scroll_node_index);
             paintable_box.set_enclosing_scroll_node_index(sticky_scroll_node_index);
             paintable_box.set_own_scroll_node_index(sticky_scroll_node_index);
         }
@@ -510,7 +510,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 }
 
                 if (!has_transform_ancestor) {
-                    // Build a context that negates all scroll frames in the ancestor chain. This keeps the background
+                    // Build a context that negates all scroll nodes in the ancestor chain. This keeps the background
                     // fixed relative to the viewport.
                     auto fixed_background_context = own_state;
                     for (auto index = own_state; index.value(); index = visual_context_tree.node_at(index).parent_index) {
@@ -544,7 +544,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             auto parent_index = creates_sticky_scroll_node ? sticky_scroll_node_index : nearest_ancestor_scroll_node_index;
             auto scroll_node_index = append_node(state_for_descendants, ScrollData { .is_sticky = false });
             state_for_descendants = scroll_node_index;
-            viewport_paintable.register_scroll_frame(visual_context_tree, scroll_node_index, paintable_box, parent_index);
+            viewport_paintable.register_scroll_node(visual_context_tree, scroll_node_index, paintable_box, parent_index);
             paintable_box.set_own_scroll_node_index(scroll_node_index);
         }
 
@@ -580,7 +580,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         return box && box->default_scroll_shift_anchor();
     };
 
-    // Anchor-positioned boxes emit AnchorScrollShift nodes by reading the enclosing scroll frames of their
+    // Anchor-positioned boxes emit AnchorScrollShift nodes by reading the enclosing scroll nodes of their
     // anchors, and an acceptable anchor may come later in tree order than the positioned box. Building such
     // boxes' subtrees is deferred until their anchors have been built; the hash table mirrors the queue so
     // readiness checks stay cheap across rounds.

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Atomic.h>
+#include <AK/HashTable.h>
 #include <AK/StringBuilder.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibIPC/Decoder.h>
@@ -351,9 +352,9 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
     auto visual_viewport_context_index = VISUAL_VIEWPORT_NODE_INDEX;
 
-    VisualContextIndex viewport_state_for_descendants = visual_viewport_context_index;
-    if (viewport_paintable.own_scroll_frame_index().value())
-        viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { viewport_paintable.own_scroll_frame_index(), false });
+    viewport_paintable.set_enclosing_scroll_frame_index({});
+    viewport_paintable.set_own_scroll_frame_index(viewport_paintable.create_scroll_frame_for(viewport_paintable, {}));
+    auto viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { viewport_paintable.own_scroll_frame_index(), false });
     viewport_paintable.set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);
     viewport_paintable.set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
 
@@ -366,6 +367,27 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
     auto build_paintable_box = [&](Paintable& paintable_box, DescendantVisualContexts inherited_contexts, bool may_be_root_element) -> DescendantVisualContexts {
         auto first_visual_context_node_index = visual_context_tree.nodes().size();
         auto& layout_node = paintable_box.layout_node();
+
+        paintable_box.set_enclosing_scroll_frame_index({});
+        paintable_box.set_own_scroll_frame_index({});
+
+        auto nearest_ancestor_scroll_frame_index = paintable_box.nearest_scroll_frame_index();
+        if (!paintable_box.is_fixed_position() && !paintable_box.is_sticky_position())
+            paintable_box.set_enclosing_scroll_frame_index(nearest_ancestor_scroll_frame_index);
+
+        ScrollFrameIndex sticky_scroll_frame_index;
+        if (paintable_box.is_sticky_position() && paintable_box.has_sticky_insets()) {
+            sticky_scroll_frame_index = viewport_paintable.create_sticky_frame_for(paintable_box, nearest_ancestor_scroll_frame_index);
+            paintable_box.set_enclosing_scroll_frame_index(sticky_scroll_frame_index);
+            paintable_box.set_own_scroll_frame_index(sticky_scroll_frame_index);
+        }
+
+        ScrollFrameIndex scrollable_overflow_scroll_frame_index;
+        if (paintable_box.has_scrollable_overflow()) {
+            auto parent_index = sticky_scroll_frame_index.value() ? sticky_scroll_frame_index : nearest_ancestor_scroll_frame_index;
+            scrollable_overflow_scroll_frame_index = viewport_paintable.create_scroll_frame_for(paintable_box, parent_index);
+            paintable_box.set_own_scroll_frame_index(scrollable_overflow_scroll_frame_index);
+        }
 
         VisualContextIndex inherited_state;
 
@@ -428,12 +450,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             state_for_fixed_position_descendants = append_node(state_for_fixed_position_descendants, data);
         };
 
-        if (paintable_box.is_sticky_position()) {
-            // For sticky elements, use enclosing_scroll_frame which holds the sticky frame.
-            // own_scroll_frame may be a different scroll frame if the sticky element also has scrollable overflow.
-            if (auto sticky_idx = paintable_box.enclosing_scroll_frame_index(); sticky_idx.value() && viewport_paintable.scroll_state().frame_at(sticky_idx).is_sticky())
-                own_state = append_node(own_state, ScrollData { sticky_idx, true });
-        }
+        if (sticky_scroll_frame_index.value())
+            own_state = append_node(own_state, ScrollData { sticky_scroll_frame_index, true });
 
         auto const& computed_values = layout_node.computed_values();
 
@@ -526,11 +544,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 state_for_descendants = append_node(state_for_descendants, clip_data.value());
         }
 
-        if (paintable_box.own_scroll_frame_index().value()) {
-            auto is_sticky_without_scrollable_overflow = paintable_box.is_sticky_position() && paintable_box.enclosing_scroll_frame_index() == paintable_box.own_scroll_frame_index();
-            if (!is_sticky_without_scrollable_overflow)
-                state_for_descendants = append_node(state_for_descendants, ScrollData { paintable_box.own_scroll_frame_index(), false });
-        }
+        if (scrollable_overflow_scroll_frame_index.value())
+            state_for_descendants = append_node(state_for_descendants, ScrollData { scrollable_overflow_scroll_frame_index, false });
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
         paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
@@ -558,15 +573,76 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         DescendantVisualContexts inherited_contexts;
         bool may_be_root_element;
     };
+
+    auto has_default_scroll_shift_anchor = [](Paintable const& paintable_box) {
+        auto const* box = as_if<Layout::Box>(paintable_box.layout_node());
+        return box && box->default_scroll_shift_anchor();
+    };
+
+    // Anchor-positioned boxes emit AnchorScrollShift nodes by reading the enclosing scroll frames of their
+    // anchors, and an acceptable anchor may come later in tree order than the positioned box. Building such
+    // boxes' subtrees is deferred until their anchors have been built; the hash table mirrors the queue so
+    // readiness checks stay cheap across rounds.
+    Vector<PendingPaintable> deferred_anchor_positioned_paintables;
+    HashTable<Paintable const*> deferred_paintables_awaiting_build;
+
+    auto build_paintables_deferring_anchor_positioned = [&](Vector<PendingPaintable, 64>& stack, Paintable const* paintable_exempt_from_deferral) {
+        while (!stack.is_empty()) {
+            auto pending = stack.take_last();
+            if (pending.paintable != paintable_exempt_from_deferral && has_default_scroll_shift_anchor(*pending.paintable)) {
+                deferred_anchor_positioned_paintables.append(pending);
+                deferred_paintables_awaiting_build.set(pending.paintable);
+                continue;
+            }
+            auto child_contexts = build_paintable_box(*pending.paintable, pending.inherited_contexts, pending.may_be_root_element);
+            for (auto* child = pending.paintable->last_child_ptr(); child; child = child->previous_sibling_ptr())
+                stack.append({ child, child_contexts, false });
+        }
+    };
+
     Vector<PendingPaintable, 64> pending_paintables;
     for (auto* child = viewport_paintable.last_child_ptr(); child; child = child->previous_sibling_ptr())
         pending_paintables.append({ child, viewport_contexts, true });
+    build_paintables_deferring_anchor_positioned(pending_paintables, nullptr);
 
-    while (!pending_paintables.is_empty()) {
-        auto pending = pending_paintables.take_last();
-        auto child_contexts = build_paintable_box(*pending.paintable, pending.inherited_contexts, pending.may_be_root_element);
-        for (auto* child = pending.paintable->last_child_ptr(); child; child = child->previous_sibling_ptr())
-            pending_paintables.append({ child, child_contexts, false });
+    auto anchor_is_awaiting_build = [&](Paintable const& paintable_box) {
+        auto const* box = as_if<Layout::Box>(paintable_box.layout_node());
+        auto const* anchor_box = box ? as_if<Layout::Box>(box->default_scroll_shift_anchor()) : nullptr;
+        auto anchor_paintable = anchor_box ? anchor_box->paintable_box() : nullptr;
+        for (auto const* paintable = anchor_paintable.ptr(); paintable; paintable = paintable->parent_ptr()) {
+            if (deferred_paintables_awaiting_build.contains(paintable))
+                return true;
+        }
+        return false;
+    };
+
+    auto build_deferred_subtree = [&](PendingPaintable& entry) {
+        deferred_paintables_awaiting_build.remove(entry.paintable);
+        pending_paintables.clear_with_capacity();
+        pending_paintables.append(entry);
+        build_paintables_deferring_anchor_positioned(pending_paintables, entry.paintable);
+    };
+
+    while (!deferred_anchor_positioned_paintables.is_empty()) {
+        auto entries = move(deferred_anchor_positioned_paintables);
+        Vector<PendingPaintable> entries_whose_anchor_is_still_deferred;
+        for (auto& entry : entries) {
+            if (anchor_is_awaiting_build(*entry.paintable))
+                entries_whose_anchor_is_still_deferred.append(entry);
+            else
+                build_deferred_subtree(entry);
+        }
+
+        bool no_entry_was_ready = entries_whose_anchor_is_still_deferred.size() == entries.size();
+        if (no_entry_was_ready) {
+            // Cyclic or otherwise malformed anchor chains can leave every remaining entry waiting on another;
+            // build them in queue order then — the anchor chain walk's visited set and depth cap bound the
+            // damage the same way they do for cycles discovered mid-walk.
+            for (auto& entry : entries_whose_anchor_is_still_deferred)
+                build_deferred_subtree(entry);
+        } else {
+            deferred_anchor_positioned_paintables.extend(move(entries_whose_anchor_is_still_deferred));
+        }
     }
 
     return visual_context_tree;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -42,21 +42,21 @@ bool ClipData::contains(DevicePixelPoint point) const
 
 static Atomic<u64> s_next_accumulated_visual_context_tree_version { 1 };
 
-static ScrollFrameIndex scroll_frame_common_ancestor(ScrollState const& scroll_state, ScrollFrameIndex a, ScrollFrameIndex b)
+static ScrollStateSlot scroll_frame_common_ancestor(ScrollState const& scroll_state, ScrollStateSlot a_slot, ScrollStateSlot b_slot)
 {
-    Vector<ScrollFrameIndex, 8> a_and_ancestors;
-    for (auto frame = a;; frame = scroll_state.frame_at(frame).parent_index()) {
-        a_and_ancestors.append(frame);
-        if (!frame.value())
+    Vector<ScrollStateSlot, 8> a_slot_and_ancestors;
+    for (auto slot = a_slot;; slot = scroll_state.frame_at_slot(slot).parent_slot()) {
+        a_slot_and_ancestors.append(slot);
+        if (slot == NO_SCROLL_STATE_SLOT)
             break;
     }
-    for (auto frame = b;; frame = scroll_state.frame_at(frame).parent_index()) {
-        if (a_and_ancestors.contains_slow(frame))
-            return frame;
-        if (!frame.value())
+    for (auto slot = b_slot;; slot = scroll_state.frame_at_slot(slot).parent_slot()) {
+        if (a_slot_and_ancestors.contains_slow(slot))
+            return slot;
+        if (slot == NO_SCROLL_STATE_SLOT)
             break;
     }
-    return {};
+    return NO_SCROLL_STATE_SLOT;
 }
 
 static TransformData identity_visual_viewport_transform()
@@ -352,9 +352,10 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
     auto visual_viewport_context_index = VISUAL_VIEWPORT_NODE_INDEX;
 
-    viewport_paintable.set_enclosing_scroll_frame_index({});
-    viewport_paintable.set_own_scroll_frame_index(viewport_paintable.create_scroll_frame_for(viewport_paintable, {}));
-    auto viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { viewport_paintable.own_scroll_frame_index(), false });
+    viewport_paintable.set_enclosing_scroll_node_index({});
+    auto viewport_state_for_descendants = append_node(visual_viewport_context_index, ScrollData { .is_sticky = false });
+    viewport_paintable.register_scroll_frame(visual_context_tree, viewport_state_for_descendants, viewport_paintable, {});
+    viewport_paintable.set_own_scroll_node_index(viewport_state_for_descendants);
     viewport_paintable.set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);
     viewport_paintable.set_accumulated_visual_context_for_descendants(viewport_state_for_descendants);
 
@@ -368,26 +369,16 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         auto first_visual_context_node_index = visual_context_tree.nodes().size();
         auto& layout_node = paintable_box.layout_node();
 
-        paintable_box.set_enclosing_scroll_frame_index({});
-        paintable_box.set_own_scroll_frame_index({});
+        paintable_box.set_enclosing_scroll_node_index({});
+        paintable_box.set_own_scroll_node_index({});
 
-        auto nearest_ancestor_scroll_frame_index = paintable_box.nearest_scroll_frame_index();
+        // One containing-block walk serves both the enclosing stamp and the parent reference of any
+        // scroll nodes this box appends at their chain positions below.
+        auto nearest_ancestor_scroll_node_index = paintable_box.nearest_scroll_node_index();
         if (!paintable_box.is_fixed_position() && !paintable_box.is_sticky_position())
-            paintable_box.set_enclosing_scroll_frame_index(nearest_ancestor_scroll_frame_index);
+            paintable_box.set_enclosing_scroll_node_index(nearest_ancestor_scroll_node_index);
 
-        ScrollFrameIndex sticky_scroll_frame_index;
-        if (paintable_box.is_sticky_position() && paintable_box.has_sticky_insets()) {
-            sticky_scroll_frame_index = viewport_paintable.create_sticky_frame_for(paintable_box, nearest_ancestor_scroll_frame_index);
-            paintable_box.set_enclosing_scroll_frame_index(sticky_scroll_frame_index);
-            paintable_box.set_own_scroll_frame_index(sticky_scroll_frame_index);
-        }
-
-        ScrollFrameIndex scrollable_overflow_scroll_frame_index;
-        if (paintable_box.has_scrollable_overflow()) {
-            auto parent_index = sticky_scroll_frame_index.value() ? sticky_scroll_frame_index : nearest_ancestor_scroll_frame_index;
-            scrollable_overflow_scroll_frame_index = viewport_paintable.create_scroll_frame_for(paintable_box, parent_index);
-            paintable_box.set_own_scroll_frame_index(scrollable_overflow_scroll_frame_index);
-        }
+        bool creates_sticky_scroll_node = paintable_box.is_sticky_position() && paintable_box.has_sticky_insets();
 
         VisualContextIndex inherited_state;
 
@@ -427,13 +418,13 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 visited.append(box);
                 compensate_horizontal_scroll = compensate_horizontal_scroll && box->compensates_for_horizontal_scroll();
                 compensate_vertical_scroll = compensate_vertical_scroll && box->compensates_for_vertical_scroll();
-                auto anchor_frame = anchor_paintable->enclosing_scroll_frame_index();
-                auto base_frame = box_paintable->enclosing_scroll_frame_index();
-                auto shared_frame = scroll_frame_common_ancestor(scroll_state, anchor_frame, base_frame);
-                for (auto frame = anchor_frame; frame.value() && frame != shared_frame; frame = scroll_state.frame_at(frame).parent_index())
-                    own_state = append_node(own_state, AnchorScrollShift { frame, false, compensate_horizontal_scroll, compensate_vertical_scroll });
-                for (auto frame = base_frame; frame.value() && frame != shared_frame; frame = scroll_state.frame_at(frame).parent_index())
-                    own_state = append_node(own_state, AnchorScrollShift { frame, true, compensate_horizontal_scroll, compensate_vertical_scroll });
+                auto anchor_frame_slot = visual_context_tree.scroll_state_slot_for_node(anchor_paintable->enclosing_scroll_node_index());
+                auto base_frame_slot = visual_context_tree.scroll_state_slot_for_node(box_paintable->enclosing_scroll_node_index());
+                auto shared_frame_slot = scroll_frame_common_ancestor(scroll_state, anchor_frame_slot, base_frame_slot);
+                for (auto slot = anchor_frame_slot; slot != NO_SCROLL_STATE_SLOT && slot != shared_frame_slot; slot = scroll_state.frame_at_slot(slot).parent_slot())
+                    own_state = append_node(own_state, AnchorScrollShift { scroll_state.node_index_for_slot(slot), false, compensate_horizontal_scroll, compensate_vertical_scroll });
+                for (auto slot = base_frame_slot; slot != NO_SCROLL_STATE_SLOT && slot != shared_frame_slot; slot = scroll_state.frame_at_slot(slot).parent_slot())
+                    own_state = append_node(own_state, AnchorScrollShift { scroll_state.node_index_for_slot(slot), true, compensate_horizontal_scroll, compensate_vertical_scroll });
                 box = anchor_box;
             }
         }
@@ -450,8 +441,14 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             state_for_fixed_position_descendants = append_node(state_for_fixed_position_descendants, data);
         };
 
-        if (sticky_scroll_frame_index.value())
-            own_state = append_node(own_state, ScrollData { sticky_scroll_frame_index, true });
+        VisualContextIndex sticky_scroll_node_index;
+        if (creates_sticky_scroll_node) {
+            sticky_scroll_node_index = append_node(own_state, ScrollData { .is_sticky = true });
+            own_state = sticky_scroll_node_index;
+            viewport_paintable.register_sticky_frame(visual_context_tree, sticky_scroll_node_index, paintable_box, nearest_ancestor_scroll_node_index);
+            paintable_box.set_enclosing_scroll_node_index(sticky_scroll_node_index);
+            paintable_box.set_own_scroll_node_index(sticky_scroll_node_index);
+        }
 
         auto const& computed_values = layout_node.computed_values();
 
@@ -518,9 +515,8 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                     auto fixed_background_context = own_state;
                     for (auto index = own_state; index.value(); index = visual_context_tree.node_at(index).parent_index) {
                         auto const& node = visual_context_tree.node_at(index);
-                        if (auto const* scroll = node.data.get_pointer<ScrollData>()) {
-                            fixed_background_context = append_node(fixed_background_context, ScrollCompensation { scroll->scroll_frame_index });
-                        }
+                        if (node.data.has<ScrollData>())
+                            fixed_background_context = append_node(fixed_background_context, ScrollCompensation { index });
                     }
                     paintable_box.set_fixed_background_visual_context(fixed_background_context);
                 }
@@ -544,8 +540,13 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 state_for_descendants = append_node(state_for_descendants, clip_data.value());
         }
 
-        if (scrollable_overflow_scroll_frame_index.value())
-            state_for_descendants = append_node(state_for_descendants, ScrollData { scrollable_overflow_scroll_frame_index, false });
+        if (paintable_box.has_scrollable_overflow()) {
+            auto parent_index = creates_sticky_scroll_node ? sticky_scroll_node_index : nearest_ancestor_scroll_node_index;
+            auto scroll_node_index = append_node(state_for_descendants, ScrollData { .is_sticky = false });
+            state_for_descendants = scroll_node_index;
+            viewport_paintable.register_scroll_frame(visual_context_tree, scroll_node_index, paintable_box, parent_index);
+            paintable_box.set_own_scroll_node_index(scroll_node_index);
+        }
 
         paintable_box.set_accumulated_visual_context_for_descendants(state_for_descendants);
         paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
@@ -804,7 +805,8 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
 
     auto point = screen_point;
     for (size_t i = chain.size(); i > 0; --i) {
-        auto const& node = m_nodes[chain[i - 1]];
+        auto node_index = VisualContextIndex { chain[i - 1] };
+        auto const& node = m_nodes[node_index.value()];
 
         auto result = node.data.visit(
             [&](PerspectiveData const& perspective) -> Optional<Gfx::FloatPoint> {
@@ -815,8 +817,8 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
                 point = inverse->map(point);
                 return point;
             },
-            [&](ScrollData const& scroll) -> Optional<Gfx::FloatPoint> {
-                point.translate_by(-scroll_state.device_offset_for_index(scroll.scroll_frame_index));
+            [&](ScrollData const&) -> Optional<Gfx::FloatPoint> {
+                point.translate_by(-scroll_state.device_offset_for_index(node_index));
                 return point;
             },
             [&](TransformData const& transform) -> Optional<Gfx::FloatPoint> {
@@ -855,7 +857,8 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
                 return point;
             },
             [&](ScrollCompensation const& compensation) -> Optional<Gfx::FloatPoint> {
-                point.translate_by(scroll_state.device_offset_for_index(compensation.scroll_frame_index));
+                auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
+                point.translate_by(compensation.negate ? offset : -offset);
                 return point;
             },
             [&](AnchorScrollShift const& shift) -> Optional<Gfx::FloatPoint> {
@@ -917,12 +920,12 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
                     auto affine = Gfx::extract_2d_affine_transform(perspective.matrix);
                     rect = affine.map(rect);
                 },
-                [&](ScrollData const& scroll) {
-                    rect.translate_by(scroll_state.device_offset_for_index(scroll.scroll_frame_index));
+                [&](ScrollData const&) {
+                    rect.translate_by(scroll_state.device_offset_for_index(VisualContextIndex { i }));
                 },
                 [&](ScrollCompensation const& compensation) {
-                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_frame_index);
-                    rect.translate_by(-offset);
+                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
+                    rect.translate_by(compensation.negate ? -offset : offset);
                 },
                 [&](AnchorScrollShift const& shift) {
                     rect.translate_by(shift.masked_offset(scroll_state));
@@ -940,7 +943,7 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
 
 Gfx::FloatPoint AnchorScrollShift::masked_offset(ScrollStateSnapshot const& scroll_state) const
 {
-    auto offset = scroll_state.device_offset_for_index(scroll_frame_index);
+    auto offset = scroll_state.device_offset_for_index(scroll_node_index);
     if (!compensate_horizontal_scroll)
         offset.set_x(0);
     if (!compensate_vertical_scroll)
@@ -956,7 +959,7 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
             builder.append("perspective"sv);
         },
         [&](ScrollData const& scroll) {
-            builder.appendff("scroll_frame_id={}", scroll.scroll_frame_index);
+            builder.append("scroll"sv);
             if (scroll.is_sticky)
                 builder.append(" (sticky)"sv);
         },
@@ -1000,10 +1003,10 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
             builder.append("]"sv);
         },
         [&](ScrollCompensation const& compensation) {
-            builder.appendff("scroll_compensation(frame_id={})", compensation.scroll_frame_index.value());
+            builder.appendff("scroll_compensation(node_index={}{})", compensation.scroll_node_index.value(), compensation.negate ? ""sv : ", applies_offset"sv);
         },
         [&](AnchorScrollShift const& shift) {
-            builder.appendff("anchor_scroll_shift(frame_id={}{}{}{})", shift.scroll_frame_index.value(),
+            builder.appendff("anchor_scroll_shift(node_index={}{}{}{})", shift.scroll_node_index.value(),
                 shift.negate ? ", negate"sv : ""sv,
                 shift.compensate_horizontal_scroll ? ""sv : ", no-x"sv,
                 shift.compensate_vertical_scroll ? ""sv : ", no-y"sv);
@@ -1017,7 +1020,6 @@ namespace IPC {
 template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollData const& data)
 {
-    TRY(encoder.encode(data.scroll_frame_index));
     TRY(encoder.encode(data.is_sticky));
     return {};
 }
@@ -1026,7 +1028,6 @@ template<>
 ErrorOr<Web::Painting::ScrollData> decode(Decoder& decoder)
 {
     return Web::Painting::ScrollData {
-        .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
         .is_sticky = TRY(decoder.decode<bool>()),
     };
 }
@@ -1121,7 +1122,8 @@ ErrorOr<Web::Painting::EffectsData> decode(Decoder& decoder)
 template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollCompensation const& data)
 {
-    TRY(encoder.encode(data.scroll_frame_index));
+    TRY(encoder.encode(data.scroll_node_index));
+    TRY(encoder.encode(data.negate));
     return {};
 }
 
@@ -1129,14 +1131,15 @@ template<>
 ErrorOr<Web::Painting::ScrollCompensation> decode(Decoder& decoder)
 {
     return Web::Painting::ScrollCompensation {
-        .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
+        .scroll_node_index = TRY(decoder.decode<Web::Painting::VisualContextIndex>()),
+        .negate = TRY(decoder.decode<bool>()),
     };
 }
 
 template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::AnchorScrollShift const& data)
 {
-    TRY(encoder.encode(data.scroll_frame_index));
+    TRY(encoder.encode(data.scroll_node_index));
     TRY(encoder.encode(data.negate));
     TRY(encoder.encode(data.compensate_horizontal_scroll));
     TRY(encoder.encode(data.compensate_vertical_scroll));
@@ -1147,7 +1150,7 @@ template<>
 ErrorOr<Web::Painting::AnchorScrollShift> decode(Decoder& decoder)
 {
     return Web::Painting::AnchorScrollShift {
-        .scroll_frame_index = TRY(decoder.decode<Web::Painting::ScrollFrameIndex>()),
+        .scroll_node_index = TRY(decoder.decode<Web::Painting::VisualContextIndex>()),
         .negate = TRY(decoder.decode<bool>()),
         .compensate_horizontal_scroll = TRY(decoder.decode<bool>()),
         .compensate_vertical_scroll = TRY(decoder.decode<bool>()),

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -33,13 +33,13 @@ namespace Web::Painting {
 class Paintable;
 class ScrollStateSnapshot;
 
-AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, VisualContextIndex);
-
-static constexpr VisualContextIndex VISUAL_VIEWPORT_NODE_INDEX { 0 };
-
+// The node's own VisualContextIndex keys the scroll offset snapshot; the paintable that owns the
+// node and its sticky constraints live in the ScrollState entry addressed by state_slot, stamped
+// at registration. The slot is process-local bookkeeping: it stays off the wire and takes no part
+// in tree compatibility or damage comparisons.
 struct ScrollData {
-    ScrollFrameIndex scroll_frame_index;
-    bool is_sticky;
+    bool is_sticky { false };
+    ScrollStateSlot state_slot { NO_SCROLL_STATE_SLOT };
 };
 
 struct ClipData {
@@ -83,16 +83,19 @@ struct EffectsData {
     }
 };
 
-// Negates a scroll frame's offset during display list replay. Used to keep fixed backgrounds stationary relative to
-// the viewport regardless of scroll position.
+// Translates by another scroll node's offset during display list replay. Negating keeps fixed backgrounds
+// stationary relative to the viewport regardless of scroll position; the non-negating form is appended when
+// inspector overlays copy a scroll node's context, since a copied ScrollData node would look its offset up
+// under the copy's own index.
 struct ScrollCompensation {
-    ScrollFrameIndex scroll_frame_index;
+    VisualContextIndex scroll_node_index;
+    bool negate { true };
 };
 
-// One scroll frame's contribution to the default scroll shift of an anchor-positioned box, masked to the axes in which
-// the box compensates for scroll. Frames that move the box but not its default anchor contribute negated.
+// One scroll node's contribution to the default scroll shift of an anchor-positioned box, masked to the axes in which
+// the box compensates for scroll. Nodes that move the box but not its default anchor contribute negated.
 struct AnchorScrollShift {
-    ScrollFrameIndex scroll_frame_index;
+    VisualContextIndex scroll_node_index;
     bool negate { false };
     bool compensate_horizontal_scroll { true };
     bool compensate_vertical_scroll { true };
@@ -153,6 +156,13 @@ public:
     void dump(VisualContextIndex, StringBuilder&) const;
 
     bool has_empty_effective_clip(VisualContextIndex i) const { return m_nodes[i.value()].has_empty_effective_clip; }
+
+    ScrollStateSlot scroll_state_slot_for_node(VisualContextIndex index) const
+    {
+        if (!index.value())
+            return NO_SCROLL_STATE_SLOT;
+        return m_nodes[index.value()].data.get<ScrollData>().state_slot;
+    }
 
 private:
     AccumulatedVisualContextTree(u64 version, Vector<AccumulatedVisualContextNode>&& nodes)

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -19,7 +19,7 @@
 #include <LibGfx/WindingRule.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
-#include <LibWeb/Painting/ScrollFrame.h>
+#include <LibWeb/Painting/ScrollNodeState.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::CSS {

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -182,7 +182,7 @@ void DisplayListPlayer::execute_impl(
     };
 
     auto apply_accumulated_visual_context =
-        [&](VisualContextIndex, AccumulatedVisualContextNode const& node) {
+        [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node) {
             node.data.visit(
                 [&](EffectsData const& effects) {
                     play_command(ApplyEffects {
@@ -197,17 +197,19 @@ void DisplayListPlayer::execute_impl(
                     play_command(Save {});
                     apply_transform({ 0, 0 }, perspective.matrix);
                 },
-                [&](ScrollData const& scroll) {
+                [&](ScrollData const&) {
                     play_command(Save {});
-                    auto offset = scroll_state.device_offset_for_index(scroll.scroll_frame_index);
+                    auto offset = scroll_state.device_offset_for_index(node_index);
                     if (!offset.is_zero())
                         play_command(Translate { .delta = offset.to_type<int>() });
                 },
                 [&](ScrollCompensation const& compensation) {
                     play_command(Save {});
-                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_frame_index);
+                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
+                    if (compensation.negate)
+                        offset = -offset;
                     if (!offset.is_zero())
-                        play_command(Translate { .delta = (-offset).to_type<int>() });
+                        play_command(Translate { .delta = offset.to_type<int>() });
                 },
                 [&](AnchorScrollShift const& shift) {
                     play_command(Save {});
@@ -335,7 +337,7 @@ void DisplayListPlayer::execute_impl(
         auto dispatch_command = [&]<DisplayListCommand Command>(auto&& callback) {
             auto command = read_display_list_command_payload<Command>(payload);
             if constexpr (IsSame<Command, PaintScrollBar>) {
-                auto device_offset = scroll_state.device_offset_for_index(command.scroll_frame_index);
+                auto device_offset = scroll_state.device_offset_for_index(command.scroll_node_index);
                 if (command.vertical)
                     command.thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * command.scroll_size));
                 else

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -201,8 +201,8 @@ void PaintNestedDisplayList::dump(StringBuilder& builder) const
 
 void CompositorScrollNode::dump(StringBuilder& builder) const
 {
-    builder.appendff(" scroll_frame_index={} parent_scroll_frame_index={} scrollport_rect={} max_scroll_offset={} is_viewport={}",
-        scroll_frame_index, parent_scroll_frame_index, scrollport_rect, max_scroll_offset, is_viewport);
+    builder.appendff(" scroll_node_index={} parent_scroll_node_index={} scrollport_rect={} max_scroll_offset={} is_viewport={}",
+        scroll_node_index, parent_scroll_node_index, scrollport_rect, max_scroll_offset, is_viewport);
 }
 
 static void dump_optional_float(StringBuilder& builder, Optional<float> value)
@@ -215,8 +215,8 @@ static void dump_optional_float(StringBuilder& builder, Optional<float> value)
 
 void CompositorStickyArea::dump(StringBuilder& builder) const
 {
-    builder.appendff(" scroll_frame_index={} parent_scroll_frame_index={} nearest_scrolling_ancestor_index={} position_relative_to_scroll_ancestor={} border_box_size={} scrollport_size={} containing_block_region={} needs_parent_offset_adjustment={} inset_top=",
-        scroll_frame_index, parent_scroll_frame_index, nearest_scrolling_ancestor_index, position_relative_to_scroll_ancestor, border_box_size, scrollport_size, containing_block_region, needs_parent_offset_adjustment);
+    builder.appendff(" scroll_node_index={} parent_scroll_node_index={} nearest_scrolling_ancestor_index={} position_relative_to_scroll_ancestor={} border_box_size={} scrollport_size={} containing_block_region={} needs_parent_offset_adjustment={} inset_top=",
+        scroll_node_index, parent_scroll_node_index, nearest_scrolling_ancestor_index, position_relative_to_scroll_ancestor, border_box_size, scrollport_size, containing_block_region, needs_parent_offset_adjustment);
     dump_optional_float(builder, inset_top);
     builder.append(" inset_right="sv);
     dump_optional_float(builder, inset_right);
@@ -233,12 +233,12 @@ void CompositorBlockingWheelEventRegion::dump(StringBuilder& builder) const
 
 void CompositorWheelHitTestTarget::dump(StringBuilder& builder) const
 {
-    builder.appendff(" target_scroll_frame_index={} rect={}", target_scroll_frame_index, rect);
+    builder.appendff(" target_scroll_node_index={} rect={}", target_scroll_node_index, rect);
 }
 
 void CompositorWheelHitTestTargetWithCornerRadii::dump(StringBuilder& builder) const
 {
-    builder.appendff(" target_scroll_frame_index={} rect={}", target_scroll_frame_index, rect);
+    builder.appendff(" target_scroll_node_index={} rect={}", target_scroll_node_index, rect);
     if (corner_radii.has_any_radius()) {
         builder.appendff(" corner_radii=[{}x{},{}x{},{}x{},{}x{}]",
             corner_radii.top_left.horizontal_radius, corner_radii.top_left.vertical_radius,
@@ -255,8 +255,8 @@ void CompositorMainThreadWheelEventRegion::dump(StringBuilder& builder) const
 
 void CompositorViewportScrollbar::dump(StringBuilder& builder) const
 {
-    builder.appendff(" scroll_frame_index={} gutter_rect={} thumb_rect={} expanded_gutter_rect={} expanded_thumb_rect={} scroll_size={} expanded_scroll_size={} max_scroll_offset={} thumb_color={} track_color={} vertical={}",
-        scroll_frame_index, gutter_rect, thumb_rect, expanded_gutter_rect, expanded_thumb_rect, scroll_size, expanded_scroll_size, max_scroll_offset, thumb_color, track_color, vertical);
+    builder.appendff(" scroll_node_index={} gutter_rect={} thumb_rect={} expanded_gutter_rect={} expanded_thumb_rect={} scroll_size={} expanded_scroll_size={} max_scroll_offset={} thumb_color={} track_color={} vertical={}",
+        scroll_node_index, gutter_rect, thumb_rect, expanded_gutter_rect, expanded_thumb_rect, scroll_size, expanded_scroll_size, max_scroll_offset, thumb_color, track_color, vertical);
 }
 
 void PaintScrollBar::dump(StringBuilder&) const

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -605,8 +605,8 @@ struct CompositorScrollNode {
 
     UniqueNodeID document_id;
     UniqueNodeID scrollable_node_id;
-    ScrollFrameIndex scroll_frame_index;
-    ScrollFrameIndex parent_scroll_frame_index;
+    VisualContextIndex scroll_node_index;
+    VisualContextIndex parent_scroll_node_index;
     Gfx::IntRect scrollport_rect;
     Gfx::FloatPoint max_scroll_offset;
     CompositorScrollNodeKind scroll_node_kind { CompositorScrollNodeKind::Element };
@@ -623,9 +623,9 @@ struct CompositorStickyArea {
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorStickyArea;
 
     UniqueNodeID document_id;
-    ScrollFrameIndex scroll_frame_index;
-    ScrollFrameIndex parent_scroll_frame_index;
-    ScrollFrameIndex nearest_scrolling_ancestor_index;
+    VisualContextIndex scroll_node_index;
+    VisualContextIndex parent_scroll_node_index;
+    VisualContextIndex nearest_scrolling_ancestor_index;
     Gfx::FloatPoint position_relative_to_scroll_ancestor;
     Gfx::FloatSize border_box_size;
     Gfx::FloatSize scrollport_size;
@@ -653,7 +653,7 @@ struct CompositorWheelHitTestTarget {
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorWheelHitTestTarget;
 
     UniqueNodeID document_id;
-    ScrollFrameIndex target_scroll_frame_index;
+    VisualContextIndex target_scroll_node_index;
     Gfx::FloatRect rect;
 
     void dump(StringBuilder&) const;
@@ -664,7 +664,7 @@ struct CompositorWheelHitTestTargetWithCornerRadii {
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorWheelHitTestTargetWithCornerRadii;
 
     UniqueNodeID document_id;
-    ScrollFrameIndex target_scroll_frame_index;
+    VisualContextIndex target_scroll_node_index;
     Gfx::FloatRect rect;
     Gfx::CornerRadii corner_radii;
 
@@ -685,7 +685,7 @@ struct CompositorViewportScrollbar {
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::CompositorViewportScrollbar;
 
     UniqueNodeID document_id;
-    ScrollFrameIndex scroll_frame_index;
+    VisualContextIndex scroll_node_index;
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
     Gfx::IntRect expanded_gutter_rect;
@@ -704,7 +704,7 @@ struct PaintScrollBar {
     static constexpr StringView command_name = "PaintScrollBar"sv;
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::PaintScrollBar;
 
-    ScrollFrameIndex scroll_frame_index;
+    VisualContextIndex scroll_node_index;
     Gfx::IntRect gutter_rect;
     Gfx::IntRect thumb_rect;
     double scroll_size;

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -106,12 +106,15 @@ static bool matrices_are_equal(Gfx::FloatMatrix4x4 const& a, Gfx::FloatMatrix4x4
     return true;
 }
 
-static bool visual_context_data_is_equal(VisualContextData const& a, VisualContextData const& b)
+static bool visual_context_data_is_equal(VisualContextIndex a_index, VisualContextData const& a, ScrollStateSnapshot const& a_scroll_state, VisualContextIndex b_index, VisualContextData const& b, ScrollStateSnapshot const& b_scroll_state)
 {
     return a.visit(
         [&](ScrollData const& data) {
             auto const* other = b.get_pointer<ScrollData>();
-            return other && data.scroll_frame_index == other->scroll_frame_index && data.is_sticky == other->is_sticky;
+            // The payload carries no offset key; replay reads the offset stored under each node's
+            // own index, so that is what has to match.
+            return other && data.is_sticky == other->is_sticky
+                && a_scroll_state.device_offset_for_index(a_index) == b_scroll_state.device_offset_for_index(b_index);
         },
         [&](ClipData const& data) {
             auto const* other = b.get_pointer<ClipData>();
@@ -149,15 +152,17 @@ static bool visual_context_data_is_equal(VisualContextData const& a, VisualConte
         },
         [&](ScrollCompensation const& data) {
             auto const* other = b.get_pointer<ScrollCompensation>();
-            return other && data.scroll_frame_index == other->scroll_frame_index;
+            return other
+                && data.negate == other->negate
+                && a_scroll_state.device_offset_for_index(data.scroll_node_index) == b_scroll_state.device_offset_for_index(other->scroll_node_index);
         },
         [&](AnchorScrollShift const& data) {
             auto const* other = b.get_pointer<AnchorScrollShift>();
             return other
-                && data.scroll_frame_index == other->scroll_frame_index
                 && data.negate == other->negate
                 && data.compensate_horizontal_scroll == other->compensate_horizontal_scroll
-                && data.compensate_vertical_scroll == other->compensate_vertical_scroll;
+                && data.compensate_vertical_scroll == other->compensate_vertical_scroll
+                && data.masked_offset(a_scroll_state) == other->masked_offset(b_scroll_state);
         });
 }
 
@@ -182,13 +187,13 @@ static bool visual_context_chains_are_compatible(VisualContextIndex old_index, A
     }
 }
 
-static bool visual_context_chains_are_equal(VisualContextIndex old_index, AccumulatedVisualContextTree const& old_tree, VisualContextIndex new_index, AccumulatedVisualContextTree const& new_tree)
+static bool visual_context_chains_are_equal(VisualContextIndex old_index, AccumulatedVisualContextTree const& old_tree, ScrollStateSnapshot const& old_scroll_state, VisualContextIndex new_index, AccumulatedVisualContextTree const& new_tree, ScrollStateSnapshot const& new_scroll_state)
 {
     for (;;) {
         auto const& old_node = old_tree.node_at(old_index);
         auto const& new_node = new_tree.node_at(new_index);
         if (old_node.has_empty_effective_clip != new_node.has_empty_effective_clip
-            || !visual_context_data_is_equal(old_node.data, new_node.data))
+            || !visual_context_data_is_equal(old_index, old_node.data, old_scroll_state, new_index, new_node.data, new_scroll_state))
             return false;
         if (old_index == VISUAL_VIEWPORT_NODE_INDEX)
             return true;
@@ -243,7 +248,7 @@ Optional<Gfx::IntRect> compute_display_list_damage(
     };
 
     auto add_visual_context_damage = [&](DisplayListCommandReference const& old_command, DisplayListCommandReference const& new_command) {
-        if (visual_context_chains_are_equal(old_command.header.context_index, old_visual_context_tree, new_command.header.context_index, new_visual_context_tree))
+        if (visual_context_chains_are_equal(old_command.header.context_index, old_visual_context_tree, old_scroll_state, new_command.header.context_index, new_visual_context_tree, new_scroll_state))
             return;
         if (!old_command.header.has_bounding_rect || !new_command.header.has_bounding_rect) {
             if (old_command.header.type == DisplayListCommandType::CompositorViewportScrollbar || old_command.header.type == DisplayListCommandType::PaintScrollBar)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -781,10 +781,10 @@ void DisplayListRecorder::fill_rect_with_rounded_corners(Gfx::IntRect const& a_r
             { bottom_left_radius, bottom_left_radius } });
 }
 
-void DisplayListRecorder::paint_scrollbar(ScrollFrameIndex scroll_frame_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical)
+void DisplayListRecorder::paint_scrollbar(VisualContextIndex scroll_node_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical)
 {
     append_command(PaintScrollBar {
-        .scroll_frame_index = scroll_frame_index,
+        .scroll_node_index = scroll_node_index,
         .gutter_rect = gutter_rect,
         .thumb_rect = thumb_rect,
         .scroll_size = scroll_size,

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -153,7 +153,7 @@ public:
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int radius);
     void fill_rect_with_rounded_corners(Gfx::IntRect const& a_rect, Color color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
 
-    void paint_scrollbar(ScrollFrameIndex scroll_frame_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical);
+    void paint_scrollbar(VisualContextIndex scroll_node_index, Gfx::IntRect gutter_rect, Gfx::IntRect thumb_rect, double scroll_size, Color thumb_color, Color track_color, bool vertical);
 
     void compositor_scroll_node(CompositorScrollNode const&);
     void compositor_sticky_area(CompositorStickyArea const&);

--- a/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
@@ -19,6 +19,7 @@
 
 namespace Web::Painting {
 
+class AccumulatedVisualContextTree;
 class HitTestDisplayList;
 class ScrollState;
 
@@ -89,11 +90,13 @@ public:
 
     void set_async_scrolling_metadata_context(
         UniqueNodeID document_id,
+        Painting::AccumulatedVisualContextTree const& visual_context_tree,
         Painting::ScrollState const& scroll_state,
         bool has_blocking_wheel_event_listeners,
         bool has_blocking_wheel_event_region_covering_viewport)
     {
         m_async_scrolling_document_id = document_id;
+        m_async_scrolling_visual_context_tree = &visual_context_tree;
         m_async_scrolling_scroll_state = &scroll_state;
         m_has_blocking_wheel_event_listeners = has_blocking_wheel_event_listeners;
         m_has_blocking_wheel_event_region_covering_viewport = has_blocking_wheel_event_region_covering_viewport;
@@ -101,6 +104,7 @@ public:
 
     bool is_recording_async_scrolling_metadata() const { return m_async_scrolling_scroll_state != nullptr; }
     UniqueNodeID async_scrolling_document_id() const { return m_async_scrolling_document_id; }
+    Painting::AccumulatedVisualContextTree const& async_scrolling_visual_context_tree() const { return *m_async_scrolling_visual_context_tree; }
     Painting::ScrollState const& async_scrolling_scroll_state() const { return *m_async_scrolling_scroll_state; }
     bool has_blocking_wheel_event_listeners() const { return m_has_blocking_wheel_event_listeners; }
     void set_has_blocking_wheel_event_listeners(bool value) { m_has_blocking_wheel_event_listeners = value; }
@@ -119,6 +123,7 @@ private:
     Gfx::AffineTransform m_svg_transform;
     u64 m_paint_generation_id { 0 };
     UniqueNodeID m_async_scrolling_document_id {};
+    Painting::AccumulatedVisualContextTree const* m_async_scrolling_visual_context_tree { nullptr };
     Painting::ScrollState const* m_async_scrolling_scroll_state { nullptr };
     bool m_has_blocking_wheel_event_listeners { false };
     bool m_has_blocking_wheel_event_region_covering_viewport { false };

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -203,8 +203,15 @@ void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext
         // NB: These nodes are transient: they're only referenced by the display list being recorded right now — and the
         //     next recording prunes them again (see ViewportPaintable::prune_inspector_overlay_visual_contexts).
         auto overlay_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
-        for (auto const& source_visual_context_index : relevant_indices.in_reverse())
-            overlay_visual_context_index = visual_context_tree.append(visual_context_tree.node_at(source_visual_context_index).data, overlay_visual_context_index);
+        for (auto const& source_visual_context_index : relevant_indices.in_reverse()) {
+            auto const& source_node_data = visual_context_tree.node_at(source_visual_context_index).data;
+            // A copied ScrollData node would look its offset up under the copy's own index, so scroll
+            // nodes are copied as non-negating compensations referencing the original instead.
+            auto data_for_overlay = source_node_data.has<ScrollData>()
+                ? VisualContextData { ScrollCompensation { source_visual_context_index, false } }
+                : source_node_data;
+            overlay_visual_context_index = visual_context_tree.append(move(data_for_overlay), overlay_visual_context_index);
+        }
 
         if (overlay_visual_context_index != VISUAL_VIEWPORT_NODE_INDEX)
             display_list_recorder.set_accumulated_visual_context(overlay_visual_context_index);
@@ -654,9 +661,9 @@ static void record_scroll_node(Paintable const& paintable_box, DisplayListRecord
     if (!scroll_node_kind.has_value())
         return;
 
-    auto parent_scroll_frame_index = ScrollFrameIndex {};
+    auto parent_scroll_node_index = VisualContextIndex {};
     if (auto scrollable_ancestor = paintable_box.nearest_scrollable_ancestor())
-        parent_scroll_frame_index = scrollable_ancestor->own_scroll_frame_index();
+        parent_scroll_node_index = scrollable_ancestor->own_scroll_node_index();
 
     auto scrollport_rect = paintable_box.is_viewport_paintable()
         ? Gfx::IntRect { {}, context.device_viewport_rect().size().to_type<int>() }
@@ -666,8 +673,8 @@ static void record_scroll_node(Paintable const& paintable_box, DisplayListRecord
     recorder.compositor_scroll_node({
         .document_id = paintable_box.document().unique_id(),
         .scrollable_node_id = scrollable_node_id_for(paintable_box),
-        .scroll_frame_index = paintable_box.own_scroll_frame_index(),
-        .parent_scroll_frame_index = parent_scroll_frame_index,
+        .scroll_node_index = paintable_box.own_scroll_node_index(),
+        .parent_scroll_node_index = parent_scroll_node_index,
         .scrollport_rect = scrollport_rect,
         .max_scroll_offset = css_point_to_device_point(maximum_scroll_offset_for(paintable_box), context.device_pixels_per_css_pixel()),
         .scroll_node_kind = *scroll_node_kind,
@@ -689,14 +696,14 @@ static void record_main_thread_wheel_event_region(Paintable const& paintable_box
     });
 }
 
-static Optional<ScrollFrameIndex> wheel_hit_test_target_scroll_frame_index_for(Paintable const& paintable_box)
+static Optional<VisualContextIndex> wheel_hit_test_target_scroll_node_index_for(Paintable const& paintable_box)
 {
-    if (paintable_box.own_scroll_frame_index().value() && paintable_box.could_be_scrolled_by_wheel_event())
-        return paintable_box.own_scroll_frame_index();
+    if (paintable_box.own_scroll_node_index().value() && paintable_box.could_be_scrolled_by_wheel_event())
+        return paintable_box.own_scroll_node_index();
     if (auto scrollable_ancestor = paintable_box.nearest_scrollable_ancestor())
-        return scrollable_ancestor->own_scroll_frame_index();
+        return scrollable_ancestor->own_scroll_node_index();
     if (auto viewport_paintable = paintable_box.document().paintable(); viewport_paintable && viewport_paintable->could_be_scrolled_by_wheel_event())
-        return viewport_paintable->own_scroll_frame_index();
+        return viewport_paintable->own_scroll_node_index();
     return {};
 }
 
@@ -709,12 +716,12 @@ static void record_wheel_hit_test_target(Paintable const& paintable_box, Display
     if (rect.is_empty())
         return;
 
-    auto target_scroll_frame_index = wheel_hit_test_target_scroll_frame_index_for(paintable_box).value_or({});
+    auto target_scroll_node_index = wheel_hit_test_target_scroll_node_index_for(paintable_box).value_or({});
     auto corner_radii = paintable_box.border_radii_data().as_corners(context.device_pixel_converter());
     if (corner_radii.has_any_radius()) {
         context.display_list_recorder().compositor_wheel_hit_test_target_with_corner_radii({
             .document_id = paintable_box.document().unique_id(),
-            .target_scroll_frame_index = target_scroll_frame_index,
+            .target_scroll_node_index = target_scroll_node_index,
             .rect = rect,
             .corner_radii = corner_radii,
         });
@@ -723,7 +730,7 @@ static void record_wheel_hit_test_target(Paintable const& paintable_box, Display
 
     context.display_list_recorder().compositor_wheel_hit_test_target({
         .document_id = paintable_box.document().unique_id(),
-        .target_scroll_frame_index = target_scroll_frame_index,
+        .target_scroll_node_index = target_scroll_node_index,
         .rect = rect,
     });
 }
@@ -815,7 +822,7 @@ static void record_viewport_scrollbar_state(Paintable const& paintable_box, Disp
 
         context.display_list_recorder().compositor_viewport_scrollbar({
             .document_id = paintable_box.document().unique_id(),
-            .scroll_frame_index = paintable_box.own_scroll_frame_index(),
+            .scroll_node_index = paintable_box.own_scroll_node_index(),
             .gutter_rect = gutter_rect,
             .thumb_rect = context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
             .expanded_gutter_rect = context.rounded_device_rect(expanded_scrollbar_data->gutter_rect).to_type<int>(),
@@ -1081,8 +1088,8 @@ void Paintable::reset_for_relayout()
 
     invalidate_absolute_geometry_cache(InvalidateDescendantGeometry::No);
 
-    m_enclosing_scroll_frame_index = {};
-    m_own_scroll_frame_index = {};
+    m_enclosing_scroll_node_index = {};
+    m_own_scroll_node_index = {};
     m_accumulated_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
     m_accumulated_visual_context_for_descendants_index = VISUAL_VIEWPORT_NODE_INDEX;
     m_fixed_background_visual_context = {};
@@ -1535,7 +1542,7 @@ Optional<Paintable::ScrollbarData> Paintable::compute_scrollbar_data(ScrollDirec
     if (overflow != CSS::Overflow::Scroll && !could_be_scrolled_by_wheel_event(direction))
         return {};
 
-    if (!m_own_scroll_frame_index.value())
+    if (!m_own_scroll_node_index.value())
         return {};
 
     auto scrollable_overflow_rect = this->scrollable_overflow_rect();
@@ -1587,7 +1594,7 @@ Optional<Paintable::ScrollbarData> Paintable::compute_scrollbar_data(ScrollDirec
         scrollbar_data.thumb_travel_to_scroll_ratio = (usable_scrollbar_length - thumb_length) / (scrollable_overflow_length - scrollport_size);
 
     if (scroll_state_snapshot) {
-        auto own_offset = scroll_state_snapshot->device_offset_for_index(m_own_scroll_frame_index);
+        auto own_offset = scroll_state_snapshot->device_offset_for_index(m_own_scroll_node_index);
         auto device_scroll_offset = is_horizontal ? -own_offset.x() : -own_offset.y();
         auto device_pixels_per_css_pixel = static_cast<float>(document().page().client().device_pixels_per_css_pixel());
         CSSPixels thumb_offset = CSSPixels::nearest_value_for(device_scroll_offset / device_pixels_per_css_pixel) * scrollbar_data.thumb_travel_to_scroll_ratio;
@@ -1611,23 +1618,24 @@ void Paintable::record_async_scrolling_metadata(DisplayListRecordingContext& con
 
     if (is_nested_navigable_container(*this)) {
         record_main_thread_wheel_event_region(*this, context);
-    } else if (own_scroll_frame_index().value() && could_be_scrolled_by_wheel_event()) {
+    } else if (own_scroll_node_index().value() && could_be_scrolled_by_wheel_event()) {
         record_scroll_node(*this, context);
     }
     record_viewport_scrollbar_state(*this, context);
 
     auto const& scroll_state = context.async_scrolling_scroll_state();
-    auto sticky_frame_index = enclosing_scroll_frame_index();
+    auto sticky_frame_index = enclosing_scroll_node_index();
     if (is_sticky_position() && sticky_frame_index.value()) {
-        auto const& frame = scroll_state.frame_at(sticky_frame_index);
+        auto sticky_slot = context.async_scrolling_visual_context_tree().scroll_state_slot_for_node(sticky_frame_index);
+        auto const& frame = scroll_state.frame_at_slot(sticky_slot);
         if (frame.is_sticky() && frame.has_sticky_constraints()) {
             auto const& constraints = frame.sticky_constraints();
             auto const& insets = constraints.insets;
             recorder.compositor_sticky_area({
                 .document_id = context.async_scrolling_document_id(),
-                .scroll_frame_index = sticky_frame_index,
-                .parent_scroll_frame_index = frame.parent_index(),
-                .nearest_scrolling_ancestor_index = scroll_state.nearest_scrolling_ancestor(sticky_frame_index),
+                .scroll_node_index = sticky_frame_index,
+                .parent_scroll_node_index = scroll_state.node_index_for_slot(frame.parent_slot()),
+                .nearest_scrolling_ancestor_index = scroll_state.node_index_for_slot(scroll_state.nearest_scrolling_ancestor_slot(sticky_slot)),
                 .position_relative_to_scroll_ancestor = css_point_to_device_point(constraints.position_relative_to_scroll_ancestor, device_pixels_per_css_pixel),
                 .border_box_size = css_size_to_device_size(constraints.border_box_size, device_pixels_per_css_pixel),
                 .scrollport_size = css_size_to_device_size(constraints.scrollport_size, device_pixels_per_css_pixel),
@@ -1720,7 +1728,7 @@ void Paintable::paint(DisplayListRecordingContext& context, PaintPhase phase) co
                     continue;
                 auto gutter_rect = context.rounded_device_rect(scrollbar_data->gutter_rect).to_type<int>();
                 context.display_list_recorder().paint_scrollbar(
-                    m_own_scroll_frame_index,
+                    m_own_scroll_node_index,
                     gutter_rect,
                     context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(),
                     scrollbar_data->thumb_travel_to_scroll_ratio.to_double(),
@@ -2807,14 +2815,14 @@ CSSPixels Paintable::outline_offset() const
     return computed_values().outline_offset();
 }
 
-ScrollFrameIndex Paintable::nearest_scroll_frame_index() const
+VisualContextIndex Paintable::nearest_scroll_node_index() const
 {
     if (is_fixed_position())
         return {};
     auto const* paintable = containing_block_ptr();
     while (paintable) {
-        if (paintable->own_scroll_frame_index().value())
-            return paintable->own_scroll_frame_index();
+        if (paintable->own_scroll_node_index().value())
+            return paintable->own_scroll_node_index();
         // Sticky elements need to find a scroll container even through fixed-position ancestors,
         // because they must reference a scrollport for their sticky offset computation.
         if (paintable->is_fixed_position() && !is_sticky_position())

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -1624,17 +1624,17 @@ void Paintable::record_async_scrolling_metadata(DisplayListRecordingContext& con
     record_viewport_scrollbar_state(*this, context);
 
     auto const& scroll_state = context.async_scrolling_scroll_state();
-    auto sticky_frame_index = enclosing_scroll_node_index();
-    if (is_sticky_position() && sticky_frame_index.value()) {
-        auto sticky_slot = context.async_scrolling_visual_context_tree().scroll_state_slot_for_node(sticky_frame_index);
-        auto const& frame = scroll_state.frame_at_slot(sticky_slot);
-        if (frame.is_sticky() && frame.has_sticky_constraints()) {
-            auto const& constraints = frame.sticky_constraints();
+    auto sticky_node_index = enclosing_scroll_node_index();
+    if (is_sticky_position() && sticky_node_index.value()) {
+        auto sticky_slot = context.async_scrolling_visual_context_tree().scroll_state_slot_for_node(sticky_node_index);
+        auto const& sticky_node_state = scroll_state.state_at_slot(sticky_slot);
+        if (sticky_node_state.is_sticky() && sticky_node_state.has_sticky_constraints()) {
+            auto const& constraints = sticky_node_state.sticky_constraints();
             auto const& insets = constraints.insets;
             recorder.compositor_sticky_area({
                 .document_id = context.async_scrolling_document_id(),
-                .scroll_node_index = sticky_frame_index,
-                .parent_scroll_node_index = scroll_state.node_index_for_slot(frame.parent_slot()),
+                .scroll_node_index = sticky_node_index,
+                .parent_scroll_node_index = scroll_state.node_index_for_slot(sticky_node_state.parent_slot()),
                 .nearest_scrolling_ancestor_index = scroll_state.node_index_for_slot(scroll_state.nearest_scrolling_ancestor_slot(sticky_slot)),
                 .position_relative_to_scroll_ancestor = css_point_to_device_point(constraints.position_relative_to_scroll_ancestor, device_pixels_per_css_pixel),
                 .border_box_size = css_size_to_device_size(constraints.border_box_size, device_pixels_per_css_pixel),

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -368,7 +368,7 @@ public:
 
     CSSPixelRect transform_reference_box() const;
 
-    ScrollFrameIndex nearest_scroll_frame_index() const;
+    VisualContextIndex nearest_scroll_node_index() const;
 
     RefPtr<Paintable const> nearest_scrollable_ancestor() const;
 
@@ -393,8 +393,8 @@ public:
     void paint_flexbox_inspector_overlay(DisplayListRecordingContext&, FlexboxInspectorOverlayOptions const&) const;
     void paint_grid_inspector_overlay(DisplayListRecordingContext&, GridInspectorOverlayOptions const&) const;
 
-    void set_enclosing_scroll_frame_index(ScrollFrameIndex index) { m_enclosing_scroll_frame_index = index; }
-    void set_own_scroll_frame_index(ScrollFrameIndex index) { m_own_scroll_frame_index = index; }
+    void set_enclosing_scroll_node_index(VisualContextIndex index) { m_enclosing_scroll_node_index = index; }
+    void set_own_scroll_node_index(VisualContextIndex index) { m_own_scroll_node_index = index; }
 
     void set_accumulated_visual_context(VisualContextIndex index) { m_accumulated_visual_context_index = index; }
     [[nodiscard]] VisualContextIndex accumulated_visual_context_index() const { return m_accumulated_visual_context_index; }
@@ -426,9 +426,9 @@ public:
     [[nodiscard]] size_t visual_context_nodes_begin() const { return m_visual_context_nodes_begin; }
     [[nodiscard]] size_t visual_context_nodes_end() const { return m_visual_context_nodes_end; }
 
-    [[nodiscard]] ScrollFrameIndex enclosing_scroll_frame_index() const { return m_enclosing_scroll_frame_index; }
+    [[nodiscard]] VisualContextIndex enclosing_scroll_node_index() const { return m_enclosing_scroll_node_index; }
 
-    [[nodiscard]] ScrollFrameIndex own_scroll_frame_index() const { return m_own_scroll_frame_index; }
+    [[nodiscard]] VisualContextIndex own_scroll_node_index() const { return m_own_scroll_node_index; }
 
 protected:
     explicit Paintable(Layout::NodeWithStyleAndBoxModelMetrics const&);
@@ -498,8 +498,8 @@ private:
     Optional<CSSPixelRect> mutable m_absolute_padding_box_rect;
     Optional<CSSPixelRect> mutable m_absolute_border_box_rect;
 
-    ScrollFrameIndex m_enclosing_scroll_frame_index {};
-    ScrollFrameIndex m_own_scroll_frame_index {};
+    VisualContextIndex m_enclosing_scroll_node_index {};
+    VisualContextIndex m_own_scroll_node_index {};
     VisualContextIndex m_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
     VisualContextIndex m_accumulated_visual_context_for_descendants_index { VISUAL_VIEWPORT_NODE_INDEX };
     Optional<VisualContextIndex> m_fixed_background_visual_context;

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -33,7 +33,7 @@
 #include <LibWeb/Painting/HitTestResult.h>
 #include <LibWeb/Painting/PaintableTypes.h>
 #include <LibWeb/Painting/ResolvedCSSFilter.h>
-#include <LibWeb/Painting/ScrollFrame.h>
+#include <LibWeb/Painting/ScrollNodeState.h>
 #include <LibWeb/Painting/ShadowData.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/RefCountedTreeNode.h>

--- a/Libraries/LibWeb/Painting/ScrollFrame.cpp
+++ b/Libraries/LibWeb/Painting/ScrollFrame.cpp
@@ -9,10 +9,11 @@
 
 namespace Web::Painting {
 
-ScrollFrame::ScrollFrame(Paintable const& paintable_box, bool sticky, ScrollFrameIndex parent_index)
+ScrollFrame::ScrollFrame(VisualContextIndex node_index, Paintable const& paintable_box, bool sticky, ScrollStateSlot parent_slot)
     : m_paintable_box(paintable_box)
     , m_sticky(sticky)
-    , m_parent_index(parent_index)
+    , m_node_index(node_index)
+    , m_parent_slot(parent_slot)
 {
 }
 

--- a/Libraries/LibWeb/Painting/ScrollFrame.cpp
+++ b/Libraries/LibWeb/Painting/ScrollFrame.cpp
@@ -16,11 +16,9 @@ ScrollFrame::ScrollFrame(Paintable const& paintable_box, bool sticky, ScrollFram
 {
 }
 
-Paintable const& ScrollFrame::paintable_box() const
+RefPtr<Paintable const> ScrollFrame::paintable_box_if_alive() const
 {
-    auto paintable_box = m_paintable_box.strong_ref();
-    VERIFY(paintable_box);
-    return *paintable_box;
+    return m_paintable_box.strong_ref();
 }
 
 }

--- a/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -7,13 +7,18 @@
 #pragma once
 
 #include <AK/DistinctNumeric.h>
+#include <AK/NumericLimits.h>
 #include <AK/WeakPtr.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Painting/VisualContextIndex.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {
 
-AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, ScrollFrameIndex);
+// Position of a scroll or sticky node's entry in the ScrollState store. Slot 0 is the viewport's
+// scroll node, so "no slot" needs a value outside the vector.
+AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, ScrollStateSlot);
+static constexpr ScrollStateSlot NO_SCROLL_STATE_SLOT { NumericLimits<size_t>::max() };
 
 struct StickyInsets {
     Optional<CSSPixels> top;
@@ -31,10 +36,16 @@ struct StickyConstraints {
     StickyInsets insets;
 };
 
+// Dynamic state of one scroll or sticky node in the accumulated visual context tree. The tree owns
+// structure and identity, and the node's ScrollData addresses its entry here by slot; the entry
+// carries the values that change without a rebuild: the scroll offset and sticky constraints. The
+// scroll-parent reference is derived from the containing block chain at build time, which
+// deliberately differs from the node's visual context parent chain for sticky content inside
+// fixed-position ancestors.
 class ScrollFrame {
 public:
     ScrollFrame() = default;
-    ScrollFrame(Paintable const& paintable_box, bool sticky, ScrollFrameIndex parent_index);
+    ScrollFrame(VisualContextIndex node_index, Paintable const& paintable_box, bool sticky, ScrollStateSlot parent_slot);
 
     RefPtr<Paintable const> paintable_box_if_alive() const;
 
@@ -47,19 +58,19 @@ public:
         m_own_offset = offset;
     }
 
-    ScrollFrameIndex parent_index() const { return m_parent_index; }
+    VisualContextIndex node_index() const { return m_node_index; }
+
+    ScrollStateSlot parent_slot() const { return m_parent_slot; }
 
     void set_sticky_constraints(StickyConstraints constraints) { m_sticky_constraints = constraints; }
     bool has_sticky_constraints() const { return m_sticky_constraints.has_value(); }
     StickyConstraints const& sticky_constraints() const { return m_sticky_constraints.value(); }
 
 private:
-    friend class ScrollState;
-    friend class ScrollStateSnapshot;
-
     WeakPtr<Paintable> m_paintable_box;
     bool m_sticky { false };
-    ScrollFrameIndex m_parent_index;
+    VisualContextIndex m_node_index;
+    ScrollStateSlot m_parent_slot { NO_SCROLL_STATE_SLOT };
     CSSPixelPoint m_own_offset;
     Optional<StickyConstraints> m_sticky_constraints;
 };

--- a/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -36,7 +36,7 @@ public:
     ScrollFrame() = default;
     ScrollFrame(Paintable const& paintable_box, bool sticky, ScrollFrameIndex parent_index);
 
-    Paintable const& paintable_box() const;
+    RefPtr<Paintable const> paintable_box_if_alive() const;
 
     bool is_sticky() const { return m_sticky; }
 

--- a/Libraries/LibWeb/Painting/ScrollNodeState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollNodeState.cpp
@@ -5,11 +5,11 @@
  */
 
 #include <LibWeb/Painting/Paintable.h>
-#include <LibWeb/Painting/ScrollFrame.h>
+#include <LibWeb/Painting/ScrollNodeState.h>
 
 namespace Web::Painting {
 
-ScrollFrame::ScrollFrame(VisualContextIndex node_index, Paintable const& paintable_box, bool sticky, ScrollStateSlot parent_slot)
+ScrollNodeState::ScrollNodeState(VisualContextIndex node_index, Paintable const& paintable_box, bool sticky, ScrollStateSlot parent_slot)
     : m_paintable_box(paintable_box)
     , m_sticky(sticky)
     , m_node_index(node_index)
@@ -17,7 +17,7 @@ ScrollFrame::ScrollFrame(VisualContextIndex node_index, Paintable const& paintab
 {
 }
 
-RefPtr<Paintable const> ScrollFrame::paintable_box_if_alive() const
+RefPtr<Paintable const> ScrollNodeState::paintable_box_if_alive() const
 {
     return m_paintable_box.strong_ref();
 }

--- a/Libraries/LibWeb/Painting/ScrollNodeState.h
+++ b/Libraries/LibWeb/Painting/ScrollNodeState.h
@@ -42,10 +42,10 @@ struct StickyConstraints {
 // scroll-parent reference is derived from the containing block chain at build time, which
 // deliberately differs from the node's visual context parent chain for sticky content inside
 // fixed-position ancestors.
-class ScrollFrame {
+class ScrollNodeState {
 public:
-    ScrollFrame() = default;
-    ScrollFrame(VisualContextIndex node_index, Paintable const& paintable_box, bool sticky, ScrollStateSlot parent_slot);
+    ScrollNodeState() = default;
+    ScrollNodeState(VisualContextIndex node_index, Paintable const& paintable_box, bool sticky, ScrollStateSlot parent_slot);
 
     RefPtr<Paintable const> paintable_box_if_alive() const;
 

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -15,8 +15,8 @@ ScrollStateSnapshot ScrollState::snapshot(double device_pixels_per_css_pixel) co
 {
     ScrollStateSnapshot snapshot;
     auto scale = static_cast<float>(device_pixels_per_css_pixel);
-    for (auto const& frame : m_frames_by_slot)
-        snapshot.set_device_offset_for_index(frame.node_index(), frame.own_offset().to_type<float>() * scale);
+    for (auto const& state : m_states_by_slot)
+        snapshot.set_device_offset_for_index(state.node_index(), state.own_offset().to_type<float>() * scale);
     return snapshot;
 }
 

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -11,22 +11,12 @@
 
 namespace Web::Painting {
 
-ScrollStateSnapshot ScrollStateSnapshot::create(Vector<ScrollFrame> const& scroll_frames, double device_pixels_per_css_pixel)
+ScrollStateSnapshot ScrollState::snapshot(double device_pixels_per_css_pixel) const
 {
     ScrollStateSnapshot snapshot;
     auto scale = static_cast<float>(device_pixels_per_css_pixel);
-    snapshot.m_device_offsets.ensure_capacity(scroll_frames.size());
-    for (auto const& scroll_frame : scroll_frames) {
-        auto const& offset = scroll_frame.own_offset();
-        snapshot.m_device_offsets.unchecked_append(offset.to_type<float>() * scale);
-    }
-    return snapshot;
-}
-
-ScrollStateSnapshot ScrollStateSnapshot::create_from_device_offsets(Vector<Gfx::FloatPoint>&& device_offsets)
-{
-    ScrollStateSnapshot snapshot;
-    snapshot.m_device_offsets = move(device_offsets);
+    for (auto const& frame : m_frames_by_slot)
+        snapshot.set_device_offset_for_index(frame.node_index(), frame.own_offset().to_type<float>() * scale);
     return snapshot;
 }
 
@@ -34,17 +24,39 @@ ScrollStateSnapshot ScrollStateSnapshot::create_from_device_offsets(Vector<Gfx::
 
 namespace IPC {
 
+// The dense in-process vector spans the whole visual context index space, but only scroll and
+// sticky node indices can hold non-zero offsets, so the wire format is sparse (index, offset)
+// pairs; holes decode back to zero offsets.
 template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollStateSnapshot const& snapshot)
 {
-    TRY(encoder.encode(snapshot.device_offsets()));
+    auto device_offsets = snapshot.device_offsets();
+    u64 non_zero_offset_count = 0;
+    for (auto const& offset : device_offsets) {
+        if (!offset.is_zero())
+            ++non_zero_offset_count;
+    }
+    TRY(encoder.encode(non_zero_offset_count));
+    for (size_t index = 0; index < device_offsets.size(); ++index) {
+        if (device_offsets[index].is_zero())
+            continue;
+        TRY(encoder.encode(static_cast<u64>(index)));
+        TRY(encoder.encode(device_offsets[index]));
+    }
     return {};
 }
 
 template<>
 ErrorOr<Web::Painting::ScrollStateSnapshot> decode(Decoder& decoder)
 {
-    return Web::Painting::ScrollStateSnapshot::create_from_device_offsets(TRY(decoder.decode<Vector<Gfx::FloatPoint>>()));
+    auto pair_count = TRY(decoder.decode<u64>());
+    Web::Painting::ScrollStateSnapshot snapshot;
+    for (u64 i = 0; i < pair_count; ++i) {
+        auto index = TRY(decoder.decode<u64>());
+        auto offset = TRY(decoder.decode<Gfx::FloatPoint>());
+        snapshot.set_device_offset_for_index(Web::Painting::VisualContextIndex { index }, offset);
+    }
+    return snapshot;
 }
 
 }

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -9,7 +9,7 @@
 #include <LibGfx/Point.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
-#include <LibWeb/Painting/ScrollFrame.h>
+#include <LibWeb/Painting/ScrollNodeState.h>
 
 namespace Web::Painting {
 
@@ -46,33 +46,33 @@ private:
 // between rebuilds.
 class ScrollState {
 public:
-    ScrollStateSlot register_scroll_frame(VisualContextIndex node_index, Paintable const& paintable_box, ScrollStateSlot parent_slot)
+    ScrollStateSlot register_scroll_node(VisualContextIndex node_index, Paintable const& paintable_box, ScrollStateSlot parent_slot)
     {
-        return append_frame(ScrollFrame { node_index, paintable_box, false, parent_slot });
+        return append_state(ScrollNodeState { node_index, paintable_box, false, parent_slot });
     }
 
-    ScrollStateSlot register_sticky_frame(VisualContextIndex node_index, Paintable const& paintable_box, ScrollStateSlot parent_slot)
+    ScrollStateSlot register_sticky_node(VisualContextIndex node_index, Paintable const& paintable_box, ScrollStateSlot parent_slot)
     {
-        return append_frame(ScrollFrame { node_index, paintable_box, true, parent_slot });
+        return append_state(ScrollNodeState { node_index, paintable_box, true, parent_slot });
     }
 
-    ScrollFrame const& frame_at_slot(ScrollStateSlot slot) const { return m_frames_by_slot[slot.value()]; }
-    ScrollFrame& frame_at_slot(ScrollStateSlot slot) { return m_frames_by_slot[slot.value()]; }
+    ScrollNodeState const& state_at_slot(ScrollStateSlot slot) const { return m_states_by_slot[slot.value()]; }
+    ScrollNodeState& state_at_slot(ScrollStateSlot slot) { return m_states_by_slot[slot.value()]; }
 
     VisualContextIndex node_index_for_slot(ScrollStateSlot slot) const
     {
         if (slot == NO_SCROLL_STATE_SLOT)
             return {};
-        return frame_at_slot(slot).node_index();
+        return state_at_slot(slot).node_index();
     }
 
     CSSPixelPoint cumulative_offset(ScrollStateSlot slot) const
     {
         CSSPixelPoint offset;
         while (slot != NO_SCROLL_STATE_SLOT) {
-            auto const& frame = frame_at_slot(slot);
-            offset += frame.own_offset();
-            slot = frame.parent_slot();
+            auto const& state = state_at_slot(slot);
+            offset += state.own_offset();
+            slot = state.parent_slot();
         }
         return offset;
     }
@@ -81,65 +81,65 @@ public:
     {
         CSSPixelPoint offset;
         while (slot != NO_SCROLL_STATE_SLOT) {
-            auto const& frame = frame_at_slot(slot);
-            if (!frame.is_sticky())
+            auto const& state = state_at_slot(slot);
+            if (!state.is_sticky())
                 break;
-            offset += frame.own_offset();
-            slot = frame.parent_slot();
+            offset += state.own_offset();
+            slot = state.parent_slot();
         }
         return offset;
     }
 
     ScrollStateSlot nearest_scrolling_ancestor_slot(ScrollStateSlot slot) const
     {
-        auto ancestor_slot = frame_at_slot(slot).parent_slot();
+        auto ancestor_slot = state_at_slot(slot).parent_slot();
         while (ancestor_slot != NO_SCROLL_STATE_SLOT) {
-            auto const& frame = frame_at_slot(ancestor_slot);
-            if (!frame.is_sticky())
+            auto const& state = state_at_slot(ancestor_slot);
+            if (!state.is_sticky())
                 return ancestor_slot;
-            ancestor_slot = frame.parent_slot();
+            ancestor_slot = state.parent_slot();
         }
         return NO_SCROLL_STATE_SLOT;
     }
 
-    // Iteration follows registration order, which is the tree's append order, so parent frames are
+    // Iteration follows registration order, which is the tree's append order, so parent nodes are
     // always visited before their descendants.
     template<typename Callback>
-    void for_each_scroll_frame(Callback callback)
+    void for_each_scroll_node(Callback callback)
     {
-        for (size_t slot_value = 0; slot_value < m_frames_by_slot.size(); ++slot_value) {
-            if (!m_frames_by_slot[slot_value].is_sticky())
-                callback(ScrollStateSlot { slot_value }, m_frames_by_slot[slot_value]);
+        for (size_t slot_value = 0; slot_value < m_states_by_slot.size(); ++slot_value) {
+            if (!m_states_by_slot[slot_value].is_sticky())
+                callback(ScrollStateSlot { slot_value }, m_states_by_slot[slot_value]);
         }
     }
 
     template<typename Callback>
-    void for_each_sticky_frame(Callback callback)
+    void for_each_sticky_node(Callback callback)
     {
-        for (size_t slot_value = 0; slot_value < m_frames_by_slot.size(); ++slot_value) {
-            if (m_frames_by_slot[slot_value].is_sticky())
-                callback(ScrollStateSlot { slot_value }, m_frames_by_slot[slot_value]);
+        for (size_t slot_value = 0; slot_value < m_states_by_slot.size(); ++slot_value) {
+            if (m_states_by_slot[slot_value].is_sticky())
+                callback(ScrollStateSlot { slot_value }, m_states_by_slot[slot_value]);
         }
     }
 
     void clear()
     {
-        m_frames_by_slot.clear_with_capacity();
+        m_states_by_slot.clear_with_capacity();
     }
 
 private:
     friend class ViewportPaintable;
 
-    ScrollStateSlot append_frame(ScrollFrame frame)
+    ScrollStateSlot append_state(ScrollNodeState state)
     {
-        auto slot = ScrollStateSlot { m_frames_by_slot.size() };
-        m_frames_by_slot.append(move(frame));
+        auto slot = ScrollStateSlot { m_states_by_slot.size() };
+        m_states_by_slot.append(move(state));
         return slot;
     }
 
     ScrollStateSnapshot snapshot(double device_pixels_per_css_pixel) const;
 
-    Vector<ScrollFrame> m_frames_by_slot;
+    Vector<ScrollNodeState> m_states_by_slot;
 };
 
 }

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -13,21 +13,21 @@
 
 namespace Web::Painting {
 
+// Device-pixel scroll offsets keyed by the scroll node's VisualContextIndex. Stored dense in
+// process so display list replay and hit testing index it directly; indices that are not scroll
+// nodes read as zero offsets. The IPC representation is sparse (index, offset) pairs.
 class ScrollStateSnapshot {
 public:
-    static ScrollStateSnapshot create(Vector<ScrollFrame> const& scroll_frames, double device_pixels_per_css_pixel);
-    static ScrollStateSnapshot create_from_device_offsets(Vector<Gfx::FloatPoint>&&);
-
     ReadonlySpan<Gfx::FloatPoint> device_offsets() const { return m_device_offsets; }
 
-    Gfx::FloatPoint device_offset_for_index(ScrollFrameIndex index) const
+    Gfx::FloatPoint device_offset_for_index(VisualContextIndex index) const
     {
         if (index.value() >= m_device_offsets.size())
             return {};
         return m_device_offsets[index.value()];
     }
 
-    void set_device_offset_for_index(ScrollFrameIndex index, Gfx::FloatPoint offset)
+    void set_device_offset_for_index(VisualContextIndex index, Gfx::FloatPoint offset)
     {
         if (index.value() >= m_device_offsets.size())
             m_device_offsets.resize(index.value() + 1);
@@ -38,98 +38,108 @@ private:
     Vector<Gfx::FloatPoint> m_device_offsets;
 };
 
+// Value store for the scroll and sticky nodes of the accumulated visual context tree: the tree
+// owns structure and identity, entries here carry the offsets, sticky constraints, and the
+// containing-block-derived scroll-parent references. Registration returns the entry's slot, which
+// the tree walk stamps into the node's ScrollData, so resolving a node to its entry is a direct
+// index in both directions. Rebuilt together with the tree; offsets are refreshed in place
+// between rebuilds.
 class ScrollState {
 public:
-    // ScrollFrameIndex is 1-based: value 0 means "no frame".
-    // Index 0 in m_scroll_frames is a sentinel (never accessed by callers).
-    // Value N maps directly to m_scroll_frames[N].
-    ScrollState()
+    ScrollStateSlot register_scroll_frame(VisualContextIndex node_index, Paintable const& paintable_box, ScrollStateSlot parent_slot)
     {
-        m_scroll_frames.empend(); // Sentinel at index 0
+        return append_frame(ScrollFrame { node_index, paintable_box, false, parent_slot });
     }
 
-    ScrollFrameIndex create_scroll_frame_for(Paintable const& paintable_box, ScrollFrameIndex parent)
+    ScrollStateSlot register_sticky_frame(VisualContextIndex node_index, Paintable const& paintable_box, ScrollStateSlot parent_slot)
     {
-        auto index = ScrollFrameIndex { m_scroll_frames.size() };
-        m_scroll_frames.empend(paintable_box, false, parent);
-        return index;
+        return append_frame(ScrollFrame { node_index, paintable_box, true, parent_slot });
     }
 
-    ScrollFrameIndex create_sticky_frame_for(Paintable const& paintable_box, ScrollFrameIndex parent)
+    ScrollFrame const& frame_at_slot(ScrollStateSlot slot) const { return m_frames_by_slot[slot.value()]; }
+    ScrollFrame& frame_at_slot(ScrollStateSlot slot) { return m_frames_by_slot[slot.value()]; }
+
+    VisualContextIndex node_index_for_slot(ScrollStateSlot slot) const
     {
-        auto index = ScrollFrameIndex { m_scroll_frames.size() };
-        m_scroll_frames.empend(paintable_box, true, parent);
-        return index;
+        if (slot == NO_SCROLL_STATE_SLOT)
+            return {};
+        return frame_at_slot(slot).node_index();
     }
 
-    ScrollFrame const& frame_at(ScrollFrameIndex index) const { return m_scroll_frames[index.value()]; }
-    ScrollFrame& frame_at(ScrollFrameIndex index) { return m_scroll_frames[index.value()]; }
-
-    CSSPixelPoint cumulative_offset(ScrollFrameIndex index) const
+    CSSPixelPoint cumulative_offset(ScrollStateSlot slot) const
     {
         CSSPixelPoint offset;
-        while (index.value()) {
-            offset += frame_at(index).own_offset();
-            index = frame_at(index).parent_index();
+        while (slot != NO_SCROLL_STATE_SLOT) {
+            auto const& frame = frame_at_slot(slot);
+            offset += frame.own_offset();
+            slot = frame.parent_slot();
         }
         return offset;
     }
 
-    CSSPixelPoint cumulative_sticky_offset(ScrollFrameIndex index) const
+    CSSPixelPoint cumulative_sticky_offset(ScrollStateSlot slot) const
     {
         CSSPixelPoint offset;
-        while (index.value() && frame_at(index).is_sticky()) {
-            offset += frame_at(index).own_offset();
-            index = frame_at(index).parent_index();
+        while (slot != NO_SCROLL_STATE_SLOT) {
+            auto const& frame = frame_at_slot(slot);
+            if (!frame.is_sticky())
+                break;
+            offset += frame.own_offset();
+            slot = frame.parent_slot();
         }
         return offset;
     }
 
-    ScrollFrameIndex nearest_scrolling_ancestor(ScrollFrameIndex index) const
+    ScrollStateSlot nearest_scrolling_ancestor_slot(ScrollStateSlot slot) const
     {
-        auto ancestor = frame_at(index).parent_index();
-        while (ancestor.value()) {
-            if (!frame_at(ancestor).is_sticky())
-                return ancestor;
-            ancestor = frame_at(ancestor).parent_index();
+        auto ancestor_slot = frame_at_slot(slot).parent_slot();
+        while (ancestor_slot != NO_SCROLL_STATE_SLOT) {
+            auto const& frame = frame_at_slot(ancestor_slot);
+            if (!frame.is_sticky())
+                return ancestor_slot;
+            ancestor_slot = frame.parent_slot();
         }
-        return {};
+        return NO_SCROLL_STATE_SLOT;
     }
 
+    // Iteration follows registration order, which is the tree's append order, so parent frames are
+    // always visited before their descendants.
     template<typename Callback>
     void for_each_scroll_frame(Callback callback)
     {
-        for (size_t i = 1; i < m_scroll_frames.size(); ++i) {
-            if (m_scroll_frames[i].is_sticky())
-                continue;
-            callback(ScrollFrameIndex { i }, m_scroll_frames[i]);
+        for (size_t slot_value = 0; slot_value < m_frames_by_slot.size(); ++slot_value) {
+            if (!m_frames_by_slot[slot_value].is_sticky())
+                callback(ScrollStateSlot { slot_value }, m_frames_by_slot[slot_value]);
         }
     }
 
     template<typename Callback>
     void for_each_sticky_frame(Callback callback)
     {
-        for (size_t i = 1; i < m_scroll_frames.size(); ++i) {
-            if (!m_scroll_frames[i].is_sticky())
-                continue;
-            callback(ScrollFrameIndex { i }, m_scroll_frames[i]);
+        for (size_t slot_value = 0; slot_value < m_frames_by_slot.size(); ++slot_value) {
+            if (m_frames_by_slot[slot_value].is_sticky())
+                callback(ScrollStateSlot { slot_value }, m_frames_by_slot[slot_value]);
         }
     }
 
     void clear()
     {
-        m_scroll_frames.resize_and_keep_capacity(1); // Keep sentinel at index 0
+        m_frames_by_slot.clear_with_capacity();
     }
 
 private:
     friend class ViewportPaintable;
 
-    ScrollStateSnapshot snapshot(double device_pixels_per_css_pixel) const
+    ScrollStateSlot append_frame(ScrollFrame frame)
     {
-        return ScrollStateSnapshot::create(m_scroll_frames, device_pixels_per_css_pixel);
+        auto slot = ScrollStateSlot { m_frames_by_slot.size() };
+        m_frames_by_slot.append(move(frame));
+        return slot;
     }
 
-    Vector<ScrollFrame> m_scroll_frames;
+    ScrollStateSnapshot snapshot(double device_pixels_per_css_pixel) const;
+
+    Vector<ScrollFrame> m_frames_by_slot;
 };
 
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -172,8 +172,10 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollFrameIndex sticky_fr
     if (!nearest_scrolling_ancestor_index.value())
         return;
 
-    auto const& scroll_ancestor_paintable = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box();
-    RefPtr<Paintable const> scroll_ancestor_paintable_ref = scroll_ancestor_paintable;
+    auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box_if_alive();
+    if (!scroll_ancestor_paintable_ref)
+        return;
+    auto const& scroll_ancestor_paintable = *scroll_ancestor_paintable_ref;
     auto sticky_border_box_rect = paintable_box.absolute_border_box_rect();
     RefPtr<Paintable const> containing_block_of_sticky = paintable_box.containing_block();
 
@@ -200,7 +202,10 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollFrameIndex sticky_fr
 void ViewportPaintable::refresh_sticky_constraints()
 {
     m_scroll_state.for_each_sticky_frame([&](ScrollFrameIndex index, ScrollFrame& frame) {
-        precompute_sticky_constraints(index, frame.paintable_box());
+        // Skip frames whose paintables a subtree relayout has replaced; the pending visual context
+        // tree rebuild recreates those frames before anything reads them.
+        if (auto paintable_box = frame.paintable_box_if_alive())
+            precompute_sticky_constraints(index, *paintable_box);
     });
     m_needs_to_refresh_scroll_state = true;
 }
@@ -266,6 +271,7 @@ void ViewportPaintable::assign_scroll_frames()
 
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
+    reassign_scroll_frames();
     auto visual_context_tree = build_accumulated_visual_context_tree(*this);
     ++m_accumulated_visual_context_tree_build_count;
     auto is_compatible = m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree);
@@ -341,7 +347,10 @@ void ViewportPaintable::refresh_scroll_state()
 
         auto const& sticky_data = frame.sticky_constraints();
         auto const& sticky_insets = sticky_data.insets;
-        auto const& scroll_ancestor_paintable = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box();
+        auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box_if_alive();
+        if (!scroll_ancestor_paintable_ref)
+            return;
+        auto const& scroll_ancestor_paintable = *scroll_ancestor_paintable_ref;
 
         // NB: For nested sticky elements, work in the coordinate space where the sticky ancestors are
         //     at their current positions. The scrolling ancestor's offset is already represented by
@@ -383,7 +392,8 @@ void ViewportPaintable::refresh_scroll_state()
     });
 
     m_scroll_state.for_each_scroll_frame([&](auto, auto& frame) {
-        frame.set_own_offset(-frame.paintable_box().scroll_offset());
+        if (auto paintable_box = frame.paintable_box_if_alive())
+            frame.set_own_offset(-paintable_box->scroll_offset());
     });
 
     m_scroll_state_snapshot = m_scroll_state.snapshot(document().page().client().device_pixels_per_css_pixel());

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -90,6 +90,7 @@ void ViewportPaintable::initialize_async_scrolling_metadata_recording(DisplayLis
     auto blocking_wheel_event_region_state = collect_root_blocking_wheel_event_regions(document());
     context.set_async_scrolling_metadata_context(
         document().unique_id(),
+        visual_context_tree(),
         scroll_state(),
         blocking_wheel_event_region_state.has_blocking_wheel_event_listeners,
         blocking_wheel_event_region_state.has_blocking_wheel_event_region_covering_viewport);
@@ -166,13 +167,13 @@ void ViewportPaintable::paint_all_phases(DisplayListRecordingContext& context)
     context.display_list_recorder().restore();
 }
 
-void ViewportPaintable::precompute_sticky_constraints(ScrollFrameIndex sticky_frame_index, Paintable const& paintable_box)
+void ViewportPaintable::precompute_sticky_constraints(ScrollStateSlot sticky_slot, Paintable const& paintable_box)
 {
-    auto nearest_scrolling_ancestor_index = m_scroll_state.nearest_scrolling_ancestor(sticky_frame_index);
-    if (!nearest_scrolling_ancestor_index.value())
+    auto nearest_scrolling_ancestor_slot = m_scroll_state.nearest_scrolling_ancestor_slot(sticky_slot);
+    if (nearest_scrolling_ancestor_slot == NO_SCROLL_STATE_SLOT)
         return;
 
-    auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box_if_alive();
+    auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at_slot(nearest_scrolling_ancestor_slot).paintable_box_if_alive();
     if (!scroll_ancestor_paintable_ref)
         return;
     auto const& scroll_ancestor_paintable = *scroll_ancestor_paintable_ref;
@@ -189,7 +190,7 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollFrameIndex sticky_fr
         needs_parent_offset_adjustment = true;
     }
 
-    m_scroll_state.frame_at(sticky_frame_index).set_sticky_constraints({
+    m_scroll_state.frame_at_slot(sticky_slot).set_sticky_constraints({
         .position_relative_to_scroll_ancestor = sticky_border_box_rect.top_left() - scroll_ancestor_paintable.absolute_rect().top_left(),
         .border_box_size = sticky_border_box_rect.size(),
         .scrollport_size = scroll_ancestor_paintable.absolute_rect().size(),
@@ -201,11 +202,11 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollFrameIndex sticky_fr
 
 void ViewportPaintable::refresh_sticky_constraints()
 {
-    m_scroll_state.for_each_sticky_frame([&](ScrollFrameIndex index, ScrollFrame& frame) {
+    m_scroll_state.for_each_sticky_frame([&](ScrollStateSlot slot, ScrollFrame& frame) {
         // Skip frames whose paintables a subtree relayout has replaced; the pending visual context
         // tree rebuild recreates those frames before anything reads them.
         if (auto paintable_box = frame.paintable_box_if_alive())
-            precompute_sticky_constraints(index, *paintable_box);
+            precompute_sticky_constraints(slot, *paintable_box);
     });
     m_needs_to_refresh_scroll_state = true;
 }
@@ -217,16 +218,22 @@ void ViewportPaintable::clear_scroll_state()
     m_needs_to_refresh_scroll_state = true;
 }
 
-ScrollFrameIndex ViewportPaintable::create_scroll_frame_for(Paintable const& paintable_box, ScrollFrameIndex parent_index)
+void ViewportPaintable::register_scroll_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
 {
-    return m_scroll_state.create_scroll_frame_for(paintable_box, parent_index);
+    auto slot = m_scroll_state.register_scroll_frame(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
+    visual_context_tree_being_built.node_at(node_index).data.get<ScrollData>().state_slot = slot;
 }
 
-ScrollFrameIndex ViewportPaintable::create_sticky_frame_for(Paintable const& paintable_box, ScrollFrameIndex parent_index)
+void ViewportPaintable::register_sticky_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
 {
-    auto sticky_frame_index = m_scroll_state.create_sticky_frame_for(paintable_box, parent_index);
-    precompute_sticky_constraints(sticky_frame_index, paintable_box);
-    return sticky_frame_index;
+    auto slot = m_scroll_state.register_sticky_frame(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
+    visual_context_tree_being_built.node_at(node_index).data.get<ScrollData>().state_slot = slot;
+    precompute_sticky_constraints(slot, paintable_box);
+}
+
+CSSPixelPoint ViewportPaintable::cumulative_scroll_offset_for_node(VisualContextIndex scroll_node_index) const
+{
+    return m_scroll_state.cumulative_offset(visual_context_tree().scroll_state_slot_for_node(scroll_node_index));
 }
 
 void ViewportPaintable::assign_accumulated_visual_contexts()
@@ -300,14 +307,14 @@ void ViewportPaintable::refresh_scroll_state()
     // https://drafts.csswg.org/css-position/#sticky-pos
     // Sticky positioning is similar to relative positioning except the offsets are automatically calculated
     // in reference to the nearest scrollport.
-    m_scroll_state.for_each_sticky_frame([&](auto idx, auto& frame) {
-        auto nearest_scrolling_ancestor_index = m_scroll_state.nearest_scrolling_ancestor(idx);
-        if (!nearest_scrolling_ancestor_index.value() || !frame.has_sticky_constraints())
+    m_scroll_state.for_each_sticky_frame([&](auto slot, auto& frame) {
+        auto nearest_scrolling_ancestor_slot = m_scroll_state.nearest_scrolling_ancestor_slot(slot);
+        if (nearest_scrolling_ancestor_slot == NO_SCROLL_STATE_SLOT || !frame.has_sticky_constraints())
             return;
 
         auto const& sticky_data = frame.sticky_constraints();
         auto const& sticky_insets = sticky_data.insets;
-        auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at(nearest_scrolling_ancestor_index).paintable_box_if_alive();
+        auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at_slot(nearest_scrolling_ancestor_slot).paintable_box_if_alive();
         if (!scroll_ancestor_paintable_ref)
             return;
         auto const& scroll_ancestor_paintable = *scroll_ancestor_paintable_ref;
@@ -315,7 +322,7 @@ void ViewportPaintable::refresh_scroll_state()
         // NB: For nested sticky elements, work in the coordinate space where the sticky ancestors are
         //     at their current positions. The scrolling ancestor's offset is already represented by
         //     scrollport_rect and must not be applied to the sticky position a second time.
-        auto parent_sticky_offset = m_scroll_state.cumulative_sticky_offset(frame.parent_index());
+        auto parent_sticky_offset = m_scroll_state.cumulative_sticky_offset(frame.parent_slot());
 
         auto sticky_position_in_ancestor = sticky_data.position_relative_to_scroll_ancestor + parent_sticky_offset;
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -217,61 +217,21 @@ void ViewportPaintable::clear_scroll_state()
     m_needs_to_refresh_scroll_state = true;
 }
 
-void ViewportPaintable::reassign_scroll_frames()
+ScrollFrameIndex ViewportPaintable::create_scroll_frame_for(Paintable const& paintable_box, ScrollFrameIndex parent_index)
 {
-    clear_scroll_state();
-    assign_scroll_frames();
+    return m_scroll_state.create_scroll_frame_for(paintable_box, parent_index);
 }
 
-void ViewportPaintable::assign_scroll_frames()
+ScrollFrameIndex ViewportPaintable::create_sticky_frame_for(Paintable const& paintable_box, ScrollFrameIndex parent_index)
 {
-    for_each_in_inclusive_subtree([&](auto& paintable_box) {
-        paintable_box.set_enclosing_scroll_frame_index({});
-        paintable_box.set_own_scroll_frame_index({});
-
-        ScrollFrameIndex sticky_scroll_frame_index;
-        if (paintable_box.is_sticky_position() && paintable_box.has_sticky_insets()) {
-            auto parent_index = paintable_box.nearest_scroll_frame_index();
-            sticky_scroll_frame_index = m_scroll_state.create_sticky_frame_for(paintable_box, parent_index);
-            precompute_sticky_constraints(sticky_scroll_frame_index, paintable_box);
-            paintable_box.set_enclosing_scroll_frame_index(sticky_scroll_frame_index);
-            paintable_box.set_own_scroll_frame_index(sticky_scroll_frame_index);
-        }
-
-        if (paintable_box.has_scrollable_overflow() || is<ViewportPaintable>(paintable_box)) {
-            ScrollFrameIndex parent_index;
-            if (sticky_scroll_frame_index.value()) {
-                parent_index = sticky_scroll_frame_index;
-            } else {
-                parent_index = paintable_box.nearest_scroll_frame_index();
-            }
-            auto scroll_frame_index = m_scroll_state.create_scroll_frame_for(paintable_box, parent_index);
-            paintable_box.set_own_scroll_frame_index(scroll_frame_index);
-        }
-
-        return TraversalDecision::Continue;
-    });
-
-    for_each_in_subtree([&](auto& paintable) {
-        if (paintable.is_fixed_position() || paintable.is_sticky_position())
-            return TraversalDecision::Continue;
-
-        for (auto const* block = paintable.containing_block_ptr(); block; block = block->containing_block_ptr()) {
-            if (auto index = block->own_scroll_frame_index(); index.value()) {
-                paintable.set_enclosing_scroll_frame_index(index);
-                return TraversalDecision::Continue;
-            }
-            if (block->is_fixed_position()) {
-                return TraversalDecision::Continue;
-            }
-        }
-        VERIFY_NOT_REACHED();
-    });
+    auto sticky_frame_index = m_scroll_state.create_sticky_frame_for(paintable_box, parent_index);
+    precompute_sticky_constraints(sticky_frame_index, paintable_box);
+    return sticky_frame_index;
 }
 
 void ViewportPaintable::assign_accumulated_visual_contexts()
 {
-    reassign_scroll_frames();
+    clear_scroll_state();
     auto visual_context_tree = build_accumulated_visual_context_tree(*this);
     ++m_accumulated_visual_context_tree_build_count;
     auto is_compatible = m_visual_context_tree.has_value() && visual_context_tree.is_compatible_with(*m_visual_context_tree);

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -19,7 +19,7 @@
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
-#include <LibWeb/Painting/ScrollFrame.h>
+#include <LibWeb/Painting/ScrollNodeState.h>
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Selection/Selection.h>
@@ -173,7 +173,7 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollStateSlot sticky_slo
     if (nearest_scrolling_ancestor_slot == NO_SCROLL_STATE_SLOT)
         return;
 
-    auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at_slot(nearest_scrolling_ancestor_slot).paintable_box_if_alive();
+    auto scroll_ancestor_paintable_ref = m_scroll_state.state_at_slot(nearest_scrolling_ancestor_slot).paintable_box_if_alive();
     if (!scroll_ancestor_paintable_ref)
         return;
     auto const& scroll_ancestor_paintable = *scroll_ancestor_paintable_ref;
@@ -190,7 +190,7 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollStateSlot sticky_slo
         needs_parent_offset_adjustment = true;
     }
 
-    m_scroll_state.frame_at_slot(sticky_slot).set_sticky_constraints({
+    m_scroll_state.state_at_slot(sticky_slot).set_sticky_constraints({
         .position_relative_to_scroll_ancestor = sticky_border_box_rect.top_left() - scroll_ancestor_paintable.absolute_rect().top_left(),
         .border_box_size = sticky_border_box_rect.size(),
         .scrollport_size = scroll_ancestor_paintable.absolute_rect().size(),
@@ -202,10 +202,10 @@ void ViewportPaintable::precompute_sticky_constraints(ScrollStateSlot sticky_slo
 
 void ViewportPaintable::refresh_sticky_constraints()
 {
-    m_scroll_state.for_each_sticky_frame([&](ScrollStateSlot slot, ScrollFrame& frame) {
-        // Skip frames whose paintables a subtree relayout has replaced; the pending visual context
-        // tree rebuild recreates those frames before anything reads them.
-        if (auto paintable_box = frame.paintable_box_if_alive())
+    m_scroll_state.for_each_sticky_node([&](ScrollStateSlot slot, ScrollNodeState& state) {
+        // Skip entries whose paintables a subtree relayout has replaced; the pending visual context
+        // tree rebuild recreates those entries before anything reads them.
+        if (auto paintable_box = state.paintable_box_if_alive())
             precompute_sticky_constraints(slot, *paintable_box);
     });
     m_needs_to_refresh_scroll_state = true;
@@ -218,15 +218,15 @@ void ViewportPaintable::clear_scroll_state()
     m_needs_to_refresh_scroll_state = true;
 }
 
-void ViewportPaintable::register_scroll_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
+void ViewportPaintable::register_scroll_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
 {
-    auto slot = m_scroll_state.register_scroll_frame(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
+    auto slot = m_scroll_state.register_scroll_node(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
     visual_context_tree_being_built.node_at(node_index).data.get<ScrollData>().state_slot = slot;
 }
 
-void ViewportPaintable::register_sticky_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
+void ViewportPaintable::register_sticky_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
 {
-    auto slot = m_scroll_state.register_sticky_frame(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
+    auto slot = m_scroll_state.register_sticky_node(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
     visual_context_tree_being_built.node_at(node_index).data.get<ScrollData>().state_slot = slot;
     precompute_sticky_constraints(slot, paintable_box);
 }
@@ -307,14 +307,14 @@ void ViewportPaintable::refresh_scroll_state()
     // https://drafts.csswg.org/css-position/#sticky-pos
     // Sticky positioning is similar to relative positioning except the offsets are automatically calculated
     // in reference to the nearest scrollport.
-    m_scroll_state.for_each_sticky_frame([&](auto slot, auto& frame) {
+    m_scroll_state.for_each_sticky_node([&](auto slot, auto& state) {
         auto nearest_scrolling_ancestor_slot = m_scroll_state.nearest_scrolling_ancestor_slot(slot);
-        if (nearest_scrolling_ancestor_slot == NO_SCROLL_STATE_SLOT || !frame.has_sticky_constraints())
+        if (nearest_scrolling_ancestor_slot == NO_SCROLL_STATE_SLOT || !state.has_sticky_constraints())
             return;
 
-        auto const& sticky_data = frame.sticky_constraints();
+        auto const& sticky_data = state.sticky_constraints();
         auto const& sticky_insets = sticky_data.insets;
-        auto scroll_ancestor_paintable_ref = m_scroll_state.frame_at_slot(nearest_scrolling_ancestor_slot).paintable_box_if_alive();
+        auto scroll_ancestor_paintable_ref = m_scroll_state.state_at_slot(nearest_scrolling_ancestor_slot).paintable_box_if_alive();
         if (!scroll_ancestor_paintable_ref)
             return;
         auto const& scroll_ancestor_paintable = *scroll_ancestor_paintable_ref;
@@ -322,7 +322,7 @@ void ViewportPaintable::refresh_scroll_state()
         // NB: For nested sticky elements, work in the coordinate space where the sticky ancestors are
         //     at their current positions. The scrolling ancestor's offset is already represented by
         //     scrollport_rect and must not be applied to the sticky position a second time.
-        auto parent_sticky_offset = m_scroll_state.cumulative_sticky_offset(frame.parent_slot());
+        auto parent_sticky_offset = m_scroll_state.cumulative_sticky_offset(state.parent_slot());
 
         auto sticky_position_in_ancestor = sticky_data.position_relative_to_scroll_ancestor + parent_sticky_offset;
 
@@ -355,12 +355,12 @@ void ViewportPaintable::refresh_scroll_state()
                 sticky_offset.set_x(max(scrollport_rect.right() - sticky_data.border_box_size.width() - *sticky_insets.right, min_offset_within_containing_block.x()) - sticky_position_in_ancestor.x());
         }
 
-        frame.set_own_offset(sticky_offset);
+        state.set_own_offset(sticky_offset);
     });
 
-    m_scroll_state.for_each_scroll_frame([&](auto, auto& frame) {
-        if (auto paintable_box = frame.paintable_box_if_alive())
-            frame.set_own_offset(-paintable_box->scroll_offset());
+    m_scroll_state.for_each_scroll_node([&](auto, auto& state) {
+        if (auto paintable_box = state.paintable_box_if_alive())
+            state.set_own_offset(-paintable_box->scroll_offset());
     });
 
     m_scroll_state_snapshot = m_scroll_state.snapshot(document().page().client().device_pixels_per_css_pixel());

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -27,8 +27,8 @@ public:
     void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext&, HTML::LocalNavigable&, Gfx::IntRect viewport_rect);
     void build_stacking_context_tree_if_needed();
 
-    void register_scroll_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
-    void register_sticky_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
+    void register_scroll_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
+    void register_sticky_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
     void refresh_scroll_state();
     void refresh_sticky_constraints();
     CSSPixelPoint cumulative_scroll_offset_for_node(VisualContextIndex scroll_node_index) const;

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -27,10 +27,11 @@ public:
     void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext&, HTML::LocalNavigable&, Gfx::IntRect viewport_rect);
     void build_stacking_context_tree_if_needed();
 
-    ScrollFrameIndex create_scroll_frame_for(Paintable const&, ScrollFrameIndex parent_index);
-    ScrollFrameIndex create_sticky_frame_for(Paintable const&, ScrollFrameIndex parent_index);
+    void register_scroll_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
+    void register_sticky_frame(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const&, VisualContextIndex parent_index);
     void refresh_scroll_state();
     void refresh_sticky_constraints();
+    CSSPixelPoint cumulative_scroll_offset_for_node(VisualContextIndex scroll_node_index) const;
 
     void assign_accumulated_visual_contexts();
     bool update_accumulated_visual_context_values(Paintable&);
@@ -71,7 +72,7 @@ private:
     void ensure_visual_context_tree() const;
     void build_stacking_context_tree();
     void clear_scroll_state();
-    void precompute_sticky_constraints(ScrollFrameIndex, Paintable const&);
+    void precompute_sticky_constraints(ScrollStateSlot, Paintable const&);
 
     explicit ViewportPaintable(Layout::Viewport const&);
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -27,8 +27,8 @@ public:
     void finalize_async_scrolling_metadata_recording(DisplayListRecordingContext&, HTML::LocalNavigable&, Gfx::IntRect viewport_rect);
     void build_stacking_context_tree_if_needed();
 
-    void assign_scroll_frames();
-    void reassign_scroll_frames();
+    ScrollFrameIndex create_scroll_frame_for(Paintable const&, ScrollFrameIndex parent_index);
+    ScrollFrameIndex create_sticky_frame_for(Paintable const&, ScrollFrameIndex parent_index);
     void refresh_scroll_state();
     void refresh_sticky_constraints();
 

--- a/Libraries/LibWeb/Painting/VisualContextIndex.h
+++ b/Libraries/LibWeb/Painting/VisualContextIndex.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/DistinctNumeric.h>
+
+namespace Web::Painting {
+
+AK_TYPEDEF_DISTINCT_ORDERED_ID(size_t, VisualContextIndex);
+
+// Node 0 is always the visual viewport transform node, so index 0 doubles as "no node" for
+// references to scroll nodes, which can never sit at the root.
+static constexpr VisualContextIndex VISUAL_VIEWPORT_NODE_INDEX { 0 };
+
+}

--- a/Services/Compositor/ViewportScrollbarController.cpp
+++ b/Services/Compositor/ViewportScrollbarController.cpp
@@ -65,7 +65,7 @@ static Gfx::IntRect translated_thumb_rect(Web::Compositor::ViewportScrollbar con
 {
     auto thumb_rect = expanded ? scrollbar.expanded_thumb_rect : scrollbar.thumb_rect;
     auto scroll_size = scrollbar_scroll_size(scrollbar, expanded);
-    auto device_offset = scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_frame_index);
+    auto device_offset = scroll_state_snapshot.device_offset_for_index(scrollbar.scroll_node_index);
     if (scrollbar.vertical)
         thumb_rect.translate_by(0, static_cast<int>(-device_offset.y() * scroll_size));
     else
@@ -222,7 +222,7 @@ bool ViewportScrollbarController::paint(Gfx::PaintingSurface& surface, Web::Pain
         auto const& scrollbar = m_scrollbars[i];
         auto expanded = is_expanded(i);
         Web::Painting::PaintScrollBar paint_scrollbar {
-            .scroll_frame_index = scrollbar.scroll_frame_index,
+            .scroll_node_index = scrollbar.scroll_node_index,
             .gutter_rect = scrollbar_gutter_rect(scrollbar, expanded),
             .thumb_rect = translated_thumb_rect(scrollbar, scroll_state_snapshot, expanded),
             .scroll_size = scrollbar_scroll_size(scrollbar, expanded),

--- a/Tests/LibWeb/Text/expected/anchor-scroll-shift-with-anchor-after-positioned-box.txt
+++ b/Tests/LibWeb/Text/expected/anchor-scroll-shift-with-anchor-after-positioned-box.txt
@@ -1,0 +1,5 @@
+top gap before scroll: 0
+left gap before scroll: 0
+anchor bottom moved by: -40
+top gap after scroll: 0
+left gap after scroll: 0

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
@@ -6,18 +6,19 @@ clipped overflow outside clip: false
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,100,0] origin=(20,20) (PaintableWithLines(BlockContainer<DIV>#transformed))
       [3] clip=[20,160 100x100]
-        [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [4] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x13]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[20,20 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x13]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[20,20 100x100]
   CompositorBlockingWheelEventRegion@2 rect=[20,20 100x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[20,160 100x100]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[20,160 200x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[20,160 100x100]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[20,160 200x100]
   CompositorBlockingWheelEventRegion@4 rect=[20,160 200x100]
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-regions.txt
@@ -25,20 +25,21 @@ removed window listener:
 display list after blocking element listener:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[0,0 200x200]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 200x200]
-  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=3 rect=[0,0 200x200]
+  CompositorScrollNode@1 scroll_node_index=3 parent_scroll_node_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,0 100x100]
   CompositorBlockingWheelEventRegion@3 rect=[0,0 100x100]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,100 1000x1000]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,100 1000x1000]
   PaintScrollBar@1
   PaintScrollBar@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
@@ -4,13 +4,14 @@ after routing admission: blocking wheel event listeners
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2013]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2013]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
@@ -4,19 +4,20 @@ outside iframe: accepted
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2013]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2000]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[40,40 160x120]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1413] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2013]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[40,40 160x120]
   CompositorMainThreadWheelEventRegion@1 rect=[40,40 160x120]
   Save@1
     AddClipRect@1 rect=[40,40 160x120]
     DrawCompositedContext@1 dst_rect=[40,40 160x120]
   Restore@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-scroller-keeps-sync-wheel.txt
@@ -3,19 +3,20 @@ window scrollY: 0
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[0,0 100x100]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
+        [3] scroll (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 100x100]
-  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x500]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=3 rect=[0,0 100x100]
+  CompositorScrollNode@1 scroll_node_index=3 parent_scroll_node_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,0 100x500]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,100 800x2000]
   PaintScrollBar@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-metadata-cache-replay.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-metadata-cache-replay.txt
@@ -3,5 +3,5 @@ scroller scrollTop: 80
 wheel target near viewport top: viewport
 upward wheel target over scroller: non-viewport
 scroll metadata:
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,2491] is_viewport=true
-  CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,2491] is_viewport=true
+  CompositorScrollNode@0 scroll_node_index=3 parent_scroll_node_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-parent-nodes.txt
@@ -5,23 +5,24 @@ child parent is viewport: true
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-      [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll (sticky) (PaintableWithLines(BlockContainer(anonymous)))
         [3] clip=[0,0 100x100]
-          [4] scroll_frame_id=3 (PaintableWithLines(BlockContainer<DIV>#spacer))
+          [4] scroll (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=1 rect=[0,0 800x100]
-  CompositorStickyArea@2 scroll_frame_index=2 parent_scroll_frame_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x100] scrollport_size=[800x600] containing_block_region=[0,0 800x2100] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=3 rect=[0,0 100x100]
-  CompositorScrollNode@2 scroll_frame_index=3 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=3 rect=[0,0 500x500]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,100 800x2000]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=1 rect=[0,0 800x100]
+  CompositorStickyArea@2 scroll_node_index=2 parent_scroll_node_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x100] scrollport_size=[800x600] containing_block_region=[0,0 800x2100] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=4 rect=[0,0 100x100]
+  CompositorScrollNode@2 scroll_node_index=4 parent_scroll_node_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=4 rect=[0,0 500x500]
   PaintScrollBar@2
   PaintScrollBar@2
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-tree-shape.txt
@@ -8,20 +8,21 @@ child parent is viewport: true
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[0,0 100x100]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#spacer))
+        [3] scroll (PaintableWithLines(BlockContainer<DIV>#spacer))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 100x100]
-  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 500x500]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=3 rect=[0,0 100x100]
+  CompositorScrollNode@1 scroll_node_index=3 parent_scroll_node_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[400,400] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,0 500x500]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,100 800x2000]
   PaintScrollBar@1
   PaintScrollBar@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
@@ -9,21 +9,21 @@ inner has top inset only: true
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-      [2] scroll_frame_id=2 (sticky) (PaintableWithLines(BlockContainer(anonymous)))
-        [3] scroll_frame_id=3 (sticky) (PaintableWithLines(BlockContainer<DIV>#inner))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll (sticky) (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll (sticky) (PaintableWithLines(BlockContainer<DIV>#inner))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1429] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2029]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2016]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,16 800x2000]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=1 rect=[0,0 800x16]
-  CompositorStickyArea@2 scroll_frame_index=2 parent_scroll_frame_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x2016] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=1 rect=[0,0 800x16]
-  CompositorStickyArea@3 scroll_frame_index=3 parent_scroll_frame_index=2 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x16] needs_parent_offset_adjustment=true inset_top=20 inset_right=none inset_bottom=none inset_left=none
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1429] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2029]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2016]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,16 800x2000]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=1 rect=[0,0 800x16]
+  CompositorStickyArea@2 scroll_node_index=2 parent_scroll_node_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x2016] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=1 rect=[0,0 800x16]
+  CompositorStickyArea@3 scroll_node_index=3 parent_scroll_node_index=2 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x16] needs_parent_offset_adjustment=true inset_top=20 inset_right=none inset_bottom=none inset_left=none
   DrawGlyphRun@3 rect=[0,0 45x16] translation=[0,12.796875] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-with-nested-scroller.txt
@@ -5,19 +5,20 @@ scroller wheel target: non-viewport
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[0,0 100x100]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>#scroller-spacer))
+        [3] scroll (PaintableWithLines(BlockContainer<DIV>#scroller-spacer))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2113]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x2100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 100x100]
-  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x500]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,100 800x2000]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,1513] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2113]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=3 rect=[0,0 100x100]
+  CompositorScrollNode@1 scroll_node_index=3 parent_scroll_node_index=1 scrollport_rect=[0,0 100x100] max_scroll_offset=[0,400] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,0 100x500]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,100 800x2000]
   PaintScrollBar@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/wheel-scroll-admission.txt
@@ -12,21 +12,22 @@ stale blocking window regions: false
 display list after blocking element listener:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[0,0 200x200]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[0,0 200x200]
-  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,0 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=3 rect=[0,0 200x200]
+  CompositorScrollNode@1 scroll_node_index=3 parent_scroll_node_index=0 scrollport_rect=[0,0 200x200] max_scroll_offset=[800,900] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,0 100x100]
   CompositorBlockingWheelEventRegion@3 rect=[0,0 100x100]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[0,100 1000x1000]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[0,100 1000x1000]
   PaintScrollBar@1
   PaintScrollBar@1
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[250,0 100x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[250,0 100x100]
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -1,15 +1,15 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x37]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 27.15625x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[43.15625,8 27.640625x16]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x37]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 27.15625x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[43.15625,8 27.640625x16]
   DrawGlyphRun@1 rect=[8,8 28x16] translation=[8,20.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[8,24] to=[35,24] color=rgb(0, 0, 0) thickness=2
   DrawGlyphRun@1 rect=[35,8 8x16] translation=[35.15625,20.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -1,17 +1,17 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
         [4] effects=[opacity=0.5]
           [7] effects=[opacity=0.3] (PaintableWithLines(BlockContainer<DIV>.abspos))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@7 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@7 rect=[8,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -1,16 +1,16 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 200x200] (PaintableWithLines(BlockContainer(anonymous)))
         [4] effects=[opacity=0.5] (PaintableWithLines(BlockContainer<DIV>.abspos))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@4 rect=[8,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/animated-transform-visual-context-update.txt
+++ b/Tests/LibWeb/Text/expected/display_list/animated-transform-visual-context-update.txt
@@ -1,30 +1,30 @@
 Before animation update:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,10,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>#box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
 After animation update:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,15,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>#box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-change-repaints.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-change-repaints.txt
@@ -1,14 +1,14 @@
 Before background-attachment change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 200x200]
   Save@1
     AddClipRect@1 rect=[0,0 200x200]
     PaintLinearGradient@1 rect=[0,0 200x600]
@@ -18,15 +18,15 @@ Restore@0
 After background-attachment change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-      [2] scroll_compensation(frame_id=1)
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll_compensation(node_index=1)
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 200x200]
   Save@1
     AddClipRect@1 rect=[0,0 200x200]
     PaintLinearGradient@2 rect=[0,0 800x600]

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -1,16 +1,16 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
-      [2] scroll_compensation(frame_id=1)
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
+      [2] scroll_compensation(node_index=1)
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=1 rect=[0,0 800x600]
-  CompositorScrollNode@0 scroll_frame_index=1 parent_scroll_frame_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,613] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,0 800x1213]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
+  CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] max_scroll_offset=[0,613] is_viewport=true
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x1213]
   Save@1
     PaintLinearGradient@2 rect=[0,0 800x600]
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=1 rect=[0,13 800x1200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,13 800x1200]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
+++ b/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
@@ -1,15 +1,15 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x90]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[100,50 50x10]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,3 102x74]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x90]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[100,50 50x10]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,3 102x74]
   FillPath@1 path_bounding_rect=[0,3 8x14]
   FillPath@1 path_bounding_rect=[0,63 8x14]
   DrawGlyphRun@1 rect=[2,5 6x10] translation=[2,13] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -1,18 +1,18 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x41]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 105.671875x20]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x41]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 105.671875x20]
   FillRect@1 rect=[8,8 106x20] color=rgb(212, 208, 200)
   FillPath@1 path_bounding_rect=[8,8 106x20]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[13,10 95.671875x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[13,10 95.671875x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[13,10 95.671875x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[13,10 95.671875x16]
   DrawGlyphRun@1 rect=[13,10 96x16] translation=[13,22.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[13,26] to=[109,26] color=rgb(0, 0, 0) thickness=2
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
@@ -1,13 +1,14 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x53]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 32x32]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x53]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 32x32]
   DrawCanvas@1 dst_rect=[8,8 32x32] content_generation=0
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/clip-auto-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-auto-invalidation.txt
@@ -1,26 +1,27 @@
 Before clip change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@1 rect=[8,13 100x100] color=rgb(0, 128, 0)
 Restore@0
 
 After clip change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,13 50x50] (PaintableWithLines(BlockContainer<DIV>#box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(0, 128, 0)
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -1,14 +1,14 @@
 Before clip change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,13 100x100] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -16,14 +16,14 @@ Restore@0
 After clip change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[18,23 80x80] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-empty-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-empty-invalidation.txt
@@ -1,27 +1,27 @@
 Before clip-path change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (PaintableWithLines(BlockContainer<DIV>#box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
 After clip-path change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -1,15 +1,15 @@
 Before clip-path change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip_path=[bounds: 8,8 100x100, path: M8 8L108 8L108 108L8 108L8 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -17,15 +17,15 @@ Restore@0
 After clip-path change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip_path=[bounds: 8,8 100x100, path: M58 8L108 58L58 108L8 58L58 8Z] (PaintableWithLines(BlockContainer<DIV>#box.box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
@@ -1,6 +1,6 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (PaintableWithLines(BlockContainer<DIV>.clip-path-ancestor))
       [3] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (PaintableWithLines(BlockContainer<DIV>.abspos))
       [5] clip=[220,0 100x100] (PaintableWithLines(BlockContainer<DIV>.clip-ancestor))
@@ -8,13 +8,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[0,0 200x200]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[0,0 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[0,0 200x200]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[0,0 200x200]
   FillRect@3 rect=[0,0 200x200] color=rgb(255, 0, 0)
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[220,0 200x200]
-  CompositorWheelHitTestTarget@7 target_scroll_frame_index=0 rect=[220,0 200x200]
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[220,0 200x200]
+  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[220,0 200x200]
   FillRect@7 rect=[220,0 200x200] color=rgb(0, 128, 0)
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -1,13 +1,13 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x41]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x20]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x41]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x20]
   FillRect@1 rect=[8,8 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 104x24]
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -1,13 +1,13 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[28,23 80x70] (PaintableWithLines(BlockContainer<DIV>.clipped))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,13 150x150]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 150x150]
   FillRect@2 rect=[8,13 150x150] color=rgb(128, 0, 128)
   DrawGlyphRun@2 rect=[8,13 71x16] translation=[8,25.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@2 rect=[8,29 72x16] translation=[8,41.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -1,6 +1,6 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[10,10 400x200] (PaintableWithLines(BlockContainer<DIV>.branch))
         [3] clip=[11,11 193x198] (PaintableWithLines(BlockContainer(anonymous)))
           [4] transform=[0.9961947,-0.08715574,0.08715574,0.9961947,0,0] origin=(91,56) (PaintableWithLines(BlockContainer<DIV>.leaf.leaf-a))
@@ -11,25 +11,25 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x225]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x204]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 404x204]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x225]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x204]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 404x204]
   FillPath@1 path_bounding_rect=[8,8 404x204]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[10,10 195x200]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[10,10 195x200]
   FillPath@2 path_bounding_rect=[10,10 195x200]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[215,10 195x200]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[215,10 195x200]
   FillPath@2 path_bounding_rect=[215,10 195x200]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[16,16 150x80]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[16,16 150x80]
   FillRect@4 rect=[16,16 150x80] color=rgb(255, 0, 0)
   DrawGlyphRun@4 rect=[16,16 15x16] translation=[16,28.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[16,101 150x80]
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[16,101 150x80]
   FillRect@5 rect=[16,101 150x80] color=rgb(0, 128, 0)
   DrawGlyphRun@5 rect=[16,101 10x16] translation=[16,113.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@7 target_scroll_frame_index=0 rect=[221,16 150x80]
+  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[221,16 150x80]
   FillRect@7 rect=[221,16 150x80] color=rgb(0, 0, 255)
   DrawGlyphRun@7 rect=[221,16 11x16] translation=[221,28.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@8 target_scroll_frame_index=0 rect=[221,101 150x80]
+  CompositorWheelHitTestTarget@8 target_scroll_node_index=0 rect=[221,101 150x80]
   FillRect@8 rect=[221,101 150x80] color=rgb(255, 165, 0)
   DrawGlyphRun@8 rect=[221,101 12x16] translation=[221,113.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
@@ -1,13 +1,13 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x70.59375]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x49.59375]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[10,8 780x49.59375]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x70.59375]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x49.59375]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[10,8 780x49.59375]
   Save@1
     AddClipRect@1 rect=[10,15 780x43]
     FillRect@1 rect=[10,8 780x50] color=rgb(0, 0, 255)
@@ -28,9 +28,9 @@ SaveLayer@0
     FillPath@1 path_bounding_rect=[10,15 780x1]
     FillPath@1 path_bounding_rect=[9,16 782x1]
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[24,8 57.328125x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[24,29.59375 752x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[24,29.59375 752x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[24,8 57.328125x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[24,29.59375 752x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[24,29.59375 752x16]
   DrawGlyphRun@1 rect=[26,8 54x16] translation=[26,20.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[24,29 63x16] translation=[24,42.390625] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -1,18 +1,18 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (PaintableWithLines(BlockContainer<DIV>.fixed))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 200x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 150x50]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 150x50]
   FillRect@2 rect=[8,8 150x50] color=rgb(0, 128, 0)
   DrawGlyphRun@2 rect=[8,8 56x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[10,10 80x40]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[10,10 80x40]
   FillRect@0 rect=[10,10 80x40] color=rgb(255, 0, 0)
   DrawGlyphRun@0 rect=[10,10 44x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
@@ -1,22 +1,22 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x51]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x30]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 147x30]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 28.59375x30]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x51]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x30]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 147x30]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 28.59375x30]
   FillRect@1 rect=[8,8 29x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[37.59375,8 28.59375x30]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[37.59375,8 28.59375x30]
   FillRect@1 rect=[38,8 28x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[67.1875,8 28.59375x30]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[67.1875,8 28.59375x30]
   FillRect@1 rect=[67,8 29x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[96.78125,8 28.59375x30]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[96.78125,8 28.59375x30]
   FillRect@1 rect=[97,8 28x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[126.375,8 28.59375x30]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[126.375,8 28.59375x30]
   FillRect@1 rect=[126,8 29x30] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
@@ -1,17 +1,18 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x93]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 120x80]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x93]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 120x80]
   CompositorMainThreadWheelEventRegion@1 rect=[0,0 120x80]
   Save@1
     AddClipRect@1 rect=[0,0 120x80]
     DrawCompositedContext@1 dst_rect=[0,0 120x80]
   Restore@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/image-object-fit-cover-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/image-object-fit-cover-clip.txt
@@ -1,13 +1,13 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
+    [1] scroll (ImagePaintable(ImageBox<IMG>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x40]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x40]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 40x40]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x40]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x40]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 40x40]
   Save@1
     AddClipRect@1 rect=[0,0 40x40]
     DrawScaledDecodedImageFrame@1 dst_rect=[0,-20 40x80]

--- a/Tests/LibWeb/Text/expected/display_list/img-alt-text-clipped-to-content-rect.txt
+++ b/Tests/LibWeb/Text/expected/display_list/img-alt-text-clipped-to-content-rect.txt
@@ -1,13 +1,13 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
+    [1] scroll (ImagePaintable(ImageBox<IMG>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x70]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,10 800x60]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,10 60x60]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x70]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,10 800x60]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,10 60x60]
   FillPath@1 path_bounding_rect=[0,10 60x60]
   Save@1
     AddClipRect@1 rect=[5,15 50x50]
@@ -16,3 +16,4 @@ SaveLayer@0
     DrawGlyphRun@1 rect=[5,15 50x50] translation=[5,43] color=rgb(0, 0, 0)
   Restore@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -1,20 +1,20 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[9,9 104x18] (PaintableWithLines(BlockContainer<DIV>))
         [3] clip=[11,10 100x16]
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x41]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 106x20]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x41]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 106x20]
   FillRect@1 rect=[8,8 106x20] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 106x20]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 100x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 100x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 100x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 100x16]
   DrawGlyphRun@3 rect=[11,10 37x16] translation=[11,22.796875] color=rgb(0, 0, 0)
   FillRect@3 rect=[11,10 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 110x24]

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -1,6 +1,6 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[9,9 204x18] (PaintableWithLines(BlockContainer<DIV>))
         [3] clip=[11,10 200x16]
       [4] clip=[223,9 204x18] (PaintableWithLines(BlockContainer<DIV>))
@@ -8,22 +8,22 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x42]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x21]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x21]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 206x20]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x42]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x21]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x21]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 206x20]
   FillRect@1 rect=[8,8 206x20] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 206x20]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 200x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[222,8 206x20]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 200x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[222,8 206x20]
   FillRect@1 rect=[222,8 206x20] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[222,8 206x20]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[225,10 200x16]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[225,10 200x16]
   DrawGlyphRun@1 rect=[214,13 8x16] translation=[214,25.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,10 200x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 200x16]
   DrawGlyphRun@3 rect=[11,10 28x16] translation=[11,22.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[225,10 200x16]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[225,10 200x16]
   DrawGlyphRun@5 rect=[225,10 28x16] translation=[225,22.796875] color=rgb(0, 0, 0)
   FillRect@5 rect=[225,10 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[220,6 210x24]

--- a/Tests/LibWeb/Text/expected/display_list/mix-blend-mode-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mix-blend-mode-invalidation.txt
@@ -1,29 +1,29 @@
 Before mix-blend-mode change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@1 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
 After mix-blend-mode change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] effects=[blend_mode=2] (PaintableWithLines(BlockContainer<DIV>#box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -1,22 +1,22 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [3] clip=[119,9 100x100]
-        [4] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [4] scroll (PaintableWithLines(BlockContainer(anonymous)))
       [2] transform=[1,0,0,1,5,5] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.transformed))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x123]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x102]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x102]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[118,8 102x102]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x123]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x102]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x102]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[118,8 102x102]
   FillPath@1 path_bounding_rect=[118,8 102x102]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[119,9 150x150]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[119,9 150x150]
   FillRect@4 rect=[119,9 150x150] color=rgb(173, 216, 230)
   DrawGlyphRun@4 rect=[119,9 55x16] translation=[119,21.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@2 rect=[8,8 88x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-color-change-inside-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-color-change-inside-opacity.txt
@@ -1,19 +1,19 @@
 Before:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] effects=[opacity=0.5] (InlinePaintable(InlineNode<SPAN>#inner))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x111]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x90]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,85 784x13]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x111]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x90]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x13]
   DrawGlyphRun@1 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 81.21875x64]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 81.21875x64]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   DrawGlyphRun@2 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 255)
@@ -23,39 +23,39 @@ Restore@0
 After:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] effects=[opacity=0.5] (InlinePaintable(InlineNode<SPAN>#inner))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x397]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x376]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,85 784x299]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x397]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x376]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x299]
   DrawGlyphRun@1 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,111 546x13] translation=[8,121.390625] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,124 479x13] translation=[8,134.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,124 404x13] translation=[8,134.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,137 473x13] translation=[8,147.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,163 74x13] translation=[8,173.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,176 85x13] translation=[8,186.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,189 558x13] translation=[8,199.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,202 548x13] translation=[8,212.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,215 545x13] translation=[8,225.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,228 543x13] translation=[8,238.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,241 550x13] translation=[8,251.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,189 551x13] translation=[8,199.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,202 541x13] translation=[8,212.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,215 538x13] translation=[8,225.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,228 536x13] translation=[8,238.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,241 542x13] translation=[8,251.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,254 531x13] translation=[8,264.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,267 575x13] translation=[8,277.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,280 575x13] translation=[8,290.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,267 567x13] translation=[8,277.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,280 567x13] translation=[8,290.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,293 540x13] translation=[8,303.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,306 545x13] translation=[8,316.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,319 546x13] translation=[8,329.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,332 546x13] translation=[8,342.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,345 72x13] translation=[8,355.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,371 40x13] translation=[8,381.39062] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 81.21875x64]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 81.21875x64]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   DrawGlyphRun@2 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-opacity.txt
@@ -1,18 +1,18 @@
 With opacity:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] effects=[opacity=0.5] (InlinePaintable(InlineNode<SPAN>#target))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x111]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x90]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,85 784x13]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x111]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x90]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x13]
   DrawGlyphRun@1 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 81.21875x64]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   FillRect@2 rect=[8,8 81x16] color=rgb(255, 165, 0)
   FillRect@2 rect=[8,24 47x16] color=rgb(255, 165, 0)
   FillRect@2 rect=[8,40 60x16] color=rgb(255, 165, 0)
@@ -26,16 +26,16 @@ Restore@0
 Without opacity:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x436]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x415]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,85 784x338]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 81.21875x64]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x436]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x415]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x338]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   FillRect@1 rect=[8,8 81x16] color=rgb(255, 165, 0)
   FillRect@1 rect=[8,24 47x16] color=rgb(255, 165, 0)
   FillRect@1 rect=[8,40 60x16] color=rgb(255, 165, 0)
@@ -47,17 +47,17 @@ SaveLayer@0
   DrawGlyphRun@1 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,111 546x13] translation=[8,121.390625] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,124 479x13] translation=[8,134.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,124 404x13] translation=[8,134.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,137 479x13] translation=[8,147.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,163 74x13] translation=[8,173.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,176 85x13] translation=[8,186.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,189 558x13] translation=[8,199.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,202 548x13] translation=[8,212.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,215 545x13] translation=[8,225.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,228 543x13] translation=[8,238.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,241 550x13] translation=[8,251.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,189 551x13] translation=[8,199.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,202 541x13] translation=[8,212.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,215 538x13] translation=[8,225.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,228 536x13] translation=[8,238.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,241 542x13] translation=[8,251.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,254 532x13] translation=[8,264.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,267 575x13] translation=[8,277.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,267 567x13] translation=[8,277.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,280 337x13] translation=[8,290.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,293 343x13] translation=[8,303.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,306 345x13] translation=[8,316.39062] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -1,15 +1,15 @@
 Before:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x85]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 69.625x64]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x85]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 69.625x64]
   DrawGlyphRun@1 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(0, 0, 255)
   DrawLine@1 from=[8,24] to=[78,24] color=rgb(0, 0, 255) thickness=2
   DrawGlyphRun@1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
@@ -23,15 +23,15 @@ Restore@0
 After:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x85]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 69.625x64]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x85]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 69.625x64]
   DrawGlyphRun@1 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(255, 0, 0)
   DrawLine@1 from=[8,24] to=[78,24] color=rgb(255, 0, 0) thickness=2
   DrawGlyphRun@1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -1,6 +1,6 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[10,10 320x270] (PaintableWithLines(BlockContainer<DIV>.level2))
         [3] clip=[21,21 143x248] (PaintableWithLines(BlockContainer(anonymous)))
           [4] transform=[0.9986295,-0.05233596,0.05233596,0.9986295,0,0] origin=(92.5,46) (PaintableWithLines(BlockContainer<DIV>.level3.t1))
@@ -11,25 +11,25 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x295]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x274]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 324x274]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x295]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x274]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 324x274]
   FillPath@1 path_bounding_rect=[8,8 324x274]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[20,20 145x250]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[20,20 145x250]
   FillPath@2 path_bounding_rect=[20,20 145x250]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[175,20 145x250]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[175,20 145x250]
   FillPath@2 path_bounding_rect=[175,20 145x250]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[26,26 133x40]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[26,26 133x40]
   FillRect@4 rect=[26,26 133x40] color=rgb(255, 136, 136)
   DrawGlyphRun@4 rect=[26,26 20x16] translation=[26,38.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[26,71 133x40]
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[26,71 133x40]
   FillRect@5 rect=[26,71 133x40] color=rgb(136, 255, 136)
   DrawGlyphRun@5 rect=[26,71 22x16] translation=[26,83.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@7 target_scroll_frame_index=0 rect=[181,26 133x40]
+  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[181,26 133x40]
   FillRect@7 rect=[181,26 133x40] color=rgb(136, 136, 255)
   DrawGlyphRun@7 rect=[181,26 22x16] translation=[181,38.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@8 target_scroll_frame_index=0 rect=[181,71 133x40]
+  CompositorWheelHitTestTarget@8 target_scroll_node_index=0 rect=[181,71 133x40]
   FillRect@8 rect=[181,71 133x40] color=rgb(255, 255, 136)
   DrawGlyphRun@8 rect=[181,71 25x16] translation=[181,83.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-overflow-containers.txt
@@ -1,24 +1,24 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[10,10 200x150]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
           [4] clip=[11,11 300x100]
-            [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+            [5] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x175]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x154]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=2 rect=[8,8 204x154]
-  CompositorScrollNode@1 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[10,10 200x150] max_scroll_offset=[102,0] is_viewport=false
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x175]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x154]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=3 rect=[8,8 204x154]
+  CompositorScrollNode@1 scroll_node_index=3 parent_scroll_node_index=0 scrollport_rect=[10,10 200x150] max_scroll_offset=[102,0] is_viewport=false
   FillPath@1 path_bounding_rect=[8,8 204x154]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=3 rect=[10,10 302x102]
-  CompositorScrollNode@3 scroll_frame_index=3 parent_scroll_frame_index=2 scrollport_rect=[11,11 300x100] max_scroll_offset=[100,0] is_viewport=false
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=5 rect=[10,10 302x102]
+  CompositorScrollNode@3 scroll_node_index=5 parent_scroll_node_index=3 scrollport_rect=[11,11 300x100] max_scroll_offset=[100,0] is_viewport=false
   FillRect@3 rect=[10,10 302x102] color=rgb(255, 255, 224)
   FillPath@3 path_bounding_rect=[10,10 302x102]
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=3 rect=[11,11 400x80]
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=5 rect=[11,11 400x80]
   FillRect@5 rect=[11,11 400x80] color=rgb(240, 128, 128)
   DrawGlyphRun@5 rect=[11,11 178x16] translation=[11,23.796875] color=rgb(0, 0, 0)
   PaintScrollBar@3

--- a/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
@@ -1,16 +1,17 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x53]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x40]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 40x40]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x53]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x40]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 40x40]
   FillRect@1 rect=[0,0 40x40] color=rgb(45, 22, 0)
   Save@1
     AddClipRect@1 rect=[0,0 40x40]
     DrawScaledDecodedImageFrame@1 dst_rect=[0,0 40x40] src_rect=[0,0 40x40] blend_mode=2 isolated_backdrop_color=rgb(45, 22, 0)
   Restore@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
+++ b/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
@@ -1,21 +1,21 @@
 -- focused --
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[1,1 84x20] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 86x22]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   FillRect@2 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
   Save@2
     AddClipRect@2 rect=[3,3 9x16]
@@ -39,21 +39,21 @@ Restore@0
 -- unfocused --
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[1,1 84x20] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 86x22]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   FillRect@2 rect=[12,3 19x16] color=rgba(16, 16, 16, 0.667)
   Save@2
     AddClipRect@2 rect=[3,3 9x16]
@@ -76,21 +76,21 @@ Restore@0
 -- focused again --
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[1,1 84x20] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 86x22]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   FillRect@2 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
   Save@2
     AddClipRect@2 rect=[3,3 9x16]
@@ -114,21 +114,21 @@ Restore@0
 -- caret, focused --
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[1,1 84x20] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 86x22]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   DrawGlyphRun@2 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
   FillRect@2 rect=[22,3 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[-2,-2 90x26]
@@ -144,21 +144,21 @@ Restore@0
 -- caret, unfocused --
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[1,1 84x20] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 86x22]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   DrawGlyphRun@2 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1
   DrawLine@1 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1
@@ -172,21 +172,21 @@ Restore@0
 -- caret, focused again --
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[1,1 84x20] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 86x22]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   DrawGlyphRun@2 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
   FillRect@2 rect=[22,3 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[-2,-2 90x26]

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -1,16 +1,16 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] perspective (PaintableWithLines(BlockContainer(anonymous)))
         [3] transform=[0.8660254,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.rotated))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 255)
   DrawGlyphRun@3 rect=[8,8 21x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/perspective-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-invalidation.txt
@@ -1,33 +1,33 @@
 Before perspective change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>#child))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
 After perspective change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] perspective
         [3] transform=[1,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>#child))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -1,18 +1,18 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,10,10] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 200x200]
   FillRect@2 rect=[8,8 200x200] color=rgb(211, 211, 211)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 200x90]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 200x90]
   FillRect@2 rect=[8,8 200x90] color=rgb(173, 216, 230)
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[33,33 100x50]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[33,33 100x50]
   FillRect@2 rect=[33,33 100x50] color=rgb(255, 127, 80)
   DrawGlyphRun@2 rect=[33,33 84x16] translation=[33,45.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -1,17 +1,17 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x321]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x300]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 300x300]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x321]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x300]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 300x300]
   FillRect@1 rect=[8,8 300x300] color=rgb(211, 211, 211)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@1 rect=[8,8 100x100] color=rgb(173, 216, 230)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[13,13 100x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[13,13 100x100]
   FillRect@1 rect=[13,13 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@1 rect=[13,13 65x16] translation=[13,25.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
+++ b/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
@@ -1,15 +1,16 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x101]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x80]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 120x80]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x101]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x80]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 120x80]
   Save@1
     AddClipRect@1 rect=[8,8 120x80]
     DrawRepeatedDisplayList@1 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80] scaling_mode=NearestNeighbor
   Restore@1
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/scrollable-in-fixed.txt
@@ -1,20 +1,20 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (PaintableWithLines(BlockContainer(anonymous)))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[33,33 180x100]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+      [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[20,20 204x154]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[20,20 204x154]
   FillRect@0 rect=[20,20 204x154] color=rgb(211, 211, 211)
   FillPath@0 path_bounding_rect=[20,20 204x154]
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=2 rect=[32,32 182x102]
-  CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[33,33 180x100] max_scroll_offset=[120,100] is_viewport=false
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=3 rect=[32,32 182x102]
+  CompositorScrollNode@0 scroll_node_index=3 parent_scroll_node_index=0 scrollport_rect=[33,33 180x100] max_scroll_offset=[120,100] is_viewport=false
   FillPath@0 path_bounding_rect=[32,32 182x102]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[33,33 300x200]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[33,33 300x200]
   FillRect@3 rect=[33,33 300x200] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[33,33 179x16] translation=[33,45.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -1,25 +1,25 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[9,9 100x80]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
       [4] clip=[131,9 100x80]
-        [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+        [5] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x103]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x82]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x82]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 102x82]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x103]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x82]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x82]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 102x82]
   FillPath@1 path_bounding_rect=[8,8 102x82]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[9,9 150x120]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[9,9 150x120]
   FillRect@3 rect=[9,9 150x120] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[9,9 110x16] translation=[9,21.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[130,8 102x82]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[130,8 102x82]
   FillPath@1 path_bounding_rect=[130,8 102x82]
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=0 rect=[131,9 150x120]
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[131,9 150x120]
   FillRect@5 rect=[131,9 150x120] color=rgb(144, 238, 144)
   DrawGlyphRun@5 rect=[131,9 119x16] translation=[131,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-scrollables-in-fixed.txt
@@ -1,40 +1,40 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (PaintableWithLines(BlockContainer<DIV>.scroll-container))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
     [2] clip=[23,23 91x150]
-      [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+      [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
     [4] clip=[126,23 92x150]
-      [5] scroll_frame_id=3 (PaintableWithLines(BlockContainer(anonymous)))
+      [5] scroll (PaintableWithLines(BlockContainer(anonymous)))
     [6] clip=[230,23 91x150]
-      [7] scroll_frame_id=4 (PaintableWithLines(BlockContainer(anonymous)))
+      [7] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[10,10 324x224]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[10,10 324x224]
   FillRect@0 rect=[10,10 324x224] color=rgb(211, 211, 211)
   FillPath@0 path_bounding_rect=[10,10 324x224]
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=2 rect=[22,22 93.328125x152]
-  CompositorScrollNode@0 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[23,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=3 rect=[22,22 93.328125x152]
+  CompositorScrollNode@0 scroll_node_index=3 parent_scroll_node_index=0 scrollport_rect=[23,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[22,22 93x152]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[23,23 200x300]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=3 rect=[23,23 200x300]
   FillRect@3 rect=[23,23 200x300] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[23,23 71x16] translation=[23,35.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=3 rect=[125.328125,22 93.328125x152]
-  CompositorScrollNode@0 scroll_frame_index=3 parent_scroll_frame_index=0 scrollport_rect=[126,23 92x150] max_scroll_offset=[108.671875,150] is_viewport=false
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=5 rect=[125.328125,22 93.328125x152]
+  CompositorScrollNode@0 scroll_node_index=5 parent_scroll_node_index=0 scrollport_rect=[126,23 92x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[125,22 94x152]
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=3 rect=[126.328125,23 200x300]
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=5 rect=[126.328125,23 200x300]
   FillRect@5 rect=[126,23 200x300] color=rgb(144, 238, 144)
   DrawGlyphRun@5 rect=[126,23 66x16] translation=[126.328125,35.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0
   PaintScrollBar@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=4 rect=[228.65625,22 93.328125x152]
-  CompositorScrollNode@0 scroll_frame_index=4 parent_scroll_frame_index=0 scrollport_rect=[230,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=7 rect=[228.65625,22 93.328125x152]
+  CompositorScrollNode@0 scroll_node_index=7 parent_scroll_node_index=0 scrollport_rect=[230,23 91x150] max_scroll_offset=[108.671875,150] is_viewport=false
   FillPath@0 path_bounding_rect=[229,22 93x152]
-  CompositorWheelHitTestTarget@7 target_scroll_frame_index=4 rect=[229.65625,23 200x300]
+  CompositorWheelHitTestTarget@7 target_scroll_node_index=7 rect=[229.65625,23 200x300]
   FillRect@7 rect=[230,23 200x300] color=rgb(173, 216, 230)
   DrawGlyphRun@7 rect=[229,23 67x16] translation=[229.65625,35.796875] color=rgb(0, 0, 0)
   PaintScrollBar@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -1,19 +1,19 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[0.9848077,-0.17364818,0.17364818,0.9848077,0,0] origin=(48,48) (PaintableWithLines(BlockContainer<DIV>.box.left))
       [3] transform=[0.8,0,0,0.8,0,0] origin=(138,48) (PaintableWithLines(BlockContainer<DIV>.box.right))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x101]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x80]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x80]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 80x80]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x101]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x80]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x80]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 80x80]
   FillRect@2 rect=[8,8 80x80] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,8 15x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[98,8 80x80]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[98,8 80x80]
   FillRect@3 rect=[98,8 80x80] color=rgb(0, 0, 255)
   DrawGlyphRun@3 rect=[98,8 10x16] translation=[98,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -1,17 +1,17 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[10,10 200x100]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer<DIV>.inner-box))
+        [3] scroll (PaintableWithLines(BlockContainer<DIV>.inner-box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x125]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x104]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 204x104]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x125]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x104]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 204x104]
   FillPath@1 path_bounding_rect=[8,8 204x104]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[10,10 300x150]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[10,10 300x150]
   FillRect@3 rect=[10,10 300x150] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[10,10 38x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
+++ b/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
@@ -1,15 +1,15 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [6] clip=[8,108 100x100] (PaintableWithLines(BlockContainer<DIV>.child))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,108 100x100]
-  CompositorWheelHitTestTarget@6 target_scroll_frame_index=0 rect=[8,108 50x50]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,108 100x100]
+  CompositorWheelHitTestTarget@6 target_scroll_node_index=0 rect=[8,108 50x50]
   FillRect@6 rect=[8,108 50x50] color=rgb(255, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -1,16 +1,16 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 100x100] (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>#fo))
         [3] clip=[9,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   Save@2
     AddClipRect@2 rect=[-2,-2 119x119]
     SaveLayer@2
@@ -24,8 +24,8 @@ SaveLayer@0
   Save@2
     AddClipRect@2 rect=[-2,-2 119x119]
     SaveLayer@2
-      CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[9,8 100x100]
-      CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[9,8 100x100]
+      CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[9,8 100x100]
+      CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[9,8 100x100]
       FillRect@3 rect=[9,8 100x100] color=rgb(0, 0, 0)
       ApplyEffects@2 opacity=1 has_filter=false
         PaintNestedDisplayList@2 rect=[-2,-2 119x119]

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-scroller-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-scroller-after-relayout.txt
@@ -1,23 +1,23 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 100x100] (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>))
         [3] clip=[8,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
           [4] clip=[8,8 80x80]
-            [5] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+            [5] scroll (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   StrokePath@2
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=2 rect=[8,8 80x80]
-  CompositorScrollNode@3 scroll_frame_index=2 parent_scroll_frame_index=0 scrollport_rect=[8,8 80x80] max_scroll_offset=[0,220] is_viewport=false
-  CompositorWheelHitTestTarget@5 target_scroll_frame_index=2 rect=[8,8 80x300]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=5 rect=[8,8 80x80]
+  CompositorScrollNode@3 scroll_node_index=5 parent_scroll_node_index=0 scrollport_rect=[8,8 80x80] max_scroll_offset=[0,220] is_viewport=false
+  CompositorWheelHitTestTarget@5 target_scroll_node_index=5 rect=[8,8 80x300]
   FillRect@5 rect=[8,8 80x300] color=rgb(0, 0, 0)
   PaintScrollBar@3
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -1,18 +1,18 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (ImagePaintable(ImageBox<IMG>))
+    [1] scroll (ImagePaintable(ImageBox<IMG>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,13 300x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 300x200]
   PaintNestedDisplayList@1 rect=[8,13 300x200]
     SaveLayer@0
-      CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 300x200]
-      CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 300x200]
+      CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 300x200]
+      CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 300x200]
       FillPath@1 path_bounding_rect=[5,0 55x56]
       FillPath@1 path_bounding_rect=[1,50 55x55]
       Save@1
@@ -29,3 +29,4 @@ SaveLayer@0
       Restore@1
     Restore@0
 Restore@0
+

--- a/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
@@ -1,15 +1,15 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[0,0 200x200] (SVGPathPaintable(SVGGeometryBox<rect>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 200x200]
   FillPath@2 path_bounding_rect=[10,10 100x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -1,17 +1,17 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 200x200]
         [3] effects=[opacity=0.5]
           [6] transform=[1,0,0,1,20,20] origin=(8,8) (SVGPathPaintable(SVGGeometryBox<rect>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
   FillPath@6 path_bounding_rect=[8,8 100x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
+++ b/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
@@ -1,14 +1,14 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x71]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x50]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x50]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,-17 168.54688x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x71]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x50]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x50]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,-17 168.54688x100]
   FillRect@1 rect=[69,-17 47x100] color=rgba(101, 2, 0, 0.8)
   Save@1
     AddClipRect@1 rect=[8,-17 61x100]

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -1,19 +1,19 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[9,9 104x30] (PaintableWithLines(BlockContainer<DIV>))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x53]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 106x32]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x53]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 106x32]
   FillRect@1 rect=[8,8 106x32] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 106x32]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,11 100x13]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[11,11 100x13]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,11 100x13]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,11 100x13]
   DrawGlyphRun@2 rect=[11,11 30x13] translation=[11,21.390625] color=rgb(0, 0, 0)
   FillRect@2 rect=[11,11 1x13] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 110x36]

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -1,23 +1,23 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[0.9659258,-0.25881904,0.25881904,0.9659258,0,0] origin=(38,38) (PaintableWithLines(BlockContainer<DIV>.box.a))
       [3] transform=[1.1,0,0,1.1,0,0] origin=(103,38) (PaintableWithLines(BlockContainer<DIV>.box.b))
       [4] transform=[1,0.17632698,0,1,0,0] origin=(168,38) (PaintableWithLines(BlockContainer<DIV>.box.c))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x81]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x60]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x60]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 60x60]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x81]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x60]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x60]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 60x60]
   FillRect@2 rect=[8,8 60x60] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,8 7x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[73,8 60x60]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[73,8 60x60]
   FillRect@3 rect=[73,8 60x60] color=rgb(0, 128, 0)
   DrawGlyphRun@3 rect=[73,8 9x16] translation=[73,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[138,8 60x60]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[138,8 60x60]
   FillRect@4 rect=[138,8 60x60] color=rgb(0, 0, 255)
   DrawGlyphRun@4 rect=[138,8 10x16] translation=[138,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -1,14 +1,14 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,50,30] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,8 38x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-invertibility-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-invertibility-invalidation.txt
@@ -1,27 +1,27 @@
 Before transform change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
 Restore@0
 
 After transform change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[1,0,0,1,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>#box))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -1,17 +1,17 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] transform=[0.70710677,-0.70710677,0.70710677,0.70710677,0,0] origin=(108,108) (PaintableWithLines(BlockContainer(anonymous)))
         [3] transform=[0.5,0,0,0.5,0,0] origin=(58,58) (PaintableWithLines(BlockContainer<DIV>.inner))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@2 target_scroll_frame_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 200x200]
   FillRect@2 rect=[8,8 200x200] color=rgb(173, 216, 230)
-  CompositorWheelHitTestTarget@3 target_scroll_frame_index=0 rect=[8,8 100x100]
+  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@3 rect=[8,8 52x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -1,18 +1,18 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[10,10 150x150]
-        [3] scroll_frame_id=2 (PaintableWithLines(BlockContainer(anonymous)))
+        [3] scroll (PaintableWithLines(BlockContainer(anonymous)))
           [4] transform=[1,0,0,1,20,20] origin=(110,110) (PaintableWithLines(BlockContainer<DIV>.transformed))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x175]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x154]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 154x154]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x175]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x154]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 154x154]
   FillPath@1 path_bounding_rect=[8,8 154x154]
-  CompositorWheelHitTestTarget@4 target_scroll_frame_index=0 rect=[10,10 200x200]
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[10,10 200x200]
   FillRect@4 rect=[10,10 200x200] color=rgb(144, 238, 144)
   DrawGlyphRun@4 rect=[10,10 185x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
+++ b/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
@@ -1,30 +1,30 @@
 Before z-index change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 50x50]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 50x50]
   FillRect@1 rect=[8,8 50x50] color=rgb(0, 0, 255)
 Restore@0
 
 After z-index change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll_frame_id=1 (PaintableWithLines(BlockContainer<PRE>#out))
+    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_frame_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@1 target_scroll_frame_index=0 rect=[8,8 50x50]
+  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
+  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 50x50]
   FillRect@1 rect=[8,8 50x50] color=rgb(0, 0, 255)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/scroll-does-not-rebuild-accumulated-visual-context-tree.txt
+++ b/Tests/LibWeb/Text/expected/scroll-does-not-rebuild-accumulated-visual-context-tree.txt
@@ -1,0 +1,4 @@
+scrollTop: 100
+scrollLeft: 50
+bounding rect y: 8
+builds after pure scroll: 0

--- a/Tests/LibWeb/Text/input/anchor-scroll-shift-with-anchor-after-positioned-box.html
+++ b/Tests/LibWeb/Text/input/anchor-scroll-shift-with-anchor-after-positioned-box.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    #container { position: relative; width: 300px; height: 300px; }
+    #anchored {
+        position: absolute;
+        position-anchor: --a;
+        top: anchor(bottom);
+        left: anchor(left);
+        width: 40px;
+        height: 20px;
+    }
+    #scroller { width: 200px; height: 200px; overflow: scroll; }
+    #anchor { anchor-name: --a; width: 60px; height: 30px; }
+</style>
+<div id="container">
+    <div id="anchored"></div>
+    <div id="scroller">
+        <div style="height: 60px"></div>
+        <div id="anchor"></div>
+        <div style="height: 600px"></div>
+    </div>
+</div>
+<script>
+    // The anchor is a later sibling subtree than the anchor-positioned box, so building the
+    // positioned box's visual context requires the anchor's scroll frame chain to be known
+    // even though the anchor has not been visited yet in tree order.
+    test(() => {
+        const anchored = document.getElementById("anchored");
+        const anchor = document.getElementById("anchor");
+        const scroller = document.getElementById("scroller");
+        const lines = [];
+
+        let anchoredRect = anchored.getBoundingClientRect();
+        let anchorRect = anchor.getBoundingClientRect();
+        const anchorBottomBeforeScroll = anchorRect.bottom;
+        lines.push(`top gap before scroll: ${anchoredRect.top - anchorRect.bottom}`);
+        lines.push(`left gap before scroll: ${anchoredRect.left - anchorRect.left}`);
+
+        scroller.scrollTop = 40;
+        anchoredRect = anchored.getBoundingClientRect();
+        anchorRect = anchor.getBoundingClientRect();
+        lines.push(`anchor bottom moved by: ${anchorRect.bottom - anchorBottomBeforeScroll}`);
+        lines.push(`top gap after scroll: ${anchoredRect.top - anchorRect.bottom}`);
+        lines.push(`left gap after scroll: ${anchoredRect.left - anchorRect.left}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/anchor-scroll-shift-with-anchor-after-positioned-box.html
+++ b/Tests/LibWeb/Text/input/anchor-scroll-shift-with-anchor-after-positioned-box.html
@@ -23,7 +23,7 @@
 </div>
 <script>
     // The anchor is a later sibling subtree than the anchor-positioned box, so building the
-    // positioned box's visual context requires the anchor's scroll frame chain to be known
+    // positioned box's visual context requires the anchor's scroll node chain to be known
     // even though the anchor has not been visited yet in tree order.
     test(() => {
         const anchored = document.getElementById("anchored");

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-parent-nodes.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-parent-nodes.html
@@ -36,10 +36,10 @@
 
     test(() => {
         const state = internals.asyncScrollingState();
-        const scrollNodeIDs = new Set(state.scrollNodes.map(node => `${node.documentID}:${node.scrollFrameIndex}`));
+        const scrollNodeIDs = new Set(state.scrollNodes.map(node => `${node.documentID}:${node.scrollNodeIndex}`));
         const viewportNode = state.scrollNodes.find(node => node.isViewport);
         const childNodes = state.scrollNodes.filter(node => !node.isViewport);
-        const danglingParentNodes = state.scrollNodes.filter(node => node.parentScrollFrameIndex !== 0 && !scrollNodeIDs.has(`${node.parentDocumentID}:${node.parentScrollFrameIndex}`));
+        const danglingParentNodes = state.scrollNodes.filter(node => node.parentScrollNodeIndex !== 0 && !scrollNodeIDs.has(`${node.parentDocumentID}:${node.parentScrollNodeIndex}`));
 
         const output = [
             `scroll nodes: ${state.scrollNodes.length}`,
@@ -47,7 +47,7 @@
             `dangling parent nodes: ${danglingParentNodes.length}`,
         ];
         for (const node of childNodes)
-            output.push(`child parent is viewport: ${node.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
+            output.push(`child parent is viewport: ${node.parentScrollNodeIndex === viewportNode.scrollNodeIndex}`);
         printOutputAndDisplayList(output);
     });
 </script>

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-shape.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-tree-shape.html
@@ -36,13 +36,13 @@
 
         const viewportNode = state.scrollNodes.find(node => node.isViewport);
         output.push(`has viewport node: ${!!viewportNode}`);
-        output.push(`viewport parent: ${viewportNode?.parentScrollFrameIndex ?? "missing"}`);
+        output.push(`viewport parent: ${viewportNode?.parentScrollNodeIndex ?? "missing"}`);
 
         const childNodes = state.scrollNodes.filter(node => !node.isViewport);
         output.push(`child nodes: ${childNodes.length}`);
         for (const node of childNodes) {
             output.push(`child has same document as viewport: ${node.documentID === viewportNode.documentID}`);
-            output.push(`child parent is viewport: ${node.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`);
+            output.push(`child parent is viewport: ${node.parentScrollNodeIndex === viewportNode.scrollNodeIndex}`);
         }
         printOutputAndDisplayList(output);
     });

--- a/Tests/LibWeb/Text/input/async-scrolling/sticky-areas.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/sticky-areas.html
@@ -35,16 +35,16 @@
     test(() => {
         const state = internals.asyncScrollingState();
         const viewportNode = state.scrollNodes.find(node => node.isViewport);
-        const outerArea = state.stickyAreas.find(area => area.parentScrollFrameIndex === viewportNode.scrollFrameIndex);
-        const innerArea = state.stickyAreas.find(area => area.parentScrollFrameIndex === outerArea.scrollFrameIndex);
+        const outerArea = state.stickyAreas.find(area => area.parentScrollNodeIndex === viewportNode.scrollNodeIndex);
+        const innerArea = state.stickyAreas.find(area => area.parentScrollNodeIndex === outerArea.scrollNodeIndex);
 
         printOutputAndDisplayList([
             `scroll nodes: ${state.scrollNodeCount}`,
             `sticky areas: ${state.stickyAreaCount}`,
-            `outer parent is viewport: ${outerArea.parentScrollFrameIndex === viewportNode.scrollFrameIndex}`,
-            `inner parent is outer: ${innerArea.parentScrollFrameIndex === outerArea.scrollFrameIndex}`,
-            `outer ancestor is viewport: ${outerArea.nearestScrollingAncestorIndex === viewportNode.scrollFrameIndex}`,
-            `inner ancestor is viewport: ${innerArea.nearestScrollingAncestorIndex === viewportNode.scrollFrameIndex}`,
+            `outer parent is viewport: ${outerArea.parentScrollNodeIndex === viewportNode.scrollNodeIndex}`,
+            `inner parent is outer: ${innerArea.parentScrollNodeIndex === outerArea.scrollNodeIndex}`,
+            `outer ancestor is viewport: ${outerArea.nearestScrollingAncestorIndex === viewportNode.scrollNodeIndex}`,
+            `inner ancestor is viewport: ${innerArea.nearestScrollingAncestorIndex === viewportNode.scrollNodeIndex}`,
             `outer has top inset only: ${outerArea.hasTopInset && !outerArea.hasRightInset && !outerArea.hasBottomInset && !outerArea.hasLeftInset}`,
             `inner has top inset only: ${innerArea.hasTopInset && !innerArea.hasRightInset && !innerArea.hasBottomInset && !innerArea.hasLeftInset}`,
         ]);

--- a/Tests/LibWeb/Text/input/scroll-does-not-rebuild-accumulated-visual-context-tree.html
+++ b/Tests/LibWeb/Text/input/scroll-does-not-rebuild-accumulated-visual-context-tree.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="scroller" style="width: 100px; height: 100px; overflow: scroll">
+    <div style="width: 500px; height: 500px"></div>
+</div>
+<script>
+    test(() => {
+        const scroller = document.getElementById('scroller');
+
+        scroller.getBoundingClientRect();
+        const initialBuildCount = internals.accumulatedVisualContextTreeBuildCount();
+        const lines = [];
+
+        scroller.scrollTop = 100;
+        scroller.scrollLeft = 50;
+        lines.push(`scrollTop: ${scroller.scrollTop}`);
+        lines.push(`scrollLeft: ${scroller.scrollLeft}`);
+        lines.push(`bounding rect y: ${scroller.getBoundingClientRect().y}`);
+        lines.push(`builds after pure scroll: ${internals.accumulatedVisualContextTreeBuildCount() - initialBuildCount}`);
+
+        for (const line of lines)
+            println(line);
+    });
+</script>


### PR DESCRIPTION
The scroll frame tree duplicated structure the accumulated visual context tree already encodes — every frame had exactly one ScrollData node — and rebuilding it cost every layout commit two extra full paintable-tree traversals on top of the AVC tree's own walk, plus a second index namespace (ScrollFrameIndex) carried across IPC.

Scroll frames are now created by the visual context tree walk, and the ScrollData node is the scroll frame, keyed by its VisualContextIndex everywhere; ScrollState remains as the value store for offsets and sticky constraints, addressed by a slot stamped into the node.

This also clears the path to partial AVC tree rebuilds: with one tree, scoping the AVC rebuild scopes scroll frames with it — no separate partial scroll frame tree rebuild to keep consistent.