### PR TITLE
LibWeb: Reset the srcset descriptor tokenizer between tokens

### DIFF
--- a/Libraries/LibWeb/HTML/SourceSet.cpp
+++ b/Libraries/LibWeb/HTML/SourceSet.cpp
@@ -162,6 +162,7 @@ splitting_loop:
                     // If current descriptor is not empty, append current descriptor to descriptors and let current descriptor be the empty string.
                     if (!current_descriptor.is_empty()) {
                         descriptors.append(current_descriptor.to_string());
+                        current_descriptor.clear();
                     }
                     // Set state to after descriptor.
                     state = State::AfterDescriptor;

--- a/Tests/LibWeb/Text/expected/HTML/image-srcset-future-compat-height-descriptor.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-srcset-future-compat-height-descriptor.txt
@@ -1,0 +1,1 @@
+currentSrc: 120.png

--- a/Tests/LibWeb/Text/input/HTML/image-srcset-future-compat-height-descriptor.html
+++ b/Tests/LibWeb/Text/input/HTML/image-srcset-future-compat-height-descriptor.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const image = new Image();
+        image.sizes = "120px";
+        image.srcset = "../../../Assets/120.png 120w 120h";
+        image.onload = () => {
+            println(`currentSrc: ${image.currentSrc.substring(image.currentSrc.lastIndexOf("/") + 1)}`);
+            done();
+        };
+        document.body.appendChild(image);
+    });
+</script>


### PR DESCRIPTION
The srcset parser appended each whitespace-terminated descriptor without clearing its builder. A valid candidate containing both width and future-compatible height descriptors therefore concatenated them and was discarded.

Clear the builder as specified and cover width and height descriptor candidate loading.

Visual progression on https://filofax.com/

Before:

<img width="1518" height="993" alt="Screenshot 2026-07-21 at 18 23 10" src="https://github.com/user-attachments/assets/b1b31337-66ed-43c4-8456-54b38280bdf9" />

After:

<img width="1518" height="993" alt="Screenshot 2026-07-21 at 18 49 28" src="https://github.com/user-attachments/assets/72157e35-26b4-45ae-9215-093faf1ddab9" />
