### PR TITLE
LibWeb: Add requestAnimationFrame and rendering updates to workers

### DIFF
--- a/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.cpp
@@ -4,14 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Math.h>
 #include <LibWeb/Bindings/DedicatedWorkerExposedInterfaces.h>
 #include <LibWeb/Bindings/DedicatedWorkerGlobalScope.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/HTML/AnimationFrameCallbackDriver.h>
 #include <LibWeb/HTML/DedicatedWorkerGlobalScope.h>
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/MessagePort.h>
+#include <LibWeb/HTML/Scripting/ExceptionReporter.h>
+#include <LibWeb/HighResolutionTime/TimeOrigin.h>
+#include <LibWeb/Page/Page.h>
+#include <LibWeb/Platform/Timer.h>
+#include <LibWeb/WebIDL/AbstractOperations.h>
+#include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::HTML {
 
@@ -42,10 +50,137 @@ void DedicatedWorkerGlobalScope::close()
     close_a_worker();
 }
 
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#concept-AnimationFrameProvider-supported
+bool DedicatedWorkerGlobalScope::is_supported() const
+{
+    // An AnimationFrameProvider provider is considered supported if any of the following are true:
+    for (auto const& owner : owner_set()) {
+        // - provider is a Window.
+        // NOTE: provider is this DedicatedWorkerGlobalScope.
+
+        // - provider's owner set contains a Document object.
+        if (owner.has<SerializedDocument>())
+            return true;
+
+        // - Any of the DedicatedWorkerGlobalScope objects in provider's owner set are supported.
+        if (owner.get<SerializedWorkerGlobalScope>().is_supported_animation_frame_provider)
+            return true;
+    }
+    return false;
+}
+
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe
+WebIDL::ExceptionOr<WebIDL::UnsignedLong> DedicatedWorkerGlobalScope::request_animation_frame(GC::Ref<WebIDL::CallbackType> callback)
+{
+    // FIXME: Make this fully spec compliant. Currently implements a mix of 'requestAnimationFrame()' and 'run the animation frame callbacks'.
+
+    // 1. If this is not supported, then throw a "NotSupportedError" DOMException.
+    if (!is_supported())
+        return WebIDL::NotSupportedError::create(realm(), "requestAnimationFrame() is not supported in a dedicated worker whose owner set does not reach a Document"_utf16);
+
+    // 2. Let target be this's target object.
+    // NOTE: For a DedicatedWorkerGlobalScope, the target object is the DedicatedWorkerGlobalScope itself.
+
+    // 3. Increment target's animation frame callback identifier by one, and let handle be the result.
+    // 4. Let callbacks be target's map of animation frame callbacks.
+    // 5. Set callbacks[handle] to callback.
+    auto handle = animation_frame_callback_driver().add(GC::create_function(heap(), [this, callback](double now) {
+        // Invoke callback with « now » and "report".
+        auto result = WebIDL::invoke_callback(*callback, {}, { { JS::Value(now) } });
+        if (result.is_error())
+            report_exception(result, realm());
+    }));
+    schedule_rendering_update();
+
+    // 6. Return handle.
+    return handle;
+}
+
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider-cancelanimationframe
+WebIDL::ExceptionOr<void> DedicatedWorkerGlobalScope::cancel_animation_frame(WebIDL::UnsignedLong handle)
+{
+    // 1. If this is not supported, then throw a "NotSupportedError" DOMException.
+    if (!is_supported())
+        return WebIDL::NotSupportedError::create(realm(), "cancelAnimationFrame() is not supported in a dedicated worker whose owner set does not reach a Document"_utf16);
+
+    // 2. Let callbacks be this's target object's map of animation frame callbacks.
+    // 3. Remove callbacks[handle].
+    if (m_animation_frame_callback_driver)
+        (void)m_animation_frame_callback_driver->remove(handle);
+    return {};
+}
+
+AnimationFrameCallbackDriver& DedicatedWorkerGlobalScope::animation_frame_callback_driver()
+{
+    if (!m_animation_frame_callback_driver)
+        m_animation_frame_callback_driver = realm().create<AnimationFrameCallbackDriver>();
+    return *m_animation_frame_callback_driver;
+}
+
+bool DedicatedWorkerGlobalScope::has_animation_frame_callbacks() const
+{
+    return m_animation_frame_callback_driver && m_animation_frame_callback_driver->has_callbacks();
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
+// The processing model only updates a dedicated worker's rendering when "the user agent
+// believes that it would benefit from having its rendering updated at this time", and notes
+// that "a user agent can determine the rate of rendering in the dedicated worker". Worker
+// event loops have no document-driven rendering, so a single-shot timer paced at the
+// rendering rate of the spawning page (communicated when the worker was started) provides
+// the rendering opportunities while animation frame callbacks or uncommitted
+// OffscreenCanvas frames are pending.
+// FIXME: The rate is fixed at worker start; propagate display rate changes to running workers.
+void DedicatedWorkerGlobalScope::schedule_rendering_update()
+{
+    if (!m_rendering_update_timer) {
+        m_rendering_update_timer = Platform::Timer::create_single_shot(heap(), 0, GC::create_function(heap(), [this] {
+            run_rendering_update();
+        }));
+    }
+    if (m_rendering_update_timer->is_active())
+        return;
+    auto interval_ms = static_cast<int>(AK::ceil(1000.0 / max(1.0, page()->client().maximum_frames_per_second())));
+    m_rendering_update_timer->start(interval_ms);
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
+void DedicatedWorkerGlobalScope::run_rendering_update()
+{
+    // If this event loop's agent's single realm's global object is a supported
+    // DedicatedWorkerGlobalScope and the user agent believes that it would benefit from having
+    // its rendering updated at this time:
+
+    // 1. Let now be the current high resolution time given the DedicatedWorkerGlobalScope.
+    auto now = HighResolutionTime::current_high_resolution_time(*this);
+
+    // 2. Run the animation frame callbacks for that DedicatedWorkerGlobalScope, passing in now
+    //    as the timestamp.
+    if (m_animation_frame_callback_driver)
+        m_animation_frame_callback_driver->run(now);
+
+    // 3. Update the rendering of that dedicated worker to reflect the current state.
+    // NOTE: This presents the frames of placeholder-linked OffscreenCanvases that were drawn to.
+    //       It runs whether or not animation frame callbacks were used, so canvases driven by
+    //       timers or messages commit too.
+    if (auto* page = this->page())
+        page->prepare_canvas_contexts_for_compositing();
+
+    if (has_animation_frame_callbacks())
+        schedule_rendering_update();
+}
+
 void DedicatedWorkerGlobalScope::finalize()
 {
     Base::finalize();
     WindowOrWorkerGlobalScopeMixin::finalize();
+}
+
+void DedicatedWorkerGlobalScope::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_animation_frame_callback_driver);
+    visitor.visit(m_rendering_update_timer);
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-dedicatedworkerglobalscope-postmessage-options

--- a/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.h
@@ -29,6 +29,16 @@ public:
 
     void close();
 
+    WebIDL::ExceptionOr<WebIDL::UnsignedLong> request_animation_frame(GC::Ref<WebIDL::CallbackType>);
+    WebIDL::ExceptionOr<void> cancel_animation_frame(WebIDL::UnsignedLong handle);
+
+    // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#concept-AnimationFrameProvider-supported
+    bool is_supported() const;
+
+    // Requests a near-term "update the rendering of that dedicated worker" pass:
+    // run pending animation frame callbacks and commit OffscreenCanvas frames.
+    void schedule_rendering_update();
+
     WebIDL::CallbackType* onmessage();
     void set_onmessage(WebIDL::CallbackType* callback);
 
@@ -41,6 +51,14 @@ private:
     DedicatedWorkerGlobalScope(JS::Realm&, GC::Ref<Web::Page>);
 
     virtual void initialize_web_interfaces_impl() override;
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    AnimationFrameCallbackDriver& animation_frame_callback_driver();
+    bool has_animation_frame_callbacks() const;
+    void run_rendering_update();
+
+    GC::Ptr<AnimationFrameCallbackDriver> m_animation_frame_callback_driver;
+    GC::Ptr<Platform::Timer> m_rendering_update_timer;
 };
 
 }

