### PR TITLE
UI: Color-manage sRGB presentation surfaces

### DIFF
--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -1079,6 +1079,8 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
     CAMetalLayer* layer = [CAMetalLayer layer];
     layer.device = m_metal_device;
     layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    static auto* color_space = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+    layer.colorspace = color_space;
     layer.framebufferOnly = YES;
     layer.displaySyncEnabled = YES;
     layer.contentsGravity = kCAGravityTopLeft;

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -18,6 +18,8 @@
 #include <QtGlobal>
 
 #if defined(AK_OS_MACOS)
+#    include <QColorSpace>
+#    include <QSurfaceFormat>
 #    include <UI/AppKit/Utilities/ApplicationIcon.h>
 #    include <UI/Qt/MacWindow.h>
 #endif
@@ -50,6 +52,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     // The web content view is a native QRhiWidget child. Keep it from forcing
     // every sibling in the tab UI to become native as well.
     QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+
+    auto surface_format = QSurfaceFormat::defaultFormat();
+    surface_format.setColorSpace(QColorSpace::SRgb);
+    QSurfaceFormat::setDefaultFormat(surface_format);
 #endif
 
     auto app = TRY(Ladybird::Application::create(arguments));


### PR DESCRIPTION
CSS colors and web content buffers use sRGB, but the macOS Metal presentation paths left their source color space unspecified. On Display P3 screens, Core Animation therefore interpreted sRGB channel values as Display P3 and rendered colors with excessive saturation.

Declare sRGB on AppKit's CAMetalLayer and on Qt's default surface format so Cocoa converts content into the display color space.

cc @kalenikaliaksandr