### PR TITLE
LibWeb: Don't create anonymous block wrappers inside SVG containers

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -133,6 +133,11 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
     if (layout_parent.is_svg_foreign_object_box())
         return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
 
+    // SVG layout ignores the inline/block distinction, and an anonymous wrapper would only hide
+    // the child from SVGFormattingContext (e.g. a shape with a foreignObject sibling).
+    if (layout_parent.is_svg_box() || layout_parent.is_svg_svg_box())
+        return layout_parent;
+
     if (layout_parent.display().is_inline_outside() && layout_parent.display().is_flow_inside())
         return layout_parent;
 
@@ -151,6 +156,11 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
     // Inline is fine for in-flow block children (interrupting blocks) and for out-of-flow children;
     // the inline formatting context emits items for both.
     if (!layout_node.is_anonymous() && layout_parent.is_inline() && layout_parent.display().is_flow_inside())
+        return layout_parent;
+
+    // SVG layout ignores the inline/block distinction; wrapping existing inline-level siblings
+    // (e.g. shapes next to a foreignObject) would only hide them from SVGFormattingContext.
+    if (layout_parent.is_svg_box() || layout_parent.is_svg_svg_box())
         return layout_parent;
 
     // Make sure we're not inserting into an inline node, since those do not support block nodes.

--- a/Tests/LibWeb/Layout/expected/svg/foreignObject-with-abspos-descendant.txt
+++ b/Tests/LibWeb/Layout/expected/svg/foreignObject-with-abspos-descendant.txt
@@ -1,16 +1,14 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 166 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 150 0+0+8] children: not-inline
-      SVGSVGBox <svg> at [8,8] [0+0+0 300 0+0+484] [0+0+0 150 0+0+0] [SVG] children: not-inline
-        BlockContainer <(anonymous)> (not painted) children: inline
-          TextNode <#text> (not painted)
+      SVGSVGBox <svg> at [8,8] [0+0+0 300 0+0+484] [0+0+0 150 0+0+0] [SVG] children: inline
+        TextNode <#text> (not painted)
         SVGForeignObjectBox <foreignObject> at [8,8] [0+0+0 100 0+0+0] [0+0+0 200 0+0+0] [BFC] children: not-inline
           BlockContainer <(anonymous)> at [8,8] [0+0+0 100 0+0+0] [0+0+0 0 0+0+0] children: inline
             TextNode <#text> (not painted)
             BlockContainer <div.el> at [8,8] positioned [0+0+0 50 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
             TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> (not painted) children: inline
-          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,158] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/svg/foreignObject-with-mask.txt
+++ b/Tests/LibWeb/Layout/expected/svg/foreignObject-with-mask.txt
@@ -2,10 +2,9 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 48 0+0+8] children: not-inline
       SVGSVGBox <svg> at [8,8] [0+0+0 48 0+0+736] [0+0+0 48 0+0+0] [SVG] children: not-inline
-        BlockContainer <(anonymous)> (not painted) children: inline
-          TextNode <#text> (not painted)
-          TextNode <#text> (not painted)
-          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
         SVGForeignObjectBox <foreignObject> at [26,36] [0+0+0 40 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
           BlockContainer <div.lmao> at [31,41] [0+5+0 40 0+5+-10] [0+5+0 40 0+5+0] children: not-inline
           SVGMaskBox <mask#rektMask> at [16,16] [0+0+0 48 0+0+0] [0+0+0 48 0+0+0] children: inline

--- a/Tests/LibWeb/Ref/expected/svg-shape-with-foreign-object-sibling-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-shape-with-foreign-object-sibling-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; }
+</style>
+<div style="width: 80px; height: 40px; margin: 10px 0 0 10px; background: #36c;"></div>
+<div style="width: 80px; height: 40px; margin: 10px 0 0 10px; background: #6c3;"></div>

--- a/Tests/LibWeb/Ref/input/svg-shape-with-foreign-object-sibling.html
+++ b/Tests/LibWeb/Ref/input/svg-shape-with-foreign-object-sibling.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-shape-with-foreign-object-sibling-ref.html" />
+<style>
+    body { margin: 0; }
+    svg { display: block; }
+</style>
+<svg width="200" height="120">
+    <rect x="10" y="10" width="80" height="40" fill="#36c" />
+    <foreignObject x="10" y="60" width="80" height="40">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="width: 100%; height: 100%; background: #6c3;"></div>
+    </foreignObject>
+</svg>


### PR DESCRIPTION
The tree builder maintained the all-block-or-all-inline invariant inside SVG containers too, so a block-level foreignObject arriving next to inline-level siblings (shapes, text nodes) wrapped those siblings in an anonymous block. SVGFormattingContext only lays out SVG boxes among its children, so the wrapped shapes were never laid out or painted.

SVG layout ignores the inline/block distinction entirely; insert children of SVG boxes directly.