### PR TITLE
Store paint command caches as ranges into the last display list

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -202,6 +202,7 @@
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/StackingContext.h>
@@ -8790,10 +8791,14 @@ void Document::set_needs_to_record_display_list()
         navigable->set_needs_to_record_display_list();
 }
 
-RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig config, Painting::DisplayListResourceStorage& resource_storage)
+RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig config, Painting::DisplayListResourceStorage& resource_storage, Painting::PaintCommandCacheMode cache_mode)
 {
     update_paint_and_hit_testing_properties_if_needed();
     VERIFY(paintable());
+
+    bool const line_box_border_overlays_replace_cacheable_content = config.should_show_line_box_borders;
+    if (line_box_border_overlays_replace_cacheable_content)
+        cache_mode = Painting::PaintCommandCacheMode::ReadOnly;
 
     // Drop the inspector-overlay context nodes appended by the previous recording; this appends its own. Safe because
     // the pruned tree only reaches the compositor together with (or after) the display list recorded against it here.
@@ -8843,6 +8848,9 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     context.set_should_paint_overlay(config.paint_overlay);
 
     auto& viewport_paintable = *paintable();
+    context.set_paint_command_cache_mode(cache_mode);
+    if (!line_box_border_overlays_replace_cacheable_content)
+        context.set_paint_command_cache_source_display_list(viewport_paintable.display_list_used_as_paint_command_cache_source());
     viewport_paintable.refresh_scroll_state();
     viewport_paintable.initialize_async_scrolling_metadata_recording(context);
 
@@ -8885,6 +8893,12 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
         display_list_recorder.draw_line({ caret_x - 4, caret_bottom }, { caret_x + 4, caret_bottom }, marker_color, 2);
     }
 
+    if (cache_mode == Painting::PaintCommandCacheMode::ReadWrite) {
+        // Rotation can drop the last reference to the list the context's raw pointer still targets.
+        context.set_paint_command_cache_source_display_list(nullptr);
+        viewport_paintable.set_display_list_used_as_paint_command_cache_source(display_list, resource_storage.collect_referenced_resources(*display_list));
+    }
+
     m_hit_test_display_list = move(hit_test_display_list);
     return display_list;
 }
@@ -8913,11 +8927,11 @@ Painting::HitTestDisplayList const* Document::ensure_hit_test_display_list()
         if (auto navigable = this->navigable()) {
             if (navigable->record_display_list_and_scroll_state(paint_config))
                 return;
-            (void)record_display_list(paint_config, navigable->display_list_resource_storage());
+            (void)record_display_list(paint_config, navigable->display_list_resource_storage(), Painting::PaintCommandCacheMode::ReadWrite);
             return;
         }
-        Painting::DisplayListResourceStorage resource_storage;
-        (void)record_display_list(paint_config, resource_storage);
+        Painting::DisplayListResourceStorage throwaway_resource_storage_for_hit_test_only_recording;
+        (void)record_display_list(paint_config, throwaway_resource_storage_for_hit_test_only_recording, Painting::PaintCommandCacheMode::ReadOnly);
     };
 
     if (!m_hit_test_display_list || m_hit_test_display_list->visual_context_tree_version() != viewport_paintable->visual_context_tree().version())
@@ -9367,7 +9381,7 @@ Utf16String Document::dump_display_list()
         return "No paintable"_utf16;
 
     auto& resource_storage = navigable()->display_list_resource_storage();
-    auto display_list = record_display_list(HTML::PaintConfig {}, resource_storage);
+    auto display_list = record_display_list(HTML::PaintConfig {}, resource_storage, Painting::PaintCommandCacheMode::ReadOnly);
     if (!display_list)
         return "No display list"_utf16;
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1140,7 +1140,7 @@ public:
         set_needs_repaint(should_invalidate_display_list);
     }
 
-    RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig, Painting::DisplayListResourceStorage&);
+    RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig, Painting::DisplayListResourceStorage&, Painting::PaintCommandCacheMode);
     Painting::HitTestDisplayList const* hit_test_display_list() const { return m_hit_test_display_list.ptr(); }
     Painting::HitTestDisplayList const* ensure_hit_test_display_list();
     Optional<Painting::HitTestResult> hit_test(CSSPixelPoint, Painting::HitTestType);

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -61,6 +61,8 @@ class DisplayList;
 class DisplayListPlayerSkia;
 class DisplayListRecorder;
 class DisplayListResourceStorage;