--- a/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.idl
+++ b/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.idl
@@ -10,3 +10,5 @@ interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;
 };
+
+DedicatedWorkerGlobalScope includes AnimationFrameProvider;

--- a/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/DOMURL/DOMURL.h>
 #include <LibWeb/Fetch/Infrastructure/FetchRecord.h>
 #include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/DedicatedWorkerGlobalScope.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/Scripting/Agent.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -525,8 +526,10 @@ SerializedEnvironmentSettingsObject EnvironmentSettingsObject::serialize()
             };
         }
         VERIFY(is<WorkerGlobalScope>(global_object()));
+        auto const* dedicated_worker_global_scope = as_if<DedicatedWorkerGlobalScope>(global_object());
         return SerializedWorkerGlobalScope {
             .relevant_settings_object_is_secure_context = relevant_settings_object_is_secure_context,
+            .is_supported_animation_frame_provider = dedicated_worker_global_scope && dedicated_worker_global_scope->is_supported(),
         };
     }();
 

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.cpp
@@ -35,6 +35,7 @@ template<>
 ErrorOr<void> encode(Encoder& encoder, Web::HTML::SerializedWorkerGlobalScope const& worker_global_scope)
 {
     TRY(encoder.encode(worker_global_scope.relevant_settings_object_is_secure_context));
+    TRY(encoder.encode(worker_global_scope.is_supported_animation_frame_provider));
     return {};
 }
 
