### PR TITLE
LibWeb: Implement compositor-driven smooth scrolling

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     Compositor/AsyncScrollTree.cpp
     Compositor/AsyncScrollingState.cpp
     Compositor/CompositorHost.cpp
+    Compositor/SmoothScrollAnimation.cpp
     Compositor/Types.cpp
     Compression/CompressionStream.cpp
     Compression/DecompressionStream.cpp

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -71,6 +71,16 @@ AsyncScrollEnqueueResult CompositorContextHandle::async_scroll_by(UniqueNodeID e
     return m_host.async_scroll_by(m_context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
+AsyncScrollEnqueueResult CompositorContextHandle::smooth_scroll_to(AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect)
+{
+    return m_host.smooth_scroll_to(m_context_id, stable_node_id, offset_in_device_pixels, viewport_rect);
+}
+
+void CompositorContextHandle::cancel_smooth_scroll(AsyncScrollNodeStableID stable_node_id)
+{
+    m_host.cancel_smooth_scroll(m_context_id, stable_node_id);
+}
+
 PendingAsyncScrollUpdates CompositorContextHandle::take_pending_async_scroll_updates()
 {
     return m_host.take_pending_async_scroll_updates(m_context_id);

--- a/Libraries/LibWeb/Compositor/CompositorHost.cpp
+++ b/Libraries/LibWeb/Compositor/CompositorHost.cpp
@@ -71,9 +71,9 @@ AsyncScrollEnqueueResult CompositorContextHandle::async_scroll_by(UniqueNodeID e
     return m_host.async_scroll_by(m_context_id, expected_document_id, position, delta_in_device_pixels, viewport_rect, operation_tracking);
 }
 
-AsyncScrollEnqueueResult CompositorContextHandle::smooth_scroll_to(AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect)
+AsyncScrollEnqueueResult CompositorContextHandle::smooth_scroll_to(AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel)
 {
-    return m_host.smooth_scroll_to(m_context_id, stable_node_id, offset_in_device_pixels, viewport_rect);
+    return m_host.smooth_scroll_to(m_context_id, stable_node_id, offset_in_device_pixels, viewport_rect, device_pixels_per_css_pixel);
 }
 
 void CompositorContextHandle::cancel_smooth_scroll(AsyncScrollNodeStableID stable_node_id)

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -43,6 +43,8 @@ public:
     void invalidate_wheel_event_listener_state(u64 generation);
     AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
         Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
+    AsyncScrollEnqueueResult smooth_scroll_to(AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect);
+    void cancel_smooth_scroll(AsyncScrollNodeStableID);
     PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void viewport_size_updated(Gfx::IntSize, WindowResizingInProgress);
     void present_frame(Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
@@ -86,6 +88,8 @@ public:
     virtual AsyncScrollEnqueueResult async_scroll_by(CompositorContextId, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking)
         = 0;
+    virtual AsyncScrollEnqueueResult smooth_scroll_to(CompositorContextId, AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect) = 0;
+    virtual void cancel_smooth_scroll(CompositorContextId, AsyncScrollNodeStableID) = 0;
     virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
     virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, WindowResizingInProgress) = 0;
     virtual void present_frame(CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) = 0;

--- a/Libraries/LibWeb/Compositor/CompositorHost.h
+++ b/Libraries/LibWeb/Compositor/CompositorHost.h
@@ -43,7 +43,7 @@ public:
     void invalidate_wheel_event_listener_state(u64 generation);
     AsyncScrollEnqueueResult async_scroll_by(UniqueNodeID expected_document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels,
         Gfx::IntRect viewport_rect, AsyncScrollOperationTracking = AsyncScrollOperationTracking::No);
-    AsyncScrollEnqueueResult smooth_scroll_to(AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect);
+    AsyncScrollEnqueueResult smooth_scroll_to(AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel);
     void cancel_smooth_scroll(AsyncScrollNodeStableID);
     PendingAsyncScrollUpdates take_pending_async_scroll_updates();
     void viewport_size_updated(Gfx::IntSize, WindowResizingInProgress);
@@ -88,7 +88,7 @@ public:
     virtual AsyncScrollEnqueueResult async_scroll_by(CompositorContextId, UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, AsyncScrollOperationTracking)
         = 0;
-    virtual AsyncScrollEnqueueResult smooth_scroll_to(CompositorContextId, AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect) = 0;
+    virtual AsyncScrollEnqueueResult smooth_scroll_to(CompositorContextId, AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel) = 0;
     virtual void cancel_smooth_scroll(CompositorContextId, AsyncScrollNodeStableID) = 0;
     virtual PendingAsyncScrollUpdates take_pending_async_scroll_updates(CompositorContextId) = 0;
     virtual void viewport_size_updated(CompositorContextId, Gfx::IntSize, WindowResizingInProgress) = 0;

--- a/Libraries/LibWeb/Compositor/SmoothScrollAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/SmoothScrollAnimation.cpp
@@ -14,12 +14,13 @@ namespace Web::Compositor {
 static constexpr double scroll_speed_in_pixels_per_second = 1000.0;
 static constexpr double maximum_scroll_duration_in_seconds = 0.2;
 
-SmoothScrollAnimation::SmoothScrollAnimation(Gfx::FloatPoint start_offset, Gfx::FloatPoint destination_offset)
+SmoothScrollAnimation::SmoothScrollAnimation(Gfx::FloatPoint start_offset, Gfx::FloatPoint destination_offset, double pixels_per_css_pixel)
     : m_start_offset(start_offset)
     , m_destination_offset(destination_offset)
 {
-    auto horizontal_distance = static_cast<double>(destination_offset.x() - start_offset.x());
-    auto vertical_distance = static_cast<double>(destination_offset.y() - start_offset.y());
+    VERIFY(pixels_per_css_pixel > 0);
+    auto horizontal_distance = static_cast<double>(destination_offset.x() - start_offset.x()) / pixels_per_css_pixel;
+    auto vertical_distance = static_cast<double>(destination_offset.y() - start_offset.y()) / pixels_per_css_pixel;
     auto distance = AK::sqrt(horizontal_distance * horizontal_distance + vertical_distance * vertical_distance);
     auto duration_in_seconds = min(distance / scroll_speed_in_pixels_per_second, maximum_scroll_duration_in_seconds);
     m_duration = AK::Duration::from_seconds_f64(duration_in_seconds);

--- a/Libraries/LibWeb/Compositor/SmoothScrollAnimation.cpp
+++ b/Libraries/LibWeb/Compositor/SmoothScrollAnimation.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/StdLibExtras.h>
+#include <LibWeb/CSS/EasingFunction.h>
+#include <LibWeb/Compositor/SmoothScrollAnimation.h>
+
+namespace Web::Compositor {
+
+static constexpr double scroll_speed_in_pixels_per_second = 1000.0;
+static constexpr double maximum_scroll_duration_in_seconds = 0.2;
+
+SmoothScrollAnimation::SmoothScrollAnimation(Gfx::FloatPoint start_offset, Gfx::FloatPoint destination_offset)
+    : m_start_offset(start_offset)
+    , m_destination_offset(destination_offset)
+{
+    auto horizontal_distance = static_cast<double>(destination_offset.x() - start_offset.x());
+    auto vertical_distance = static_cast<double>(destination_offset.y() - start_offset.y());
+    auto distance = AK::sqrt(horizontal_distance * horizontal_distance + vertical_distance * vertical_distance);
+    auto duration_in_seconds = min(distance / scroll_speed_in_pixels_per_second, maximum_scroll_duration_in_seconds);
+    m_duration = AK::Duration::from_seconds_f64(duration_in_seconds);
+}
+
+SmoothScrollAnimation::Sample SmoothScrollAnimation::sample(AK::Duration elapsed) const
+{
+    if (m_duration.is_zero() || elapsed >= m_duration)
+        return { m_destination_offset, true };
+
+    auto progress = clamp(elapsed.to_seconds_f64() / m_duration.to_seconds_f64(), 0.0, 1.0);
+
+    // https://drafts.csswg.org/cssom-view/#smooth-scroll
+    // A smooth scroll follows a user-agent-defined timing function. Match the
+    // ease-in-out curve used by WebKit for programmatic smooth scrolling.
+    static CSS::CubicBezierEasingFunction const easing_function { 0.42, 0, 0.58, 1, {} };
+    auto eased_progress = easing_function.evaluate_at(progress, false);
+
+    return {
+        {
+            static_cast<float>(m_start_offset.x() + (m_destination_offset.x() - m_start_offset.x()) * eased_progress),
+            static_cast<float>(m_start_offset.y() + (m_destination_offset.y() - m_start_offset.y()) * eased_progress),
+        },
+        false,
+    };
+}
+
+}

--- a/Libraries/LibWeb/Compositor/SmoothScrollAnimation.h
+++ b/Libraries/LibWeb/Compositor/SmoothScrollAnimation.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Time.h>
+#include <LibGfx/Point.h>
+#include <LibWeb/Export.h>
+
+namespace Web::Compositor {
+
+class WEB_API SmoothScrollAnimation {
+public:
+    struct Sample {
+        Gfx::FloatPoint offset;
+        bool complete { false };
+    };
+
+    SmoothScrollAnimation(Gfx::FloatPoint start_offset, Gfx::FloatPoint destination_offset);
+
+    AK::Duration duration() const { return m_duration; }
+    Sample sample(AK::Duration elapsed) const;
+
+private:
+    Gfx::FloatPoint m_start_offset;
+    Gfx::FloatPoint m_destination_offset;
+    AK::Duration m_duration;
+};
+
+}

--- a/Libraries/LibWeb/Compositor/SmoothScrollAnimation.h
+++ b/Libraries/LibWeb/Compositor/SmoothScrollAnimation.h
@@ -19,7 +19,7 @@ public:
         bool complete { false };
     };
 
-    SmoothScrollAnimation(Gfx::FloatPoint start_offset, Gfx::FloatPoint destination_offset);
+    SmoothScrollAnimation(Gfx::FloatPoint start_offset, Gfx::FloatPoint destination_offset, double pixels_per_css_pixel);
 
     AK::Duration duration() const { return m_duration; }
     Sample sample(AK::Duration elapsed) const;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3363,7 +3363,8 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
         if (true) {
             // -> If scrolling box is associated with an element
             if (auto* element = as_if<Element>(scrolling_box)) {
-                ancestor_promises.append(element->document().navigable()->perform_a_scroll_of_an_element(*element, position, behavior));
+                if (auto navigable = element->document().navigable())
+                    ancestor_promises.append(navigable->perform_a_scroll_of_an_element(*element, position, behavior));
             }
             // -> If scrolling box is associated with a viewport
             else if (scrolling_box.is_document()) {
@@ -3373,7 +3374,8 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
                 // 2. Let root element be document’s root element, if there is one, or null otherwise.
                 // 3. Perform a scroll of the viewport to position, with root element as the associated element and behavior as the scroll behavior.
                 //    Add the Promise returned from this step in the set ancestorPromises.
-                ancestor_promises.append(document.navigable()->perform_a_scroll_of_the_viewport(position, behavior));
+                if (auto navigable = document.navigable())
+                    ancestor_promises.append(navigable->perform_a_scroll_of_the_viewport(position, behavior));
             }
         }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2612,10 +2612,10 @@ void Element::set_scroll_left(double x)
     // FIXME: or the element has no overflow.
 
     // 11. Scroll the element to x,scrollTop, with the scroll behavior being "auto".
-    // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(CSSPixels::nearest_value_for(x));
-    paintable_box()->set_scroll_offset(scroll_offset);
+    if (auto navigable = document.navigable())
+        navigable->perform_a_scroll_of_an_element(*this, scroll_offset, Bindings::ScrollBehavior::Auto);
 }
 
 void Element::set_scroll_top(double y)
@@ -2669,10 +2669,10 @@ void Element::set_scroll_top(double y)
     // FIXME: or the element has no overflow.
 
     // 11. Scroll the element to scrollLeft,y, with the scroll behavior being "auto".
-    // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_y(CSSPixels::nearest_value_for(y));
-    paintable_box()->set_scroll_offset(scroll_offset);
+    if (auto navigable = document.navigable())
+        navigable->perform_a_scroll_of_an_element(*this, scroll_offset, Bindings::ScrollBehavior::Auto);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth
@@ -3333,7 +3333,8 @@ static CSSPixelPoint determine_the_scroll_into_view_position(Element& target, Bi
 // https://drafts.csswg.org/cssom-view-1/#scroll-a-target-into-view
 static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bindings::ScrollBehavior behavior, Bindings::ScrollLogicalPosition block, Bindings::ScrollLogicalPosition inline_, GC::Ptr<Element> container)
 {
-    // FIXME: 1. Let ancestorPromises be an empty set of Promises.
+    // 1. Let ancestorPromises be an empty set of Promises.
+    GC::RootVector<GC::Ref<WebIDL::Promise>> ancestor_promises;
 
     // 2. For each ancestor element or viewport that establishes a scrolling box scrolling box, in order of innermost
     //    to outermost scrolling box, run these substeps:
@@ -3354,7 +3355,6 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
         // 2. Let position be the scroll position resulting from running the steps to determine the scroll-into-view
         //    position of target with behavior as the scroll behavior, block as the block flow position, inline as the
         //    inline base direction position and scrolling box as the scrolling box.
-        // FIXME: Pass in behavior.
         auto position = determine_the_scroll_into_view_position(target, block, inline_, scrolling_box);
 
         // 3. If position is not the same as scrolling box’s current scroll position, or scrolling box has an ongoing
@@ -3363,20 +3363,17 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
         if (true) {
             // -> If scrolling box is associated with an element
             if (auto* element = as_if<Element>(scrolling_box)) {
-                // FIXME: Perform a scroll of the element’s scrolling box to position, with the element as the associated element and behavior as the scroll behavior.
-                element->paintable_box()->set_scroll_offset(position);
+                ancestor_promises.append(element->document().navigable()->perform_a_scroll_of_an_element(*element, position, behavior));
             }
             // -> If scrolling box is associated with a viewport
             else if (scrolling_box.is_document()) {
                 // 1. Let document be the viewport’s associated Document.
                 auto& document = static_cast<Document&>(scrolling_box);
 
-                // FIXME: 2. Let root element be document’s root element, if there is one, or null otherwise.
-                // FIXME: 3. Perform a scroll of the viewport to position, with root element as the associated element and behavior as the scroll behavior.
-                //           Add the Promise returned from this step in the set ancestorPromises.
-                (void)behavior;
-
-                document.navigable()->perform_a_scroll_of_the_viewport(position);
+                // 2. Let root element be document’s root element, if there is one, or null otherwise.
+                // 3. Perform a scroll of the viewport to position, with root element as the associated element and behavior as the scroll behavior.
+                //    Add the Promise returned from this step in the set ancestorPromises.
+                ancestor_promises.append(document.navigable()->perform_a_scroll_of_the_viewport(position, behavior));
             }
         }
 
@@ -3389,13 +3386,20 @@ static GC::Ref<WebIDL::Promise> scroll_an_element_into_view(Element& target, Bin
     }
 
     // 3. Let scrollPromise be a new Promise.
-    auto scroll_promise = WebIDL::create_promise(target.realm());
+    auto& realm = target.realm();
+    auto scroll_promise = WebIDL::create_promise(realm);
 
     // 4. Return scrollPromise, and run the remaining steps in parallel.
     // 5. Resolve scrollPromise when all Promises in ancestorPromises have settled.
-    // FIXME: Actually wait for those promises.
-    WebIDL::resolve_promise(target.realm(), scroll_promise);
-
+    auto resolve_scroll_promise = [&realm, scroll_promise] {
+        HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+        WebIDL::resolve_promise(realm, scroll_promise);
+    };
+    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    WebIDL::wait_for_all(
+        realm, ancestor_promises,
+        [resolve_scroll_promise](auto const&) { resolve_scroll_promise(); },
+        [resolve_scroll_promise](JS::Value) { resolve_scroll_promise(); });
     return scroll_promise;
 }
 
@@ -4152,8 +4156,22 @@ GC::Ref<WebIDL::Promise> Element::scroll(double x, double y)
     //     3. Normalize non-finite values for x and y.
     //     4. Let the left dictionary member of options have the value x.
     //     5. Let the top dictionary member of options have the value y.
-    x = HTML::normalize_non_finite_values(x);
-    y = HTML::normalize_non_finite_values(y);
+    Bindings::ScrollToOptions options;
+    options.left = HTML::normalize_non_finite_values(x);
+    options.top = HTML::normalize_non_finite_values(y);
+    return scroll(options);
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-element-scroll
+GC::Ref<WebIDL::Promise> Element::scroll(Bindings::ScrollToOptions options)
+{
+    // 1. If invoked with one argument, follow these substeps:
+    //     1. Let options be the argument.
+    //     2. Normalize non-finite values for left and top dictionary members of options, if present.
+    //     3. Let x be the value of the left dictionary member of options, if present, or the element’s current scroll position on the x axis otherwise.
+    //     4. Let y be the value of the top dictionary member of options, if present, or the element’s current scroll position on the y axis otherwise.
+    auto x = options.left.has_value() ? HTML::normalize_non_finite_values(options.left.value()) : scroll_left();
+    auto y = options.top.has_value() ? HTML::normalize_non_finite_values(options.top.value()) : scroll_top();
 
     // 3. Let document be the element’s node document.
     auto& document = this->document();
@@ -4175,29 +4193,25 @@ GC::Ref<WebIDL::Promise> Element::scroll(double x, double y)
     if (document.document_element() == this && document.in_quirks_mode())
         return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
 
-    // OPTIMIZATION: Scrolling an unscrolled element to (0, 0) is a no-op as long
-    //               as the element is not eligible to be the Document.scrollingElement.
-    if (x == 0
-        && y == 0
-        && scroll_offset({}).is_zero()
-        && this != document.body()
-        && this != document.document_element()) {
-        return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
-    }
-
     // NB: Ensure that layout is up-to-date before looking at metrics.
     document.update_layout(UpdateLayoutReason::ElementScroll);
 
     // 8. If the element is the root element, return the Promise returned by scroll() on window after the method is
     //    invoked with scrollX on window as first argument and y as second argument, and abort the remaining steps.
-    if (document.document_element() == this)
-        return window->scroll(window->scroll_x(), y);
+    if (document.document_element() == this) {
+        options.left = window->scroll_x();
+        options.top = y;
+        return window->scroll(options);
+    }
 
     // 9. If the element is the body element, document is in quirks mode, and the element is not potentially
     //    scrollable, return the Promise returned by scroll() on window after the method is invoked with options as the
     //    only argument, and abort the remaining steps.
-    if (document.body() == this && document.in_quirks_mode() && !is_potentially_scrollable())
-        return window->scroll(x, y);
+    if (document.body() == this && document.in_quirks_mode() && !is_potentially_scrollable()) {
+        options.left = x;
+        options.top = y;
+        return window->scroll(options);
+    }
 
     // 10. If the element does not have any associated box, the element has no associated scrolling box, or the element
     //     has no overflow, return a resolved Promise and abort the remaining steps.
@@ -4207,29 +4221,16 @@ GC::Ref<WebIDL::Promise> Element::scroll(double x, double y)
 
     // 11. Scroll the element to x,y, with the scroll behavior being the value of the behavior dictionary member of
     //     options. Let scrollPromise be the Promise returned from this step.
-    // FIXME: Implement this in terms of calling "scroll the element".
     auto scroll_offset = paintable_box()->scroll_offset();
     scroll_offset.set_x(CSSPixels::nearest_value_for(x));
     scroll_offset.set_y(CSSPixels::nearest_value_for(y));
-    paintable_box()->set_scroll_offset(scroll_offset);
-    auto scroll_promise = WebIDL::create_resolved_promise(realm(), JS::js_undefined());
+    auto navigable = document.navigable();
+    if (!navigable)
+        return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
+    auto scroll_promise = navigable->perform_a_scroll_of_an_element(*this, scroll_offset, options.behavior);
 
     // 12. Return scrollPromise.
     return scroll_promise;
-}
-
-// https://drafts.csswg.org/cssom-view/#dom-element-scroll
-GC::Ref<WebIDL::Promise> Element::scroll(Bindings::ScrollToOptions options)
-{
-    // 1. If invoked with one argument, follow these substeps:
-    //     1. Let options be the argument.
-    //     2. Normalize non-finite values for left and top dictionary members of options, if present.
-    //     3. Let x be the value of the left dictionary member of options, if present, or the element’s current scroll position on the x axis otherwise.
-    //     4. Let y be the value of the top dictionary member of options, if present, or the element’s current scroll position on the y axis otherwise.
-    // NOTE: remaining steps performed by Element::scroll(double x, double y)
-    auto x = options.left.has_value() ? HTML::normalize_non_finite_values(options.left.value()) : scroll_left();
-    auto y = options.top.has_value() ? HTML::normalize_non_finite_values(options.top.value()) : scroll_top();
-    return scroll(x, y);
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollby

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -379,8 +379,10 @@ void EventLoop::update_the_rendering()
 
     // 9. For each doc of docs, run the scroll steps for doc. [CSSOMVIEW]
     for (auto& document : docs) {
-        if (auto navigable = document->navigable())
+        if (auto navigable = document->navigable()) {
+            navigable->process_main_thread_smooth_scrolls();
             navigable->adopt_pending_async_scroll_offsets();
+        }
         document->run_the_scroll_steps();
     }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3750,7 +3750,12 @@ void LocalNavigable::wait_for_async_scroll_operation(Compositor::AsyncScrollOper
         return;
     }
 
-    m_pending_async_scroll_operations.append({ .operation_id = operation_id, .promise = promise });
+    m_pending_async_scroll_operations.append({
+        .operation_id = operation_id,
+        .promise = promise,
+        .stable_node_id = {},
+        .initial_scroll_offset = {},
+    });
 }
 
 void LocalNavigable::resolve_async_scroll_operation(Compositor::AsyncScrollOperationID operation_id)

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4640,7 +4640,7 @@ GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_a_scrolling_box(Com
             static_cast<float>(position.y().to_double() * device_pixels_per_css_pixel),
         };
         auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
-        auto enqueue_result = compositor_context().smooth_scroll_to(stable_node_id, target_offset, viewport_rect);
+        auto enqueue_result = compositor_context().smooth_scroll_to(stable_node_id, target_offset, viewport_rect, device_pixels_per_css_pixel);
         if (enqueue_result.accepted) {
             VERIFY(enqueue_result.operation_id.has_value());
             m_pending_async_scroll_operations.append({
@@ -4672,7 +4672,7 @@ GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_a_scrolling_box(Com
     }
     m_main_thread_smooth_scrolls.append({
         .stable_node_id = stable_node_id,
-        .animation = Compositor::SmoothScrollAnimation { initial_scroll_offset->to_type<float>(), position.to_type<float>() },
+        .animation = Compositor::SmoothScrollAnimation { initial_scroll_offset->to_type<float>(), position.to_type<float>(), 1.0 },
         .last_tick = MonotonicTime::now(),
         .elapsed = AK::Duration::zero(),
         .initial_scroll_offset = *initial_scroll_offset,

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -678,6 +678,8 @@ void LocalNavigable::visit_edges(Cell::Visitor& visitor)
 
     for (auto& async_scroll_operation : m_pending_async_scroll_operations)
         visitor.visit(async_scroll_operation.promise);
+    for (auto& smooth_scroll : m_main_thread_smooth_scrolls)
+        visitor.visit(smooth_scroll.promise);
 }
 
 void LocalNavigable::NavigateParams::visit_edges(Cell::Visitor& visitor)
@@ -3748,7 +3750,7 @@ void LocalNavigable::wait_for_async_scroll_operation(Compositor::AsyncScrollOper
         return;
     }
 
-    m_pending_async_scroll_operations.append({ operation_id, promise });
+    m_pending_async_scroll_operations.append({ .operation_id = operation_id, .promise = promise });
 }
 
 void LocalNavigable::resolve_async_scroll_operation(Compositor::AsyncScrollOperationID operation_id)
@@ -3757,6 +3759,11 @@ void LocalNavigable::resolve_async_scroll_operation(Compositor::AsyncScrollOpera
         if (pending.operation_id != operation_id)
             return false;
 
+        if (pending.stable_node_id.has_value() && pending.initial_scroll_offset.has_value()) {
+            auto final_scroll_offset = scroll_offset_for(*pending.stable_node_id);
+            if (final_scroll_offset.has_value() && *final_scroll_offset != *pending.initial_scroll_offset)
+                queue_scrollend_event(*pending.stable_node_id);
+        }
         queue_async_scroll_operation_promise_resolution(pending.promise);
         return true;
     });
@@ -3766,8 +3773,157 @@ void LocalNavigable::resolve_all_pending_async_scroll_operations()
 {
     while (!m_pending_async_scroll_operations.is_empty()) {
         auto pending = m_pending_async_scroll_operations.take_last();
+        if (pending.stable_node_id.has_value() && pending.initial_scroll_offset.has_value()) {
+            auto final_scroll_offset = scroll_offset_for(*pending.stable_node_id);
+            if (final_scroll_offset.has_value() && *final_scroll_offset != *pending.initial_scroll_offset)
+                queue_scrollend_event(*pending.stable_node_id);
+        }
         queue_async_scroll_operation_promise_resolution(pending.promise);
     }
+
+    while (!m_main_thread_smooth_scrolls.is_empty()) {
+        auto smooth_scroll = m_main_thread_smooth_scrolls.take_last();
+        auto final_scroll_offset = scroll_offset_for(smooth_scroll.stable_node_id);
+        if (final_scroll_offset.has_value() && *final_scroll_offset != smooth_scroll.initial_scroll_offset)
+            queue_scrollend_event(smooth_scroll.stable_node_id);
+        queue_async_scroll_operation_promise_resolution(smooth_scroll.promise);
+    }
+}
+
+Optional<CSSPixelPoint> LocalNavigable::scroll_offset_for(Compositor::AsyncScrollNodeStableID stable_node_id) const
+{
+    auto document = active_document();
+    if (!document)
+        return {};
+
+    if (stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
+        if (stable_node_id.node_id != document->unique_id())
+            return {};
+        return m_viewport_scroll_offset;
+    }
+
+    auto* element = element_for_async_scroll_node_stable_id(*document, stable_node_id);
+    if (!element)
+        return {};
+    return element->scroll_offset(pseudo_element_from_async_scroll_node_stable_id(stable_node_id));
+}
+
+bool LocalNavigable::set_scroll_offset_for(Compositor::AsyncScrollNodeStableID stable_node_id, CSSPixelPoint scroll_offset)
+{
+    auto document = active_document();
+    if (!document)
+        return false;
+
+    if (stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
+        if (stable_node_id.node_id != document->unique_id())
+            return false;
+        auto old_scroll_offset = m_viewport_scroll_offset;
+        perform_scroll_of_viewport_scrolling_box(scroll_offset);
+        return old_scroll_offset != m_viewport_scroll_offset;
+    }
+
+    auto* element = element_for_async_scroll_node_stable_id(*document, stable_node_id);
+    if (!element)
+        return false;
+    document->update_layout(DOM::UpdateLayoutReason::ElementScroll);
+    Optional<CSS::PseudoElement> pseudo_element = pseudo_element_from_async_scroll_node_stable_id(stable_node_id);
+    RefPtr<Painting::Paintable> paintable;
+    if (pseudo_element.has_value()) {
+        auto synthetic_pseudo_element = element->get_synthetic_pseudo_element(*pseudo_element);
+        if (!synthetic_pseudo_element.has_value() || !synthetic_pseudo_element->layout_node())
+            return false;
+        paintable = synthetic_pseudo_element->layout_node()->paintable();
+    } else {
+        paintable = element->paintable_box();
+    }
+    if (!paintable)
+        return false;
+    return paintable->set_scroll_offset(scroll_offset) == Painting::Paintable::ScrollHandled::Yes;
+}
+
+void LocalNavigable::queue_scrollend_event(Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    auto document = active_document();
+    if (!document)
+        return;
+
+    GC::Ptr<DOM::EventTarget> target;
+    if (stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
+        if (stable_node_id.node_id != document->unique_id())
+            return;
+        target = document;
+    } else {
+        target = element_for_async_scroll_node_stable_id(*document, stable_node_id);
+    }
+    if (!target)
+        return;
+
+    DOM::Document::PendingScrollEvent pending_event { *target, EventNames::scrollend };
+    if (!document->pending_scroll_events().contains_slow(pending_event))
+        document->pending_scroll_events().append(pending_event);
+}
+
+void LocalNavigable::resolve_pending_smooth_scrolls(Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    for (size_t index = 0; index < m_pending_async_scroll_operations.size();) {
+        auto const& pending = m_pending_async_scroll_operations[index];
+        if (pending.stable_node_id != stable_node_id) {
+            ++index;
+            continue;
+        }
+        if (pending.initial_scroll_offset.has_value()) {
+            auto final_scroll_offset = scroll_offset_for(stable_node_id);
+            if (final_scroll_offset.has_value() && *final_scroll_offset != *pending.initial_scroll_offset)
+                queue_scrollend_event(stable_node_id);
+        }
+        queue_async_scroll_operation_promise_resolution(pending.promise);
+        m_pending_async_scroll_operations.remove(index);
+    }
+
+    for (size_t index = 0; index < m_main_thread_smooth_scrolls.size();) {
+        auto const& smooth_scroll = m_main_thread_smooth_scrolls[index];
+        if (smooth_scroll.stable_node_id != stable_node_id) {
+            ++index;
+            continue;
+        }
+        auto final_scroll_offset = scroll_offset_for(stable_node_id);
+        if (final_scroll_offset.has_value() && *final_scroll_offset != smooth_scroll.initial_scroll_offset)
+            queue_scrollend_event(stable_node_id);
+        queue_async_scroll_operation_promise_resolution(smooth_scroll.promise);
+        m_main_thread_smooth_scrolls.remove(index);
+    }
+}
+
+void LocalNavigable::process_main_thread_smooth_scrolls()
+{
+    auto now = MonotonicTime::now();
+    for (size_t index = 0; index < m_main_thread_smooth_scrolls.size();) {
+        auto& smooth_scroll = m_main_thread_smooth_scrolls[index];
+        if (!scroll_offset_for(smooth_scroll.stable_node_id).has_value()) {
+            queue_async_scroll_operation_promise_resolution(smooth_scroll.promise);
+            m_main_thread_smooth_scrolls.remove(index);
+            continue;
+        }
+
+        auto elapsed_since_last_tick = now - smooth_scroll.last_tick;
+        auto minimum_tick_duration = AK::Duration::from_milliseconds(1);
+        smooth_scroll.elapsed += max(elapsed_since_last_tick, minimum_tick_duration);
+        smooth_scroll.last_tick = now;
+        auto sample = smooth_scroll.animation.sample(smooth_scroll.elapsed);
+        set_scroll_offset_for(smooth_scroll.stable_node_id, sample.offset.to_type<CSSPixels>());
+        if (sample.complete) {
+            auto final_scroll_offset = scroll_offset_for(smooth_scroll.stable_node_id);
+            if (final_scroll_offset.has_value() && *final_scroll_offset != smooth_scroll.initial_scroll_offset)
+                queue_scrollend_event(smooth_scroll.stable_node_id);
+            queue_async_scroll_operation_promise_resolution(smooth_scroll.promise);
+            m_main_thread_smooth_scrolls.remove(index);
+        } else {
+            ++index;
+        }
+    }
+
+    if (!m_main_thread_smooth_scrolls.is_empty())
+        main_thread_event_loop().queue_task_to_update_the_rendering();
 }
 
 static bool adopt_async_viewport_scroll_delta(LocalNavigable& navigable, CSSPixelPoint scroll_delta)
@@ -3805,14 +3961,35 @@ void LocalNavigable::adopt_pending_async_scroll_offsets()
     }
 
     auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
-    bool adopted_any_scroll_delta = false;
+    bool adopted_any_scroll_offset = false;
     for (auto const& async_scroll_offset : async_scroll_updates.scroll_offsets) {
         auto css_scroll_delta = async_scroll_offset_to_css_pixels(async_scroll_offset.unadopted_scroll_delta, device_pixels_per_css_pixel);
+        bool is_programmatic_smooth_scroll = false;
+        for (auto const& pending_operation : m_pending_async_scroll_operations) {
+            if (pending_operation.stable_node_id == async_scroll_offset.stable_node_id) {
+                is_programmatic_smooth_scroll = true;
+                break;
+            }
+        }
+
+        // NB: A programmatic smooth scroll has an absolute destination. Adopt the
+        //     compositor's absolute position so that replacing scroll snapshots
+        //     during the animation cannot cause overlapping deltas to accumulate.
+        if (is_programmatic_smooth_scroll) {
+            auto css_scroll_offset = async_scroll_offset_to_css_pixels(async_scroll_offset.compositor_scroll_offset, device_pixels_per_css_pixel);
+            if (set_scroll_offset_for(async_scroll_offset.stable_node_id, css_scroll_offset)) {
+                adopted_any_scroll_offset = true;
+                dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async programmatic scroll offset {},{}",
+                    async_scroll_offset.compositor_scroll_offset.x(), async_scroll_offset.compositor_scroll_offset.y());
+            }
+            continue;
+        }
+
         if (async_scroll_offset.stable_node_id.kind == Compositor::AsyncScrollNodeKind::Viewport) {
             if (async_scroll_offset.stable_node_id.node_id != document->unique_id())
                 continue;
             if (adopt_async_viewport_scroll_delta(*this, css_scroll_delta)) {
-                adopted_any_scroll_delta = true;
+                adopted_any_scroll_offset = true;
                 dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async viewport delta {},{}",
                     async_scroll_offset.unadopted_scroll_delta.x(), async_scroll_offset.unadopted_scroll_delta.y());
             }
@@ -3820,13 +3997,13 @@ void LocalNavigable::adopt_pending_async_scroll_offsets()
         }
 
         if (adopt_async_element_scroll_delta(*document, async_scroll_offset.stable_node_id, css_scroll_delta)) {
-            adopted_any_scroll_delta = true;
+            adopted_any_scroll_offset = true;
             dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread adopting async element delta {},{}",
                 async_scroll_offset.unadopted_scroll_delta.x(), async_scroll_offset.unadopted_scroll_delta.y());
         }
     }
 
-    if (adopted_any_scroll_delta)
+    if (adopted_any_scroll_offset)
         schedule_hover_update_after_async_scroll();
 
     for (auto operation_id : async_scroll_updates.completed_operation_ids)
@@ -4411,15 +4588,113 @@ void LocalNavigable::render_screenshot(Gfx::PaintingSurface& painting_surface, P
     compositor_context().request_screenshot(painting_surface, move(callback));
 }
 
+GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_a_scrolling_box(Compositor::AsyncScrollNodeStableID stable_node_id, CSSPixelPoint position, Bindings::ScrollBehavior behavior, GC::Ptr<DOM::Element> associated_element)
+{
+    auto document = active_document();
+    VERIFY(document);
+    auto initial_scroll_offset = scroll_offset_for(stable_node_id);
+    if (!initial_scroll_offset.has_value())
+        return WebIDL::create_resolved_promise(document->realm(), JS::js_undefined());
+
+    auto should_scroll_smoothly = behavior == Bindings::ScrollBehavior::Smooth;
+    if (behavior == Bindings::ScrollBehavior::Auto && associated_element) {
+        if (auto computed_values = associated_element->computed_values())
+            should_scroll_smoothly = computed_values->scroll_behavior() == CSS::ScrollBehavior::Smooth;
+    }
+
+    // https://drafts.csswg.org/cssom-view-1/#perform-a-scroll
+    // 1. Abort any ongoing smooth scroll for box.
+    if (has_compositor_context())
+        compositor_context().cancel_smooth_scroll(stable_node_id);
+    // 2. Resolve all pending scroll promises for box.
+    resolve_pending_smooth_scrolls(stable_node_id);
+
+    // 3. Let scrollPromise be a new promise and return it while the remaining
+    //    steps run in parallel.
+    auto scroll_promise = WebIDL::create_promise(document->realm());
+
+    // 4. If the user agent honors the scroll-behavior property and either the
+    //    requested behavior or the associated element's computed behavior is
+    //    smooth, perform a smooth scroll. Otherwise, perform an instant scroll.
+    if (!should_scroll_smoothly) {
+        auto did_scroll = set_scroll_offset_for(stable_node_id, position);
+        if (did_scroll)
+            queue_scrollend_event(stable_node_id);
+        WebIDL::resolve_promise(document->realm(), scroll_promise);
+        return scroll_promise;
+    }
+
+    if (has_compositor_context()) {
+        // NB: Do not adopt compositor progress while replacing one smooth scroll
+        //     with another. All listeners in the current JavaScript task must
+        //     observe the same main-thread scroll offset. The compositor starts
+        //     the replacement from its own current visual offset.
+        auto device_pixels_per_css_pixel = page().client().device_pixels_per_css_pixel();
+        auto target_offset = Gfx::FloatPoint {
+            static_cast<float>(position.x().to_double() * device_pixels_per_css_pixel),
+            static_cast<float>(position.y().to_double() * device_pixels_per_css_pixel),
+        };
+        auto viewport_rect = page().css_to_device_rect(this->viewport_rect()).to_type<int>();
+        auto enqueue_result = compositor_context().smooth_scroll_to(stable_node_id, target_offset, viewport_rect);
+        if (enqueue_result.accepted) {
+            VERIFY(enqueue_result.operation_id.has_value());
+            m_pending_async_scroll_operations.append({
+                .operation_id = *enqueue_result.operation_id,
+                .promise = scroll_promise,
+                .stable_node_id = stable_node_id,
+                .initial_scroll_offset = *initial_scroll_offset,
+            });
+            return scroll_promise;
+        }
+    }
+
+    // NB: A page can lack compositor scroll state before its first paint, or
+    //     asynchronous scrolling can be disabled. Keep the same algorithm on
+    //     the main thread in those cases.
+    if (has_compositor_context()) {
+        // NB: The compositor rejected the replacement, so consume its last
+        //     offset before falling back to a main-thread animation.
+        adopt_pending_async_scroll_offsets();
+        initial_scroll_offset = scroll_offset_for(stable_node_id);
+        if (!initial_scroll_offset.has_value()) {
+            WebIDL::resolve_promise(document->realm(), scroll_promise);
+            return scroll_promise;
+        }
+    }
+    if (position == *initial_scroll_offset) {
+        WebIDL::resolve_promise(document->realm(), scroll_promise);
+        return scroll_promise;
+    }
+    m_main_thread_smooth_scrolls.append({
+        .stable_node_id = stable_node_id,
+        .animation = Compositor::SmoothScrollAnimation { initial_scroll_offset->to_type<float>(), position.to_type<float>() },
+        .last_tick = MonotonicTime::now(),
+        .elapsed = AK::Duration::zero(),
+        .initial_scroll_offset = *initial_scroll_offset,
+        .promise = scroll_promise,
+    });
+    main_thread_event_loop().queue_task_to_update_the_rendering();
+    return scroll_promise;
+}
+
+GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_an_element(DOM::Element& element, CSSPixelPoint position, Bindings::ScrollBehavior behavior)
+{
+    return perform_a_scroll_of_a_scrolling_box({
+                                                   .node_id = element.unique_id(),
+                                                   .kind = Compositor::AsyncScrollNodeKind::Element,
+                                               },
+        position, behavior, element);
+}
+
 GC::Ref<WebIDL::Promise> LocalNavigable::scroll_viewport_by_delta(CSSPixelPoint delta)
 {
     auto vv = active_document()->visual_viewport();
     CSSPixelPoint page_position { CSSPixels(vv->page_left()), CSSPixels(vv->page_top()) };
-    return perform_a_scroll_of_the_viewport(page_position + delta);
+    return perform_a_scroll_of_the_viewport(page_position + delta, Bindings::ScrollBehavior::Instant);
 }
 
 // https://drafts.csswg.org/cssom-view/#viewport-perform-a-scroll
-GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_the_viewport(CSSPixelPoint position)
+GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_the_viewport(CSSPixelPoint position, Bindings::ScrollBehavior behavior)
 {
     // 1. Let doc be the viewport’s associated Document.
     auto doc = active_document();
@@ -4475,13 +4750,11 @@ GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_the_viewport(CSSPix
     new_viewport_scroll_offset.set_x(max(0.0, min(new_viewport_scroll_offset.x(), scrolling_area.width() - viewport_size().width().to_double())));
     new_viewport_scroll_offset.set_y(max(0.0, min(new_viewport_scroll_offset.y(), scrolling_area.height() - viewport_size().height().to_double())));
 
-    // AD-HOC: If the scroll position would not change, return early to avoid unnecessary display invalidation
-    //         and event loop scheduling (e.g. during momentum scrolling against a boundary).
-    if (new_viewport_scroll_offset.to_type<CSSPixels>() == m_viewport_scroll_offset && visual_dx == 0.0 && visual_dy == 0.0)
-        return WebIDL::create_resolved_promise(doc->realm(), JS::js_undefined());
-
-    // FIXME: Get a Promise from this.
-    perform_scroll_of_viewport_scrolling_box(new_viewport_scroll_offset.to_type<CSSPixels>());
+    auto scroll_promise = perform_a_scroll_of_a_scrolling_box({
+                                                                  .node_id = doc->unique_id(),
+                                                                  .kind = Compositor::AsyncScrollNodeKind::Viewport,
+                                                              },
+        new_viewport_scroll_offset.to_type<CSSPixels>(), behavior, doc->document_element());
 
     // 15. Perform a scroll of vv’s scrolling box to its current scroll position + (visual dx, visual dy) with element
     //     as the associated element, and behavior as the scroll behavior. Let scrollPromise2 be the Promise returned
@@ -4491,13 +4764,9 @@ GC::Ref<WebIDL::Promise> LocalNavigable::perform_a_scroll_of_the_viewport(CSSPix
     if (visual_dx == 0.0 && visual_dy == 0.0)
         doc->set_needs_repaint(Badge<HTML::LocalNavigable> {}, InvalidateDisplayList::No);
 
-    // 16. Let scrollPromise be a new Promise.
-    auto scroll_promise = WebIDL::create_promise(doc->realm());
-
     // 17. Return scrollPromise, and run the remaining steps in parallel.
     // 18. Resolve scrollPromise when both scrollPromise1 and scrollPromise2 have settled.
-    // FIXME: Actually wait for scroll to occur. For now, all our scrolls are instant.
-    WebIDL::resolve_promise(doc->realm(), scroll_promise);
+    // FIXME: Actually wait for visual viewport scrolling to settle as well.
     return scroll_promise;
 }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -15,7 +15,9 @@
 #include <AK/Utf16View.h>
 #include <LibCore/Forward.h>
 #include <LibWeb/Bindings/Navigation.h>
+#include <LibWeb/Bindings/Window.h>
 #include <LibWeb/Compositor/CompositorHost.h>
+#include <LibWeb/Compositor/SmoothScrollAnimation.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
@@ -230,6 +232,7 @@ public:
     void set_viewport_size(CSSPixelSize, InvalidateDisplayList = InvalidateDisplayList::No);
     void perform_scroll_of_viewport_scrolling_box(CSSPixelPoint position);
     void adopt_pending_async_scroll_offsets();
+    void process_main_thread_smooth_scrolls();
     void wait_for_async_scroll_operation(Compositor::AsyncScrollOperationID, GC::Ref<WebIDL::Promise>);
     void clamp_viewport_scroll_offset();
 
@@ -307,7 +310,8 @@ public:
     bool fast_is() const = delete;
 
     GC::Ref<WebIDL::Promise> scroll_viewport_by_delta(CSSPixelPoint delta);
-    GC::Ref<WebIDL::Promise> perform_a_scroll_of_the_viewport(CSSPixelPoint position);
+    GC::Ref<WebIDL::Promise> perform_a_scroll_of_the_viewport(CSSPixelPoint position, Bindings::ScrollBehavior = Bindings::ScrollBehavior::Auto);
+    GC::Ref<WebIDL::Promise> perform_a_scroll_of_an_element(DOM::Element&, CSSPixelPoint position, Bindings::ScrollBehavior);
     void reset_zoom();
 
 protected:
@@ -343,6 +347,11 @@ private:
     void inform_the_navigation_api_about_aborting_navigation();
     void resolve_async_scroll_operation(Compositor::AsyncScrollOperationID);
     void resolve_all_pending_async_scroll_operations();
+    void resolve_pending_smooth_scrolls(Compositor::AsyncScrollNodeStableID);
+    GC::Ref<WebIDL::Promise> perform_a_scroll_of_a_scrolling_box(Compositor::AsyncScrollNodeStableID, CSSPixelPoint position, Bindings::ScrollBehavior, GC::Ptr<DOM::Element> associated_element);
+    Optional<CSSPixelPoint> scroll_offset_for(Compositor::AsyncScrollNodeStableID) const;
+    bool set_scroll_offset_for(Compositor::AsyncScrollNodeStableID, CSSPixelPoint);
+    void queue_scrollend_event(Compositor::AsyncScrollNodeStableID);
     void schedule_hover_update_after_async_scroll();
     void update_hover_after_async_scroll_stops();
     void cancel_hover_update_after_async_scroll();
@@ -411,8 +420,20 @@ private:
     struct PendingAsyncScrollOperation {
         Compositor::AsyncScrollOperationID operation_id { 0 };
         GC::Ref<WebIDL::Promise> promise;
+        Optional<Compositor::AsyncScrollNodeStableID> stable_node_id;
+        Optional<CSSPixelPoint> initial_scroll_offset;
     };
     Vector<PendingAsyncScrollOperation> m_pending_async_scroll_operations;
+
+    struct MainThreadSmoothScroll {
+        Compositor::AsyncScrollNodeStableID stable_node_id;
+        Compositor::SmoothScrollAnimation animation;
+        MonotonicTime last_tick;
+        AK::Duration elapsed;
+        CSSPixelPoint initial_scroll_offset;
+        GC::Ref<WebIDL::Promise> promise;
+    };
+    Vector<MainThreadSmoothScroll> m_main_thread_smooth_scrolls;
 };
 
 struct PopulateSessionHistoryEntryDocumentOutput final : public JS::Cell {

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1610,14 +1610,11 @@ GC::Ref<WebIDL::Promise> Window::scroll(Bindings::ScrollToOptions const& options
     // FIXME: 9. Let position be the scroll position the viewport would have by aligning the x-coordinate x of the viewport
     //           scrolling area with the left of the viewport and aligning the y-coordinate y of the viewport scrolling area
     //           with the top of the viewport.
-    auto position = Gfx::FloatPoint { x, y };
+    auto position = CSSPixelPoint { x, y };
 
     // 10. If position is the same as the viewport’s current scroll position, and the viewport does not have an ongoing
     //     smooth scroll, return a resolved Promise and abort the remaining steps.
-    if (position == viewport_rect.location()) {
-        TemporaryExecutionContext temporary_execution_context { realm() };
-        return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
-    }
+    // NB: perform a scroll checks this after aborting any ongoing smooth scroll.
 
     // 11. Let document be the viewport’s associated Document.
     // NB: document is already defined above.
@@ -1625,7 +1622,7 @@ GC::Ref<WebIDL::Promise> Window::scroll(Bindings::ScrollToOptions const& options
     // 12. Perform a scroll of the viewport to position, document’s root element as the associated element, if there is
     //     one, or null otherwise, and the scroll behavior being the value of the behavior dictionary member of options.
     //     Let scrollPromise be the Promise returned from this step.
-    auto scroll_promise = navigable->perform_a_scroll_of_the_viewport({ x, y });
+    auto scroll_promise = navigable->perform_a_scroll_of_the_viewport(position, options.behavior);
 
     // 13. Return scrollPromise.
     return scroll_promise;

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -103,13 +103,18 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
     paintable.record_hit_test_items(context, phase);
 
     auto& recorder = context.display_list_recorder();
+    auto const* cache_source_display_list = context.paint_command_cache_source_display_list();
+    // NB: Some commands embed visual context indices in their payloads. Those
+    //     indices can change when the visual context tree is rebuilt, so commands
+    //     from an incompatible tree must be recorded and cached against the new tree.
+    bool const cache_reads_enabled = cache_source_display_list
+        && cache_source_display_list->compatible_visual_context_tree_version() == recorder.visual_context_tree().version();
     bool const skip_cache = paintable.fixed_background_visual_context().has_value();
     bool const cache_writes_enabled = context.paint_command_cache_mode() == PaintCommandCacheMode::ReadWrite;
-    auto const* cache_source_display_list = context.paint_command_cache_source_display_list();
     auto const phase_context_index = recorder.accumulated_visual_context();
     bool const phase_has_empty_effective_clip = recorder.visual_context_tree().has_empty_effective_clip(phase_context_index);
 
-    auto cached_commands = !skip_cache && cache_source_display_list
+    auto cached_commands = !skip_cache && cache_reads_enabled
         ? paintable.valid_cached_commands(phase, cache_source_display_list->id(), phase_has_empty_effective_clip)
         : Optional<Paintable::CachedCommandRange> {};
 

--- a/Libraries/LibWebView/CompositorConnection.cpp
+++ b/Libraries/LibWebView/CompositorConnection.cpp
@@ -162,12 +162,12 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::async_scroll_by(
     return response->take_result();
 }
 
-Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect)
+Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel)
 {
     if (!can_send_message_to_compositor())
         return {};
 
-    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::SmoothScrollTo>(context_id, stable_node_id, offset, viewport_rect);
+    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::SmoothScrollTo>(context_id, stable_node_id, offset, viewport_rect, device_pixels_per_css_pixel);
     if (!response) {
         did_lose_compositor();
         return {};

--- a/Libraries/LibWebView/CompositorConnection.cpp
+++ b/Libraries/LibWebView/CompositorConnection.cpp
@@ -162,6 +162,26 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::async_scroll_by(
     return response->take_result();
 }
 
+Web::Compositor::AsyncScrollEnqueueResult CompositorConnection::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect)
+{
+    if (!can_send_message_to_compositor())
+        return {};
+
+    auto response = send_sync_but_allow_failure<Messages::CompositorWebContentServer::SmoothScrollTo>(context_id, stable_node_id, offset, viewport_rect);
+    if (!response) {
+        did_lose_compositor();
+        return {};
+    }
+    return response->take_result();
+}
+
+void CompositorConnection::cancel_smooth_scroll(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    if (!can_send_message_to_compositor())
+        return;
+    async_cancel_smooth_scroll(context_id, stable_node_id);
+}
+
 Web::Compositor::PendingAsyncScrollUpdates CompositorConnection::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
     if (!can_send_message_to_compositor())

--- a/Libraries/LibWebView/CompositorConnection.h
+++ b/Libraries/LibWebView/CompositorConnection.h
@@ -53,6 +53,8 @@ public:
     Gfx::ShareableBitmap get_canvas_pixels(Web::Painting::CanvasId, Gfx::IntRect);
     void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
+    Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect);
+    void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);

--- a/Libraries/LibWebView/CompositorConnection.h
+++ b/Libraries/LibWebView/CompositorConnection.h
@@ -53,7 +53,7 @@ public:
     Gfx::ShareableBitmap get_canvas_pixels(Web::Painting::CanvasId, Gfx::IntRect);
     void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
-    Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect);
+    Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel);
     void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);

