### PR TITLE
LibWebView: Coalesce equivalent omnibox origins

### DIFF
--- a/Libraries/LibWebView/AutocompleteMuxer.cpp
+++ b/Libraries/LibWebView/AutocompleteMuxer.cpp
@@ -118,8 +118,6 @@ static bool are_equivalent_origin_presentations(AutocompleteSuggestion const& le
         return false;
     if (!is_origin_navigation(left) || !is_origin_navigation(right))
         return false;
-    if (left.title.has_value() && right.title.has_value() && left.title != right.title)
-        return false;
 
     auto left_url = URL::Parser::basic_parse(left.text);
     auto right_url = URL::Parser::basic_parse(right.text);
@@ -136,15 +134,28 @@ static void coalesce_equivalent_origin_presentations(Vector<AutocompleteSuggesti
 {
     Vector<AutocompleteSuggestion> representatives;
     representatives.ensure_capacity(candidates.size());
+    Vector<Optional<String>> group_titles;
+    group_titles.ensure_capacity(candidates.size());
 
     for (auto& candidate : candidates) {
-        auto existing_index = representatives.find_first_index_if([&](auto const& existing) {
-            return are_equivalent_origin_presentations(existing, candidate);
-        });
+        Optional<size_t> existing_index;
+        for (size_t index = 0; index < representatives.size(); ++index) {
+            if (!are_equivalent_origin_presentations(representatives[index], candidate))
+                continue;
+            if (group_titles[index].has_value() && candidate.title.has_value() && group_titles[index] != candidate.title)
+                continue;
+            existing_index = index;
+            break;
+        }
+
         if (!existing_index.has_value()) {
+            group_titles.append(candidate.title);
             representatives.append(move(candidate));
             continue;
         }
+
+        if (!group_titles[*existing_index].has_value() && candidate.title.has_value())
+            group_titles[*existing_index] = candidate.title;
 
         auto& existing = representatives[*existing_index];
         if (suggestion_is_better(candidate, existing))

--- a/Libraries/LibWebView/AutocompleteMuxer.cpp
+++ b/Libraries/LibWebView/AutocompleteMuxer.cpp
@@ -112,6 +112,48 @@ static bool is_origin_navigation(AutocompleteSuggestion const& suggestion)
         && !url->query().has_value();
 }
 
+static bool are_equivalent_origin_presentations(AutocompleteSuggestion const& left, AutocompleteSuggestion const& right)
+{
+    if (left.source == AutocompleteSuggestionSource::Search || right.source == AutocompleteSuggestionSource::Search)
+        return false;
+    if (!is_origin_navigation(left) || !is_origin_navigation(right))
+        return false;
+    if (left.title.has_value() && right.title.has_value() && left.title != right.title)
+        return false;
+
+    auto left_url = URL::Parser::basic_parse(left.text);
+    auto right_url = URL::Parser::basic_parse(right.text);
+    VERIFY(left_url.has_value() && right_url.has_value());
+    if (!left_url->scheme().is_one_of("http"sv, "https"sv) || !right_url->scheme().is_one_of("http"sv, "https"sv))
+        return false;
+
+    return left_url->scheme() == right_url->scheme()
+        && left_url->port() == right_url->port()
+        && origin_family(left) == origin_family(right);
+}
+
+static void coalesce_equivalent_origin_presentations(Vector<AutocompleteSuggestion>& candidates)
+{
+    Vector<AutocompleteSuggestion> representatives;
+    representatives.ensure_capacity(candidates.size());
+
+    for (auto& candidate : candidates) {
+        auto existing_index = representatives.find_first_index_if([&](auto const& existing) {
+            return are_equivalent_origin_presentations(existing, candidate);
+        });
+        if (!existing_index.has_value()) {
+            representatives.append(move(candidate));
+            continue;
+        }
+
+        auto& existing = representatives[*existing_index];
+        if (suggestion_is_better(candidate, existing))
+            existing = move(candidate);
+    }
+
+    candidates = move(representatives);
+}
+
 static u8 short_query_origin_preference(AutocompleteSuggestion const& suggestion, size_t query_length)
 {
     if (suggestion.adaptive_relevance > 0 && suggestion.can_be_automatically_selected)
@@ -158,6 +200,9 @@ Vector<AutocompleteSuggestion> mux_autocomplete_suggestions(
     auto query_contains_path = query_contains_url_suffix(query);
     auto query_length = Utf8View { query }.length();
     auto is_short_host_query = !query_contains_path && query_length <= 2;
+
+    if (!query_contains_path)
+        coalesce_equivalent_origin_presentations(candidates);
 
     if (is_short_host_query) {
         Vector<AutocompleteSuggestion> representatives;

--- a/Tests/LibWebView/TestAutocompleteMuxer.cpp
+++ b/Tests/LibWebView/TestAutocompleteMuxer.cpp
@@ -331,21 +331,52 @@ TEST_CASE(equivalent_origin_presentations_do_not_crowd_out_deep_pages)
     }));
 }
 
-TEST_CASE(origin_presentations_with_distinct_titles_are_not_coalesced)
+TEST_CASE(untitled_origin_presentation_does_not_bridge_distinct_titles)
 {
-    auto bare_host = history("https://example.com/"sv, 1000);
-    bare_host.title = "Bare host"_string;
-    auto www_host = history("https://www.example.com/"sv, 990);
-    www_host.title = "WWW host"_string;
+    auto first_titled = history("https://example.com/"sv, 1000);
+    first_titled.title = "First title"_string;
+    auto untitled = history("https://www.example.com/"sv, 1100);
+    auto second_titled = history("https://user@example.com/"sv, 900);
+    second_titled.title = "Second title"_string;
 
     auto results = WebView::mux_autocomplete_suggestions(
         "example"sv,
         {},
-        { move(bare_host), move(www_host) },
+        { move(first_titled), move(untitled), move(second_titled) },
         {},
         8);
 
     EXPECT_EQ(results.size(), 2u);
+    EXPECT(results.contains([](auto const& result) {
+        return result.text == "https://www.example.com/"sv;
+    }));
+    EXPECT(results.contains([](auto const& result) {
+        return result.text == "https://user@example.com/"sv;
+    }));
+}
+
+TEST_CASE(untitled_origin_group_adopts_a_later_title)
+{
+    auto untitled = history("https://www.example.com/"sv, 1100);
+    auto first_titled = history("https://example.com/"sv, 1000);
+    first_titled.title = "First title"_string;
+    auto second_titled = history("https://user@example.com/"sv, 900);
+    second_titled.title = "Second title"_string;
+
+    auto results = WebView::mux_autocomplete_suggestions(
+        "example"sv,
+        {},
+        { move(untitled), move(first_titled), move(second_titled) },
+        {},
+        8);
+
+    EXPECT_EQ(results.size(), 2u);
+    EXPECT(results.contains([](auto const& result) {
+        return result.text == "https://www.example.com/"sv;
+    }));
+    EXPECT(results.contains([](auto const& result) {
+        return result.text == "https://user@example.com/"sv;
+    }));
 }
 
 TEST_CASE(a_scheme_does_not_disable_origin_diversity)

--- a/Tests/LibWebView/TestAutocompleteMuxer.cpp
+++ b/Tests/LibWebView/TestAutocompleteMuxer.cpp
@@ -305,6 +305,49 @@ TEST_CASE(www_and_bare_hosts_share_a_diversity_family)
     EXPECT_EQ(results[3].text, "https://third.example/example"sv);
 }
 
+TEST_CASE(equivalent_origin_presentations_do_not_crowd_out_deep_pages)
+{
+    auto results = WebView::mux_autocomplete_suggestions(
+        "frag"sv,
+        search("frag"sv, 900, true),
+        {
+            history("https://www.fragrantica.com/"sv, 1484),
+            history("https://fragnado.com/"sv, 1009),
+            history("https://fragonard.com/"sv, 1005),
+            history("https://fragrantica.com/"sv, 934),
+            history("https://www.fragrantica.com/perfume/Indult/Manakara-4345.html"sv, 746),
+        },
+        { search("fragrantica perfume"sv, 700) },
+        8);
+
+    EXPECT(results.contains([](auto const& result) {
+        return result.text == "https://www.fragrantica.com/"sv;
+    }));
+    EXPECT(results.contains([](auto const& result) {
+        return result.text == "https://www.fragrantica.com/perfume/Indult/Manakara-4345.html"sv;
+    }));
+    EXPECT(!results.contains([](auto const& result) {
+        return result.text == "https://fragrantica.com/"sv;
+    }));
+}
+
+TEST_CASE(origin_presentations_with_distinct_titles_are_not_coalesced)
+{
+    auto bare_host = history("https://example.com/"sv, 1000);
+    bare_host.title = "Bare host"_string;
+    auto www_host = history("https://www.example.com/"sv, 990);
+    www_host.title = "WWW host"_string;
+
+    auto results = WebView::mux_autocomplete_suggestions(
+        "example"sv,
+        {},
+        { move(bare_host), move(www_host) },
+        {},
+        8);
+
+    EXPECT_EQ(results.size(), 2u);
+}
+
 TEST_CASE(a_scheme_does_not_disable_origin_diversity)
 {
     auto results = WebView::mux_autocomplete_suggestions(


### PR DESCRIPTION
Prevent equivalent bare-host and www homepage presentations from consuming separate slots in an origin's result quota. Keep different schemes, ports, deep URLs, and distinctly titled homepages separate.

Cover the reported ranking pattern where the redundant homepage hid a recently visited deep page.