### PR TITLE
LibWeb: Download hyperlinks with a `download` attribute 

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -856,6 +856,7 @@ set(SOURCES
     Layout/VideoBox.cpp
     Layout/Viewport.cpp
     Loader/ContentBlocker.cpp
+    Loader/DownloadFilename.cpp
     Loader/FileRequest.cpp
     Loader/GeneratedPagesLoader.cpp
     Loader/ProxyMappings.cpp

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -65,6 +65,11 @@
 #include <LibWeb/DOM/SelectorQuery.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
+#include <LibWeb/Fetch/Fetching/Fetching.h>
+#include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
+#include <LibWeb/Fetch/Infrastructure/FetchController.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/Geometry/DOMRect.h>
 #include <LibWeb/Geometry/DOMRectList.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -102,6 +107,7 @@
 #include <LibWeb/HTML/HTMLUListElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/LocalTraversableNavigable.h>
+#include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -449,6 +455,106 @@ void Element::follow_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTML:
         : URL::Parser::basic_parse(url_string);
     VERIFY(url.has_value());
     MUST(target_navigable->navigate({ .url = url.release_value(), .source_document = document(), .referrer_policy = referrer_policy, .user_involvement = user_involvement }));
+}
+
+// https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks
+void Element::download_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTML::UserNavigationInvolvement user_involvement)
+{
+    // 1. If subject cannot navigate, then return.
+    if (cannot_navigate())
+        return;
+
+    // 2. If subject's node document's active sandboxing flag set has the sandboxed downloads browsing context flag
+    //    set, then return.
+    if (has_flag(document().active_sandboxing_flag_set(), HTML::SandboxingFlagSet::SandboxedDownloads))
+        return;
+
+    // 3. Let urlString be the result of encoding-parsing-and-serializing a URL given subject's href attribute
+    //    value, relative to subject's node document.
+    auto url_record = document().encoding_parse_url(get_attribute_value_view(HTML::AttributeNames::href).value_or({}));
+
+    // 4. If urlString is failure, then return.
+    if (!url_record.has_value())
+        return;
+
+    auto url = url_record.release_value();
+
+    // 5. If hyperlinkSuffix is non-null, then append it to urlString.
+    if (hyperlink_suffix.has_value()) {
+        auto url_string = url.serialize();
+        Utf16StringBuilder url_string_builder;
+        url_string_builder.append_ascii(url_string.bytes_as_string_view());
+        url_string_builder.append(hyperlink_suffix->utf16_view());
+        auto url_string_with_suffix = url_string_builder.to_string();
+        auto url_with_suffix = URL::Parser::basic_parse(url_string_with_suffix.utf16_view());
+        VERIFY(url_with_suffix.has_value());
+        url = url_with_suffix.release_value();
+    }
+
+    // NB: The download attribute is read once here, before any script can run, so the proposed filename used when
+    //     getting the suggested filename reflects its value at the time the download was initiated.
+    auto download_attribute = attribute(HTML::AttributeNames::download);
+
+    // 6. If userInvolvement is not "browser UI":
+    if (user_involvement != HTML::UserNavigationInvolvement::BrowserUI) {
+        // 1. Assert: subject has a download attribute.
+        VERIFY(download_attribute.has_value());
+
+        // 2. Let navigation be subject's relevant global object's navigation API.
+        auto navigation = as<HTML::Window>(HTML::relevant_global_object(*this)).navigation();
+
+        // 3. Let filename be the value of subject's download attribute.
+        auto filename = download_attribute.value();
+
+        // 4. Let continue be the result of firing a download request navigate event at navigation with
+        //    destinationURL set to urlString, userInvolvement set to userInvolvement, sourceElement set to
+        //    subject, and filename set to filename.
+        auto continue_ = navigation->fire_a_download_request_navigate_event(url, user_involvement, this, move(filename));
+
+        // 5. If continue is false, then return.
+        if (!continue_)
+            return;
+
+        // 6. Inform the navigation API about aborting navigation given subject's node navigable.
+        if (auto navigable = document().navigable())
+            navigable->inform_the_navigation_api_about_aborting_navigation();
+    }
+
+    // NB: Firing the navigate event above runs script, which may have detached this element's document from its
+    //     navigable.
+    auto navigable = document().navigable();
+    if (!navigable)
+        return;
+
+    auto proposed_filename = download_attribute.map([](auto const& filename) {
+        return filename.utf16_view().to_utf8_but_should_be_ported_to_utf16().to_byte_string();
+    });
+
+    // 7. Run these steps in parallel:
+    //    1. Optionally, the user agent may abort these steps, if it believes doing so would safeguard the user
+    //       from a potentially hostile download.
+    //    2. Let request be a new request whose URL is urlString, client is entry settings object, initiator is
+    //       "download", destination is the empty string, and whose synchronous flag and use-URL-credentials flag
+    //       are set.
+    // AD-HOC: The entry settings object may be empty when a hyperlink is activated by the user, so the node
+    //         document's relevant settings object is used as the request client instead.
+    auto request = Fetch::Infrastructure::Request::create(vm());
+    request->set_url(url);
+    request->set_client(&document().relevant_settings_object());
+    request->set_initiator(Fetch::Infrastructure::Request::Initiator::Download);
+    request->set_use_url_credentials(true);
+    // NB: The synchronous flag is not set; the response is instead processed asynchronously on the main thread.
+
+    //    3. Let response be the result of fetching request.
+    //    4. Handle as a download response with subject's node navigable and null.
+    auto controller_holder = Fetch::Infrastructure::FetchControllerHolder::create(vm());
+    Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+    fetch_algorithms_input.process_response = [navigable = GC::Ref { *navigable }, url, proposed_filename = move(proposed_filename), interface_origin = document().origin(), controller_holder](GC::Ref<Fetch::Infrastructure::Response> response) {
+        if (response->is_network_error())
+            return;
+        navigable->handle_as_a_download(response->unsafe_response(), url, controller_holder->controller(), proposed_filename, interface_origin);
+    };
+    controller_holder->set_controller(Fetch::Fetching::fetch(realm(), request, Fetch::Infrastructure::FetchAlgorithms::create(vm(), move(fetch_algorithms_input))));
 }
 
 // https://dom.spec.whatwg.org/#dom-element-getattributenode

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -144,6 +144,7 @@ public:
     bool cannot_navigate() const;
 
     void follow_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTML::UserNavigationInvolvement = HTML::UserNavigationInvolvement::None);