--- a/Libraries/LibWebView/CompositorHostBase.cpp
+++ b/Libraries/LibWebView/CompositorHostBase.cpp
@@ -257,6 +257,19 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorHostBase::async_scroll_by(We
     return {};
 }
 
+Web::Compositor::AsyncScrollEnqueueResult CompositorHostBase::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect)
+{
+    if (auto* connection = compositor_connection())
+        return connection->smooth_scroll_to(context_id, stable_node_id, offset_in_device_pixels, viewport_rect);
+    return {};
+}
+
+void CompositorHostBase::cancel_smooth_scroll(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    if (auto* connection = compositor_connection())
+        connection->cancel_smooth_scroll(context_id, stable_node_id);
+}
+
 Web::Compositor::PendingAsyncScrollUpdates CompositorHostBase::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
     if (auto* connection = compositor_connection())

--- a/Libraries/LibWebView/CompositorHostBase.cpp
+++ b/Libraries/LibWebView/CompositorHostBase.cpp
@@ -257,10 +257,10 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorHostBase::async_scroll_by(We
     return {};
 }
 
-Web::Compositor::AsyncScrollEnqueueResult CompositorHostBase::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect)
+Web::Compositor::AsyncScrollEnqueueResult CompositorHostBase::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel)
 {
     if (auto* connection = compositor_connection())
-        return connection->smooth_scroll_to(context_id, stable_node_id, offset_in_device_pixels, viewport_rect);
+        return connection->smooth_scroll_to(context_id, stable_node_id, offset_in_device_pixels, viewport_rect, device_pixels_per_css_pixel);
     return {};
 }
 

