### PR TITLE
LibWeb: Compute getBBox() for the outermost <svg> element

### DIFF
--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -367,6 +367,17 @@ Optional<float> SVGGraphicsElement::stroke_width() const
     return resolve_relative_to_viewport_size(unsafe_layout_node()->computed_values().stroke_width());
 }
 
+static Painting::SVGGraphicsPaintable::ComputedTransforms const* computed_svg_transforms_of(Painting::Paintable const& paintable)
+{
+    if (auto const* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(paintable))
+        return &svg_graphics_paintable->computed_transforms();
+    if (auto const* svg_foreign_object_paintable = as_if<Painting::SVGForeignObjectPaintable>(paintable))
+        return &svg_foreign_object_paintable->computed_transforms();
+    if (auto const* svg_svg_paintable = as_if<Painting::SVGSVGPaintable>(paintable))
+        return &svg_svg_paintable->computed_transforms();
+    return nullptr;
+}
+
 // https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox
 WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Optional<Bindings::SVGBoundingBoxOptions> const&)
 {
@@ -385,11 +396,35 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Op
     document().update_layout_if_needed_for_node(*this, DOM::UpdateLayoutReason::SVGGraphicsElementGetBBox);
     if (!layout_node())
         return Geometry::DOMRect::create(realm());
-    // Invert the SVG -> screen space transform.
-    auto owner_svg_element = this->owner_svg_element();
-    if (!owner_svg_element)
-        return Geometry::DOMRect::create(realm());
 
+    auto owner_svg_element = this->owner_svg_element();
+
+    // The outermost svg element has no ancestor svg element to measure against; per the bounding box
+    // algorithm its bounding box is the union of its children's bounding boxes in its own user
+    // coordinate system (i.e. with the viewBox transform undone, but each child's own transforms kept).
+    if (!owner_svg_element) {
+        if (!is<SVGSVGElement>(*this))
+            return Geometry::DOMRect::create(realm());
+        auto self_paintable = paintable_box();
+        if (!self_paintable)
+            return Geometry::DOMRect::create(realm());
+        auto viewport_origin = self_paintable->absolute_rect().location().to_type<float>();
+        Gfx::FloatRect united_rect;
+        self_paintable->for_each_child([&](Painting::Paintable const& child) {
+            auto child_rect = child.absolute_rect().to_type<float>().translated(-viewport_origin);
+            if (auto const* transforms = computed_svg_transforms_of(child)) {
+                if (auto inverse = transforms->svg_to_viewbox_transform().inverse(); inverse.has_value())
+                    child_rect = inverse->map(child_rect);
+            }
+            united_rect.unite(child_rect);
+            return IterationDecision::Continue;
+        });
+        if (united_rect.is_empty())
+            return Geometry::DOMRect::create(realm());
+        return Geometry::DOMRect::create(realm(), united_rect);
+    }
+
+    // Invert the SVG -> screen space transform.
     auto owner_paintable = owner_svg_element->paintable_box();
     auto self_paintable = paintable_box();
     if (!owner_paintable || !self_paintable)
@@ -397,17 +432,8 @@ WebIDL::ExceptionOr<GC::Ref<Geometry::DOMRect>> SVGGraphicsElement::get_b_box(Op
 
     auto svg_rect = owner_paintable->absolute_rect();
     auto rect = self_paintable->absolute_rect().to_type<float>().translated(-svg_rect.location().to_type<float>());
-    auto svg_to_css_pixels_transform = [&]() -> Optional<Gfx::AffineTransform> {
-        if (auto const* svg_graphics_paintable = as_if<Painting::SVGGraphicsPaintable>(*self_paintable))
-            return svg_graphics_paintable->computed_transforms().svg_to_css_pixels_transform();
-        if (auto const* svg_foreign_object_paintable = as_if<Painting::SVGForeignObjectPaintable>(*self_paintable))
-            return svg_foreign_object_paintable->computed_transforms().svg_to_css_pixels_transform();
-        if (auto const* svg_svg_paintable = as_if<Painting::SVGSVGPaintable>(*self_paintable))
-            return svg_svg_paintable->computed_transforms().svg_to_css_pixels_transform();
-        return {};
-    }();
-    if (svg_to_css_pixels_transform.has_value()) {
-        auto inv = svg_to_css_pixels_transform->inverse();
+    if (auto const* transforms = computed_svg_transforms_of(*self_paintable)) {
+        auto inv = transforms->svg_to_css_pixels_transform().inverse();
         if (inv.has_value())
             rect = inv->map(rect);
     }

--- a/Tests/LibWeb/Text/expected/SVG/getBBox-outermost-svg-element.txt
+++ b/Tests/LibWeb/Text/expected/SVG/getBBox-outermost-svg-element.txt
@@ -1,0 +1,5 @@
+plain: x=60 y=30 width=100 height=40
+with-viewbox: x=10 y=10 width=30 height=20
+multiple-children: x=20 y=30 width=150 height=90
+with-foreign-object: x=10 y=10 width=150 height=100
+display-none: x=0 y=0 width=0 height=0

--- a/Tests/LibWeb/Text/input/SVG/getBBox-outermost-svg-element.html
+++ b/Tests/LibWeb/Text/input/SVG/getBBox-outermost-svg-element.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg id="plain" width="500" height="200">
+    <g transform="translate(50, 20)">
+        <rect x="10" y="10" width="100" height="40" />
+    </g>
+</svg>
+<svg id="with-viewbox" width="200" height="100" viewBox="0 0 100 50">
+    <rect x="10" y="10" width="30" height="20" />
+</svg>
+<svg id="multiple-children" width="300" height="300">
+    <rect x="20" y="30" width="40" height="50" />
+    <path d="M130,80 L170,80 L170,120 L130,120 Z" />
+</svg>
+<svg id="with-foreign-object" width="300" height="150">
+    <rect x="10" y="10" width="20" height="20" />
+    <foreignObject x="40" y="50" width="120" height="60"></foreignObject>
+</svg>
+<svg id="display-none" width="100" height="100" style="display: none">
+    <rect x="10" y="10" width="30" height="30" />
+</svg>
+<script>
+    test(() => {
+        for (const id of ["plain", "with-viewbox", "multiple-children", "with-foreign-object", "display-none"]) {
+            const box = document.getElementById(id).getBBox();
+            println(`${id}: x=${box.x} y=${box.y} width=${box.width} height=${box.height}`);
+        }
+    });
+</script>


### PR DESCRIPTION
getBBox() bailed out with an empty rect whenever ownerSVGElement was null, which is precisely the outermost <svg> element, so svg.getBBox() always returned 0x0.

For the outermost svg, return the union of the child paintables' absolute rects translated to the svg's origin and inverse-mapped through the viewBox transform: the bounding box of a container is the union of its children's boxes in the container's user coordinate system, with each child's own transforms applied.

Fixes mermaid diagrams on GitHub.