@@ -43,6 +44,7 @@ ErrorOr<Web::HTML::SerializedWorkerGlobalScope> decode(Decoder& decoder)
 {
     return Web::HTML::SerializedWorkerGlobalScope {
         .relevant_settings_object_is_secure_context = TRY(decoder.decode<bool>()),
+        .is_supported_animation_frame_provider = TRY(decoder.decode<bool>()),
     };
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/SerializedEnvironmentSettingsObject.h
@@ -31,6 +31,12 @@ struct SerializedWindow {
 
 struct SerializedWorkerGlobalScope {
     bool relevant_settings_object_is_secure_context { false };
+
+    // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#concept-AnimationFrameProvider-supported
+    // Whether the serialized global is a DedicatedWorkerGlobalScope that is a supported
+    // AnimationFrameProvider. Recorded at serialization time so that a nested dedicated
+    // worker can compute its own supported-ness without reaching across processes.
+    bool is_supported_animation_frame_provider { false };
 };
 
 using SerializedGlobal = Variant<SerializedWindow, SerializedWorkerGlobalScope>;

--- a/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentParent.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/Worker.h>
 #include <LibWeb/HTML/WorkerAgentParent.h>
+#include <LibWeb/HTML/WorkerGlobalScope.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/StorageAPI/StorageKey.h>
 
@@ -63,6 +64,17 @@ void WorkerAgentParent::initialize(JS::Realm& realm)
 
     auto serialized_outside_settings = m_outside_settings->serialize();
 
+    // The worker process has no display connection of its own, so capture the spawning page's
+    // rendering rate to let the worker pace its rendering updates to match.
+    auto maximum_frames_per_second = [&]() -> double {
+        auto& global = m_outside_settings->global_object();
+        if (auto* window = as_if<Window>(global))
+            return window->page().client().maximum_frames_per_second();
+        if (auto* worker_global_scope = as_if<WorkerGlobalScope>(global))
+            return worker_global_scope->page()->client().maximum_frames_per_second();
+        return 60.0;
+    }();
+
     // 8. Let callerIsSecureContext be true if outside settings is a secure context; otherwise, false.
     // 9. Let outsideStorageKey be the result of running obtain a storage key for non-storage purposes
     //    given outsideSettings.
@@ -76,6 +88,7 @@ void WorkerAgentParent::initialize(JS::Realm& realm)
         .outside_settings = serialized_outside_settings,
         .storage_key = StorageAPI::obtain_a_storage_key_for_non_storage_purposes(*m_outside_settings),
         .caller_is_secure_context = is_secure_context(*m_outside_settings),
+        .maximum_frames_per_second = maximum_frames_per_second,
         .owner_token = m_owner_token,
     };
 

--- a/Libraries/LibWeb/HTML/WorkerAgentTypes.cpp
+++ b/Libraries/LibWeb/HTML/WorkerAgentTypes.cpp
@@ -23,6 +23,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::HTML::WorkerAgentStartRequest const&
     TRY(encoder.encode(request.outside_settings));
     TRY(encoder.encode(request.storage_key));
     TRY(encoder.encode(request.caller_is_secure_context));
+    TRY(encoder.encode(request.maximum_frames_per_second));
     TRY(encoder.encode(request.owner_token));
     return {};
 }
