### PR TITLE
LibWeb: Further WebAudio's AudioParam implementation

### DIFF
--- a/Libraries/LibWeb/WebAudio/AudioListener.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioListener.cpp
@@ -39,13 +39,13 @@ WebIDL::ExceptionOr<void> AudioListener::set_position(float x, float y, float z)
     // This method is DEPRECATED. It is equivalent to setting positionX.value, positionY.value, and
     // positionZ.value directly with the given x, y, and z values, respectively.
 
-    // FIXME: Consequently, any of the positionX, positionY, and positionZ AudioParams for this
-    //        AudioListener have an automation curve set using setValueCurveAtTime() at the time this
-    //        method is called, a NotSupportedError MUST be thrown.
+    // Consequently, if any of the positionX, positionY, and positionZ AudioParams for this AudioListener have an
+    // automation curve set using setValueCurveAtTime() at the time this method is called, a NotSupportedError MUST be
+    // thrown.
 
-    m_position_x->set_value(x);
-    m_position_y->set_value(y);
-    m_position_z->set_value(z);
+    TRY(m_position_x->set_value(x));
+    TRY(m_position_y->set_value(y));
+    TRY(m_position_z->set_value(z));
 
     return {};
 }
@@ -57,16 +57,15 @@ WebIDL::ExceptionOr<void> AudioListener::set_orientation(float x, float y, float
     // forwardZ.value, upX.value, upY.value, and upZ.value directly with the given x, y, z, xUp,
     // yUp, and zUp values, respectively.
 
-    // FIXME: Consequently, if any of the forwardX, forwardY, forwardZ, upX, upY and upZ
-    //        AudioParams have an automation curve set using setValueCurveAtTime() at the time this
-    //        method is called, a NotSupportedError MUST be thrown.
+    // Consequently, if any of the forwardX, forwardY, forwardZ, upX, upY and upZ AudioParams have an automation curve
+    // set using setValueCurveAtTime() at the time this method is called, a NotSupportedError MUST be thrown.
 
-    m_forward_x->set_value(x);
-    m_forward_y->set_value(y);
-    m_forward_z->set_value(z);
-    m_up_x->set_value(x_up);
-    m_up_y->set_value(y_up);
-    m_up_z->set_value(z_up);
+    TRY(m_forward_x->set_value(x));
+    TRY(m_forward_y->set_value(y));
+    TRY(m_forward_z->set_value(z));
+    TRY(m_up_x->set_value(x_up));
+    TRY(m_up_y->set_value(y_up));
+    TRY(m_up_z->set_value(z_up));
 
     return {};
 }

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/BinarySearch.h>
+#include <AK/Math.h>
 #include <LibWeb/Bindings/AudioParam.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAudio/AudioParam.h>
@@ -74,6 +75,19 @@ float AudioParam::intrinsic_value_at_time(double time) const
             VERIFY(cache.minimum_time.has_value());
             auto progress = static_cast<float>((time - *cache.minimum_time) / (event.time - *cache.minimum_time));
             return cache.starting_value + (linear_ramp.value - cache.starting_value) * progress;
+        },
+        [&](ExponentialRamp const& exponential_ramp) {
+            if (time >= event.time)
+                return exponential_ramp.value;
+
+            if (cache.starting_value == 0
+                || (cache.starting_value < 0 && exponential_ramp.value > 0)
+                || (cache.starting_value > 0 && exponential_ramp.value < 0))
+                return cache.starting_value;
+
+            VERIFY(cache.minimum_time.has_value());
+            auto progress = static_cast<float>((time - *cache.minimum_time) / (event.time - *cache.minimum_time));
+            return cache.starting_value * static_cast<float>(pow(exponential_ramp.value / cache.starting_value, progress));
         });
 }
 
@@ -122,7 +136,7 @@ float AudioParam::event_value_at_time(size_t event_index, double) const
 {
     auto const& event = m_automation_events[event_index];
     return event.parameterization.visit(
-        [](OneOf<SetValue, LinearRamp> auto const& parameterization) {
+        [](OneOf<SetValue, LinearRamp, ExponentialRamp> auto const& parameterization) {
             return parameterization.value;
         });
 }
@@ -148,7 +162,7 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
             [](SetValue const&) -> Optional<ParameterizationCache> {
                 return {};
             },
-            [&](LinearRamp const&) -> Optional<ParameterizationCache> {
+            [&](OneOf<LinearRamp, ExponentialRamp> auto const&) -> Optional<ParameterizationCache> {
                 auto const& previous_event = m_automation_events[event_index - 1];
                 return ParameterizationCache {
                     .event_index = event_index,
@@ -210,9 +224,26 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::linear_ramp_to_value_at_tim
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-exponentialramptovalueattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::exponential_ramp_to_value_at_time(float value, double end_time)
 {
-    (void)value;
-    (void)end_time;
-    dbgln("FIXME: Implement AudioParam::exponential_ramp_to_value_at_time");
+    // A RangeError exception MUST be thrown if value is equal to 0.
+    if (value == 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "value must not be zero"_utf16 };
+
+    // A RangeError exception MUST be thrown if endTime is negative or is not a finite number.
+    if (end_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "endTime must not be negative"_utf16 };
+
+    // If endTime is less than currentTime, it is clamped to currentTime.
+    end_time = max(end_time, context()->current_time());
+
+    // If there is no event preceding this event, the exponential ramp behaves as if setValueAtTime(value, currentTime)
+    // were called, where value is the current value of the attribute.
+    if (first_event_index_after(end_time) == 0)
+        MUST(set_value_at_time(m_current_value, context()->current_time()));
+
+    insert_event({
+        .time = end_time,
+        .parameterization = ExponentialRamp { value },
+    });
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -88,6 +88,11 @@ float AudioParam::intrinsic_value_at_time(double time) const
             VERIFY(cache.minimum_time.has_value());
             auto progress = static_cast<float>((time - *cache.minimum_time) / (event.time - *cache.minimum_time));
             return cache.starting_value * static_cast<float>(pow(exponential_ramp.value / cache.starting_value, progress));
+        },
+        [&](SetTarget const& set_target) -> float {
+            if (set_target.time_constant == 0)
+                return set_target.target;
+            return set_target.target + (cache.starting_value - set_target.target) * static_cast<float>(exp(-(time - event.time) / set_target.time_constant));
         });
 }
 
@@ -132,13 +137,45 @@ size_t AudioParam::first_event_index_after(double time) const
     });
 }
 
-float AudioParam::event_value_at_time(size_t event_index, double) const
+float AudioParam::event_value_at_time(size_t event_index, double time) const
 {
-    auto const& event = m_automation_events[event_index];
-    return event.parameterization.visit(
-        [](OneOf<SetValue, LinearRamp, ExponentialRamp> auto const& parameterization) {
-            return parameterization.value;
-        });
+    auto first_event_index = event_index;
+    while (first_event_index > 0 && m_automation_events[first_event_index].parameterization.has<SetTarget>())
+        --first_event_index;
+
+    auto value = m_default_value;
+    for (auto current_event_index = first_event_index; current_event_index <= event_index; ++current_event_index) {
+        auto const& event = m_automation_events[current_event_index];
+        auto evaluation_time = current_event_index == event_index ? time : m_automation_events[current_event_index + 1].time;
+        value = event.parameterization.visit(
+            [](OneOf<SetValue, LinearRamp, ExponentialRamp> auto const& parameterization) {
+                return parameterization.value;
+            },
+            [&](SetTarget const& set_target) -> float {
+                if (set_target.time_constant == 0)
+                    return set_target.target;
+                return set_target.target + (value - set_target.target) * static_cast<float>(exp(-(evaluation_time - event.time) / set_target.time_constant));
+            });
+    }
+    return value;
+}
+
+// A ramp after an already-started SetTarget begins at currentTime using the target's value at that time.
+Optional<AudioParam::RampStart> AudioParam::ramp_start_for_insertion_index(size_t event_index) const
+{
+    if (event_index == 0)
+        return {};
+
+    auto const& previous_event = m_automation_events[event_index - 1];
+    auto current_time = context()->current_time();
+    if (previous_event.time >= current_time || !previous_event.parameterization.has<SetTarget>())
+        return {};
+
+    return RampStart {
+        .set_target_event_id = previous_event.id,
+        .time = current_time,
+        .value = event_value_at_time(event_index - 1, current_time),
+    };
 }
 
 AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_time(double time) const
@@ -159,16 +196,24 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
     // to caching the preceding event below.
     if (event_index < m_automation_events.size()) {
         auto cache = m_automation_events[event_index].parameterization.visit(
-            [](SetValue const&) -> Optional<ParameterizationCache> {
+            [](OneOf<SetValue, SetTarget> auto const&) -> Optional<ParameterizationCache> {
                 return {};
             },
-            [&](OneOf<LinearRamp, ExponentialRamp> auto const&) -> Optional<ParameterizationCache> {
+            [&](OneOf<LinearRamp, ExponentialRamp> auto const& ramp) -> Optional<ParameterizationCache> {
                 auto const& previous_event = m_automation_events[event_index - 1];
+                auto minimum_time = previous_event.time;
+                auto starting_value = event_value_at_time(event_index - 1, minimum_time);
+                if (ramp.start.has_value() && ramp.start->set_target_event_id == previous_event.id) {
+                    minimum_time = ramp.start->time;
+                    starting_value = ramp.start->value;
+                }
+                if (time < minimum_time)
+                    return {};
                 return ParameterizationCache {
                     .event_index = event_index,
-                    .minimum_time = previous_event.time,
+                    .minimum_time = minimum_time,
                     .maximum_time = m_automation_events[event_index].time,
-                    .starting_value = event_value_at_time(event_index - 1, previous_event.time),
+                    .starting_value = starting_value,
                 };
             });
         if (cache.has_value()) {
@@ -179,10 +224,23 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
 
     auto selected_event_index = event_index - 1;
     auto const& selected_event = m_automation_events[selected_event_index];
+    Optional<double> maximum_time;
+    if (event_index < m_automation_events.size()) {
+        auto const& next_event = m_automation_events[event_index];
+        maximum_time = next_event.parameterization.visit(
+            [&](OneOf<LinearRamp, ExponentialRamp> auto const& ramp) {
+                if (ramp.start.has_value() && ramp.start->set_target_event_id == selected_event.id)
+                    return ramp.start->time;
+                return next_event.time;
+            },
+            [&](auto const&) {
+                return next_event.time;
+            });
+    }
     m_parameterization_cache = {
         .event_index = selected_event_index,
         .minimum_time = selected_event.time,
-        .maximum_time = event_index < m_automation_events.size() ? Optional<double> { m_automation_events[event_index].time } : Optional<double> {},
+        .maximum_time = maximum_time,
         .starting_value = event_value_at_time(selected_event_index, selected_event.time),
     };
     return *m_parameterization_cache;
@@ -192,6 +250,7 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
 void AudioParam::insert_event(AutomationEvent event)
 {
     // If an event is added at a time where there are already events, it is placed after them but before later events.
+    event.id = m_next_event_id++;
     auto event_time = event.time;
     m_automation_events.insert_before_matching(move(event), [event_time](auto const& existing_event) {
         return event_time < existing_event.time;
@@ -211,12 +270,14 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::linear_ramp_to_value_at_tim
 
     // If there is no event preceding this event, the linear ramp behaves as if setValueAtTime(value, currentTime) were
     // called, where value is the current value of the attribute.
-    if (first_event_index_after(end_time) == 0)
+    auto event_index = first_event_index_after(end_time);
+    auto ramp_start = ramp_start_for_insertion_index(event_index);
+    if (event_index == 0)
         MUST(set_value_at_time(m_current_value, context()->current_time()));
 
     insert_event({
         .time = end_time,
-        .parameterization = LinearRamp { value },
+        .parameterization = LinearRamp { value, ramp_start },
     });
     return GC::Ref { *this };
 }
@@ -237,12 +298,14 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::exponential_ramp_to_value_a
 
     // If there is no event preceding this event, the exponential ramp behaves as if setValueAtTime(value, currentTime)
     // were called, where value is the current value of the attribute.
-    if (first_event_index_after(end_time) == 0)
+    auto event_index = first_event_index_after(end_time);
+    auto ramp_start = ramp_start_for_insertion_index(event_index);
+    if (event_index == 0)
         MUST(set_value_at_time(m_current_value, context()->current_time()));
 
     insert_event({
         .time = end_time,
-        .parameterization = ExponentialRamp { value },
+        .parameterization = ExponentialRamp { value, ramp_start },
     });
     return GC::Ref { *this };
 }
@@ -250,10 +313,21 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::exponential_ramp_to_value_a
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-settargetattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_target_at_time(float target, double start_time, float time_constant)
 {
-    (void)target;
-    (void)start_time;
-    (void)time_constant;
-    dbgln("FIXME: Implement AudioParam::set_target_at_time");
+    // A RangeError exception MUST be thrown if startTime is negative or is not a finite number.
+    if (start_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "startTime must not be negative"_utf16 };
+
+    // A RangeError exception MUST be thrown if timeConstant is negative or is not a finite number.
+    if (time_constant < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "timeConstant must not be negative"_utf16 };
+
+    // If startTime is less than currentTime, it is clamped to currentTime.
+    start_time = max(start_time, context()->current_time());
+
+    insert_event({
+        .time = start_time,
+        .parameterization = SetTarget { target, time_constant },
+    });
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -66,6 +66,14 @@ float AudioParam::intrinsic_value_at_time(double time) const
     return event.parameterization.visit(
         [](SetValue const& parameterization) {
             return parameterization.value;
+        },
+        [&](LinearRamp const& linear_ramp) {
+            if (time >= event.time)
+                return linear_ramp.value;
+
+            VERIFY(cache.minimum_time.has_value());
+            auto progress = static_cast<float>((time - *cache.minimum_time) / (event.time - *cache.minimum_time));
+            return cache.starting_value + (linear_ramp.value - cache.starting_value) * progress;
         });
 }
 
@@ -114,7 +122,7 @@ float AudioParam::event_value_at_time(size_t event_index, double) const
 {
     auto const& event = m_automation_events[event_index];
     return event.parameterization.visit(
-        [](SetValue const& parameterization) {
+        [](OneOf<SetValue, LinearRamp> auto const& parameterization) {
             return parameterization.value;
         });
 }
@@ -131,6 +139,28 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
             .starting_value = m_default_value,
         };
         return *m_parameterization_cache;
+    }
+
+    // A following ramp parameterization owns the interval before its event time. Other parameterizations fall through
+    // to caching the preceding event below.
+    if (event_index < m_automation_events.size()) {
+        auto cache = m_automation_events[event_index].parameterization.visit(
+            [](SetValue const&) -> Optional<ParameterizationCache> {
+                return {};
+            },
+            [&](LinearRamp const&) -> Optional<ParameterizationCache> {
+                auto const& previous_event = m_automation_events[event_index - 1];
+                return ParameterizationCache {
+                    .event_index = event_index,
+                    .minimum_time = previous_event.time,
+                    .maximum_time = m_automation_events[event_index].time,
+                    .starting_value = event_value_at_time(event_index - 1, previous_event.time),
+                };
+            });
+        if (cache.has_value()) {
+            m_parameterization_cache = cache.release_value();
+            return *m_parameterization_cache;
+        }
     }
 
     auto selected_event_index = event_index - 1;
@@ -158,9 +188,22 @@ void AudioParam::insert_event(AutomationEvent event)
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-linearramptovalueattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::linear_ramp_to_value_at_time(float value, double end_time)
 {
-    (void)value;
-    (void)end_time;
-    dbgln("FIXME: Implement AudioParam::linear_ramp_to_value_at_time");
+    // A RangeError exception MUST be thrown if endTime is negative or is not a finite number.
+    if (end_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "endTime must not be negative"_utf16 };
+
+    // If endTime is less than currentTime, it is clamped to currentTime.
+    end_time = max(end_time, context()->current_time());
+
+    // If there is no event preceding this event, the linear ramp behaves as if setValueAtTime(value, currentTime) were
+    // called, where value is the current value of the attribute.
+    if (first_event_index_after(end_time) == 0)
+        MUST(set_value_at_time(m_current_value, context()->current_time()));
+
+    insert_event({
+        .time = end_time,
+        .parameterization = LinearRamp { value },
+    });
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -94,6 +94,9 @@ float AudioParam::intrinsic_value_at_time(double time) const
             if (set_target.time_constant == 0)
                 return set_target.target;
             return set_target.target + (cache.starting_value - set_target.target) * static_cast<float>(exp(-(time - event.time) / set_target.time_constant));
+        },
+        [&](SetValueCurve const&) {
+            return event_value_at_time(*cache.event_index, time);
         });
 }
 
@@ -156,6 +159,18 @@ float AudioParam::event_value_at_time(size_t event_index, double time) const
                 if (set_target.time_constant == 0)
                     return set_target.target;
                 return set_target.target + (value - set_target.target) * static_cast<float>(exp(-(evaluation_time - event.time) / set_target.time_constant));
+            },
+            [&](SetValueCurve const& set_value_curve) {
+                if (evaluation_time >= event.time + set_value_curve.duration)
+                    return set_value_curve.values.last();
+
+                auto curve_position = (set_value_curve.values.size() - 1) * (evaluation_time - event.time) / set_value_curve.duration;
+                // NB: Floating-point rounding can push curve_position to size() - 1 even though evaluation_time is
+                //     still strictly less than the curve's end time, so value_index is clamped to keep value_index + 1 in bounds.
+                auto value_index = min(static_cast<size_t>(floor(curve_position)), set_value_curve.values.size() - 2);
+                auto interpolation_factor = static_cast<float>(curve_position - value_index);
+                return set_value_curve.values[value_index]
+                    + (set_value_curve.values[value_index + 1] - set_value_curve.values[value_index]) * interpolation_factor;
             });
     }
     return value;
