### PR TITLE
UI/Qt: Present only damaged macOS web content

### DIFF
--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -129,7 +129,11 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     initialize_client((parent_client == nullptr) ? CreateNewClient::Yes : CreateNewClient::No);
 
     on_ready_to_paint = [this]() {
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+        schedule_frame_damage_repaint();
+#else
         schedule_repaint();
+#endif
     };
 
     on_cursor_change = [this](auto cursor) {
@@ -810,7 +814,45 @@ void WebContentView::schedule_repaint()
 #ifdef LADYBIRD_QT_USE_VULKAN_WINDOW
     schedule_vulkan_window_update();
 #else
+#    ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    m_force_full_repaint = true;
+#    endif
     update();
+#endif
+}
+
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+void WebContentView::schedule_frame_damage_repaint()
+{
+    if (m_force_full_repaint) {
+        update();
+        return;
+    }
+
+    if (!m_has_pending_frame_damage || m_pending_frame_damage.is_empty()) {
+        m_has_pending_frame_damage = false;
+        m_pending_frame_damage = {};
+        return;
+    }
+
+    auto logical_left = static_cast<int>(floor(m_pending_frame_damage.x() / m_device_pixel_ratio));
+    auto logical_top = static_cast<int>(floor(m_pending_frame_damage.y() / m_device_pixel_ratio));
+    auto logical_right = static_cast<int>(ceil(m_pending_frame_damage.right() / m_device_pixel_ratio));
+    auto logical_bottom = static_cast<int>(ceil(m_pending_frame_damage.bottom() / m_device_pixel_ratio));
+    update(QRect(logical_left, logical_top, logical_right - logical_left, logical_bottom - logical_top).intersected(rect()));
+}
+#endif
+
+void WebContentView::did_accept_presented_backing_store(i32, Gfx::IntRect damage_rect)
+{
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    if (m_has_pending_frame_damage)
+        m_pending_frame_damage.unite(damage_rect);
+    else
+        m_pending_frame_damage = damage_rect;
+    m_has_pending_frame_damage = true;
+#else
+    (void)damage_rect;
 #endif
 }
 
@@ -883,6 +925,9 @@ Optional<QPixmap> WebContentView::tab_preview_pixmap(QSize const& maximum_size) 
 void WebContentView::resizeEvent(QResizeEvent* event)
 {
     WebContentViewBase::resizeEvent(event);
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    m_force_full_repaint = true;
+#endif
 #ifdef LADYBIRD_QT_USE_VULKAN_WINDOW
     update_vulkan_window_geometry();
 #endif

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -121,6 +121,7 @@ private:
     virtual Web::DevicePixelSize viewport_size() const override;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const override;
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint content_position) const override;
+    virtual void did_accept_presented_backing_store(i32, Gfx::IntRect) override;
 
 #ifdef LADYBIRD_QT_USE_RHI_WIDGET
     // ^QRhiWidget
@@ -140,6 +141,9 @@ private:
     void update_cursor(Gfx::Cursor cursor);
     void apply_web_content_cursor(QCursor const&);
     void schedule_repaint();
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    void schedule_frame_damage_repaint();
+#endif
     void update_compositor_display_metadata();
 
     Web::DevicePixelPoint node_picker_position_for(QSinglePointEvent const&) const;
@@ -179,6 +183,11 @@ private:
     void* m_imported_iosurface_texture { nullptr };
     Gfx::SharedImageBuffer const* m_imported_shared_image_buffer { nullptr };
     unsigned long m_render_target_pixel_format { 0 };
+
+    bool m_force_full_repaint { true };
+    bool m_has_pending_frame_damage { false };
+    bool m_repaint_retry_scheduled { false };
+    Gfx::IntRect m_pending_frame_damage;
 #endif
 
 #ifdef LADYBIRD_QT_USE_VULKAN_WINDOW

--- a/UI/Qt/WebContentViewMac.mm
+++ b/UI/Qt/WebContentViewMac.mm
@@ -6,6 +6,7 @@
 
 #include <AK/Debug.h>
 #include <AK/Math.h>
+#include <AK/ScopeGuard.h>
 #include <LibGfx/SharedImageBuffer.h>
 #include <UI/Qt/WebContentView.h>
 