@@ -41,6 +42,7 @@ ErrorOr<Web::HTML::WorkerAgentStartRequest> decode(Decoder& decoder)
         .outside_settings = TRY(decoder.decode<Web::HTML::SerializedEnvironmentSettingsObject>()),
         .storage_key = TRY(decoder.decode<Web::StorageAPI::StorageKey>()),
         .caller_is_secure_context = TRY(decoder.decode<bool>()),
+        .maximum_frames_per_second = TRY(decoder.decode<double>()),
         .owner_token = TRY(decoder.decode<Web::HTML::WorkerAgentOwnerToken>()),
     };
 }

--- a/Libraries/LibWeb/HTML/WorkerAgentTypes.h
+++ b/Libraries/LibWeb/HTML/WorkerAgentTypes.h
@@ -31,6 +31,9 @@ struct WEB_API WorkerAgentStartRequest {
     SerializedEnvironmentSettingsObject outside_settings;
     StorageAPI::StorageKey storage_key;
     bool caller_is_secure_context { false };
+    // The rendering rate of the spawning page, used to pace rendering updates in worker event
+    // loops, which have no display connection of their own.
+    double maximum_frames_per_second { 60.0 };
     WorkerAgentOwnerToken owner_token { 0 };
 };
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -475,6 +475,7 @@ public:
     virtual double zoom_level() const = 0;
     virtual double device_pixel_ratio() const = 0;
     virtual double device_pixels_per_css_pixel() const = 0;
+    virtual double maximum_frames_per_second() const { return 60.0; }
     virtual CSS::PreferredColorScheme preferred_color_scheme() const = 0;
     virtual CSS::PreferredContrast preferred_contrast() const = 0;
     virtual CSS::PreferredMotion preferred_motion() const = 0;

--- a/Libraries/LibWeb/Worker/WebWorkerServer.ipc
+++ b/Libraries/LibWeb/Worker/WebWorkerServer.ipc
@@ -23,7 +23,8 @@ endpoint WebWorkerServer {
                  Utf16String name,
                  Web::HTML::TransferDataEncoder message_port,
                  Web::HTML::SerializedEnvironmentSettingsObject outside_settings,
-                 Web::Bindings::AgentType agent_type) =|
+                 Web::Bindings::AgentType agent_type,
+                 double maximum_frames_per_second) =|
 
     connect_shared_worker(Web::HTML::TransferDataEncoder message_port,
                           Web::HTML::SerializedEnvironmentSettingsObject outside_settings) =|