--- a/Libraries/LibWebView/CompositorHostBase.h
+++ b/Libraries/LibWebView/CompositorHostBase.h
@@ -30,6 +30,8 @@ public:
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
     virtual Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
+    virtual Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect) override;
+    virtual void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID) override;
     virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;
     virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) override;

--- a/Libraries/LibWebView/CompositorHostBase.h
+++ b/Libraries/LibWebView/CompositorHostBase.h
@@ -30,7 +30,7 @@ public:
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
     virtual Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID expected_document_id, Gfx::FloatPoint position,
         Gfx::FloatPoint delta_in_device_pixels, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
-    virtual Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect) override;
+    virtual Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset_in_device_pixels, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel) override;
     virtual void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID) override;
     virtual Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress) override;

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -234,7 +234,7 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::
     return result.enqueue_result;
 }
 
-Web::Compositor::AsyncScrollEnqueueResult CompositorState::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect)
+Web::Compositor::AsyncScrollEnqueueResult CompositorState::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel)
 {
     if (!m_async_scrolling_enabled)
         return {};
@@ -242,7 +242,7 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorState::smooth_scroll_to(Web:
     auto* context = context_if_present(context_id);
     VERIFY(context);
 
-    auto result = context->smooth_scroll_to(stable_node_id, offset, viewport_rect);
+    auto result = context->smooth_scroll_to(stable_node_id, offset, viewport_rect, device_pixels_per_css_pixel);
     if (result.frame_to_present.has_value())
         schedule_present_frame(context_id, *context, *result.frame_to_present);
     return result.enqueue_result;

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -404,7 +404,8 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
     for (auto& context_entry : m_contexts) {
         auto context_id = context_entry.key;
         auto& context = *context_entry.value;
-        if (!context.has_pending_present_frame_scheduled_on(display_id))
+        auto has_active_smooth_scroll_animation_on_display = context.has_active_smooth_scroll_animations() && context.display_id() == display_id;
+        if (!context.has_pending_present_frame_scheduled_on(display_id) && !has_active_smooth_scroll_animation_on_display)
             continue;
 
         if (auto animation_frame = context.advance_smooth_scroll_animations(now); animation_frame.has_value())
@@ -415,7 +416,8 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
         if (!pending_present_frame.has_value()) {
-            if (context.has_pending_present_frame_scheduled_on(display_id))
+            has_active_smooth_scroll_animation_on_display = context.has_active_smooth_scroll_animations() && context.display_id() == display_id;
+            if (context.has_pending_present_frame_scheduled_on(display_id) || has_active_smooth_scroll_animation_on_display)
                 vsync_scheduler_for_display(display_id).schedule(context.display_refresh_rate());
             continue;
         }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -234,6 +234,28 @@ Web::Compositor::AsyncScrollEnqueueResult CompositorState::async_scroll_by(Web::
     return result.enqueue_result;
 }
 
+Web::Compositor::AsyncScrollEnqueueResult CompositorState::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect)
+{
+    if (!m_async_scrolling_enabled)
+        return {};
+
+    auto* context = context_if_present(context_id);
+    VERIFY(context);
+
+    auto result = context->smooth_scroll_to(stable_node_id, offset, viewport_rect);
+    if (result.frame_to_present.has_value())
+        schedule_present_frame(context_id, *context, *result.frame_to_present);
+    return result.enqueue_result;
+}
+
+void CompositorState::cancel_smooth_scroll(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    auto* context = context_if_present(context_id);
+    if (!context)
+        return;
+    context->cancel_smooth_scroll(stable_node_id);
+}
+
 bool CompositorState::async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta)
 {
     if (!m_async_scrolling_enabled)
@@ -373,11 +395,18 @@ VSyncScheduler& CompositorState::vsync_scheduler_for_display(Optional<u64> displ
 
 void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
 {
+    auto now = MonotonicTime::now();
     for (auto& context_entry : m_contexts) {
         auto context_id = context_entry.key;
         auto& context = *context_entry.value;
         if (!context.has_pending_present_frame_scheduled_on(display_id))
             continue;
+
+        if (auto animation_frame = context.advance_smooth_scroll_animations(now); animation_frame.has_value())
+            context.queue_present_frame({
+                .viewport_rect = *animation_frame,
+                .damage_rect = { {}, animation_frame->size() },
+            });
 
         auto pending_present_frame = context.take_pending_present_frame_if_unblocked();
         if (!pending_present_frame.has_value()) {
@@ -385,6 +414,8 @@ void CompositorState::present_pending_frames_on_vsync(Optional<u64> display_id)
                 vsync_scheduler_for_display(display_id).schedule(context.display_refresh_rate());
             continue;
         }
+        if (context.has_active_smooth_scroll_animations())
+            schedule_present_frame(context_id, context, pending_present_frame->viewport_rect);
         present_frame(context_id, context, *pending_present_frame);
     }
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -308,6 +308,11 @@ void CompositorState::present_frame(Web::Compositor::CompositorContextId context
     VERIFY(context);
     if (context->should_defer_main_thread_present_for_async_scroll()) {
         dbgln_if(COMPOSITOR_DEBUG, "[Compositor] Main thread deferred present while async scroll is pending");
+        // NB: The in-flight compositor frame may have been rasterized before the
+        //     main thread installed its new display list. Preserve the present as
+        //     a full repaint so that it uses both the new list and the latest
+        //     compositor scroll state once presentation is unblocked.
+        schedule_present_frame(context_id, *context, viewport_rect);
         return;
     }
     damage_rect.intersect({ {}, viewport_rect.size() });

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -91,7 +91,7 @@ public:
     bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     bool handle_pinch_event(Web::Compositor::CompositorContextId, Web::PinchEvent const&);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
-    Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect);
+    Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel);
     void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID);
     bool async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -91,6 +91,8 @@ public:
     bool dispatch_mouse_event_to_web_content(Web::Compositor::CompositorContextId, Web::MouseEvent const&);
     bool handle_pinch_event(Web::Compositor::CompositorContextId, Web::PinchEvent const&);
     Web::Compositor::AsyncScrollEnqueueResult async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking);
+    Web::Compositor::AsyncScrollEnqueueResult smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect);
+    void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID);
     bool async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta);
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates(Web::Compositor::CompositorContextId);
     void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize, Web::Compositor::WindowResizingInProgress);

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -50,6 +50,8 @@ endpoint CompositorWebContentServer
 
     invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) =|
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) => (Web::Compositor::AsyncScrollEnqueueResult result)
+    smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect) => (Web::Compositor::AsyncScrollEnqueueResult result)
+    cancel_smooth_scroll(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id) =|
     take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
 
     viewport_size_updated(Web::Compositor::CompositorContextId context_id, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress window_resize_in_progress) =|