+struct DisplayListResourceSet;
+enum class PaintCommandCacheMode : u8;
 struct GradientPaintStyle;
 struct PatternPaintStyle;
 class ScrollStateSnapshot;

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -75,6 +75,7 @@
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListDamage.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
@@ -4298,14 +4299,20 @@ bool LocalNavigable::record_display_list_and_scroll_state(PaintConfig paint_conf
     Painting::DisplayListResourceTransaction resource_transaction;
     Optional<Painting::AccumulatedVisualContextTree> visual_context_tree;
     if (should_record_display_list) {
-        display_list = document->record_display_list(paint_config, m_display_list_resource_storage);
+        display_list = document->record_display_list(paint_config, m_display_list_resource_storage, Painting::PaintCommandCacheMode::ReadWrite);
         if (!display_list)
             return false;
         auto recorded_document_paintable = document->paintable();
         VERIFY(recorded_document_paintable);
         visual_context_tree = recorded_document_paintable->visual_context_tree();
-        display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
-        display_list_resources.include(m_display_list_resource_storage.cache_referenced_resources());
+        if (recorded_document_paintable->display_list_used_as_paint_command_cache_source() == display_list.ptr()) {
+            display_list_resources.include(recorded_document_paintable->paint_command_cache_source_referenced_resources());
+        } else {
+            // A recording downgraded to cache-read-only leaves the retained source and the cached ranges
+            // into it live, so the resources they reference must survive the pruning below.
+            display_list_resources = m_display_list_resource_storage.collect_referenced_resources(*display_list);
+            recorded_document_paintable->append_paint_command_cache_source_resources(display_list_resources);
+        }
         resource_transaction = m_display_list_resource_storage.create_transaction(
             m_compositor_display_list_resources,
             display_list_resources);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -59,6 +59,7 @@
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
@@ -1058,7 +1059,7 @@ static Optional<AsyncScrollingStateSnapshot> capture_async_scrolling_state(DOM::
     auto document_paintable = document.paintable();
     if (!navigable || !document_paintable)
         return {};
-    auto display_list = document.record_display_list(HTML::PaintConfig {}, navigable->display_list_resource_storage());
+    auto display_list = document.record_display_list(HTML::PaintConfig {}, navigable->display_list_resource_storage(), Painting::PaintCommandCacheMode::ReadWrite);
     if (!display_list)
         return {};
     return AsyncScrollingStateSnapshot {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -615,19 +615,6 @@ void NodeWithStyle::ImageObserver::image_style_value_did_update(CSS::ImageStyleV
 
     if (auto paintable = m_owner->paintable())
         paintable->set_needs_repaint();
-
-    // The body's background propagates to the root element's paintable, which holds the cached draw commands.
-    if (m_owner->is_body()) {
-        auto* html_element = m_owner->document().html_element();
-        if (html_element) {
-            if (auto html_layout_node = html_element->unsafe_layout_node()) {
-                if (html_element->should_use_body_background_properties()) {
-                    if (auto paintable = html_layout_node->paintable())
-                        paintable->set_needs_repaint();
-                }
-            }
-        }
-    }
 }
 
 NodeWithStyle::~NodeWithStyle()

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -80,29 +80,26 @@ bool DisplayList::append_bytes(
     return true;
 }
 
-void DisplayList::append_command_sequence(
-    ReadonlyBytes command_sequence,
+u32 DisplayList::append_command_range_from(
+    DisplayList const& source_display_list,
+    DisplayListCommandRange source_range,
     AccumulatedVisualContextTree const& visual_context_tree,
     VisualContextIndex context_index)
 {
+    VERIFY(&source_display_list != this);
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
-
-    auto command_bytes = MUST(ByteBuffer::copy(command_sequence));
-
-    set_command_sequence_visual_context(command_bytes.span(), context_index);
     VERIFY(m_command_bytes.size() % DisplayList::command_alignment == 0);
-    VERIFY(command_bytes.size() % DisplayList::command_alignment == 0);
+    VERIFY(source_range.size % DisplayList::command_alignment == 0);
+    VERIFY(static_cast<size_t>(source_range.offset) + source_range.size <= source_display_list.m_command_bytes.size());
 
-    if (!command_bytes.is_empty())
-        m_command_bytes.append(command_bytes.data(), command_bytes.size());
-}
+    auto destination_offset = m_command_bytes.size();
+    VERIFY(destination_offset + source_range.size <= NumericLimits<u32>::max());
+    if (source_range.is_empty())
+        return static_cast<u32>(destination_offset);
 
-ByteBuffer DisplayList::copy_command_bytes_from(size_t command_start_offset) const
-{
-    VERIFY(command_start_offset <= m_command_bytes.size());
-    return MUST(m_command_bytes.slice(
-        command_start_offset,
-        m_command_bytes.size() - command_start_offset));
+    m_command_bytes.append(source_display_list.m_command_bytes.data() + source_range.offset, source_range.size);
+    set_command_sequence_visual_context(m_command_bytes.span().slice(destination_offset, source_range.size), context_index);
+    return static_cast<u32>(destination_offset);
 }
 
 void DisplayListPlayer::execute(

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -84,7 +84,8 @@ u32 DisplayList::append_command_range_from(
     DisplayList const& source_display_list,
     DisplayListCommandRange source_range,
     AccumulatedVisualContextTree const& visual_context_tree,
-    VisualContextIndex context_index)
+    VisualContextIndex recorded_context_index,
+    VisualContextIndex current_context_index)
 {
     VERIFY(&source_display_list != this);
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
@@ -98,7 +99,10 @@ u32 DisplayList::append_command_range_from(
         return static_cast<u32>(destination_offset);
 
     m_command_bytes.append(source_display_list.m_command_bytes.data() + source_range.offset, source_range.size);
-    set_command_sequence_visual_context(m_command_bytes.span().slice(destination_offset, source_range.size), context_index);
+    // The copied headers already carry the index the range was recorded under, so they only need rewriting
+    // when the paintable's context was assigned a different index since then.
+    if (recorded_context_index != current_context_index)
+        set_command_sequence_visual_context(m_command_bytes.span().slice(destination_offset, source_range.size), current_context_index);
     return static_cast<u32>(destination_offset);
 }
 

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -24,6 +24,7 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
 #include <LibWeb/Painting/DisplayListCommand.h>
+#include <LibWeb/Painting/DisplayListCommandRange.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/ScrollState.h>
 
@@ -136,8 +137,7 @@ public:
         for_each_command_header(command_bytes(), move(callback));
     }
 
-    void append_command_sequence(ReadonlyBytes, AccumulatedVisualContextTree const&, VisualContextIndex);
-    ByteBuffer copy_command_bytes_from(size_t command_start_offset) const;
+    u32 append_command_range_from(DisplayList const& source_display_list, DisplayListCommandRange, AccumulatedVisualContextTree const&, VisualContextIndex);
     size_t command_byte_size() const { return m_command_bytes.size(); }
 
 private:

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -137,7 +137,7 @@ public:
         for_each_command_header(command_bytes(), move(callback));
     }
 
-    u32 append_command_range_from(DisplayList const& source_display_list, DisplayListCommandRange, AccumulatedVisualContextTree const&, VisualContextIndex);
+    u32 append_command_range_from(DisplayList const& source_display_list, DisplayListCommandRange, AccumulatedVisualContextTree const&, VisualContextIndex recorded_context_index, VisualContextIndex current_context_index);
     size_t command_byte_size() const { return m_command_bytes.size(); }
 
 private:

--- a/Libraries/LibWeb/Painting/DisplayListCommandRange.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommandRange.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Web::Painting {
+
+struct DisplayListCommandRange {
+    u32 offset { 0 };
+    u32 size { 0 };
+
+    [[nodiscard]] bool is_empty() const { return size == 0; }
+};
+
+}

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -298,12 +298,13 @@ static DisplayListDataSpan append_filter_data(
 }
 
 // Captures are save/restore balanced (verified at capture end), so splicing never shifts the save nesting level.
-DisplayListCommandRange DisplayListRecorder::append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange source_range)
+DisplayListCommandRange DisplayListRecorder::append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange source_range, VisualContextIndex recorded_context_index)
 {
     auto destination_offset = m_display_list.append_command_range_from(
         source_display_list,
         source_range,
         m_visual_context_tree,
+        recorded_context_index,
         m_accumulated_visual_context_index);
     return { destination_offset, source_range.size };
 }

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -32,14 +32,19 @@ DisplayListRecorder::CommandCapture::~CommandCapture()
         m_recorder->end_capture();
 }
 
-ByteBuffer DisplayListRecorder::CommandCapture::take()
+DisplayListCommandRange DisplayListRecorder::CommandCapture::take()
 {
     VERIFY(m_recorder);
-    auto commands = m_recorder->m_display_list.copy_command_bytes_from(
-        m_recorder->m_capture_start_command_offset);
+    auto capture_start_offset = m_recorder->m_capture_start_command_offset;
+    auto capture_end_offset = m_recorder->m_display_list.command_byte_size();
     m_recorder->m_is_capturing = false;
     m_recorder = nullptr;
-    return commands;
+    VERIFY(capture_end_offset >= capture_start_offset);
+    VERIFY(capture_end_offset <= NumericLimits<u32>::max());
+    return {
+        static_cast<u32>(capture_start_offset),
+        static_cast<u32>(capture_end_offset - capture_start_offset),
+    };
 }
 
 DisplayListRecorder::CommandCapture DisplayListRecorder::begin_command_capture()
@@ -47,6 +52,7 @@ DisplayListRecorder::CommandCapture DisplayListRecorder::begin_command_capture()
     VERIFY(!m_is_capturing);
     m_is_capturing = true;
     m_capture_start_command_offset = m_display_list.command_byte_size();
+    m_capture_accumulated_visual_context_index = m_accumulated_visual_context_index;
     return CommandCapture(*this);
 }
 