--- a/Libraries/LibWebView/WorkerProcessManager.cpp
+++ b/Libraries/LibWebView/WorkerProcessManager.cpp
@@ -154,7 +154,7 @@ Web::HTML::WorkerAgentId WorkerProcessManager::start_worker_agent(Owner owner, W
     }
 
     m_agents.set(agent_id, move(agent));
-    client->async_start_worker(request.url, request.type, request.credentials, request.name, move(request.outside_port), request.outside_settings, request.agent_type);
+    client->async_start_worker(request.url, request.type, request.credentials, request.name, move(request.outside_port), request.outside_settings, request.agent_type, request.maximum_frames_per_second);
 
     return agent_id;
 }

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -71,6 +71,7 @@ public:
     }
     void set_zoom_level(double zoom_level);
     void set_maximum_frames_per_second(double maximum_frames_per_second);
+    virtual double maximum_frames_per_second() const override { return m_maximum_frames_per_second; }
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
     void set_preferred_motion(Web::CSS::PreferredMotion);

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -110,8 +110,9 @@ Web::Page const& ConnectionFromClient::page() const
     return m_page_host->page();
 }
 
-void ConnectionFromClient::start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, Utf16String name, Web::HTML::TransferDataEncoder implicit_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings, Web::Bindings::AgentType agent_type)
+void ConnectionFromClient::start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, Utf16String name, Web::HTML::TransferDataEncoder implicit_port, Web::HTML::SerializedEnvironmentSettingsObject outside_settings, Web::Bindings::AgentType agent_type, double maximum_frames_per_second)
 {
+    m_page_host->set_maximum_frames_per_second(maximum_frames_per_second);
     m_worker_host = make_ref_counted<WorkerHost>(move(url), type, move(name));
 
     bool const is_shared = agent_type == Web::Bindings::AgentType::SharedWorker;

--- a/Services/WebWorker/ConnectionFromClient.h
+++ b/Services/WebWorker/ConnectionFromClient.h
@@ -55,7 +55,7 @@ private:
     virtual void connect_to_image_decoder(IPC::TransportHandle handle) override;
     virtual void connect_to_compositor(IPC::TransportHandle handle) override;
     virtual void set_system_font_family(String family) override;
-    virtual void start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, Utf16String name, Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject, Web::Bindings::AgentType) override;
+    virtual void start_worker(URL::URL url, Web::Bindings::WorkerType type, Web::Bindings::RequestCredentials credentials, Utf16String name, Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject, Web::Bindings::AgentType, double maximum_frames_per_second) override;
     virtual void connect_shared_worker(Web::HTML::TransferDataEncoder, Web::HTML::SerializedEnvironmentSettingsObject) override;
     virtual void handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) override;
     virtual void did_worker_agent_finish_loading_script(Web::HTML::WorkerAgentOwnerToken owner_token) override;

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -53,6 +53,8 @@ public:
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
     virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { VERIFY_NOT_REACHED(); }
     virtual void request_frame() override { VERIFY_NOT_REACHED(); }
+    virtual double maximum_frames_per_second() const override { return m_maximum_frames_per_second; }
+    void set_maximum_frames_per_second(double maximum_frames_per_second) { m_maximum_frames_per_second = maximum_frames_per_second; }
     void did_finish_loading_worker_script(bool worker_is_secure_context);
     void did_fail_loading_worker_script();
 
@@ -66,6 +68,7 @@ private:
     OwnPtr<Web::Compositor::CompositorHost> m_compositor_host;
     GC::Ref<Web::Page> m_page;
     RefPtr<Gfx::PaletteImpl> m_palette_impl;
+    double m_maximum_frames_per_second { 60.0 };
 };
 
 }

--- a/Tests/LibWeb/Text/expected/Worker/Worker-requestAnimationFrame-supported.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-requestAnimationFrame-supported.txt
@@ -1,0 +1,2 @@
+nested in dedicated worker: raf callback ran
+nested in shared worker: raf threw: NotSupportedError, caf threw: NotSupportedError