--- a/Services/Compositor/CompositorWebContentServer.ipc
+++ b/Services/Compositor/CompositorWebContentServer.ipc
@@ -50,7 +50,7 @@ endpoint CompositorWebContentServer
 
     invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId context_id, u64 generation) =|
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking operation_tracking) => (Web::Compositor::AsyncScrollEnqueueResult result)
-    smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect) => (Web::Compositor::AsyncScrollEnqueueResult result)
+    smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel) => (Web::Compositor::AsyncScrollEnqueueResult result)
     cancel_smooth_scroll(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id) =|
     take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id) => (Web::Compositor::PendingAsyncScrollUpdates updates)
 

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -238,6 +238,23 @@ Messages::CompositorWebContentServer::AsyncScrollByResponse ConnectionFromWebCon
     return result;
 }
 
+Messages::CompositorWebContentServer::SmoothScrollToResponse ConnectionFromWebContent::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect)
+{
+    if (!context_is_owned_by_this_connection(context_id))
+        return Web::Compositor::AsyncScrollEnqueueResult {};
+    auto result = m_compositor_state->smooth_scroll_to(context_id, stable_node_id, offset, viewport_rect);
+    if (result.accepted)
+        async_request_rendering_update();
+    return result;
+}
+
+void ConnectionFromWebContent::cancel_smooth_scroll(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    if (!context_is_owned_by_this_connection(context_id))
+        return;
+    m_compositor_state->cancel_smooth_scroll(context_id, stable_node_id);
+}
+
 Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse ConnectionFromWebContent::take_pending_async_scroll_updates(Web::Compositor::CompositorContextId context_id)
 {
     if (!context_is_owned_by_this_connection(context_id))

--- a/Services/Compositor/ConnectionFromWebContent.cpp
+++ b/Services/Compositor/ConnectionFromWebContent.cpp
@@ -238,11 +238,11 @@ Messages::CompositorWebContentServer::AsyncScrollByResponse ConnectionFromWebCon
     return result;
 }
 