+    void download_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTML::UserNavigationInvolvement = HTML::UserNavigationInvolvement::None);
 
     Optional<Utf16String> lang() const;
     void invalidate_lang_value();

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -105,22 +105,21 @@ void HTMLAnchorElement::activation_behavior(Web::DOM::Event const& event)
     // 4. Let userInvolvement be event's user navigation involvement.
     auto user_involvement = user_navigation_involvement(event);
 
-    // 5. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
+    // FIXME: 5. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
     // NOTE: That is, if the user has expressed a specific preference for downloading, this no longer counts as merely "activation".
-    if (has_download_preference())
-        user_involvement = UserNavigationInvolvement::BrowserUI;
+    // NB: There is currently no way for the user to express a preference to download a hyperlink at activation
+    //     time.
 
-    // FIXME: 6. If element has a download attribute, or if the user has expressed a preference to download the
-    //     hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
-    //     userInvolvement set to userInvolvement.
+    // 6. If element has a download attribute, or if the user has expressed a preference to download the
+    //    hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
+    //    userInvolvement set to userInvolvement.
+    if (has_attribute(HTML::AttributeNames::download)) {
+        download_the_hyperlink(hyperlink_suffix, user_involvement);
+        return;
+    }
 
     // 7. Otherwise, follow the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and userInvolvement set to userInvolvement.
     follow_the_hyperlink(hyperlink_suffix, user_involvement);
-}
-
-bool HTMLAnchorElement::has_download_preference() const
-{
-    return has_attribute(HTML::AttributeNames::download);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -47,8 +47,6 @@ public:
 private:
     HTMLAnchorElement(DOM::Document&, DOM::QualifiedName);
 
-    bool has_download_preference() const;
-
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -356,6 +356,11 @@ static ByteString suggested_download_filename(URL::URL const& url, HTTP::HeaderL
     if (content_disposition.is_attachment && content_disposition.filename.has_value())
         return sanitize_suggested_download_filename(content_disposition.filename.release_value());
 
+    // The filename is derived from the URL of the response. URLs with an opaque path, such as data: URLs, do not
+    // contain a usable filename, so the default filename is used instead.
+    if (url.has_an_opaque_path())
+        return sanitize_suggested_download_filename({});
+
     return sanitize_suggested_download_filename(url.basename());
 }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -329,22 +329,108 @@ static ContentDispositionInfo parse_content_disposition(HTTP::HeaderList const& 
     return info;
 }
 
-static ByteString suggested_download_filename(URL::URL const& url, HTTP::HeaderList const& headers)
+// https://html.spec.whatwg.org/multipage/links.html#getting-the-suggested-filename
+static ByteString suggested_download_filename(URL::URL const& url, HTTP::HeaderList const& headers, Optional<ByteString> const& proposed_filename, Optional<URL::Origin> const& interface_origin)
 {
-    // https://html.spec.whatwg.org/multipage/links.html#getting-the-suggested-filename
-    // FIXME: This is a partial implementation. We do not yet model the
-    //        hyperlink download attribute, trusted operation, or extension
-    //        adjustment steps.
+    // 1. Let filename be the undefined value.
+    Optional<ByteString> filename;
+
+    // 2. If response has a `Content-Disposition` header, that header specifies the attachment disposition type,
+    //    and the header includes filename information, then let filename have the value specified by the header,
+    //    and jump to the step labeled sanitize below.
     auto content_disposition = parse_content_disposition(headers);
-    if (content_disposition.is_attachment && content_disposition.filename.has_value())
-        return sanitize_suggested_download_filename(content_disposition.filename.release_value());
+    if (content_disposition.is_attachment && content_disposition.filename.has_value()) {
+        filename = content_disposition.filename.value();
+        goto sanitize;
+    }
 
-    // The filename is derived from the URL of the response. URLs with an opaque path, such as data: URLs, do not
-    // contain a usable filename, so the default filename is used instead.
-    if (url.has_an_opaque_path())
-        return sanitize_suggested_download_filename({});
+    // NB: Steps 3 to 10 are enclosed in a scope, so the jumps below may bypass the variables declared here.
+    {
+        // 3. Let interface origin be the origin of the Document in which the download or navigate action resulting
+        //    in the download was initiated, if any.
+        // NB: The interface origin is provided by the caller.
 
-    return sanitize_suggested_download_filename(url.basename());
+        // 4. Let response origin be the origin of the URL of response, unless that URL's scheme component is data,
+        //    in which case let response origin be the same as the interface origin, if any.
+        Optional<URL::Origin> response_origin = url.scheme() == "data"sv ? interface_origin : url.origin();
+
+        // 5. If there is no interface origin, then let trusted operation be true. Otherwise, let trusted operation
+        //    be true if response origin is the same origin as interface origin, and false otherwise.
+        auto trusted_operation = !interface_origin.has_value() || response_origin->is_same_origin(*interface_origin);
+
+        // 6. If trusted operation is true and response has a `Content-Disposition` header and that header includes
+        //    filename information, then let filename have the value specified by the header, and jump to the step
+        //    labeled sanitize below.
+        if (trusted_operation && content_disposition.filename.has_value()) {
+            filename = content_disposition.filename.value();
+            goto sanitize;
+        }
+
+        // 7. If the download was not initiated from a hyperlink created by an a or area element, or if the element
+        //    of the hyperlink from which it was initiated did not have a download attribute when the download was
+        //    initiated, or if there was such an attribute but its value when the download was initiated was the
+        //    empty string, then jump to the step labeled no proposed filename.
+        if (!proposed_filename.has_value() || proposed_filename->is_empty())
+            goto no_proposed_filename;
+
+        // 8. Let proposed filename have the value of the download attribute of the element of the hyperlink that
+        //    initiated the download at the time the download was initiated.
+        // NB: The proposed filename is provided by the caller.
+
+        // 9. If trusted operation is true, let filename have the value of proposed filename, and jump to the step
+        //    labeled sanitize below.
+        if (trusted_operation) {
+            filename = proposed_filename.value();
+            goto sanitize;
+        }
+
+        // 10. If response has a `Content-Disposition` header and that header specifies the attachment disposition
+        //     type, let filename have the value of proposed filename, and jump to the step labeled sanitize below.
+        if (content_disposition.is_attachment) {
+            filename = proposed_filename.value();
+            goto sanitize;
+        }
+    }
+
+    // 11. No proposed filename: If trusted operation is true, or if the user indicated a preference for having the
+    //     response in question downloaded, let filename have a value derived from the URL of response in an
+    //     implementation-defined manner, and jump to the step labeled sanitize below.
+no_proposed_filename:
+    // 12. Let filename be set to the user's preferred filename or to a filename selected by the user agent, and
+    //     jump to the step labeled sanitize below.
+    // NB: In both cases the filename is derived from the URL of the response. URLs with an opaque path, such as
+    //     data: URLs, do not contain a usable filename, so the default filename is used instead.
+    if (!url.has_an_opaque_path())
+        filename = url.basename();
+
+    // 13. Sanitize: Optionally, allow the user to influence filename. For example, a user agent could prompt the
+    //     user for a filename, potentially providing the value of filename as determined above as a default value.
+sanitize:
+
+    // 14. Adjust filename to be suitable for the local file system.
+    filename = sanitize_suggested_download_filename(filename.value_or({}));
+
+    // FIXME: 15. If the platform conventions do not in any way use extensions to determine the types of file on
+    //        the file system, then return filename as the filename.
+
+    // FIXME: 16. Let claimed type be the type given by response's Content-Type metadata, if any is known. Let
+    //        named type be the type given by filename's extension, if any is known. For the purposes of this step, a
+    //        type is a mapping of a MIME type to an extension.
+
+    // FIXME: 17. If named type is consistent with the user's preferences (e.g., because the value of filename was
+    //        determined by prompting the user), then return filename as the filename.
+
+    // FIXME: 18. If claimed type and named type are the same type (i.e., the type given by response's Content-Type
+    //        metadata is consistent with the type given by filename's extension), then return filename as the filename.
+
+    // FIXME: 19. If the claimed type is known, then alter filename to add an extension corresponding to claimed
+    //        type. Otherwise, if named type is known to be potentially dangerous (e.g. it will be treated by the
+    //        platform conventions as a native executable, shell script, HTML application, or
+    //        executable-macro-capable document), then optionally alter filename to add a known-safe extension
+    //        (e.g. ".txt").
+
+    // 20. Return filename as the filename.
+    return filename.release_value();
 }
 
 static Optional<u64> response_content_length(HTTP::HeaderList const& headers)
@@ -355,8 +441,65 @@ static Optional<u64> response_content_length(HTTP::HeaderList const& headers)
     return {};
 }
 
