### PR TITLE
LibWeb: Apply inspector overlay contexts in geometry-only mode

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8800,10 +8800,6 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     if (line_box_border_overlays_replace_cacheable_content)
         cache_mode = Painting::PaintCommandCacheMode::ReadOnly;
 
-    // Drop the inspector-overlay context nodes appended by the previous recording; this appends its own. Safe because
-    // the pruned tree only reaches the compositor together with (or after) the display list recorded against it here.
-    paintable()->prune_inspector_overlay_visual_contexts();
-
     auto display_list = Painting::DisplayList::create(paintable()->visual_context_tree());
     Painting::DisplayListRecorder display_list_recorder(display_list, paintable()->visual_context_tree(), resource_storage);
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -849,8 +849,7 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
                 return point;
             },
             [&](ScrollCompensation const& compensation) -> Optional<Gfx::FloatPoint> {
-                auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
-                point.translate_by(compensation.negate ? offset : -offset);
+                point.translate_by(scroll_state.device_offset_for_index(compensation.scroll_node_index));
                 return point;
             },
             [&](AnchorScrollShift const& shift) -> Optional<Gfx::FloatPoint> {
@@ -916,8 +915,7 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
                     rect.translate_by(scroll_state.device_offset_for_index(VisualContextIndex { i }));
                 },
                 [&](ScrollCompensation const& compensation) {
-                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
-                    rect.translate_by(compensation.negate ? -offset : offset);
+                    rect.translate_by(-scroll_state.device_offset_for_index(compensation.scroll_node_index));
                 },
                 [&](AnchorScrollShift const& shift) {
                     rect.translate_by(shift.masked_offset(scroll_state));
@@ -995,7 +993,7 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
             builder.append("]"sv);
         },
         [&](ScrollCompensation const& compensation) {
-            builder.appendff("scroll_compensation(node_index={}{})", compensation.scroll_node_index.value(), compensation.negate ? ""sv : ", applies_offset"sv);
+            builder.appendff("scroll_compensation(node_index={})", compensation.scroll_node_index.value());
         },
         [&](AnchorScrollShift const& shift) {
             builder.appendff("anchor_scroll_shift(node_index={}{}{}{})", shift.scroll_node_index.value(),
@@ -1115,7 +1113,6 @@ template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::ScrollCompensation const& data)
 {
     TRY(encoder.encode(data.scroll_node_index));
-    TRY(encoder.encode(data.negate));
     return {};
 }
 
@@ -1124,7 +1121,6 @@ ErrorOr<Web::Painting::ScrollCompensation> decode(Decoder& decoder)
 {
     return Web::Painting::ScrollCompensation {
         .scroll_node_index = TRY(decoder.decode<Web::Painting::VisualContextIndex>()),
-        .negate = TRY(decoder.decode<bool>()),
     };
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -725,14 +725,6 @@ VisualContextIndex AccumulatedVisualContextTree::append(VisualContextData data, 
     return index;
 }
 
-void AccumulatedVisualContextTree::shrink(size_t node_count)
-{
-    // The visual viewport root node must always remain.
-    VERIFY(node_count >= 1);
-    VERIFY(node_count <= m_nodes.size());
-    m_nodes.shrink(node_count, true);
-}
-
 void AccumulatedVisualContextTree::set_visual_viewport_transform(TransformData transform)
 {
     VERIFY(!m_nodes.is_empty());

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -140,7 +140,6 @@ public:
     u64 version() const { return m_version; }
 
     WEB_API VisualContextIndex append(VisualContextData data, VisualContextIndex parent_index);
-    WEB_API void shrink(size_t node_count);
     WEB_API void set_visual_viewport_transform(TransformData);
     WEB_API bool is_compatible_with(AccumulatedVisualContextTree const&) const;
     WEB_API void reuse_version_from(AccumulatedVisualContextTree const&);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -83,13 +83,10 @@ struct EffectsData {
     }
 };
 
-// Translates by another scroll node's offset during display list replay. Negating keeps fixed backgrounds
-// stationary relative to the viewport regardless of scroll position; the non-negating form is appended when
-// inspector overlays copy a scroll node's context, since a copied ScrollData node would look its offset up
-// under the copy's own index.
+// Translates by another scroll node's negated offset during display list replay, keeping fixed
+// backgrounds stationary relative to the viewport regardless of scroll position.
 struct ScrollCompensation {
     VisualContextIndex scroll_node_index;
-    bool negate { true };
 };
 
 // One scroll node's contribution to the default scroll shift of an anchor-positioned box, masked to the axes in which

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -215,9 +215,7 @@ void DisplayListPlayer::execute_impl(
                 },
                 [&](ScrollCompensation const& compensation) {
                     play_command(Save {});
-                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
-                    if (compensation.negate)
-                        offset = -offset;
+                    auto offset = -scroll_state.device_offset_for_index(compensation.scroll_node_index);
                     if (!offset.is_zero())
                         play_command(Translate { .delta = offset.to_type<int>() });
                 },

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -49,11 +49,13 @@ bool DisplayList::append_bytes(
     ReadonlyBytes inline_data,
     AccumulatedVisualContextTree const& visual_context_tree,
     VisualContextIndex context_index,
+    bool context_geometry_only,
     Optional<Gfx::IntRect> bounding_rect,
     bool is_clip)
 {
     VERIFY(visual_context_tree.version() == m_compatible_visual_context_tree_version);
-    if (visual_context_tree.has_empty_effective_clip(context_index))
+    // Geometry-only commands ignore the chain's clips, so an empty effective clip doesn't make them invisible.
+    if (!context_geometry_only && visual_context_tree.has_empty_effective_clip(context_index))
         return false;
     VERIFY(m_command_bytes.size() % DisplayList::command_alignment == 0);
     VERIFY(payload.size() <= NumericLimits<u32>::max());
@@ -67,6 +69,7 @@ bool DisplayList::append_bytes(
         .type = type,
         .payload_size = static_cast<u32>(payload_size + trailing_padding),
         .context_index = context_index,
+        .context_geometry_only = context_geometry_only,
         .has_bounding_rect = bounding_rect.has_value(),
         .is_clip = is_clip,
         .bounding_rect = bounding_rect.value_or({}),
@@ -183,7 +186,13 @@ void DisplayListPlayer::execute_impl(
     };
 
     auto apply_accumulated_visual_context =
-        [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node) {
+        [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node, bool geometry_only) {
+            // Geometry-only application skips nodes that don't affect coordinates, but still pushes a
+            // save so the chain keeps one canvas save per node, which restore_to_depth relies on.
+            if (geometry_only && (node.data.has<ClipData>() || node.data.has<ClipPathData>() || node.data.has<EffectsData>())) {
+                play_command(Save {});
+                return;
+            }
             node.data.visit(
                 [&](EffectsData const& effects) {
                     play_command(ApplyEffects {
@@ -242,6 +251,7 @@ void DisplayListPlayer::execute_impl(
 
     VisualContextIndex applied_context_index;
     bool has_applied_context { false };
+    bool applied_context_geometry_only { false };
     size_t applied_depth = 0;
 
     // OPTIMIZATION: When walking down to apply effects (opacity, filters, blend modes), check culling before applying
@@ -251,9 +261,19 @@ void DisplayListPlayer::execute_impl(
         Switched,
         CulledByEffect,
     };
-    auto switch_to_context = [&](VisualContextIndex target_index, Optional<Gfx::IntRect> bounding_rect = {}) -> SwitchResult {
-        if (has_applied_context && applied_context_index == target_index)
+    auto switch_to_context = [&](VisualContextIndex target_index, bool geometry_only, Optional<Gfx::IntRect> bounding_rect = {}) -> SwitchResult {
+        if (has_applied_context && applied_context_index == target_index && applied_context_geometry_only == geometry_only)
             return SwitchResult::Switched;
+
+        // A chain applied in one mode can't be partially reused in the other: the modes disagree on what
+        // every shared ancestor contributes. Unwind fully and reapply from the root instead.
+        if (has_applied_context && applied_context_geometry_only != geometry_only) {
+            while (applied_depth > 0) {
+                play_command(Restore {});
+                --applied_depth;
+            }
+            has_applied_context = false;
+        }
 
         Optional<VisualContextIndex> common_ancestor_index;
         if (has_applied_context)
@@ -290,20 +310,21 @@ void DisplayListPlayer::execute_impl(
             common_ancestor_index,
             target_index,
             [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node) {
-                if (bounding_rect.has_value() && node.data.has<EffectsData>()) {
+                if (!geometry_only && bounding_rect.has_value() && node.data.has<EffectsData>()) {
                     auto can_cull_before_effect = !has_coordinate_changing_descendant(Optional<VisualContextIndex> { node_index });
                     if (bounding_rect->is_empty() || (can_cull_before_effect && would_be_fully_clipped_by_painter(*bounding_rect))) {
                         result = SwitchResult::CulledByEffect;
                         return IterationDecision::Break;
                     }
                 }
-                apply_accumulated_visual_context(node_index, node);
+                apply_accumulated_visual_context(node_index, node, geometry_only);
                 applied_depth++;
                 return IterationDecision::Continue;
             });
 
         if (result == SwitchResult::Switched) {
             applied_context_index = target_index;
+            applied_context_geometry_only = geometry_only;
             has_applied_context = true;
         } else {
             restore_to_depth(common_ancestor_depth);
@@ -319,7 +340,7 @@ void DisplayListPlayer::execute_impl(
             ? Optional<Gfx::IntRect>(header.bounding_rect)
             : Optional<Gfx::IntRect> {};
 
-        if (switch_to_context(header.context_index, bounding_rect) == SwitchResult::CulledByEffect)
+        if (switch_to_context(header.context_index, header.context_geometry_only, bounding_rect) == SwitchResult::CulledByEffect)
             return;
 
         if (bounding_rect.has_value() && (bounding_rect->is_empty() || would_be_fully_clipped_by_painter(*bounding_rect))) {

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -95,7 +95,7 @@ public:
     }
 
     template<DisplayListCommand Command>
-    bool append(Command const& command, AccumulatedVisualContextTree const& visual_context_tree, VisualContextIndex context_index, ReadonlyBytes inline_data = {})
+    bool append(Command const& command, AccumulatedVisualContextTree const& visual_context_tree, VisualContextIndex context_index, bool context_geometry_only, ReadonlyBytes inline_data = {})
     {
         return append_bytes(
             Command::command_type,
@@ -103,6 +103,7 @@ public:
             inline_data,
             visual_context_tree,
             context_index,
+            context_geometry_only,
             command_bounding_rectangle(command),
             command_is_clip(command));
     }
@@ -166,6 +167,7 @@ private:
         ReadonlyBytes inline_data,
         AccumulatedVisualContextTree const&,
         VisualContextIndex context_index,
+        bool context_geometry_only,
         Optional<Gfx::IntRect> bounding_rect,
         bool is_clip);
 

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -122,6 +122,10 @@ struct DisplayListCommandHeader {
     DisplayListCommandType type;
     u32 payload_size { 0 };
     VisualContextIndex context_index { VISUAL_VIEWPORT_NODE_INDEX };
+    // Apply only the coordinate-affecting nodes of the context chain, skipping clips and effects. Used
+    // by inspector overlays, which track the highlighted element's transforms and scroll offsets but
+    // must not be clipped or faded by its ancestors.
+    bool context_geometry_only { false };
     bool has_bounding_rect { false };
     bool is_clip { false };
     Gfx::IntRect bounding_rect {};

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -36,6 +36,7 @@ static Vector<DisplayListCommandReference> collect_display_list_command_referenc
 static bool display_list_commands_are_equal(DisplayListCommandReference const& a, DisplayListCommandReference const& b)
 {
     if (a.header.type != b.header.type
+        || a.header.context_geometry_only != b.header.context_geometry_only
         || a.header.has_bounding_rect != b.header.has_bounding_rect
         || a.header.is_clip != b.header.is_clip
         || a.header.bounding_rect != b.header.bounding_rect)

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -154,7 +154,6 @@ static bool visual_context_data_is_equal(VisualContextIndex a_index, VisualConte
         [&](ScrollCompensation const& data) {
             auto const* other = b.get_pointer<ScrollCompensation>();
             return other
-                && data.negate == other->negate
                 && a_scroll_state.device_offset_for_index(data.scroll_node_index) == b_scroll_state.device_offset_for_index(other->scroll_node_index);
         },
         [&](AnchorScrollShift const& data) {

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -111,6 +111,14 @@ public:
     }
     VisualContextIndex accumulated_visual_context() const { return m_accumulated_visual_context_index; }
 
+    void set_context_geometry_only(bool context_geometry_only)
+    {
+        // A cached range is spliced with the context its commands were recorded under, so a capture
+        // must not span a change of context application mode either.
+        VERIFY(!m_is_capturing || context_geometry_only == m_context_geometry_only);
+        m_context_geometry_only = context_geometry_only;
+    }
+
     DisplayList const& display_list() const { return m_display_list; }
     AccumulatedVisualContextTree const& visual_context_tree() const { return m_visual_context_tree; }
 
@@ -188,10 +196,11 @@ private:
     void append_command(Command const& command, ReadonlyBytes inline_data = {})
     {
         m_save_nesting_level += display_list_command_nesting_level_change<Command>();
-        m_display_list.append(command, m_visual_context_tree, m_accumulated_visual_context_index, inline_data);
+        m_display_list.append(command, m_visual_context_tree, m_accumulated_visual_context_index, m_context_geometry_only, inline_data);
     }
 
     VisualContextIndex m_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
+    bool m_context_geometry_only { false };
     DisplayList& m_display_list;
     AccumulatedVisualContextTree const& m_visual_context_tree;
     DisplayListResourceStorage& m_resource_storage;

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -179,45 +179,12 @@ void Paintable::paint_with_inspector_overlay_context(DisplayListRecordingContext
     auto& display_list_recorder = context.display_list_recorder();
     auto previous_visual_context_index = display_list_recorder.accumulated_visual_context();
 
-    auto viewport_paintable = document().paintable();
-    VERIFY(viewport_paintable);
-    auto& visual_context_tree = const_cast<ViewportPaintable&>(*viewport_paintable).visual_context_tree();
-    auto visual_context_index = accumulated_visual_context_index();
-
-    if (visual_context_index != VISUAL_VIEWPORT_NODE_INDEX) {
-        Vector<VisualContextIndex> relevant_indices;
-        for (auto i = visual_context_index; i != VISUAL_VIEWPORT_NODE_INDEX; i = visual_context_tree.node_at(i).parent_index) {
-            auto should_keep = visual_context_tree.node_at(i).data.visit(
-                [](ScrollData const&) { return true; },
-                [](ClipData const&) { return false; },
-                [](TransformData const&) { return true; },
-                [](PerspectiveData const&) { return true; },
-                [](ClipPathData const&) { return false; },
-                [](EffectsData const&) { return false; },
-                [](ScrollCompensation const&) { return true; },
-                [](AnchorScrollShift const&) { return true; });
-            if (should_keep)
-                relevant_indices.append(i);
-        }
-
-        // NB: These nodes are transient: they're only referenced by the display list being recorded right now — and the
-        //     next recording prunes them again (see ViewportPaintable::prune_inspector_overlay_visual_contexts).
-        auto overlay_visual_context_index = VISUAL_VIEWPORT_NODE_INDEX;
-        for (auto const& source_visual_context_index : relevant_indices.in_reverse()) {
-            auto const& source_node_data = visual_context_tree.node_at(source_visual_context_index).data;
-            // A copied ScrollData node would look its offset up under the copy's own index, so scroll
-            // nodes are copied as non-negating compensations referencing the original instead.
-            auto data_for_overlay = source_node_data.has<ScrollData>()
-                ? VisualContextData { ScrollCompensation { source_visual_context_index, false } }
-                : source_node_data;
-            overlay_visual_context_index = visual_context_tree.append(move(data_for_overlay), overlay_visual_context_index);
-        }
-
-        if (overlay_visual_context_index != VISUAL_VIEWPORT_NODE_INDEX)
-            display_list_recorder.set_accumulated_visual_context(overlay_visual_context_index);
-    }
-
+    // Overlays follow the highlighted element's transforms and scroll offsets, but must not be clipped
+    // or faded by its ancestors, so their commands apply the element's context in geometry-only mode.
+    display_list_recorder.set_accumulated_visual_context(accumulated_visual_context_index());
+    display_list_recorder.set_context_geometry_only(true);
     callback();
+    display_list_recorder.set_context_geometry_only(false);
     display_list_recorder.set_accumulated_visual_context(previous_visual_context_index);
 }
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -117,7 +117,6 @@ void ViewportPaintable::reset_for_relayout()
     m_paint_command_cache_source_referenced_resources = {};
     m_paintable_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree.clear();
-    m_visual_context_tree_node_count_without_inspector_overlays = 0;
     m_visual_context_tree_needs_compositor_update = false;
 }
 
@@ -254,7 +253,6 @@ void ViewportPaintable::assign_accumulated_visual_contexts()
         document().set_needs_to_record_display_list();
     }
     m_visual_context_tree = move(visual_context_tree);
-    m_visual_context_tree_node_count_without_inspector_overlays = m_visual_context_tree->nodes().size();
     m_visual_context_tree_needs_compositor_update = true;
 }
 
@@ -278,17 +276,6 @@ void ViewportPaintable::update_visual_viewport_accumulated_visual_context()
     }
     Painting::update_visual_viewport_accumulated_visual_context(*this);
     m_visual_context_tree_needs_compositor_update = true;
-}
-
-// Painting inspector overlays appends the highlighted elements' transform/scroll ancestor contexts onto the visual
-// context tree (see Paintable::paint_with_inspector_overlay_context). Those nodes are only referenced by the display
-// list recorded alongside them — so each new recording prunes the ones appended by the previous recording before
-// appending its own; otherwise they would accumulate without bound.
-void ViewportPaintable::prune_inspector_overlay_visual_contexts()
-{
-    if (!m_visual_context_tree.has_value())
-        return;
-    m_visual_context_tree->shrink(m_visual_context_tree_node_count_without_inspector_overlays);
 }
 
 void ViewportPaintable::append_paint_command_cache_source_resources(DisplayListResourceSet& retained_resources) const

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -37,7 +37,6 @@ public:
     void assign_accumulated_visual_contexts();
     bool update_accumulated_visual_context_values(Paintable&);
     void update_visual_viewport_accumulated_visual_context();
-    void prune_inspector_overlay_visual_contexts();
     bool visual_context_tree_needs_compositor_update() const { return m_visual_context_tree_needs_compositor_update; }
     void did_update_visual_context_tree_in_compositor() { m_visual_context_tree_needs_compositor_update = false; }
     void set_force_incompatible_visual_context_tree_rebuild_for_testing() { m_force_incompatible_visual_context_tree_rebuild_for_testing = true; }
@@ -100,7 +99,6 @@ private:
 
     Optional<AccumulatedVisualContextTree> m_visual_context_tree;
     u64 m_accumulated_visual_context_tree_build_count { 0 };
-    size_t m_visual_context_tree_node_count_without_inspector_overlays { 0 };
     bool m_visual_context_tree_needs_compositor_update { false };
     bool m_force_incompatible_visual_context_tree_rebuild_for_testing { false };
 };

--- a/Tests/LibWeb/Ref/expected/inspector-highlighted-node-overlay-inside-empty-clip-ref.html
+++ b/Tests/LibWeb/Ref/expected/inspector-highlighted-node-overlay-inside-empty-clip-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+#outer {
+  position: relative;
+  width: 0;
+  height: 0;
+}
+#inner {
+  position: absolute;
+  left: 50px;
+  top: 50px;
+  width: 100px;
+  height: 100px;
+}
+</style>
+<div id="outer"><div id="inner"></div></div>
+<script>
+window.internals.setHighlightedNode(document.getElementById("inner"));
+</script>

--- a/Tests/LibWeb/Ref/input/inspector-highlighted-node-overlay-inside-empty-clip.html
+++ b/Tests/LibWeb/Ref/input/inspector-highlighted-node-overlay-inside-empty-clip.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/inspector-highlighted-node-overlay-inside-empty-clip-ref.html" />
+<!-- The highlighted element sits inside an ancestor whose overflow clip rect is empty, so all of its regular
+     paint commands are dropped as invisible — but the inspector overlay ignores ancestor clips and must still
+     be drawn. The reference paints the overlay for the same box without the empty clip (and with the content
+     made invisible to match). -->
+<style>
+#outer {
+  position: relative;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+#inner {
+  position: absolute;
+  left: 50px;
+  top: 50px;
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div id="outer"><div id="inner"></div></div>
+<script>
+if (!window.internals?.setHighlightedNode) {
+  document.body.innerText = "FAIL";
+} else {
+  window.internals.setHighlightedNode(document.getElementById("inner"));
+}
+</script>

--- a/Tests/LibWeb/Text/expected/inspector-overlay-visual-context-tree-growth.txt
+++ b/Tests/LibWeb/Text/expected/inspector-overlay-visual-context-tree-growth.txt
@@ -1,3 +1,2 @@
-PASS: recording with an inspector highlight appends overlay context nodes
-PASS: repeated recordings while highlighted do not grow the visual context tree
-PASS: overlay context nodes are pruned once the highlight is cleared
+PASS: recording with an inspector highlight does not modify the visual context tree
+PASS: visual context tree is unchanged after clearing the highlight

--- a/Tests/LibWeb/Text/input/inspector-overlay-visual-context-tree-growth.html
+++ b/Tests/LibWeb/Text/input/inspector-overlay-visual-context-tree-growth.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<!-- Each display-list recording that paints an inspector overlay appends the highlighted element's transform/scroll
-     contexts onto the accumulated visual context tree. Those nodes are transient: the next recording must prune them
-     before appending its own — rather than letting them accumulate (and get shipped to the compositor) for the lifetime
-     of the tree. See #10368.
+<!-- Inspector overlays used to append transient copies of the highlighted element's transform/scroll contexts onto
+     the accumulated visual context tree on every recording, which had to be pruned again by the next recording to
+     avoid unbounded growth (see #10368). Overlay commands now reference the element's existing context and apply it
+     in geometry-only mode, so recording an overlay must not modify the tree at all.
 
      NB: The tree is only rebuilt from scratch when layout is invalidated. Mutating the DOM between measurements (e.g.,
-     via println) would dirty layout and force a rebuild — masking the growth. So, as in
+     via println) would dirty layout and force a rebuild — masking accidental growth. So, as in
      visual-context-value-only-updates.html, all measurements are taken first, and printed at the end. -->
 <style>
     #box {
@@ -22,7 +22,7 @@
         const box = document.getElementById("box");
 
         // dumpDisplayList() records a fresh display list; the count that follows is the resulting live visual context
-        // tree size (base nodes plus any inspector-overlay nodes appended).
+        // tree size.
         const recordAndCount = () => {
             internals.dumpDisplayList();
             return internals.visualContextTreeNodeCount();
@@ -38,18 +38,14 @@
         internals.setHighlightedNode(null);
         const clearedCount = recordAndCount();
 
-        const overlayAppended = highlightedCounts[0] > baseCount;
-        const stayedFlat = highlightedCounts.every(c => c === highlightedCounts[0]);
-        const returnedToBase = clearedCount === baseCount;
+        const untouchedWhileHighlighted = highlightedCounts.every(c => c === baseCount);
+        const untouchedAfterClearing = clearedCount === baseCount;
 
-        println(overlayAppended
-            ? "PASS: recording with an inspector highlight appends overlay context nodes"
-            : `FAIL: expected overlay nodes to be appended (base ${baseCount}, highlighted ${highlightedCounts[0]})`);
-        println(stayedFlat
-            ? "PASS: repeated recordings while highlighted do not grow the visual context tree"
-            : `FAIL: visual context tree grew across repeated recordings: ${highlightedCounts.join(", ")}`);
-        println(returnedToBase
-            ? "PASS: overlay context nodes are pruned once the highlight is cleared"
+        println(untouchedWhileHighlighted
+            ? "PASS: recording with an inspector highlight does not modify the visual context tree"
+            : `FAIL: visual context tree changed while highlighted: base ${baseCount}, got ${highlightedCounts.join(", ")}`);
+        println(untouchedAfterClearing
+            ? "PASS: visual context tree is unchanged after clearing the highlight"
             : `FAIL: expected ${baseCount} nodes after clearing the highlight, got ${clearedCount}`);
     });
 </script>


### PR DESCRIPTION
Inspector overlays follow the highlighted element's transforms and
scroll offsets, but must not be clipped or faded by its ancestors.
Until now this was done by appending transient filtered copies of the
element's context chain onto the visual context tree during display
list recording, with ScrollData nodes rewritten into non-negating
ScrollCompensations (a copied scroll node would look its offset up
under the copy's own index). The copies had to be pruned again by the
next recording, mutated the tree behind the recorder's const
reference, and weakened what a tree version identifies: the same
version could refer to different node contents depending on which
recording last appended its overlay chains.
Instead, let the display list express the filtering: a command header
can now mark its context as geometry-only, and the player applies such
chains by skipping clip, clip-path and effects nodes — pushing a plain
save for them, to keep the one-canvas-save-per-node invariant that
context unwinding relies on. Overlay commands then simply reference
the highlighted element's existing context. Geometry-only commands
also skip the empty-effective-clip drop at append time, since they
ignore the chain's clips.

Besides making the tree immutable between builds, this fixes two
issues with the transient copies:
- Rebuilding the tree while a highlight was active always compared as
  incompatible (the old tree still carried the transient nodes), which
  spuriously bumped the tree version and dropped the paint command
  cache.
- Value-only updates (e.g. a repaint-only transform change) patched
  the element's own nodes but not the overlay's copies, so the overlay
  could desync from the content until the next full re-record.