-Messages::CompositorWebContentServer::SmoothScrollToResponse ConnectionFromWebContent::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect)
+Messages::CompositorWebContentServer::SmoothScrollToResponse ConnectionFromWebContent::smooth_scroll_to(Web::Compositor::CompositorContextId context_id, Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel)
 {
     if (!context_is_owned_by_this_connection(context_id))
         return Web::Compositor::AsyncScrollEnqueueResult {};
-    auto result = m_compositor_state->smooth_scroll_to(context_id, stable_node_id, offset, viewport_rect);
+    auto result = m_compositor_state->smooth_scroll_to(context_id, stable_node_id, offset, viewport_rect, device_pixels_per_css_pixel);
     if (result.accepted)
         async_request_rendering_update();
     return result;

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -62,7 +62,7 @@ private:
     virtual Messages::CompositorWebContentServer::WebglReadBufferSubDataResponse webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) override;
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
     virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
-    virtual Messages::CompositorWebContentServer::SmoothScrollToResponse smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect) override;
+    virtual Messages::CompositorWebContentServer::SmoothScrollToResponse smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel) override;
     virtual void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID) override;
     virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress) override;

--- a/Services/Compositor/ConnectionFromWebContent.h
+++ b/Services/Compositor/ConnectionFromWebContent.h
@@ -62,6 +62,8 @@ private:
     virtual Messages::CompositorWebContentServer::WebglReadBufferSubDataResponse webgl_read_buffer_sub_data(Web::Painting::CanvasId canvas_id, u32 target, i64 offset, i64 size, Core::AnonymousBuffer data) override;
     virtual void invalidate_wheel_event_listener_state(Web::Compositor::CompositorContextId, u64 generation) override;
     virtual Messages::CompositorWebContentServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Web::UniqueNodeID document_id, Gfx::FloatPoint position, Gfx::FloatPoint delta, Gfx::IntRect viewport_rect, Web::Compositor::AsyncScrollOperationTracking) override;