@@ -197,16 +212,25 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
     // to caching the preceding event below.
     if (event_index < m_automation_events.size()) {
         auto cache = m_automation_events[event_index].parameterization.visit(
-            [](OneOf<SetValue, SetTarget> auto const&) -> Optional<ParameterizationCache> {
+            [](OneOf<SetValue, SetTarget, SetValueCurve> auto const&) -> Optional<ParameterizationCache> {
                 return {};
             },
             [&](OneOf<LinearRamp, ExponentialRamp> auto const& ramp) -> Optional<ParameterizationCache> {
                 auto const& previous_event = m_automation_events[event_index - 1];
-                auto minimum_time = previous_event.time;
-                auto starting_value = event_value_at_time(event_index - 1, minimum_time);
+                double minimum_time;
+                float starting_value;
                 if (ramp.start.has_value() && ramp.start->set_target_event_id == previous_event.id) {
                     minimum_time = ramp.start->time;
                     starting_value = ramp.start->value;
+                } else {
+                    minimum_time = previous_event.parameterization.visit(
+                        [&](SetValueCurve const& set_value_curve) {
+                            return previous_event.time + set_value_curve.duration;
+                        },
+                        [&](auto const&) {
+                            return previous_event.time;
+                        });
+                    starting_value = event_value_at_time(event_index - 1, minimum_time);
                 }
                 if (time < minimum_time)
                     return {};
@@ -250,6 +274,21 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
 // https://webaudio.github.io/web-audio-api/#dfn-automation-event
 WebIDL::ExceptionOr<void> AudioParam::insert_event(AutomationEvent event)
 {
+    // If any automation method is called at a time contained in a SetValueCurve event, a NotSupportedError exception
+    // MUST be thrown.
+    for (auto const& existing_event : m_automation_events) {
+        auto is_contained_in_curve = existing_event.parameterization.visit(
+            [&](SetValueCurve const& set_value_curve) {
+                return event.time >= existing_event.time
+                    && event.time < existing_event.time + set_value_curve.duration;
+            },
+            [](auto const&) {
+                return false;
+            });
+        if (is_contained_in_curve)
+            return WebIDL::NotSupportedError::create(realm(), "Cannot schedule an automation event during a value curve"_utf16);
+    }
+
     // If an event is added at a time where there are already events, it is placed after them but before later events.
     event.id = m_next_event_id++;
     auto event_time = event.time;
@@ -326,20 +365,42 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_target_at_time(float ta
     // If startTime is less than currentTime, it is clamped to currentTime.
     start_time = max(start_time, context()->current_time());
 
-    insert_event({
+    TRY(insert_event({
         .time = start_time,
         .parameterization = SetTarget { target, time_constant },
-    });
+    }));
     return GC::Ref { *this };
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-setvaluecurveattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_value_curve_at_time(Span<float> values, double start_time, double duration)
 {
-    (void)values;
-    (void)start_time;
-    (void)duration;
-    dbgln("FIXME: Implement AudioParam::set_value_curve_at_time");
+    // An InvalidStateError exception MUST be thrown if values has a length less than 2.
+    if (values.size() < 2)
+        return WebIDL::InvalidStateError::create(realm(), "values must contain at least two elements"_utf16);
+
+    // A RangeError exception MUST be thrown if startTime is negative or is not a finite number.
+    if (start_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "startTime must not be negative"_utf16 };
+
+    // A RangeError exception MUST be thrown if duration is not strictly positive or is not a finite number.
+    if (duration <= 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "duration must be positive"_utf16 };
+
+    // If startTime is less than currentTime, it is clamped to currentTime.
+    start_time = max(start_time, context()->current_time());
+
+    // If there are any events with a time strictly greater than startTime but strictly less than startTime + duration,
+    // a NotSupportedError exception MUST be thrown.
+    for (auto const& event : m_automation_events) {
+        if (event.time > start_time && event.time < start_time + duration)
+            return WebIDL::NotSupportedError::create(realm(), "Cannot schedule a value curve containing an automation event"_utf16);
+    }
+
+    TRY(insert_event({
+        .time = start_time,
+        .parameterization = SetValueCurve { Vector<float> { values }, duration },
+    }));
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BinarySearch.h>
 #include <LibWeb/Bindings/AudioParam.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAudio/AudioParam.h>
@@ -45,7 +46,27 @@ float AudioParam::value() const
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-value
 void AudioParam::set_value(float value)
 {
+    // Setting this attribute has the effect of assigning the requested value to the [[current value]] slot, and calling
+    // the setValueAtTime() method with the current AudioContext's currentTime and [[current value]].
     m_current_value = value;
+    MUST(set_value_at_time(m_current_value, context()->current_time()));
+}
+
+// https://webaudio.github.io/web-audio-api/#computedvalue
+float AudioParam::intrinsic_value_at_time(double time) const
+{
+    // paramIntrinsicValue will be calculated at each time, which is either the value set directly to the value
+    // attribute, or, if there are any automation events with times before or at this time, the value as calculated from
+    // these events.
+    auto const& cache = parameterization_cache_for_time(time);
+    if (!cache.event_index.has_value())
+        return cache.starting_value;
+
+    auto const& event = m_automation_events[*cache.event_index];
+    return event.parameterization.visit(
+        [](SetValue const& parameterization) {
+            return parameterization.value;
+        });
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-automationrate
@@ -67,10 +88,71 @@ WebIDL::ExceptionOr<void> AudioParam::set_automation_rate(Bindings::AutomationRa
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-setvalueattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_value_at_time(float value, double start_time)
 {
-    (void)value;
-    (void)start_time;
-    dbgln("FIXME: Implement AudioParam::set_value_at_time");
+    // A RangeError exception MUST be thrown if startTime is negative or is not a finite number.
+    if (start_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "startTime must not be negative"_utf16 };
+
+    // If startTime is less than currentTime, it is clamped to currentTime.
+    start_time = max(start_time, context()->current_time());
+
+    insert_event({
+        .time = start_time,
+        .parameterization = SetValue { value },
+    });
     return GC::Ref { *this };
+}
+
+// https://webaudio.github.io/web-audio-api/#dfn-automation-event
+size_t AudioParam::first_event_index_after(double time) const
+{
+    return AK::lower_bound_index(m_automation_events, time, [](auto const& event, double time) {
+        return event.time <= time ? -1 : 1;
+    });
+}
+
+float AudioParam::event_value_at_time(size_t event_index, double) const
+{
+    auto const& event = m_automation_events[event_index];
+    return event.parameterization.visit(
+        [](SetValue const& parameterization) {
+            return parameterization.value;
+        });
+}
+
+AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_time(double time) const
+{
+    if (m_parameterization_cache.has_value() && m_parameterization_cache->contains(time))
+        return *m_parameterization_cache;
+
+    auto event_index = first_event_index_after(time);
+    if (event_index == 0) {
+        m_parameterization_cache = {
+            .maximum_time = m_automation_events.is_empty() ? Optional<double> {} : m_automation_events.first().time,
+            .starting_value = m_default_value,
+        };
+        return *m_parameterization_cache;
+    }
+
+    auto selected_event_index = event_index - 1;
+    auto const& selected_event = m_automation_events[selected_event_index];
+    m_parameterization_cache = {
+        .event_index = selected_event_index,
+        .minimum_time = selected_event.time,
+        .maximum_time = event_index < m_automation_events.size() ? Optional<double> { m_automation_events[event_index].time } : Optional<double> {},
+        .starting_value = event_value_at_time(selected_event_index, selected_event.time),
+    };
+    return *m_parameterization_cache;
+}
+
+// https://webaudio.github.io/web-audio-api/#dfn-automation-event
+void AudioParam::insert_event(AutomationEvent event)
+{
+    // If an event is added at a time where there are already events, it is placed after them but before later events.
+    auto event_time = event.time;
+    m_automation_events.insert_before_matching(move(event), [event_time](auto const& existing_event) {
+        return event_time < existing_event.time;
+    });
+    m_parameterization_cache = {};
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-linearramptovalueattime

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -45,12 +45,13 @@ float AudioParam::value() const
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-value
-void AudioParam::set_value(float value)
+WebIDL::ExceptionOr<void> AudioParam::set_value(float value)
 {
     // Setting this attribute has the effect of assigning the requested value to the [[current value]] slot, and calling
     // the setValueAtTime() method with the current AudioContext's currentTime and [[current value]].
     m_current_value = value;
-    MUST(set_value_at_time(m_current_value, context()->current_time()));
+    TRY(set_value_at_time(m_current_value, context()->current_time()));
+    return {};
 }
 
 // https://webaudio.github.io/web-audio-api/#computedvalue
@@ -122,10 +123,10 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_value_at_time(float val
     // If startTime is less than currentTime, it is clamped to currentTime.
     start_time = max(start_time, context()->current_time());
 
-    insert_event({
+    TRY(insert_event({
         .time = start_time,
         .parameterization = SetValue { value },
-    });
+    }));
     return GC::Ref { *this };
 }
 
@@ -247,7 +248,7 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
 }
 
 // https://webaudio.github.io/web-audio-api/#dfn-automation-event
-void AudioParam::insert_event(AutomationEvent event)
+WebIDL::ExceptionOr<void> AudioParam::insert_event(AutomationEvent event)
 {
     // If an event is added at a time where there are already events, it is placed after them but before later events.
     event.id = m_next_event_id++;
@@ -256,6 +257,7 @@ void AudioParam::insert_event(AutomationEvent event)
         return event_time < existing_event.time;
     });
     m_parameterization_cache = {};
+    return {};
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-linearramptovalueattime
@@ -275,10 +277,10 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::linear_ramp_to_value_at_tim
     if (event_index == 0)
         MUST(set_value_at_time(m_current_value, context()->current_time()));
 
-    insert_event({
+    TRY(insert_event({
         .time = end_time,
         .parameterization = LinearRamp { value, ramp_start },
-    });
+    }));
     return GC::Ref { *this };
 }
 
@@ -303,10 +305,10 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::exponential_ramp_to_value_a
     if (event_index == 0)
         MUST(set_value_at_time(m_current_value, context()->current_time()));
 
-    insert_event({
+    TRY(insert_event({
         .time = end_time,
         .parameterization = ExponentialRamp { value, ramp_start },
-    });
+    }));
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -407,8 +407,39 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_value_curve_at_time(Spa
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelscheduledvalues
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::cancel_scheduled_values(double cancel_time)
 {
-    (void)cancel_time;
-    dbgln("FIXME: Implement AudioParam::cancel_scheduled_values");
+    // A RangeError exception MUST be thrown if cancelTime is negative.
+    if (cancel_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "cancelTime must not be negative"_utf16 };
+
+    // If cancelTime is less than currentTime, it is clamped to currentTime.
+    cancel_time = max(cancel_time, context()->current_time());
+
+    // Cancel all scheduled parameter changes with times greater than or equal to cancelTime.
+    auto first_event_to_remove = AK::lower_bound_index(m_automation_events, cancel_time, [](auto const& event, double time) {
+        return event.time < time ? -1 : 1;
+    });
+
+    // Any active automations whose event time is less than cancelTime are also cancelled. A SetTarget remains active
+    // until the next event, while a SetValueCurve is active through the end of its duration.
+    if (first_event_to_remove > 0) {
+        auto const& previous_event = m_automation_events[first_event_to_remove - 1];
+        auto is_active_automation = previous_event.parameterization.visit(
+            [](SetTarget const&) {
+                return true;
+            },
+            [&](SetValueCurve const& set_value_curve) {
+                return cancel_time <= previous_event.time + set_value_curve.duration;
+            },
+            [](auto const&) {
+                return false;
+            });
+        if (is_active_automation)
+            --first_event_to_remove;
+    }
+
+    if (first_event_to_remove < m_automation_events.size())
+        m_automation_events.remove(first_event_to_remove, m_automation_events.size() - first_event_to_remove);
+    m_parameterization_cache = {};
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -64,24 +64,6 @@ WebIDL::ExceptionOr<void> AudioParam::set_automation_rate(Bindings::AutomationRa
     return {};
 }
 
-// https://webaudio.github.io/web-audio-api/#dom-audioparam-defaultvalue
-float AudioParam::default_value() const
-{
-    return m_default_value;
-}
-
-// https://webaudio.github.io/web-audio-api/#dom-audioparam-minvalue
-float AudioParam::min_value() const
-{
-    return m_min_value;
-}
-
-// https://webaudio.github.io/web-audio-api/#dom-audioparam-maxvalue
-float AudioParam::max_value() const
-{
-    return m_max_value;
-}
-
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-setvalueattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::set_value_at_time(float value, double start_time)
 {

--- a/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -66,7 +66,7 @@ float AudioParam::intrinsic_value_at_time(double time) const
 
     auto const& event = m_automation_events[*cache.event_index];
     return event.parameterization.visit(
-        [](SetValue const& parameterization) {
+        [](OneOf<SetValue, Hold> auto const& parameterization) {
             return parameterization.value;
         },
         [&](LinearRamp const& linear_ramp) {
@@ -152,7 +152,7 @@ float AudioParam::event_value_at_time(size_t event_index, double time) const
         auto const& event = m_automation_events[current_event_index];
         auto evaluation_time = current_event_index == event_index ? time : m_automation_events[current_event_index + 1].time;
         value = event.parameterization.visit(
-            [](OneOf<SetValue, LinearRamp, ExponentialRamp> auto const& parameterization) {
+            [](OneOf<SetValue, LinearRamp, ExponentialRamp, Hold> auto const& parameterization) {
                 return parameterization.value;
             },
             [&](SetTarget const& set_target) -> float {
@@ -212,7 +212,7 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
     // to caching the preceding event below.
     if (event_index < m_automation_events.size()) {
         auto cache = m_automation_events[event_index].parameterization.visit(
-            [](OneOf<SetValue, SetTarget, SetValueCurve> auto const&) -> Optional<ParameterizationCache> {
+            [](OneOf<SetValue, SetTarget, SetValueCurve, Hold> auto const&) -> Optional<ParameterizationCache> {
                 return {};
             },
             [&](OneOf<LinearRamp, ExponentialRamp> auto const& ramp) -> Optional<ParameterizationCache> {
@@ -232,7 +232,9 @@ AudioParam::ParameterizationCache const& AudioParam::parameterization_cache_for_
                         });
                     starting_value = event_value_at_time(event_index - 1, minimum_time);
                 }
-                if (time < minimum_time)
+                // NB: A ramp rewritten by cancelAndHoldAtTime() can end before a preceding value curve's original end.
+                //     In that case, the curve owns the interval before the ramp endpoint.
+                if (time < minimum_time || minimum_time >= m_automation_events[event_index].time)
                     return {};
                 return ParameterizationCache {
                     .event_index = event_index,
@@ -276,16 +278,23 @@ WebIDL::ExceptionOr<void> AudioParam::insert_event(AutomationEvent event)
 {
     // If any automation method is called at a time contained in a SetValueCurve event, a NotSupportedError exception
     // MUST be thrown.
-    for (auto const& existing_event : m_automation_events) {
+    for (size_t event_index = 0; event_index < m_automation_events.size(); ++event_index) {
+        auto const& existing_event = m_automation_events[event_index];
         auto is_contained_in_curve = existing_event.parameterization.visit(
             [&](SetValueCurve const& set_value_curve) {
+                auto curve_end_time = existing_event.time + set_value_curve.duration;
+                if (event_index + 1 < m_automation_events.size()
+                    && m_automation_events[event_index + 1].parameterization.has<Hold>()) {
+                    curve_end_time = min(curve_end_time, m_automation_events[event_index + 1].time);
+                }
                 return event.time >= existing_event.time
-                    && event.time < existing_event.time + set_value_curve.duration;
+                    && event.time < curve_end_time;
             },
             [](auto const&) {
                 return false;
             });
-        if (is_contained_in_curve)
+        // NB: A hold event ends an active value curve without changing how the curve is sampled before the hold time.
+        if (is_contained_in_curve && !event.parameterization.has<Hold>())
             return WebIDL::NotSupportedError::create(realm(), "Cannot schedule an automation event during a value curve"_utf16);
     }
 
@@ -446,8 +455,56 @@ WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::cancel_scheduled_values(dou
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelandholdattime
 WebIDL::ExceptionOr<GC::Ref<AudioParam>> AudioParam::cancel_and_hold_at_time(double cancel_time)
 {
-    (void)cancel_time;
-    dbgln("FIXME: Implement AudioParam::cancel_and_hold_at_time");
+    // A RangeError exception MUST be thrown if cancelTime is negative.
+    if (cancel_time < 0)
+        return WebIDL::SimpleException { WebIDL::SimpleExceptionType::RangeError, "cancelTime must not be negative"_utf16 };
+
+    // If cancelTime is less than currentTime, it is clamped to currentTime.
+    cancel_time = max(cancel_time, context()->current_time());
+
+    auto value_to_hold = intrinsic_value_at_time(cancel_time);
+    auto event_index = first_event_index_after(cancel_time);
+    auto rewrote_ramp = false;
+
+    // If the next event is a ramp, rewrite it to end at cancelTime with the value from the original timeline.
+    if (event_index < m_automation_events.size()) {
+        auto& event = m_automation_events[event_index];
+        rewrote_ramp = event.parameterization.visit(
+            [&](OneOf<LinearRamp, ExponentialRamp> auto& ramp) {
+                event.time = cancel_time;
+                ramp.value = value_to_hold;
+                return true;
+            },
+            [](auto&) {
+                return false;
+            });
+    }
+
+    if (!rewrote_ramp && event_index > 0) {
+        auto const& previous_event = m_automation_events[event_index - 1];
+        auto needs_hold_event = previous_event.parameterization.visit(
+            [](SetTarget const&) {
+                return true;
+            },
+            [&](SetValueCurve const& set_value_curve) {
+                return cancel_time <= previous_event.time + set_value_curve.duration;
+            },
+            [](auto const&) {
+                return false;
+            });
+        if (needs_hold_event) {
+            TRY(insert_event({
+                .time = cancel_time,
+                .parameterization = Hold { value_to_hold },
+            }));
+        }
+    }
+
+    // Remove all events with times greater than cancelTime. The rewritten ramp or inserted hold remains at cancelTime.
+    auto first_event_to_remove = first_event_index_after(cancel_time);
+    if (first_event_to_remove < m_automation_events.size())
+        m_automation_events.remove(first_event_to_remove, m_automation_events.size() - first_event_to_remove);
+    m_parameterization_cache = {};
     return GC::Ref { *this };
 }
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -88,7 +88,11 @@ private:
         double duration { 0 };
     };
 
-    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp, SetTarget, SetValueCurve>;
+    struct Hold {
+        float value { 0 };
+    };
+
+    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp, SetTarget, SetValueCurve, Hold>;
 
     struct AutomationEvent {
         double time { 0 };

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -62,19 +62,33 @@ private:
         float value { 0 };
     };
 
+    struct RampStart {
+        size_t set_target_event_id { 0 };
+        double time { 0 };
+        float value { 0 };
+    };
+
     struct LinearRamp {
         float value { 0 };
+        Optional<RampStart> start;
     };
 
     struct ExponentialRamp {
         float value { 0 };
+        Optional<RampStart> start;
     };
 
-    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp>;
+    struct SetTarget {
+        float target { 0 };
+        float time_constant { 0 };
+    };
+
+    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp, SetTarget>;
 
     struct AutomationEvent {
         double time { 0 };
         Parameterization parameterization;
+        size_t id { 0 };
     };
 
     struct ParameterizationCache {
@@ -94,6 +108,8 @@ private:
 
     // https://webaudio.github.io/web-audio-api/#dfn-automation-event
     size_t first_event_index_after(double) const;
+
+    Optional<RampStart> ramp_start_for_insertion_index(size_t) const;
 
     float event_value_at_time(size_t event_index, double time) const;
 
@@ -119,6 +135,7 @@ private:
 
     // https://webaudio.github.io/web-audio-api/#dfn-automation-event
     Vector<AutomationEvent> m_automation_events;
+    size_t m_next_event_id { 0 };
 
     mutable Optional<ParameterizationCache> m_parameterization_cache;
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -34,9 +34,14 @@ public:
     Bindings::AutomationRate automation_rate() const;
     WebIDL::ExceptionOr<void> set_automation_rate(Bindings::AutomationRate);
 
-    float default_value() const;
-    float min_value() const;
-    float max_value() const;
+    // https://webaudio.github.io/web-audio-api/#dom-audioparam-defaultvalue
+    float default_value() const { return m_default_value; }
+
+    // https://webaudio.github.io/web-audio-api/#dom-audioparam-minvalue
+    float min_value() const { return m_min_value; }
+
+    // https://webaudio.github.io/web-audio-api/#dom-audioparam-maxvalue
+    float max_value() const { return m_max_value; }
 
     WebIDL::ExceptionOr<GC::Ref<AudioParam>> set_value_at_time(float value, double start_time);
     WebIDL::ExceptionOr<GC::Ref<AudioParam>> linear_ramp_to_value_at_time(float value, double end_time);

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -83,7 +83,12 @@ private:
         float time_constant { 0 };
     };
 
-    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp, SetTarget>;
+    struct SetValueCurve {
+        Vector<float> values;
+        double duration { 0 };
+    };
+
+    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp, SetTarget, SetValueCurve>;
 
     struct AutomationEvent {
         double time { 0 };

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -32,7 +32,7 @@ public:
     GC::Ref<BaseAudioContext> context() const { return m_context; }
 
     float value() const;
-    void set_value(float);
+    WebIDL::ExceptionOr<void> set_value(float);
 
     // https://webaudio.github.io/web-audio-api/#computedvalue
     float intrinsic_value_at_time(double) const;
@@ -117,7 +117,7 @@ private:
     ParameterizationCache const& parameterization_cache_for_time(double) const;
 
     // https://webaudio.github.io/web-audio-api/#dfn-automation-event
-    void insert_event(AutomationEvent);
+    WebIDL::ExceptionOr<void> insert_event(AutomationEvent);
 
     GC::Ref<BaseAudioContext> m_context;
 

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/Optional.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/AudioParam.h>
 #include <LibWeb/Bindings/PlatformObject.h>
@@ -31,6 +34,9 @@ public:
     float value() const;
     void set_value(float);
 
+    // https://webaudio.github.io/web-audio-api/#computedvalue
+    float intrinsic_value_at_time(double) const;
+
     Bindings::AutomationRate automation_rate() const;
     WebIDL::ExceptionOr<void> set_automation_rate(Bindings::AutomationRate);
 
@@ -52,7 +58,42 @@ public:
     WebIDL::ExceptionOr<GC::Ref<AudioParam>> cancel_and_hold_at_time(double cancel_time);
 
 private:
+    struct SetValue {
+        float value { 0 };
+    };
+
+    using Parameterization = Variant<SetValue>;
+
+    struct AutomationEvent {
+        double time { 0 };
+        Parameterization parameterization;
+    };
+
+    struct ParameterizationCache {
+        Optional<size_t> event_index {};
+        Optional<double> minimum_time {};
+        Optional<double> maximum_time {};
+        float starting_value { 0 };
+
+        bool contains(double time) const
+        {
+            return (!minimum_time.has_value() || time >= *minimum_time)
+                && (!maximum_time.has_value() || time < *maximum_time);
+        }
+    };
+
     AudioParam(JS::Realm&, GC::Ref<BaseAudioContext>, float default_value, float min_value, float max_value, Bindings::AutomationRate, FixedAutomationRate = FixedAutomationRate::No);
+
+    // https://webaudio.github.io/web-audio-api/#dfn-automation-event
+    size_t first_event_index_after(double) const;
+
+    float event_value_at_time(size_t event_index, double time) const;
+
+    // https://webaudio.github.io/web-audio-api/#computedvalue
+    ParameterizationCache const& parameterization_cache_for_time(double) const;
+
+    // https://webaudio.github.io/web-audio-api/#dfn-automation-event
+    void insert_event(AutomationEvent);
 
     GC::Ref<BaseAudioContext> m_context;
 
@@ -67,6 +108,11 @@ private:
     Bindings::AutomationRate m_automation_rate {};
 
     FixedAutomationRate m_fixed_automation_rate { FixedAutomationRate::No };
+
+    // https://webaudio.github.io/web-audio-api/#dfn-automation-event
+    Vector<AutomationEvent> m_automation_events;
+
+    mutable Optional<ParameterizationCache> m_parameterization_cache;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -66,7 +66,11 @@ private:
         float value { 0 };
     };
 
-    using Parameterization = Variant<SetValue, LinearRamp>;
+    struct ExponentialRamp {
+        float value { 0 };
+    };
+
+    using Parameterization = Variant<SetValue, LinearRamp, ExponentialRamp>;
 
     struct AutomationEvent {
         double time { 0 };

--- a/Libraries/LibWeb/WebAudio/AudioParam.h
+++ b/Libraries/LibWeb/WebAudio/AudioParam.h
@@ -62,7 +62,11 @@ private:
         float value { 0 };
     };
 
-    using Parameterization = Variant<SetValue>;
+    struct LinearRamp {
+        float value { 0 };
+    };
+
+    using Parameterization = Variant<SetValue, LinearRamp>;
 
     struct AutomationEvent {
         double time { 0 };

--- a/Libraries/LibWeb/WebAudio/PannerNode.cpp
+++ b/Libraries/LibWeb/WebAudio/PannerNode.cpp
@@ -144,11 +144,11 @@ WebIDL::ExceptionOr<void> PannerNode::set_position(float x, float y, float z)
 {
     // This method is DEPRECATED. It is equivalent to setting positionX.value, positionY.value, and positionZ.value
     // attribute directly with the x, y and z parameters, respectively.
-    // FIXME: Consequently, if any of the positionX, positionY, and positionZ AudioParams have an automation curve
-    //        set using setValueCurveAtTime() at the time this method is called, a NotSupportedError MUST be thrown.
-    m_position_x->set_value(x);
-    m_position_y->set_value(y);
-    m_position_z->set_value(z);
+    // Consequently, if any of the positionX, positionY, and positionZ AudioParams have an automation curve set using
+    // setValueCurveAtTime() at the time this method is called, a NotSupportedError MUST be thrown.
+    TRY(m_position_x->set_value(x));
+    TRY(m_position_y->set_value(y));
+    TRY(m_position_z->set_value(z));
     return {};
 }
 
@@ -157,11 +157,11 @@ WebIDL::ExceptionOr<void> PannerNode::set_orientation(float x, float y, float z)
 {
     // This method is DEPRECATED. It is equivalent to setting orientationX.value, orientationY.value, and
     // orientationZ.value attribute directly, with the x, y and z parameters, respectively.
-    // FIXME: Consequently, if any of the orientationX, orientationY, and orientationZ AudioParams have an automation
-    //        curve set using setValueCurveAtTime() at the time this method is called, a NotSupportedError MUST be thrown.
-    m_orientation_x->set_value(x);
-    m_orientation_y->set_value(y);
-    m_orientation_z->set_value(z);
+    // Consequently, if any of the orientationX, orientationY, and orientationZ AudioParams have an automation curve set
+    // using setValueCurveAtTime() at the time this method is called, a NotSupportedError MUST be thrown.
+    TRY(m_orientation_x->set_value(x));
+    TRY(m_orientation_y->set_value(y));
+    TRY(m_orientation_z->set_value(z));
     return {};
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-cancel-and-hold.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-cancel-and-hold.txt
@@ -1,0 +1,136 @@
+Harness status: OK
+
+Found 106 tests
+
+72 Pass
+34 Fail
+Pass	# AUDIT TASK RUNNER STARTED.
+Pass	Executing "cancelTime"
+Pass	Executing "linear"
+Pass	Executing "exponential"
+Pass	Executing "setTarget"
+Pass	Executing "setValueCurve"
+Pass	Executing "setValueCurve after end"
+Pass	Executing "initial setTarget"
+Pass	Executing "post cancel: Linear"
+Pass	Executing "post cancel: Exponential"
+Pass	Executing "post cancel: ValueCurve"
+Pass	Executing "post cancel: setTarget"
+Pass	Executing "post cancel: setValue"
+Pass	Executing "cancel future setTarget"
+Pass	Executing "cancel setTarget now"
+Pass	Executing "cancel future setValueCurve"
+Pass	Executing "cancel setValueCurve now"
+Pass	Executing "linear, cancel, linear, cancel, linear"
+Pass	Audit report
+Pass	> [cancelTime] Test Invalid Values
+Fail	X cancelAndHoldAtTime(-1) did not throw an exception.
+Pass	  cancelAndHoldAtTime(NaN) threw TypeError: "Expected cancelTime to be a finite floating-point number".
+Pass	  cancelAndHoldAtTime(Infinity) threw TypeError: "Expected cancelTime to be a finite floating-point number".
+Fail	< [cancelTime] 1 out of 3 assertions were failed.
+Pass	> [linear] Cancel linearRampToValueAtTime
+Pass	  linearRampToValueAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0.000059605,"relativeThreshold":0}.
+Pass	  Cancelling linearRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling linearRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0.000083998 (RelErr=1). Got 0.
+Fail	< [linear] 1 out of 3 assertions were failed.
+Pass	> [exponential] Cancel exponentialRampAtTime
+Pass	  exponentialRampToValue(0.001, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling exponentialRampToValue(0.001, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling exponentialRampToValue(0.001, 0.5) at time 0.25 is not close to 0.033932216465473175 within a relative error of 0.0000018664 (RelErr=1). Got 0.
+Fail	< [exponential] 1 out of 3 assertions were failed.
+Pass	> [setTarget] Cancel setTargetAtTime
+Pass	  setTargetAtTime(0, 0.01, 0.05) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Pass	  Cancelling setTargetAtTime(0, 0.01, 0.05) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling setTargetAtTime(0, 0.01, 0.05) at time 0.25 is not close to 0.008229747414588928 within a relative error of 4.5267e-7 (RelErr=1). Got 0.
+Fail	< [setTarget] 1 out of 3 assertions were failed.
+Pass	> [setValueCurve] Cancel setValueCurveAtTime
+Pass	  setValueCurveAtTime([1,0], 0.01, 0.49) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Pass	  Cancelling setValueCurveAtTime([1,0], 0.01, 0.49) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling setValueCurveAtTime([1,0], 0.01, 0.49) at time 0.25 is not close to 0.510204081632653 within a relative error of 9.5368e-9 (RelErr=1). Got 0.
+Fail	< [setValueCurve] 1 out of 3 assertions were failed.
+Pass	> [setValueCurve after end] Cancel setValueCurveAtTime after the end
+Pass	  setValueCurveAtTime([1,0], 0.01, 0.11499999999999999) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Pass	  Cancelling setValueCurveAtTime([1,0], 0.01, 0.11499999999999999) at time 0.25 contains only the constant 0.
+Pass	  Expected value for cancelling setValueCurveAtTime([1,0], 0.01, 0.11499999999999999) at time 0.25 is 0 within an error of 0.
+Pass	< [setValueCurve after end] All assertions passed. (total 3 assertions)
+Pass	> [initial setTarget] Cancel with initial setTargetAtTime
+Pass	  setTargetAtTime(0, 0.01, 0.1) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Pass	  Cancelling setTargetAtTime(0, 0.01, 0.1) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling setTargetAtTime(0, 0.01, 0.1) at time 0.25 is not close to 0.09071795642375946 within a relative error of 0.000003121 (RelErr=1). Got 0.
+Fail	< [initial setTarget] 1 out of 3 assertions were failed.
+Pass	> [post cancel: Linear] LinearRamp after cancelling
+Pass	  Post cancellation linearRampToValueAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling Post cancellation linearRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling Post cancellation linearRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0.000083998 (RelErr=1). Got 0.
+Pass	  Post linearRamp(2, 0.375) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Fail	< [post cancel: Linear] 1 out of 4 assertions were failed.
+Pass	> [post cancel: Exponential] ExponentialRamp after cancelling
+Pass	  Post cancel exponentialRampToValueAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling Post cancel exponentialRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling Post cancel exponentialRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0.000083998 (RelErr=1). Got 0.
+Pass	  Post exponentialRamp(2, 0.375) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Fail	< [post cancel: Exponential] 1 out of 4 assertions were failed.
+Pass	> [post cancel: ValueCurve] 
+Pass	  Post cancel setValueCurveAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling Post cancel setValueCurveAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling Post cancel setValueCurveAtTime: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0.000083998 (RelErr=1). Got 0.
+Pass	  Post setValueCurve([0.125,2], 0.375, 0.125) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0.000083998,"relativeThreshold":0}.
+Fail	< [post cancel: ValueCurve] 1 out of 4 assertions were failed.
+Pass	> [post cancel: setTarget] 
+Pass	  Post cancel setTargetAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling Post cancel setTargetAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling Post cancel setTargetAtTime: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0.000083998 (RelErr=1). Got 0.
+Pass	  Post setTargetAtTime(0.125, 0.375, 0.1) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0.000084037,"relativeThreshold":0}.
+Fail	< [post cancel: setTarget] 1 out of 4 assertions were failed.
+Pass	> [post cancel: setValue] 
+Pass	  Post cancel setValueAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling Post cancel setValueAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling Post cancel setValueAtTime: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0.000083998 (RelErr=1). Got 0.
+Pass	  Post setValueAtTime(0.125, 0.375) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Fail	< [post cancel: setValue] 1 out of 4 assertions were failed.
+Pass	> [cancel future setTarget] 
+Fail	X After cancelling future setTarget event, output: Expected 0.5 for all values but found 24000 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 23996 more errors.
+Fail	< [cancel future setTarget] 1 out of 1 assertions were failed.
+Pass	> [cancel setTarget now] 
+Fail	X After cancelling setTarget event starting now, output: Expected 0.5 for all values but found 24000 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 23996 more errors.
+Fail	< [cancel setTarget now] 1 out of 1 assertions were failed.
+Pass	> [cancel future setValueCurve] 
+Fail	X After cancelling future setValueCurve event, output: Expected 0.5 for all values but found 24000 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 23996 more errors.
+Fail	< [cancel future setValueCurve] 1 out of 1 assertions were failed.
+Pass	> [cancel setValueCurve now] 
+Fail	X After cancelling current setValueCurve event starting now, output: Expected 0.5 for all values but found 24000 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 23996 more errors.
+Fail	< [cancel setValueCurve now] 1 out of 1 assertions were failed.
+Pass	> [linear, cancel, linear, cancel, linear] Schedules 3 linear ramps, cancelling 2 of them, so that we end up with 2 cancel events next to each other
+Pass	  1st linearRamp: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":5.9605e-8,"relativeThreshold":0}.
+Pass	  Cancelling 1st linearRamp: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
+Fail	X Expected value for cancelling 1st linearRamp: linearRampToValue(0, 0.5) at time 0.25 is not close to 0.5102040767669678 within a relative error of 0 (RelErr=1). Got 0.
+Pass	  2nd linearRamp(2, 0.5) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Pass	  Cancelling 2nd linearRamp(2, 0.5) at time 0.375 contains only the constant 0.
+Fail	X Expected value for cancelling 2nd linearRamp(2, 0.5) at time 0.375 is not close to 1.2551020383834839 within a relative error of 0 (RelErr=1). Got 0.
+Pass	  3rd linearRamp(0, 0.5) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
+Fail	< [linear, cancel, linear, cancel, linear] 2 out of 7 assertions were failed.
+Fail	# AUDIT TASK RUNNER FINISHED: 16 out of 17 tasks were failed.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-cancel-and-hold.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-cancel-and-hold.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 106 tests
 
-72 Pass
-34 Fail
+74 Pass
+32 Fail
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "cancelTime"
 Pass	Executing "linear"
@@ -24,10 +24,10 @@ Pass	Executing "cancel setValueCurve now"
 Pass	Executing "linear, cancel, linear, cancel, linear"
 Pass	Audit report
 Pass	> [cancelTime] Test Invalid Values
-Fail	X cancelAndHoldAtTime(-1) did not throw an exception.
+Pass	  cancelAndHoldAtTime(-1) threw RangeError: "cancelTime must not be negative".
 Pass	  cancelAndHoldAtTime(NaN) threw TypeError: "Expected cancelTime to be a finite floating-point number".
 Pass	  cancelAndHoldAtTime(Infinity) threw TypeError: "Expected cancelTime to be a finite floating-point number".
-Fail	< [cancelTime] 1 out of 3 assertions were failed.
+Pass	< [cancelTime] All assertions passed. (total 3 assertions)
 Pass	> [linear] Cancel linearRampToValueAtTime
 Pass	  linearRampToValueAtTime: linearRampToValue(0, 0.5) up to time 0.25 equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0.000059605,"relativeThreshold":0}.
 Pass	  Cancelling linearRampToValueAtTime: linearRampToValue(0, 0.5) at time 0.25 contains only the constant 0.
@@ -133,4 +133,4 @@ Pass	  Cancelling 2nd linearRamp(2, 0.5) at time 0.375 contains only the constan
 Fail	X Expected value for cancelling 2nd linearRamp(2, 0.5) at time 0.375 is not close to 1.2551020383834839 within a relative error of 0 (RelErr=1). Got 0.
 Pass	  3rd linearRamp(0, 0.5) equals [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":0}.
 Fail	< [linear, cancel, linear, cancel, linear] 2 out of 7 assertions were failed.
-Fail	# AUDIT TASK RUNNER FINISHED: 16 out of 17 tasks were failed.
+Fail	# AUDIT TASK RUNNER FINISHED: 15 out of 17 tasks were failed.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
@@ -1,0 +1,72 @@
+Harness status: OK
+
+Found 66 tests
+
+51 Pass
+15 Fail
+Pass	# AUDIT TASK RUNNER STARTED.
+Pass	Executing "initialize"
+Pass	Executing "test value"
+Pass	Executing "test time"
+Pass	Executing "test setValueCurve"
+Pass	Executing "special cases 1"
+Pass	Executing "special cases 2"
+Pass	Audit report
+Pass	> [initialize] 
+Pass	  Creating context for testing did not throw an exception.
+Pass	< [initialize] All assertions passed. (total 1 assertions)
+Pass	> [test value] Test non-finite arguments for AudioParam value
+Pass	  gain.gain.setValueAtTime(Infinity,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.linearRampToValueAtTime(Infinity,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.exponentialRampToValueAtTime(Infinity,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(Infinity,1,1) threw TypeError: "Expected target to be a finite floating-point number".
+Pass	  gain.gain.setValueAtTime(-Infinity,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.linearRampToValueAtTime(-Infinity,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.exponentialRampToValueAtTime(-Infinity,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(-Infinity,1,1) threw TypeError: "Expected target to be a finite floating-point number".
+Pass	  gain.gain.setValueAtTime(NaN,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.linearRampToValueAtTime(NaN,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.exponentialRampToValueAtTime(NaN,1) threw TypeError: "Expected value to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(NaN,1,1) threw TypeError: "Expected target to be a finite floating-point number".
+Pass	< [test value] All assertions passed. (total 12 assertions)
+Pass	> [test time] Test non-finite arguments for AudioParam time
+Pass	  gain.gain.setValueAtTime(1,Infinity) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.linearRampToValueAtTime(1,Infinity) threw TypeError: "Expected endTime to be a finite floating-point number".
+Pass	  gain.gain.exponentialRampToValueAtTime(1,Infinity) threw TypeError: "Expected endTime to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(1,Infinity,1) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(1,1,Infinity) threw TypeError: "Expected timeConstant to be a finite floating-point number".
+Pass	  gain.gain.setValueAtTime(1,-Infinity) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.linearRampToValueAtTime(1,-Infinity) threw TypeError: "Expected endTime to be a finite floating-point number".
+Pass	  gain.gain.exponentialRampToValueAtTime(1,-Infinity) threw TypeError: "Expected endTime to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(1,-Infinity,1) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(1,1,-Infinity) threw TypeError: "Expected timeConstant to be a finite floating-point number".
+Pass	  gain.gain.setValueAtTime(1,NaN) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.linearRampToValueAtTime(1,NaN) threw TypeError: "Expected endTime to be a finite floating-point number".
+Pass	  gain.gain.exponentialRampToValueAtTime(1,NaN) threw TypeError: "Expected endTime to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(1,NaN,1) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.setTargetAtTime(1,1,NaN) threw TypeError: "Expected timeConstant to be a finite floating-point number".
+Pass	< [test time] All assertions passed. (total 15 assertions)
+Pass	> [test setValueCurve] Test non-finite arguments for setValueCurveAtTime
+Pass	  gain.gain.setValueCurveAtTime([0,0,0],Infinity,1) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.setValueCurveAtTime([0,0,0],-Infinity,1) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.setValueCurveAtTime([0,0,0],NaN,1) threw TypeError: "Expected startTime to be a finite floating-point number".
+Pass	  gain.gain.setValueCurveAtTime([1,2,Infinity,3],1,1) threw TypeError: "Expected values to be a finite floating-point number".
+Pass	  gain.gain.setValueCurveAtTime([1,NaN,2,3],1,1) threw TypeError: "Expected values to be a finite floating-point number".
+Pass	< [test setValueCurve] All assertions passed. (total 5 assertions)
+Pass	> [special cases 1] Test exceptions for finite values
+Fail	X gain.gain.setValueAtTime(1,-1) did not throw an exception.
+Fail	X gain.gain.linearRampToValueAtTime(1,-1) did not throw an exception.
+Fail	X gain.gain.exponentialRampToValueAtTime(1,-1) did not throw an exception.
+Fail	X gain.gain.setTargetAtTime(1,-1,1) did not throw an exception.
+Fail	X gain.gain.setTargetAtTime(1,1,-1) did not throw an exception.
+Fail	X gain.gain.setValueCurveAtTime([0,0,0],-1,1) did not throw an exception.
+Fail	X gain.gain.setValueCurveAtTime([0,0,0],1,-1) did not throw an exception.
+Fail	X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.
+Fail	X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.
+Fail	< [special cases 1] 9 out of 9 assertions were failed.
+Pass	> [special cases 2] Test special cases for expeonentialRamp
+Fail	X gain.gain.exponentialRampToValueAtTime(0,1) did not throw an exception.
+Fail	X gain.gain.exponentialRampToValueAtTime(-1e-100,1) did not throw an exception.
+Fail	X gain.gain.exponentialRampToValueAtTime(1e-100,1) did not throw an exception.
+Fail	< [special cases 2] 3 out of 3 assertions were failed.
+Fail	# AUDIT TASK RUNNER FINISHED: 2 out of 6 tasks were failed.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 66 tests
 
-53 Pass
-13 Fail
+58 Pass
+8 Fail
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "initialize"
 Pass	Executing "test value"
@@ -56,17 +56,17 @@ Pass	< [test setValueCurve] All assertions passed. (total 5 assertions)
 Pass	> [special cases 1] Test exceptions for finite values
 Pass	  gain.gain.setValueAtTime(1,-1) threw RangeError: "startTime must not be negative".
 Pass	  gain.gain.linearRampToValueAtTime(1,-1) threw RangeError: "endTime must not be negative".
-Fail	X gain.gain.exponentialRampToValueAtTime(1,-1) did not throw an exception.
+Pass	  gain.gain.exponentialRampToValueAtTime(1,-1) threw RangeError: "endTime must not be negative".
 Fail	X gain.gain.setTargetAtTime(1,-1,1) did not throw an exception.
 Fail	X gain.gain.setTargetAtTime(1,1,-1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime([0,0,0],-1,1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime([0,0,0],1,-1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.
-Fail	< [special cases 1] 7 out of 9 assertions were failed.
+Fail	< [special cases 1] 6 out of 9 assertions were failed.
 Pass	> [special cases 2] Test special cases for expeonentialRamp
-Fail	X gain.gain.exponentialRampToValueAtTime(0,1) did not throw an exception.
-Fail	X gain.gain.exponentialRampToValueAtTime(-1e-100,1) did not throw an exception.
-Fail	X gain.gain.exponentialRampToValueAtTime(1e-100,1) did not throw an exception.
-Fail	< [special cases 2] 3 out of 3 assertions were failed.
-Fail	# AUDIT TASK RUNNER FINISHED: 2 out of 6 tasks were failed.
+Pass	  gain.gain.exponentialRampToValueAtTime(0,1) threw RangeError: "value must not be zero".
+Pass	  gain.gain.exponentialRampToValueAtTime(-1e-100,1) threw RangeError: "value must not be zero".
+Pass	  gain.gain.exponentialRampToValueAtTime(1e-100,1) threw RangeError: "value must not be zero".
+Pass	< [special cases 2] All assertions passed. (total 3 assertions)
+Fail	# AUDIT TASK RUNNER FINISHED: 1 out of 6 tasks were failed.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 66 tests
 
-52 Pass
-14 Fail
+53 Pass
+13 Fail
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "initialize"
 Pass	Executing "test value"
@@ -55,7 +55,7 @@ Pass	  gain.gain.setValueCurveAtTime([1,NaN,2,3],1,1) threw TypeError: "Expected
 Pass	< [test setValueCurve] All assertions passed. (total 5 assertions)
 Pass	> [special cases 1] Test exceptions for finite values
 Pass	  gain.gain.setValueAtTime(1,-1) threw RangeError: "startTime must not be negative".
-Fail	X gain.gain.linearRampToValueAtTime(1,-1) did not throw an exception.
+Pass	  gain.gain.linearRampToValueAtTime(1,-1) threw RangeError: "endTime must not be negative".
 Fail	X gain.gain.exponentialRampToValueAtTime(1,-1) did not throw an exception.
 Fail	X gain.gain.setTargetAtTime(1,-1,1) did not throw an exception.
 Fail	X gain.gain.setTargetAtTime(1,1,-1) did not throw an exception.
@@ -63,7 +63,7 @@ Fail	X gain.gain.setValueCurveAtTime([0,0,0],-1,1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime([0,0,0],1,-1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.
-Fail	< [special cases 1] 8 out of 9 assertions were failed.
+Fail	< [special cases 1] 7 out of 9 assertions were failed.
 Pass	> [special cases 2] Test special cases for expeonentialRamp
 Fail	X gain.gain.exponentialRampToValueAtTime(0,1) did not throw an exception.
 Fail	X gain.gain.exponentialRampToValueAtTime(-1e-100,1) did not throw an exception.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 66 tests
 
-60 Pass
-6 Fail
+66 Pass
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "initialize"
 Pass	Executing "test value"
@@ -59,14 +58,14 @@ Pass	  gain.gain.linearRampToValueAtTime(1,-1) threw RangeError: "endTime must n
 Pass	  gain.gain.exponentialRampToValueAtTime(1,-1) threw RangeError: "endTime must not be negative".
 Pass	  gain.gain.setTargetAtTime(1,-1,1) threw RangeError: "startTime must not be negative".
 Pass	  gain.gain.setTargetAtTime(1,1,-1) threw RangeError: "timeConstant must not be negative".
-Fail	X gain.gain.setValueCurveAtTime([0,0,0],-1,1) did not throw an exception.
-Fail	X gain.gain.setValueCurveAtTime([0,0,0],1,-1) did not throw an exception.
-Fail	X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.
-Fail	X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.
-Fail	< [special cases 1] 4 out of 9 assertions were failed.
+Pass	  gain.gain.setValueCurveAtTime([0,0,0],-1,1) threw RangeError: "startTime must not be negative".
+Pass	  gain.gain.setValueCurveAtTime([0,0,0],1,-1) threw RangeError: "duration must be positive".
+Pass	  gain.gain.setValueCurveAtTime(curve, 1, 0) threw RangeError: "duration must be positive".
+Pass	  gain.gain.setValueCurveAtTime(curve, 1, -1) threw RangeError: "duration must be positive".
+Pass	< [special cases 1] All assertions passed. (total 9 assertions)
 Pass	> [special cases 2] Test special cases for expeonentialRamp
 Pass	  gain.gain.exponentialRampToValueAtTime(0,1) threw RangeError: "value must not be zero".
 Pass	  gain.gain.exponentialRampToValueAtTime(-1e-100,1) threw RangeError: "value must not be zero".
 Pass	  gain.gain.exponentialRampToValueAtTime(1e-100,1) threw RangeError: "value must not be zero".
 Pass	< [special cases 2] All assertions passed. (total 3 assertions)
-Fail	# AUDIT TASK RUNNER FINISHED: 1 out of 6 tasks were failed.
+Pass	# AUDIT TASK RUNNER FINISHED: 6 tasks ran successfully.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 66 tests
 
-51 Pass
-15 Fail
+52 Pass
+14 Fail
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "initialize"
 Pass	Executing "test value"
@@ -54,7 +54,7 @@ Pass	  gain.gain.setValueCurveAtTime([1,2,Infinity,3],1,1) threw TypeError: "Exp
 Pass	  gain.gain.setValueCurveAtTime([1,NaN,2,3],1,1) threw TypeError: "Expected values to be a finite floating-point number".
 Pass	< [test setValueCurve] All assertions passed. (total 5 assertions)
 Pass	> [special cases 1] Test exceptions for finite values
-Fail	X gain.gain.setValueAtTime(1,-1) did not throw an exception.
+Pass	  gain.gain.setValueAtTime(1,-1) threw RangeError: "startTime must not be negative".
 Fail	X gain.gain.linearRampToValueAtTime(1,-1) did not throw an exception.
 Fail	X gain.gain.exponentialRampToValueAtTime(1,-1) did not throw an exception.
 Fail	X gain.gain.setTargetAtTime(1,-1,1) did not throw an exception.
@@ -63,7 +63,7 @@ Fail	X gain.gain.setValueCurveAtTime([0,0,0],-1,1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime([0,0,0],1,-1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.
-Fail	< [special cases 1] 9 out of 9 assertions were failed.
+Fail	< [special cases 1] 8 out of 9 assertions were failed.
 Pass	> [special cases 2] Test special cases for expeonentialRamp
 Fail	X gain.gain.exponentialRampToValueAtTime(0,1) did not throw an exception.
 Fail	X gain.gain.exponentialRampToValueAtTime(-1e-100,1) did not throw an exception.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 66 tests
 
-58 Pass
-8 Fail
+60 Pass
+6 Fail
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "initialize"
 Pass	Executing "test value"
@@ -57,13 +57,13 @@ Pass	> [special cases 1] Test exceptions for finite values
 Pass	  gain.gain.setValueAtTime(1,-1) threw RangeError: "startTime must not be negative".
 Pass	  gain.gain.linearRampToValueAtTime(1,-1) threw RangeError: "endTime must not be negative".
 Pass	  gain.gain.exponentialRampToValueAtTime(1,-1) threw RangeError: "endTime must not be negative".
-Fail	X gain.gain.setTargetAtTime(1,-1,1) did not throw an exception.
-Fail	X gain.gain.setTargetAtTime(1,1,-1) did not throw an exception.
+Pass	  gain.gain.setTargetAtTime(1,-1,1) threw RangeError: "startTime must not be negative".
+Pass	  gain.gain.setTargetAtTime(1,1,-1) threw RangeError: "timeConstant must not be negative".
 Fail	X gain.gain.setValueCurveAtTime([0,0,0],-1,1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime([0,0,0],1,-1) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.
 Fail	X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.
-Fail	< [special cases 1] 6 out of 9 assertions were failed.
+Fail	< [special cases 1] 4 out of 9 assertions were failed.
 Pass	> [special cases 2] Test special cases for expeonentialRamp
 Pass	  gain.gain.exponentialRampToValueAtTime(0,1) threw RangeError: "value must not be zero".
 Pass	  gain.gain.exponentialRampToValueAtTime(-1e-100,1) threw RangeError: "value must not be zero".

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-large-endtime.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-large-endtime.txt
@@ -1,0 +1,16 @@
+Harness status: OK
+
+Found 11 tests
+
+11 Pass
+Pass	# AUDIT TASK RUNNER STARTED.
+Pass	Executing "linearRamp"
+Pass	Executing "exponentialRamp"
+Pass	Audit report
+Pass	> [linearRamp] 
+Pass	  linearRampToValue(0.1, 1e+300) successfully rendered
+Pass	< [linearRamp] All assertions passed. (total 1 assertions)
+Pass	> [exponentialRamp] 
+Pass	  exponentialRampToValue(0.1, 1e+300) successfully rendered
+Pass	< [exponentialRamp] All assertions passed. (total 1 assertions)
+Pass	# AUDIT TASK RUNNER FINISHED: 2 tasks ran successfully.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+1 Pass
+2 Fail
+Pass	AudioParam: Each method returns the same object to allow chaining
+Fail	AudioParam: Chaining with invalid operations does not apply later effects
+Fail	AudioParam: Chaining of envelope methods schedules values as expected

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 66 tests
 
-40 Pass
-26 Fail
+63 Pass
+3 Fail
 Pass	# AUDIT TASK RUNNER STARTED.
 Pass	Executing "setValueCurve"
 Pass	Executing "value setter"
@@ -15,31 +15,31 @@ Pass	Executing "curve lengths"
 Pass	Audit report
 Pass	> [setValueCurve] 
 Pass	  setValueCurveAtTime(curve, 0.0125, 0.0125) did not throw an exception.
-Fail	X setValueAtTime(1, 0.018750000000000003) did not throw an exception.
-Fail	X linearRampToValueAtTime(1, 0.018750000000000003) did not throw an exception.
-Fail	X exponentialRampToValueAtTime(1, 0.018750000000000003) did not throw an exception.
-Fail	X setTargetAtTime(1, 0.018750000000000003, 1) did not throw an exception.
+Pass	  setValueAtTime(1, 0.018750000000000003) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  linearRampToValueAtTime(1, 0.018750000000000003) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  exponentialRampToValueAtTime(1, 0.018750000000000003) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  setTargetAtTime(1, 0.018750000000000003, 1) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
 Pass	  setValueAtTime(1, 0.026250000000000002) did not throw an exception.
-Fail	< [setValueCurve] 4 out of 6 assertions were failed.
+Pass	< [setValueCurve] All assertions passed. (total 6 assertions)
 Pass	> [value setter] 
 Pass	  setValueCurveAtTime(curve, 0, 0.025) did not throw an exception.
-Fail	X value setter did not throw an exception.
-Fail	< [value setter] 1 out of 2 assertions were failed.
+Pass	  value setter threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	< [value setter] All assertions passed. (total 2 assertions)
 Pass	> [automations] 
 Pass	  linearRampToValueAtTime(1, 0.0125) did not throw an exception.
 Pass	  exponentialRampToValueAtTime(1, 0.025) did not throw an exception.
 Pass	  setTargetAtTime(1, 0.037500000000000006, 0.1) did not throw an exception.
 Pass	  setValueCurveAtTime(curve, 0.05, 0.1) did not throw an exception.
-Fail	X setValueCurveAtTime(curve, 0.00625, 0.01) did not throw an exception.
-Fail	X setValueCurveAtTime(curve, 0.018750000000000003, 0.01) did not throw an exception.
-Fail	X setValueCurveAtTime(curve, 0.03125, 0.01) did not throw an exception.
-Fail	X setValueCurveAtTime(curve, 0.043750000000000004, 0.01) did not throw an exception.
+Pass	  setValueCurveAtTime(curve, 0.00625, 0.01) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
+Pass	  setValueCurveAtTime(curve, 0.018750000000000003, 0.01) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
+Pass	  setValueCurveAtTime(curve, 0.03125, 0.01) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
+Pass	  setValueCurveAtTime(curve, 0.043750000000000004, 0.01) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
 Pass	  setValueCurveAtTime([NaN, NaN], 0.043750000000000004, 0.01) threw TypeError: "Expected values to be a finite floating-point number".
 Pass	  setValueCurveAtTime([1, Infinity], 0.043750000000000004, 0.01) threw TypeError: "Expected values to be a finite floating-point number".
 Pass	  delayTime.setValueCurveAtTime([1, 5], 0.043750000000000004, 0.01) did not throw an exception.
 Pass	  delayTime.setValueCurveAtTime([1, 5, Infinity], 0.043750000000000004, 0.01) threw TypeError: "Expected values to be a finite floating-point number".
-Fail	X setValueCurveAtTime(curve, 0.031415926535897934, 0.01) did not throw an exception.
-Fail	< [automations] 5 out of 13 assertions were failed.
+Pass	  setValueCurveAtTime(curve, 0.031415926535897934, 0.01) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
+Pass	< [automations] All assertions passed. (total 13 assertions)
 Pass	> [catch-exception] 
 Fail	X Handled setValueCurve exception so output: Expected 1 for all values but found 6000 unexpected values: 
 	Index	Actual
@@ -62,17 +62,17 @@ Pass	  setTargetAtTime(1, 0.015000000000000001, 1) did not throw an exception.
 Pass	< [start-end] All assertions passed. (total 9 assertions)
 Pass	> [curve overlap] 
 Pass	  g.gain.setValueCurveAtTime([1,2,3], 5, 10) did not throw an exception.
-Fail	X second g.gain.setValueCurveAtTime([1,2,3], 5, 10) did not throw an exception.
-Fail	X g.gain.setValueCurveAtTime([1,2,3], 5, 5) did not throw an exception.
-Fail	X g.gain.setValueCurveAtTime([1,2,3], 2.5, 10) did not throw an exception.
-Fail	X g.gain.setValueCurveAtTime([1,2,3], 10, 10) did not throw an exception.
-Fail	X g.gain.setValueCurveAtTime([1,2,3], 6, 9) did not throw an exception.
-Fail	X g.gain.setValueCurveAtTime([1,2,3], 4, 11) did not throw an exception.
+Pass	  second g.gain.setValueCurveAtTime([1,2,3], 5, 10) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  g.gain.setValueCurveAtTime([1,2,3], 5, 5) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  g.gain.setValueCurveAtTime([1,2,3], 2.5, 10) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
+Pass	  g.gain.setValueCurveAtTime([1,2,3], 10, 10) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  g.gain.setValueCurveAtTime([1,2,3], 6, 9) threw NotSupportedError: "Cannot schedule an automation event during a value curve".
+Pass	  g.gain.setValueCurveAtTime([1,2,3], 4, 11) threw NotSupportedError: "Cannot schedule a value curve containing an automation event".
 Pass	  g.gain.setValueAtTime(1.0, 15) did not throw an exception.
-Fail	< [curve overlap] 6 out of 8 assertions were failed.
+Pass	< [curve overlap] All assertions passed. (total 8 assertions)
 Pass	> [curve lengths] 
-Fail	X setValueCurveAtTime([], 0, 0.01) did not throw an exception.
-Fail	X setValueCurveAtTime([1], 0, 0.01) did not throw an exception.
+Pass	  setValueCurveAtTime([], 0, 0.01) threw InvalidStateError: "values must contain at least two elements".
+Pass	  setValueCurveAtTime([1], 0, 0.01) threw InvalidStateError: "values must contain at least two elements".
 Pass	  setValueCurveAtTime([1,2], 0, 0.01) did not throw an exception.
-Fail	< [curve lengths] 2 out of 3 assertions were failed.
-Fail	# AUDIT TASK RUNNER FINISHED: 6 out of 7 tasks were failed.
+Pass	< [curve lengths] All assertions passed. (total 3 assertions)
+Fail	# AUDIT TASK RUNNER FINISHED: 1 out of 7 tasks were failed.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.txt
@@ -1,0 +1,78 @@
+Harness status: OK
+
+Found 66 tests
+
+40 Pass
+26 Fail
+Pass	# AUDIT TASK RUNNER STARTED.
+Pass	Executing "setValueCurve"
+Pass	Executing "value setter"
+Pass	Executing "automations"
+Pass	Executing "catch-exception"
+Pass	Executing "start-end"
+Pass	Executing "curve overlap"
+Pass	Executing "curve lengths"
+Pass	Audit report
+Pass	> [setValueCurve] 
+Pass	  setValueCurveAtTime(curve, 0.0125, 0.0125) did not throw an exception.
+Fail	X setValueAtTime(1, 0.018750000000000003) did not throw an exception.
+Fail	X linearRampToValueAtTime(1, 0.018750000000000003) did not throw an exception.
+Fail	X exponentialRampToValueAtTime(1, 0.018750000000000003) did not throw an exception.
+Fail	X setTargetAtTime(1, 0.018750000000000003, 1) did not throw an exception.
+Pass	  setValueAtTime(1, 0.026250000000000002) did not throw an exception.
+Fail	< [setValueCurve] 4 out of 6 assertions were failed.
+Pass	> [value setter] 
+Pass	  setValueCurveAtTime(curve, 0, 0.025) did not throw an exception.
+Fail	X value setter did not throw an exception.
+Fail	< [value setter] 1 out of 2 assertions were failed.
+Pass	> [automations] 
+Pass	  linearRampToValueAtTime(1, 0.0125) did not throw an exception.
+Pass	  exponentialRampToValueAtTime(1, 0.025) did not throw an exception.
+Pass	  setTargetAtTime(1, 0.037500000000000006, 0.1) did not throw an exception.
+Pass	  setValueCurveAtTime(curve, 0.05, 0.1) did not throw an exception.
+Fail	X setValueCurveAtTime(curve, 0.00625, 0.01) did not throw an exception.
+Fail	X setValueCurveAtTime(curve, 0.018750000000000003, 0.01) did not throw an exception.
+Fail	X setValueCurveAtTime(curve, 0.03125, 0.01) did not throw an exception.
+Fail	X setValueCurveAtTime(curve, 0.043750000000000004, 0.01) did not throw an exception.
+Pass	  setValueCurveAtTime([NaN, NaN], 0.043750000000000004, 0.01) threw TypeError: "Expected values to be a finite floating-point number".
+Pass	  setValueCurveAtTime([1, Infinity], 0.043750000000000004, 0.01) threw TypeError: "Expected values to be a finite floating-point number".
+Pass	  delayTime.setValueCurveAtTime([1, 5], 0.043750000000000004, 0.01) did not throw an exception.
+Pass	  delayTime.setValueCurveAtTime([1, 5, Infinity], 0.043750000000000004, 0.01) threw TypeError: "Expected values to be a finite floating-point number".
+Fail	X setValueCurveAtTime(curve, 0.031415926535897934, 0.01) did not throw an exception.
+Fail	< [automations] 5 out of 13 assertions were failed.
+Pass	> [catch-exception] 
+Fail	X Handled setValueCurve exception so output: Expected 1 for all values but found 6000 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 5996 more errors.
+Fail	< [catch-exception] 1 out of 1 assertions were failed.
+Pass	> [start-end] 
+Pass	  setValueAtTime(1, 0) did not throw an exception.
+Pass	  linearRampToValueAtTime(0, 0.0025) did not throw an exception.
+Pass	  setValueCurveAtTime(..., 0.0025, 0.0025) did not throw an exception.
+Pass	  exponentialRampToValueAtTime(1, 0.0075) did not throw an exception.
+Pass	  setValueCurveAtTime(..., 0.0075, 0.0025) did not throw an exception.
+Pass	  setValueCurveAtTime(..., 0.01, 0.0025) did not throw an exception.
+Pass	  setValueAtTime(0, 0.0125) did not throw an exception.
+Pass	  setValueCurveAtTime(..., 0.0125, 0.0025) did not throw an exception.
+Pass	  setTargetAtTime(1, 0.015000000000000001, 1) did not throw an exception.
+Pass	< [start-end] All assertions passed. (total 9 assertions)
+Pass	> [curve overlap] 
+Pass	  g.gain.setValueCurveAtTime([1,2,3], 5, 10) did not throw an exception.
+Fail	X second g.gain.setValueCurveAtTime([1,2,3], 5, 10) did not throw an exception.
+Fail	X g.gain.setValueCurveAtTime([1,2,3], 5, 5) did not throw an exception.
+Fail	X g.gain.setValueCurveAtTime([1,2,3], 2.5, 10) did not throw an exception.
+Fail	X g.gain.setValueCurveAtTime([1,2,3], 10, 10) did not throw an exception.
+Fail	X g.gain.setValueCurveAtTime([1,2,3], 6, 9) did not throw an exception.
+Fail	X g.gain.setValueCurveAtTime([1,2,3], 4, 11) did not throw an exception.
+Pass	  g.gain.setValueAtTime(1.0, 15) did not throw an exception.
+Fail	< [curve overlap] 6 out of 8 assertions were failed.
+Pass	> [curve lengths] 
+Fail	X setValueCurveAtTime([], 0, 0.01) did not throw an exception.
+Fail	X setValueCurveAtTime([1], 0, 0.01) did not throw an exception.
+Pass	  setValueCurveAtTime([1,2], 0, 0.01) did not throw an exception.
+Fail	< [curve lengths] 2 out of 3 assertions were failed.
+Fail	# AUDIT TASK RUNNER FINISHED: 6 out of 7 tasks were failed.

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Fail
+Fail	cancel‑time: handle cancelTime values
+Fail	cancel1: cancel setValueCurve

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	cancel‑time: handle cancelTime values
+1 Pass
+1 Fail
+Pass	cancel‑time: handle cancelTime values
 Fail	cancel1: cancel setValueCurve

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/event-insertion.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audioparam-interface/event-insertion.txt
@@ -1,0 +1,95 @@
+Harness status: OK
+
+Found 67 tests
+
+44 Pass
+23 Fail
+Pass	# AUDIT TASK RUNNER STARTED.
+Pass	Executing "Insert same event at same time"
+Pass	Executing "Linear + Expo"
+Pass	Executing "Expo + Linear"
+Pass	Executing "Linear + SetTarget"
+Pass	Executing "Multiple linear ramps at the same time"
+Pass	Executing "Multiple exponential ramps at the same time"
+Pass	Audit report
+Pass	> [Insert same event at same time] 
+Pass	  setValueAtTime(99, 0.0078125) did not throw an exception.
+Pass	  setValueAtTime(1, 0.0078125) did not throw an exception.
+Pass	  linearRampToValueAtTime(99, 0.015625) did not throw an exception.
+Pass	  linearRampToValueAtTime(2, 0.015625) did not throw an exception.
+Pass	  exponentialRampToValueAtTime(99, 0.0234375) did not throw an exception.
+Pass	  exponentialRampToValueAtTime(3, 0.0234375) did not throw an exception.
+Pass	  setValueCurveAtTime([3,4], 0.0234375, 0.0078125) did not throw an exception.
+Pass	  setValueAtTime(99, 0.03900146484375) did not throw an exception.
+Pass	  setValueAtTime(1, 0.03900146484375) did not throw an exception.
+Pass	  setValueAtTime(5, 0.03900146484375) did not throw an exception.
+Fail	X Output at frame 128 (time 0.0078125) is not equal to 1. Got 0.
+Fail	X Output at frame 256 (time 0.015625) is not equal to 2. Got 0.
+Fail	X Output at frame 384 (time 0.0234375) is not equal to 3. Got 0.
+Fail	X Output at frame 512 (time 0.03125) is not equal to 4. Got 0.
+Fail	X Output at frame 640 (time 0.0390625) is not equal to 5. Got 0.
+Fail	< [Insert same event at same time] 5 out of 15 assertions were failed.
+Pass	> [Linear + Expo] Different events at same time
+Pass	  Linear+Expo: Context length is long enough for the test is true.
+Pass	  Linear+Expo: linearRampToValueAtTime(2, 0.015625) did not throw an exception.
+Pass	  Linear+Expo: setValueAtTime(99, 0.015625) did not throw an exception.
+Pass	  Linear+Expo: exponentialRampToValueAtTime(3, 0.015625) did not throw an exception.
+Fail	X Linear+Expo: At time 0.01556396484375 (frame 255) output is not close to 1.99609375 within a relative error of 0 (RelErr=1). Got 0.
+Fail	X Linear+Expo: At time 0.015625 (frame 256) and later, output: Expected 3 for all values but found 256 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 252 more errors.
+Fail	< [Linear + Expo] 2 out of 6 assertions were failed.
+Pass	> [Expo + Linear] Different events at same time
+Pass	  Expo+Linear: Context length is long enough for the test is true.
+Pass	  Expo+Linear: exponentialRampToValueAtTime(3, 0.015625) did not throw an exception.
+Pass	  Expo+Linear: setValueAtTime(99, 0.015625) did not throw an exception.
+Pass	  Expo+Linear: linearRampToValueAtTime(2, 0.015625) did not throw an exception.
+Fail	X Expo+Linear: At time 0.01556396484375 (frame 255) output is not close to 2.9871532226369792 within a relative error of 0.0000042533 (RelErr=1). Got 0.
+Fail	X Expo+Linear: At time 0.015625 (frame 256) and later, output: Expected 2 for all values but found 256 unexpected values: 
+	Index	Actual
+	[0]	0
+	[1]	0
+	[2]	0
+	[3]	0
+	...and 252 more errors.
+Fail	< [Expo + Linear] 2 out of 6 assertions were failed.
+Pass	> [Linear + SetTarget] Different events at same time
+Pass	  Linear+SetTarget: Context length is long enough for the test is true.
+Pass	  Linear+SetTarget: linearRampToValueAtTime(3, 0.015625) did not throw an exception.
+Pass	  Linear+SetTarget: setValueAtTime(100, 0.015625) did not throw an exception.
+Pass	  Linear+SetTarget: setTargetAtTime(0, 0.015625, 0.1) did not throw an exception.
+Fail	X Linear+SetTarget: At time 0.01556396484375 (frame 255) output is not close to 2.9921875 within a relative error of 0 (RelErr=1). Got 0.
+Fail	X Linear+SetTarget: At time 0.015625 (frame 256) output is not equal to 100. Got 0.
+Fail	X Linear+SetTarget: At time 0.015625 (frame 256) and later does not equal [100,99.93898010253906,99.87800598144531,99.81706237792969,99.75615692138672,99.6952896118164,99.63446044921875,99.57366180419922,99.51290893554688,99.45218658447266,99.39151000976562,99.33086395263672,99.27025604248047,99.20968627929688,99.1491470336914,99.08865356445312...] with an element-wise tolerance of {"absoluteThreshold":0,"relativeThreshold":2.6694e-7}.
+	Index	Actual			Expected		AbsError		RelError		Test threshold
+	[0]	0.0000000000000000e+0	1.0000000000000000e+2	1.0000000000000000e+2	1.0000000000000000e+0	2.6693999999999999e-5
+	[1]	0.0000000000000000e+0	9.9938980102539063e+1	9.9938980102539063e+1	1.0000000000000000e+0	2.6677711348571775e-5
+	[2]	0.0000000000000000e+0	9.9878005981445313e+1	9.9878005981445313e+1	1.0000000000000000e+0	2.6661434916687009e-5
+	[3]	0.0000000000000000e+0	9.9817062377929688e+1	9.9817062377929688e+1	1.0000000000000000e+0	2.6645166631164548e-5
+	[4]	0.0000000000000000e+0	9.9756156921386719e+1	9.9756156921386719e+1	1.0000000000000000e+0	2.6628908528594970e-5
+	...and 251 more errors.
+	Max AbsError of 1.0000000000000000e+2 at index of 0.
+	Max RelError of 1.0000000000000000e+0 at index of 0.
+
+Fail	< [Linear + SetTarget] 3 out of 7 assertions were failed.
+Pass	> [Multiple linear ramps at the same time] Verify output
+Pass	  Multiple linear ramps: setValueAtTime(1, 0) did not throw an exception.
+Pass	  Multiple linear ramps: linearRampToValueAtTime(2, 0.00390625) did not throw an exception.
+Pass	  Multiple linear ramps: linearRampToValueAtTime(7, 0.00390625) did not throw an exception.
+Pass	  Multiple linear ramps: linearRampToValueAtTime(10, 0.00390625) did not throw an exception.
+Fail	X Multiple linear ramps: Output at frame 63 is not close to 1.984375 within a relative error of 0 (RelErr=1). Got 0.
+Fail	X Multiple linear ramps: Output at frame 64 (0.00390625 sec) is not equal to 10. Got 0.
+Fail	< [Multiple linear ramps at the same time] 2 out of 6 assertions were failed.
+Pass	> [Multiple exponential ramps at the same time] Verify output
+Pass	  Multiple exponential ramps: setValueAtTime(1, 0) did not throw an exception.
+Pass	  Multiple exponential ramps: exponentialRampToValueAtTime(2, 0.00390625) did not throw an exception.
+Pass	  Multiple exponential ramps: exponentialRampToValueAtTime(7, 0.00390625) did not throw an exception.
+Pass	  Multiple exponential ramps: exponentialRampToValueAtTime(10, 0.00390625) did not throw an exception.
+Fail	X Multiple exponential ramps: Output at frame 63 is not close to 1.978456026387951 within a relative error of 5.3924e-7 (RelErr=1). Got 0.
+Fail	X Multiple exponential ramps: Output at frame 64 (0.00390625 sec) is not equal to 10. Got 0.
+Fail	< [Multiple exponential ramps at the same time] 2 out of 6 assertions were failed.
+Fail	# AUDIT TASK RUNNER FINISHED: 6 out of 6 tasks were failed.

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/resources/audio-param.js
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/resources/audio-param.js
@@ -1,0 +1,44 @@
+// Define functions that implement the formulas for AudioParam automations.
+
+// AudioParam linearRamp value at time t for a linear ramp between (t0, v0) and
+// (t1, v1).  It is assumed that t0 <= t.  Results are undefined otherwise.
+function audioParamLinearRamp(t, v0, t0, v1, t1) {
+  if (t >= t1)
+    return v1;
+  return (v0 + (v1 - v0) * (t - t0) / (t1 - t0))
+}
+
+// AudioParam exponentialRamp value at time t for an exponential ramp between
+// (t0, v0) and (t1, v1). It is assumed that t0 <= t.  Results are undefined
+// otherwise.
+function audioParamExponentialRamp(t, v0, t0, v1, t1) {
+  if (t >= t1)
+    return v1;
+  return v0 * Math.pow(v1 / v0, (t - t0) / (t1 - t0));
+}
+
+// AudioParam setTarget value at time t for a setTarget curve starting at (t0,
+// v0) with a final value of vFainal and a time constant of timeConstant.  It is
+// assumed that t0 <= t.  Results are undefined otherwise.
+function audioParamSetTarget(t, v0, t0, vFinal, timeConstant) {
+  return vFinal + (v0 - vFinal) * Math.exp(-(t - t0) / timeConstant);
+}
+
+// AudioParam setValueCurve value at time t for a setValueCurve starting at time
+// t0 with curve, curve, and duration duration.  The sample rate is sampleRate.
+// It is assumed that t0 <= t.
+function audioParamSetValueCurve(t, curve, t0, duration) {
+  if (t > t0 + duration)
+    return curve[curve.length - 1];
+
+  let curvePointsPerSecond = (curve.length - 1) / duration;
+
+  let virtualIndex = (t - t0) * curvePointsPerSecond;
+  let index = Math.floor(virtualIndex);
+
+  let delta = virtualIndex - index;
+
+  let c0 = curve[index];
+  let c1 = curve[Math.min(index + 1, curve.length - 1)];
+  return c0 + (c1 - c0) * delta;
+}

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/resources/audioparam-testing.js
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/resources/audioparam-testing.js
@@ -1,0 +1,550 @@
+(function(global) {
+
+  // Information about the starting/ending times and starting/ending values for
+  // each time interval.
+  let timeValueInfo;
+
+  // The difference between starting values between each time interval.
+  let startingValueDelta;
+
+  // For any automation function that has an end or target value, the end value
+  // is based the starting value of the time interval.  The starting value will
+  // be increased or decreased by |startEndValueChange|. We choose half of
+  // |startingValueDelta| so that the ending value will be distinct from the
+  // starting value for next time interval.  This allows us to detect where the
+  // ramp begins and ends.
+  let startEndValueChange;
+
+  // Default threshold to use for detecting discontinuities that should appear
+  // at each time interval.
+  let discontinuityThreshold;
+
+  // Time interval between value changes.  It is best if 1 / numberOfTests is
+  // not close to timeInterval.
+  let timeIntervalInternal = .03;
+
+  let context;
+
+  // Make sure we render long enough to capture all of our test data.
+  function renderLength(numberOfTests) {
+    return timeToSampleFrame((numberOfTests + 1) * timeInterval, sampleRate);
+  }
+
+  // Create a constant reference signal with the given |value|.  Basically the
+  // same as |createConstantBuffer|, but with the parameters to match the other
+  // create functions.  The |endValue| is ignored.
+  function createConstantArray(
+      startTime, endTime, value, endValue, sampleRate) {
+    let startFrame = timeToSampleFrame(startTime, sampleRate);
+    let endFrame = timeToSampleFrame(endTime, sampleRate);
+    let length = endFrame - startFrame;
+
+    let buffer = createConstantBuffer(context, length, value);
+
+    return buffer.getChannelData(0);
+  }
+
+  function getStartEndFrames(startTime, endTime, sampleRate) {
+    // Start frame is the ceiling of the start time because the ramp starts at
+    // or after the sample frame.  End frame is the ceiling because it's the
+    // exclusive ending frame of the automation.
+    let startFrame = Math.ceil(startTime * sampleRate);
+    let endFrame = Math.ceil(endTime * sampleRate);
+
+    return {startFrame: startFrame, endFrame: endFrame};
+  }
+
+  // Create a linear ramp starting at |startValue| and ending at |endValue|. The
+  // ramp starts at time |startTime| and ends at |endTime|.  (The start and end
+  // times are only used to compute how many samples to return.)
+  function createLinearRampArray(
+      startTime, endTime, startValue, endValue, sampleRate) {
+    let frameInfo = getStartEndFrames(startTime, endTime, sampleRate);
+    let startFrame = frameInfo.startFrame;
+    let endFrame = frameInfo.endFrame;
+    let length = endFrame - startFrame;
+    let array = new Array(length);
+
+    let step = Math.fround(
+        (endValue - startValue) / (endTime - startTime) / sampleRate);
+    let start = Math.fround(
+        startValue +
+        (endValue - startValue) * (startFrame / sampleRate - startTime) /
+            (endTime - startTime));
+
+    let slope = (endValue - startValue) / (endTime - startTime);
+
+    // v(t) = v0 + (v1 - v0)*(t-t0)/(t1-t0)
+    for (k = 0; k < length; ++k) {
+      // array[k] = Math.fround(start + k * step);
+      let t = (startFrame + k) / sampleRate;
+      array[k] = startValue + slope * (t - startTime);
+    }
+
+    return array;
+  }
+
+  // Create an exponential ramp starting at |startValue| and ending at
+  // |endValue|. The ramp starts at time |startTime| and ends at |endTime|.
+  // (The start and end times are only used to compute how many samples to
+  // return.)
+  function createExponentialRampArray(
+      startTime, endTime, startValue, endValue, sampleRate) {
+    let deltaTime = endTime - startTime;
+
+    let frameInfo = getStartEndFrames(startTime, endTime, sampleRate);
+    let startFrame = frameInfo.startFrame;
+    let endFrame = frameInfo.endFrame;
+    let length = endFrame - startFrame;
+    let array = new Array(length);
+
+    let ratio = endValue / startValue;
+
+    // v(t) = v0*(v1/v0)^((t-t0)/(t1-t0))
+    for (let k = 0; k < length; ++k) {
+      let t = Math.fround((startFrame + k) / sampleRate);
+      array[k] = Math.fround(
+          startValue * Math.pow(ratio, (t - startTime) / deltaTime));
+    }
+
+    return array;
+  }
+
+  function discreteTimeConstantForSampleRate(timeConstant, sampleRate) {
+    return 1 - Math.exp(-1 / (sampleRate * timeConstant));
+  }
+
+  // Create a signal that starts at |startValue| and exponentially approaches
+  // the target value of |targetValue|, using a time constant of |timeConstant|.
+  // The ramp starts at time |startTime| and ends at |endTime|.  (The start and
+  // end times are only used to compute how many samples to return.)
+  function createExponentialApproachArray(
+      startTime, endTime, startValue, targetValue, sampleRate, timeConstant) {
+    let startFrameFloat = startTime * sampleRate;
+    let frameInfo = getStartEndFrames(startTime, endTime, sampleRate);
+    let startFrame = frameInfo.startFrame;
+    let endFrame = frameInfo.endFrame;
+    let length = Math.floor(endFrame - startFrame);
+    let array = new Array(length);
+    let c = discreteTimeConstantForSampleRate(timeConstant, sampleRate);
+
+    let delta = startValue - targetValue;
+
+    // v(t) = v1 + (v0 - v1) * exp(-(t-t0)/tau)
+    for (let k = 0; k < length; ++k) {
+      let t = (startFrame + k) / sampleRate;
+      let value =
+          targetValue + delta * Math.exp(-(t - startTime) / timeConstant);
+      array[k] = value;
+    }
+
+    return array;
+  }
+
+  // Create a sine wave of the specified duration.
+  function createReferenceSineArray(
+      startTime, endTime, startValue, endValue, sampleRate) {
+    // Ignore |startValue| and |endValue| for the sine wave.
+    let curve = createSineWaveArray(
+        endTime - startTime, freqHz, sineAmplitude, sampleRate);
+    // Sample the curve appropriately.
+    let frameInfo = getStartEndFrames(startTime, endTime, sampleRate);
+    let startFrame = frameInfo.startFrame;
+    let endFrame = frameInfo.endFrame;
+    let length = Math.floor(endFrame - startFrame);
+    let array = new Array(length);
+
+    // v(t) = linearly interpolate between V[k] and V[k + 1] where k =
+    // floor((N-1)/duration*(t - t0))
+    let f = (length - 1) / (endTime - startTime);
+
+    for (let k = 0; k < length; ++k) {
+      let t = (startFrame + k) / sampleRate;
+      let indexFloat = f * (t - startTime);
+      let index = Math.floor(indexFloat);
+      if (index + 1 < length) {
+        let v0 = curve[index];
+        let v1 = curve[index + 1];
+        array[k] = v0 + (v1 - v0) * (indexFloat - index);
+      } else {
+        array[k] = curve[length - 1];
+      }
+    }
+
+    return array;
+  }
+
+  // Create a sine wave of the given frequency and amplitude.  The sine wave is
+  // offset by half the amplitude so that result is always positive.
+  function createSineWaveArray(durationSeconds, freqHz, amplitude, sampleRate) {
+    let length = timeToSampleFrame(durationSeconds, sampleRate);
+    let signal = new Float32Array(length);
+    let omega = 2 * Math.PI * freqHz / sampleRate;
+    let halfAmplitude = amplitude / 2;
+
+    for (let k = 0; k < length; ++k) {
+      signal[k] = halfAmplitude + halfAmplitude * Math.sin(omega * k);
+    }
+
+    return signal;
+  }
+
+  // Return the difference between the starting value and the ending value for
+  // time interval |timeIntervalIndex|.  We alternate between an end value that
+  // is above or below the starting value.
+  function endValueDelta(timeIntervalIndex) {
+    if (timeIntervalIndex & 1) {
+      return -startEndValueChange;
+    } else {
+      return startEndValueChange;
+    }
+  }
+
+  // Relative error metric
+  function relativeErrorMetric(actual, expected) {
+    return (actual - expected) / Math.abs(expected);
+  }
+
+  // Difference metric
+  function differenceErrorMetric(actual, expected) {
+    return actual - expected;
+  }
+
+  // Return the difference between the starting value at |timeIntervalIndex| and
+  // the starting value at the next time interval.  Since we started at a large
+  // initial value, we decrease the value at each time interval.
+  function valueUpdate(timeIntervalIndex) {
+    return -startingValueDelta;
+  }
+
+  // Compare a section of the rendered data against our expected signal.
+  function comparePartialSignals(
+      rendered, expectedFunction, startTime, endTime, valueInfo,
+      sampleRateParam, errorMetric) {
+    let startSample = timeToSampleFrame(startTime, sampleRateParam);
+    let expected = expectedFunction(
+        startTime, endTime, valueInfo.startValue, valueInfo.endValue,
+        sampleRateParam, timeConstant);
+
+    let n = expected.length;
+    let maxError = -1;
+    let maxErrorIndex = -1;
+
+    for (let k = 0; k < n; ++k) {
+      // Make sure we don't pass these tests because a NaN has been generated in
+      // either the
+      // rendered data or the reference data.
+      if (!isValidNumber(rendered[startSample + k])) {
+        maxError = Infinity;
+        maxErrorIndex = startSample + k;
+        assert_true(
+            isValidNumber(rendered[startSample + k]),
+            `NaN or infinity for rendered data at ${maxErrorIndex}`);
+        break;
+      }
+      if (!isValidNumber(expected[k])) {
+        maxError = Infinity;
+        maxErrorIndex = startSample + k;
+        assert_true(
+            isValidNumber(expected[k]),
+            `NaN or infinity for rendered data at ${maxErrorIndex}`);
+        break;
+      }
+      let error = Math.abs(errorMetric(rendered[startSample + k], expected[k]));
+      if (error > maxError) {
+        maxError = error;
+        maxErrorIndex = k;
+      }
+    }
+
+    return {maxError: maxError, index: maxErrorIndex, expected: expected};
+  };
+
+  // Find the discontinuities in the data and compare the locations of the
+  // discontinuities with the times that define the time intervals. There is a
+  // discontinuity if the difference between successive samples exceeds the
+  // threshold.
+  function verifyDiscontinuities(values, times, threshold) {
+    let n = values.length;
+    let success = true;
+    let badLocations = 0;
+    let breaks = [];
+
+    // Find discontinuities.
+    for (let k = 1; k < n; ++k) {
+      if (Math.abs(values[k] - values[k - 1]) > threshold) {
+        breaks.push(k);
+      }
+    }
+
+    let testCount;
+
+    // If there are numberOfTests intervals, there are only numberOfTests - 1
+    // internal interval boundaries. Hence the maximum number of discontinuties
+    // we expect to find is numberOfTests - 1. If we find more than that, we
+    // have no reference to compare against. We also assume that the actual
+    // discontinuities are close to the expected ones.
+    //
+    // This is just a sanity check when something goes really wrong.  For
+    // example, if the threshold is too low, every sample frame looks like a
+    // discontinuity.
+    if (breaks.length >= numberOfTests) {
+      testCount = numberOfTests - 1;
+      assert_less_than(
+          breaks.length, numberOfTests, 'Number of discontinuities');
+      success = false;
+    } else {
+      testCount = breaks.length;
+    }
+
+    // Compare the location of each discontinuity with the end time of each
+    // interval. (There is no discontinuity at the start of the signal.)
+    for (let k = 0; k < testCount; ++k) {
+      let expectedSampleFrame = timeToSampleFrame(times[k + 1], sampleRate);
+      if (breaks[k] != expectedSampleFrame) {
+        success = false;
+        ++badLocations;
+        assert_equals(breaks[k], expectedSampleFrame, 'Discontinuity at index');
+      }
+    }
+
+    if (badLocations) {
+      assert_equals(
+          badLocations, 0, 'Number of discontinuites at incorrect locations');
+      success = false;
+    } else {
+      assert_equals(
+          breaks.length + 1,
+          numberOfTests,
+          'Number of tests started and ended at the correct time');
+    }
+
+    return success;
+  };
+
+  // Compare the rendered data with the expected data.
+  //
+  // testName - string describing the test
+  //
+  // maxError - maximum allowed difference between the rendered data and the
+  // expected data
+  //
+  // rendererdData - array containing the rendered (actual) data
+  //
+  // expectedFunction - function to compute the expected data
+  //
+  // timeValueInfo - array containing information about the start and end times
+  // and the start and end values of each interval.
+  //
+  // breakThreshold - threshold to use for determining discontinuities.
+  function compareSignals(
+      testName, maxError, renderedData, expectedFunction, timeValueInfo,
+      breakThreshold, errorMetric) {
+    let success = true;
+    const failedTestCount = 0;
+    const times = timeValueInfo.times;
+    const values = timeValueInfo.values;
+    const n = values.length;
+    let expectedSignal = [];
+
+    success =
+        verifyDiscontinuities(renderedData, times, breakThreshold);
+
+    for (let k = 0; k < n; ++k) {
+      const result = comparePartialSignals(
+          renderedData, expectedFunction, times[k], times[k + 1],
+          values[k], sampleRate, errorMetric);
+
+      expectedSignal =
+          expectedSignal.concat(Array.prototype.slice.call(result.expected));
+
+      assert_less_than_equal(
+          result.maxError,
+          maxError,
+          `Max error for test ${k} at offset ` +
+              `${result.index + timeToSampleFrame(times[k], sampleRate)}`);
+    }
+
+    assert_equals(
+        failedTestCount,
+        0,
+        `Number of failed tests with an acceptable relative ` +
+            `tolerance of ${maxError}`);
+  };
+
+  // Create a function to test the rendered data with the reference data.
+  //
+  // testName - string describing the test
+  //
+  // error - max allowed error between rendered data and the reference data.
+  //
+  // referenceFunction - function that generates the reference data to be
+  // compared with the rendered data.
+  //
+  // jumpThreshold - optional parameter that specifies the threshold to use for
+  // detecting discontinuities.  If not specified, defaults to
+  // discontinuityThreshold.
+  //
+  function checkResultFunction(
+      task, testName, error, referenceFunction, jumpThreshold,
+      errorMetric) {
+    return function(event) {
+      let buffer = event.renderedBuffer;
+      renderedData = buffer.getChannelData(0);
+
+      let threshold;
+
+      if (!jumpThreshold) {
+        threshold = discontinuityThreshold;
+      } else {
+        threshold = jumpThreshold;
+      }
+
+      compareSignals(
+          testName, error, renderedData, referenceFunction,
+          timeValueInfo, threshold, errorMetric);
+      task.done();
+    }
+  }
+
+  // Run all the automation tests.
+  //
+  // numberOfTests - number of tests (time intervals) to run.
+  //
+  // initialValue - The initial value of the first time interval.
+  //
+  // setValueFunction - function that sets the specified value at the start of a
+  // time interval.
+  //
+  // automationFunction - function that sets the end value for the time
+  // interval. It specifies how the value approaches the end value.
+  //
+  // An object is returned containing an array of start times for each time
+  // interval, and an array giving the start and end values for the interval.
+  function doAutomation(
+      numberOfTests, initialValue, setValueFunction, automationFunction) {
+    let timeInfo = [0];
+    let valueInfo = [];
+    let value = initialValue;
+
+    for (let k = 0; k < numberOfTests; ++k) {
+      let startTime = k * timeInterval;
+      let endTime = (k + 1) * timeInterval;
+      let endValue = value + endValueDelta(k);
+
+      // Set the value at the start of the time interval.
+      setValueFunction(value, startTime);
+
+      // Specify the end or target value, and how we should approach it.
+      automationFunction(endValue, startTime, endTime);
+
+      // Keep track of the start times, and the start and end values for each
+      // time interval.
+      timeInfo.push(endTime);
+      valueInfo.push({startValue: value, endValue: endValue});
+
+      value += valueUpdate(k);
+    }
+
+    return {times: timeInfo, values: valueInfo};
+  }
+
+  // Create the audio graph for the test and then run the test.
+  //
+  // numberOfTests - number of time intervals (tests) to run.
+  //
+  // initialValue - the initial value of the gain at time 0.
+  //
+  // setValueFunction - function to set the value at the beginning of each time
+  // interval.
+  //
+  // automationFunction - the AudioParamTimeline automation function
+  //
+  // testName - string indicating the test that is being run.
+  //
+  // maxError - maximum allowed error between the rendered data and the
+  // reference data
+  //
+  // referenceFunction - function that generates the reference data to be
+  // compared against the rendered data.
+  //
+  // jumpThreshold - optional parameter that specifies the threshold to use for
+  // detecting discontinuities.  If not specified, defaults to
+  // discontinuityThreshold.
+  function createAudioGraphAndTest(
+      task, should, numberOfTests, initialValue, setValueFunction,
+      automationFunction, testName, maxError, referenceFunction, jumpThreshold,
+      errorMetric) {
+    // Create offline audio context.
+    context =
+        new OfflineAudioContext(2, renderLength(numberOfTests), sampleRate);
+    let constantBuffer =
+        createConstantBuffer(context, renderLength(numberOfTests), 1);
+
+    // We use an AudioGainNode here simply as a convenient way to test the
+    // AudioParam automation, since it's easy to pass a constant value through
+    // the node, automate the .gain attribute and observe the resulting values.
+
+    gainNode = context.createGain();
+
+    let bufferSource = context.createBufferSource();
+    bufferSource.buffer = constantBuffer;
+    bufferSource.connect(gainNode);
+    gainNode.connect(context.destination);
+
+    // Set up default values for the parameters that control how the automation
+    // test values progress for each time interval.
+    startingValueDelta = initialValue / numberOfTests;
+    startEndValueChange = startingValueDelta / 2;
+    discontinuityThreshold = startEndValueChange / 2;
+
+    // Run the automation tests.
+    timeValueInfo = doAutomation(
+        numberOfTests, initialValue, setValueFunction, automationFunction);
+    bufferSource.start(0);
+
+    context.oncomplete = checkResultFunction(
+        task, testName, maxError, referenceFunction, jumpThreshold,
+        errorMetric || relativeErrorMetric);
+    context.startRendering();
+  }
+
+  // Export local references to global scope. All the new objects in this file
+  // must be exported through this if it is to be used in the actual test HTML
+  // page.
+  let exports = {
+    'sampleRate': 44100,
+    'gainNode': null,
+    'timeInterval': timeIntervalInternal,
+
+    // Some suitable time constant so that we can see a significant change over
+    // a timeInterval.  This is only needed by setTargetAtTime() which needs a
+    // time constant.
+    'timeConstant': timeIntervalInternal / 3,
+
+    'renderLength': renderLength,
+    'createConstantArray': createConstantArray,
+    'getStartEndFrames': getStartEndFrames,
+    'createLinearRampArray': createLinearRampArray,
+    'createExponentialRampArray': createExponentialRampArray,
+    'discreteTimeConstantForSampleRate': discreteTimeConstantForSampleRate,
+    'createExponentialApproachArray': createExponentialApproachArray,
+    'createReferenceSineArray': createReferenceSineArray,
+    'createSineWaveArray': createSineWaveArray,
+    'endValueDelta': endValueDelta,
+    'relativeErrorMetric': relativeErrorMetric,
+    'differenceErrorMetric': differenceErrorMetric,
+    'valueUpdate': valueUpdate,
+    'comparePartialSignals': comparePartialSignals,
+    'verifyDiscontinuities': verifyDiscontinuities,
+    'compareSignals': compareSignals,
+    'checkResultFunction': checkResultFunction,
+    'doAutomation': doAutomation,
+    'createAudioGraphAndTest': createAudioGraphAndTest
+  };
+
+  for (let reference in exports) {
+    global[reference] = exports[reference];
+  }
+
+})(window);

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-cancel-and-hold.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-cancel-and-hold.html
@@ -1,0 +1,855 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test CancelValuesAndHoldAtTime
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audio-param.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+    <script src="../../../webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      let sampleRate = 48000;
+      let renderDuration = 0.5;
+
+      let audit = Audit.createTaskRunner();
+
+      audit.define(
+          {label: 'cancelTime', description: 'Test Invalid Values'},
+          (task, should) => {
+            let context = new OfflineAudioContext({
+              numberOfChannels: 1,
+              length: 1,
+              sampleRate: 8000
+            });
+
+            let src = new ConstantSourceNode(context);
+            src.connect(context.destination);
+
+            should(
+                () => src.offset.cancelAndHoldAtTime(-1),
+                'cancelAndHoldAtTime(-1)')
+                .throw(RangeError);
+
+            // These are TypeErrors because |cancelTime| is a
+            // double, not unrestricted double.
+            should(
+                () => src.offset.cancelAndHoldAtTime(NaN),
+                'cancelAndHoldAtTime(NaN)')
+                .throw(TypeError);
+
+            should(
+                () => src.offset.cancelAndHoldAtTime(Infinity),
+                'cancelAndHoldAtTime(Infinity)')
+                .throw(TypeError);
+
+            task.done();
+          });
+
+      // The first few tasks test the cancellation of each relevant automation
+      // function.  For the test, a simple linear ramp from 0 to 1 is used to
+      // start things off.  Then the automation to be tested is scheduled and
+      // cancelled.
+
+      audit.define(
+          {label: 'linear', description: 'Cancel linearRampToValueAtTime'},
+          function(task, should) {
+            cancelTest(should, linearRampTest('linearRampToValueAtTime'), {
+              valueThreshold: 8.3998e-5,
+              curveThreshold: 5.9605e-5
+            }).then(task.done.bind(task));
+          });
+
+      audit.define(
+          {label: 'exponential', description: 'Cancel exponentialRampAtTime'},
+          function(task, should) {
+            // Cancel an exponential ramp.  The thresholds are experimentally
+            // determined.
+            cancelTest(should, function(g, v0, t0, cancelTime) {
+              // Initialize values to 0.
+              g[0].gain.setValueAtTime(0, 0);
+              g[1].gain.setValueAtTime(0, 0);
+              // Schedule a short linear ramp to start things off.
+              g[0].gain.linearRampToValueAtTime(v0, t0);
+              g[1].gain.linearRampToValueAtTime(v0, t0);
+
+              // After the linear ramp, schedule an exponential ramp to the end.
+              // (This is the event that will be be cancelled.)
+              let v1 = 0.001;
+              let t1 = renderDuration;
+
+              g[0].gain.exponentialRampToValueAtTime(v1, t1);
+              g[1].gain.exponentialRampToValueAtTime(v1, t1);
+
+              expectedConstant = Math.fround(
+                  v0 * Math.pow(v1 / v0, (cancelTime - t0) / (t1 - t0)));
+              return {
+                expectedConstant: expectedConstant,
+                autoMessage: 'exponentialRampToValue(' + v1 + ', ' + t1 + ')',
+                summary: 'exponentialRampToValueAtTime',
+              };
+            }, {
+              valueThreshold: 1.8664e-6,
+              curveThreshold: 5.9605e-8
+            }).then(task.done.bind(task));
+          });
+
+      audit.define(
+          {label: 'setTarget', description: 'Cancel setTargetAtTime'},
+          function(task, should) {
+            // Cancel a setTarget event.
+            cancelTest(should, function(g, v0, t0, cancelTime) {
+              // Initialize values to 0.
+              g[0].gain.setValueAtTime(0, 0);
+              g[1].gain.setValueAtTime(0, 0);
+              // Schedule a short linear ramp to start things off.
+              g[0].gain.linearRampToValueAtTime(v0, t0);
+              g[1].gain.linearRampToValueAtTime(v0, t0);
+
+              // At the end of the linear ramp, schedule a setTarget.  (This is
+              // the event that will be cancelled.)
+              let v1 = 0;
+              let t1 = t0;
+              let timeConstant = 0.05;
+
+              g[0].gain.setTargetAtTime(v1, t1, timeConstant);
+              g[1].gain.setTargetAtTime(v1, t1, timeConstant);
+
+              expectedConstant = Math.fround(
+                  v1 + (v0 - v1) * Math.exp(-(cancelTime - t0) / timeConstant));
+              return {
+                expectedConstant: expectedConstant,
+                autoMessage: 'setTargetAtTime(' + v1 + ', ' + t1 + ', ' +
+                    timeConstant + ')',
+                summary: 'setTargetAtTime',
+              };
+            }, {
+              valueThreshold: 4.5267e-7,  // 1.1317e-7,
+              curveThreshold: 0
+            }).then(task.done.bind(task));
+          });
+
+      audit.define(
+          {label: 'setValueCurve', description: 'Cancel setValueCurveAtTime'},
+          function(task, should) {
+            // Cancel a setValueCurve event.
+            cancelTest(should, function(g, v0, t0, cancelTime) {
+              // Initialize values to 0.
+              g[0].gain.setValueAtTime(0, 0);
+              g[1].gain.setValueAtTime(0, 0);
+              // Schedule a short linear ramp to start things off.
+              g[0].gain.linearRampToValueAtTime(v0, t0);
+              g[1].gain.linearRampToValueAtTime(v0, t0);
+
+              // After the linear ramp, schedule a setValuesCurve. (This is the
+              // event that will be cancelled.)
+              let v1 = 0;
+              let duration = renderDuration - t0;
+
+              // For simplicity, a 2-point curve so we get a linear interpolated
+              // result.
+              let curve = Float32Array.from([v0, 0]);
+
+              g[0].gain.setValueCurveAtTime(curve, t0, duration);
+              g[1].gain.setValueCurveAtTime(curve, t0, duration);
+
+              let index =
+                  Math.floor((curve.length - 1) / duration * (cancelTime - t0));
+
+              let curvePointsPerFrame =
+                  (curve.length - 1) / duration / sampleRate;
+              let virtualIndex =
+                  (cancelTime - t0) * sampleRate * curvePointsPerFrame;
+
+              let delta = virtualIndex - index;
+              expectedConstant = curve[0] + (curve[1] - curve[0]) * delta;
+              return {
+                expectedConstant: expectedConstant,
+                autoMessage: 'setValueCurveAtTime([' + curve + '], ' + t0 +
+                    ', ' + duration + ')',
+                summary: 'setValueCurveAtTime',
+              };
+            }, {
+              valueThreshold: 9.5368e-9,
+              curveThreshold: 0
+            }).then(task.done.bind(task));
+          });
+
+      audit.define(
+          {
+            label: 'setValueCurve after end',
+            description: 'Cancel setValueCurveAtTime after the end'
+          },
+          function(task, should) {
+            cancelTest(should, function(g, v0, t0, cancelTime) {
+              // Initialize values to 0.
+              g[0].gain.setValueAtTime(0, 0);
+              g[1].gain.setValueAtTime(0, 0);
+              // Schedule a short linear ramp to start things off.
+              g[0].gain.linearRampToValueAtTime(v0, t0);
+              g[1].gain.linearRampToValueAtTime(v0, t0);
+
+              // After the linear ramp, schedule a setValuesCurve. (This is the
+              // event that will be cancelled.)  Make sure the curve ends before
+              // the cancellation time.
+              let v1 = 0;
+              let duration = cancelTime - t0 - 0.125;
+
+              // For simplicity, a 2-point curve so we get a linear interpolated
+              // result.
+              let curve = Float32Array.from([v0, 0]);
+
+              g[0].gain.setValueCurveAtTime(curve, t0, duration);
+              g[1].gain.setValueCurveAtTime(curve, t0, duration);
+
+              expectedConstant = curve[1];
+              return {
+                expectedConstant: expectedConstant,
+                autoMessage: 'setValueCurveAtTime([' + curve + '], ' + t0 +
+                    ', ' + duration + ')',
+                summary: 'setValueCurveAtTime',
+              };
+            }, {
+              valueThreshold: 0,
+              curveThreshold: 0
+            }).then(task.done.bind(task));
+          });
+
+      // Special case where we schedule a setTarget and there is no earlier
+      // automation event.  This tests that we pick up the starting point
+      // correctly from the last setting of the AudioParam value attribute.
+
+
+      audit.define(
+          {
+            label: 'initial setTarget',
+            description: 'Cancel with initial setTargetAtTime'
+          },
+          function(task, should) {
+            cancelTest(should, function(g, v0, t0, cancelTime) {
+              let v1 = 0;
+              let timeConstant = 0.1;
+              g[0].gain.value = 1;
+              g[0].gain.setTargetAtTime(v1, t0, timeConstant);
+              g[1].gain.value = 1;
+              g[1].gain.setTargetAtTime(v1, t0, timeConstant);
+
+              let expectedConstant = Math.fround(
+                  v1 + (v0 - v1) * Math.exp(-(cancelTime - t0) / timeConstant));
+
+              return {
+                expectedConstant: expectedConstant,
+                autoMessage: 'setTargetAtTime(' + v1 + ', ' + t0 + ', ' +
+                    timeConstant + ')',
+                summary: 'Initial setTargetAtTime',
+              };
+            }, {
+              valueThreshold: 3.1210e-6,
+              curveThreshold: 0
+            }).then(task.done.bind(task));
+          });
+
+      // Test automations scheduled after the call to cancelAndHoldAtTime.
+      // Very similar to the above tests, but we also schedule an event after
+      // cancelAndHoldAtTime and verify that curve after cancellation has
+      // the correct values.
+
+      audit.define(
+          {
+            label: 'post cancel: Linear',
+            description: 'LinearRamp after cancelling'
+          },
+          function(task, should) {
+            // Run the cancel test using a linearRamp as the event to be
+            // cancelled. Then schedule another linear ramp after the
+            // cancellation.
+            cancelTest(
+                should,
+                linearRampTest('Post cancellation linearRampToValueAtTime'),
+                {valueThreshold: 8.3998e-5, curveThreshold: 5.9605e-8},
+                function(g, cancelTime, expectedConstant) {
+                  // Schedule the linear ramp on g[0], and do the same for g[2],
+                  // using the starting point given by expectedConstant.
+                  let v2 = 2;
+                  let t2 = cancelTime + 0.125;
+                  g[0].gain.linearRampToValueAtTime(v2, t2);
+                  g[2].gain.setValueAtTime(expectedConstant, cancelTime);
+                  g[2].gain.linearRampToValueAtTime(v2, t2);
+                  return {
+                    constantEndTime: cancelTime,
+                    message: 'Post linearRamp(' + v2 + ', ' + t2 + ')'
+                  };
+                })
+                .then(task.done.bind(task));
+          });
+
+      audit.define(
+          {
+            label: 'post cancel: Exponential',
+            description: 'ExponentialRamp after cancelling'
+          },
+          function(task, should) {
+            // Run the cancel test using a linearRamp as the event to be
+            // cancelled. Then schedule an exponential ramp after the
+            // cancellation.
+            cancelTest(
+                should,
+                linearRampTest('Post cancel exponentialRampToValueAtTime'),
+                {valueThreshold: 8.3998e-5, curveThreshold: 5.9605e-8},
+                function(g, cancelTime, expectedConstant) {
+                  // Schedule the exponential ramp on g[0], and do the same for
+                  // g[2], using the starting point given by expectedConstant.
+                  let v2 = 2;
+                  let t2 = cancelTime + 0.125;
+                  g[0].gain.exponentialRampToValueAtTime(v2, t2);
+                  g[2].gain.setValueAtTime(expectedConstant, cancelTime);
+                  g[2].gain.exponentialRampToValueAtTime(v2, t2);
+                  return {
+                    constantEndTime: cancelTime,
+                    message: 'Post exponentialRamp(' + v2 + ', ' + t2 + ')'
+                  };
+                })
+                .then(task.done.bind(task));
+          });
+
+      audit.define('post cancel: ValueCurve', function(task, should) {
+        // Run the cancel test using a linearRamp as the event to be cancelled.
+        // Then schedule a setValueCurve after the cancellation.
+        cancelTest(
+            should, linearRampTest('Post cancel setValueCurveAtTime'),
+            {valueThreshold: 8.3998e-5, curveThreshold: 5.9605e-8},
+            function(g, cancelTime, expectedConstant) {
+              // Schedule the exponential ramp on g[0], and do the same for
+              // g[2], using the starting point given by expectedConstant.
+              let t2 = cancelTime + 0.125;
+              let duration = 0.125;
+              let curve = Float32Array.from([.125, 2]);
+              g[0].gain.setValueCurveAtTime(curve, t2, duration);
+              g[2].gain.setValueAtTime(expectedConstant, cancelTime);
+              g[2].gain.setValueCurveAtTime(curve, t2, duration);
+              return {
+                constantEndTime: cancelTime,
+                message: 'Post setValueCurve([' + curve + '], ' + t2 + ', ' +
+                    duration + ')',
+                errorThreshold: 8.3998e-5
+              };
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define('post cancel: setTarget', function(task, should) {
+        // Run the cancel test using a linearRamp as the event to be cancelled.
+        // Then schedule a setTarget after the cancellation.
+        cancelTest(
+            should, linearRampTest('Post cancel setTargetAtTime'),
+            {valueThreshold: 8.3998e-5, curveThreshold: 5.9605e-8},
+            function(g, cancelTime, expectedConstant) {
+              // Schedule the exponential ramp on g[0], and do the same for
+              // g[2], using the starting point given by expectedConstant.
+              let v2 = 0.125;
+              let t2 = cancelTime + 0.125;
+              let timeConstant = 0.1;
+              g[0].gain.setTargetAtTime(v2, t2, timeConstant);
+              g[2].gain.setValueAtTime(expectedConstant, cancelTime);
+              g[2].gain.setTargetAtTime(v2, t2, timeConstant);
+              return {
+                constantEndTime: cancelTime + 0.125,
+                message: 'Post setTargetAtTime(' + v2 + ', ' + t2 + ', ' +
+                    timeConstant + ')',
+                errorThreshold: 8.4037e-5
+              };
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define('post cancel: setValue', function(task, should) {
+        // Run the cancel test using a linearRamp as the event to be cancelled.
+        // Then schedule a setTarget after the cancellation.
+        cancelTest(
+            should, linearRampTest('Post cancel setValueAtTime'),
+            {valueThreshold: 8.3998e-5, curveThreshold: 5.9605e-8},
+            function(g, cancelTime, expectedConstant) {
+              // Schedule the exponential ramp on g[0], and do the same for
+              // g[2], using the starting point given by expectedConstant.
+              let v2 = 0.125;
+              let t2 = cancelTime + 0.125;
+              g[0].gain.setValueAtTime(v2, t2);
+              g[2].gain.setValueAtTime(expectedConstant, cancelTime);
+              g[2].gain.setValueAtTime(v2, t2);
+              return {
+                constantEndTime: cancelTime + 0.125,
+                message: 'Post setValueAtTime(' + v2 + ', ' + t2 + ')'
+              };
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define('cancel future setTarget', (task, should) => {
+        const context =
+            new OfflineAudioContext(1, renderDuration * sampleRate, sampleRate);
+        const src = new ConstantSourceNode(context);
+        src.connect(context.destination);
+
+        src.offset.setValueAtTime(0.5, 0);
+        src.offset.setTargetAtTime(0, 0.75 * renderDuration, 0.1);
+        // Now cancel the effect of the setTarget.
+        src.offset.cancelAndHoldAtTime(0.5 * renderDuration);
+
+        src.start();
+        context.startRendering()
+            .then(buffer => {
+              let actual = buffer.getChannelData(0);
+              // Because the setTarget was cancelled, the output should be a
+              // constant.
+              should(actual, 'After cancelling future setTarget event, output')
+                  .beConstantValueOf(0.5);
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define('cancel setTarget now', (task, should) => {
+        const context =
+            new OfflineAudioContext(1, renderDuration * sampleRate, sampleRate);
+        const src = new ConstantSourceNode(context);
+        src.connect(context.destination);
+
+        src.offset.setValueAtTime(0.5, 0);
+        src.offset.setTargetAtTime(0, 0.5 * renderDuration, 0.1);
+        // Now cancel the effect of the setTarget.
+        src.offset.cancelAndHoldAtTime(0.5 * renderDuration);
+
+        src.start();
+        context.startRendering()
+            .then(buffer => {
+              let actual = buffer.getChannelData(0);
+              // Because the setTarget was cancelled, the output should be a
+              // constant.
+              should(
+                  actual,
+                  'After cancelling setTarget event starting now, output')
+                  .beConstantValueOf(0.5);
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define('cancel future setValueCurve', (task, should) => {
+        const context =
+            new OfflineAudioContext(1, renderDuration * sampleRate, sampleRate);
+        const src = new ConstantSourceNode(context);
+        src.connect(context.destination);
+
+        src.offset.setValueAtTime(0.5, 0);
+        src.offset.setValueCurveAtTime([-1, 1], 0.75 * renderDuration, 0.1);
+        // Now cancel the effect of the setTarget.
+        src.offset.cancelAndHoldAtTime(0.5 * renderDuration);
+
+        src.start();
+        context.startRendering()
+            .then(buffer => {
+              let actual = buffer.getChannelData(0);
+              // Because the setTarget was cancelled, the output should be a
+              // constant.
+              should(
+                  actual, 'After cancelling future setValueCurve event, output')
+                  .beConstantValueOf(0.5);
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define('cancel setValueCurve now', (task, should) => {
+        const context =
+            new OfflineAudioContext(1, renderDuration * sampleRate, sampleRate);
+        const src = new ConstantSourceNode(context);
+        src.connect(context.destination);
+
+        src.offset.setValueAtTime(0.5, 0);
+        src.offset.setValueCurveAtTime([-1, 1], 0.5 * renderDuration, 0.1);
+        // Now cancel the effect of the setTarget.
+        src.offset.cancelAndHoldAtTime(0.5 * renderDuration);
+
+        src.start();
+        context.startRendering()
+            .then(buffer => {
+              let actual = buffer.getChannelData(0);
+              // Because the setTarget was cancelled, the output should be a
+              // constant.
+              should(
+                  actual,
+                  'After cancelling current setValueCurve event starting now, output')
+                  .beConstantValueOf(0.5);
+            })
+            .then(task.done.bind(task));
+      });
+
+      audit.define(
+        {
+          label: 'linear, cancel, linear, cancel, linear',
+          description: 'Schedules 3 linear ramps, cancelling 2 of them, '
+            + 'so that we end up with 2 cancel events next to each other'
+        },
+        (task, should) => {
+          cancelTest2(
+            should,
+            linearRampTest('1st linearRamp'),
+            {valueThreshold: 0, curveThreshold: 5.9605e-8},
+            (g, cancelTime, expectedConstant, cancelTime2) => {
+              // Ramp from first cancel time to the end will be cancelled at
+              // second cancel time.
+              const v1 = expectedConstant;
+              const t1 = cancelTime;
+              const v2 = 2;
+              const t2 = renderDuration;
+              g[0].gain.linearRampToValueAtTime(v2, t2);
+              g[2].gain.setValueAtTime(v1, t1);
+              g[2].gain.linearRampToValueAtTime(v2, t2);
+
+              const expectedConstant2 =
+                audioParamLinearRamp(cancelTime2, v1, t1, v2, t2);
+
+              return {
+                constantEndTime: cancelTime,
+                message: `2nd linearRamp(${v2}, ${t2})`,
+                expectedConstant2
+              };
+            },
+            (g, cancelTime2, expectedConstant2) => {
+              // Ramp from second cancel time to the end.
+              const v3 = 0;
+              const t3 = renderDuration;
+              g[0].gain.linearRampToValueAtTime(v3, t3);
+              g[3].gain.setValueAtTime(expectedConstant2, cancelTime2);
+              g[3].gain.linearRampToValueAtTime(v3, t3);
+              return {
+                constantEndTime2: cancelTime2,
+                message2: `3rd linearRamp(${v3}, ${t3})`,
+              };
+            })
+            .then(() => task.done());
+        });
+
+      audit.run();
+
+      // Common function for doing a linearRamp test.  This just does a linear
+      // ramp from 0 to v0 at from time 0 to t0.  Then another linear ramp is
+      // scheduled from v0 to 0 from time t0 to t1.  This is the ramp that is to
+      // be cancelled.
+      function linearRampTest(message) {
+        return function(g, v0, t0, cancelTime) {
+          g[0].gain.setValueAtTime(0, 0);
+          g[1].gain.setValueAtTime(0, 0);
+          g[0].gain.linearRampToValueAtTime(v0, t0);
+          g[1].gain.linearRampToValueAtTime(v0, t0);
+
+          let v1 = 0;
+          let t1 = renderDuration;
+          g[0].gain.linearRampToValueAtTime(v1, t1);
+          g[1].gain.linearRampToValueAtTime(v1, t1);
+
+          expectedConstant =
+              Math.fround(v0 + (v1 - v0) * (cancelTime - t0) / (t1 - t0));
+
+          return {
+            expectedConstant: expectedConstant,
+            autoMessage:
+                message + ': linearRampToValue(' + v1 + ', ' + t1 + ')',
+            summary: message,
+          };
+        }
+      }
+
+      // Run the cancellation test. A set of automations is created and
+      // canceled.
+      //
+      // |testerFunction| is a function that generates the automation to be
+      // tested.  It is given an array of 3 gain nodes, the value and time of an
+      // initial linear ramp, and the time where the cancellation should occur.
+      // The function must do the automations for the first two gain nodes.  It
+      // must return a dictionary with |expectedConstant| being the value at the
+      // cancellation time, |autoMessage| for message to describe the test, and
+      // |summary| for general summary message to be printed at the end of the
+      // test.
+      //
+      // |thresholdOptions| is a property bag that specifies the error threshold
+      // to use. |thresholdOptions.valueThreshold| is the error threshold for
+      // comparing the actual constant output after cancelling to the expected
+      // value.  |thresholdOptions.curveThreshold| is the error threshold for
+      // comparing the actual and expected automation curves before the
+      // cancelation point.
+      //
+      // For cancellation tests, |postCancelTest| is a function that schedules
+      // some automation after the cancellation.  It takes 3 arguments: an array
+      // of the gain nodes, the cancellation time, and the expected value at the
+      // cancellation time.  This function must return a dictionary consisting
+      // of |constantEndtime| indicating when the held constant from
+      // cancellation stops being constant, |message| giving a summary of what
+      // automation is being used, and |errorThreshold| that is the error
+      // threshold between the expected curve and the actual curve.
+      //
+      function cancelTest(
+          should, testerFunction, thresholdOptions, postCancelTest) {
+        // Create a context with three channels.  Channel 0 is the test channel
+        // containing the actual output that includes the cancellation of
+        // events.  Channel 1 is the expected data upto the cancellation so we
+        // can verify the cancellation produced the correct result.  Channel 2
+        // is for verifying events inserted after the cancellation so we can
+        // verify that automations are correctly generated after the
+        // cancellation point.
+        let context =
+            new OfflineAudioContext(3, renderDuration * sampleRate, sampleRate);
+
+        // Test source is a constant signal
+        let src = context.createBufferSource();
+        src.buffer = createConstantBuffer(context, 1, 1);
+        src.loop = true;
+
+        // We'll do the automation tests with three gain nodes.  One (g0) will
+        // have cancelAndHoldAtTime and the other (g1) will not.  g1 is
+        // used as the expected result for that automation up to the
+        // cancellation point.  They should be the same.  The third node (g2) is
+        // used for testing automations inserted after the cancellation point,
+        // if any.  g2 is the expected result from the cancellation point to the
+        // end of the test.
+
+        let g0 = context.createGain();
+        let g1 = context.createGain();
+        let g2 = context.createGain();
+        let v0 = 1;
+        let t0 = 0.01;
+
+        let cancelTime = renderDuration / 2;
+
+        // Test automation here.  The tester function is responsible for setting
+        // up the gain nodes with the desired automation for testing.
+        autoResult = testerFunction([g0, g1, g2], v0, t0, cancelTime);
+        let expectedConstant = autoResult.expectedConstant;
+        let autoMessage = autoResult.autoMessage;
+        let summaryMessage = autoResult.summary;
+
+        // Cancel scheduled events somewhere in the middle of the test
+        // automation.
+        g0.gain.cancelAndHoldAtTime(cancelTime);
+
+        let constantEndTime;
+        if (postCancelTest) {
+          postResult =
+              postCancelTest([g0, g1, g2], cancelTime, expectedConstant);
+          constantEndTime = postResult.constantEndTime;
+        }
+
+        // Connect everything together (with a merger to make a two-channel
+        // result).  Channel 0 is the test (with cancelAndHoldAtTime) and
+        // channel 1 is the reference (without cancelAndHoldAtTime).
+        // Channel 1 is used to verify that everything up to the cancellation
+        // has the correct values.
+        src.connect(g0);
+        src.connect(g1);
+        src.connect(g2);
+        let merger = context.createChannelMerger(3);
+        g0.connect(merger, 0, 0);
+        g1.connect(merger, 0, 1);
+        g2.connect(merger, 0, 2);
+        merger.connect(context.destination);
+
+        // Go!
+        src.start();
+
+        return context.startRendering().then(function(buffer) {
+          let actual = buffer.getChannelData(0);
+          let expected = buffer.getChannelData(1);
+
+          // The actual output should be a constant from the cancel time to the
+          // end.  We use the last value of the actual output as the constant,
+          // but we also want to compare that with what we thought it should
+          // really be.
+
+          let cancelFrame = Math.ceil(cancelTime * sampleRate);
+
+          // Verify that the curves up to the cancel time are "identical".  The
+          // should be but round-off may make them differ slightly due to the
+          // way cancelling is done.
+          let endFrame = Math.floor(cancelTime * sampleRate);
+          should(
+              actual.slice(0, endFrame),
+              autoMessage + ' up to time ' + cancelTime)
+              .beCloseToArray(
+                  expected.slice(0, endFrame),
+                  {absoluteThreshold: thresholdOptions.curveThreshold});
+
+          // Verify the output after the cancellation is a constant.
+          let actualTail;
+          let constantEndFrame;
+
+          if (postCancelTest) {
+            constantEndFrame = Math.ceil(constantEndTime * sampleRate);
+            actualTail = actual.slice(cancelFrame, constantEndFrame);
+          } else {
+            actualTail = actual.slice(cancelFrame);
+          }
+
+          let actualConstant = actual[cancelFrame];
+
+          should(
+              actualTail,
+              'Cancelling ' + autoMessage + ' at time ' + cancelTime)
+              .beConstantValueOf(actualConstant);
+
+          // Verify that the constant is the value we expect.
+          should(
+              actualConstant,
+              'Expected value for cancelling ' + autoMessage + ' at time ' +
+                  cancelTime)
+              .beCloseTo(
+                  expectedConstant,
+                  {threshold: thresholdOptions.valueThreshold});
+
+          // Verify the curve after the constantEndTime matches our
+          // expectations.
+          if (postCancelTest) {
+            let c2 = buffer.getChannelData(2);
+            should(actual.slice(constantEndFrame), postResult.message)
+                .beCloseToArray(
+                    c2.slice(constantEndFrame),
+                    {absoluteThreshold: postResult.errorThreshold || 0});
+          }
+        });
+      }
+
+      // Similar to cancelTest, but does 2 cancels.
+      function cancelTest2(
+          should, testerFunction, thresholdOptions,
+          postCancelTest, postCancelTest2) {
+        // Channel 0: Actual output that includes the cancellation of events.
+        // Channel 1: Expected data up to the first cancellation.
+        // Channel 2: Expected data from 1st cancellation to 2nd cancellation.
+        // Channel 3: Expected data from 2nd cancellation to the end.
+        const context =
+          new OfflineAudioContext(4, renderDuration * sampleRate, sampleRate);
+
+        const src = context.createConstantSource();
+
+        // g0: Actual gain which will have cancelAndHoldAtTime called on it
+        // twice.
+        // g1: Expected gain from start to the 1st cancel.
+        // g2: Expected gain from 1st cancel to the 2nd cancel.
+        // g3: Expected gain from the 2nd cancel to the end.
+        const g0 = context.createGain();
+        const g1 = context.createGain();
+        const g2 = context.createGain();
+        const g3 = context.createGain();
+        const v0 = 1;
+        const t0 = 0.01;
+
+        const cancelTime1 = renderDuration * 0.5;
+        const cancelTime2 = renderDuration * 0.75;
+
+        // Run testerFunction to generate the 1st ramp.
+        const {
+          expectedConstant, autoMessage, summaryMessage} =
+            testerFunction([g0, g1, g2], v0, t0, cancelTime1);
+
+        // 1st cancel, cancelling the 1st ramp.
+        g0.gain.cancelAndHoldAtTime(cancelTime1);
+
+        // Run postCancelTest to generate the 2nd ramp.
+        const {
+          constantEndTime, message, errorThreshold = 0, expectedConstant2} =
+            postCancelTest(
+              [g0, g1, g2], cancelTime1, expectedConstant, cancelTime2);
+
+        // 2nd cancel, cancelling the 2nd ramp.
+        g0.gain.cancelAndHoldAtTime(cancelTime2);
+
+        // Run postCancelTest2 to generate the 3rd ramp.
+        const {constantEndTime2, message2} =
+          postCancelTest2([g0, g1, g2, g3], cancelTime2, expectedConstant2);
+
+        // Connect everything together
+        src.connect(g0);
+        src.connect(g1);
+        src.connect(g2);
+        src.connect(g3);
+        const merger = context.createChannelMerger(4);
+        g0.connect(merger, 0, 0);
+        g1.connect(merger, 0, 1);
+        g2.connect(merger, 0, 2);
+        g3.connect(merger, 0, 3);
+        merger.connect(context.destination);
+
+        // Go!
+        src.start();
+
+        return context.startRendering().then(function (buffer) {
+          const actual = buffer.getChannelData(0);
+          const expected1 = buffer.getChannelData(1);
+          const expected2 = buffer.getChannelData(2);
+          const expected3 = buffer.getChannelData(3);
+
+          const cancelFrame1 = Math.ceil(cancelTime1 * sampleRate);
+          const cancelFrame2 = Math.ceil(cancelTime2 * sampleRate);
+
+          const constantEndFrame1 = Math.ceil(constantEndTime * sampleRate);
+          const constantEndFrame2 = Math.ceil(constantEndTime2 * sampleRate);
+
+          const actualTail1 = actual.slice(cancelFrame1, constantEndFrame1);
+          const actualTail2 = actual.slice(cancelFrame2, constantEndFrame2);
+
+          const actualConstant1 = actual[cancelFrame1];
+          const actualConstant2 = actual[cancelFrame2];
+
+          // Verify first section curve
+          should(
+            actual.slice(0, cancelFrame1),
+            autoMessage + ' up to time ' + cancelTime1)
+            .beCloseToArray(
+              expected1.slice(0, cancelFrame1),
+              {absoluteThreshold: thresholdOptions.curveThreshold});
+
+          // Verify that a value was held after 1st cancel
+          should(
+            actualTail1,
+            'Cancelling ' + autoMessage + ' at time ' + cancelTime1)
+            .beConstantValueOf(actualConstant1);
+
+          // Verify that held value after 1st cancel was correct
+          should(
+            actualConstant1,
+            'Expected value for cancelling ' + autoMessage + ' at time ' +
+            cancelTime1)
+            .beCloseTo(
+              expectedConstant,
+              {threshold: thresholdOptions.valueThreshold});
+
+          // Verify middle section curve
+          should(actual.slice(constantEndFrame1, cancelFrame2), message)
+            .beCloseToArray(
+              expected2.slice(constantEndFrame1, cancelFrame2),
+              {absoluteThreshold: errorThreshold});
+
+          // Verify that a value was held after 2nd cancel
+          should(
+            actualTail2,
+            'Cancelling ' + message + ' at time ' + cancelTime2)
+            .beConstantValueOf(actualConstant2);
+
+          // Verify that held value after 2nd cancel was correct
+          should(
+            actualConstant2,
+            'Expected value for cancelling ' + message + ' at time ' +
+            cancelTime2)
+            .beCloseTo(
+              expectedConstant2,
+              {threshold: thresholdOptions.valueThreshold});
+
+          // Verify end section curve
+          should(actual.slice(constantEndFrame2), message2)
+            .beCloseToArray(
+              expected3.slice(constantEndFrame2),
+              {absoluteThreshold: errorThreshold || 0});
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      audioparam-exceptional-values.html
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+    <script src="../../../webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      let audit = Audit.createTaskRunner();
+
+      // Context to use for all of the tests.  The context isn't used for any
+      // processing; just need one for creating a gain node, which is used for
+      // all the tests.
+      let context;
+
+      // For these values, AudioParam methods should throw a Typeerror because
+      // they are not finite values.
+      let nonFiniteValues = [Infinity, -Infinity, NaN];
+
+      audit.define('initialize', (task, should) => {
+        should(() => {
+          // Context for testing.  Rendering isn't done, so any valid values can
+          // be used here so might as well make them small.
+          context = new OfflineAudioContext(1, 1, 8000);
+        }, 'Creating context for testing').notThrow();
+
+        task.done();
+      });
+
+      audit.define(
+          {
+            label: 'test value',
+            description: 'Test non-finite arguments for AudioParam value'
+          },
+          (task, should) => {
+            let gain = context.createGain();
+
+            // Default method for generating the arguments for an automation
+            // method for testing the value of the automation.
+            let defaultFuncArg = (value) => [value, 1];
+
+            // Test the value parameter
+            doTests(should, gain, TypeError, nonFiniteValues, [
+              {automationName: 'setValueAtTime', funcArg: defaultFuncArg}, {
+                automationName: 'linearRampToValueAtTime',
+                funcArg: defaultFuncArg
+              },
+              {
+                automationName: 'exponentialRampToValueAtTime',
+                funcArg: defaultFuncArg
+              },
+              {
+                automationName: 'setTargetAtTime',
+                funcArg: (value) => [value, 1, 1]
+              }
+            ]);
+            task.done();
+          });
+
+      audit.define(
+          {
+            label: 'test time',
+            description: 'Test non-finite arguments for AudioParam time'
+          },
+          (task, should) => {
+            let gain = context.createGain();
+
+            // Default method for generating the arguments for an automation
+            // method for testing the time parameter of the automation.
+            let defaultFuncArg = (startTime) => [1, startTime];
+
+            // Test the time parameter
+            doTests(should, gain, TypeError, nonFiniteValues, [
+              {automationName: 'setValueAtTime', funcArg: defaultFuncArg},
+              {
+                automationName: 'linearRampToValueAtTime',
+                funcArg: defaultFuncArg
+              },
+              {
+                automationName: 'exponentialRampToValueAtTime',
+                funcArg: defaultFuncArg
+              },
+              // Test start time for setTarget
+              {
+                automationName: 'setTargetAtTime',
+                funcArg: (startTime) => [1, startTime, 1]
+              },
+              // Test time constant for setTarget
+              {
+                automationName: 'setTargetAtTime',
+                funcArg: (timeConstant) => [1, 1, timeConstant]
+              },
+            ]);
+
+            task.done();
+          });
+
+      audit.define(
+          {
+            label: 'test setValueCurve',
+            description: 'Test non-finite arguments for setValueCurveAtTime'
+          },
+          (task, should) => {
+            let gain = context.createGain();
+
+            // Just an array for use by setValueCurveAtTime. The length and
+            // contents of the array are not important.
+            let curve = new Float32Array(3);
+
+            doTests(should, gain, TypeError, nonFiniteValues, [
+              {
+                automationName: 'setValueCurveAtTime',
+                funcArg: (startTime) => [curve, startTime, 1]
+              },
+            ]);
+
+            // Non-finite values for the curve should signal an error
+            doTests(
+                should, gain, TypeError,
+                [[1, 2, Infinity, 3], [1, NaN, 2, 3]], [{
+                  automationName: 'setValueCurveAtTime',
+                  funcArg: (c) => [c, 1, 1]
+                }]);
+
+            task.done();
+          });
+
+      audit.define(
+          {
+            label: 'special cases 1',
+            description: 'Test exceptions for finite values'
+          },
+          (task, should) => {
+            let gain = context.createGain();
+
+            // Default method for generating the arguments for an automation
+            // method for testing the time parameter of the automation.
+            let defaultFuncArg = (startTime) => [1, startTime];
+
+            // Test the time parameter
+            let curve = new Float32Array(3);
+            doTests(should, gain, RangeError, [-1], [
+              {automationName: 'setValueAtTime', funcArg: defaultFuncArg},
+              {
+                automationName: 'linearRampToValueAtTime',
+                funcArg: defaultFuncArg
+              },
+              {
+                automationName: 'exponentialRampToValueAtTime',
+                funcArg: defaultFuncArg
+              },
+              {
+                automationName: 'setTargetAtTime',
+                funcArg: (startTime) => [1, startTime, 1]
+              },
+              // Test time constant
+              {
+                automationName: 'setTargetAtTime',
+                funcArg: (timeConstant) => [1, 1, timeConstant]
+              },
+              // startTime and duration for setValueCurve
+              {
+                automationName: 'setValueCurveAtTime',
+                funcArg: (startTime) => [curve, startTime, 1]
+              },
+              {
+                automationName: 'setValueCurveAtTime',
+                funcArg: (duration) => [curve, 1, duration]
+              },
+            ]);
+
+            // Two final tests for setValueCurve: duration must be strictly
+            // positive.
+            should(
+                () => gain.gain.setValueCurveAtTime(curve, 1, 0),
+                'gain.gain.setValueCurveAtTime(curve, 1, 0)')
+                .throw(RangeError);
+            should(
+                () => gain.gain.setValueCurveAtTime(curve, 1, -1),
+                'gain.gain.setValueCurveAtTime(curve, 1, -1)')
+                .throw(RangeError);
+
+            task.done();
+          });
+
+      audit.define(
+          {
+            label: 'special cases 2',
+            description: 'Test special cases for expeonentialRamp'
+          },
+          (task, should) => {
+            let gain = context.createGain();
+
+            doTests(should, gain, RangeError, [0, -1e-100, 1e-100], [{
+                      automationName: 'exponentialRampToValueAtTime',
+                      funcArg: (value) => [value, 1]
+                    }]);
+
+            task.done();
+          });
+
+      audit.run();
+
+      // Run test over the set of values in |testValues| for all of the
+      // automation methods in |testMethods|.  The expected error type is
+      // |errorName|. |testMethods| is an array of dictionaries with attributes
+      // |automationName| giving the name of the automation method to be tested
+      // and |funcArg| being a function of one parameter that produces an array
+      // that will be used as the argument to the automation method.
+      function doTests(should, node, errorName, testValues, testMethods) {
+        testValues.forEach(value => {
+          testMethods.forEach(method => {
+            let args = method.funcArg(value);
+            let message = 'gain.gain.' + method.automationName + '(' +
+                argString(args) + ')';
+            should(() => node.gain[method.automationName](...args), message)
+                .throw(errorName);
+          });
+        });
+      }
+
+      // Specialized printer for automation arguments so that messages make
+      // sense.  We assume the first element is either a number or an array.  If
+      // it's an array, there are always three elements, and we want to print
+      // out the brackets for the array argument.
+      function argString(arg) {
+        if (typeof(arg[0]) === 'number') {
+          return arg.toString();
+        }
+
+        return '[' + arg[0] + '],' + arg[1] + ',' + arg[2];
+      }
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-large-endtime.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-large-endtime.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      AudioParam with Huge End Time
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+    <script src="../../../webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      let sampleRate = 48000;
+      // Render for some small (but fairly arbitrary) time.
+      let renderDuration = 0.125;
+      // Any huge time value that won't fit in a size_t (2^64 on a 64-bit
+      // machine).
+      let largeTime = 1e300;
+
+      let audit = Audit.createTaskRunner();
+
+      // See crbug.com/582701.  Create an audioparam with a huge end time and
+      // verify that to automation is run.  We don't care about the actual
+      // results, just that it runs.
+
+      // Test linear ramp with huge end time
+      audit.define('linearRamp', (task, should) => {
+        let graph = createGraph();
+        graph.gain.gain.linearRampToValueAtTime(0.1, largeTime);
+
+        graph.source.start();
+        graph.context.startRendering()
+            .then(function(buffer) {
+              should(true, 'linearRampToValue(0.1, ' + largeTime + ')')
+                  .message('successfully rendered', 'unsuccessfully rendered');
+            })
+            .then(() => task.done());
+      });
+
+      // Test exponential ramp with huge end time
+      audit.define('exponentialRamp', (task, should) => {
+        let graph = createGraph();
+        graph.gain.gain.exponentialRampToValueAtTime(.1, largeTime);
+
+        graph.source.start();
+        graph.context.startRendering()
+            .then(function(buffer) {
+              should(true, 'exponentialRampToValue(0.1, ' + largeTime + ')')
+                  .message('successfully rendered', 'unsuccessfully rendered');
+            })
+            .then(() => task.done());
+      });
+
+      audit.run();
+
+      // Create the graph and return the context, the source, and the gain node.
+      function createGraph() {
+        let context =
+            new OfflineAudioContext(1, renderDuration * sampleRate, sampleRate);
+        let src = context.createBufferSource();
+        src.buffer = createConstantBuffer(context, 1, 1);
+        src.loop = true;
+        let gain = context.createGain();
+        src.connect(gain);
+        gain.connect(context.destination);
+        gain.gain.setValueAtTime(1, 0.1 / sampleRate);
+
+        return {context: context, gain: gain, source: src};
+      }
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>AudioParam Method Chaining</title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+    <script src="../../../webaudio/resources/audioparam-testing.js"></script>
+  </head>
+  <body>
+    <script>
+      const sampleRate = 8000;
+
+      // Create a dummy array for setValueCurveAtTime method.
+      const curveArray = new Float32Array([5.0, 6.0]);
+
+      // Method and argument combinations to test method chaining
+      const methodDictionary = [
+        {name: 'setValueAtTime', args: [1.0, 0.0]},
+        {name: 'linearRampToValueAtTime', args: [2.0, 1.0]},
+        {name: 'exponentialRampToValueAtTime', args: [3.0, 2.0]},
+        {name: 'setTargetAtTime', args: [4.0, 2.0, 0.5]},
+        {name: 'setValueCurveAtTime', args: [curveArray, 5.0, 1.0]},
+        {name: 'cancelScheduledValues', args: [6.0]}
+      ];
+
+      test(() => {
+        const context = new AudioContext();
+        methodDictionary.forEach(({name, args}) => {
+          const sourceParam = context.createGain().gain;
+          const returnParam = sourceParam[name](...args);
+          assert_equals(
+            returnParam, sourceParam,
+            `AudioParam.${name}() should return same AudioParam for chaining`
+          );
+        });
+      }, 'AudioParam: Each method returns the same object to allow chaining');
+
+      // Task: test method chaining with invalid operation.
+      promise_test(async () => {
+        const context = new OfflineAudioContext(1, sampleRate, sampleRate);
+
+        const osc = context.createOscillator();
+        const amp1 = context.createGain();
+        const amp2 = context.createGain();
+
+        osc.connect(amp1);
+        osc.connect(amp2);
+        amp1.connect(context.destination);
+        amp2.connect(context.destination);
+
+        // The first operation fails with an exception, thus the second one
+        // should not have effect on the parameter value. Instead, it should
+        // maintain the default value of 1.0.
+        assert_throws_js(
+          RangeError,
+          () => amp1.gain.setValueAtTime(0.25, -1.0)
+              .linearRampToValueAtTime(2.0, 1.0),
+          'Chained call should throw if setValueAtTime() called ' +
+              'with a negative end time'
+        );
+
+        // The first operation succeeds but the second fails due to zero target
+        // value for the exponential ramp. Thus only the first should have
+        // effect on the parameter value, setting the value to 0.5.
+        assert_throws_js(
+          RangeError,
+          () => amp2.gain.setValueAtTime(0.5, 0.0)
+              .exponentialRampToValueAtTime(0.0, 1.0),
+          'Chained call should throw if exponentialRampToValueAtTime() ' +
+              'called with a zero target value'
+        );
+
+        osc.start();
+        osc.stop(1.0);
+
+        const renderedBuffer = await context.startRendering();
+
+        assert_equals(
+          amp1.gain.value, 1.0,
+          'amp1.gain.value should remain default 1 because setValueAtTime threw'
+        );
+
+        assert_equals(
+          amp2.gain.value, 0.5,
+          'amp2.gain.value should be set by setValueAtTime ' +
+              'since exponentialRampToValueAtTime threw'
+        );
+      }, 'AudioParam: Chaining with invalid operations does ' +
+          'not apply later effects');
+
+      // Task: verify if the method chaining actually works. Create an arbitrary
+      // envelope and compare the result with the expected one created by JS
+      // code.
+      promise_test(async () => {
+        const context = new OfflineAudioContext(1, sampleRate * 4, sampleRate);
+        const constantBuffer = createConstantBuffer(context, 1, 1.0);
+
+        const source = context.createBufferSource();
+        source.buffer = constantBuffer;
+        source.loop = true;
+
+        const envelope = context.createGain();
+        source.connect(envelope);
+        envelope.connect(context.destination);
+
+        // Apply a series of scheduled events via method chaining.
+        envelope.gain.setValueAtTime(0.0, 0.0)
+          .linearRampToValueAtTime(1.0, 1.0)
+          .exponentialRampToValueAtTime(0.5, 2.0)
+          .setTargetAtTime(0.001, 2.0, 0.5);
+
+        source.start();
+
+        const rendered = await context.startRendering();
+
+        // Create expected envelope using helper functions
+        const expectedEnvelope = [
+          ...createLinearRampArray(0.0, 1.0, 0.0, 1.0, sampleRate),
+          ...createExponentialRampArray(1.0, 2.0, 1.0, 0.5, sampleRate),
+          ...createExponentialApproachArray(2.0, 4.0, 0.5, 0.001,
+              sampleRate, 0.5)
+        ];
+
+        // There are slight differences between JS implementation of
+        // AudioParam envelope and the internal implementation. (i.e.
+        // double/float and rounding up) The error threshold is adjusted
+        // empirically through the local testing.
+        assert_array_approx_equals(
+          rendered.getChannelData(0),
+          expectedEnvelope,
+          4.0532e-6,
+          'Rendered gain envelope should match expected ' +
+              'values from scheduled events'
+        );
+      }, 'AudioParam: Chaining of envelope methods schedules ' +
+          'values as expected');
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.html
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test Exceptions from setValueCurveAtTime
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+    <script src="../../../webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      let sampleRate = 48000;
+      // Some short duration because we don't need to run the test for very
+      // long.
+      let testDurationSec = 0.125;
+      let testDurationFrames = testDurationSec * sampleRate;
+
+      let audit = Audit.createTaskRunner();
+
+      audit.define('setValueCurve', (task, should) => {
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let g = context.createGain();
+        let curve = new Float32Array(2);
+
+        // Start time and duration for setValueCurveAtTime
+        let curveStartTime = 0.1 * testDurationSec;
+        let duration = 0.1 * testDurationSec;
+
+        // Some time that is known to be during the setValueCurveTime interval.
+        let automationTime = curveStartTime + duration / 2;
+
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, curveStartTime, duration);
+            },
+            'setValueCurveAtTime(curve, ' + curveStartTime + ', ' + duration +
+                ')')
+            .notThrow();
+
+        should(
+            function() {
+              g.gain.setValueAtTime(1, automationTime);
+            },
+            'setValueAtTime(1, ' + automationTime + ')')
+            .throw(DOMException, 'NotSupportedError');
+
+        should(
+            function() {
+              g.gain.linearRampToValueAtTime(1, automationTime);
+            },
+            'linearRampToValueAtTime(1, ' + automationTime + ')')
+            .throw(DOMException, 'NotSupportedError');
+
+        should(
+            function() {
+              g.gain.exponentialRampToValueAtTime(1, automationTime);
+            },
+            'exponentialRampToValueAtTime(1, ' + automationTime + ')')
+            .throw(DOMException, 'NotSupportedError');
+
+        should(
+            function() {
+              g.gain.setTargetAtTime(1, automationTime, 1);
+            },
+            'setTargetAtTime(1, ' + automationTime + ', 1)')
+            .throw(DOMException, 'NotSupportedError');
+
+        should(
+            function() {
+              g.gain.setValueAtTime(1, curveStartTime + 1.1 * duration);
+            },
+            'setValueAtTime(1, ' + (curveStartTime + 1.1 * duration) + ')')
+            .notThrow();
+
+        task.done();
+      });
+
+      audit.define('value setter', (task, should) => {
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let g = context.createGain();
+        let curve = new Float32Array(2);
+
+        // Start time and duration for setValueCurveAtTime
+        let curveStartTime = 0.;
+        let duration = 0.2 * testDurationSec;
+
+        // Some time that is known to be during the setValueCurveTime interval.
+        let automationTime = 0.;
+
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, curveStartTime, duration);
+            },
+            'setValueCurveAtTime(curve, ' + curveStartTime + ', ' + duration +
+                ')')
+            .notThrow();
+
+        should(
+            function() {
+              g.gain.value = 0.;
+            },
+            'value setter')
+            .throw(DOMException, 'NotSupportedError');
+
+        task.done();
+      });
+
+      audit.define('automations', (task, should) => {
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let g = context.createGain();
+
+        let curve = new Float32Array(2);
+        // Start time and duration for setValueCurveAtTime
+        let startTime = 0;
+        let timeInterval = testDurationSec / 10;
+        let time;
+
+        startTime += timeInterval;
+        should(() => {
+          g.gain.linearRampToValueAtTime(1, startTime);
+        }, 'linearRampToValueAtTime(1, ' + startTime + ')').notThrow();
+
+        startTime += timeInterval;
+        should(() => {
+          g.gain.exponentialRampToValueAtTime(1, startTime);
+        }, 'exponentialRampToValueAtTime(1, ' + startTime + ')').notThrow();
+
+        startTime += timeInterval;
+        should(() => {
+          g.gain.setTargetAtTime(1, startTime, 0.1);
+        }, 'setTargetAtTime(1, ' + startTime + ', 0.1)').notThrow();
+
+        startTime += timeInterval;
+        should(() => {
+          g.gain.setValueCurveAtTime(curve, startTime, 0.1);
+        }, 'setValueCurveAtTime(curve, ' + startTime + ', 0.1)').notThrow();
+
+        // Now try to setValueCurve that overlaps each of the above automations
+        startTime = timeInterval / 2;
+
+        for (let k = 0; k < 4; ++k) {
+          time = startTime + timeInterval * k;
+          should(
+              () => {
+                g.gain.setValueCurveAtTime(curve, time, 0.01);
+              },
+              'setValueCurveAtTime(curve, ' + time + ', 0.01)')
+              .throw(DOMException, 'NotSupportedError');
+        }
+
+        // Elements of setValueCurve should be finite.
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(
+                  Float32Array.from([NaN, NaN]), time, 0.01);
+            },
+            'setValueCurveAtTime([NaN, NaN], ' + time + ', 0.01)')
+            .throw(TypeError);
+
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(
+                  Float32Array.from([1, Infinity]), time, 0.01);
+            },
+            'setValueCurveAtTime([1, Infinity], ' + time + ', 0.01)')
+            .throw(TypeError);
+
+        let d = context.createDelay();
+        // Check that we get warnings for out-of-range values and also throw for
+        // non-finite values.
+        should(
+            () => {
+              d.delayTime.setValueCurveAtTime(
+                  Float32Array.from([1, 5]), time, 0.01);
+            },
+            'delayTime.setValueCurveAtTime([1, 5], ' + time + ', 0.01)')
+            .notThrow();
+
+        should(
+            () => {
+              d.delayTime.setValueCurveAtTime(
+                  Float32Array.from([1, 5, Infinity]), time, 0.01);
+            },
+            'delayTime.setValueCurveAtTime([1, 5, Infinity], ' + time +
+                ', 0.01)')
+            .throw(TypeError);
+
+        // One last test that prints out lots of digits for the time.
+        time = Math.PI / 100;
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, time, 0.01);
+            },
+            'setValueCurveAtTime(curve, ' + time + ', 0.01)')
+            .throw(DOMException, 'NotSupportedError');
+
+        task.done();
+      });
+
+      audit.define('catch-exception', (task, should) => {
+        // Verify that the curve isn't inserted into the time line even if we
+        // catch the exception.
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let gain = context.createGain();
+        let source = context.createBufferSource();
+        let buffer = context.createBuffer(1, 1, context.sampleRate);
+        buffer.getChannelData(0)[0] = 1;
+        source.buffer = buffer;
+        source.loop = true;
+
+        source.connect(gain);
+        gain.connect(context.destination);
+
+        gain.gain.setValueAtTime(1, 0);
+        try {
+          // The value curve has an invalid element. This automation shouldn't
+          // be inserted into the timeline at all.
+          gain.gain.setValueCurveAtTime(
+              Float32Array.from([0, NaN]), 128 / context.sampleRate, .5);
+        } catch (e) {
+        };
+        source.start();
+
+        context.startRendering()
+            .then(function(resultBuffer) {
+              // Since the setValueCurve wasn't inserted, the output should be
+              // exactly 1 for the entire duration.
+              should(
+                  resultBuffer.getChannelData(0),
+                  'Handled setValueCurve exception so output')
+                  .beConstantValueOf(1);
+
+            })
+            .then(() => task.done());
+      });
+
+      audit.define('start-end', (task, should) => {
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let g = context.createGain();
+        let curve = new Float32Array(2);
+
+        // Verify that a setValueCurve can start at the end of an automation.
+        let time = 0;
+        let timeInterval = testDurationSec / 50;
+        should(() => {
+          g.gain.setValueAtTime(1, time);
+        }, 'setValueAtTime(1, ' + time + ')').notThrow();
+
+        time += timeInterval;
+        should(() => {
+          g.gain.linearRampToValueAtTime(0, time);
+        }, 'linearRampToValueAtTime(0, ' + time + ')').notThrow();
+
+        // setValueCurve starts at the end of the linear ramp. This should be
+        // fine.
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, time, timeInterval);
+            },
+            'setValueCurveAtTime(..., ' + time + ', ' + timeInterval + ')')
+            .notThrow();
+
+        // exponentialRamp ending one interval past the setValueCurve should be
+        // fine.
+        time += 2 * timeInterval;
+        should(() => {
+          g.gain.exponentialRampToValueAtTime(1, time);
+        }, 'exponentialRampToValueAtTime(1, ' + time + ')').notThrow();
+
+        // setValueCurve starts at the end of the exponential ramp. This should
+        // be fine.
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, time, timeInterval);
+            },
+            'setValueCurveAtTime(..., ' + time + ', ' + timeInterval + ')')
+            .notThrow();
+
+        // setValueCurve at the end of the setValueCurve should be fine.
+        time += timeInterval;
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, time, timeInterval);
+            },
+            'setValueCurveAtTime(..., ' + time + ', ' + timeInterval + ')')
+            .notThrow();
+
+        // setValueAtTime at the end of setValueCurve should be fine.
+        time += timeInterval;
+        should(() => {
+          g.gain.setValueAtTime(0, time);
+        }, 'setValueAtTime(0, ' + time + ')').notThrow();
+
+        // setValueCurve at the end of setValueAtTime should be fine.
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, time, timeInterval);
+            },
+            'setValueCurveAtTime(..., ' + time + ', ' + timeInterval + ')')
+            .notThrow();
+
+        // setTarget starting at the end of setValueCurve should be fine.
+        time += timeInterval;
+        should(() => {
+          g.gain.setTargetAtTime(1, time, 1);
+        }, 'setTargetAtTime(1, ' + time + ', 1)').notThrow();
+
+        task.done();
+      });
+
+      audit.define('curve overlap', (task, should) => {
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let g = context.createGain();
+        let startTime = 5;
+        let startTimeLater = 10;
+        let startTimeEarlier = 2.5;
+        let curveDuration = 10;
+        let curveDurationShorter = 5;
+        let curve = [1, 2, 3];
+
+        // An initial curve event
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTime, curveDuration);
+            },
+            `g.gain.setValueCurveAtTime([${curve}], ${startTime}, ${curveDuration})`)
+            .notThrow();
+
+        // Check that an exception is thrown when trying to overlap two curves,
+        // in various ways
+
+        // Same start time and end time (curve exactly overlapping)
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTime, curveDuration);
+            },
+            `second g.gain.setValueCurveAtTime([${curve}], ${startTime}, ${curveDuration})`)
+            .throw(DOMException, 'NotSupportedError');
+        // Same start time, shorter end time
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTime, curveDurationShorter);
+            },
+            `g.gain.setValueCurveAtTime([${curve}], ${startTime}, ${curveDurationShorter})`)
+            .throw(DOMException, 'NotSupportedError');
+        // Earlier start time, end time after the start time an another curve
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTimeEarlier, curveDuration);
+            },
+            `g.gain.setValueCurveAtTime([${curve}], ${startTimeEarlier}, ${curveDuration})`)
+            .throw(DOMException, 'NotSupportedError');
+        // Start time after the start time of the other curve, but earlier than
+        // its end.
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTimeLater, curveDuration);
+            },
+            `g.gain.setValueCurveAtTime([${curve}], ${startTimeLater}, ${curveDuration})`)
+            .throw(DOMException, 'NotSupportedError');
+
+        // New event wholly contained inside existing event
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTime + 1, curveDuration - 1);
+            },
+            `g.gain.setValueCurveAtTime([${curve}], ${startTime+1}, ${curveDuration-1})`)
+            .throw(DOMException, 'NotSupportedError');
+        // Old event completely contained inside new event
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(curve, startTime - 1, curveDuration + 1);
+            },
+            `g.gain.setValueCurveAtTime([${curve}], ${startTime-1}, ${curveDuration+1})`)
+            .throw(DOMException, 'NotSupportedError');
+        // Setting an event exactly at the end of the curve should work.
+        should(
+            () => {
+              g.gain.setValueAtTime(1.0, startTime + curveDuration);
+            },
+            `g.gain.setValueAtTime(1.0, ${startTime + curveDuration})`)
+            .notThrow();
+
+        task.done();
+      });
+
+      audit.define('curve lengths', (task, should) => {
+        let context =
+            new OfflineAudioContext(1, testDurationFrames, sampleRate);
+        let g = context.createGain();
+        let time = 0;
+
+        // Check for invalid curve lengths
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(Float32Array.from([]), time, 0.01);
+            },
+            'setValueCurveAtTime([], ' + time + ', 0.01)')
+            .throw(DOMException, 'InvalidStateError');
+
+        should(
+            () => {
+              g.gain.setValueCurveAtTime(Float32Array.from([1]), time, 0.01);
+            },
+            'setValueCurveAtTime([1], ' + time + ', 0.01)')
+            .throw(DOMException, 'InvalidStateError');
+
+        should(() => {
+          g.gain.setValueCurveAtTime(Float32Array.from([1, 2]), time, 0.01);
+        }, 'setValueCurveAtTime([1,2], ' + time + ', 0.01)').notThrow();
+
+        task.done();
+      });
+
+      audit.run();
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/cancel-scheduled-values.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html>
+  <head>
+    <title>
+      cancelScheduledValues
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+  </head>
+  <body>
+    <script>
+
+      const sampleRate = 8000;
+      const renderFrames = 8000;
+
+
+      test(t => {
+        const context = new OfflineAudioContext({
+          numberOfChannels: 1,
+          length: renderFrames,
+          sampleRate: sampleRate
+        });
+
+        const source = new ConstantSourceNode(context);
+        source.connect(context.destination);
+
+        assert_throws_js(RangeError,
+          () => source.offset.cancelScheduledValues(-1),
+          'cancelScheduledValues(-1)');
+
+        // |cancelTime| is a double, so NaN and Infinity must throw TypeError.
+        assert_throws_js(TypeError,
+          () => source.offset.cancelScheduledValues(NaN),
+          'cancelScheduledValues(NaN)');
+
+        assert_throws_js(TypeError,
+          () => source.offset.cancelScheduledValues(Infinity),
+          'cancelScheduledValues(Infinity)');
+      }, 'cancel‑time: handle cancelTime values');
+
+      promise_test(async t => {
+        const context = new OfflineAudioContext({
+          numberOfChannels: 1,
+          length: renderFrames,
+          sampleRate: sampleRate
+        });
+
+        const source = new ConstantSourceNode(context);
+        const gain = new GainNode(context);
+        source.connect(gain).connect(context.destination);
+
+        // Initial time and value for first automation (setValue)
+        const time0 = 0;
+        const value0 = 0.5;
+
+        // Time and duration of the setValueCurve. We'll also schedule a
+        // setValue at the same time.
+        const value1 = 1.5;
+        const curveStartTime = 0.25;
+        const curveDuration = 0.25;
+
+        // Time at which to cancel events
+        const cancelTime = 0.3;
+
+        // Time and value for event added after cancelScheduledValues has
+        // been called.
+        const time2 = curveStartTime + curveDuration / 2;
+        const value2 = 3;
+
+        // Self‑consistency checks for the test.
+        assert_greater_than(cancelTime, curveStartTime,
+                            'cancelTime is after curve start');
+        assert_less_than(cancelTime, curveStartTime + curveDuration,
+                         'cancelTime is before curve ends');
+
+        // These assertions are just to show what's happening
+        gain.gain.setValueAtTime(value0, time0);
+        // setValue at the same time as the curve, to test that this event
+        // wasn't removed.
+        gain.gain.setValueAtTime(value1, curveStartTime);
+
+        gain.gain.setValueCurveAtTime([1, -1], curveStartTime, curveDuration);
+
+        // An event after the curve to verify this is removed.
+        gain.gain.setValueAtTime(99, curveStartTime + curveDuration);
+
+        // Cancel events now.
+        gain.gain.cancelScheduledValues(cancelTime);
+
+        // Simple check that the setValueCurve is gone, by scheduling
+        // something in the middle of the (now deleted) event
+        gain.gain.setValueAtTime(value2, time2);
+
+        source.start();
+        const buffer = await context.startRendering();
+        const audio = buffer.getChannelData(0);
+
+        const curveFrame = curveStartTime * context.sampleRate;
+        const time2Frame = time2 * context.sampleRate;
+
+        assert_constant_value(audio.slice(0, curveFrame),
+                              value0,
+                              `output[0:${curveFrame - 1}]`);
+
+        assert_constant_value(audio.slice(curveFrame, time2Frame),
+                              value1,
+                              `output[${curveFrame}:${time2Frame - 1}]`);
+
+        assert_constant_value(audio.slice(time2Frame),
+                              value2,
+                              `output[${time2Frame}:]`);
+      }, 'cancel1: cancel setValueCurve');
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/event-insertion.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audioparam-interface/event-insertion.html
@@ -1,0 +1,411 @@
+<!doctype html>
+<html>
+  <head>
+    <title>
+      Test Handling of Event Insertion
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit-util.js"></script>
+    <script src="../../../webaudio/resources/audit.js"></script>
+    <script src="../../../webaudio/resources/audio-param.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      let audit = Audit.createTaskRunner();
+
+      // Use a power of two for the sample rate so there's no round-off in
+      // computing time from frame.
+      let sampleRate = 16384;
+
+      audit.define(
+          {label: 'Insert same event at same time'}, (task, should) => {
+            // Context for testing.
+            let context = new OfflineAudioContext(
+                {length: 16384, sampleRate: sampleRate});
+
+            // The source node to use.  Automations will be scheduled here.
+            let src = new ConstantSourceNode(context, {offset: 0});
+            src.connect(context.destination);
+
+            // An array of tests to be done.  Each entry specifies the event
+            // type and the event time.  The events are inserted in the order
+            // given (in |values|), and the second event should be inserted
+            // after the first one, as required by the spec.
+            let testCases = [
+              {
+                event: 'setValueAtTime',
+                frame: RENDER_QUANTUM_FRAMES,
+                values: [99, 1],
+                outputTestFrame: RENDER_QUANTUM_FRAMES,
+                expectedOutputValue: 1
+              },
+              {
+                event: 'linearRampToValueAtTime',
+                frame: 2 * RENDER_QUANTUM_FRAMES,
+                values: [99, 2],
+                outputTestFrame: 2 * RENDER_QUANTUM_FRAMES,
+                expectedOutputValue: 2
+              },
+              {
+                event: 'exponentialRampToValueAtTime',
+                frame: 3 * RENDER_QUANTUM_FRAMES,
+                values: [99, 3],
+                outputTestFrame: 3 * RENDER_QUANTUM_FRAMES,
+                expectedOutputValue: 3
+              },
+              {
+                event: 'setValueCurveAtTime',
+                frame: 3 * RENDER_QUANTUM_FRAMES,
+                values: [[3, 4]],
+                extraArgs: RENDER_QUANTUM_FRAMES / context.sampleRate,
+                outputTestFrame: 4 * RENDER_QUANTUM_FRAMES,
+                expectedOutputValue: 4
+              },
+              {
+                event: 'setValueAtTime',
+                frame: 5 * RENDER_QUANTUM_FRAMES - 1,
+                values: [99, 1, 5],
+                outputTestFrame: 5 * RENDER_QUANTUM_FRAMES,
+                expectedOutputValue: 5
+              }
+            ];
+
+            testCases.forEach(entry => {
+              entry.values.forEach(value => {
+                let eventTime = entry.frame / context.sampleRate;
+                let message = eventToString(
+                    entry.event, value, eventTime, entry.extraArgs);
+                // This is mostly to print out the event that is getting
+                // inserted.  It should never ever throw.
+                should(() => {
+                  src.offset[entry.event](value, eventTime, entry.extraArgs);
+                }, message).notThrow();
+              });
+            });
+
+            src.start();
+
+            context.startRendering()
+                .then(audioBuffer => {
+                  let audio = audioBuffer.getChannelData(0);
+
+                  // Look through the test cases to figure out what the correct
+                  // output values should be.
+                  testCases.forEach(entry => {
+                    let expected = entry.expectedOutputValue;
+                    let frame = entry.outputTestFrame;
+                    let time = frame / context.sampleRate;
+                    should(
+                        audio[frame], `Output at frame ${frame} (time ${time})`)
+                        .beEqualTo(expected);
+                  });
+                })
+                .then(() => task.done());
+          });
+
+      audit.define(
+          {
+            label: 'Linear + Expo',
+            description: 'Different events at same time'
+          },
+          (task, should) => {
+            // Should be a linear ramp up to the event time, and after a
+            // constant value because the exponential ramp has ended.
+            let testCase = [
+              {event: 'linearRampToValueAtTime', value: 2, relError: 0},
+              {event: 'setValueAtTime', value: 99},
+              {event: 'exponentialRampToValueAtTime', value: 3},
+            ];
+            let eventFrame = 2 * RENDER_QUANTUM_FRAMES;
+            let prefix = 'Linear+Expo: ';
+
+            testEventInsertion(prefix, should, eventFrame, testCase)
+                .then(expectConstant(prefix, should, eventFrame, testCase))
+                .then(() => task.done());
+          });
+
+      audit.define(
+          {
+            label: 'Expo + Linear',
+            description: 'Different events at same time',
+          },
+          (task, should) => {
+            // Should be an exponential ramp up to the event time, and after a
+            // constant value because the linear ramp has ended.
+            let testCase = [
+              {
+                event: 'exponentialRampToValueAtTime',
+                value: 3,
+                relError: 4.2533e-6
+              },
+              {event: 'setValueAtTime', value: 99},
+              {event: 'linearRampToValueAtTime', value: 2},
+            ];
+            let eventFrame = 2 * RENDER_QUANTUM_FRAMES;
+            let prefix = 'Expo+Linear: ';
+
+            testEventInsertion(prefix, should, eventFrame, testCase)
+                .then(expectConstant(prefix, should, eventFrame, testCase))
+                .then(() => task.done());
+          });
+
+      audit.define(
+          {
+            label: 'Linear + SetTarget',
+            description: 'Different events at same time',
+          },
+          (task, should) => {
+            // Should be a linear ramp up to the event time, and then a
+            // decaying value.
+            let testCase = [
+              {event: 'linearRampToValueAtTime', value: 3, relError: 0},
+              {event: 'setValueAtTime', value: 100},
+              {event: 'setTargetAtTime', value: 0, extraArgs: 0.1},
+            ];
+            let eventFrame = 2 * RENDER_QUANTUM_FRAMES;
+            let prefix = 'Linear+SetTarget: ';
+
+            testEventInsertion(prefix, should, eventFrame, testCase)
+                .then(audioBuffer => {
+                  let audio = audioBuffer.getChannelData(0);
+                  let prefix = 'Linear+SetTarget: ';
+                  let eventTime = eventFrame / sampleRate;
+                  let expectedValue = methodMap[testCase[0].event](
+                      (eventFrame - 1) / sampleRate, 1, 0, testCase[0].value,
+                      eventTime);
+                  should(
+                      audio[eventFrame - 1],
+                      prefix +
+                          `At time ${
+                                     (eventFrame - 1) / sampleRate
+                                   } (frame ${eventFrame - 1}) output`)
+                      .beCloseTo(
+                          expectedValue,
+                          {threshold: testCase[0].relError || 0});
+
+                  // The setValue should have taken effect
+                  should(
+                      audio[eventFrame],
+                      prefix +
+                          `At time ${eventTime} (frame ${eventFrame}) output`)
+                      .beEqualTo(testCase[1].value);
+
+                  // The final event is setTarget.  Compute the expected output.
+                  let actual = audio.slice(eventFrame);
+                  let expected = new Float32Array(actual.length);
+                  for (let k = 0; k < expected.length; ++k) {
+                    let t = (eventFrame + k) / sampleRate;
+                    expected[k] = audioParamSetTarget(
+                        t, testCase[1].value, eventTime, testCase[2].value,
+                        testCase[2].extraArgs);
+                  }
+                  should(
+                      actual,
+                      prefix +
+                          `At time ${eventTime} (frame ${
+                                                         eventFrame
+                                                       }) and later`)
+                      .beCloseToArray(expected, {relativeThreshold: 2.6694e-7});
+                })
+                .then(() => task.done());
+          });
+
+      audit.define(
+          {
+            label: 'Multiple linear ramps at the same time',
+            description: 'Verify output'
+          },
+          (task, should) => {
+            testMultipleSameEvents(should, {
+              method: 'linearRampToValueAtTime',
+              prefix: 'Multiple linear ramps: ',
+              threshold: 0
+            }).then(() => task.done());
+          });
+
+      audit.define(
+          {
+            label: 'Multiple exponential ramps at the same time',
+            description: 'Verify output'
+          },
+          (task, should) => {
+            testMultipleSameEvents(should, {
+              method: 'exponentialRampToValueAtTime',
+              prefix: 'Multiple exponential ramps: ',
+              threshold: 5.3924e-7
+            }).then(() => task.done());
+          });
+
+      audit.run();
+
+      // Takes a list of |testCases| consisting of automation methods and
+      // schedules them to occur at |eventFrame|. |prefix| is a prefix for
+      // messages produced by |should|.
+      //
+      // Each item in |testCases| is a dictionary with members:
+      //   event     - the name of automation method to be inserted,
+      //   value     - the value for the event,
+      //   extraArgs - extra arguments if the event needs more than the value
+      //               and time (such as setTargetAtTime).
+      function testEventInsertion(prefix, should, eventFrame, testCases) {
+        let context = new OfflineAudioContext(
+            {length: 4 * RENDER_QUANTUM_FRAMES, sampleRate: sampleRate});
+
+        // The source node to use.  Automations will be scheduled here.
+        let src = new ConstantSourceNode(context, {offset: 0});
+        src.connect(context.destination);
+
+        // Initialize value to 1 at the beginning.
+        src.offset.setValueAtTime(1, 0);
+
+        // Test automations have this event time.
+        let eventTime = eventFrame / context.sampleRate;
+
+        // Sanity check that context is long enough for the test
+        should(
+            eventFrame < context.length,
+            prefix + 'Context length is long enough for the test')
+            .beTrue();
+
+        // Automations to be tested.  The first event should be the actual
+        // output up to the event time.  The last event should be the final
+        // output from the event time and onwards.
+        testCases.forEach(entry => {
+          should(
+              () => {
+                src.offset[entry.event](
+                    entry.value, eventTime, entry.extraArgs);
+              },
+              prefix +
+                  eventToString(
+                      entry.event, entry.value, eventTime, entry.extraArgs))
+              .notThrow();
+        });
+
+        src.start();
+
+        return context.startRendering();
+      }
+
+      // Verify output of test where the final value of the automation is
+      // expected to be constant.
+      function expectConstant(prefix, should, eventFrame, testCases) {
+        return audioBuffer => {
+          let audio = audioBuffer.getChannelData(0);
+
+          let eventTime = eventFrame / sampleRate;
+
+          // Compute the expected value of the first automation one frame before
+          // the event time.  This is a quick check that the correct automation
+          // was done.
+          let expectedValue = methodMap[testCases[0].event](
+              (eventFrame - 1) / sampleRate, 1, 0, testCases[0].value,
+              eventTime);
+          should(
+              audio[eventFrame - 1],
+              prefix +
+                  `At time ${
+                             (eventFrame - 1) / sampleRate
+                           } (frame ${eventFrame - 1}) output`)
+              .beCloseTo(expectedValue, {threshold: testCases[0].relError});
+
+          // The last event scheduled is expected to set the value for all
+          // future times.  Verify that the output has the expected value.
+          should(
+              audio.slice(eventFrame),
+              prefix +
+                  `At time ${eventTime} (frame ${
+                                                 eventFrame
+                                               }) and later, output`)
+              .beConstantValueOf(testCases[testCases.length - 1].value);
+        };
+      }
+
+      // Test output when two events of the same time are scheduled at the same
+      // time.
+      function testMultipleSameEvents(should, options) {
+        let {method, prefix, threshold} = options;
+
+        // Context for testing.
+        let context =
+            new OfflineAudioContext({length: 16384, sampleRate: sampleRate});
+
+        let src = new ConstantSourceNode(context);
+        src.connect(context.destination);
+
+        let initialValue = 1;
+
+        // Informative print
+        should(() => {
+          src.offset.setValueAtTime(initialValue, 0);
+        }, prefix + `setValueAtTime(${initialValue}, 0)`).notThrow();
+
+        let frame = 64;
+        let time = frame / context.sampleRate;
+        let values = [2, 7, 10];
+
+        // Schedule two events of the same type at the same time, but with
+        // different values.
+
+        values.forEach(value => {
+          // Informative prints to show what we're doing in this test.
+          should(
+              () => {
+                src.offset[method](value, time);
+              },
+              prefix +
+                  eventToString(
+                      method,
+                      value,
+                      time,
+                      ))
+              .notThrow();
+        })
+
+        src.start();
+
+        return context.startRendering().then(audioBuffer => {
+          let actual = audioBuffer.getChannelData(0);
+
+          // The output should be a ramp from time 0 to the event time.  But we
+          // only verify the value just before the event time, which should be
+          // fairly close to values[0].  (But compute the actual expected value
+          // to be sure.)
+          let expected = methodMap[method](
+              (frame - 1) / context.sampleRate, initialValue, 0, values[0],
+              time);
+          should(actual[frame - 1], prefix + `Output at frame ${frame - 1}`)
+              .beCloseTo(expected, {threshold: threshold, precision: 3});
+
+          // Any other values shouldn't show up in the output.  Only the value
+          // from last event should appear.  We only check the value at the
+          // event time.
+          should(
+              actual[frame], prefix + `Output at frame ${frame} (${time} sec)`)
+              .beEqualTo(values[values.length - 1]);
+        });
+      }
+
+      // Convert an automation method to a string for printing.
+      function eventToString(method, value, time, extras) {
+        let string = method + '(';
+        string += (value instanceof Array) ? `[${value}]` : value;
+        string += ', ' + time;
+        if (extras) {
+          string += ', ' + extras;
+        }
+        string += ')';
+        return string;
+      }
+
+      // Map between the automation method name and a function that computes the
+      // output value of the automation method.
+      const methodMap = {
+        linearRampToValueAtTime: audioParamLinearRamp,
+        exponentialRampToValueAtTime: audioParamExponentialRamp,
+        setValueAtTime: (t, v) => v
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This puts the basic parameterization types in place for AudioParam. We don't render any audio yet, but we can at least gain about 40 WPT subtest passes by implementing these APIs.