+void LocalNavigable::start_download_for_response(GC::Ref<Fetch::Infrastructure::Response> response, URL::URL const& download_url, ByteString suggested_filename, GC::Ptr<Fetch::Infrastructure::FetchController> fetch_controller)
+{
+    auto active_window = this->active_window();
+    if (!active_window) {
+        response->release_request_for_transfer();
+        return;
+    }
+    auto& realm = active_window->realm();
+
+    auto download_id = page().client().page_did_start_download(download_url, suggested_filename, response_content_length(*response->header_list()));
+    if (!download_id.has_value()) {
+        if (fetch_controller)
+            fetch_controller->stop_fetch();
+        return;
+    }
+
+    if (fetch_controller)
+        page().client().page_did_register_download_controller(*download_id, *fetch_controller);
+
+    auto process_body_chunk = GC::create_function(realm.heap(), [navigable = GC::Ref { *this }, download_id = *download_id](ByteBuffer data) {
+        if (navigable->page().client().page_is_download_canceled(download_id))
+            return;
+
+        navigable->page().client().page_did_receive_download_data(download_id, move(data));
+    });
+
+    auto process_end_of_body = GC::create_function(realm.heap(), [navigable = GC::Ref { *this }, download_id = *download_id]() {
+        if (navigable->page().client().page_is_download_canceled(download_id))
+            return;
+
+        navigable->page().client().page_did_finish_download(download_id);
+    });
+
+    auto process_body_error = GC::create_function(realm.heap(), [navigable = GC::Ref { *this }, download_id = *download_id](JS::Value) {
+        if (navigable->page().client().page_is_download_canceled(download_id))
+            return;
+
+        navigable->page().client().page_did_fail_download(download_id, "Unable to read downloaded file"_string);
+    });
+
+    // https://fetch.spec.whatwg.org/#body-incrementally-read
+    auto reader = response->body()->incrementally_read(process_body_chunk, process_end_of_body, process_body_error, GC::Ref { realm.global_object() });
+    page().client().page_did_register_download_reader(*download_id, reader);
+    response->resume_body_delivery();
+}
+
 // https://html.spec.whatwg.org/multipage/links.html#handle-as-a-download