+    virtual Messages::CompositorWebContentServer::SmoothScrollToResponse smooth_scroll_to(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect) override;
+    virtual void cancel_smooth_scroll(Web::Compositor::CompositorContextId, Web::Compositor::AsyncScrollNodeStableID) override;
     virtual Messages::CompositorWebContentServer::TakePendingAsyncScrollUpdatesResponse take_pending_async_scroll_updates(Web::Compositor::CompositorContextId) override;
     virtual void viewport_size_updated(Web::Compositor::CompositorContextId, Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress) override;
     virtual void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect) override;

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -401,6 +401,116 @@ ContextState::AsyncScrollResult ContextState::async_scroll_by(
     return { .enqueue_result = { true, operation_id }, .frame_to_present = async_scroll_viewport_rect };
 }
 
+ContextState::AsyncScrollResult ContextState::smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint destination_offset, Gfx::IntRect viewport_rect)
+{
+    if (!m_has_async_scrolling_state)
+        return {};
+
+    auto node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(stable_node_id);
+    if (!node_id.has_value())
+        return {};
+    auto current_offset = m_async_scroll_tree.scroll_offset_for_node(*node_id, m_scroll_state_snapshot);
+    if (!current_offset.has_value())
+        return {};
+
+    cancel_smooth_scroll(stable_node_id);
+
+    auto operation_id = ++m_next_async_scroll_operation_id;
+    Web::Compositor::SmoothScrollAnimation animation { *current_offset, destination_offset };
+    if (animation.duration().is_zero()) {
+        m_completed_async_scroll_operation_ids.append(operation_id);
+        request_rendering_update();
+        return {
+            .enqueue_result = { true, operation_id },
+            .frame_to_present = {},
+        };
+    }
+
+    m_smooth_scroll_animations.append({
+        .stable_node_id = stable_node_id,
+        .operation_id = operation_id,
+        .animation = move(animation),
+        .started_at = MonotonicTime::now(),
+    });
+    m_async_scrolling_viewport_rect = viewport_rect;
+    return {
+        .enqueue_result = { true, operation_id },
+        .frame_to_present = viewport_rect,
+    };
+}
+
+void ContextState::cancel_smooth_scroll(Web::Compositor::AsyncScrollNodeStableID stable_node_id)
+{
+    for (size_t index = 0; index < m_smooth_scroll_animations.size(); ++index) {
+        auto const& smooth_scroll_animation = m_smooth_scroll_animations[index];
+        if (smooth_scroll_animation.stable_node_id != stable_node_id)
+            continue;
+        m_completed_async_scroll_operation_ids.append(smooth_scroll_animation.operation_id);
+        m_smooth_scroll_animations.remove(index);
+        request_rendering_update();
+        return;
+    }
+}
+
+Optional<Gfx::IntRect> ContextState::advance_smooth_scroll_animations(MonotonicTime now)
+{
+    Vector<Web::Compositor::AsyncScrollOffset> scroll_offsets;
+    bool changed_scroll_offset = false;
+    bool completed_operation = false;
+
+    for (size_t index = 0; index < m_smooth_scroll_animations.size();) {
+        auto& active_animation = m_smooth_scroll_animations[index];
+        auto node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(active_animation.stable_node_id);
+        if (!node_id.has_value()) {
+            m_completed_async_scroll_operation_ids.append(active_animation.operation_id);
+            completed_operation = true;
+            m_smooth_scroll_animations.remove(index);
+            continue;
+        }
+
+        auto old_offset = m_async_scroll_tree.scroll_offset_for_node(*node_id, m_scroll_state_snapshot);
+        if (!old_offset.has_value()) {
+            m_completed_async_scroll_operation_ids.append(active_animation.operation_id);
+            completed_operation = true;
+            m_smooth_scroll_animations.remove(index);
+            continue;
+        }
+
+        auto sample = active_animation.animation.sample(now - active_animation.started_at);
+        auto new_offset = m_async_scroll_tree.set_scroll_offset(*node_id, sample.offset, m_scroll_state_snapshot);
+        VERIFY(new_offset.has_value());
+        auto scroll_delta = *new_offset - *old_offset;
+        if (!scroll_delta.is_zero()) {
+            scroll_offsets.append({
+                .stable_node_id = active_animation.stable_node_id,
+                .compositor_scroll_offset = *new_offset,
+                .unadopted_scroll_delta = scroll_delta,
+            });
+            changed_scroll_offset = true;
+            if (m_async_scroll_tree.scroll_node_is_viewport(*node_id))
+                m_async_scrolling_viewport_rect.set_location(new_offset->to_type<int>());
+        }
+
+        if (sample.complete) {
+            m_completed_async_scroll_operation_ids.append(active_animation.operation_id);
+            completed_operation = true;
+            m_smooth_scroll_animations.remove(index);
+        } else {
+            ++index;
+        }
+    }
+
+    if (!scroll_offsets.is_empty()) {
+        rebuild_wheel_hit_test_targets();
+        store_pending_async_scroll_offsets(scroll_offsets);
+    }
+    if (changed_scroll_offset || completed_operation)
+        request_rendering_update();
+    if (changed_scroll_offset)
+        return m_async_scrolling_viewport_rect;
+    return {};
+}
+
 ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta)
 {
     if (!presents_to_client())

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -403,7 +403,7 @@ ContextState::AsyncScrollResult ContextState::async_scroll_by(
     return { .enqueue_result = { true, operation_id }, .frame_to_present = async_scroll_viewport_rect };
 }
 
-ContextState::AsyncScrollResult ContextState::smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint destination_offset, Gfx::IntRect viewport_rect)
+ContextState::AsyncScrollResult ContextState::smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID stable_node_id, Gfx::FloatPoint destination_offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel)
 {
     if (!m_has_async_scrolling_state)
         return {};
@@ -418,7 +418,7 @@ ContextState::AsyncScrollResult ContextState::smooth_scroll_to(Web::Compositor::
     cancel_smooth_scroll(stable_node_id);
 
     auto operation_id = ++m_next_async_scroll_operation_id;
-    Web::Compositor::SmoothScrollAnimation animation { *current_offset, destination_offset };
+    Web::Compositor::SmoothScrollAnimation animation { *current_offset, destination_offset, device_pixels_per_css_pixel };
     if (animation.duration().is_zero()) {
         m_completed_async_scroll_operation_ids.append(operation_id);
         request_rendering_update();

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -378,6 +378,8 @@ ContextState::AsyncScrollResult ContextState::async_scroll_by(
     if (scroll_target.node_id->document_id != expected_document_id)
         return {};
 
+    cancel_smooth_scroll_for_node(*scroll_target.node_id);
+
     Optional<Web::Compositor::AsyncScrollOperationID> operation_id;
     if (operation_tracking == Web::Compositor::AsyncScrollOperationTracking::Yes)
         operation_id = ++m_next_async_scroll_operation_id;
@@ -553,6 +555,8 @@ ContextState::ContextUpdateResult ContextState::async_scroll_by(Gfx::FloatPoint 
             };
         return {};
     }
+
+    cancel_smooth_scroll_for_node(*scroll_target.node_id);
 
     auto async_scroll_viewport_rect = m_async_scrolling_viewport_rect;
     auto scroll_offsets = m_async_scroll_tree.apply_scroll_delta(*scroll_target.node_id, async_scroll_delta, m_scroll_state_snapshot);
@@ -897,12 +901,24 @@ void ContextState::store_pending_async_scroll_offsets(
         m_completed_async_scroll_operation_ids.append(*operation_id);
 }
 
+void ContextState::cancel_smooth_scroll_for_node(Web::Compositor::AsyncScrollNodeID node_id)
+{
+    for (auto const& smooth_scroll_animation : m_smooth_scroll_animations) {
+        auto animated_node_id = m_async_scroll_tree.scroll_node_id_for_stable_id(smooth_scroll_animation.stable_node_id);
+        if (animated_node_id != node_id)
+            continue;
+        cancel_smooth_scroll(smooth_scroll_animation.stable_node_id);
+        return;
+    }
+}
+
 Optional<Gfx::IntRect> ContextState::apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const& drag)
 {
     auto scroll_delta = m_viewport_scrollbar_controller.scroll_delta_for_drag(m_async_scroll_tree, m_scroll_state_snapshot, drag);
     if (!scroll_delta.has_value())
         return {};
 
+    cancel_smooth_scroll_for_node(scroll_delta->scroll_node_id);
     auto scroll_offsets = m_async_scroll_tree.apply_scroll_delta(scroll_delta->scroll_node_id, scroll_delta->delta, m_scroll_state_snapshot);
     if (scroll_offsets.is_empty())
         return {};

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -22,6 +22,7 @@
 #include <LibGfx/Size.h>
 #include <LibWeb/Compositor/AsyncScrollTree.h>
 #include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Compositor/SmoothScrollAnimation.h>
 #include <LibWeb/Compositor/Types.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/AccumulatedVisualContext.h>
@@ -114,6 +115,10 @@ public:
         Gfx::FloatPoint delta,
         Gfx::IntRect viewport_rect,
         Web::Compositor::AsyncScrollOperationTracking);
+    AsyncScrollResult smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect);
+    void cancel_smooth_scroll(Web::Compositor::AsyncScrollNodeStableID);
+    Optional<Gfx::IntRect> advance_smooth_scroll_animations(MonotonicTime now);
+    bool has_active_smooth_scroll_animations() const { return !m_smooth_scroll_animations.is_empty(); }
     ContextUpdateResult async_scroll_by(Gfx::FloatPoint position, Gfx::FloatPoint delta);
     bool should_defer_main_thread_present_for_async_scroll() const;
     Web::Compositor::PendingAsyncScrollUpdates take_pending_async_scroll_updates();
@@ -144,6 +149,13 @@ public:
     void did_finish_gpu_present(i32 bitmap_id);
 
 private:
+    struct ActiveSmoothScrollAnimation {
+        Web::Compositor::AsyncScrollNodeStableID stable_node_id;
+        Web::Compositor::AsyncScrollOperationID operation_id;
+        Web::Compositor::SmoothScrollAnimation animation;
+        MonotonicTime started_at;
+    };
+
     struct VisualViewportScrollDelta {
         Web::Compositor::AsyncScrollOffset scroll_offset;
         Gfx::FloatPoint consumed_delta;
@@ -185,6 +197,7 @@ private:
 
     Vector<Web::Compositor::AsyncScrollOffset> m_pending_async_scroll_offsets;
     Vector<Web::Compositor::AsyncScrollOperationID> m_completed_async_scroll_operation_ids;
+    Vector<ActiveSmoothScrollAnimation> m_smooth_scroll_animations;
     Web::Compositor::AsyncScrollOperationID m_next_async_scroll_operation_id { 0 };
     Gfx::IntRect m_async_scrolling_viewport_rect;
     bool m_has_async_scrolling_state { false };

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -168,6 +168,7 @@ private:
     Optional<VisualViewportScrollDelta> apply_visual_viewport_scroll_delta(Gfx::FloatPoint);
     Optional<Gfx::FloatPoint> reapply_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const&);
     void store_pending_async_scroll_offsets(Vector<Web::Compositor::AsyncScrollOffset> const&, Optional<Web::Compositor::AsyncScrollOperationID> = {});
+    void cancel_smooth_scroll_for_node(Web::Compositor::AsyncScrollNodeID);
     Optional<Gfx::IntRect> apply_viewport_scrollbar_drag(ViewportScrollbarController::Drag const&);
     void rebuild_wheel_hit_test_targets();
     bool is_present_blocked() const;

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -115,7 +115,7 @@ public:
         Gfx::FloatPoint delta,
         Gfx::IntRect viewport_rect,
         Web::Compositor::AsyncScrollOperationTracking);