--- a/Tests/LibWeb/Text/expected/Worker/Worker-requestAnimationFrame.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-requestAnimationFrame.txt
@@ -1,0 +1,4 @@
+has requestAnimationFrame: true
+has cancelAnimationFrame: true
+callback ran with numeric timestamp: true
+second frame not before first: true

--- a/Tests/LibWeb/Text/input/Worker/Worker-requestAnimationFrame-supported.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-requestAnimationFrame-supported.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#concept-AnimationFrameProvider-supported
+    // A dedicated worker is a supported AnimationFrameProvider only if its owner set reaches a
+    // Document: a worker nested inside a page-owned dedicated worker is supported, while a worker
+    // nested inside a shared worker is not and must throw "NotSupportedError".
+    asyncTest(done => {
+        function testNestedInDedicatedWorker(next) {
+            const parentScript = `
+                const nestedScript = 'try { requestAnimationFrame(() => postMessage("raf callback ran")); } catch (e) { postMessage("raf threw: " + e.name); }';
+                const nested = new Worker(URL.createObjectURL(new Blob([nestedScript], { type: "application/javascript" })));
+                nested.onmessage = evt => postMessage(evt.data);
+            `;
+            const blob = new Blob([parentScript], { type: "application/javascript" });
+            const worker = new Worker(URL.createObjectURL(blob));
+            worker.onmessage = evt => {
+                println("nested in dedicated worker: " + evt.data);
+                next();
+            };
+        }
+
+        function testNestedInSharedWorker(next) {
+            const sharedScript = `
+                onconnect = event => {
+                    const port = event.ports[0];
+                    const nestedScript = 'let result; try { requestAnimationFrame(() => {}); result = "raf did not throw"; } catch (e) { result = "raf threw: " + e.name; } try { cancelAnimationFrame(1); result += ", caf did not throw"; } catch (e) { result += ", caf threw: " + e.name; } postMessage(result);';
+                    const nested = new Worker(URL.createObjectURL(new Blob([nestedScript], { type: "application/javascript" })));
+                    nested.onmessage = evt => port.postMessage(evt.data);
+                };
+            `;
+            const blob = new Blob([sharedScript], { type: "application/javascript" });
+            const worker = new SharedWorker(URL.createObjectURL(blob), "raf-supported-test");
+            worker.port.onmessage = evt => {
+                println("nested in shared worker: " + evt.data);
+                next();
+            };
+            worker.port.start();
+        }
+
+        testNestedInDedicatedWorker(() => testNestedInSharedWorker(done));
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Worker/Worker-requestAnimationFrame.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-requestAnimationFrame.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const workerScript = `
+            const results = [];
+            results.push("has requestAnimationFrame: " + (typeof self.requestAnimationFrame === "function"));
+            results.push("has cancelAnimationFrame: " + (typeof self.cancelAnimationFrame === "function"));
+
+            const cancelledHandle = self.requestAnimationFrame(() => {
+                results.push("FAIL: cancelled callback ran");
+            });
+            self.cancelAnimationFrame(cancelledHandle);
+
+            self.requestAnimationFrame(timestamp => {
+                results.push("callback ran with numeric timestamp: " + (typeof timestamp === "number"));
+                self.requestAnimationFrame(secondTimestamp => {
+                    results.push("second frame not before first: " + (secondTimestamp >= timestamp));
+                    self.postMessage(results);
+                });
+            });
+        `;
+        const blob = new Blob([workerScript], { type: "application/javascript" });
+        const worker = new Worker(URL.createObjectURL(blob));
+        worker.onmessage = evt => {
+            for (const line of evt.data)
+                println(line);
+            done();
+        };
+    });
+</script>


### PR DESCRIPTION
Include AnimationFrameProvider on DedicatedWorkerGlobalScope and add a rendering update to worker event loops that runs animation frame callbacks.