@@ -195,6 +196,7 @@ bool WebContentView::update_imported_iosurface_texture(Gfx::SharedImageBuffer co
 void WebContentView::initialize(QRhiCommandBuffer*)
 {
     release_metal_resources();
+    m_force_full_repaint = true;
 }
 
 void WebContentView::releaseResources()
@@ -204,9 +206,49 @@ void WebContentView::releaseResources()
 
 void WebContentView::render(QRhiCommandBuffer* command_buffer)
 {
+    auto repaint_entire_target = m_force_full_repaint;
+
+    Optional<Gfx::IntRect> damage_rect;
+    if (repaint_entire_target) {
+        auto target_size = colorTexture()->pixelSize();
+        damage_rect = Gfx::IntRect { 0, 0, target_size.width(), target_size.height() };
+    } else if (m_has_pending_frame_damage) {
+        damage_rect = m_pending_frame_damage;
+    } else {
+        return;
+    }
+
+    ArmedScopeGuard schedule_repaint_retry = [this] {
+        if (!m_repaint_retry_scheduled) {
+            m_repaint_retry_scheduled = true;
+            update();
+        }
+    };
+    auto consume_repaint_state = [&] {
+        schedule_repaint_retry.disarm();
+        m_force_full_repaint = false;
+        m_has_pending_frame_damage = false;
+        m_repaint_retry_scheduled = false;
+        m_pending_frame_damage = {};
+    };
+
+    auto render_target_size = colorTexture()->pixelSize();
+    damage_rect->intersect(Gfx::IntRect { 0, 0, render_target_size.width(), render_target_size.height() });
+    if (damage_rect->is_empty()) {
+        consume_repaint_state();
+        return;
+    }
+
     auto background_color = page_background_color();
     auto clear_color = QColor(background_color.red(), background_color.green(), background_color.blue());
 
+    auto* texture_render_target = static_cast<QRhiTextureRenderTarget*>(renderTarget());
+    auto render_target_flags = repaint_entire_target ? QRhiTextureRenderTarget::Flags {} : QRhiTextureRenderTarget::Flags { QRhiTextureRenderTarget::PreserveColorContents };
+    if (texture_render_target->flags() != render_target_flags) {
+        texture_render_target->setFlags(render_target_flags);
+        if (!texture_render_target->create())
+            return;
+    }
     command_buffer->beginPass(renderTarget(), clear_color, { 1.0f, 0 }, nullptr, QRhiCommandBuffer::ExternalContent);
 
     auto paintable = current_paintable();
@@ -244,17 +286,31 @@ void WebContentView::render(QRhiCommandBuffer* command_buffer)
     // directly into Qt's command buffer.
     command_buffer->beginExternal();
     auto const* command_buffer_native_handles = static_cast<QRhiMetalCommandBufferNativeHandles const*>(command_buffer->nativeHandles());
-    if (command_buffer_native_handles && command_buffer_native_handles->encoder) {
-        auto* encoder = command_buffer_native_handles->encoder;
-        [encoder setRenderPipelineState:(id<MTLRenderPipelineState>)m_metal_pipeline_state];
-        [encoder setVertexBytes:&uniforms length:sizeof(uniforms) atIndex:0];
-        [encoder setFragmentTexture:(id<MTLTexture>)m_imported_iosurface_texture atIndex:0];
-        [encoder setFragmentSamplerState:(id<MTLSamplerState>)m_metal_sampler_state atIndex:0];
-        [encoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount:4];
+    if (!command_buffer_native_handles || !command_buffer_native_handles->encoder) {
+        command_buffer->endExternal();
+        command_buffer->endPass();
+        return;
     }
+
+    auto* encoder = command_buffer_native_handles->encoder;
+    if (!repaint_entire_target) {
+        MTLScissorRect scissor_rect {
+            static_cast<NSUInteger>(damage_rect->x()),
+            static_cast<NSUInteger>(damage_rect->y()),
+            static_cast<NSUInteger>(damage_rect->width()),
+            static_cast<NSUInteger>(damage_rect->height()),
+        };
+        [encoder setScissorRect:scissor_rect];
+    }
+    [encoder setRenderPipelineState:(id<MTLRenderPipelineState>)m_metal_pipeline_state];
+    [encoder setVertexBytes:&uniforms length:sizeof(uniforms) atIndex:0];
+    [encoder setFragmentTexture:(id<MTLTexture>)m_imported_iosurface_texture atIndex:0];
+    [encoder setFragmentSamplerState:(id<MTLSamplerState>)m_metal_sampler_state atIndex:0];
+    [encoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount:4];
     command_buffer->endExternal();
 
     command_buffer->endPass();
+    consume_repaint_state();
 }
 
 }


### PR DESCRIPTION
Carry compositor damage into the `QRhiWidget` and coalesce it until Qt renders. Skip empty updates, limit `QWidget` invalidation and Metal rasterization to the damaged region, and preserve prior color contents for partial updates.

Keep clear semantics for initialization, resizing, and UI-driven repaints. Recreate the `QRhi` texture render target whenever its flags change because QRhi bakes attachment load behavior into native state.

In an eight-second synthetic animation invalidating a 33-by-33 logical pixel region, this lowers median fragment time for the widget presentation pass from 130 us to 15 us and reduces its accumulated fragment time by 72% relative to full-widget damage. This does not include Qt's subsequent full-window composition pass.