@@ -291,15 +297,15 @@ static DisplayListDataSpan append_filter_data(
     return payload_builder.append_data(filter_data, alignof(u32));
 }
 
-void DisplayListRecorder::replay_cached_commands(ReadonlyBytes command_bytes)
+// Captures are save/restore balanced (verified at capture end), so splicing never shifts the save nesting level.
+DisplayListCommandRange DisplayListRecorder::append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange source_range)
 {
-    if (command_bytes.is_empty())
-        return;
-
-    DisplayList::for_each_command_header(command_bytes, [&](DisplayListCommandHeader const& header, ReadonlyBytes) {
-        m_save_nesting_level += display_list_command_nesting_level_change(header.type);
-    });
-    m_display_list.append_command_sequence(command_bytes, m_visual_context_tree, m_accumulated_visual_context_index);
+    auto destination_offset = m_display_list.append_command_range_from(
+        source_display_list,
+        source_range,
+        m_visual_context_tree,
+        m_accumulated_visual_context_index);
+    return { destination_offset, source_range.size };
 }
 
 void DisplayListRecorder::paint_nested_display_list(DisplayListResource const& display_list, Gfx::IntRect rect)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -103,10 +103,18 @@ public:
 
     void translate(Gfx::IntPoint delta);
 
-    void set_accumulated_visual_context(VisualContextIndex index) { m_accumulated_visual_context_index = index; }
+    void set_accumulated_visual_context(VisualContextIndex index)
+    {
+        // A cached range stores a single recorded context index, so a capture must not span a context switch.
+        VERIFY(!m_is_capturing || index == m_capture_accumulated_visual_context_index);
+        m_accumulated_visual_context_index = index;
+    }
     VisualContextIndex accumulated_visual_context() const { return m_accumulated_visual_context_index; }
 