-static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<NavigationParams> navigation_params, GC::Ref<SourceSnapshotParams> source_snapshot_params, Optional<ReadonlyBytes> initial_data = {})
+void LocalNavigable::handle_as_a_download(GC::Ref<Fetch::Infrastructure::Response> response, URL::URL const& fallback_url, GC::Ptr<Fetch::Infrastructure::FetchController> fetch_controller, Optional<ByteString> proposed_filename, Optional<URL::Origin> interface_origin)
+{
+    if (!response->body())
+        return;
+
+    auto download_url = response->url().value_or(fallback_url);
+    auto suggested_filename = suggested_download_filename(download_url, *response->header_list(), proposed_filename, interface_origin);
+
+    start_download_for_response(response, download_url, move(suggested_filename), fetch_controller);
+}
+
+static bool handle_navigation_response_as_download(GC::Ref<NavigationParams> navigation_params, GC::Ref<SourceSnapshotParams> source_snapshot_params, Optional<ReadonlyBytes> initial_data = {})
 {
     auto response = navigation_params->response;
     if (!response || !response->body())
@@ -382,8 +525,8 @@ static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<Nav
     }
 
     auto download_url = response->url().value_or(navigation_params->request ? navigation_params->request->current_url() : URL::about_blank());
-    auto suggested_filename = suggested_download_filename(download_url, *response->header_list());
     if (auto const& request_server_request = response->request_server_request(); request_server_request.has_value()) {
+        auto suggested_filename = suggested_download_filename(download_url, *response->header_list(), {}, source_snapshot_params->fetch_client->origin());
         auto response_body_will_be_transferred_in_full = request_server_request->request && request_server_request->request->has_file_backed_response_body();
         ByteBuffer initial_data_buffer;
         if (initial_data.has_value() && !initial_data->is_empty() && !response_body_will_be_transferred_in_full)
@@ -402,42 +545,7 @@ static bool handle_navigation_response_as_download(JS::Realm& realm, GC::Ref<Nav
         return true;
     }
 
-    auto download_id = navigation_params->navigable->page().client().page_did_start_download(download_url, suggested_filename, response_content_length(*response->header_list()));
-    if (!download_id.has_value()) {
-        if (navigation_params->fetch_controller)
-            navigation_params->fetch_controller->stop_fetch();
-        return true;
-    }
-
-    if (navigation_params->fetch_controller)
-        navigation_params->navigable->page().client().page_did_register_download_controller(*download_id, *navigation_params->fetch_controller);
-
-    auto process_body_chunk = GC::create_function(realm.heap(), [navigable = navigation_params->navigable, download_id = *download_id](ByteBuffer data) {
-        if (navigable->page().client().page_is_download_canceled(download_id))
-            return;
-
-        navigable->page().client().page_did_receive_download_data(download_id, move(data));
-    });
-
-    auto process_end_of_body = GC::create_function(realm.heap(), [navigable = navigation_params->navigable, download_id = *download_id]() {
-        if (navigable->page().client().page_is_download_canceled(download_id))
-            return;
-
-        navigable->page().client().page_did_finish_download(download_id);
-    });
-
-    auto process_body_error = GC::create_function(realm.heap(), [navigable = navigation_params->navigable, download_id = *download_id](JS::Value) {
-        if (navigable->page().client().page_is_download_canceled(download_id))
-            return;
-
-        navigable->page().client().page_did_fail_download(download_id, "Unable to read downloaded file"_string);
-    });
-
-    // https://fetch.spec.whatwg.org/#body-incrementally-read
-    auto reader = response->body()->incrementally_read(process_body_chunk, process_end_of_body, process_body_error, GC::Ref { realm.global_object() });
-    navigation_params->navigable->page().client().page_did_register_download_reader(*download_id, reader);
-    response->resume_body_delivery();
-
+    navigation_params->navigable->handle_as_a_download(*response, download_url, navigation_params->fetch_controller, {}, source_snapshot_params->fetch_client->origin());
     return true;
 }
 