-    AsyncScrollResult smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect);
+    AsyncScrollResult smooth_scroll_to(Web::Compositor::AsyncScrollNodeStableID, Gfx::FloatPoint offset, Gfx::IntRect viewport_rect, double device_pixels_per_css_pixel);
     void cancel_smooth_scroll(Web::Compositor::AsyncScrollNodeStableID);
     Optional<Gfx::IntRect> advance_smooth_scroll_animations(MonotonicTime now);
     bool has_active_smooth_scroll_animations() const { return !m_smooth_scroll_animations.is_empty(); }

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TEST_SOURCES
     TestRefCountedTreeNode.cpp
     TestSecureContexts.cpp
     TestSessionHistoryEntry.cpp
+    TestSmoothScrollAnimation.cpp
     TestSourceHighlighter.cpp
     TestStructuredSerializeCorpus.cpp
     TestStructuredSerializeDurability.cpp

--- a/Tests/LibWeb/Ref/expected/scrollbar-after-visual-context-change-ref.html
+++ b/Tests/LibWeb/Ref/expected/scrollbar-after-visual-context-change-ref.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+    body {
+        margin: 0;
+    }
+
+    #before {
+        width: 20px;
+        height: 20px;
+        transform: translateX(0);
+    }
+
+    #scroller {
+        width: 200px;
+        height: 100px;
+        overflow-x: scroll;
+        overflow-y: hidden;
+    }
+
+    #content {
+        width: 600px;
+        height: 100px;
+        background: linear-gradient(to right, red 0 33%, green 33% 66%, blue 66%);
+    }
+</style>
+<div id="before"></div>
+<div id="scroller"><div id="content"></div></div>
+<script>
+    const scroller = document.getElementById("scroller");
+    scroller.scrollLeft = 200;
+    requestAnimationFrame(() => requestAnimationFrame(() =>
+        document.documentElement.classList.remove("reftest-wait")));
+</script>
+</html>