-    void replay_cached_commands(ReadonlyBytes commands);
+    DisplayList const& display_list() const { return m_display_list; }
+    AccumulatedVisualContextTree const& visual_context_tree() const { return m_visual_context_tree; }
+
+    DisplayListCommandRange append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange);
 
     class CommandCapture {
         AK_MAKE_NONCOPYABLE(CommandCapture);
@@ -117,7 +125,7 @@ public:
         {
         }
         ~CommandCapture();
-        ByteBuffer take();
+        DisplayListCommandRange take();
 
     private:
         friend class DisplayListRecorder;
@@ -189,6 +197,7 @@ private:
     DisplayListResourceStorage& m_resource_storage;
     bool m_is_capturing { false };
     size_t m_capture_start_command_offset { 0 };
+    VisualContextIndex m_capture_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
 };
 
 class DisplayListRecorderStateSaver {

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -114,7 +114,7 @@ public:
     DisplayList const& display_list() const { return m_display_list; }
     AccumulatedVisualContextTree const& visual_context_tree() const { return m_visual_context_tree; }
 
-    DisplayListCommandRange append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange);
+    DisplayListCommandRange append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange, VisualContextIndex recorded_context_index);
 
     class CommandCapture {
         AK_MAKE_NONCOPYABLE(CommandCapture);

--- a/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
@@ -20,8 +20,14 @@
 namespace Web::Painting {
 
 class AccumulatedVisualContextTree;
+class DisplayList;
 class HitTestDisplayList;
 class ScrollState;
+
+enum class PaintCommandCacheMode : u8 {
+    ReadOnly,
+    ReadWrite,
+};
 
 }
 
@@ -40,6 +46,12 @@ public:
 
     bool should_paint_overlay() const { return m_should_paint_overlay; }
     void set_should_paint_overlay(bool should_paint_overlay) { m_should_paint_overlay = should_paint_overlay; }
+
+    Painting::PaintCommandCacheMode paint_command_cache_mode() const { return m_paint_command_cache_mode; }
+    void set_paint_command_cache_mode(Painting::PaintCommandCacheMode mode) { m_paint_command_cache_mode = mode; }
+
+    Painting::DisplayList const* paint_command_cache_source_display_list() const { return m_paint_command_cache_source_display_list; }
+    void set_paint_command_cache_source_display_list(Painting::DisplayList const* display_list) { m_paint_command_cache_source_display_list = display_list; }
 
     DevicePixelRect device_viewport_rect() const { return m_device_viewport_rect; }
     void set_device_viewport_rect(DevicePixelRect const& rect) { m_device_viewport_rect = rect; }
@@ -117,6 +129,8 @@ private:
     Painting::DevicePixelConverter m_device_pixel_converter;
     ChromeMetrics m_chrome_metrics;
     DevicePixelRect m_device_viewport_rect;
+    Painting::PaintCommandCacheMode m_paint_command_cache_mode { Painting::PaintCommandCacheMode::ReadOnly };
+    Painting::DisplayList const* m_paint_command_cache_source_display_list { nullptr };
     bool m_should_show_line_box_borders { false };
     bool m_should_paint_overlay { true };
     bool m_draw_svg_geometry_for_clip_path { false };

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.cpp
@@ -427,58 +427,6 @@ DisplayListResourceSet DisplayListResourceStorage::collect_referenced_resources(
     return collect_referenced_resources(display_list.command_bytes());
 }
 
-template<typename ResourceId>
-static void increment_cache_reference_counts(HashMap<u64, size_t>& counts, HashTable<ResourceId> const& ids)
-{
-    for (auto id : ids) {
-        auto& count = counts.ensure(id.value(), [] { return 0; });
-        ++count;
-    }
-}
-
-template<typename ResourceId>
-static void decrement_cache_reference_counts(HashMap<u64, size_t>& counts, HashTable<ResourceId> const& ids)
-{
-    for (auto id : ids) {
-        auto it = counts.find(id.value());
-        VERIFY(it != counts.end());
-        VERIFY(it->value > 0);
-        --it->value;
-        if (it->value == 0)
-            counts.remove(it);
-    }
-}
-
-void DisplayListResourceStorage::acquire_cache_references(DisplayListResourceSet const& resource_set)
-{
-    increment_cache_reference_counts(m_font_cache_reference_counts, resource_set.fonts);
-    increment_cache_reference_counts(m_image_frame_cache_reference_counts, resource_set.image_frames);
-    increment_cache_reference_counts(m_video_frame_cache_reference_counts, resource_set.video_frames);
-    increment_cache_reference_counts(m_display_list_cache_reference_counts, resource_set.display_lists);
-}
-
-void DisplayListResourceStorage::release_cache_references(DisplayListResourceSet const& resource_set)
-{
-    decrement_cache_reference_counts(m_font_cache_reference_counts, resource_set.fonts);
-    decrement_cache_reference_counts(m_image_frame_cache_reference_counts, resource_set.image_frames);
-    decrement_cache_reference_counts(m_video_frame_cache_reference_counts, resource_set.video_frames);
-    decrement_cache_reference_counts(m_display_list_cache_reference_counts, resource_set.display_lists);
-}
-
-DisplayListResourceSet DisplayListResourceStorage::cache_referenced_resources() const
-{
-    DisplayListResourceSet resource_set;
-    for (auto id : m_font_cache_reference_counts.keys())
-        resource_set.fonts.set(FontResourceId { id });
-    for (auto id : m_image_frame_cache_reference_counts.keys())
-        resource_set.image_frames.set(ImageFrameResourceId { id });
-    for (auto id : m_video_frame_cache_reference_counts.keys())
-        resource_set.video_frames.set(VideoFrameResourceId { id });
-    for (auto id : m_display_list_cache_reference_counts.keys())
-        resource_set.display_lists.set(DisplayListResourceId { id });
-    return resource_set;
-}
-
 DisplayListResourceTransaction DisplayListResourceStorage::create_transaction(
     DisplayListResourceSet const& previous,
     DisplayListResourceSet const& current) const
@@ -549,29 +497,22 @@ void DisplayListResourceStorage::apply_transaction(DisplayListResourceTransactio
 void DisplayListResourceStorage::retain_only(DisplayListResourceSet const& resource_set)
 {
     m_fonts.remove_all_matching([&](auto id, auto const&) {
-        return !resource_set.fonts.contains(FontResourceId { id })
-            && !m_font_cache_reference_counts.contains(id);
+        return !resource_set.fonts.contains(FontResourceId { id });
     });
     m_image_frames.remove_all_matching([&](auto id, auto const&) {
-        auto image_frame_id = ImageFrameResourceId { id };
-        return !resource_set.image_frames.contains(image_frame_id)
-            && !m_image_frame_cache_reference_counts.contains(id);
+        return !resource_set.image_frames.contains(ImageFrameResourceId { id });
     });
     m_video_frames.remove_all_matching([&](auto id, auto const&) {
-        return !resource_set.video_frames.contains(VideoFrameResourceId { id })
-            && !m_video_frame_cache_reference_counts.contains(id);
+        return !resource_set.video_frames.contains(VideoFrameResourceId { id });
     });
     m_display_lists.remove_all_matching([&](auto id, auto const&) {
-        return !resource_set.display_lists.contains(DisplayListResourceId { id })
-            && !m_display_list_cache_reference_counts.contains(id);
+        return !resource_set.display_lists.contains(DisplayListResourceId { id });
     });
     m_display_list_cached_skia_images.remove_all_matching([&](auto id, auto const&) {
-        return !resource_set.display_lists.contains(DisplayListResourceId { id })
-            && !m_display_list_cache_reference_counts.contains(id);
+        return !resource_set.display_lists.contains(DisplayListResourceId { id });
     });
     m_display_list_cached_nested_rasters.remove_all_matching([&](auto id, auto const&) {
-        return !resource_set.display_lists.contains(DisplayListResourceId { id })
-            && !m_display_list_cache_reference_counts.contains(id);
+        return !resource_set.display_lists.contains(DisplayListResourceId { id });
     });
 }
 

--- a/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
+++ b/Libraries/LibWeb/Painting/DisplayListResourceStorage.h
@@ -101,9 +101,6 @@ public:
     DisplayListResourceTransaction create_transaction(DisplayListResourceSet const& previous, DisplayListResourceSet const& current) const;
     DisplayListResourceSet collect_referenced_resources(DisplayList const&) const;
     DisplayListResourceSet collect_referenced_resources(ReadonlyBytes command_bytes) const;
-    void acquire_cache_references(DisplayListResourceSet const&);
-    void release_cache_references(DisplayListResourceSet const&);
-    DisplayListResourceSet cache_referenced_resources() const;
     void retain_only(DisplayListResourceSet const&);
     void update_video_frame(VideoFrameResourceId, NonnullRefPtr<Media::VideoFrame const>);
     void clear_video_frame(VideoFrameResourceId);
@@ -131,11 +128,6 @@ private:
     HashMap<u64, DisplayListResource> m_display_lists;
     mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedSkiaImageResource>> m_display_list_cached_skia_images;
     mutable HashMap<u64, NonnullOwnPtr<DisplayListCachedNestedRasterResource>> m_display_list_cached_nested_rasters;
-
-    HashMap<u64, size_t> m_font_cache_reference_counts;
-    HashMap<u64, size_t> m_image_frame_cache_reference_counts;
-    HashMap<u64, size_t> m_video_frame_cache_reference_counts;
-    HashMap<u64, size_t> m_display_list_cache_reference_counts;
 };
 
 }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -679,8 +679,11 @@ static void record_wheel_hit_test_target(Paintable const& paintable_box, Display
 
 bool body_background_is_propagated_to_root(Layout::NodeWithStyle const& layout_node)
 {
+    if (!layout_node.is_body())
+        return false;
+    // Reachable at invalidation time, when the root element's layout node may already be detached.
     auto const* html_element = layout_node.document().html_element();
-    return layout_node.is_body() && html_element && html_element->should_use_body_background_properties();
+    return html_element && html_element->unsafe_layout_node() && html_element->should_use_body_background_properties();
 }
 
 static bool is_canvas_background_source(Layout::NodeWithStyle const& layout_node)
@@ -2633,6 +2636,21 @@ void Paintable::set_needs_repaint(InvalidateDisplayList should_invalidate_displa
                 child.set_needs_repaint(should_invalidate_display_list);
             return IterationDecision::Continue;
         });