@@ -2154,7 +2262,7 @@ void LocalNavigable::populate_session_history_entry_document(
             //    disposition type, then:
             else if (auto nav_params = navigation_params.get<GC::Ref<NavigationParams>>();
                 parse_content_disposition(*nav_params->response->header_list()).is_attachment) {
-                output->download_handled = handle_navigation_response_as_download(active_window()->realm(), nav_params, source_snapshot_params);
+                output->download_handled = handle_navigation_response_as_download(nav_params, source_snapshot_params);
                 output->save_extra_document_state = false;
             }
 
@@ -2177,7 +2285,7 @@ void LocalNavigable::populate_session_history_entry_document(
                             if (nav_params->navigable->active_browsing_context()) {
                                 output->document = load_document(nav_params, sniff_bytes);
                                 if (!output->document) {
-                                    output->download_handled = handle_navigation_response_as_download(nav_params->navigable->active_window()->realm(), nav_params, source_snapshot_params, sniff_bytes);
+                                    output->download_handled = handle_navigation_response_as_download(nav_params, source_snapshot_params, sniff_bytes);
                                     output->save_extra_document_state = false;
                                 } else {
                                     nav_params->response->resume_body_delivery();
@@ -2195,7 +2303,7 @@ void LocalNavigable::populate_session_history_entry_document(
                 // Sync path: bytes available immediately
                 output->document = load_document(nav_params, sniff_bytes.value());
                 if (!output->document) {
-                    output->download_handled = handle_navigation_response_as_download(active_window()->realm(), nav_params, source_snapshot_params, sniff_bytes.value());
+                    output->download_handled = handle_navigation_response_as_download(nav_params, source_snapshot_params, sniff_bytes.value());
                     output->save_extra_document_state = false;
                 } else {
                     nav_params->response->resume_body_delivery();

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -72,6 +72,7 @@
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Loader/DownloadFilename.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListDamage.h>
@@ -326,24 +327,6 @@ static ContentDispositionInfo parse_content_disposition(HTTP::HeaderList const& 
 
     info.filename = extended_filename.has_value() ? move(extended_filename) : move(filename);
     return info;
-}
-
-static ByteString sanitize_suggested_download_filename(ByteString filename)
-{
-    filename = LexicalPath::basename(move(filename));
-
-    StringBuilder builder;
-    for (auto byte : filename.bytes()) {
-        if (byte == '\0' || byte == '/' || byte == '\\')
-            builder.append('_');
-        else
-            builder.append(static_cast<char>(byte));
-    }
-
-    auto sanitized = builder.to_byte_string();
-    if (sanitized.is_empty() || sanitized == "."sv || sanitized == ".."sv)
-        return "download";
-    return sanitized;
 }
 
 static ByteString suggested_download_filename(URL::URL const& url, HTTP::HeaderList const& headers)

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -153,6 +153,10 @@ public:
 
     GC::Ptr<LocalNavigable> find_a_navigable_by_target_name(Utf16View name);
 
+    void handle_as_a_download(GC::Ref<Fetch::Infrastructure::Response>, URL::URL const& fallback_url, GC::Ptr<Fetch::Infrastructure::FetchController>, Optional<ByteString> proposed_filename, Optional<URL::Origin> interface_origin);
+
+    void inform_the_navigation_api_about_aborting_navigation();
+
     enum class Traversal {
         Tag
     };
@@ -340,7 +344,8 @@ private:
     void clear_parent_compositor_context();
     void destroy_compositor_context();
 
-    void inform_the_navigation_api_about_aborting_navigation();
+    void start_download_for_response(GC::Ref<Fetch::Infrastructure::Response>, URL::URL const& download_url, ByteString suggested_filename, GC::Ptr<Fetch::Infrastructure::FetchController>);
+
     void resolve_async_scroll_operation(Compositor::AsyncScrollOperationID);
     void resolve_all_pending_async_scroll_operations();
     void schedule_hover_update_after_async_scroll();

--- a/Libraries/LibWeb/Loader/DownloadFilename.cpp
+++ b/Libraries/LibWeb/Loader/DownloadFilename.cpp
@@ -10,6 +10,25 @@
 
 namespace Web {
 
+ByteString truncate_filename_to_byte_length(ByteString filename, size_t maximum_byte_length)
+{
+    if (filename.length() <= maximum_byte_length)
+        return filename;
+
+    auto is_utf8_continuation_byte = [](char byte) {
+        return (static_cast<u8>(byte) & 0b1100'0000) == 0b1000'0000;
+    };
+
+    // Avoid truncating in the middle of a multi-byte UTF-8 sequence.
+    auto length = maximum_byte_length;
+    for (size_t i = 0; i < 3; ++i) {
+        if (length == 0 || !is_utf8_continuation_byte(filename[length]))
+            break;
+        --length;
+    }
+    return filename.substring(0, length);
+}
+
 ByteString sanitize_suggested_download_filename(ByteString filename)
 {
     filename = LexicalPath::basename(move(filename));
@@ -25,6 +44,17 @@ ByteString sanitize_suggested_download_filename(ByteString filename)
     auto sanitized = builder.to_byte_string();
     if (sanitized.is_empty() || sanitized == "."sv || sanitized == ".."sv)
         return "download";
+
+    if (sanitized.length() > maximum_filename_byte_length) {
+        // Preserve the extension when truncating, so the file type is not lost.
+        auto lexical_filename = LexicalPath { sanitized };
+        auto extension = lexical_filename.extension();
+        if (!extension.is_empty() && extension.length() + 1 < maximum_filename_byte_length) {
+            auto truncated_title = truncate_filename_to_byte_length(lexical_filename.title(), maximum_filename_byte_length - extension.length() - 1);
+            return ByteString::formatted("{}.{}", truncated_title, extension);
+        }
+        return truncate_filename_to_byte_length(move(sanitized), maximum_filename_byte_length);
+    }
     return sanitized;
 }
 

--- a/Libraries/LibWeb/Loader/DownloadFilename.cpp
+++ b/Libraries/LibWeb/Loader/DownloadFilename.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <AK/StringBuilder.h>
+#include <LibWeb/Loader/DownloadFilename.h>
+
+namespace Web {
+
+ByteString sanitize_suggested_download_filename(ByteString filename)
+{
+    filename = LexicalPath::basename(move(filename));
+
+    StringBuilder builder;
+    for (auto byte : filename.bytes()) {
+        if (byte == '\0' || byte == '/' || byte == '\\')
+            builder.append('_');
+        else
+            builder.append(static_cast<char>(byte));
+    }
+
+    auto sanitized = builder.to_byte_string();
+    if (sanitized.is_empty() || sanitized == "."sv || sanitized == ".."sv)
+        return "download";
+    return sanitized;
+}
+
+}

--- a/Libraries/LibWeb/Loader/DownloadFilename.h
+++ b/Libraries/LibWeb/Loader/DownloadFilename.h
@@ -11,6 +11,9 @@
 
 namespace Web {
 
+inline constexpr size_t maximum_filename_byte_length = 255;
+
+WEB_API ByteString truncate_filename_to_byte_length(ByteString, size_t maximum_byte_length);
 WEB_API ByteString sanitize_suggested_download_filename(ByteString);
 
 }

--- a/Libraries/LibWeb/Loader/DownloadFilename.h
+++ b/Libraries/LibWeb/Loader/DownloadFilename.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteString.h>
+#include <LibWeb/Export.h>
+
+namespace Web {
+
+WEB_API ByteString sanitize_suggested_download_filename(ByteString);
+
+}

--- a/Libraries/LibWeb/SVG/SVGAElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGAElement.cpp
@@ -107,9 +107,13 @@ void SVGAElement::activation_behavior(DOM::Event const& event)
 
     // FIXME: 5. If the user has expressed a preference to download the hyperlink, then set userInvolvement to "browser UI".
 
-    // FIXME: 6. If element has a download attribute, or if the user has expressed a preference to download the
-    //     hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
-    //     userInvolvement set to userInvolvement.
+    // 6. If element has a download attribute, or if the user has expressed a preference to download the
+    //    hyperlink, then download the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and
+    //    userInvolvement set to userInvolvement.
+    if (has_attribute(HTML::AttributeNames::download)) {
+        download_the_hyperlink(hyperlink_suffix, user_involvement);
+        return;
+    }
 
     // 7. Otherwise, follow the hyperlink created by element with hyperlinkSuffix set to hyperlinkSuffix and userInvolvement set to userInvolvement.
     follow_the_hyperlink(hyperlink_suffix, user_involvement);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1519,9 +1519,11 @@ static LexicalPath unique_download_path(ByteString const& downloads_directory, B
     auto title = lexical_file.title();
     auto extension = lexical_file.extension();
     for (u64 index = 1;; ++index) {
-        auto candidate_filename = extension.is_empty()
-            ? ByteString::formatted("{} ({})", title, index)
-            : ByteString::formatted("{} ({}).{}", title, index, extension);
+        auto suffix = extension.is_empty()
+            ? ByteString::formatted(" ({})", index)
+            : ByteString::formatted(" ({}).{}", index, extension);
+        auto truncated_title = Web::truncate_filename_to_byte_length(title, Web::maximum_filename_byte_length - min(suffix.length(), Web::maximum_filename_byte_length));
+        auto candidate_filename = ByteString::formatted("{}{}", truncated_title, suffix);
         auto candidate = LexicalPath::join(downloads_directory, candidate_filename.view());
         if (download_path_is_available(candidate))
             return candidate;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -27,6 +27,7 @@
 #include <LibURL/InternalURLs.h>
 #include <LibURL/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/Loader/DownloadFilename.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWebView/Application.h>
@@ -1527,24 +1528,6 @@ static LexicalPath unique_download_path(ByteString const& downloads_directory, B
     }
 }
 
-static ByteString sanitize_suggested_download_filename(ByteString filename)
-{
-    filename = LexicalPath::basename(move(filename));
-
-    StringBuilder builder;
-    for (auto byte : filename.bytes()) {
-        if (byte == '\0' || byte == '/' || byte == '\\')
-            builder.append('_');
-        else
-            builder.append(static_cast<char>(byte));
-    }
-
-    auto sanitized = builder.to_byte_string();
-    if (sanitized.is_empty() || sanitized == "."sv || sanitized == ".."sv)
-        return "download";
-    return sanitized;
-}
-
 ErrorOr<LexicalPath> Application::default_path_for_downloaded_file(ByteString const& file) const
 {
     auto downloads_directory = Core::StandardPaths::downloads_directory();
@@ -1554,7 +1537,7 @@ ErrorOr<LexicalPath> Application::default_path_for_downloaded_file(ByteString co
         return Error::from_errno(ENOENT);
     }
 
-    return unique_download_path(downloads_directory, sanitize_suggested_download_filename(file));
+    return unique_download_path(downloads_directory, Web::sanitize_suggested_download_filename(file));
 }
 
 ErrorOr<LexicalPath> Application::path_for_downloaded_file(ByteString const& file) const
@@ -1562,7 +1545,7 @@ ErrorOr<LexicalPath> Application::path_for_downloaded_file(ByteString const& fil
     if (browser_options().headless_mode.has_value())
         return default_path_for_downloaded_file(file);
 
-    auto download_path = ask_user_for_download_path(sanitize_suggested_download_filename(file));
+    auto download_path = ask_user_for_download_path(Web::sanitize_suggested_download_filename(file));
     if (!download_path.has_value())
         return Error::from_errno(ECANCELED);
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -178,7 +178,7 @@ public:
 
     virtual bool should_capture_web_content_output() const { return false; }
 
-    ErrorOr<LexicalPath> default_path_for_downloaded_file(ByteString const& file) const;
+    virtual ErrorOr<LexicalPath> default_path_for_downloaded_file(ByteString const& file) const;
     ErrorOr<LexicalPath> path_for_downloaded_file(ByteString const& file) const;
 
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const;

--- a/Libraries/LibWebView/FileDownloader.cpp
+++ b/Libraries/LibWebView/FileDownloader.cpp
@@ -12,6 +12,7 @@
 #include <LibHTTP/HeaderList.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
+#include <LibWeb/Loader/DownloadFilename.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/FileDownloader.h>
@@ -53,7 +54,10 @@ FileDownloader::~FileDownloader() = default;
 
 static LexicalPath temporary_destination_for(LexicalPath const& destination, u64 download_id)
 {
-    return LexicalPath { ByteString::formatted("{}.{}.{}.download", destination.string(), download_id, generate_random_uuid()) };
+    auto suffix = ByteString::formatted(".{}.{}.download", download_id, generate_random_uuid());
+    auto truncated_basename = Web::truncate_filename_to_byte_length(destination.basename(), Web::maximum_filename_byte_length - suffix.length());
+    auto temporary_filename = ByteString::formatted("{}{}", truncated_basename, suffix);
+    return LexicalPath::join(destination.dirname(), temporary_filename.view());
 }
 
 static String status_to_error_string(Optional<Requests::NetworkError> const& network_error, Optional<u32> response_code, Optional<String> const& reason_phrase)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2721,9 +2721,12 @@ void ViewImplementation::did_request_link_context_menu(Badge<WebContentClient>, 
 
 void ViewImplementation::download_context_menu_url(PromptForPath prompt_for_path)
 {
+    // URLs with an opaque path, such as data: URLs, do not contain a usable filename, so the default filename is
+    // used instead.
+    auto suggested_filename = m_context_menu_url.has_an_opaque_path() ? ByteString {} : m_context_menu_url.basename();
     auto download_path = prompt_for_path == PromptForPath::Yes
-        ? Application::the().path_for_downloaded_file(m_context_menu_url.basename())
-        : Application::the().default_path_for_downloaded_file(m_context_menu_url.basename());
+        ? Application::the().path_for_downloaded_file(suggested_filename)
+        : Application::the().default_path_for_downloaded_file(suggested_filename);
     if (download_path.is_error())
         return;
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -79,6 +79,7 @@ Text/input/wpt-import/navigation-api/navigate-event/navigate-multiple-history-pu
 Text/input/wpt-import/navigation-api/navigate-event/navigate-destination-getState-back-forward.html
 Text/input/wpt-import/navigation-api/navigate-event/defaultPrevented-navigation-preempted.html
 Text/input/wpt-import/navigation-api/navigate-event/event-constructor.html
+Text/input/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept.html
 
 Text/input/wpt-import/navigation-api/state/history-pushState.html
 Text/input/wpt-import/navigation-api/state/history-replaceState.html

--- a/Tests/LibWeb/Text/expected/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept@currententrychange.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept@currententrychange.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	event and promise ordering for <a download> intercepted by intercept()

--- a/Tests/LibWeb/Text/expected/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept@no-currententrychange.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept@no-currententrychange.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	event and promise ordering for <a download> intercepted by intercept()

--- a/Tests/LibWeb/Text/input/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept.html
+++ b/Tests/LibWeb/Text/input/wpt-import/navigation-api/ordering-and-transition/anchor-download-intercept.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<meta name="variant" content="?no-currententrychange">
+<meta name="variant" content="?currententrychange">
+
+<script type="module">
+import { Recorder, hasVariant } from "./resources/helpers.mjs";
+
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+
+  const from = navigation.currentEntry;
+
+  const recorder = new Recorder({
+    skipCurrentChange: !hasVariant("currententrychange"),
+    finalExpectedEvent: "transition.finished fulfilled"
+  });
+
+  recorder.setUpNavigationAPIListeners();
+
+  navigation.addEventListener("navigate", e => {
+    e.intercept({ handler() { recorder.record("handler run"); } });
+  });
+
+  let a = document.createElement("a");
+  a.href = "/common/blank.html#1";
+  a.download = "";
+  document.body.appendChild(a);
+  a.click();
+
+  Promise.resolve().then(() => recorder.record("promise microtask"));
+
+  await recorder.readyToAssert;
+
+  recorder.assert([
+    /* event name, location.hash value, navigation.transition properties */
+    ["navigate", "", null],
+    ["currententrychange", "#1", { from, navigationType: "push" }],
+    ["handler run", "#1", { from, navigationType: "push" }],
+    ["navigatesuccess", "#1", { from, navigationType: "push" }],
+    ["promise microtask", "#1", null],
+    ["transition.finished fulfilled", "#1", null],
+  ]);
+}, "event and promise ordering for <a download> intercepted by intercept()");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/navigation-api/ordering-and-transition/resources/helpers.mjs
+++ b/Tests/LibWeb/Text/input/wpt-import/navigation-api/ordering-and-transition/resources/helpers.mjs
@@ -1,0 +1,206 @@
+const variants = new Set((new URLSearchParams(location.search)).keys());
+
+export function hasVariant(name) {
+  return variants.has(name);
+}
+
+export class Recorder {
+  #events = [];
+  #errors = [];
+  #navigationAPI;
+  #domExceptionConstructor;
+  #location;
+  #skipCurrentChange;
+  #finalExpectedEvent;
+  #finalExpectedEventCount;
+  #currentFinalEventCount = 0;
+
+  #readyToAssertResolve;
+  #readyToAssertPromise = new Promise(resolve => { this.#readyToAssertResolve = resolve; });
+
+  constructor({ window = self, skipCurrentChange = false, finalExpectedEvent, finalExpectedEventCount = 1 }) {
+    assert_equals(typeof finalExpectedEvent, "string", "Must pass a string for finalExpectedEvent");
+
+    this.#navigationAPI = window.navigation;
+    this.#domExceptionConstructor = window.DOMException;
+    this.#location = window.location;
+
+    this.#skipCurrentChange = skipCurrentChange;
+    this.#finalExpectedEvent = finalExpectedEvent;
+    this.#finalExpectedEventCount = finalExpectedEventCount;
+  }
+
+  setUpNavigationAPIListeners() {
+    this.#navigationAPI.addEventListener("navigate", e => {
+      this.record("navigate");
+
+      e.signal.addEventListener("abort", () => {
+        this.recordWithError("AbortSignal abort", e.signal.reason);
+      });
+    });
+
+    this.#navigationAPI.addEventListener("navigateerror", e => {
+      this.recordWithError("navigateerror", e.error);
+
+      this.#navigationAPI.transition?.finished.then(
+        () => this.record("transition.finished fulfilled"),
+        err => this.recordWithError("transition.finished rejected", err)
+      );
+    });
+
+    this.#navigationAPI.addEventListener("navigatesuccess", () => {
+      this.record("navigatesuccess");
+
+      this.#navigationAPI.transition?.finished.then(
+        () => this.record("transition.finished fulfilled"),
+        err => this.recordWithError("transition.finished rejected", err)
+      );
+    });
+
+    if (!this.#skipCurrentChange) {
+      this.#navigationAPI.addEventListener("currententrychange", () => this.record("currententrychange"));
+    }
+  }
+
+  setUpResultListeners(result, suffix = "") {
+
+    result.committed.then(
+      () => this.record(`committed fulfilled${suffix}`),
+      err => this.recordWithError(`committed rejected${suffix}`, err)
+    );
+
+    result.finished.then(
+      () => this.record(`finished fulfilled${suffix}`),
+      err => this.recordWithError(`finished rejected${suffix}`, err)
+    );
+
+    this.#navigationAPI.transition?.committed?.then(
+      () => this.record(`transition.committed fulfilled${suffix}`),
+      err => this.recordWithError(`transition.committed rejected${suffix}`, err)
+    );
+  }
+
+  record(name) {
+    const transitionProps = this.#navigationAPI.transition === null ? null : {
+      from: this.#navigationAPI.transition.from,
+      navigationType: this.#navigationAPI.transition.navigationType
+    };
+
+    this.#events.push({ name, location: this.#location.hash, transitionProps });
+
+    if (name === this.#finalExpectedEvent && ++this.#currentFinalEventCount === this.#finalExpectedEventCount) {
+      this.#readyToAssertResolve();
+    }
+  }
+
+  recordWithError(name, errorObject) {
+    this.record(name);
+    this.#errors.push({ name, errorObject });
+  }
+
+  get readyToAssert() {
+    return this.#readyToAssertPromise;
+  }
+
+  // Usage:
+  //   recorder.assert([
+  //     /* event name, location.hash value, navigation.transition properties */
+  //     ["currententrychange", "", null],
+  //     ["committed fulfilled", "#1", { from, navigationType }],
+  //     ...
+  //   ]);
+  //
+  // The array format is to avoid repitition at the call site, but I recommend
+  // you document it like above.
+  //
+  // This will automatically also assert that any error objects recorded are
+  // equal to each other. Use the other assert functions to check the actual
+  // contents of the error objects.
+  assert(expectedAsArray) {
+    if (this.#skipCurrentChange) {
+      expectedAsArray = expectedAsArray.filter(expected => expected[0] !== "currententrychange");
+    }
+    // TODO: Remove once https://github.com/whatwg/html/pull/10919 is merged.
+    if (!('committed' in NavigationTransition.prototype)) {
+      expectedAsArray = expectedAsArray.filter(expected => {
+         return !expected[0].includes("transition.committed fulfilled") &&
+                !expected[0].includes("transition.committed rejected")
+      });
+    }
+
+    // Doing this up front gives nicer error messages because
+    // assert_array_equals is nice.
+    const recordedNames = this.#events.map(e => e.name);
+    const expectedNames = expectedAsArray.map(e => e[0]);
+    assert_array_equals(recordedNames, expectedNames);
+
+    for (let i = 0; i < expectedAsArray.length; ++i) {
+      const recorded = this.#events[i];
+      const expected = expectedAsArray[i];
+
+      assert_equals(
+        recorded.location,
+        expected[1],
+        `event ${i} (${recorded.name}): location.hash value`
+      );
+
+      if (expected[2] === null) {
+        assert_equals(
+          recorded.transitionProps,
+          null,
+          `event ${i} (${recorded.name}): navigation.transition expected to be null`
+        );
+      } else {
+        assert_not_equals(
+          recorded.transitionProps,
+          null,
+          `event ${i} (${recorded.name}): navigation.transition expected not to be null`
+        );
+        assert_equals(
+          recorded.transitionProps.from,
+          expected[2].from,
+          `event ${i} (${recorded.name}): navigation.transition.from`
+        );
+        assert_equals(
+          recorded.transitionProps.navigationType,
+          expected[2].navigationType,
+          `event ${i} (${recorded.name}): navigation.transition.navigationType`
+        );
+      }
+    }
+
+    if (this.#errors.length > 1) {
+      for (let i = 1; i < this.#errors.length; ++i) {
+        assert_equals(
+          this.#errors[i].errorObject,
+          this.#errors[0].errorObject,
+          `error objects must match: error object for ${this.#errors[i].name} did not match the one for ${this.#errors[0].name}`
+        );
+      }
+    }
+  }
+
+  assertErrorsAreAbortErrors() {
+    assert_greater_than(
+      this.#errors.length,
+      0,
+      "No errors were recorded but assertErrorsAreAbortErrors() was called"
+    );
+
+    // Assume assert() has been called so all error objects are the same.
+    const { errorObject } = this.#errors[0];
+    assert_throws_dom("AbortError", this.#domExceptionConstructor, () => { throw errorObject; });
+  }
+
+  assertErrorsAre(expectedErrorObject) {
+    assert_greater_than(
+      this.#errors.length,
+      0,
+      "No errors were recorded but assertErrorsAre() was called"
+    );
+
+    // Assume assert() has been called so all error objects are the same.
+    const { errorObject } = this.#errors[0];
+    assert_equals(errorObject, expectedErrorObject);
+  }
+}

--- a/Tests/LibWeb/test-web/Application.h
+++ b/Tests/LibWeb/test-web/Application.h
@@ -8,9 +8,11 @@
 
 #include <AK/ByteString.h>
 #include <AK/Error.h>
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWebView/Application.h>
+#include <errno.h>
 
 namespace TestWeb {
 
@@ -25,6 +27,8 @@ public:
     virtual void create_platform_options(WebView::BrowserOptions&, WebView::RequestServerOptions&, WebView::WebContentOptions&) override;
     virtual bool should_coordinate_browser_process() const override { return false; }
     virtual bool should_capture_web_content_output() const override { return true; }
+
+    virtual ErrorOr<LexicalPath> default_path_for_downloaded_file(ByteString const&) const override { return Error::from_errno(ECANCELED); }
 
     ErrorOr<void> launch_test_fixtures();
 


### PR DESCRIPTION
Previously, activating a hyperlink with a `download` attribute followed the hyperlink, so the linked resource was downloaded only if the response could not be displayed, and the filename proposed by the attribute was ignored. We now implement the download the hyperlink algorithm: fire a download request navigate event, then fetch the resource and handle the response as a download without navigating. The suggested filename is now determined per specification, considering the proposed filename and whether the download is a trusted operation.

`data:` and other URLs with an opaque path now use the default "download" filename.

Filenames of downloaded files are now truncated to 255 characters, preserving the extension where possible.

Known limitations
* The `download` attribute is not currently supported for `<area>` elements.
* There is no mechanism to limit the rate of either user initiated or programmatic downloads.

Fixes #10761