--- a/Tests/LibWeb/Ref/expected/smooth-scroll-carousel-ref.html
+++ b/Tests/LibWeb/Ref/expected/smooth-scroll-carousel-ref.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+    body {
+        margin: 0;
+        background: white;
+    }
+
+    .carousel {
+        display: flex;
+        gap: 16px;
+        width: 565px;
+        margin: 20px;
+        overflow-x: auto;
+    }
+
+    .card {
+        flex: 0 0 144px;
+        height: 120px;
+        color: white;
+        font: 24px sans-serif;
+        line-height: 120px;
+        text-align: center;
+    }
+
+    .card:nth-child(4n + 1) { background: #c33; }
+    .card:nth-child(4n + 2) { background: #3a6; }
+    .card:nth-child(4n + 3) { background: #36c; }
+    .card:nth-child(4n + 4) { background: #a63; }
+</style>
+<div class="carousel"></div>
+<div class="carousel"></div>
+<script>
+    const carousels = document.querySelectorAll(".carousel");
+    for (const carousel of carousels) {
+        for (let i = 1; i <= 20; ++i) {
+            const card = document.createElement("div");
+            card.className = "card";
+            card.textContent = i;
+            carousel.append(card);
+        }
+        carousel.scrollLeft = 640;
+    }
+
+    requestAnimationFrame(() => requestAnimationFrame(() =>
+        document.documentElement.classList.remove("reftest-wait")));
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/scrollbar-after-visual-context-change.html
+++ b/Tests/LibWeb/Ref/input/scrollbar-after-visual-context-change.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/scrollbar-after-visual-context-change-ref.html">
+<style>
+    body {
+        margin: 0;
+    }
+
+    #before {
+        width: 20px;
+        height: 20px;
+    }
+
+    #scroller {
+        width: 200px;
+        height: 100px;
+        overflow-x: scroll;
+        overflow-y: hidden;
+    }
+
+    #content {
+        width: 600px;
+        height: 100px;
+        background: linear-gradient(to right, red 0 33%, green 33% 66%, blue 66%);
+    }
+</style>
+<div id="before"></div>
+<div id="scroller"><div id="content"></div></div>
+<script>
+    const before = document.getElementById("before");
+    const scroller = document.getElementById("scroller");
+    requestAnimationFrame(() => requestAnimationFrame(async () => {
+        before.style.transform = "translateX(0)";
+        await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        await scroller.scrollTo({ left: 200, behavior: "smooth" });
+        document.documentElement.classList.remove("reftest-wait");
+    }));
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/smooth-scroll-carousel.html
+++ b/Tests/LibWeb/Ref/input/smooth-scroll-carousel.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<link rel="match" href="../expected/smooth-scroll-carousel-ref.html">
+<style>
+    body {
+        margin: 0;
+        background: white;
+    }
+
+    .carousel {
+        display: flex;
+        gap: 16px;
+        width: 565px;
+        margin: 20px;
+        overflow-x: auto;
+        scroll-behavior: smooth;
+    }
+
+    .card {
+        flex: 0 0 144px;
+        height: 120px;
+        color: white;
+        font: 24px sans-serif;
+        line-height: 120px;
+        text-align: center;
+    }
+
+    .card:nth-child(4n + 1) { background: #c33; }
+    .card:nth-child(4n + 2) { background: #3a6; }
+    .card:nth-child(4n + 3) { background: #36c; }
+    .card:nth-child(4n + 4) { background: #a63; }
+</style>
+<div class="carousel"></div>
+<div class="carousel"></div>
+<script>
+    const carousels = document.querySelectorAll(".carousel");
+    const buttons = [];
+    const scrollPromises = [];
+    for (let carouselIndex = 0; carouselIndex < carousels.length; ++carouselIndex) {
+        const carousel = carousels[carouselIndex];
+        for (let i = 1; i <= 20; ++i) {
+            const card = document.createElement("div");
+            card.className = "card";
+            card.textContent = i;
+            carousel.append(card);
+        }
+
+        const button = document.createElement("button");
+        button.hidden = true;
+        for (let listenerIndex = 0; listenerIndex < carouselIndex + 2; ++listenerIndex) {
+            button.addEventListener("click", () =>
+                scrollPromises.push(carousel.scrollBy({ left: 320, behavior: "smooth" })));
+        }
+        buttons.push(button);
+    }
+
+    async function clickAllButtons() {
+        const firstNewPromise = scrollPromises.length;
+        for (const button of buttons)
+            button.click();
+        await Promise.all(scrollPromises.slice(firstNewPromise));
+    }
+
+    requestAnimationFrame(() => requestAnimationFrame(async () => {
+        await clickAllButtons();
+        await clickAllButtons();
+        document.documentElement.classList.remove("reftest-wait");
+    }));
+</script>
+</html>

--- a/Tests/LibWeb/TestSmoothScrollAnimation.cpp
+++ b/Tests/LibWeb/TestSmoothScrollAnimation.cpp
@@ -11,7 +11,7 @@ using Web::Compositor::SmoothScrollAnimation;
 
 TEST_CASE(zero_distance_completes_immediately)
 {
-    SmoothScrollAnimation animation({ 20, 40 }, { 20, 40 });
+    SmoothScrollAnimation animation({ 20, 40 }, { 20, 40 }, 1.0);
 
     EXPECT_EQ(animation.duration(), AK::Duration::zero());
     auto sample = animation.sample(AK::Duration::zero());
@@ -21,16 +21,16 @@ TEST_CASE(zero_distance_completes_immediately)
 
 TEST_CASE(duration_is_based_on_distance_and_capped)
 {
-    SmoothScrollAnimation short_animation({ 0, 0 }, { 60, 80 });
+    SmoothScrollAnimation short_animation({ 0, 0 }, { 60, 80 }, 1.0);
     EXPECT_EQ(short_animation.duration(), AK::Duration::from_milliseconds(100));
 
-    SmoothScrollAnimation long_animation({ 0, 0 }, { 1000, 1000 });
+    SmoothScrollAnimation long_animation({ 0, 0 }, { 1000, 1000 }, 1.0);
     EXPECT_EQ(long_animation.duration(), AK::Duration::from_milliseconds(200));
 }
 
 TEST_CASE(samples_an_ease_in_out_curve)
 {
-    SmoothScrollAnimation animation({ 10, 20 }, { 110, 220 });
+    SmoothScrollAnimation animation({ 10, 20 }, { 110, 220 }, 1.0);
 
     auto start = animation.sample(AK::Duration::zero());
     EXPECT(!start.complete);
@@ -44,4 +44,12 @@ TEST_CASE(samples_an_ease_in_out_curve)
     auto end = animation.sample(animation.duration());
     EXPECT(end.complete);
     EXPECT_EQ(end.offset, Gfx::FloatPoint(110, 220));
+}
+
+TEST_CASE(duration_is_independent_of_device_scale)
+{
+    SmoothScrollAnimation css_pixel_animation({ 0, 0 }, { 60, 80 }, 1.0);
+    SmoothScrollAnimation device_pixel_animation({ 0, 0 }, { 120, 160 }, 2.0);
+
+    EXPECT_EQ(css_pixel_animation.duration(), device_pixel_animation.duration());
 }

--- a/Tests/LibWeb/TestSmoothScrollAnimation.cpp
+++ b/Tests/LibWeb/TestSmoothScrollAnimation.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibWeb/Compositor/SmoothScrollAnimation.h>
+
+using Web::Compositor::SmoothScrollAnimation;
+
+TEST_CASE(zero_distance_completes_immediately)
+{
+    SmoothScrollAnimation animation({ 20, 40 }, { 20, 40 });
+
+    EXPECT_EQ(animation.duration(), AK::Duration::zero());
+    auto sample = animation.sample(AK::Duration::zero());
+    EXPECT(sample.complete);
+    EXPECT_EQ(sample.offset, Gfx::FloatPoint(20, 40));
+}
+
+TEST_CASE(duration_is_based_on_distance_and_capped)
+{
+    SmoothScrollAnimation short_animation({ 0, 0 }, { 60, 80 });
+    EXPECT_EQ(short_animation.duration(), AK::Duration::from_milliseconds(100));
+
+    SmoothScrollAnimation long_animation({ 0, 0 }, { 1000, 1000 });
+    EXPECT_EQ(long_animation.duration(), AK::Duration::from_milliseconds(200));
+}
+
+TEST_CASE(samples_an_ease_in_out_curve)
+{
+    SmoothScrollAnimation animation({ 10, 20 }, { 110, 220 });
+
+    auto start = animation.sample(AK::Duration::zero());
+    EXPECT(!start.complete);
+    EXPECT_EQ(start.offset, Gfx::FloatPoint(10, 20));
+
+    auto midpoint = animation.sample(AK::Duration::from_milliseconds(animation.duration().to_milliseconds() / 2));
+    EXPECT(!midpoint.complete);
+    EXPECT_APPROXIMATE(midpoint.offset.x(), 60.0f);
+    EXPECT_APPROXIMATE(midpoint.offset.y(), 120.0f);
+
+    auto end = animation.sample(animation.duration());
+    EXPECT(end.complete);
+    EXPECT_EQ(end.offset, Gfx::FloatPoint(110, 220));
+}

--- a/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-index-after-visual-context-change.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/scroll-node-index-after-visual-context-change.txt
@@ -1,0 +1,1 @@
+scroll node index changed: true

--- a/Tests/LibWeb/Text/expected/async-scrolling/smooth-scroll-in-nested-navigable.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/smooth-scroll-in-nested-navigable.txt
@@ -1,0 +1,2 @@
+immediate: 0
+final: 300

--- a/Tests/LibWeb/Text/expected/smooth-scroll-promise.txt
+++ b/Tests/LibWeb/Text/expected/smooth-scroll-promise.txt
@@ -1,0 +1,14 @@
+immediate: 0,0
+final: 400,200
+scrollend: received
+css behavior final: 0,0
+replacement final: 200,0
+instant: 300,0
+setter interruption: 250,0
+duplicate carousel handlers: 320,0
+viewport immediate: 0
+viewport final: 300
+viewport scrollend: received
+scrollIntoView immediate: true
+scrollIntoView final: 310,200
+scrollIntoView result: undefined

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-default-css.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scroll-behavior-default-css.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 3 tests
 
-2 Pass
-1 Fail
+3 Pass
 Pass	Make sure the page is ready for animation.
 Pass	Instant scrolling of an element with default scroll-behavior
-Fail	Smooth scrolling of an element with default scroll-behavior
+Pass	Smooth scrolling of an element with default scroll-behavior

--- a/Tests/LibWeb/Text/input/async-scrolling/scroll-node-index-after-visual-context-change.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/scroll-node-index-after-visual-context-change.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #before {
+        width: 20px;
+        height: 20px;
+    }
+
+    #scroller {
+        width: 100px;
+        height: 100px;
+        overflow: scroll;
+    }
+
+    #content {
+        width: 500px;
+        height: 500px;
+    }
+</style>
+<div id="before"></div>
+<div id="scroller"><div id="content"></div></div>
+<script>
+    test(() => {
+        const initialState = internals.asyncScrollingState();
+        const initialNode = initialState.scrollNodes.find(node => !node.isViewport);
+
+        document.getElementById("before").style.transform = "translateX(0)";
+
+        const updatedState = internals.asyncScrollingState();
+        const updatedNode = updatedState.scrollNodes.find(node => !node.isViewport);
+
+        println(`scroll node index changed: ${initialNode.scrollNodeIndex !== updatedNode.scrollNodeIndex}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/async-scrolling/smooth-scroll-in-nested-navigable.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/smooth-scroll-in-nested-navigable.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<iframe id="frame" srcdoc="
+    <div id='scroller' style='width: 100px; height: 100px; overflow: scroll'>
+        <div style='width: 600px; height: 100px'></div>
+    </div>
+"></iframe>
+<script>
+    promiseTest(async () => {
+        await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
+        await animationFrame();
+        await animationFrame();
+
+        const scroller = frame.contentDocument.getElementById("scroller");
+        const scrollPromise = scroller.scroll({ left: 300, behavior: "smooth" });
+        println(`immediate: ${scroller.scrollLeft}`);
+        await scrollPromise;
+        println(`final: ${scroller.scrollLeft}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/smooth-scroll-promise.html
+++ b/Tests/LibWeb/Text/input/smooth-scroll-promise.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<div id="scroller" style="width: 100px; height: 100px; overflow: scroll">
+    <div style="position: relative; width: 600px; height: 400px">
+        <div id="target" style="position: absolute; left: 400px; top: 200px; width: 10px; height: 10px"></div>
+    </div>
+</div>
+<div style="height: 1200px"></div>
+<script>
+    asyncTest(async done => {
+        const scroller = document.getElementById("scroller");
+
+        await animationFrame();
+        await animationFrame();
+
+        const scrollend = new Promise(resolve => scroller.addEventListener("scrollend", resolve, { once: true }));
+        const promise = scroller.scroll({ left: 400, top: 200, behavior: "smooth" });
+        println(`immediate: ${scroller.scrollLeft},${scroller.scrollTop}`);
+
+        await Promise.all([promise, scrollend]);
+        println(`final: ${scroller.scrollLeft},${scroller.scrollTop}`);
+        println("scrollend: received");
+
+        scroller.style.scrollBehavior = "smooth";
+        await scroller.scroll({ left: 0, top: 0 });
+        println(`css behavior final: ${scroller.scrollLeft},${scroller.scrollTop}`);
+
+        const aborted = scroller.scroll({ left: 400, behavior: "smooth" });
+        const replacement = scroller.scroll({ left: 200, behavior: "smooth" });
+        await aborted;
+        await replacement;
+        println(`replacement final: ${scroller.scrollLeft},${scroller.scrollTop}`);
+
+        const interrupted = scroller.scroll({ left: 400, behavior: "smooth" });
+        await new Promise(resolve => scroller.addEventListener("scroll", resolve, { once: true }));
+        const instant = scroller.scroll({ left: 300, behavior: "instant" });
+        await Promise.all([interrupted, instant]);
+        println(`instant: ${scroller.scrollLeft},${scroller.scrollTop}`);
+
+        scroller.style.scrollBehavior = "auto";
+        const interruptedBySetter = scroller.scroll({ left: 400, behavior: "smooth" });
+        await new Promise(resolve => scroller.addEventListener("scroll", resolve, { once: true }));
+        scroller.scrollLeft = 250;
+        await interruptedBySetter;
+        println(`setter interruption: ${scroller.scrollLeft},${scroller.scrollTop}`);
+
+        scroller.scroll({ left: 0, behavior: "instant" });
+        const carouselButton = document.createElement("button");
+        const duplicateScrollPromises = [];
+        for (let i = 0; i < 3; ++i) {
+            carouselButton.addEventListener("click", event => {
+                event.stopPropagation();
+                duplicateScrollPromises.push(scroller.scrollBy({ left: 320, behavior: "smooth" }));
+            });
+        }
+        carouselButton.click();
+        await Promise.all(duplicateScrollPromises);
+        println(`duplicate carousel handlers: ${scroller.scrollLeft},${scroller.scrollTop}`);
+
+        const viewport_scrollend = new Promise(resolve => document.addEventListener("scrollend", resolve, { once: true }));
+        const viewport_promise = window.scroll({ top: 300, behavior: "smooth" });
+        println(`viewport immediate: ${window.scrollY}`);
+        await Promise.all([viewport_promise, viewport_scrollend]);
+        println(`viewport final: ${window.scrollY}`);
+        println("viewport scrollend: received");
+
+        window.scroll({ top: 0, behavior: "instant" });
+        scroller.scroll({ left: 0, top: 0, behavior: "instant" });
+        const scroll_into_view_promise = document.getElementById("target").scrollIntoView({ behavior: "smooth" });
+        println(`scrollIntoView immediate: ${scroller.scrollLeft === 0}`);
+        const scroll_into_view_result = await scroll_into_view_promise;
+        println(`scrollIntoView final: ${scroller.scrollLeft},${scroller.scrollTop}`);
+        println(`scrollIntoView result: ${scroll_into_view_result}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Implement smooth programmatic scrolling following CSSOM View behavior resolution for elements and viewports. Run animations in the Compositor on vsync so scrolling remains responsive while the main thread is busy, with a rendering-step fallback when asynchronous scrolling is unavailable.

Support interruption by direct input, animation retargeting, `scrollLeft` and `scrollTop` assignments, `scrollIntoView()` promises, and `scrollend` events. Preserve deferred asynchronous frames and refresh cached display-list commands after visual context tree rebuilds to prevent stale scroll metadata, blank content, and incorrect overlay scrollbar positions.

Add coverage for explicit and CSS-selected behavior, repeated carousel scrolling, interruption, setters, promises, events, `scrollIntoView()`, compositor scroll-node changes, and overlay scrollbar painting.