+
+        // The root element paints the body's propagated background, so a body repaint must also refresh the
+        // root's cached background. A root repaint can conversely flip whether propagation applies, changing
+        // what the body itself paints.
+        if (body_background_is_propagated_to_root(layout_node())) {
+            if (auto const* document_element = document().document_element()) {
+                if (auto document_element_paintable = document_element->unsafe_paintable())
+                    document_element_paintable->invalidate_paint_cache();
+            }
+        } else if (layout_node().is_root_element()) {
+            if (auto const* body = document().body()) {
+                if (auto body_paintable = body->unsafe_paintable())
+                    body_paintable->invalidate_paint_cache();
+            }
+        }
     }
     document().set_needs_repaint(Badge<Painting::Paintable> {}, should_invalidate_display_list);
 }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -475,73 +475,15 @@ void Paintable::scroll_ancestor_to_offset_into_view(size_t offset)
 static bool g_paint_viewport_scrollbars = true;
 
 struct Paintable::CachedPaintData {
-    bool has(PaintPhase phase) const
-    {
-        return m_present_phases[to_underlying(phase)];
-    }
-
-    ReadonlyBytes bytes_for(PaintPhase phase) const
-    {
-        auto const& span = m_phase_spans[to_underlying(phase)];
-        return m_command_bytes.span().slice(span.offset, span.size);
-    }
-
-    void set(PaintPhase phase, ReadonlyBytes command_bytes)
-    {
-        auto const phase_index = to_underlying(phase);
-        if (m_present_phases[phase_index]) {
-            replace(phase, command_bytes);
-            return;
-        }
-
-        m_phase_spans[phase_index] = append_to(m_command_bytes, command_bytes);
-        m_present_phases[phase_index] = true;
-    }
-
-    template<typename Callback>
-    void for_each_present_phase(Callback callback) const
-    {
-        for (size_t phase_index = 0; phase_index < paint_phase_count; ++phase_index) {
-            if (!m_present_phases[phase_index])
-                continue;
-            auto phase = static_cast<PaintPhase>(phase_index);
-            callback(phase, bytes_for(phase));
-        }
-    }
-
-private:
-    struct Span {
-        u32 offset { 0 };
-        u32 size { 0 };
+    struct PhaseEntry {
+        // Display list ids start at 1, so a default-constructed entry never matches a real source list.
+        u64 source_display_list_id { 0 };
+        DisplayListCommandRange range;
+        VisualContextIndex recorded_context_index {};
+        bool captured_under_empty_effective_clip { false };
     };
 
-    static Span append_to(ByteBuffer& command_buffer, ReadonlyBytes command_bytes)
-    {
-        auto const offset = command_buffer.size();
-        command_buffer.append(command_bytes);
-        return { static_cast<u32>(offset), static_cast<u32>(command_bytes.size()) };
-    }
-
-    void replace(PaintPhase phase, ReadonlyBytes replacement_bytes)
-    {
-        ByteBuffer command_buffer;
-        Array<Span, paint_phase_count> phase_spans {};
-
-        for (size_t phase_index = 0; phase_index < paint_phase_count; ++phase_index) {
-            if (!m_present_phases[phase_index])
-                continue;
-            auto present_phase = static_cast<PaintPhase>(phase_index);
-            auto command_bytes = present_phase == phase ? replacement_bytes : bytes_for(present_phase);
-            phase_spans[phase_index] = append_to(command_buffer, command_bytes);
-        }
-
-        m_command_bytes = move(command_buffer);
-        m_phase_spans = phase_spans;
-    }
-
-    ByteBuffer m_command_bytes;
-    Array<bool, paint_phase_count> m_present_phases {};
-    Array<Span, paint_phase_count> m_phase_spans {};
+    Array<PhaseEntry, paint_phase_count> phase_entries {};
 };
 
 static bool content_size_change_affects_container_queries(Paintable const& paintable_box, CSSPixelSize old_size, CSSPixelSize new_size)
@@ -976,11 +918,7 @@ Paintable::Paintable(Layout::Box const& layout_box)
 {
 }
 
-Paintable::~Paintable()
-{
-    if (has_layout_node())
-        invalidate_paint_cache();
-}
+Paintable::~Paintable() = default;
 
 void Paintable::detach_from_layout_node(Badge<Layout::Node>)
 {
@@ -1010,56 +948,33 @@ bool Paintable::has_css_transform() const
     return layout_node().has_css_transform();
 }
 
-void Paintable::acquire_cache_references_for_cached_commands(ReadonlyBytes command_bytes) const
+Optional<Paintable::CachedCommandRange> Paintable::valid_cached_commands(PaintPhase phase, u64 source_display_list_id, bool phase_has_empty_effective_clip) const
 {
-    auto& resource_storage = navigable()->display_list_resource_storage();
-    auto referenced_resources = resource_storage.collect_referenced_resources(command_bytes);
-    if (referenced_resources.is_empty())
-        return;
-    resource_storage.acquire_cache_references(referenced_resources);
-}
-
-void Paintable::release_cache_references_for_cached_commands(ReadonlyBytes command_bytes) const
-{
-    auto& resource_storage = navigable()->display_list_resource_storage();
-    auto referenced_resources = resource_storage.collect_referenced_resources(command_bytes);
-    if (referenced_resources.is_empty())
-        return;
-    resource_storage.release_cache_references(referenced_resources);
-}
-
-bool Paintable::has_cached_commands(PaintPhase phase) const
-{
-    return m_cached_paint_data && m_cached_paint_data->has(phase);
-}
-
-ReadonlyBytes Paintable::cached_commands(PaintPhase phase) const
-{
-    return m_cached_paint_data->bytes_for(phase);
+    if (!m_cached_paint_data)
+        return {};
+    auto const& entry = m_cached_paint_data->phase_entries[to_underlying(phase)];
+    if (entry.source_display_list_id != source_display_list_id
+        || entry.captured_under_empty_effective_clip != phase_has_empty_effective_clip)
+        return {};
+    return CachedCommandRange { entry.range, entry.recorded_context_index };
 }
 
 void Paintable::invalidate_paint_cache() const
 {
-    if (!m_cached_paint_data)
-        return;
-
-    m_cached_paint_data->for_each_present_phase([&](PaintPhase, ReadonlyBytes command_bytes) {
-        release_cache_references_for_cached_commands(command_bytes);
-    });
     m_cached_paint_data = nullptr;
 }
 
-void Paintable::set_cached_commands(PaintPhase phase, ByteBuffer const& commands) const
+void Paintable::set_cached_commands(PaintPhase phase, u64 display_list_id, DisplayListCommandRange range, VisualContextIndex recorded_context_index, bool captured_under_empty_effective_clip) const
 {
     if (!m_cached_paint_data)
         m_cached_paint_data = make<CachedPaintData>();
 
-    if (m_cached_paint_data->has(phase))
-        release_cache_references_for_cached_commands(m_cached_paint_data->bytes_for(phase));
-
-    auto command_bytes = commands.span();
-    acquire_cache_references_for_cached_commands(command_bytes);
-    m_cached_paint_data->set(phase, command_bytes);
+    m_cached_paint_data->phase_entries[to_underlying(phase)] = {
+        .source_display_list_id = display_list_id,
+        .range = range,
+        .recorded_context_index = recorded_context_index,
+        .captured_under_empty_effective_clip = captured_under_empty_effective_clip,
+    };
 }
 
 void Paintable::reset_for_relayout()

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -410,9 +410,14 @@ public:
 
     void invalidate_paint_cache() const;
 
-    bool has_cached_commands(PaintPhase) const;
-    ReadonlyBytes cached_commands(PaintPhase) const;
-    void set_cached_commands(PaintPhase phase, ByteBuffer const& commands) const;
+    // Commands recorded under an empty effective clip are dropped at append time, so a cached range is
+    // usable only while the emptiness of the phase's effective clip matches what it was at capture time.
+    struct CachedCommandRange {
+        DisplayListCommandRange range;
+        VisualContextIndex recorded_context_index {};
+    };
+    Optional<CachedCommandRange> valid_cached_commands(PaintPhase, u64 source_display_list_id, bool phase_has_empty_effective_clip) const;
+    void set_cached_commands(PaintPhase, u64 display_list_id, DisplayListCommandRange, VisualContextIndex recorded_context_index, bool captured_under_empty_effective_clip) const;
 
     void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
     [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const { return m_fixed_background_visual_context; }
@@ -469,8 +474,6 @@ private:
     void set_containing_block(Paintable* containing_block);
 
     void paint_middle_button_scroll_indicator(DisplayListRecordingContext&) const;
-    void acquire_cache_references_for_cached_commands(ReadonlyBytes) const;
-    void release_cache_references_for_cached_commands(ReadonlyBytes) const;
     void invalidate_absolute_geometry_cache(InvalidateDescendantGeometry);
 
     GC::Weak<DOM::Node> m_dom_node;

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -39,19 +39,30 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
 
     paintable.record_hit_test_items(context, phase);
 
-    bool const skip_cache = context.should_show_line_box_borders() || paintable.fixed_background_visual_context().has_value();
-    if (!skip_cache && paintable.has_cached_commands(phase)) {
-        context.display_list_recorder().replay_cached_commands(paintable.cached_commands(phase));
-    } else if (!skip_cache) {
-        auto capture = context.display_list_recorder().begin_command_capture();
-        if (phase == PaintPhase::Background)
-            paintable.record_async_scrolling_metadata(context);
-        paintable.paint(context, phase);
-        paintable.set_cached_commands(phase, capture.take());
+    auto& recorder = context.display_list_recorder();
+    bool const skip_cache = paintable.fixed_background_visual_context().has_value();
+    bool const cache_writes_enabled = context.paint_command_cache_mode() == PaintCommandCacheMode::ReadWrite;
+    auto const* cache_source_display_list = context.paint_command_cache_source_display_list();
+    auto const phase_context_index = recorder.accumulated_visual_context();
+    bool const phase_has_empty_effective_clip = recorder.visual_context_tree().has_empty_effective_clip(phase_context_index);
+
+    auto cached_commands = !skip_cache && cache_source_display_list
+        ? paintable.valid_cached_commands(phase, cache_source_display_list->id(), phase_has_empty_effective_clip)
+        : Optional<Paintable::CachedCommandRange> {};
+
+    if (cached_commands.has_value()) {
+        auto destination_range = recorder.append_cached_command_range(*cache_source_display_list, cached_commands->range);
+        if (cache_writes_enabled)
+            paintable.set_cached_commands(phase, recorder.display_list().id(), destination_range, phase_context_index, phase_has_empty_effective_clip);
     } else {
+        auto capture = !skip_cache && cache_writes_enabled
+            ? Optional<DisplayListRecorder::CommandCapture>(recorder.begin_command_capture())
+            : Optional<DisplayListRecorder::CommandCapture> {};
         if (phase == PaintPhase::Background)
             paintable.record_async_scrolling_metadata(context);
         paintable.paint(context, phase);
+        if (capture.has_value())
+            paintable.set_cached_commands(phase, recorder.display_list().id(), capture->take(), phase_context_index, phase_has_empty_effective_clip);
     }
 
     context.display_list_recorder().set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/QuickSort.h>
 #include <AK/TemporaryChange.h>
+#include <LibCore/Environment.h>
 #include <LibGfx/Rect.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/ReplacedBox.h>
@@ -25,6 +26,68 @@
 #include <LibWeb/SVG/SVGMaskElement.h>
 
 namespace Web::Painting {
+
+static bool verify_display_list_cache_enabled()
+{
+    static bool enabled = Core::Environment::has("LADYBIRD_VERIFY_DISPLAY_LIST_CACHE"sv);
+    return enabled;
+}
+
+// Commands are compared through their dump() representations — the same canonical form the display list
+// dump tests diff — because raw payload bytes contain uninitialized struct padding. Compositor metadata is
+// dropped because the scratch context used for the fresh side has no async scrolling state, so the fresh
+// recording never emits it. Context indices are not part of the comparison: splice rewrites them.
+static Vector<String> dump_commands_for_cache_verification(ReadonlyBytes command_bytes)
+{
+    Vector<String> dumped_commands;
+    DisplayList::for_each_command_header(command_bytes, [&](DisplayListCommandHeader const& header, ReadonlyBytes payload) {
+        if (display_list_command_is_compositor_metadata(header.type))
+            return;
+        StringBuilder builder;
+        visit_display_list_command(header.type, payload, [&]<typename Command>(Command const& command) {
+            builder.appendff("{} payload_size={}", Command::command_name, header.payload_size);
+            command.dump(builder);
+        });
+        dumped_commands.append(MUST(builder.to_string()));
+    });
+    return dumped_commands;
+}
+
+static void verify_spliced_commands_match_fresh_recording(Paintable const& paintable, DisplayListRecordingContext& context, PaintPhase phase, DisplayListCommandRange spliced_range)
+{
+    auto& recorder = context.display_list_recorder();
+    auto const& visual_context_tree = recorder.visual_context_tree();
+
+    auto scratch_display_list = DisplayList::create(visual_context_tree);
+    DisplayListRecorder scratch_recorder(scratch_display_list, visual_context_tree, recorder.resource_storage());
+    auto scratch_context = context.clone(scratch_recorder);
+    scratch_recorder.set_accumulated_visual_context(recorder.accumulated_visual_context());
+    paintable.paint(scratch_context, phase);
+
+    auto spliced_bytes = recorder.display_list().command_bytes().slice(spliced_range.offset, spliced_range.size);
+    auto fresh_bytes = scratch_display_list->command_bytes();
+
+    // Commands that embed nested display list resources reference lists freshly minted per recording
+    // (e.g. pattern tile backgrounds), so their ids differ from the spliced ones by construction.
+    auto& resource_storage = recorder.resource_storage();
+    if (!resource_storage.collect_referenced_resources(spliced_bytes).display_lists.is_empty()
+        || !resource_storage.collect_referenced_resources(fresh_bytes).display_lists.is_empty())
+        return;
+
+    auto spliced_commands = dump_commands_for_cache_verification(spliced_bytes);
+    auto fresh_commands = dump_commands_for_cache_verification(fresh_bytes);
+
+    if (spliced_commands == fresh_commands)
+        return;
+
+    dbgln("Spliced display list cache mismatch for {} in paint phase {} ({} spliced commands, {} fresh commands)",
+        paintable.layout_node().debug_description(), to_underlying(phase), spliced_commands.size(), fresh_commands.size());
+    for (auto const& command : spliced_commands)
+        dbgln("  spliced: {}", command);
+    for (auto const& command : fresh_commands)
+        dbgln("  fresh:   {}", command);
+    VERIFY_NOT_REACHED();
+}
 
 static void paint_node(Paintable const& paintable, DisplayListRecordingContext& context, PaintPhase phase)
 {
@@ -52,6 +115,8 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
 
     if (cached_commands.has_value()) {
         auto destination_range = recorder.append_cached_command_range(*cache_source_display_list, cached_commands->range);
+        if (verify_display_list_cache_enabled()) [[unlikely]]
+            verify_spliced_commands_match_fresh_recording(paintable, context, phase, destination_range);
         if (cache_writes_enabled)
             paintable.set_cached_commands(phase, recorder.display_list().id(), destination_range, phase_context_index, phase_has_empty_effective_clip);
     } else {

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -114,7 +114,7 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
         : Optional<Paintable::CachedCommandRange> {};
 
     if (cached_commands.has_value()) {
-        auto destination_range = recorder.append_cached_command_range(*cache_source_display_list, cached_commands->range);
+        auto destination_range = recorder.append_cached_command_range(*cache_source_display_list, cached_commands->range, cached_commands->recorded_context_index);
         if (verify_display_list_cache_enabled()) [[unlikely]]
             verify_spliced_commands_match_fresh_recording(paintable, context, phase, destination_range);
         if (cache_writes_enabled)

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -113,6 +113,8 @@ void ViewportPaintable::reset_for_relayout()
 {
     PaintableWithLines::reset_for_relayout();
     clear_scroll_state();
+    m_display_list_used_as_paint_command_cache_source = nullptr;
+    m_paint_command_cache_source_referenced_resources = {};
     m_paintable_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree.clear();
     m_visual_context_tree_node_count_without_inspector_overlays = 0;
@@ -287,6 +289,11 @@ void ViewportPaintable::prune_inspector_overlay_visual_contexts()
     if (!m_visual_context_tree.has_value())
         return;
     m_visual_context_tree->shrink(m_visual_context_tree_node_count_without_inspector_overlays);
+}
+
+void ViewportPaintable::append_paint_command_cache_source_resources(DisplayListResourceSet& retained_resources) const
+{
+    retained_resources.include(m_paint_command_cache_source_referenced_resources);
 }
 
 void ViewportPaintable::invalidate_all_cached_paint()

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -9,6 +9,7 @@
 
 #include <AK/Optional.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/ScrollState.h>
 
@@ -64,6 +65,18 @@ public:
     AccumulatedVisualContextTree const& visual_context_tree() const;
     AccumulatedVisualContextTree& visual_context_tree();
 
+    void set_display_list_used_as_paint_command_cache_source(RefPtr<DisplayList const> display_list, DisplayListResourceSet referenced_resources)
+    {
+        m_display_list_used_as_paint_command_cache_source = move(display_list);
+        m_paint_command_cache_source_referenced_resources = move(referenced_resources);
+    }
+    DisplayList const* display_list_used_as_paint_command_cache_source() const { return m_display_list_used_as_paint_command_cache_source.ptr(); }
+    DisplayListResourceSet const& paint_command_cache_source_referenced_resources() const { return m_paint_command_cache_source_referenced_resources; }
+
+    // Cached command ranges keep pointing into the retained source until it rotates, so pruning the
+    // backing resource storage must keep everything the source references alive.
+    void append_paint_command_cache_source_resources(DisplayListResourceSet&) const;
+
 private:
     friend void update_visual_viewport_accumulated_visual_context(ViewportPaintable&);
 
@@ -81,6 +94,9 @@ private:
     bool m_needs_to_refresh_scroll_state { true };
 
     Vector<WeakPtr<Paintable>> m_paintable_boxes_with_auto_content_visibility;
+
+    RefPtr<DisplayList const> m_display_list_used_as_paint_command_cache_source;
+    DisplayListResourceSet m_paint_command_cache_source_referenced_resources;
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
     u64 m_accumulated_visual_context_tree_build_count { 0 };

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -207,6 +207,14 @@ void SVGDecodedImageData::append_cached_display_list_resources(Painting::Display
         retained_resources.include(cached_display_list.value.referenced_resources);
 }
 
+void SVGDecodedImageData::append_paint_command_cache_source_resources(Painting::DisplayListResourceSet& retained_resources) const
+{
+    auto document_paintable = m_document->unsafe_paintable();
+    if (!document_paintable)
+        return;
+    document_paintable->append_paint_command_cache_source_resources(retained_resources);
+}
+
 Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& destination_resource_storage) const
 {
     ScopedSVGImageDocument scoped_document { *m_page_client, *m_document, ScopedSVGImageDocument::FrameRequests::RouteToCurrentImage, const_cast<SVGDecodedImageData&>(*this) };
@@ -241,14 +249,15 @@ Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list
 
     navigable.set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout(DOM::UpdateLayoutReason::SVGDecodedImageDataRender);
-    auto display_list = m_document->record_display_list({}, resource_storage);
+    auto display_list = m_document->record_display_list({}, resource_storage, Painting::PaintCommandCacheMode::ReadWrite);
     if (!display_list)
         return {};
 
-    auto referenced_resources = resource_storage.collect_referenced_resources(*display_list);
-    copy_referenced_resources_to(destination_resource_storage, resource_storage, referenced_resources);
     auto document_paintable = m_document->paintable();
     VERIFY(document_paintable);
+    VERIFY(document_paintable->display_list_used_as_paint_command_cache_source() == display_list.ptr());
+    auto referenced_resources = document_paintable->paint_command_cache_source_referenced_resources();
+    copy_referenced_resources_to(destination_resource_storage, resource_storage, referenced_resources);
     auto visual_context_tree = document_paintable->visual_context_tree();
     auto display_list_resource = Painting::DisplayListResource { *display_list, visual_context_tree };
     m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree), move(referenced_resources) });
@@ -382,8 +391,10 @@ void SVGDecodedImageData::SVGPageClient::prune_cached_display_list_resources() c
 void SVGDecodedImageData::SVGPageClient::prune_cached_display_list_resources_now() const
 {
     Painting::DisplayListResourceSet retained_resources;
-    for (auto& svg_image_data : m_svg_image_data)
+    for (auto& svg_image_data : m_svg_image_data) {
         svg_image_data.append_cached_display_list_resources(retained_resources);
+        svg_image_data.append_paint_command_cache_source_resources(retained_resources);
+    }
 
     m_svg_page->top_level_traversable()->display_list_resource_storage().retain_only(retained_resources);
 }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -49,6 +49,7 @@ private:
     RefPtr<Gfx::PaintingSurface> render_to_surface(Gfx::IntSize) const;
     void prune_cached_display_list_resources() const;
     void append_cached_display_list_resources(Painting::DisplayListResourceSet&) const;
+    void append_paint_command_cache_source_resources(Painting::DisplayListResourceSet&) const;
     void did_request_frame();
     void invalidate_cached_rendering();
 

--- a/Tests/LibWeb/Text/expected/display_list/body-background-change-invalidates-root.txt
+++ b/Tests/LibWeb/Text/expected/display_list/body-background-change-invalidates-root.txt
@@ -1,0 +1,2 @@
+stale propagated background painted: false
+fresh propagated background painted: true

--- a/Tests/LibWeb/Text/input/display_list/body-background-change-invalidates-root.html
+++ b/Tests/LibWeb/Text/input/display_list/body-background-change-invalidates-root.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+
+        // The root element paints the body's propagated background, so changing the body's background must
+        // invalidate the root's cached background commands even though the body itself paints nothing.
+        document.body.style.backgroundColor = "rgb(1, 2, 3)";
+        // Two frames: the requestAnimationFrame continuation resumes before this frame's display list is
+        // recorded, and the stale color must actually get recorded and cached before it changes.
+        await nextFrame();
+        await nextFrame();
+
+        document.body.style.backgroundColor = "rgb(4, 5, 6)";
+        await nextFrame();
+
+        const dump = internals.dumpDisplayList();
+        println(`stale propagated background painted: ${dump.includes("rgb(1, 2, 3)")}`);
+        println(`fresh propagated background painted: ${dump.includes("rgb(4, 5, 6)")}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Per-paintable paint command caches used to hold their own ByteBuffer
copies of the serialized commands, which together nearly duplicated the
display list's entire byte stream. Since the previous frame's list is
already retained for damage computation, cached phases can instead be
(offset, size) ranges into it: a cache hit is a single memcpy from the
retained list into the one under construction, and the per-paintable
copies disappear — roughly halving steady-state display list memory.

Making the retained list the only splice source also removes the
resource reference-counting machinery: everything a future splice can
reference is exactly what the source list references, so retention
becomes a pure function of the source's resource set, collected once
when the source rotates. And since recording is a linear append, a
stacking context's commands form a contiguous range of the stream, so
caching whole stacking-context phase slices later is this same
mechanism with larger ranges.

Before:
```mermaid
flowchart LR
    subgraph PT["Paintable tree (per-phase caches)"]
        A["Paintable A<br>private ByteBuffer copy"]
        B["Paintable B<br>private ByteBuffer copy"]
        C["Paintable N<br>private ByteBuffer copy"]
    end
    NEW["DisplayList being recorded"]
    RC["DisplayListResourceStorage:<br>per-resource cache reference counts"]
    A -- "hit: copy bytes again +<br>rewrite every header" --> NEW
    B --> NEW
    C --> NEW
    A -. "acquire/release scan on<br>every cache set and invalidate" .-> RC
    B -.-> RC
    C -.-> RC
```

After:
```mermaid
flowchart LR
    subgraph PT["Paintable tree (per-phase caches)"]
        A["Paintable A<br>(source list id, offset, size)"]
        B["Paintable B<br>(source list id, offset, size)"]
        C["Paintable N<br>(source list id, offset, size)"]
    end
    SRC["cache source: last recorded DisplayList<br>(same list already retained for damage)<br>+ its resource set, collected once at rotation"]
    NEW["DisplayList being recorded"]
    VP["ViewportPaintable"] -- retains --> SRC
    A -- "points into" --> SRC
    B --> SRC
    C --> SRC
    SRC -- "hit: one memcpy of the range<br>(headers restamped only if the<br>context index changed)" --> NEW
```
