### PR TITLE
LibWeb: Match selectors against the live DOM from Rust

### DIFF
--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -566,6 +566,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("FfiElementQualifiedName", "ElementQualifiedName"),
         ("FfiInternedStringList", "InternedStringList"),
         ("FfiDomStringView", "DomStringView"),
+        ("FfiDomAttribute", "DomAttribute"),
         ("FfiResolvedNamespaceType", "ResolvedNamespaceType"),
         ("FfiResolvedNamespace", "ResolvedNamespace"),
         ("FfiElementAndShadowHost", "ElementAndShadowHost"),

--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -563,6 +563,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("FfiCompoundSelector", "CompoundSelector"),
         ("FfiSelector", "Selector"),
         ("FfiElement", "Element"),
+        ("FfiDefaultNamespaceType", "DefaultNamespaceType"),
+        ("FfiNamespaceContext", "NamespaceContext"),
         ("FfiElementAndShadowHost", "ElementAndShadowHost"),
     ] {
         selector_config

--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -562,6 +562,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("FfiSimpleSelector", "SimpleSelector"),
         ("FfiCompoundSelector", "CompoundSelector"),
         ("FfiSelector", "Selector"),
+        ("FfiElement", "Element"),
         ("FfiElementAndShadowHost", "ElementAndShadowHost"),
     ] {
         selector_config

--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -565,8 +565,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("FfiElement", "Element"),
         ("FfiElementQualifiedName", "ElementQualifiedName"),
         ("FfiInternedStringList", "InternedStringList"),
-        ("FfiDefaultNamespaceType", "DefaultNamespaceType"),
-        ("FfiNamespaceContext", "NamespaceContext"),
+        ("FfiResolvedNamespaceType", "ResolvedNamespaceType"),
+        ("FfiResolvedNamespace", "ResolvedNamespace"),
         ("FfiElementAndShadowHost", "ElementAndShadowHost"),
     ] {
         selector_config

--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -565,6 +565,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("FfiElement", "Element"),
         ("FfiElementQualifiedName", "ElementQualifiedName"),
         ("FfiInternedStringList", "InternedStringList"),
+        ("FfiDomStringView", "DomStringView"),
         ("FfiResolvedNamespaceType", "ResolvedNamespaceType"),
         ("FfiResolvedNamespace", "ResolvedNamespace"),
         ("FfiElementAndShadowHost", "ElementAndShadowHost"),

--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -563,6 +563,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         ("FfiCompoundSelector", "CompoundSelector"),
         ("FfiSelector", "Selector"),
         ("FfiElement", "Element"),
+        ("FfiElementQualifiedName", "ElementQualifiedName"),
+        ("FfiInternedStringList", "InternedStringList"),
         ("FfiDefaultNamespaceType", "DefaultNamespaceType"),
         ("FfiNamespaceContext", "NamespaceContext"),
         ("FfiElementAndShadowHost", "ElementAndShadowHost"),

--- a/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
@@ -55,7 +55,6 @@ define_ffi_ops! {
     // Callbacks: Rust -> C++.
     SelectorDomReadCallback => "selectorDomReadCallbacks",
     SelectorSimpleSelectorCallback => "selectorSimpleSelectorCallbacks",
-    SelectorTreeNavigationCallback => "selectorTreeNavigationCallbacks",
     SelectorMetadataCallback => "selectorMetadataCallbacks",
     CascadePropertyDisallowedCallback => "cascadePropertyDisallowedCallbacks",
     CascadeResolveUnresolvedCallback => "cascadeResolveUnresolvedCallbacks",

--- a/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
@@ -53,6 +53,7 @@ define_ffi_ops! {
     StyleGroupCloneEntry => "styleGroupCloneEntries",
     StyleGroupFreeEntry => "styleGroupFreeEntries",
     // Callbacks: Rust -> C++.
+    SelectorDomReadCallback => "selectorDomReadCallbacks",
     SelectorSimpleSelectorCallback => "selectorSimpleSelectorCallbacks",
     SelectorTreeNavigationCallback => "selectorTreeNavigationCallbacks",
     SelectorMetadataCallback => "selectorMetadataCallbacks",

--- a/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
@@ -54,7 +54,6 @@ define_ffi_ops! {
     StyleGroupFreeEntry => "styleGroupFreeEntries",
     // Callbacks: Rust -> C++.
     SelectorDomReadCallback => "selectorDomReadCallbacks",
-    SelectorSimpleSelectorCallback => "selectorSimpleSelectorCallbacks",
     SelectorMetadataCallback => "selectorMetadataCallbacks",
     CascadePropertyDisallowedCallback => "cascadePropertyDisallowedCallbacks",
     CascadeResolveUnresolvedCallback => "cascadeResolveUnresolvedCallbacks",

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1619,6 +1619,12 @@ impl FfiElement {
         unsafe { selector_ffi_element_is_link(self.pointer) }
     }
 
+    fn is_fullscreen(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_fullscreen(self.pointer) }
+    }
+
     fn is_focused(self) -> bool {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
@@ -1887,6 +1893,7 @@ unsafe extern "C" {
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
     fn selector_ffi_element_is_link(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_fullscreen(element: *const c_void) -> bool;
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
@@ -2343,6 +2350,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
     fn matches_pseudo_class_state(&mut self, element: FfiNode<'a>, pseudo_class: &PseudoClassSelector) -> bool {
         match pseudo_class.pseudo_class {
             PseudoClassType::AnyLink | PseudoClassType::Link => element.as_element().is_link(),
+            PseudoClassType::Fullscreen => element.as_element().is_fullscreen(),
             PseudoClassType::Focus => element.as_element().is_focused(),
             PseudoClassType::FocusVisible => {
                 element.as_element().is_focused() && element.as_element().should_indicate_focus()

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1634,6 +1634,18 @@ impl FfiElement {
         }
     }
 
+    fn has_popover_attribute(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_has_popover_attribute(self.pointer) }
+    }
+
+    fn popover_is_showing(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_popover_is_showing(self.pointer) }
+    }
+
     fn is_focused(self) -> bool {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
@@ -1904,6 +1916,8 @@ unsafe extern "C" {
     fn selector_ffi_element_is_link(element: *const c_void) -> bool;
     fn selector_ffi_element_is_fullscreen(element: *const c_void) -> bool;
     fn selector_ffi_element_heading_level(element: *const c_void) -> i64;
+    fn selector_ffi_element_has_popover_attribute(element: *const c_void) -> bool;
+    fn selector_ffi_element_popover_is_showing(element: *const c_void) -> bool;
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
@@ -2419,6 +2433,10 @@ impl<'a> SelectorDom for FfiDom<'a> {
                 .as_element()
                 .heading_level()
                 .is_some_and(|level| pseudo_class.levels.is_empty() || pseudo_class.levels.contains(&level)),
+            // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open
+            PseudoClassType::PopoverOpen => {
+                element.as_element().has_popover_attribute() && element.as_element().popover_is_showing()
+            }
             _ => {
                 crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
                 // SAFETY: `FfiDom` guarantees that the element remains valid for matching.

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1582,6 +1582,7 @@ pub struct FfiElement {
     pub class_names_are_case_insensitive: bool,
     pub namespace_is_null: bool,
     pub is_html_element_in_html_document: bool,
+    pub is_document_root: bool,
 }
 
 impl FfiElement {
@@ -1719,7 +1720,6 @@ unsafe extern "C" {
     fn selector_ffi_next_element_descendant(element: *const c_void, root: *const c_void) -> FfiElement;
     fn selector_ffi_has_no_element_or_nonempty_text_children(element: *const c_void) -> bool;
     fn selector_ffi_has_same_type(first: *const c_void, second: *const c_void) -> bool;
-    fn selector_ffi_is_document_root(element: *const c_void) -> bool;
 
     fn selector_ffi_is_shadow_tree_slot(element: *const c_void) -> bool;
     fn selector_ffi_slotted_parent(context: *mut c_void, element: *const c_void) -> FfiElementAndShadowHost;
@@ -1802,6 +1802,7 @@ impl<'a> FfiDom<'a> {
                 class_names_are_case_insensitive: false,
                 namespace_is_null: true,
                 is_html_element_in_html_document: false,
+                is_document_root: false,
             },
             marker: PhantomData,
         })
@@ -2059,9 +2060,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn is_document_root(&mut self, element: FfiNode<'a>) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
-        // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
-        unsafe { selector_ffi_is_document_root(element.as_element_pointer()) }
+        element.as_element().is_document_root
     }
 
     fn is_shadow_tree_slot(&mut self, element: FfiNode<'a>) -> bool {

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1661,6 +1661,17 @@ impl FfiElement {
         unsafe { selector_ffi_element_has_custom_state(self.pointer, state) }
     }
 
+    unsafe fn language<'a>(self) -> Option<DomStringView<'a>> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element. C++ returns its current language with
+        // backing storage owned by the element for this matching call.
+        let view = unsafe { selector_ffi_element_language(self.pointer) };
+        (view.length != 0).then_some(DomStringView {
+            view,
+            marker: PhantomData,
+        })
+    }
+
     fn is_focused(self) -> bool {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
@@ -1911,6 +1922,12 @@ impl<'a> FfiNode<'a> {
         // current attribute storage. Callers obtain `index` from the live attribute count.
         unsafe { self.as_element().attribute(index) }
     }
+
+    fn language(self) -> Option<DomStringView<'a>> {
+        // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
+        // current language storage.
+        unsafe { self.as_element().language() }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1935,6 +1952,7 @@ unsafe extern "C" {
     fn selector_ffi_element_popover_is_showing(element: *const c_void) -> bool;
     fn selector_ffi_element_direction(element: *const c_void) -> FfiDirection;
     fn selector_ffi_element_has_custom_state(element: *const c_void, state: usize) -> bool;
+    fn selector_ffi_element_language(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
@@ -1947,7 +1965,6 @@ unsafe extern "C" {
     fn selector_ffi_resolve_namespace(context: *mut c_void, prefix: FfiStringView) -> FfiResolvedNamespace;
 
     fn selector_ffi_matches_pseudo_class(element: *const c_void, pseudo_class: u8) -> bool;
-    fn selector_ffi_matches_language(element: *const c_void, language: FfiStringView) -> bool;
     fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> FfiElement;
     fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> FfiElement;
     fn selector_ffi_previous_element_sibling(element: *const c_void) -> FfiElement;
@@ -2010,6 +2027,163 @@ fn utf16_equals_ignoring_ascii_case(first: DomStringView<'_>, second: &[u16]) ->
             .iter()
             .enumerate()
             .all(|(index, &second)| ascii_lowercase(first.code_unit_at(index)) == ascii_lowercase(second))
+}
+
+struct SelectorSubtags<'a> {
+    value: &'a [u16],
+    position: usize,
+    finished: bool,
+}
+
+impl<'a> SelectorSubtags<'a> {
+    fn new(value: &'a [u16]) -> Self {
+        Self {
+            value,
+            position: 0,
+            finished: false,
+        }
+    }
+}
+
+impl Iterator for SelectorSubtags<'_> {
+    type Item = std::ops::Range<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+        let start = self.position;
+        while self.position < self.value.len() && self.value[self.position] != u16::from(b'-') {
+            self.position += 1;
+        }
+        let end = self.position;
+        if self.position < self.value.len() {
+            self.position += 1;
+        } else {
+            self.finished = true;
+        }
+        Some(start..end)
+    }
+}
+
+struct DomSubtags<'a> {
+    value: DomStringView<'a>,
+    position: usize,
+    finished: bool,
+}
+
+impl<'a> DomSubtags<'a> {
+    fn new(value: DomStringView<'a>) -> Self {
+        Self {
+            value,
+            position: 0,
+            finished: false,
+        }
+    }
+}
+
+impl Iterator for DomSubtags<'_> {
+    type Item = std::ops::Range<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+        let start = self.position;
+        while self.position < self.value.len() && self.value.code_unit_at(self.position) != u16::from(b'-') {
+            self.position += 1;
+        }
+        let end = self.position;
+        if self.position < self.value.len() {
+            self.position += 1;
+        } else {
+            self.finished = true;
+        }
+        Some(start..end)
+    }
+}
+
+fn language_subtags_match(
+    language_range: &[u16],
+    range_subtag: &std::ops::Range<usize>,
+    language_tag: DomStringView<'_>,
+    tag_subtag: &std::ops::Range<usize>,
+) -> bool {
+    if range_subtag.len() == 1 && language_range[range_subtag.start] == u16::from(b'*') {
+        return true;
+    }
+    range_subtag.len() == tag_subtag.len()
+        && (0..range_subtag.len()).all(|offset| {
+            ascii_lowercase(language_range[range_subtag.start + offset])
+                == ascii_lowercase(language_tag.code_unit_at(tag_subtag.start + offset))
+        })
+}
+
+fn is_ascii_alphanumeric(code_unit: u16) -> bool {
+    (u16::from(b'0')..=u16::from(b'9')).contains(&code_unit)
+        || (u16::from(b'A')..=u16::from(b'Z')).contains(&code_unit)
+        || (u16::from(b'a')..=u16::from(b'z')).contains(&code_unit)
+}
+
+// https://www.rfc-editor.org/rfc/rfc4647#section-3.3.2
+fn language_range_matches_tag(language_range: &[u16], language_tag: DomStringView<'_>) -> bool {
+    // 1. Split both the extended language range and the language tag being compared into a list
+    //    of subtags by dividing on the hyphen (%x2D) character.
+    let mut range_subtags = SelectorSubtags::new(language_range);
+    let mut tag_subtags = DomSubtags::new(language_tag);
+
+    //    Two subtags match if either they are the same when compared case-insensitively or the
+    //    language range's subtag is the wildcard '*'.
+
+    // 2. Begin with the first subtag in each list. If the first subtag in the range does not match
+    //    the first subtag in the tag, the overall match fails. Otherwise, move to the next subtag
+    //    in both the range and the tag.
+    let first_range_subtag = range_subtags.next().unwrap();
+    let first_tag_subtag = tag_subtags.next().unwrap();
+    if !language_subtags_match(language_range, &first_range_subtag, language_tag, &first_tag_subtag) {
+        return false;
+    }
+
+    let mut tag_subtag = tag_subtags.next();
+
+    // 3. While there are more subtags left in the language range's list:
+    for range_subtag in range_subtags {
+        // A. If the subtag currently being examined in the range is the wildcard ('*'), move to
+        //    the next subtag in the range and continue with the loop.
+        if range_subtag.len() == 1 && language_range[range_subtag.start] == u16::from(b'*') {
+            continue;
+        }
+
+        // B. Else, if there are no more subtags in the language tag's list, the match fails.
+        loop {
+            let Some(current_tag_subtag) = tag_subtag else {
+                return false;
+            };
+
+            // C. Else, if the current subtag in the range's list matches the current subtag in the
+            //    language tag's list, move to the next subtag in both lists and continue with the
+            //    loop.
+            if language_subtags_match(language_range, &range_subtag, language_tag, &current_tag_subtag) {
+                tag_subtag = tag_subtags.next();
+                break;
+            }
+
+            // D. Else, if the language tag's subtag is a "singleton" (a single letter or digit,
+            //    which includes the private-use subtag 'x') the match fails.
+            if current_tag_subtag.len() == 1
+                && is_ascii_alphanumeric(language_tag.code_unit_at(current_tag_subtag.start))
+            {
+                return false;
+            }
+
+            // E. Else, move to the next subtag in the language tag's list and continue with the
+            //    loop.
+            tag_subtag = tag_subtags.next();
+        }
+    }
+
+    // 4. When the language range's list has no more subtags, the match succeeds.
+    true
 }
 
 #[derive(Clone, Copy)]
@@ -2412,11 +2586,11 @@ impl<'a> SelectorDom for FfiDom<'a> {
                 //        is always false. Once we do, implement this!
                 false
             }
-            PseudoClassType::Lang => pseudo_class.languages.iter().any(|language| {
-                crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-                // SAFETY: `FfiDom` guarantees that the element remains valid, and the string
-                // view is borrowed from `language` for this callback only.
-                unsafe { selector_ffi_matches_language(element.as_element_pointer(), ffi_string_view(language)) }
+            PseudoClassType::Lang => element.language().is_some_and(|language_tag| {
+                pseudo_class
+                    .languages
+                    .iter()
+                    .any(|language_range| language_range_matches_tag(language_range, language_tag))
             }),
             PseudoClassType::Dir => pseudo_class
                 .direction

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -73,6 +73,10 @@ pub struct QualifiedName {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NameSelector {
     pub name: SelectorString,
+    /// The one-word identity of the C++ `Utf16FlyString` backing `name`. This is present for
+    /// selectors compiled from C++ and allows the live DOM wrapper to compare interned names
+    /// without crossing the FFI.
+    interned_name: Option<usize>,
     /// See [`QualifiedName::cxx_simple_selector`].
     cxx_simple_selector: RetainedCxxPointer,
 }
@@ -1512,6 +1516,7 @@ pub struct FfiStringView {
 pub struct FfiSimpleSelector {
     pub selector_type: FfiSimpleSelectorType,
     pub cxx_simple_selector: *const c_void,
+    pub interned_name: *const usize,
     pub namespace_type: NamespaceType,
     pub namespace: FfiStringView,
     pub name: FfiStringView,
@@ -1559,6 +1564,42 @@ pub struct RustSelector {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
+/// A borrowed view of the element's current selector-relevant identifier data.
+///
+/// C++ constructs this immediately before crossing the FFI and after every tree navigation. The
+/// pointers must not be retained beyond the matching call.
+pub struct FfiElement {
+    pub pointer: *const c_void,
+    pub id: *const usize,
+    pub classes: *const usize,
+    pub class_count: usize,
+    pub class_names_are_case_insensitive: bool,
+}
+
+impl FfiElement {
+    fn is_null(self) -> bool {
+        self.pointer.is_null()
+    }
+
+    fn id(self) -> Option<usize> {
+        // SAFETY: The C++ wrapper points at the live element's `Utf16FlyString` storage, which is
+        // pinned for the duration of the matching call.
+        unsafe { self.id.as_ref().copied() }
+    }
+
+    unsafe fn classes<'a>(self) -> &'a [usize] {
+        if self.class_count == 0 {
+            return &[];
+        }
+        assert!(!self.classes.is_null());
+        // SAFETY: C++ guarantees that `Utf16FlyString` has the size and alignment of `usize` and
+        // that the element's class vector cannot mutate during this matching call.
+        unsafe { std::slice::from_raw_parts(self.classes, self.class_count) }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FfiNodeKind {
     Element,
     Scope,
@@ -1572,6 +1613,7 @@ enum FfiNodeKind {
 struct FfiNode<'a> {
     pointer: *const c_void,
     kind: FfiNodeKind,
+    element: FfiElement,
     marker: PhantomData<&'a FfiCallScope>,
 }
 
@@ -1588,13 +1630,26 @@ impl FfiNode<'_> {
         assert_eq!(self.kind, FfiNodeKind::Element);
         self.pointer
     }
+
+    fn as_element(self) -> FfiElement {
+        assert_eq!(self.kind, FfiNodeKind::Element);
+        self.element
+    }
+}
+
+impl<'a> FfiNode<'a> {
+    fn classes(self) -> &'a [usize] {
+        // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
+        // current class storage.
+        unsafe { self.as_element().classes() }
+    }
 }
 
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiElementAndShadowHost {
-    pub element: *const c_void,
-    pub shadow_host: *const c_void,
+    pub element: FfiElement,
+    pub shadow_host: FfiElement,
 }
 
 unsafe extern "C" {
@@ -1609,8 +1664,7 @@ unsafe extern "C" {
         cxx_simple_selector: *const c_void,
         matching_mode: TagNameMatchingMode,
     ) -> bool;
-    fn selector_ffi_matches_id(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
-    fn selector_ffi_matches_class(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
+    fn selector_ffi_matches_class_quirks(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
     fn selector_ffi_matches_attribute(
         context: *mut c_void,
         element: *const c_void,
@@ -1622,13 +1676,13 @@ unsafe extern "C" {
     fn selector_ffi_matches_state(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
     fn selector_ffi_matches_heading(element: *const c_void, levels: *const i64, level_count: usize) -> bool;
 
-    fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> *const c_void;
-    fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> *const c_void;
-    fn selector_ffi_previous_element_sibling(element: *const c_void) -> *const c_void;
-    fn selector_ffi_next_element_sibling(element: *const c_void) -> *const c_void;
-    fn selector_ffi_first_element_child(element: *const c_void) -> *const c_void;
-    fn selector_ffi_first_element_descendant(element: *const c_void) -> *const c_void;
-    fn selector_ffi_next_element_descendant(element: *const c_void, root: *const c_void) -> *const c_void;
+    fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> FfiElement;
+    fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> FfiElement;
+    fn selector_ffi_previous_element_sibling(element: *const c_void) -> FfiElement;
+    fn selector_ffi_next_element_sibling(element: *const c_void) -> FfiElement;
+    fn selector_ffi_first_element_child(element: *const c_void) -> FfiElement;
+    fn selector_ffi_first_element_descendant(element: *const c_void) -> FfiElement;
+    fn selector_ffi_next_element_descendant(element: *const c_void, root: *const c_void) -> FfiElement;
     fn selector_ffi_has_no_element_or_nonempty_text_children(element: *const c_void) -> bool;
     fn selector_ffi_has_same_type(first: *const c_void, second: *const c_void) -> bool;
     fn selector_ffi_is_document_root(element: *const c_void) -> bool;
@@ -1701,13 +1755,27 @@ impl<'a> FfiDom<'a> {
         (!pointer.is_null()).then_some(FfiNode {
             pointer,
             kind,
+            element: FfiElement {
+                pointer: std::ptr::null(),
+                id: std::ptr::null(),
+                classes: std::ptr::null(),
+                class_count: 0,
+                class_names_are_case_insensitive: false,
+            },
             marker: PhantomData,
         })
     }
 
-    unsafe fn element(&self, element: *const c_void) -> Option<FfiNode<'a>> {
-        // SAFETY: The caller guarantees that a non-null pointer identifies a live DOM element.
-        unsafe { self.node(element, FfiNodeKind::Element) }
+    unsafe fn element(&self, element: FfiElement) -> Option<FfiNode<'a>> {
+        if element.is_null() {
+            return None;
+        }
+        Some(FfiNode {
+            pointer: element.pointer,
+            kind: FfiNodeKind::Element,
+            element,
+            marker: PhantomData,
+        })
     }
 
     unsafe fn scope(&self, scope: *const c_void) -> Option<FfiNode<'a>> {
@@ -1763,17 +1831,22 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn matches_id_selector(&mut self, element: FfiNode<'a>, id: &NameSelector) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-        // SAFETY: `FfiDom` guarantees that the element and retained simple selector remain valid
-        // for the duration of matching.
-        unsafe { selector_ffi_matches_id(element.as_element_pointer(), id.cxx_simple_selector.as_ptr()) }
+        id.interned_name.is_some_and(|id| element.as_element().id() == Some(id))
     }
 
     fn matches_class_selector(&mut self, element: FfiNode<'a>, class_name: &NameSelector) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-        // SAFETY: `FfiDom` guarantees that the element and retained simple selector remain valid
-        // for the duration of matching.
-        unsafe { selector_ffi_matches_class(element.as_element_pointer(), class_name.cxx_simple_selector.as_ptr()) }
+        let ffi_element = element.as_element();
+        if ffi_element.class_names_are_case_insensitive {
+            crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
+            // SAFETY: `FfiDom` guarantees that the element and retained simple selector remain
+            // valid for the duration of matching.
+            return unsafe {
+                selector_ffi_matches_class_quirks(element.as_element_pointer(), class_name.cxx_simple_selector.as_ptr())
+            };
+        }
+        class_name
+            .interned_name
+            .is_some_and(|class_name| element.classes().contains(&class_name))
     }
 
     fn matches_attribute_selector(&mut self, element: FfiNode<'a>, attribute: &AttributeSelector) -> bool {
@@ -2100,6 +2173,12 @@ unsafe fn string_from_ffi(value: FfiStringView) -> SelectorString {
     unsafe { copy_ffi_slice(value.data, value.length) }
 }
 
+unsafe fn interned_name_from_ffi(selector: &FfiSimpleSelector) -> Option<usize> {
+    // SAFETY: The caller guarantees that a non-null pointer identifies the one-word storage of a
+    // live C++ `Utf16FlyString` for the duration of selector compilation.
+    unsafe { selector.interned_name.as_ref().copied() }
+}
+
 unsafe fn qualified_name_from_ffi(selector: &FfiSimpleSelector) -> QualifiedName {
     QualifiedName {
         namespace_type: selector.namespace_type,
@@ -2132,11 +2211,15 @@ unsafe fn simple_selector_from_ffi(selector: &FfiSimpleSelector) -> SimpleSelect
         FfiSimpleSelectorType::Id => SimpleSelector::Id(NameSelector {
             // SAFETY: The caller guarantees that every string view in `selector` is valid.
             name: unsafe { string_from_ffi(selector.name) },
+            // SAFETY: The caller guarantees that all retained C++ selector data is valid.
+            interned_name: unsafe { interned_name_from_ffi(selector) },
             cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
         }),
         FfiSimpleSelectorType::Class => SimpleSelector::Class(NameSelector {
             // SAFETY: The caller guarantees that every string view in `selector` is valid.
             name: unsafe { string_from_ffi(selector.name) },
+            // SAFETY: The caller guarantees that all retained C++ selector data is valid.
+            interned_name: unsafe { interned_name_from_ffi(selector) },
             cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
         }),
         FfiSimpleSelectorType::Attribute => SimpleSelector::Attribute(AttributeSelector {
@@ -2255,8 +2338,8 @@ unsafe fn compiled_selector_from_ffi(selector: &FfiSelector) -> Rc<CompiledSelec
 }
 
 unsafe fn with_ffi_dom<R>(
-    element: *const c_void,
-    shadow_host: *const c_void,
+    element: FfiElement,
+    shadow_host: FfiElement,
     context: *mut c_void,
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
@@ -2274,9 +2357,9 @@ unsafe fn with_ffi_dom<R>(
             inside_has_argument,
         )
     };
-    // SAFETY: The caller guarantees that `element` points to a DOM element.
+    // SAFETY: The caller guarantees that `element` wraps a live DOM element.
     let element = unsafe { dom.element(element) }.unwrap();
-    // SAFETY: The caller guarantees that a non-null `shadow_host` points to a DOM element.
+    // SAFETY: The caller guarantees that a non-null `shadow_host` wraps a live DOM element.
     let shadow_host = unsafe { dom.element(shadow_host) };
     // SAFETY: The caller guarantees that a non-null `scope` points to a DOM parent node.
     let scope = unsafe { dom.scope(scope) };
@@ -2330,15 +2413,15 @@ pub unsafe extern "C" fn rust_selector_target_pseudo_element(selector: *const Ru
 
 /// # Safety
 /// The `selector` handle must have been returned by `rust_selector_create`. `element` and a
-/// non-null `shadow_host` must point to C++ DOM elements, a non-null `scope` must point to a C++
+/// non-null `shadow_host` must wrap live C++ DOM elements, a non-null `scope` must point to a C++
 /// DOM parent node, and `context` must point to a C++ Rust matching context. All referenced objects
 /// must remain valid for this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_matches(
     selector: *const RustSelector,
-    element: *const c_void,
+    element: FfiElement,
     pseudo_element: u8,
-    shadow_host: *const c_void,
+    shadow_host: FfiElement,
     context: *mut c_void,
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
@@ -2378,15 +2461,15 @@ pub unsafe extern "C" fn rust_selector_matches(
 
 /// # Safety
 /// The `selector` handle must have been returned by `rust_selector_create`. `element` and a
-/// non-null `shadow_host` must point to C++ DOM elements, a non-null `scope` must point to a C++
+/// non-null `shadow_host` must wrap live C++ DOM elements, a non-null `scope` must point to a C++
 /// DOM parent node, and `context` must point to a C++ Rust matching context. All referenced objects
 /// must remain valid for this call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_matches_originating_element(
     selector: *const RustSelector,
     pseudo_element: u8,
-    element: *const c_void,
-    shadow_host: *const c_void,
+    element: FfiElement,
+    shadow_host: FfiElement,
     context: *mut c_void,
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
@@ -2658,6 +2741,7 @@ mod tests {
     fn class(name: &str) -> SimpleSelector {
         SimpleSelector::Class(NameSelector {
             name: name.encode_utf16().collect(),
+            interned_name: None,
             cxx_simple_selector: RetainedCxxPointer::default(),
         })
     }
@@ -2712,6 +2796,7 @@ mod tests {
                 combinator: *combinator,
                 simple_selectors: vec![SimpleSelector::Id(NameSelector {
                     name: Box::from([b'x' as u16]),
+                    interned_name: None,
                     cxx_simple_selector: RetainedCxxPointer::default(),
                 })]
                 .into_boxed_slice(),

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1619,6 +1619,24 @@ impl FfiElement {
         unsafe { selector_ffi_element_is_link(self.pointer) }
     }
 
+    fn is_focused(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_focused(self.pointer) }
+    }
+
+    fn should_indicate_focus(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_should_indicate_focus(self.pointer) }
+    }
+
+    fn has_focus_within(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_has_focus_within(self.pointer) }
+    }
+
     unsafe fn local_name<'a>(self) -> DomStringView<'a> {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns a string view borrowed
@@ -1869,6 +1887,9 @@ unsafe extern "C" {
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
     fn selector_ffi_element_is_link(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
+    fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
+    fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
     fn selector_ffi_element_attribute_count(element: *const c_void) -> usize;
@@ -2322,6 +2343,11 @@ impl<'a> SelectorDom for FfiDom<'a> {
     fn matches_pseudo_class_state(&mut self, element: FfiNode<'a>, pseudo_class: &PseudoClassSelector) -> bool {
         match pseudo_class.pseudo_class {
             PseudoClassType::AnyLink | PseudoClassType::Link => element.as_element().is_link(),
+            PseudoClassType::Focus => element.as_element().is_focused(),
+            PseudoClassType::FocusVisible => {
+                element.as_element().is_focused() && element.as_element().should_indicate_focus()
+            }
+            PseudoClassType::FocusWithin => element.as_element().has_focus_within(),
             PseudoClassType::Autofill => {
                 // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill
                 // FIXME: The :autofill and :-webkit-autofill pseudo-classes must match input

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -79,8 +79,6 @@ pub struct NameSelector {
     /// selectors compiled from C++ and allows the live DOM wrapper to compare interned names
     /// without crossing the FFI.
     interned_name: Option<usize>,
-    /// See [`QualifiedName::cxx_simple_selector`].
-    cxx_simple_selector: RetainedCxxPointer,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1629,6 +1627,17 @@ impl FfiElement {
         }
     }
 
+    unsafe fn class_name<'a>(self, index: usize) -> DomStringView<'a> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element and `index` identifies one of its
+        // current classes. C++ returns a view borrowed for this matching call.
+        DomStringView {
+            // SAFETY: The caller guarantees that `index` is within the current class list.
+            view: unsafe { selector_ffi_element_class_name(self.pointer, index) },
+            marker: PhantomData,
+        }
+    }
+
     unsafe fn classes<'a>(self) -> &'a [usize] {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns its current class storage,
@@ -1774,6 +1783,12 @@ impl<'a> FfiNode<'a> {
         // current local-name storage.
         unsafe { self.as_element().local_name() }
     }
+
+    fn class_name(self, index: usize) -> DomStringView<'a> {
+        // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
+        // current class-name storage. Callers obtain `index` from the same live class list.
+        unsafe { self.as_element().class_name(index) }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1792,11 +1807,11 @@ unsafe extern "C" {
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
+    fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
 
     fn selector_ffi_default_namespace(context: *mut c_void) -> FfiResolvedNamespace;
     fn selector_ffi_resolve_namespace(context: *mut c_void, prefix: FfiStringView) -> FfiResolvedNamespace;
 
-    fn selector_ffi_matches_class_quirks(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
     fn selector_ffi_matches_attribute(
         context: *mut c_void,
         element: *const c_void,
@@ -2010,12 +2025,8 @@ impl<'a> SelectorDom for FfiDom<'a> {
     fn matches_class_selector(&mut self, element: FfiNode<'a>, class_name: &NameSelector) -> bool {
         let ffi_element = element.as_element();
         if ffi_element.class_names_are_case_insensitive() {
-            crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-            // SAFETY: `FfiDom` guarantees that the element and retained simple selector remain
-            // valid for the duration of matching.
-            return unsafe {
-                selector_ffi_matches_class_quirks(element.as_element_pointer(), class_name.cxx_simple_selector.as_ptr())
-            };
+            return (0..element.classes().len())
+                .any(|index| utf16_equals_ignoring_ascii_case(element.class_name(index), &class_name.name));
         }
         class_name
             .interned_name
@@ -2389,14 +2400,12 @@ unsafe fn simple_selector_from_ffi(selector: &FfiSimpleSelector) -> SimpleSelect
             name: unsafe { string_from_ffi(selector.name) },
             // SAFETY: The caller guarantees that all retained C++ selector data is valid.
             interned_name: unsafe { interned_name_from_ffi(selector) },
-            cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
         }),
         FfiSimpleSelectorType::Class => SimpleSelector::Class(NameSelector {
             // SAFETY: The caller guarantees that every string view in `selector` is valid.
             name: unsafe { string_from_ffi(selector.name) },
             // SAFETY: The caller guarantees that all retained C++ selector data is valid.
             interned_name: unsafe { interned_name_from_ffi(selector) },
-            cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
         }),
         FfiSimpleSelectorType::Attribute => SimpleSelector::Attribute(AttributeSelector {
             match_type: selector.attribute_match_type,
@@ -2927,7 +2936,6 @@ mod tests {
         SimpleSelector::Class(NameSelector {
             name: name.encode_utf16().collect(),
             interned_name: None,
-            cxx_simple_selector: RetainedCxxPointer::default(),
         })
     }
 
@@ -2982,7 +2990,6 @@ mod tests {
                 simple_selectors: vec![SimpleSelector::Id(NameSelector {
                     name: Box::from([b'x' as u16]),
                     interned_name: None,
-                    cxx_simple_selector: RetainedCxxPointer::default(),
                 })]
                 .into_boxed_slice(),
             })

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1568,21 +1568,12 @@ pub struct RustSelector {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
-/// A borrowed view of the element's current selector-relevant identifier data.
+/// A DOM element borrowed for one selector-matching call.
 ///
-/// C++ constructs this immediately before crossing the FFI and after every tree navigation. The
-/// pointers must not be retained beyond the matching call.
+/// This handle contains no DOM-derived state. All facts are read from C++ on demand so mutations
+/// observed by later matching calls cannot be hidden by retained data.
 pub struct FfiElement {
     pub pointer: *const c_void,
-    pub local_name: *const usize,
-    pub namespace_: *const usize,
-    pub id: *const usize,
-    pub classes: *const usize,
-    pub class_count: usize,
-    pub class_names_are_case_insensitive: bool,
-    pub namespace_is_null: bool,
-    pub is_html_element_in_html_document: bool,
-    pub is_document_root: bool,
 }
 
 impl FfiElement {
@@ -1590,31 +1581,82 @@ impl FfiElement {
         self.pointer.is_null()
     }
 
-    fn id(self) -> Option<usize> {
-        // SAFETY: The C++ wrapper points at the live element's `Utf16FlyString` storage, which is
-        // pinned for the duration of the matching call.
-        unsafe { self.id.as_ref().copied() }
+    fn qualified_name(self) -> FfiElementQualifiedName {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_qualified_name(self.pointer) }
     }
 
+    fn id(self) -> Option<usize> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element. A non-null result points at its
+        // current pinned `Utf16FlyString` storage for this matching call.
+        unsafe { selector_ffi_element_id(self.pointer).as_ref().copied() }
+    }
+
+    fn class_names_are_case_insensitive(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_class_names_are_case_insensitive(self.pointer) }
+    }
+
+    fn namespace_is_null(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_namespace_is_null(self.pointer) }
+    }
+
+    fn is_html_element_in_html_document(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_html_element_in_html_document(self.pointer) }
+    }
+
+    fn is_document_root(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_document_root(self.pointer) }
+    }
+
+    unsafe fn classes<'a>(self) -> &'a [usize] {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element. C++ returns its current class storage,
+        // borrowed for this matching call.
+        let classes = unsafe { selector_ffi_element_classes(self.pointer) };
+        if classes.count == 0 {
+            return &[];
+        }
+        assert!(!classes.data.is_null());
+        // SAFETY: C++ guarantees that `Utf16FlyString` has the size and alignment of `usize` and
+        // that the element's class vector cannot mutate during this matching call.
+        unsafe { std::slice::from_raw_parts(classes.data, classes.count) }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiElementQualifiedName {
+    pub local_name: *const usize,
+    pub namespace_: *const usize,
+}
+
+impl FfiElementQualifiedName {
     fn local_name(self) -> Option<usize> {
-        // SAFETY: The C++ wrapper points at the live element's pinned `Utf16FlyString` storage.
+        // SAFETY: C++ points at the live element's pinned `Utf16FlyString` storage.
         unsafe { self.local_name.as_ref().copied() }
     }
 
     fn namespace(self) -> Option<usize> {
-        // SAFETY: The C++ wrapper points at the live element's pinned `Utf16FlyString` storage.
+        // SAFETY: C++ points at the live element's pinned `Utf16FlyString` storage.
         unsafe { self.namespace_.as_ref().copied() }
     }
+}
 
-    unsafe fn classes<'a>(self) -> &'a [usize] {
-        if self.class_count == 0 {
-            return &[];
-        }
-        assert!(!self.classes.is_null());
-        // SAFETY: C++ guarantees that `Utf16FlyString` has the size and alignment of `usize` and
-        // that the element's class vector cannot mutate during this matching call.
-        unsafe { std::slice::from_raw_parts(self.classes, self.class_count) }
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiInternedStringList {
+    pub data: *const usize,
+    pub count: usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1688,6 +1730,14 @@ pub struct FfiElementAndShadowHost {
 }
 
 unsafe extern "C" {
+    fn selector_ffi_element_qualified_name(element: *const c_void) -> FfiElementQualifiedName;
+    fn selector_ffi_element_id(element: *const c_void) -> *const usize;
+    fn selector_ffi_element_classes(element: *const c_void) -> FfiInternedStringList;
+    fn selector_ffi_element_class_names_are_case_insensitive(element: *const c_void) -> bool;
+    fn selector_ffi_element_namespace_is_null(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
+
     fn selector_ffi_matches_universal(
         context: *mut c_void,
         element: *const c_void,
@@ -1793,15 +1843,6 @@ impl<'a> FfiDom<'a> {
             kind,
             element: FfiElement {
                 pointer: std::ptr::null(),
-                local_name: std::ptr::null(),
-                namespace_: std::ptr::null(),
-                id: std::ptr::null(),
-                classes: std::ptr::null(),
-                class_count: 0,
-                class_names_are_case_insensitive: false,
-                namespace_is_null: true,
-                is_html_element_in_html_document: false,
-                is_document_root: false,
             },
             marker: PhantomData,
         })
@@ -1843,16 +1884,16 @@ impl<'a> SelectorDom for FfiDom<'a> {
         match name.namespace_type {
             NamespaceType::Default => match self.namespace_context.default_namespace_type {
                 FfiDefaultNamespaceType::Any => return true,
-                FfiDefaultNamespaceType::None => return element.as_element().namespace_is_null,
+                FfiDefaultNamespaceType::None => return element.as_element().namespace_is_null(),
                 FfiDefaultNamespaceType::Named => {
                     // SAFETY: C++ guarantees that the default namespace remains pinned for this
                     // matching call.
                     let default_namespace = unsafe { self.namespace_context.default_namespace.as_ref().copied() };
                     return default_namespace
-                        .is_some_and(|namespace| element.as_element().namespace() == Some(namespace));
+                        .is_some_and(|namespace| element.as_element().qualified_name().namespace() == Some(namespace));
                 }
             },
-            NamespaceType::None => return element.as_element().namespace_is_null,
+            NamespaceType::None => return element.as_element().namespace_is_null(),
             NamespaceType::Any => return true,
             NamespaceType::Named => {}
         }
@@ -1875,13 +1916,14 @@ impl<'a> SelectorDom for FfiDom<'a> {
         mode: TagNameMatchingMode,
     ) -> bool {
         let ffi_element = element.as_element();
-        if ffi_element.is_html_element_in_html_document || mode == TagNameMatchingMode::Fast {
-            let interned_name = if ffi_element.is_html_element_in_html_document {
+        let is_html_element_in_html_document = ffi_element.is_html_element_in_html_document();
+        if is_html_element_in_html_document || mode == TagNameMatchingMode::Fast {
+            let interned_name = if is_html_element_in_html_document {
                 name.interned_lowercase_name
             } else {
                 name.interned_name
             };
-            if interned_name.is_none_or(|name| ffi_element.local_name() != Some(name)) {
+            if interned_name.is_none_or(|name| ffi_element.qualified_name().local_name() != Some(name)) {
                 return false;
             }
             return self.matches_universal_selector(element, name);
@@ -1905,7 +1947,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
 
     fn matches_class_selector(&mut self, element: FfiNode<'a>, class_name: &NameSelector) -> bool {
         let ffi_element = element.as_element();
-        if ffi_element.class_names_are_case_insensitive {
+        if ffi_element.class_names_are_case_insensitive() {
             crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
             // SAFETY: `FfiDom` guarantees that the element and retained simple selector remain
             // valid for the duration of matching.
@@ -2053,13 +2095,13 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn has_same_type(&mut self, first: FfiNode<'a>, second: FfiNode<'a>) -> bool {
-        let first = first.as_element();
-        let second = second.as_element();
+        let first = first.as_element().qualified_name();
+        let second = second.as_element().qualified_name();
         first.local_name() == second.local_name() && first.namespace() == second.namespace()
     }
 
     fn is_document_root(&mut self, element: FfiNode<'a>) -> bool {
-        element.as_element().is_document_root
+        element.as_element().is_document_root()
     }
 
     fn is_shadow_tree_slot(&mut self, element: FfiNode<'a>) -> bool {

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1646,6 +1646,16 @@ impl FfiElement {
         unsafe { selector_ffi_element_popover_is_showing(self.pointer) }
     }
 
+    fn direction(self) -> Direction {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        match unsafe { selector_ffi_element_direction(self.pointer) } {
+            FfiDirection::LeftToRight => Direction::LeftToRight,
+            FfiDirection::RightToLeft => Direction::RightToLeft,
+            FfiDirection::None | FfiDirection::Other => unreachable!(),
+        }
+    }
+
     fn is_focused(self) -> bool {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
@@ -1918,6 +1928,7 @@ unsafe extern "C" {
     fn selector_ffi_element_heading_level(element: *const c_void) -> i64;
     fn selector_ffi_element_has_popover_attribute(element: *const c_void) -> bool;
     fn selector_ffi_element_popover_is_showing(element: *const c_void) -> bool;
+    fn selector_ffi_element_direction(element: *const c_void) -> FfiDirection;
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
@@ -1931,7 +1942,6 @@ unsafe extern "C" {
 
     fn selector_ffi_matches_pseudo_class(element: *const c_void, pseudo_class: u8) -> bool;
     fn selector_ffi_matches_language(element: *const c_void, language: FfiStringView) -> bool;
-    fn selector_ffi_matches_direction(element: *const c_void, direction: FfiDirection) -> bool;
     fn selector_ffi_matches_state(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
     fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> FfiElement;
     fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> FfiElement;
@@ -2403,19 +2413,9 @@ impl<'a> SelectorDom for FfiDom<'a> {
                 // view is borrowed from `language` for this callback only.
                 unsafe { selector_ffi_matches_language(element.as_element_pointer(), ffi_string_view(language)) }
             }),
-            PseudoClassType::Dir => match pseudo_class.direction {
-                Some(Direction::LeftToRight) => {
-                    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-                    // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
-                    unsafe { selector_ffi_matches_direction(element.as_element_pointer(), FfiDirection::LeftToRight) }
-                }
-                Some(Direction::RightToLeft) => {
-                    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-                    // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
-                    unsafe { selector_ffi_matches_direction(element.as_element_pointer(), FfiDirection::RightToLeft) }
-                }
-                _ => false,
-            },
+            PseudoClassType::Dir => pseudo_class
+                .direction
+                .is_some_and(|direction| direction == element.as_element().direction()),
             PseudoClassType::State => {
                 pseudo_class.identifier.is_some() && {
                     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1614,10 +1614,21 @@ impl FfiElement {
         unsafe { selector_ffi_element_id(self.pointer).as_ref().copied() }
     }
 
-    fn class_names_are_case_insensitive(self) -> bool {
+    unsafe fn id_value<'a>(self) -> DomStringView<'a> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element. C++ returns its current ID with
+        // backing storage owned by the element for this matching call.
+        DomStringView {
+            // SAFETY: C++ guarantees that the returned string view remains valid for matching.
+            view: unsafe { selector_ffi_element_id_value(self.pointer) },
+            marker: PhantomData,
+        }
+    }
+
+    fn id_and_class_names_are_case_insensitive(self) -> bool {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
-        unsafe { selector_ffi_element_class_names_are_case_insensitive(self.pointer) }
+        unsafe { selector_ffi_element_id_and_class_names_are_case_insensitive(self.pointer) }
     }
 
     fn namespace_is_null(self) -> bool {
@@ -2077,6 +2088,12 @@ impl FfiNode<'_> {
 }
 
 impl<'a> FfiNode<'a> {
+    fn id_value(self) -> DomStringView<'a> {
+        // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
+        // current ID storage.
+        unsafe { self.as_element().id_value() }
+    }
+
     fn classes(self) -> &'a [usize] {
         // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
         // current class storage.
@@ -2122,8 +2139,9 @@ pub struct FfiElementAndShadowHost {
 unsafe extern "C" {
     fn selector_ffi_element_qualified_name(element: *const c_void) -> FfiElementQualifiedName;
     fn selector_ffi_element_id(element: *const c_void) -> *const usize;
+    fn selector_ffi_element_id_value(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_classes(element: *const c_void) -> FfiInternedStringList;
-    fn selector_ffi_element_class_names_are_case_insensitive(element: *const c_void) -> bool;
+    fn selector_ffi_element_id_and_class_names_are_case_insensitive(element: *const c_void) -> bool;
     fn selector_ffi_element_namespace_is_null(element: *const c_void) -> bool;
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
@@ -2685,12 +2703,16 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn matches_id_selector(&mut self, element: FfiNode<'a>, id: &NameSelector) -> bool {
-        id.interned_name.is_some_and(|id| element.as_element().id() == Some(id))
+        let ffi_element = element.as_element();
+        if ffi_element.id_and_class_names_are_case_insensitive() {
+            return utf16_equals_ignoring_ascii_case(element.id_value(), &id.name);
+        }
+        id.interned_name.is_some_and(|id| ffi_element.id() == Some(id))
     }
 
     fn matches_class_selector(&mut self, element: FfiNode<'a>, class_name: &NameSelector) -> bool {
         let ffi_element = element.as_element();
-        if ffi_element.class_names_are_case_insensitive() {
+        if ffi_element.id_and_class_names_are_case_insensitive() {
             return (0..element.classes().len())
                 .any(|index| utf16_equals_ignoring_ascii_case(element.class_name(index), &class_name.name));
         }

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1613,6 +1613,12 @@ impl FfiElement {
         unsafe { selector_ffi_element_is_document_root(self.pointer) }
     }
 
+    fn is_link(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_link(self.pointer) }
+    }
+
     unsafe fn local_name<'a>(self) -> DomStringView<'a> {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns a string view borrowed
@@ -1862,6 +1868,7 @@ unsafe extern "C" {
     fn selector_ffi_element_namespace_is_null(element: *const c_void) -> bool;
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_link(element: *const c_void) -> bool;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
     fn selector_ffi_element_attribute_count(element: *const c_void) -> usize;
@@ -2314,6 +2321,26 @@ impl<'a> SelectorDom for FfiDom<'a> {
 
     fn matches_pseudo_class_state(&mut self, element: FfiNode<'a>, pseudo_class: &PseudoClassSelector) -> bool {
         match pseudo_class.pseudo_class {
+            PseudoClassType::AnyLink | PseudoClassType::Link => element.as_element().is_link(),
+            PseudoClassType::Autofill => {
+                // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill
+                // FIXME: The :autofill and :-webkit-autofill pseudo-classes must match input
+                //        elements which have been autofilled by user agent. These pseudo-classes
+                //        must stop matching if the user edits the autofilled field.
+                // NB: We don't support autofilling inputs yet, so this is always false.
+                false
+            }
+            PseudoClassType::Visited => {
+                // https://drafts.csswg.org/selectors/#visited-pseudo
+                // FIXME: For simplicity we currently have :visited never match. We may want to
+                //        rethink this in the future.
+                false
+            }
+            PseudoClassType::VolumeLocked => {
+                // FIXME: Currently we don't allow the user to specify an override volume, so this
+                //        is always false. Once we do, implement this!
+                false
+            }
             PseudoClassType::Lang => pseudo_class.languages.iter().any(|language| {
                 crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
                 // SAFETY: `FfiDom` guarantees that the element remains valid, and the string

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1618,6 +1618,17 @@ impl FfiElement {
         unsafe { selector_ffi_element_is_document_root(self.pointer) }
     }
 
+    unsafe fn local_name<'a>(self) -> DomStringView<'a> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element. C++ returns a string view borrowed
+        // from its current local name for this matching call.
+        DomStringView {
+            // SAFETY: C++ guarantees that the returned string view remains valid for matching.
+            view: unsafe { selector_ffi_element_local_name(self.pointer) },
+            marker: PhantomData,
+        }
+    }
+
     unsafe fn classes<'a>(self) -> &'a [usize] {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns its current class storage,
@@ -1657,6 +1668,37 @@ impl FfiElementQualifiedName {
 pub struct FfiInternedStringList {
     pub data: *const usize,
     pub count: usize,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiDomStringView {
+    pub data: *const c_void,
+    pub length: usize,
+    pub is_ascii: bool,
+}
+
+#[derive(Clone, Copy)]
+struct DomStringView<'a> {
+    view: FfiDomStringView,
+    marker: PhantomData<&'a FfiCallScope>,
+}
+
+impl DomStringView<'_> {
+    fn len(self) -> usize {
+        self.view.length
+    }
+
+    fn code_unit_at(self, index: usize) -> u16 {
+        assert!(index < self.len());
+        assert!(!self.view.data.is_null());
+        if self.view.is_ascii {
+            // SAFETY: C++ guarantees that an ASCII view points at `length` bytes.
+            return u16::from(unsafe { *(self.view.data.cast::<u8>().add(index)) });
+        }
+        // SAFETY: C++ guarantees that a UTF-16 view points at `length` aligned code units.
+        unsafe { *(self.view.data.cast::<u16>().add(index)) }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1726,6 +1768,12 @@ impl<'a> FfiNode<'a> {
         // current class storage.
         unsafe { self.as_element().classes() }
     }
+
+    fn local_name(self) -> DomStringView<'a> {
+        // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
+        // current local-name storage.
+        unsafe { self.as_element().local_name() }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1743,16 +1791,11 @@ unsafe extern "C" {
     fn selector_ffi_element_namespace_is_null(element: *const c_void) -> bool;
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
+    fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
 
     fn selector_ffi_default_namespace(context: *mut c_void) -> FfiResolvedNamespace;
     fn selector_ffi_resolve_namespace(context: *mut c_void, prefix: FfiStringView) -> FfiResolvedNamespace;
 
-    fn selector_ffi_matches_tag_name(
-        context: *mut c_void,
-        element: *const c_void,
-        cxx_simple_selector: *const c_void,
-        matching_mode: TagNameMatchingMode,
-    ) -> bool;
     fn selector_ffi_matches_class_quirks(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
     fn selector_ffi_matches_attribute(
         context: *mut c_void,
@@ -1811,6 +1854,22 @@ fn ffi_string_view(string: &[u16]) -> FfiStringView {
         data: string.as_ptr(),
         length: string.len(),
     }
+}
+
+fn ascii_lowercase(code_unit: u16) -> u16 {
+    if (u16::from(b'A')..=u16::from(b'Z')).contains(&code_unit) {
+        code_unit + u16::from(b'a' - b'A')
+    } else {
+        code_unit
+    }
+}
+
+fn utf16_equals_ignoring_ascii_case(first: DomStringView<'_>, second: &[u16]) -> bool {
+    first.len() == second.len()
+        && second
+            .iter()
+            .enumerate()
+            .all(|(index, &second)| ascii_lowercase(first.code_unit_at(index)) == ascii_lowercase(second))
 }
 
 struct FfiCallScope;
@@ -1928,28 +1987,20 @@ impl<'a> SelectorDom for FfiDom<'a> {
     ) -> bool {
         let ffi_element = element.as_element();
         let is_html_element_in_html_document = ffi_element.is_html_element_in_html_document();
-        if is_html_element_in_html_document || mode == TagNameMatchingMode::Fast {
+        let name_matches = if is_html_element_in_html_document || mode == TagNameMatchingMode::Fast {
             let interned_name = if is_html_element_in_html_document {
                 name.interned_lowercase_name
             } else {
                 name.interned_name
             };
-            if interned_name.is_none_or(|name| ffi_element.qualified_name().local_name() != Some(name)) {
-                return false;
-            }
-            return self.matches_universal_selector(element, name);
+            interned_name.is_some_and(|name| ffi_element.qualified_name().local_name() == Some(name))
+        } else {
+            utf16_equals_ignoring_ascii_case(element.local_name(), &name.name)
+        };
+        if !name_matches {
+            return false;
         }
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-        // SAFETY: `FfiDom` guarantees that the context, element, and retained simple selector
-        // remain valid for the duration of matching.
-        unsafe {
-            selector_ffi_matches_tag_name(
-                self.context,
-                element.as_element_pointer(),
-                name.cxx_simple_selector.as_ptr(),
-                mode,
-            )
-        }
+        self.matches_universal_selector(element, name)
     }
 
     fn matches_id_selector(&mut self, element: FfiNode<'a>, id: &NameSelector) -> bool {

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1744,6 +1744,42 @@ impl FfiElement {
         unsafe { selector_ffi_element_is_unchecked(self.pointer) }
     }
 
+    fn is_media_element(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_media_element(self.pointer) }
+    }
+
+    fn media_is_blocked(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_media_is_blocked(self.pointer) }
+    }
+
+    fn media_is_muted(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_media_is_muted(self.pointer) }
+    }
+
+    fn media_is_paused(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_media_is_paused(self.pointer) }
+    }
+
+    fn media_is_seeking(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_media_is_seeking(self.pointer) }
+    }
+
+    fn media_is_stalled(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_media_is_stalled(self.pointer) }
+    }
+
     unsafe fn local_name<'a>(self) -> DomStringView<'a> {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns a string view borrowed
@@ -2019,6 +2055,12 @@ unsafe extern "C" {
     fn selector_ffi_element_is_placeholder_shown(element: *const c_void) -> bool;
     fn selector_ffi_element_is_target(element: *const c_void) -> bool;
     fn selector_ffi_element_is_unchecked(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_media_element(element: *const c_void) -> bool;
+    fn selector_ffi_element_media_is_blocked(element: *const c_void) -> bool;
+    fn selector_ffi_element_media_is_muted(element: *const c_void) -> bool;
+    fn selector_ffi_element_media_is_paused(element: *const c_void) -> bool;
+    fn selector_ffi_element_media_is_seeking(element: *const c_void) -> bool;
+    fn selector_ffi_element_media_is_stalled(element: *const c_void) -> bool;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
     fn selector_ffi_element_attribute_count(element: *const c_void) -> usize;
@@ -2633,6 +2675,15 @@ impl<'a> SelectorDom for FfiDom<'a> {
             PseudoClassType::PlaceholderShown => element.as_element().is_placeholder_shown(),
             PseudoClassType::Target => element.as_element().is_target(),
             PseudoClassType::Unchecked => element.as_element().is_unchecked(),
+            PseudoClassType::Buffering => element.as_element().media_is_blocked(),
+            PseudoClassType::Muted => element.as_element().media_is_muted(),
+            PseudoClassType::Paused => element.as_element().media_is_paused(),
+            PseudoClassType::Playing => {
+                let element = element.as_element();
+                element.is_media_element() && !element.media_is_paused()
+            }
+            PseudoClassType::Seeking => element.as_element().media_is_seeking(),
+            PseudoClassType::Stalled => element.as_element().media_is_stalled(),
             PseudoClassType::Fullscreen => element.as_element().is_fullscreen(),
             PseudoClassType::Focus => element.as_element().is_focused(),
             PseudoClassType::FocusVisible => {

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -2238,6 +2238,14 @@ fn utf16_equals_ignoring_ascii_case(first: DomStringView<'_>, second: &[u16]) ->
             .all(|(index, &second)| ascii_lowercase(first.code_unit_at(index)) == ascii_lowercase(second))
 }
 
+fn utf16_equals(first: DomStringView<'_>, second: &[u16]) -> bool {
+    first.len() == second.len()
+        && second
+            .iter()
+            .enumerate()
+            .all(|(index, &second)| first.code_unit_at(index) == second)
+}
+
 struct SelectorSubtags<'a> {
     value: &'a [u16],
     position: usize,
@@ -2654,6 +2662,10 @@ impl<'a> SelectorDom for FfiDom<'a> {
         name: &QualifiedName,
         mode: TagNameMatchingMode,
     ) -> bool {
+        // https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
+        // The same selector when compared to other elements must be compared according to its
+        // original case. In both cases, to match, the values must be identical to each other (and
+        // therefore the comparison is case sensitive).
         let ffi_element = element.as_element();
         let is_html_element_in_html_document = ffi_element.is_html_element_in_html_document();
         let name_matches = if is_html_element_in_html_document || mode == TagNameMatchingMode::Fast {
@@ -2664,7 +2676,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
             };
             interned_name.is_some_and(|name| ffi_element.qualified_name().local_name() == Some(name))
         } else {
-            utf16_equals_ignoring_ascii_case(element.local_name(), &name.name)
+            utf16_equals(element.local_name(), &name.name)
         };
         if !name_matches {
             return false;

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1690,6 +1690,60 @@ impl FfiElement {
         unsafe { selector_ffi_element_has_focus_within(self.pointer) }
     }
 
+    fn is_active(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_active(self.pointer) }
+    }
+
+    fn is_checked(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_checked(self.pointer) }
+    }
+
+    fn is_defined(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_defined(self.pointer) }
+    }
+
+    fn is_disabled(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_disabled(self.pointer) }
+    }
+
+    fn is_enabled(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_enabled(self.pointer) }
+    }
+
+    fn is_local_link(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_local_link(self.pointer) }
+    }
+
+    fn is_placeholder_shown(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_placeholder_shown(self.pointer) }
+    }
+
+    fn is_target(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_target(self.pointer) }
+    }
+
+    fn is_unchecked(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_unchecked(self.pointer) }
+    }
+
     unsafe fn local_name<'a>(self) -> DomStringView<'a> {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns a string view borrowed
@@ -1956,6 +2010,15 @@ unsafe extern "C" {
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_active(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_checked(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_defined(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_disabled(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_enabled(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_local_link(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_placeholder_shown(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_target(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_unchecked(element: *const c_void) -> bool;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
     fn selector_ffi_element_attribute_count(element: *const c_void) -> usize;
@@ -2561,6 +2624,15 @@ impl<'a> SelectorDom for FfiDom<'a> {
     fn matches_pseudo_class_state(&mut self, element: FfiNode<'a>, pseudo_class: &PseudoClassSelector) -> bool {
         match pseudo_class.pseudo_class {
             PseudoClassType::AnyLink | PseudoClassType::Link => element.as_element().is_link(),
+            PseudoClassType::Active => element.as_element().is_active(),
+            PseudoClassType::Checked => element.as_element().is_checked(),
+            PseudoClassType::Defined => element.as_element().is_defined(),
+            PseudoClassType::Disabled => element.as_element().is_disabled(),
+            PseudoClassType::Enabled => element.as_element().is_enabled(),
+            PseudoClassType::LocalLink => element.as_element().is_local_link(),
+            PseudoClassType::PlaceholderShown => element.as_element().is_placeholder_shown(),
+            PseudoClassType::Target => element.as_element().is_target(),
+            PseudoClassType::Unchecked => element.as_element().is_unchecked(),
             PseudoClassType::Fullscreen => element.as_element().is_fullscreen(),
             PseudoClassType::Focus => element.as_element().is_focused(),
             PseudoClassType::FocusVisible => {

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -150,9 +150,8 @@ pub struct PseudoClassSelector {
     pub languages: Box<[SelectorString]>,
     pub direction: Option<Direction>,
     pub identifier: Option<SelectorString>,
+    pub identifier_identity: Option<usize>,
     pub levels: Box<[i64]>,
-    /// Pointer to the C++ simple selector used by the custom-state matching callback.
-    cxx_simple_selector: RetainedCxxPointer,
 }
 
 impl PseudoClassSelector {
@@ -165,8 +164,8 @@ impl PseudoClassSelector {
             languages: Box::new([]),
             direction: None,
             identifier: None,
+            identifier_identity: None,
             levels: Box::new([]),
-            cxx_simple_selector: RetainedCxxPointer::default(),
         }
     }
 }
@@ -1512,7 +1511,6 @@ pub struct FfiStringView {
 #[repr(C)]
 pub struct FfiSimpleSelector {
     pub selector_type: FfiSimpleSelectorType,
-    pub cxx_simple_selector: *const c_void,
     pub interned_name: *const usize,
     pub interned_lowercase_name: *const usize,
     pub namespace_type: NamespaceType,
@@ -1654,6 +1652,13 @@ impl FfiElement {
             FfiDirection::RightToLeft => Direction::RightToLeft,
             FfiDirection::None | FfiDirection::Other => unreachable!(),
         }
+    }
+
+    fn has_custom_state(self, state: usize) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element and `state` is the copied identity of
+        // an interned selector identifier.
+        unsafe { selector_ffi_element_has_custom_state(self.pointer, state) }
     }
 
     fn is_focused(self) -> bool {
@@ -1929,6 +1934,7 @@ unsafe extern "C" {
     fn selector_ffi_element_has_popover_attribute(element: *const c_void) -> bool;
     fn selector_ffi_element_popover_is_showing(element: *const c_void) -> bool;
     fn selector_ffi_element_direction(element: *const c_void) -> FfiDirection;
+    fn selector_ffi_element_has_custom_state(element: *const c_void, state: usize) -> bool;
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
@@ -1942,7 +1948,6 @@ unsafe extern "C" {
 
     fn selector_ffi_matches_pseudo_class(element: *const c_void, pseudo_class: u8) -> bool;
     fn selector_ffi_matches_language(element: *const c_void, language: FfiStringView) -> bool;
-    fn selector_ffi_matches_state(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
     fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> FfiElement;
     fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> FfiElement;
     fn selector_ffi_previous_element_sibling(element: *const c_void) -> FfiElement;
@@ -2416,19 +2421,9 @@ impl<'a> SelectorDom for FfiDom<'a> {
             PseudoClassType::Dir => pseudo_class
                 .direction
                 .is_some_and(|direction| direction == element.as_element().direction()),
-            PseudoClassType::State => {
-                pseudo_class.identifier.is_some() && {
-                    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-                    // SAFETY: `FfiDom` guarantees that the element and retained simple selector
-                    // remain valid for the duration of matching.
-                    unsafe {
-                        selector_ffi_matches_state(
-                            element.as_element_pointer(),
-                            pseudo_class.cxx_simple_selector.as_ptr(),
-                        )
-                    }
-                }
-            }
+            PseudoClassType::State => pseudo_class
+                .identifier_identity
+                .is_some_and(|state| element.as_element().has_custom_state(state)),
             PseudoClassType::Heading => element
                 .as_element()
                 .heading_level()
@@ -2788,6 +2783,9 @@ unsafe fn simple_selector_from_ffi(selector: &FfiSimpleSelector) -> SimpleSelect
                 // SAFETY: The caller guarantees that every string view in `selector` is valid.
                 unsafe { string_from_ffi(selector.identifier) }
             });
+            // SAFETY: The caller guarantees that a non-null pointer identifies a live C++
+            // `Utf16FlyString` for the duration of selector compilation.
+            let identifier_identity = unsafe { interned_name_from_ffi(selector) };
             // SAFETY: The caller guarantees that the levels array is valid.
             let levels = unsafe { copy_ffi_slice(selector.levels, selector.level_count) };
 
@@ -2801,8 +2799,8 @@ unsafe fn simple_selector_from_ffi(selector: &FfiSimpleSelector) -> SimpleSelect
                 languages,
                 direction,
                 identifier,
+                identifier_identity,
                 levels,
-                cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
             })
         }
         FfiSimpleSelectorType::PseudoElement => {
@@ -2906,9 +2904,8 @@ struct FfiDomConfiguration {
 /// properly aligned and valid for reads for the duration of this call. Every enum field must
 /// contain a valid discriminant.
 ///
-/// `FfiSelector::cxx_selector` and every `FfiSimpleSelector::cxx_simple_selector` must remain valid
-/// until the returned handle is passed to `rust_selector_destroy`. The returned handle must be
-/// destroyed exactly once.
+/// `FfiSelector::cxx_selector` must remain valid until the returned handle is passed to
+/// `rust_selector_destroy`. The returned handle must be destroyed exactly once.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_selector_create(selector: *const FfiSelector) -> *mut RustSelector {
     abort_on_panic(|| {
@@ -3493,8 +3490,8 @@ mod tests {
             languages: Box::new([]),
             direction: None,
             identifier: None,
+            identifier_identity: None,
             levels: Box::new([]),
-            cxx_simple_selector: RetainedCxxPointer::default(),
         });
         let selector = selector(vec![compound(Combinator::None, vec![class("anchor"), has])]);
         let mut dom = test_tree();
@@ -3535,8 +3532,8 @@ mod tests {
             languages: Box::new([]),
             direction: None,
             identifier: None,
+            identifier_identity: None,
             levels: Box::new([]),
-            cxx_simple_selector: RetainedCxxPointer::default(),
         });
         let selector = selector(vec![compound(Combinator::None, vec![nth_child])]);
         let mut dom = test_tree();

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1601,10 +1601,6 @@ pub struct FfiElement {
 }
 
 impl FfiElement {
-    fn is_null(self) -> bool {
-        self.pointer.is_null()
-    }
-
     fn qualified_name(self) -> FfiElementQualifiedName {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
@@ -2043,12 +2039,6 @@ pub struct FfiResolvedNamespace {
     pub namespace_: usize,
 }
 
-impl FfiResolvedNamespace {
-    fn namespace(self) -> Option<usize> {
-        (self.namespace_type == FfiResolvedNamespaceType::Named).then_some(self.namespace_)
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FfiNodeKind {
     Element,
@@ -2063,7 +2053,6 @@ enum FfiNodeKind {
 struct FfiNode<'a> {
     pointer: *const c_void,
     kind: FfiNodeKind,
-    element: FfiElement,
     marker: PhantomData<&'a FfiCallScope>,
 }
 
@@ -2083,7 +2072,7 @@ impl FfiNode<'_> {
 
     fn as_element(self) -> FfiElement {
         assert_eq!(self.kind, FfiNodeKind::Element);
-        self.element
+        FfiElement { pointer: self.pointer }
     }
 }
 
@@ -2591,23 +2580,13 @@ impl<'a> FfiDom<'a> {
         (!pointer.is_null()).then_some(FfiNode {
             pointer,
             kind,
-            element: FfiElement {
-                pointer: std::ptr::null(),
-            },
             marker: PhantomData,
         })
     }
 
     unsafe fn element(&self, element: FfiElement) -> Option<FfiNode<'a>> {
-        if element.is_null() {
-            return None;
-        }
-        Some(FfiNode {
-            pointer: element.pointer,
-            kind: FfiNodeKind::Element,
-            element,
-            marker: PhantomData,
-        })
+        // SAFETY: The caller guarantees that a non-null pointer identifies a live DOM element.
+        unsafe { self.node(element.pointer, FfiNodeKind::Element) }
     }
 
     unsafe fn scope(&self, scope: *const c_void) -> Option<FfiNode<'a>> {
@@ -2643,9 +2622,9 @@ impl<'a> FfiDom<'a> {
         match namespace.namespace_type {
             FfiResolvedNamespaceType::Missing => false,
             FfiResolvedNamespaceType::Null => element.as_element().namespace_is_null(),
-            FfiResolvedNamespaceType::Named => namespace
-                .namespace()
-                .is_some_and(|namespace| element.as_element().qualified_name().namespace() == Some(namespace)),
+            FfiResolvedNamespaceType::Named => {
+                element.as_element().qualified_name().namespace() == Some(namespace.namespace_)
+            }
         }
     }
 }
@@ -2760,13 +2739,16 @@ impl<'a> SelectorDom for FfiDom<'a> {
                 // "|attr").
                 NamespaceType::Default | NamespaceType::None => dom_attribute.namespace().is_none(),
                 NamespaceType::Any => true,
-                NamespaceType::Named => match resolved_namespace.unwrap().namespace_type {
-                    FfiResolvedNamespaceType::Missing => false,
-                    FfiResolvedNamespaceType::Null => dom_attribute.namespace().is_none(),
-                    FfiResolvedNamespaceType::Named => {
-                        dom_attribute.namespace() == resolved_namespace.unwrap().namespace()
+                NamespaceType::Named => {
+                    let resolved_namespace = resolved_namespace.unwrap();
+                    match resolved_namespace.namespace_type {
+                        FfiResolvedNamespaceType::Missing => false,
+                        FfiResolvedNamespaceType::Null => dom_attribute.namespace().is_none(),
+                        FfiResolvedNamespaceType::Named => {
+                            dom_attribute.namespace() == Some(resolved_namespace.namespace_)
+                        }
                     }
-                },
+                }
             };
             namespace_matches
                 && matches_attribute_value(
@@ -3394,7 +3376,7 @@ pub unsafe extern "C" fn rust_selector_matches(
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorMatchEntry);
     abort_on_panic(|| {
         assert!(!selector.is_null());
-        assert!(!element.is_null());
+        assert!(!element.pointer.is_null());
         assert!(!context.is_null());
         // SAFETY: The caller guarantees that the selector handle remains valid for this call.
         let selector = unsafe { &(*selector).selector };
@@ -3444,7 +3426,7 @@ pub unsafe extern "C" fn rust_selector_matches_originating_element(
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorMatchEntry);
     abort_on_panic(|| {
         assert!(!selector.is_null());
-        assert!(!element.is_null());
+        assert!(!element.pointer.is_null());
         assert!(!context.is_null());
         // SAFETY: The caller guarantees that the selector handle remains valid for this call.
         let selector = unsafe { &(*selector).selector };

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1719,7 +1719,6 @@ unsafe extern "C" {
     fn selector_ffi_first_element_descendant(element: *const c_void) -> FfiElement;
     fn selector_ffi_next_element_descendant(element: *const c_void, root: *const c_void) -> FfiElement;
     fn selector_ffi_has_no_element_or_nonempty_text_children(element: *const c_void) -> bool;
-    fn selector_ffi_has_same_type(first: *const c_void, second: *const c_void) -> bool;
 
     fn selector_ffi_is_shadow_tree_slot(element: *const c_void) -> bool;
     fn selector_ffi_slotted_parent(context: *mut c_void, element: *const c_void) -> FfiElementAndShadowHost;
@@ -2054,9 +2053,9 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn has_same_type(&mut self, first: FfiNode<'a>, second: FfiNode<'a>) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
-        // SAFETY: `FfiDom` guarantees that both elements remain valid for matching.
-        unsafe { selector_ffi_has_same_type(first.as_element_pointer(), second.as_element_pointer()) }
+        let first = first.as_element();
+        let second = second.as_element();
+        first.local_name() == second.local_name() && first.namespace() == second.namespace()
     }
 
     fn is_document_root(&mut self, element: FfiNode<'a>) -> bool {

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1625,6 +1625,15 @@ impl FfiElement {
         unsafe { selector_ffi_element_is_fullscreen(self.pointer) }
     }
 
+    fn heading_level(self) -> Option<i64> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        match unsafe { selector_ffi_element_heading_level(self.pointer) } {
+            0 => None,
+            level => Some(level),
+        }
+    }
+
     fn is_focused(self) -> bool {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element for the duration of matching.
@@ -1894,6 +1903,7 @@ unsafe extern "C" {
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
     fn selector_ffi_element_is_link(element: *const c_void) -> bool;
     fn selector_ffi_element_is_fullscreen(element: *const c_void) -> bool;
+    fn selector_ffi_element_heading_level(element: *const c_void) -> i64;
     fn selector_ffi_element_is_focused(element: *const c_void) -> bool;
     fn selector_ffi_element_should_indicate_focus(element: *const c_void) -> bool;
     fn selector_ffi_element_has_focus_within(element: *const c_void) -> bool;
@@ -1909,8 +1919,6 @@ unsafe extern "C" {
     fn selector_ffi_matches_language(element: *const c_void, language: FfiStringView) -> bool;
     fn selector_ffi_matches_direction(element: *const c_void, direction: FfiDirection) -> bool;
     fn selector_ffi_matches_state(element: *const c_void, cxx_simple_selector: *const c_void) -> bool;
-    fn selector_ffi_matches_heading(element: *const c_void, levels: *const i64, level_count: usize) -> bool;
-
     fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> FfiElement;
     fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> FfiElement;
     fn selector_ffi_previous_element_sibling(element: *const c_void) -> FfiElement;
@@ -2407,18 +2415,10 @@ impl<'a> SelectorDom for FfiDom<'a> {
                     }
                 }
             }
-            PseudoClassType::Heading => {
-                crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-                // SAFETY: `FfiDom` guarantees that the element remains valid, and the levels array
-                // remains valid for this callback.
-                unsafe {
-                    selector_ffi_matches_heading(
-                        element.as_element_pointer(),
-                        pseudo_class.levels.as_ptr(),
-                        pseudo_class.levels.len(),
-                    )
-                }
-            }
+            PseudoClassType::Heading => element
+                .as_element()
+                .heading_level()
+                .is_some_and(|level| pseudo_class.levels.is_empty() || pseudo_class.levels.contains(&level)),
             _ => {
                 crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
                 // SAFETY: `FfiDom` guarantees that the element remains valid for matching.

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1663,17 +1663,23 @@ pub struct FfiInternedStringList {
 #[repr(u8)]
 // NB: Constructed by C++ through the FFI.
 #[allow(dead_code)]
-pub enum FfiDefaultNamespaceType {
-    Any,
-    None,
+pub enum FfiResolvedNamespaceType {
+    Missing,
+    Null,
     Named,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(C)]
-pub struct FfiNamespaceContext {
-    pub default_namespace_type: FfiDefaultNamespaceType,
-    pub default_namespace: *const usize,
+pub struct FfiResolvedNamespace {
+    pub namespace_type: FfiResolvedNamespaceType,
+    pub namespace_: usize,
+}
+
+impl FfiResolvedNamespace {
+    fn namespace(self) -> Option<usize> {
+        (self.namespace_type == FfiResolvedNamespaceType::Named).then_some(self.namespace_)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1738,11 +1744,9 @@ unsafe extern "C" {
     fn selector_ffi_element_is_html_element_in_html_document(element: *const c_void) -> bool;
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
 
-    fn selector_ffi_matches_universal(
-        context: *mut c_void,
-        element: *const c_void,
-        cxx_simple_selector: *const c_void,
-    ) -> bool;
+    fn selector_ffi_default_namespace(context: *mut c_void) -> FfiResolvedNamespace;
+    fn selector_ffi_resolve_namespace(context: *mut c_void, prefix: FfiStringView) -> FfiResolvedNamespace;
+
     fn selector_ffi_matches_tag_name(
         context: *mut c_void,
         element: *const c_void,
@@ -1813,7 +1817,6 @@ struct FfiCallScope;
 
 struct FfiDom<'a> {
     context: *mut c_void,
-    namespace_context: FfiNamespaceContext,
     marker: PhantomData<&'a mut FfiCallScope>,
     // NB: Both flags are mirrored here so that the hot matching loops can skip the note_*
     //     callbacks without crossing the FFI; the common case collects no metadata.
@@ -1827,11 +1830,9 @@ impl<'a> FfiDom<'a> {
         _call_scope: &'a mut FfiCallScope,
         collects_selector_involvement_metadata: bool,
         inside_has_argument: bool,
-        namespace_context: FfiNamespaceContext,
     ) -> Self {
         Self {
             context,
-            namespace_context,
             marker: PhantomData,
             collects_selector_involvement_metadata,
             inside_has_argument,
@@ -1875,6 +1876,29 @@ impl<'a> FfiDom<'a> {
             self.element(value.shadow_host)
         }))
     }
+
+    fn default_namespace(&self) -> FfiResolvedNamespace {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The matching context remains live for this matching call.
+        unsafe { selector_ffi_default_namespace(self.context) }
+    }
+
+    fn resolve_namespace(&self, prefix: &[u16]) -> FfiResolvedNamespace {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The matching context remains live, and the prefix view is borrowed for this
+        // accessor call only.
+        unsafe { selector_ffi_resolve_namespace(self.context, ffi_string_view(prefix)) }
+    }
+
+    fn matches_resolved_namespace(&self, element: FfiNode<'a>, namespace: FfiResolvedNamespace) -> bool {
+        match namespace.namespace_type {
+            FfiResolvedNamespaceType::Missing => false,
+            FfiResolvedNamespaceType::Null => element.as_element().namespace_is_null(),
+            FfiResolvedNamespaceType::Named => namespace
+                .namespace()
+                .is_some_and(|namespace| element.as_element().qualified_name().namespace() == Some(namespace)),
+        }
+    }
 }
 
 impl<'a> SelectorDom for FfiDom<'a> {
@@ -1882,30 +1906,17 @@ impl<'a> SelectorDom for FfiDom<'a> {
 
     fn matches_universal_selector(&mut self, element: FfiNode<'a>, name: &QualifiedName) -> bool {
         match name.namespace_type {
-            NamespaceType::Default => match self.namespace_context.default_namespace_type {
-                FfiDefaultNamespaceType::Any => return true,
-                FfiDefaultNamespaceType::None => return element.as_element().namespace_is_null(),
-                FfiDefaultNamespaceType::Named => {
-                    // SAFETY: C++ guarantees that the default namespace remains pinned for this
-                    // matching call.
-                    let default_namespace = unsafe { self.namespace_context.default_namespace.as_ref().copied() };
-                    return default_namespace
-                        .is_some_and(|namespace| element.as_element().qualified_name().namespace() == Some(namespace));
-                }
-            },
-            NamespaceType::None => return element.as_element().namespace_is_null(),
-            NamespaceType::Any => return true,
-            NamespaceType::Named => {}
-        }
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-        // SAFETY: `FfiDom` guarantees that the context, element, and retained simple selector
-        // remain valid for the duration of matching.
-        unsafe {
-            selector_ffi_matches_universal(
-                self.context,
-                element.as_element_pointer(),
-                name.cxx_simple_selector.as_ptr(),
-            )
+            NamespaceType::Default => {
+                let namespace = self.default_namespace();
+                namespace.namespace_type == FfiResolvedNamespaceType::Missing
+                    || self.matches_resolved_namespace(element, namespace)
+            }
+            NamespaceType::None => element.as_element().namespace_is_null(),
+            NamespaceType::Any => true,
+            NamespaceType::Named => {
+                let namespace = self.resolve_namespace(&name.namespace);
+                self.matches_resolved_namespace(element, namespace)
+            }
         }
     }
 
@@ -2467,7 +2478,6 @@ unsafe fn with_ffi_dom<R>(
             &mut call_scope,
             configuration.collects_selector_involvement_metadata,
             configuration.inside_has_argument,
-            configuration.namespace_context,
         )
     };
     // SAFETY: The caller guarantees that `element` wraps a live DOM element.
@@ -2484,7 +2494,6 @@ struct FfiDomConfiguration {
     context: *mut c_void,
     collects_selector_involvement_metadata: bool,
     inside_has_argument: bool,
-    namespace_context: FfiNamespaceContext,
 }
 
 /// # Safety
@@ -2547,7 +2556,6 @@ pub unsafe extern "C" fn rust_selector_matches(
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
     inside_has_argument: bool,
-    namespace_context: FfiNamespaceContext,
 ) -> bool {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorMatchEntry);
     abort_on_panic(|| {
@@ -2567,7 +2575,6 @@ pub unsafe extern "C" fn rust_selector_matches(
                     context,
                     collects_selector_involvement_metadata,
                     inside_has_argument,
-                    namespace_context,
                 },
                 |element, shadow_host, scope, dom| {
                     let target = MatchTarget {
@@ -2599,7 +2606,6 @@ pub unsafe extern "C" fn rust_selector_matches_originating_element(
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
     inside_has_argument: bool,
-    namespace_context: FfiNamespaceContext,
 ) -> bool {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorMatchEntry);
     abort_on_panic(|| {
@@ -2619,7 +2625,6 @@ pub unsafe extern "C" fn rust_selector_matches_originating_element(
                     context,
                     collects_selector_involvement_metadata,
                     inside_has_argument,
-                    namespace_context,
                 },
                 |element, shadow_host, scope, dom| {
                     matches_originating_element_for_pseudo_element(

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -2191,7 +2191,8 @@ unsafe extern "C" {
     fn selector_ffi_first_element_child(element: *const c_void) -> FfiElement;
     fn selector_ffi_first_element_descendant(element: *const c_void) -> FfiElement;
     fn selector_ffi_next_element_descendant(element: *const c_void, root: *const c_void) -> FfiElement;
-    fn selector_ffi_has_no_element_or_nonempty_text_children(element: *const c_void) -> bool;
+    fn selector_ffi_element_has_element_child(element: *const c_void) -> bool;
+    fn selector_ffi_element_has_nonempty_text_child(element: *const c_void) -> bool;
 
     fn selector_ffi_is_shadow_tree_slot(element: *const c_void) -> bool;
     fn selector_ffi_slotted_parent(context: *mut c_void, element: *const c_void) -> FfiElementAndShadowHost;
@@ -2870,7 +2871,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn parent_element(&mut self, element: FfiNode<'a>, shadow_host: Option<FfiNode<'a>>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the input handles remain valid. The callback returns
         // either null or another live element borrowed for the same lifetime.
         unsafe {
@@ -2882,42 +2883,42 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn parent_element_in_light_tree(&mut self, element: FfiNode<'a>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the input remains valid. The callback returns either
         // null or another live element borrowed for the same lifetime.
         unsafe { self.element(selector_ffi_parent_element_in_light_tree(element.as_element_pointer())) }
     }
 
     fn previous_element_sibling(&mut self, element: FfiNode<'a>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the input remains valid. The callback returns either
         // null or another live element borrowed for the same lifetime.
         unsafe { self.element(selector_ffi_previous_element_sibling(element.as_element_pointer())) }
     }
 
     fn next_element_sibling(&mut self, element: FfiNode<'a>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the input remains valid. The callback returns either
         // null or another live element borrowed for the same lifetime.
         unsafe { self.element(selector_ffi_next_element_sibling(element.as_element_pointer())) }
     }
 
     fn first_element_child(&mut self, element: FfiNode<'a>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the input remains valid. The callback returns either
         // null or another live element borrowed for the same lifetime.
         unsafe { self.element(selector_ffi_first_element_child(element.as_element_pointer())) }
     }
 
     fn first_element_descendant(&mut self, element: FfiNode<'a>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the input remains valid. The callback returns either
         // null or another live element borrowed for the same lifetime.
         unsafe { self.element(selector_ffi_first_element_descendant(element.as_element_pointer())) }
     }
 
     fn next_element_descendant(&mut self, element: FfiNode<'a>, root: FfiNode<'a>) -> Option<FfiNode<'a>> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that both element handles remain valid for this call. The
         // callback returns either null or another live element borrowed for the same lifetime.
         unsafe {
@@ -2929,9 +2930,14 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn has_no_element_or_nonempty_text_children(&mut self, element: FfiNode<'a>) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
-        unsafe { selector_ffi_has_no_element_or_nonempty_text_children(element.as_element_pointer()) }
+        if unsafe { selector_ffi_element_has_element_child(element.as_element_pointer()) } {
+            return false;
+        }
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
+        !unsafe { selector_ffi_element_has_nonempty_text_child(element.as_element_pointer()) }
     }
 
     fn has_same_type(&mut self, first: FfiNode<'a>, second: FfiNode<'a>) -> bool {
@@ -2945,13 +2951,13 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn is_shadow_tree_slot(&mut self, element: FfiNode<'a>) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
         unsafe { selector_ffi_is_shadow_tree_slot(element.as_element_pointer()) }
     }
 
     fn slotted_parent(&mut self, element: FfiNode<'a>) -> Option<(FfiNode<'a>, Option<FfiNode<'a>>)> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: `FfiDom` guarantees that the context and element remain valid. The callback
         // returns null or live elements borrowed for the same lifetime.
         unsafe { self.element_and_shadow_host(selector_ffi_slotted_parent(self.context, element.as_element_pointer())) }
@@ -2964,7 +2970,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
         allow_same_shadow_root_scope: bool,
         shadow_host: Option<FfiNode<'a>>,
     ) -> Option<(FfiNode<'a>, Option<FfiNode<'a>>)> {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorTreeNavigationCallback);
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         let identifiers = identifiers
             .iter()
             .map(|identifier| ffi_string_view(identifier))

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -67,9 +67,6 @@ pub struct QualifiedName {
     pub lowercase_name: SelectorString,
     interned_name: Option<usize>,
     interned_lowercase_name: Option<usize>,
-    /// Pointer to the C++ simple selector this was compiled from, so that matching callbacks can
-    /// compare its interned strings without copying. Null in unit tests.
-    cxx_simple_selector: RetainedCxxPointer,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -154,7 +151,7 @@ pub struct PseudoClassSelector {
     pub direction: Option<Direction>,
     pub identifier: Option<SelectorString>,
     pub levels: Box<[i64]>,
-    /// See [`QualifiedName::cxx_simple_selector`].
+    /// Pointer to the C++ simple selector used by the custom-state matching callback.
     cxx_simple_selector: RetainedCxxPointer,
 }
 
@@ -1638,6 +1635,23 @@ impl FfiElement {
         }
     }
 
+    fn attribute_count(self) -> usize {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_attribute_count(self.pointer) }
+    }
+
+    unsafe fn attribute<'a>(self, index: usize) -> DomAttribute<'a> {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element and `index` identifies one of its
+        // current attributes. C++ returns its facts and a value view borrowed for matching.
+        DomAttribute {
+            // SAFETY: The caller guarantees that `index` is within the current attribute list.
+            attribute: unsafe { selector_ffi_element_attribute(self.pointer, index) },
+            marker: PhantomData,
+        }
+    }
+
     unsafe fn classes<'a>(self) -> &'a [usize] {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns its current class storage,
@@ -1685,6 +1699,38 @@ pub struct FfiDomStringView {
     pub data: *const c_void,
     pub length: usize,
     pub is_ascii: bool,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiDomAttribute {
+    pub local_name: usize,
+    pub namespace_: usize,
+    pub has_namespace: bool,
+    pub value: FfiDomStringView,
+}
+
+#[derive(Clone, Copy)]
+struct DomAttribute<'a> {
+    attribute: FfiDomAttribute,
+    marker: PhantomData<&'a FfiCallScope>,
+}
+
+impl<'a> DomAttribute<'a> {
+    fn local_name(self) -> usize {
+        self.attribute.local_name
+    }
+
+    fn namespace(self) -> Option<usize> {
+        self.attribute.has_namespace.then_some(self.attribute.namespace_)
+    }
+
+    fn value(self) -> DomStringView<'a> {
+        DomStringView {
+            view: self.attribute.value,
+            marker: PhantomData,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1789,6 +1835,16 @@ impl<'a> FfiNode<'a> {
         // current class-name storage. Callers obtain `index` from the same live class list.
         unsafe { self.as_element().class_name(index) }
     }
+
+    fn attribute_count(self) -> usize {
+        self.as_element().attribute_count()
+    }
+
+    fn attribute(self, index: usize) -> DomAttribute<'a> {
+        // SAFETY: `FfiNode` cannot outlive the call scope which pins the C++ element and its
+        // current attribute storage. Callers obtain `index` from the live attribute count.
+        unsafe { self.as_element().attribute(index) }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1808,15 +1864,12 @@ unsafe extern "C" {
     fn selector_ffi_element_is_document_root(element: *const c_void) -> bool;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
+    fn selector_ffi_element_attribute_count(element: *const c_void) -> usize;
+    fn selector_ffi_element_attribute(element: *const c_void, index: usize) -> FfiDomAttribute;
 
     fn selector_ffi_default_namespace(context: *mut c_void) -> FfiResolvedNamespace;
     fn selector_ffi_resolve_namespace(context: *mut c_void, prefix: FfiStringView) -> FfiResolvedNamespace;
 
-    fn selector_ffi_matches_attribute(
-        context: *mut c_void,
-        element: *const c_void,
-        cxx_simple_selector: *const c_void,
-    ) -> bool;
     fn selector_ffi_matches_pseudo_class(element: *const c_void, pseudo_class: u8) -> bool;
     fn selector_ffi_matches_language(element: *const c_void, language: FfiStringView) -> bool;
     fn selector_ffi_matches_direction(element: *const c_void, direction: FfiDirection) -> bool;
@@ -1885,6 +1938,162 @@ fn utf16_equals_ignoring_ascii_case(first: DomStringView<'_>, second: &[u16]) ->
             .iter()
             .enumerate()
             .all(|(index, &second)| ascii_lowercase(first.code_unit_at(index)) == ascii_lowercase(second))
+}
+
+#[derive(Clone, Copy)]
+enum StringCaseSensitivity {
+    Sensitive,
+    AsciiInsensitive,
+}
+
+fn code_units_equal(first: u16, second: u16, case_sensitivity: StringCaseSensitivity) -> bool {
+    match case_sensitivity {
+        StringCaseSensitivity::Sensitive => first == second,
+        StringCaseSensitivity::AsciiInsensitive => ascii_lowercase(first) == ascii_lowercase(second),
+    }
+}
+
+fn dom_string_matches_at(
+    value: DomStringView<'_>,
+    start: usize,
+    selector_value: &[u16],
+    case_sensitivity: StringCaseSensitivity,
+) -> bool {
+    start
+        .checked_add(selector_value.len())
+        .is_some_and(|end| end <= value.len())
+        && selector_value
+            .iter()
+            .enumerate()
+            .all(|(index, &selector)| code_units_equal(value.code_unit_at(start + index), selector, case_sensitivity))
+}
+
+fn dom_string_equals(
+    value: DomStringView<'_>,
+    selector_value: &[u16],
+    case_sensitivity: StringCaseSensitivity,
+) -> bool {
+    value.len() == selector_value.len() && dom_string_matches_at(value, 0, selector_value, case_sensitivity)
+}
+
+fn matches_attribute_value(
+    match_type: AttributeMatchType,
+    selector_value: &[u16],
+    attribute_value: DomStringView<'_>,
+    case_sensitivity: StringCaseSensitivity,
+) -> bool {
+    match match_type {
+        AttributeMatchType::HasAttribute => true,
+        AttributeMatchType::ExactValue => dom_string_equals(attribute_value, selector_value, case_sensitivity),
+        AttributeMatchType::ContainsWord => {
+            if selector_value.is_empty()
+                || selector_value.contains(&u16::from(b' '))
+                || selector_value.len() > attribute_value.len()
+            {
+                return false;
+            }
+            (0..=attribute_value.len() - selector_value.len()).any(|start| {
+                (start == 0 || attribute_value.code_unit_at(start - 1) == u16::from(b' '))
+                    && (start + selector_value.len() == attribute_value.len()
+                        || attribute_value.code_unit_at(start + selector_value.len()) == u16::from(b' '))
+                    && dom_string_matches_at(attribute_value, start, selector_value, case_sensitivity)
+            })
+        }
+        AttributeMatchType::ContainsString => {
+            if selector_value.is_empty() || selector_value.len() > attribute_value.len() {
+                return false;
+            }
+            (0..=attribute_value.len() - selector_value.len())
+                .any(|start| dom_string_matches_at(attribute_value, start, selector_value, case_sensitivity))
+        }
+        AttributeMatchType::StartsWithSegment => {
+            if attribute_value.len() == 0 {
+                return selector_value.is_empty();
+            }
+            if selector_value.is_empty() || selector_value.len() > attribute_value.len() {
+                return false;
+            }
+            dom_string_matches_at(attribute_value, 0, selector_value, case_sensitivity)
+                && (selector_value.len() == attribute_value.len()
+                    || attribute_value.code_unit_at(selector_value.len()) == u16::from(b'-'))
+        }
+        AttributeMatchType::StartsWithString => {
+            !selector_value.is_empty() && dom_string_matches_at(attribute_value, 0, selector_value, case_sensitivity)
+        }
+        AttributeMatchType::EndsWithString => {
+            !selector_value.is_empty()
+                && selector_value.len() <= attribute_value.len()
+                && dom_string_matches_at(
+                    attribute_value,
+                    attribute_value.len() - selector_value.len(),
+                    selector_value,
+                    case_sensitivity,
+                )
+        }
+    }
+}
+
+fn utf16_equals_ascii(value: &[u16], ascii: &[u8]) -> bool {
+    value.len() == ascii.len()
+        && value
+            .iter()
+            .zip(ascii)
+            .all(|(&code_unit, &byte)| code_unit == u16::from(byte))
+}
+
+// https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
+// Attribute selectors on an HTML element in an HTML document must treat the values of attributes
+// with the following names as ASCII case-insensitive:
+fn is_ascii_case_insensitive_html_attribute(name: &[u16]) -> bool {
+    const NAMES: &[&[u8]] = &[
+        b"accept",
+        b"accept-charset",
+        b"align",
+        b"alink",
+        b"axis",
+        b"bgcolor",
+        b"charset",
+        b"checked",
+        b"clear",
+        b"codetype",
+        b"color",
+        b"compact",
+        b"declare",
+        b"defer",
+        b"dir",
+        b"direction",
+        b"disabled",
+        b"enctype",
+        b"face",
+        b"frame",
+        b"hreflang",
+        b"http-equiv",
+        b"lang",
+        b"language",
+        b"link",
+        b"media",
+        b"method",
+        b"multiple",
+        b"nohref",
+        b"noresize",
+        b"noshade",
+        b"nowrap",
+        b"readonly",
+        b"rel",
+        b"rev",
+        b"rules",
+        b"scope",
+        b"scrolling",
+        b"selected",
+        b"shape",
+        b"target",
+        b"text",
+        b"type",
+        b"valign",
+        b"valuetype",
+        b"vlink",
+    ];
+    NAMES.iter().any(|candidate| utf16_equals_ascii(name, candidate))
 }
 
 struct FfiCallScope;
@@ -2034,16 +2243,73 @@ impl<'a> SelectorDom for FfiDom<'a> {
     }
 
     fn matches_attribute_selector(&mut self, element: FfiNode<'a>, attribute: &AttributeSelector) -> bool {
-        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-        // SAFETY: `FfiDom` guarantees that the context, element, and retained simple selector
-        // remain valid for the duration of matching.
-        unsafe {
-            selector_ffi_matches_attribute(
-                self.context,
-                element.as_element_pointer(),
-                attribute.qualified_name.cxx_simple_selector.as_ptr(),
-            )
-        }
+        let qualified_name = &attribute.qualified_name;
+        let is_html_element_in_html_document = element.as_element().is_html_element_in_html_document();
+        let use_lowercase_name =
+            is_html_element_in_html_document && qualified_name.namespace_type != NamespaceType::Named;
+        let name_to_match = if use_lowercase_name {
+            qualified_name.interned_lowercase_name
+        } else {
+            qualified_name.interned_name
+        };
+        let Some(name_to_match) = name_to_match else {
+            return false;
+        };
+
+        let resolved_namespace = if qualified_name.namespace_type == NamespaceType::Named {
+            let namespace = self.resolve_namespace(&qualified_name.namespace);
+            if namespace.namespace_type == FfiResolvedNamespaceType::Missing {
+                return false;
+            }
+            Some(namespace)
+        } else {
+            None
+        };
+
+        let case_sensitivity = match attribute.case_type {
+            AttributeCaseType::Sensitive => StringCaseSensitivity::Sensitive,
+            AttributeCaseType::Insensitive => StringCaseSensitivity::AsciiInsensitive,
+            AttributeCaseType::Default => {
+                if is_html_element_in_html_document
+                    && qualified_name.namespace_type == NamespaceType::Default
+                    && is_ascii_case_insensitive_html_attribute(&qualified_name.name)
+                {
+                    StringCaseSensitivity::AsciiInsensitive
+                } else {
+                    StringCaseSensitivity::Sensitive
+                }
+            }
+        };
+
+        (0..element.attribute_count()).any(|index| {
+            let dom_attribute = element.attribute(index);
+            if dom_attribute.local_name() != name_to_match {
+                return false;
+            }
+            let namespace_matches = match qualified_name.namespace_type {
+                // https://www.w3.org/TR/selectors-4/#attrnmsp
+                // In keeping with the Namespaces in the XML recommendation, default namespaces do
+                // not apply to attributes, therefore attribute selectors without a namespace
+                // component apply only to attributes that have no namespace (equivalent to
+                // "|attr").
+                NamespaceType::Default | NamespaceType::None => dom_attribute.namespace().is_none(),
+                NamespaceType::Any => true,
+                NamespaceType::Named => match resolved_namespace.unwrap().namespace_type {
+                    FfiResolvedNamespaceType::Missing => false,
+                    FfiResolvedNamespaceType::Null => dom_attribute.namespace().is_none(),
+                    FfiResolvedNamespaceType::Named => {
+                        dom_attribute.namespace() == resolved_namespace.unwrap().namespace()
+                    }
+                },
+            };
+            namespace_matches
+                && matches_attribute_value(
+                    attribute.match_type,
+                    &attribute.value,
+                    dom_attribute.value(),
+                    case_sensitivity,
+                )
+        })
     }
 
     fn matches_pseudo_class_state(&mut self, element: FfiNode<'a>, pseudo_class: &PseudoClassSelector) -> bool {
@@ -2375,7 +2641,6 @@ unsafe fn qualified_name_from_ffi(selector: &FfiSimpleSelector) -> QualifiedName
         // SAFETY: The caller guarantees that a non-null pointer identifies retained C++ selector
         // data for the duration of selector compilation.
         interned_lowercase_name: unsafe { selector.interned_lowercase_name.as_ref().copied() },
-        cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
     }
 }
 

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -1479,6 +1479,37 @@ pub enum FfiDirection {
     Other,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+// NB: Constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiMeterValueState {
+    NotMeter,
+    EvenLessGood,
+    Suboptimal,
+    Optimal,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+// NB: Constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiRequiredState {
+    NotApplicable,
+    Optional,
+    Required,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+// NB: Constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiValidityState {
+    NotApplicable,
+    Invalid,
+    Valid,
+}
+
 #[derive(Clone, Copy)]
 #[repr(u8)]
 // NB: Constructed by C++ through the FFI.
@@ -1780,6 +1811,78 @@ impl FfiElement {
         unsafe { selector_ffi_element_media_is_stalled(self.pointer) }
     }
 
+    fn is_default(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_default(self.pointer) }
+    }
+
+    fn meter_value_state(self) -> FfiMeterValueState {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_meter_value_state(self.pointer) }
+    }
+
+    fn meter_value_is_high(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_meter_value_is_high(self.pointer) }
+    }
+
+    fn meter_value_is_low(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_meter_value_is_low(self.pointer) }
+    }
+
+    fn is_hovered(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_hovered(self.pointer) }
+    }
+
+    fn is_indeterminate(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_indeterminate(self.pointer) }
+    }
+
+    fn validity_state(self) -> FfiValidityState {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_validity_state(self.pointer) }
+    }
+
+    fn is_modal(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_modal(self.pointer) }
+    }
+
+    fn is_open(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_open(self.pointer) }
+    }
+
+    fn required_state(self) -> FfiRequiredState {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_required_state(self.pointer) }
+    }
+
+    fn is_read_write(self) -> bool {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_is_read_write(self.pointer) }
+    }
+
+    fn user_validity_state(self) -> FfiValidityState {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
+        // SAFETY: The handle identifies a live DOM element for the duration of matching.
+        unsafe { selector_ffi_element_user_validity_state(self.pointer) }
+    }
+
     unsafe fn local_name<'a>(self) -> DomStringView<'a> {
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorDomReadCallback);
         // SAFETY: The handle identifies a live DOM element. C++ returns a string view borrowed
@@ -2061,6 +2164,18 @@ unsafe extern "C" {
     fn selector_ffi_element_media_is_paused(element: *const c_void) -> bool;
     fn selector_ffi_element_media_is_seeking(element: *const c_void) -> bool;
     fn selector_ffi_element_media_is_stalled(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_default(element: *const c_void) -> bool;
+    fn selector_ffi_element_meter_value_state(element: *const c_void) -> FfiMeterValueState;
+    fn selector_ffi_element_meter_value_is_high(element: *const c_void) -> bool;
+    fn selector_ffi_element_meter_value_is_low(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_hovered(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_indeterminate(element: *const c_void) -> bool;
+    fn selector_ffi_element_validity_state(element: *const c_void) -> FfiValidityState;
+    fn selector_ffi_element_is_modal(element: *const c_void) -> bool;
+    fn selector_ffi_element_is_open(element: *const c_void) -> bool;
+    fn selector_ffi_element_required_state(element: *const c_void) -> FfiRequiredState;
+    fn selector_ffi_element_is_read_write(element: *const c_void) -> bool;
+    fn selector_ffi_element_user_validity_state(element: *const c_void) -> FfiValidityState;
     fn selector_ffi_element_local_name(element: *const c_void) -> FfiDomStringView;
     fn selector_ffi_element_class_name(element: *const c_void, index: usize) -> FfiDomStringView;
     fn selector_ffi_element_attribute_count(element: *const c_void) -> usize;
@@ -2069,7 +2184,6 @@ unsafe extern "C" {
     fn selector_ffi_default_namespace(context: *mut c_void) -> FfiResolvedNamespace;
     fn selector_ffi_resolve_namespace(context: *mut c_void, prefix: FfiStringView) -> FfiResolvedNamespace;
 
-    fn selector_ffi_matches_pseudo_class(element: *const c_void, pseudo_class: u8) -> bool;
     fn selector_ffi_parent_element(element: *const c_void, shadow_host: *const c_void) -> FfiElement;
     fn selector_ffi_parent_element_in_light_tree(element: *const c_void) -> FfiElement;
     fn selector_ffi_previous_element_sibling(element: *const c_void) -> FfiElement;
@@ -2684,6 +2798,28 @@ impl<'a> SelectorDom for FfiDom<'a> {
             }
             PseudoClassType::Seeking => element.as_element().media_is_seeking(),
             PseudoClassType::Stalled => element.as_element().media_is_stalled(),
+            PseudoClassType::Default => element.as_element().is_default(),
+            PseudoClassType::EvenLessGoodValue => {
+                element.as_element().meter_value_state() == FfiMeterValueState::EvenLessGood
+            }
+            PseudoClassType::HighValue => element.as_element().meter_value_is_high(),
+            PseudoClassType::Hover => element.as_element().is_hovered(),
+            PseudoClassType::Indeterminate => element.as_element().is_indeterminate(),
+            PseudoClassType::Invalid => element.as_element().validity_state() == FfiValidityState::Invalid,
+            PseudoClassType::LowValue => element.as_element().meter_value_is_low(),
+            PseudoClassType::Modal => element.as_element().is_modal(),
+            PseudoClassType::Open => element.as_element().is_open(),
+            PseudoClassType::OptimalValue => element.as_element().meter_value_state() == FfiMeterValueState::Optimal,
+            PseudoClassType::Optional => element.as_element().required_state() == FfiRequiredState::Optional,
+            PseudoClassType::ReadOnly => !element.as_element().is_read_write(),
+            PseudoClassType::ReadWrite => element.as_element().is_read_write(),
+            PseudoClassType::Required => element.as_element().required_state() == FfiRequiredState::Required,
+            PseudoClassType::SuboptimalValue => {
+                element.as_element().meter_value_state() == FfiMeterValueState::Suboptimal
+            }
+            PseudoClassType::UserInvalid => element.as_element().user_validity_state() == FfiValidityState::Invalid,
+            PseudoClassType::UserValid => element.as_element().user_validity_state() == FfiValidityState::Valid,
+            PseudoClassType::Valid => element.as_element().validity_state() == FfiValidityState::Valid,
             PseudoClassType::Fullscreen => element.as_element().is_fullscreen(),
             PseudoClassType::Focus => element.as_element().is_focused(),
             PseudoClassType::FocusVisible => {
@@ -2729,13 +2865,7 @@ impl<'a> SelectorDom for FfiDom<'a> {
             PseudoClassType::PopoverOpen => {
                 element.as_element().has_popover_attribute() && element.as_element().popover_is_showing()
             }
-            _ => {
-                crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
-                // SAFETY: `FfiDom` guarantees that the element remains valid for matching.
-                unsafe {
-                    selector_ffi_matches_pseudo_class(element.as_element_pointer(), pseudo_class.pseudo_class as u8)
-                }
-            }
+            _ => unreachable!("structural pseudo-class reached state matching"),
         }
     }
 

--- a/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/selector_engine.rs
@@ -65,6 +65,8 @@ pub struct QualifiedName {
     pub namespace: SelectorString,
     pub name: SelectorString,
     pub lowercase_name: SelectorString,
+    interned_name: Option<usize>,
+    interned_lowercase_name: Option<usize>,
     /// Pointer to the C++ simple selector this was compiled from, so that matching callbacks can
     /// compare its interned strings without copying. Null in unit tests.
     cxx_simple_selector: RetainedCxxPointer,
@@ -1517,6 +1519,7 @@ pub struct FfiSimpleSelector {
     pub selector_type: FfiSimpleSelectorType,
     pub cxx_simple_selector: *const c_void,
     pub interned_name: *const usize,
+    pub interned_lowercase_name: *const usize,
     pub namespace_type: NamespaceType,
     pub namespace: FfiStringView,
     pub name: FfiStringView,
@@ -1571,10 +1574,14 @@ pub struct RustSelector {
 /// pointers must not be retained beyond the matching call.
 pub struct FfiElement {
     pub pointer: *const c_void,
+    pub local_name: *const usize,
+    pub namespace_: *const usize,
     pub id: *const usize,
     pub classes: *const usize,
     pub class_count: usize,
     pub class_names_are_case_insensitive: bool,
+    pub namespace_is_null: bool,
+    pub is_html_element_in_html_document: bool,
 }
 
 impl FfiElement {
@@ -1588,6 +1595,16 @@ impl FfiElement {
         unsafe { self.id.as_ref().copied() }
     }
 
+    fn local_name(self) -> Option<usize> {
+        // SAFETY: The C++ wrapper points at the live element's pinned `Utf16FlyString` storage.
+        unsafe { self.local_name.as_ref().copied() }
+    }
+
+    fn namespace(self) -> Option<usize> {
+        // SAFETY: The C++ wrapper points at the live element's pinned `Utf16FlyString` storage.
+        unsafe { self.namespace_.as_ref().copied() }
+    }
+
     unsafe fn classes<'a>(self) -> &'a [usize] {
         if self.class_count == 0 {
             return &[];
@@ -1597,6 +1614,23 @@ impl FfiElement {
         // that the element's class vector cannot mutate during this matching call.
         unsafe { std::slice::from_raw_parts(self.classes, self.class_count) }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+// NB: Constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiDefaultNamespaceType {
+    Any,
+    None,
+    Named,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiNamespaceContext {
+    pub default_namespace_type: FfiDefaultNamespaceType,
+    pub default_namespace: *const usize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1730,6 +1764,7 @@ struct FfiCallScope;
 
 struct FfiDom<'a> {
     context: *mut c_void,
+    namespace_context: FfiNamespaceContext,
     marker: PhantomData<&'a mut FfiCallScope>,
     // NB: Both flags are mirrored here so that the hot matching loops can skip the note_*
     //     callbacks without crossing the FFI; the common case collects no metadata.
@@ -1743,9 +1778,11 @@ impl<'a> FfiDom<'a> {
         _call_scope: &'a mut FfiCallScope,
         collects_selector_involvement_metadata: bool,
         inside_has_argument: bool,
+        namespace_context: FfiNamespaceContext,
     ) -> Self {
         Self {
             context,
+            namespace_context,
             marker: PhantomData,
             collects_selector_involvement_metadata,
             inside_has_argument,
@@ -1757,10 +1794,14 @@ impl<'a> FfiDom<'a> {
             kind,
             element: FfiElement {
                 pointer: std::ptr::null(),
+                local_name: std::ptr::null(),
+                namespace_: std::ptr::null(),
                 id: std::ptr::null(),
                 classes: std::ptr::null(),
                 class_count: 0,
                 class_names_are_case_insensitive: false,
+                namespace_is_null: true,
+                is_html_element_in_html_document: false,
             },
             marker: PhantomData,
         })
@@ -1799,6 +1840,22 @@ impl<'a> SelectorDom for FfiDom<'a> {
     type Element = FfiNode<'a>;
 
     fn matches_universal_selector(&mut self, element: FfiNode<'a>, name: &QualifiedName) -> bool {
+        match name.namespace_type {
+            NamespaceType::Default => match self.namespace_context.default_namespace_type {
+                FfiDefaultNamespaceType::Any => return true,
+                FfiDefaultNamespaceType::None => return element.as_element().namespace_is_null,
+                FfiDefaultNamespaceType::Named => {
+                    // SAFETY: C++ guarantees that the default namespace remains pinned for this
+                    // matching call.
+                    let default_namespace = unsafe { self.namespace_context.default_namespace.as_ref().copied() };
+                    return default_namespace
+                        .is_some_and(|namespace| element.as_element().namespace() == Some(namespace));
+                }
+            },
+            NamespaceType::None => return element.as_element().namespace_is_null,
+            NamespaceType::Any => return true,
+            NamespaceType::Named => {}
+        }
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
         // SAFETY: `FfiDom` guarantees that the context, element, and retained simple selector
         // remain valid for the duration of matching.
@@ -1817,6 +1874,18 @@ impl<'a> SelectorDom for FfiDom<'a> {
         name: &QualifiedName,
         mode: TagNameMatchingMode,
     ) -> bool {
+        let ffi_element = element.as_element();
+        if ffi_element.is_html_element_in_html_document || mode == TagNameMatchingMode::Fast {
+            let interned_name = if ffi_element.is_html_element_in_html_document {
+                name.interned_lowercase_name
+            } else {
+                name.interned_name
+            };
+            if interned_name.is_none_or(|name| ffi_element.local_name() != Some(name)) {
+                return false;
+            }
+            return self.matches_universal_selector(element, name);
+        }
         crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorSimpleSelectorCallback);
         // SAFETY: `FfiDom` guarantees that the context, element, and retained simple selector
         // remain valid for the duration of matching.
@@ -2188,6 +2257,11 @@ unsafe fn qualified_name_from_ffi(selector: &FfiSimpleSelector) -> QualifiedName
         name: unsafe { string_from_ffi(selector.name) },
         // SAFETY: The caller guarantees that every string view in `selector` is valid.
         lowercase_name: unsafe { string_from_ffi(selector.lowercase_name) },
+        // SAFETY: The caller guarantees that all retained C++ selector data is valid.
+        interned_name: unsafe { interned_name_from_ffi(selector) },
+        // SAFETY: The caller guarantees that a non-null pointer identifies retained C++ selector
+        // data for the duration of selector compilation.
+        interned_lowercase_name: unsafe { selector.interned_lowercase_name.as_ref().copied() },
         cxx_simple_selector: RetainedCxxPointer::new(selector.cxx_simple_selector),
     }
 }
@@ -2340,10 +2414,8 @@ unsafe fn compiled_selector_from_ffi(selector: &FfiSelector) -> Rc<CompiledSelec
 unsafe fn with_ffi_dom<R>(
     element: FfiElement,
     shadow_host: FfiElement,
-    context: *mut c_void,
     scope: *const c_void,
-    collects_selector_involvement_metadata: bool,
-    inside_has_argument: bool,
+    configuration: FfiDomConfiguration,
     callback: impl for<'a> FnOnce(FfiNode<'a>, Option<FfiNode<'a>>, Option<FfiNode<'a>>, &mut FfiDom<'a>) -> R,
 ) -> R {
     let mut call_scope = FfiCallScope;
@@ -2351,10 +2423,11 @@ unsafe fn with_ffi_dom<R>(
     // callback. Borrowing `call_scope` prevents the DOM wrapper and its nodes from escaping it.
     let mut dom = unsafe {
         FfiDom::new(
-            context,
+            configuration.context,
             &mut call_scope,
-            collects_selector_involvement_metadata,
-            inside_has_argument,
+            configuration.collects_selector_involvement_metadata,
+            configuration.inside_has_argument,
+            configuration.namespace_context,
         )
     };
     // SAFETY: The caller guarantees that `element` wraps a live DOM element.
@@ -2364,6 +2437,14 @@ unsafe fn with_ffi_dom<R>(
     // SAFETY: The caller guarantees that a non-null `scope` points to a DOM parent node.
     let scope = unsafe { dom.scope(scope) };
     callback(element, shadow_host, scope, &mut dom)
+}
+
+#[derive(Clone, Copy)]
+struct FfiDomConfiguration {
+    context: *mut c_void,
+    collects_selector_involvement_metadata: bool,
+    inside_has_argument: bool,
+    namespace_context: FfiNamespaceContext,
 }
 
 /// # Safety
@@ -2426,6 +2507,7 @@ pub unsafe extern "C" fn rust_selector_matches(
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
     inside_has_argument: bool,
+    namespace_context: FfiNamespaceContext,
 ) -> bool {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorMatchEntry);
     abort_on_panic(|| {
@@ -2440,10 +2522,13 @@ pub unsafe extern "C" fn rust_selector_matches(
             with_ffi_dom(
                 element,
                 shadow_host,
-                context,
                 scope,
-                collects_selector_involvement_metadata,
-                inside_has_argument,
+                FfiDomConfiguration {
+                    context,
+                    collects_selector_involvement_metadata,
+                    inside_has_argument,
+                    namespace_context,
+                },
                 |element, shadow_host, scope, dom| {
                     let target = MatchTarget {
                         element,
@@ -2474,6 +2559,7 @@ pub unsafe extern "C" fn rust_selector_matches_originating_element(
     scope: *const c_void,
     collects_selector_involvement_metadata: bool,
     inside_has_argument: bool,
+    namespace_context: FfiNamespaceContext,
 ) -> bool {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::SelectorMatchEntry);
     abort_on_panic(|| {
@@ -2488,10 +2574,13 @@ pub unsafe extern "C" fn rust_selector_matches_originating_element(
             with_ffi_dom(
                 element,
                 shadow_host,
-                context,
                 scope,
-                collects_selector_involvement_metadata,
-                inside_has_argument,
+                FfiDomConfiguration {
+                    context,
+                    collects_selector_involvement_metadata,
+                    inside_has_argument,
+                    namespace_context,
+                },
                 |element, shadow_host, scope, dom| {
                     matches_originating_element_for_pseudo_element(
                         selector,

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -438,7 +438,8 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_next_element_sibling);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_first_element_child);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_first_element_descendant);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_next_element_descendant);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_has_no_element_or_nonempty_text_children);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_element_child);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_nonempty_text_child);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_is_shadow_tree_slot);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_slotted_parent);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_part_parent);
@@ -970,22 +971,22 @@ extern "C" CSS::SelectorFFI::Element selector_ffi_next_element_descendant(void c
     return {};
 }
 
-extern "C" bool selector_ffi_has_no_element_or_nonempty_text_children(void const* element)
+extern "C" bool selector_ffi_element_has_element_child(void const* element)
 {
-    auto const& target = ffi_element(element);
-    if (!target.has_children())
-        return true;
-    if (target.first_child_of_type<DOM::Element>())
-        return false;
+    return ffi_element(element).first_child_of_type<DOM::Element>();
+}
+
+extern "C" bool selector_ffi_element_has_nonempty_text_child(void const* element)
+{
     bool has_nonempty_text_child = false;
-    target.for_each_child_of_type<DOM::Text>([&](auto const& text) {
+    ffi_element(element).for_each_child_of_type<DOM::Text>([&](auto const& text) {
         if (!text.data().is_empty()) {
             has_nonempty_text_child = true;
             return IterationDecision::Break;
         }
         return IterationDecision::Continue;
     });
-    return !has_nonempty_text_child;
+    return has_nonempty_text_child;
 }
 
 extern "C" bool selector_ffi_is_shadow_tree_slot(void const* element)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -713,6 +713,7 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_fullscreen);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_heading_level);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_popover_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_popover_is_showing);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_direction);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
@@ -724,7 +725,6 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_direction);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_state);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element_in_light_tree);
@@ -852,6 +852,17 @@ extern "C" bool selector_ffi_element_popover_is_showing(void const* element)
     auto const* html_element = as_if<HTML::HTMLElement>(ffi_element(element));
     return html_element
         && html_element->popover_visibility_state() == HTML::HTMLElement::PopoverVisibilityState::Showing;
+}
+
+extern "C" Direction selector_ffi_element_direction(void const* element)
+{
+    switch (ffi_element(element).directionality()) {
+    case DOM::Element::Directionality::Ltr:
+        return Direction::LeftToRight;
+    case DOM::Element::Directionality::Rtl:
+        return Direction::RightToLeft;
+    }
+    VERIFY_NOT_REACHED();
 }
 
 extern "C" bool selector_ffi_element_is_focused(void const* element)
@@ -1005,17 +1016,6 @@ extern "C" bool selector_ffi_matches_language(void const* element, StringView la
     auto element_language = ffi_element(element).lang();
     return element_language.has_value()
         && language_range_matches_tag(ffi_string_view(language), *element_language);
-}
-
-extern "C" bool selector_ffi_matches_direction(void const* element, Direction direction)
-{
-    switch (ffi_element(element).directionality()) {
-    case DOM::Element::Directionality::Ltr:
-        return direction == Direction::LeftToRight;
-    case DOM::Element::Directionality::Rtl:
-        return direction == Direction::RightToLeft;
-    }
-    VERIFY_NOT_REACHED();
 }
 
 extern "C" bool selector_ffi_matches_state(void const* element, void const* cxx_simple_selector)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -675,6 +675,7 @@ static CSS::SelectorFFI::Element element_to_ffi(DOM::Element const* element)
         .namespace_is_null = !element->namespace_uri().has_value() || element->namespace_uri()->is_empty(),
         .is_html_element_in_html_document = element->namespace_uri() == Namespace::HTML
             && element->document().document_type() == DOM::Document::Type::HTML,
+        .is_document_root = is<HTML::HTMLHtmlElement>(*element),
     };
 }
 
@@ -833,7 +834,6 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_first_element_descendant);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_next_element_descendant);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_has_no_element_or_nonempty_text_children);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_has_same_type);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_is_shadow_tree_slot);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_slotted_parent);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_part_parent);
@@ -1160,11 +1160,6 @@ extern "C" bool selector_ffi_has_same_type(void const* first, void const* second
     auto const& second_element = ffi_element(second);
     return first_element.local_name() == second_element.local_name()
         && first_element.namespace_uri() == second_element.namespace_uri();
-}
-
-extern "C" bool selector_ffi_is_document_root(void const* element)
-{
-    return is<HTML::HTMLHtmlElement>(ffi_element(element));
 }
 
 extern "C" bool selector_ffi_is_shadow_tree_slot(void const* element)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -377,17 +377,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     switch (pseudo_class) {
     case CSS::PseudoClass::Active:
         return element.is_being_activated();
-    case CSS::PseudoClass::AnyLink:
-    case CSS::PseudoClass::Link:
-        // NOTE: AnyLink should match whether the link is visited or not, so if we ever start matching
-        //       :visited, we'll need to handle these differently.
-        return element.matches_link_pseudo_class();
-    case CSS::PseudoClass::Autofill:
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill
-        // FIXME: The :autofill and :-webkit-autofill pseudo-classes must match input elements which have been autofilled by
-        //        user agent. These pseudo-classes must stop matching if the user edits the autofilled field.
-        // NB: We don't support autofilling inputs yet, so this is always false.
-        return false;
     case CSS::PseudoClass::Buffering:
         if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
             return media_element->blocked();
@@ -610,12 +599,10 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         return false;
     }
     case CSS::PseudoClass::Visited:
-        return element.matches_visited_pseudo_class();
     case CSS::PseudoClass::VolumeLocked:
-        // FIXME: Currently we don't allow the user to specify an override volume, so this is always false.
-        //        Once we do, implement this!
-        return false;
     case CSS::PseudoClass::__Count:
+    case CSS::PseudoClass::AnyLink:
+    case CSS::PseudoClass::Autofill:
     case CSS::PseudoClass::Dir:
     case CSS::PseudoClass::Empty:
     case CSS::PseudoClass::FirstChild:
@@ -627,6 +614,7 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::Lang:
     case CSS::PseudoClass::LastChild:
     case CSS::PseudoClass::LastOfType:
+    case CSS::PseudoClass::Link:
     case CSS::PseudoClass::Not:
     case CSS::PseudoClass::NthChild:
     case CSS::PseudoClass::NthLastChild:
@@ -730,6 +718,7 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_names_are_case_insensit
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_link);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute_count);
@@ -841,6 +830,11 @@ extern "C" bool selector_ffi_element_is_document_root(void const* element)
     return is<HTML::HTMLHtmlElement>(ffi_element(element));
 }
 
+extern "C" bool selector_ffi_element_is_link(void const* element)
+{
+    return ffi_element(element).matches_link_pseudo_class();
+}
+
 extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
 {
     return dom_string_view(ffi_element(element).local_name());
@@ -926,10 +920,12 @@ extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_resolve_namespace(vo
     };
 }
 
-static bool is_rust_structural_or_functional_pseudo_class(CSS::PseudoClass pseudo_class)
+static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
 {
     return first_is_one_of(
         pseudo_class,
+        CSS::PseudoClass::AnyLink,
+        CSS::PseudoClass::Autofill,
         CSS::PseudoClass::Empty,
         CSS::PseudoClass::FirstChild,
         CSS::PseudoClass::FirstOfType,
@@ -938,6 +934,7 @@ static bool is_rust_structural_or_functional_pseudo_class(CSS::PseudoClass pseud
         CSS::PseudoClass::Is,
         CSS::PseudoClass::LastChild,
         CSS::PseudoClass::LastOfType,
+        CSS::PseudoClass::Link,
         CSS::PseudoClass::Not,
         CSS::PseudoClass::NthChild,
         CSS::PseudoClass::NthLastChild,
@@ -951,14 +948,16 @@ static bool is_rust_structural_or_functional_pseudo_class(CSS::PseudoClass pseud
         CSS::PseudoClass::Dir,
         CSS::PseudoClass::Heading,
         CSS::PseudoClass::Lang,
-        CSS::PseudoClass::State);
+        CSS::PseudoClass::State,
+        CSS::PseudoClass::Visited,
+        CSS::PseudoClass::VolumeLocked);
 }
 
 extern "C" bool selector_ffi_matches_pseudo_class(void const* element, u8 pseudo_class_value)
 {
     auto pseudo_class = static_cast<CSS::PseudoClass>(pseudo_class_value);
     VERIFY(pseudo_class < CSS::PseudoClass::__Count);
-    VERIFY(!is_rust_structural_or_functional_pseudo_class(pseudo_class));
+    VERIFY(!is_rust_matched_pseudo_class(pseudo_class));
     return matches_pseudo_class_state(pseudo_class, ffi_element(element));
 }
 

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -285,7 +285,7 @@ static bool matches_read_write_pseudo_class(DOM::Element const& element)
 }
 
 // https://drafts.csswg.org/selectors-4/#open-state
-static bool matches_open_state_pseudo_class(DOM::Element const& element, bool open)
+static bool matches_open_state_pseudo_class(DOM::Element const& element)
 {
     // The :open pseudo-class represents an element that has both “open” and “closed” states,
     // and which is currently in the “open” state.
@@ -295,13 +295,13 @@ static bool matches_open_state_pseudo_class(DOM::Element const& element, bool op
     // - details elements that have an open attribute
     // - dialog elements that have an open attribute
     if (is<HTML::HTMLDetailsElement>(element) || is<HTML::HTMLDialogElement>(element))
-        return open == element.has_attribute(HTML::AttributeNames::open);
+        return element.has_attribute(HTML::AttributeNames::open);
     // - select elements that are a drop-down box and whose drop-down boxes are open
     if (auto const* select = as_if<HTML::HTMLSelectElement>(element))
-        return open == select->is_open();
+        return select->is_open();
     // - input elements that support a picker and whose pickers are open
     if (auto const* input = as_if<HTML::HTMLInputElement>(element))
-        return open == (input->supports_a_picker() && input->is_open());
+        return input->supports_a_picker() && input->is_open();
 
     return false;
 }
@@ -781,7 +781,7 @@ extern "C" bool selector_ffi_element_is_modal(void const* element)
 
 extern "C" bool selector_ffi_element_is_open(void const* element)
 {
-    return matches_open_state_pseudo_class(ffi_element(element), true);
+    return matches_open_state_pseudo_class(ffi_element(element));
 }
 
 // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-optional

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -382,8 +382,9 @@ using CSS::SelectorFFI::StringView;
 
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_qualified_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_id);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_id_value);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_classes);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_names_are_case_insensitive);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_id_and_class_names_are_case_insensitive);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
@@ -501,6 +502,12 @@ extern "C" uintptr_t const* selector_ffi_element_id(void const* element)
     return id.has_value() ? reinterpret_cast<uintptr_t const*>(&id.value()) : nullptr;
 }
 
+extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_id_value(void const* element)
+{
+    auto const& id = ffi_element(element).id();
+    return id.has_value() ? dom_string_view(id.value()) : CSS::SelectorFFI::DomStringView {};
+}
+
 extern "C" CSS::SelectorFFI::InternedStringList selector_ffi_element_classes(void const* element)
 {
     auto const& classes = ffi_element(element).class_names();
@@ -510,7 +517,7 @@ extern "C" CSS::SelectorFFI::InternedStringList selector_ffi_element_classes(voi
     };
 }
 
-extern "C" bool selector_ffi_element_class_names_are_case_insensitive(void const* element)
+extern "C" bool selector_ffi_element_id_and_class_names_are_case_insensitive(void const* element)
 {
     return ffi_element(element).document().in_quirks_mode();
 }

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -407,12 +407,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         return element.matches_enabled_pseudo_class();
     case CSS::PseudoClass::EvenLessGoodValue:
         return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::EvenLessGood);
-    case CSS::PseudoClass::Focus:
-        return element.is_focused();
-    case CSS::PseudoClass::FocusVisible:
-        return element.is_focused() && element.should_indicate_focus();
-    case CSS::PseudoClass::FocusWithin:
-        return element.matches_focus_within_pseudo_class();
     case CSS::PseudoClass::Fullscreen:
         return element.is_fullscreen_element();
     case CSS::PseudoClass::HighValue:
@@ -607,6 +601,9 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::Empty:
     case CSS::PseudoClass::FirstChild:
     case CSS::PseudoClass::FirstOfType:
+    case CSS::PseudoClass::Focus:
+    case CSS::PseudoClass::FocusVisible:
+    case CSS::PseudoClass::FocusWithin:
     case CSS::PseudoClass::Has:
     case CSS::PseudoClass::Heading:
     case CSS::PseudoClass::Host:
@@ -719,6 +716,9 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_link);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute_count);
@@ -835,6 +835,21 @@ extern "C" bool selector_ffi_element_is_link(void const* element)
     return ffi_element(element).matches_link_pseudo_class();
 }
 
+extern "C" bool selector_ffi_element_is_focused(void const* element)
+{
+    return ffi_element(element).is_focused();
+}
+
+extern "C" bool selector_ffi_element_should_indicate_focus(void const* element)
+{
+    return ffi_element(element).should_indicate_focus();
+}
+
+extern "C" bool selector_ffi_element_has_focus_within(void const* element)
+{
+    return ffi_element(element).matches_focus_within_pseudo_class();
+}
+
 extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
 {
     return dom_string_view(ffi_element(element).local_name());
@@ -929,6 +944,9 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::Empty,
         CSS::PseudoClass::FirstChild,
         CSS::PseudoClass::FirstOfType,
+        CSS::PseudoClass::Focus,
+        CSS::PseudoClass::FocusVisible,
+        CSS::PseudoClass::FocusWithin,
         CSS::PseudoClass::Has,
         CSS::PseudoClass::Host,
         CSS::PseudoClass::Is,

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -833,7 +833,6 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_first_element_child);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_first_element_descendant);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_next_element_descendant);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_has_no_element_or_nonempty_text_children);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_has_same_type);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_is_shadow_tree_slot);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_slotted_parent);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_part_parent);
@@ -1152,14 +1151,6 @@ extern "C" bool selector_ffi_has_no_element_or_nonempty_text_children(void const
         return IterationDecision::Continue;
     });
     return !has_nonempty_text_child;
-}
-
-extern "C" bool selector_ffi_has_same_type(void const* first, void const* second)
-{
-    auto const& first_element = ffi_element(first);
-    auto const& second_element = ffi_element(second);
-    return first_element.local_name() == second_element.local_name()
-        && first_element.namespace_uri() == second_element.namespace_uri();
 }
 
 extern "C" bool selector_ffi_is_shadow_tree_slot(void const* element)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -724,46 +724,6 @@ static bool is_in_null_namespace(DOM::Element const& element)
     return !element.namespace_uri().has_value() || element.namespace_uri()->is_empty();
 }
 
-static bool matches_namespace(CSS::Selector::SimpleSelector::QualifiedName const& qualified_name, DOM::Element const& element, GC::Ptr<CSS::CSSStyleSheet const> style_sheet_for_rule)
-{
-    switch (qualified_name.namespace_type) {
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Default:
-        // "if no default namespace has been declared for selectors, this is equivalent to *|E."
-        if (!style_sheet_for_rule || !style_sheet_for_rule->default_namespace_rule())
-            return true;
-        // "Otherwise it is equivalent to ns|E where ns is the default namespace."
-        if (style_sheet_for_rule->default_namespace_rule()->namespace_uri().is_empty())
-            return is_in_null_namespace(element);
-
-        return element.namespace_uri().has_value()
-            && style_sheet_for_rule->default_namespace_rule()->namespace_uri() == element.namespace_uri()->view();
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::None:
-        // "elements with name E without a namespace"
-        return is_in_null_namespace(element);
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Any:
-        // "elements with name E in any namespace, including those without a namespace"
-        return true;
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Named: {
-        // "elements with name E in namespace ns"
-        // Unrecognized namespace prefixes are invalid, so don't match.
-        // (We can't detect this at parse time, since a namespace rule may be inserted later.)
-        // So, if we don't have a context to look up namespaces from, we fail to match.
-        if (!style_sheet_for_rule)
-            return false;
-        auto selector_namespace = style_sheet_for_rule->namespace_uri(qualified_name.namespace_);
-        // https://www.w3.org/TR/css-namespaces-3/#terminology
-        // In CSS Namespaces a namespace name consisting of the empty string is taken to represent the null namespace
-        // or lack of a namespace.
-        if (selector_namespace.has_value() && selector_namespace->is_empty())
-            return is_in_null_namespace(element);
-        return selector_namespace.has_value()
-            && element.namespace_uri().has_value()
-            && *selector_namespace == element.namespace_uri()->view();
-    }
-    }
-    VERIFY_NOT_REACHED();
-}
-
 using CSS::SelectorFFI::AttributeCaseType;
 using CSS::SelectorFFI::AttributeMatchType;
 using CSS::SelectorFFI::Combinator;
@@ -771,7 +731,6 @@ using CSS::SelectorFFI::Direction;
 using CSS::SelectorFFI::HasCacheResult;
 using CSS::SelectorFFI::NamespaceType;
 using CSS::SelectorFFI::StringView;
-using CSS::SelectorFFI::TagNameMatchingMode;
 
 #define DECLARE_SELECTOR_FFI_CALLBACK(function) \
     extern "C" decltype(CSS::SelectorFFI::function) function
@@ -783,9 +742,9 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_names_are_case_insensit
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_tag_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_class_quirks);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
@@ -875,6 +834,25 @@ extern "C" bool selector_ffi_element_is_document_root(void const* element)
     return is<HTML::HTMLHtmlElement>(ffi_element(element));
 }
 
+extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
+{
+    auto local_name = ffi_element(element).local_name().view();
+    if (local_name.has_ascii_storage()) {
+        auto storage = local_name.ascii_span();
+        return {
+            .data = storage.data(),
+            .length = storage.size(),
+            .is_ascii = true,
+        };
+    }
+    auto storage = local_name.utf16_span();
+    return {
+        .data = storage.data(),
+        .length = storage.size(),
+        .is_ascii = false,
+    };
+}
+
 extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_default_namespace(void* context)
 {
     auto& match_context = rust_match_context(context);
@@ -925,23 +903,6 @@ extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_resolve_namespace(vo
         .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Named,
         .namespace_ = interned_string_identity(*namespace_),
     };
-}
-
-extern "C" bool selector_ffi_matches_tag_name(void* context, void const* element, void const* cxx_simple_selector, TagNameMatchingMode matching_mode)
-{
-    auto& match_context = rust_match_context(context);
-    auto const& target = ffi_element(element);
-    auto const& qualified_name = ffi_simple_selector(cxx_simple_selector).qualified_name();
-    bool const is_html_element_in_html_document = target.namespace_uri() == Namespace::HTML
-        && target.document().document_type() == DOM::Document::Type::HTML;
-    auto const& name_to_match = is_html_element_in_html_document ? qualified_name.name.lowercase_name : qualified_name.name.name;
-    bool name_matches;
-    if (is_html_element_in_html_document || matching_mode == TagNameMatchingMode::Fast)
-        name_matches = target.local_name() == name_to_match;
-    else
-        name_matches = target.local_name().equals_ignoring_ascii_case(name_to_match);
-    return name_matches
-        && matches_namespace(qualified_name, target, match_context.style_sheet_for_rule);
 }
 
 extern "C" bool selector_ffi_matches_class_quirks(void const* element, void const* cxx_simple_selector)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -663,28 +663,6 @@ static CSS::SelectorFFI::Element element_to_ffi(DOM::Element const* element)
     };
 }
 
-static CSS::SelectorFFI::NamespaceContext namespace_context_to_ffi(MatchContext const& context)
-{
-    if (!context.style_sheet_for_rule || !context.style_sheet_for_rule->default_namespace_rule()) {
-        return {
-            .default_namespace_type = CSS::SelectorFFI::DefaultNamespaceType::Any,
-            .default_namespace = nullptr,
-        };
-    }
-
-    auto const& default_namespace = context.style_sheet_for_rule->default_namespace_rule()->namespace_uri();
-    if (default_namespace.is_empty()) {
-        return {
-            .default_namespace_type = CSS::SelectorFFI::DefaultNamespaceType::None,
-            .default_namespace = nullptr,
-        };
-    }
-    return {
-        .default_namespace_type = CSS::SelectorFFI::DefaultNamespaceType::Named,
-        .default_namespace = reinterpret_cast<uintptr_t const*>(&default_namespace),
-    };
-}
-
 bool matches(CSS::Selector const& selector, DOM::AbstractElement const& target, GC::Ptr<DOM::Element const> shadow_host,
     MatchContext& context, GC::Ptr<DOM::ParentNode const> scope)
 {
@@ -696,8 +674,7 @@ bool matches(CSS::Selector const& selector, DOM::AbstractElement const& target, 
         &context,
         scope.ptr(),
         context.collect_per_element_selector_involvement_metadata,
-        context.inside_has_argument_match,
-        namespace_context_to_ffi(context));
+        context.inside_has_argument_match);
 }
 
 bool matches_originating_element_for_pseudo_element(CSS::Selector const& selector, CSS::PseudoElement pseudo_element, DOM::AbstractElement const& target, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ptr<DOM::ParentNode const> scope)
@@ -712,8 +689,7 @@ bool matches_originating_element_for_pseudo_element(CSS::Selector const& selecto
         &context,
         scope.ptr(),
         context.collect_per_element_selector_involvement_metadata,
-        context.inside_has_argument_match,
-        namespace_context_to_ffi(context));
+        context.inside_has_argument_match);
 }
 
 static MatchContext& rust_match_context(void* context)
@@ -807,7 +783,8 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_names_are_case_insensit
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_universal);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_tag_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_class_quirks);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_attribute);
@@ -844,6 +821,13 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_should_reject_has_argument);
 // to live words only for the duration of the synchronous selector-matching call.
 static_assert(sizeof(Utf16FlyString) == sizeof(uintptr_t));
 static_assert(alignof(Utf16FlyString) == alignof(uintptr_t));
+
+static uintptr_t interned_string_identity(Utf16FlyString const& string)
+{
+    uintptr_t identity;
+    __builtin_memcpy(&identity, &string, sizeof(identity));
+    return identity;
+}
 
 extern "C" CSS::SelectorFFI::ElementQualifiedName selector_ffi_element_qualified_name(void const* element)
 {
@@ -891,11 +875,56 @@ extern "C" bool selector_ffi_element_is_document_root(void const* element)
     return is<HTML::HTMLHtmlElement>(ffi_element(element));
 }
 
-extern "C" bool selector_ffi_matches_universal(void* context, void const* element, void const* cxx_simple_selector)
+extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_default_namespace(void* context)
 {
     auto& match_context = rust_match_context(context);
-    auto const& qualified_name = ffi_simple_selector(cxx_simple_selector).qualified_name();
-    return matches_namespace(qualified_name, ffi_element(element), match_context.style_sheet_for_rule);
+    if (!match_context.style_sheet_for_rule || !match_context.style_sheet_for_rule->default_namespace_rule()) {
+        return {
+            .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Missing,
+            .namespace_ = 0,
+        };
+    }
+
+    auto const& namespace_ = match_context.style_sheet_for_rule->default_namespace_rule()->namespace_uri();
+    if (namespace_.is_empty()) {
+        return {
+            .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Null,
+            .namespace_ = 0,
+        };
+    }
+    return {
+        .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Named,
+        .namespace_ = interned_string_identity(namespace_),
+    };
+}
+
+extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_resolve_namespace(void* context, StringView prefix)
+{
+    auto& match_context = rust_match_context(context);
+    if (!match_context.style_sheet_for_rule) {
+        return {
+            .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Missing,
+            .namespace_ = 0,
+        };
+    }
+
+    auto namespace_ = match_context.style_sheet_for_rule->namespace_uri(ffi_string_view(prefix));
+    if (!namespace_.has_value()) {
+        return {
+            .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Missing,
+            .namespace_ = 0,
+        };
+    }
+    if (namespace_->is_empty()) {
+        return {
+            .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Null,
+            .namespace_ = 0,
+        };
+    }
+    return {
+        .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Named,
+        .namespace_ = interned_string_identity(*namespace_),
+    };
 }
 
 extern "C" bool selector_ffi_matches_tag_name(void* context, void const* element, void const* cxx_simple_selector, TagNameMatchingMode matching_mode)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -235,65 +235,6 @@ static bool should_reject_with_has_fast_reject_filter(CSS::Selector const& selec
     return false;
 }
 
-static bool language_range_matches_tag(Utf16View language_range, Utf16View language_tag)
-{
-    // 1. Split both the extended language range and the language tag being compared into a list of subtags by
-    //    dividing on the hyphen (%x2D) character.
-    auto range_subtags = language_range.split_view('-', SplitBehavior::KeepEmpty);
-    auto tag_subtags = language_tag.split_view('-', SplitBehavior::KeepEmpty);
-
-    //    Two subtags match if either they are the same when compared case-insensitively or the language range's subtag
-    //    is the wildcard '*'.
-    auto subtags_match = [](Utf16View language_range_subtag, Utf16View language_subtag) {
-        return language_range_subtag == u"*"sv
-            || language_range_subtag.equals_ignoring_ascii_case(language_subtag);
-    };
-
-    // 2. Begin with the first subtag in each list. If the first subtag in the range does not match the first
-    //    subtag in the tag, the overall match fails. Otherwise, move to the next subtag in both the range and the
-    //    tag.
-    auto tag_subtag = tag_subtags.begin();
-    auto range_subtag = range_subtags.begin();
-    if (!subtags_match(*range_subtag, *tag_subtag))
-        return false;
-    ++tag_subtag;
-    ++range_subtag;
-
-    // 3. While there are more subtags left in the language range's list:
-    while (!range_subtag.is_end()) {
-        // A. If the subtag currently being examined in the range is the wildcard ('*'), move to the next subtag in
-        //    the range and continue with the loop.
-        if (*range_subtag == u"*"sv) {
-            ++range_subtag;
-            continue;
-        }
-
-        // B. Else, if there are no more subtags in the language tag's list, the match fails.
-        if (tag_subtag.is_end())
-            return false;
-
-        // C. Else, if the current subtag in the range's list matches the current subtag in the language tag's
-        //    list, move to the next subtag in both lists and continue with the loop.
-        if (subtags_match(*range_subtag, *tag_subtag)) {
-            ++range_subtag;
-            ++tag_subtag;
-            continue;
-        }
-
-        // D. Else, if the language tag's subtag is a "singleton" (a single letter or digit, which includes the
-        //    private-use subtag 'x') the match fails.
-        if (tag_subtag->length_in_code_units() == 1 && is_ascii_alphanumeric(tag_subtag->code_unit_at(0))) {
-            return false;
-        }
-
-        // E. Else, move to the next subtag in the language tag's list and continue with the loop.
-        ++tag_subtag;
-    }
-
-    // 4. When the language range's list has no more subtags, the match succeeds.
-    return true;
-}
-
 static bool matches_hover_pseudo_class(DOM::Element const& element)
 {
     auto* hovered_node = element.document().hovered_node();
@@ -709,6 +650,7 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_popover_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_popover_is_showing);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_direction);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_custom_state);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_language);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
@@ -719,7 +661,6 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element_in_light_tree);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_previous_element_sibling);
@@ -869,6 +810,12 @@ extern "C" bool selector_ffi_element_has_custom_state(void const* element, uintp
     return false;
 }
 
+extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_language(void const* element)
+{
+    auto language = ffi_element(element).lang_view();
+    return language.has_value() ? dom_string_view(*language) : CSS::SelectorFFI::DomStringView {};
+}
+
 extern "C" bool selector_ffi_element_is_focused(void const* element)
 {
     return ffi_element(element).is_focused();
@@ -1013,13 +960,6 @@ extern "C" bool selector_ffi_matches_pseudo_class(void const* element, u8 pseudo
     VERIFY(pseudo_class < CSS::PseudoClass::__Count);
     VERIFY(!is_rust_matched_pseudo_class(pseudo_class));
     return matches_pseudo_class_state(pseudo_class, ffi_element(element));
-}
-
-extern "C" bool selector_ffi_matches_language(void const* element, StringView language)
-{
-    auto element_language = ffi_element(element).lang();
-    return element_language.has_value()
-        && language_range_matches_tag(ffi_string_view(language), *element_language);
 }
 
 extern "C" CSS::SelectorFFI::Element selector_ffi_parent_element(void const* element, void const* shadow_host)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -743,9 +743,9 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_class_quirks);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
@@ -786,6 +786,24 @@ static uintptr_t interned_string_identity(Utf16FlyString const& string)
     uintptr_t identity;
     __builtin_memcpy(&identity, &string, sizeof(identity));
     return identity;
+}
+
+static CSS::SelectorFFI::DomStringView dom_string_view(Utf16View string)
+{
+    if (string.has_ascii_storage()) {
+        auto storage = string.ascii_span();
+        return {
+            .data = storage.data(),
+            .length = storage.size(),
+            .is_ascii = true,
+        };
+    }
+    auto storage = string.utf16_span();
+    return {
+        .data = storage.data(),
+        .length = storage.size(),
+        .is_ascii = false,
+    };
 }
 
 extern "C" CSS::SelectorFFI::ElementQualifiedName selector_ffi_element_qualified_name(void const* element)
@@ -836,21 +854,14 @@ extern "C" bool selector_ffi_element_is_document_root(void const* element)
 
 extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
 {
-    auto local_name = ffi_element(element).local_name().view();
-    if (local_name.has_ascii_storage()) {
-        auto storage = local_name.ascii_span();
-        return {
-            .data = storage.data(),
-            .length = storage.size(),
-            .is_ascii = true,
-        };
-    }
-    auto storage = local_name.utf16_span();
-    return {
-        .data = storage.data(),
-        .length = storage.size(),
-        .is_ascii = false,
-    };
+    return dom_string_view(ffi_element(element).local_name());
+}
+
+extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_class_name(void const* element, size_t index)
+{
+    auto const& classes = ffi_element(element).class_names();
+    VERIFY(index < classes.size());
+    return dom_string_view(classes[index]);
 }
 
 extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_default_namespace(void* context)
@@ -903,13 +914,6 @@ extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_resolve_namespace(vo
         .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Named,
         .namespace_ = interned_string_identity(*namespace_),
     };
-}
-
-extern "C" bool selector_ffi_matches_class_quirks(void const* element, void const* cxx_simple_selector)
-{
-    auto const& target = ffi_element(element);
-    VERIFY(target.document().in_quirks_mode());
-    return target.has_class(ffi_simple_selector(cxx_simple_selector).class_name(), CaseSensitivity::CaseInsensitive);
 }
 
 static bool matches_attribute_value(CSS::Selector::SimpleSelector::Attribute::MatchType match_type, Utf16View selector_value, Utf16View element_value, CaseSensitivity case_sensitivity)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -306,235 +306,6 @@ static bool matches_open_state_pseudo_class(DOM::Element const& element, bool op
     return false;
 }
 
-static bool matches_optimal_value_pseudo_class(DOM::Element const& element, HTML::HTMLMeterElement::ValueState desired_state)
-{
-    if (auto* meter = as_if<HTML::HTMLMeterElement>(element))
-        return meter->value_state() == desired_state;
-    return false;
-}
-
-static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Element const& element)
-{
-    switch (pseudo_class) {
-    case CSS::PseudoClass::Default: {
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-default
-        if (auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(element)) {
-            if (form_associated_element->is_submit_button() && form_associated_element->form() && form_associated_element->form()->default_button() == form_associated_element)
-                return true;
-            if (auto const* input_element = as_if<HTML::HTMLInputElement>(form_associated_element)) {
-                if (input_element->checked_applies() && input_element->has_attribute(HTML::AttributeNames::checked))
-                    return true;
-            }
-            if (auto const* option_element = as_if<HTML::HTMLOptionElement>(form_associated_element)) {
-                if (option_element->has_attribute(HTML::AttributeNames::selected))
-                    return true;
-            }
-        }
-        return false;
-    }
-    case CSS::PseudoClass::EvenLessGoodValue:
-        return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::EvenLessGood);
-    case CSS::PseudoClass::HighValue:
-        if (auto const* meter = as_if<HTML::HTMLMeterElement>(element))
-            return meter->value() > meter->high();
-        return false;
-    case CSS::PseudoClass::Hover:
-        return matches_hover_pseudo_class(element);
-    case CSS::PseudoClass::Indeterminate:
-        return matches_indeterminate_pseudo_class(element);
-    case CSS::PseudoClass::Invalid: {
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-invalid
-        if (auto form_associated_element = as_if<HTML::FormAssociatedElement>(element)) {
-            if (form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints())
-                return true;
-        }
-
-        if (auto form_element = as_if<HTML::HTMLFormElement>(element)) {
-            bool has_invalid_elements = false;
-            element.for_each_in_subtree([&](auto& node) {
-                if (auto form_associated_element = as_if<HTML::FormAssociatedElement>(&node)) {
-                    if (form_associated_element->form() == form_element && form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {
-                        has_invalid_elements = true;
-                        return TraversalDecision::Break;
-                    }
-                }
-                return TraversalDecision::Continue;
-            });
-            if (has_invalid_elements)
-                return true;
-        }
-
-        if (is<HTML::HTMLFieldSetElement>(element)) {
-            bool has_invalid_children = false;
-            element.for_each_in_subtree([&](auto& node) {
-                if (auto form_associated_element = as_if<HTML::FormAssociatedElement>(&node)) {
-                    if (form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {
-                        has_invalid_children = true;
-                        return TraversalDecision::Break;
-                    }
-                }
-                return TraversalDecision::Continue;
-            });
-            if (has_invalid_children)
-                return true;
-        }
-        return false;
-    }
-    case CSS::PseudoClass::LowValue:
-        if (auto const* meter = as_if<HTML::HTMLMeterElement>(element))
-            return meter->value() < meter->low();
-        return false;
-    case CSS::PseudoClass::Modal:
-        // https://drafts.csswg.org/selectors/#modal-state
-        if (auto const* dialog_element = as_if<HTML::HTMLDialogElement>(element))
-            return dialog_element->is_modal();
-        // FIXME: fullscreen elements are also modal.
-        return false;
-    case CSS::PseudoClass::Open:
-        return matches_open_state_pseudo_class(element, true);
-    case CSS::PseudoClass::OptimalValue:
-        return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::Optimal);
-    case CSS::PseudoClass::Optional:
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-optional
-        if (auto const* input_element = as_if<HTML::HTMLInputElement>(element)) {
-            if (input_element->required_applies() && !input_element->has_attribute(HTML::AttributeNames::required))
-                return true;
-            // AD-HOC: Chromium and Webkit also match for hidden inputs (and WPT expects this)
-            // See: https://github.com/whatwg/html/issues/11273
-            return input_element->type_state() == HTML::HTMLInputElement::TypeAttributeState::Hidden;
-        }
-        if (auto const* select_element = as_if<HTML::HTMLSelectElement>(element))
-            return !select_element->has_attribute(HTML::AttributeNames::required);
-        if (auto const* textarea_element = as_if<HTML::HTMLTextAreaElement>(element))
-            return !textarea_element->has_attribute(HTML::AttributeNames::required);
-        return false;
-    case CSS::PseudoClass::ReadOnly:
-        return !matches_read_write_pseudo_class(element);
-    case CSS::PseudoClass::ReadWrite:
-        return matches_read_write_pseudo_class(element);
-    case CSS::PseudoClass::Required:
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-required
-        if (auto const* input_element = as_if<HTML::HTMLInputElement>(element))
-            return input_element->required_applies() && input_element->has_attribute(HTML::AttributeNames::required);
-        if (auto const* select_element = as_if<HTML::HTMLSelectElement>(element))
-            return select_element->has_attribute(HTML::AttributeNames::required);
-        if (auto const* textarea_element = as_if<HTML::HTMLTextAreaElement>(element))
-            return textarea_element->has_attribute(HTML::AttributeNames::required);
-        return false;
-    case CSS::PseudoClass::SuboptimalValue:
-        return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::Suboptimal);
-    case CSS::PseudoClass::UserInvalid:
-    case CSS::PseudoClass::UserValid: {
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-valid
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-invalid
-        bool user_validity = false;
-        if (auto const* input_element = as_if<HTML::HTMLInputElement>(element))
-            user_validity = input_element->user_validity();
-        else if (auto const* select_element = as_if<HTML::HTMLSelectElement>(element))
-            user_validity = select_element->user_validity();
-        else if (auto const* text_area_element = as_if<HTML::HTMLTextAreaElement>(element))
-            user_validity = text_area_element->user_validity();
-        if (!user_validity)
-            return false;
-
-        auto const& form_associated_element = as<HTML::FormAssociatedElement>(element);
-        if (!form_associated_element.is_candidate_for_constraint_validation())
-            return false;
-        return pseudo_class == CSS::PseudoClass::UserValid
-            ? form_associated_element.satisfies_its_constraints()
-            : !form_associated_element.satisfies_its_constraints();
-    }
-    case CSS::PseudoClass::Valid: {
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid
-        if (auto form_associated_element = as_if<HTML::FormAssociatedElement>(element)) {
-            if (form_associated_element->is_candidate_for_constraint_validation() && form_associated_element->satisfies_its_constraints())
-                return true;
-        }
-
-        if (auto form_element = as_if<HTML::HTMLFormElement>(element)) {
-            bool has_invalid_elements = false;
-            element.for_each_in_subtree([&](auto& node) {
-                if (auto form_associated_element = as_if<HTML::FormAssociatedElement>(&node)) {
-                    if (form_associated_element->form() == form_element && form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {
-                        has_invalid_elements = true;
-                        return TraversalDecision::Break;
-                    }
-                }
-                return TraversalDecision::Continue;
-            });
-            if (!has_invalid_elements)
-                return true;
-        }
-
-        if (is<HTML::HTMLFieldSetElement>(element)) {
-            bool has_invalid_children = false;
-            element.for_each_in_subtree([&](auto& node) {
-                if (auto form_associated_element = as_if<HTML::FormAssociatedElement>(&node)) {
-                    if (form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {
-                        has_invalid_children = true;
-                        return TraversalDecision::Break;
-                    }
-                }
-                return TraversalDecision::Continue;
-            });
-            if (!has_invalid_children)
-                return true;
-        }
-        return false;
-    }
-    case CSS::PseudoClass::Visited:
-    case CSS::PseudoClass::VolumeLocked:
-    case CSS::PseudoClass::__Count:
-    case CSS::PseudoClass::Active:
-    case CSS::PseudoClass::AnyLink:
-    case CSS::PseudoClass::Autofill:
-    case CSS::PseudoClass::Buffering:
-    case CSS::PseudoClass::Checked:
-    case CSS::PseudoClass::Defined:
-    case CSS::PseudoClass::Dir:
-    case CSS::PseudoClass::Disabled:
-    case CSS::PseudoClass::Empty:
-    case CSS::PseudoClass::Enabled:
-    case CSS::PseudoClass::FirstChild:
-    case CSS::PseudoClass::FirstOfType:
-    case CSS::PseudoClass::Focus:
-    case CSS::PseudoClass::FocusVisible:
-    case CSS::PseudoClass::FocusWithin:
-    case CSS::PseudoClass::Fullscreen:
-    case CSS::PseudoClass::Has:
-    case CSS::PseudoClass::Heading:
-    case CSS::PseudoClass::Host:
-    case CSS::PseudoClass::Is:
-    case CSS::PseudoClass::Lang:
-    case CSS::PseudoClass::LastChild:
-    case CSS::PseudoClass::LastOfType:
-    case CSS::PseudoClass::Link:
-    case CSS::PseudoClass::LocalLink:
-    case CSS::PseudoClass::Muted:
-    case CSS::PseudoClass::Not:
-    case CSS::PseudoClass::NthChild:
-    case CSS::PseudoClass::NthLastChild:
-    case CSS::PseudoClass::NthLastOfType:
-    case CSS::PseudoClass::NthOfType:
-    case CSS::PseudoClass::OnlyChild:
-    case CSS::PseudoClass::OnlyOfType:
-    case CSS::PseudoClass::Paused:
-    case CSS::PseudoClass::PlaceholderShown:
-    case CSS::PseudoClass::PopoverOpen:
-    case CSS::PseudoClass::Playing:
-    case CSS::PseudoClass::Root:
-    case CSS::PseudoClass::Scope:
-    case CSS::PseudoClass::Seeking:
-    case CSS::PseudoClass::State:
-    case CSS::PseudoClass::Stalled:
-    case CSS::PseudoClass::Target:
-    case CSS::PseudoClass::Unchecked:
-    case CSS::PseudoClass::Where:
-        VERIFY_NOT_REACHED();
-    }
-    VERIFY_NOT_REACHED();
-}
-
 static CSS::SelectorFFI::Element element_to_ffi(DOM::Element const* element)
 {
     if (!element)
@@ -642,13 +413,24 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_muted);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_paused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_seeking);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_stalled);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_default);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_meter_value_state);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_meter_value_is_high);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_meter_value_is_low);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_hovered);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_indeterminate);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_validity_state);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_modal);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_open);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_required_state);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_read_write);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_user_validity_state);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute_count);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element_in_light_tree);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_previous_element_sibling);
@@ -899,6 +681,160 @@ extern "C" bool selector_ffi_element_media_is_stalled(void const* element)
     return media_element && media_element->stalled();
 }
 
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-default
+extern "C" bool selector_ffi_element_is_default(void const* element)
+{
+    auto const& target = ffi_element(element);
+    auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(target);
+    if (!form_associated_element)
+        return false;
+    if (form_associated_element->is_submit_button() && form_associated_element->form() && form_associated_element->form()->default_button() == form_associated_element)
+        return true;
+    if (auto const* input_element = as_if<HTML::HTMLInputElement>(form_associated_element))
+        return input_element->checked_applies() && input_element->has_attribute(HTML::AttributeNames::checked);
+    if (auto const* option_element = as_if<HTML::HTMLOptionElement>(form_associated_element))
+        return option_element->has_attribute(HTML::AttributeNames::selected);
+    return false;
+}
+
+extern "C" CSS::SelectorFFI::FfiMeterValueState selector_ffi_element_meter_value_state(void const* element)
+{
+    auto const* meter = as_if<HTML::HTMLMeterElement>(ffi_element(element));
+    if (!meter)
+        return CSS::SelectorFFI::FfiMeterValueState::NotMeter;
+    switch (meter->value_state()) {
+    case HTML::HTMLMeterElement::ValueState::EvenLessGood:
+        return CSS::SelectorFFI::FfiMeterValueState::EvenLessGood;
+    case HTML::HTMLMeterElement::ValueState::Suboptimal:
+        return CSS::SelectorFFI::FfiMeterValueState::Suboptimal;
+    case HTML::HTMLMeterElement::ValueState::Optimal:
+        return CSS::SelectorFFI::FfiMeterValueState::Optimal;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+extern "C" bool selector_ffi_element_meter_value_is_high(void const* element)
+{
+    auto const* meter = as_if<HTML::HTMLMeterElement>(ffi_element(element));
+    return meter && meter->value() > meter->high();
+}
+
+extern "C" bool selector_ffi_element_meter_value_is_low(void const* element)
+{
+    auto const* meter = as_if<HTML::HTMLMeterElement>(ffi_element(element));
+    return meter && meter->value() < meter->low();
+}
+
+extern "C" bool selector_ffi_element_is_hovered(void const* element)
+{
+    return matches_hover_pseudo_class(ffi_element(element));
+}
+
+extern "C" bool selector_ffi_element_is_indeterminate(void const* element)
+{
+    return matches_indeterminate_pseudo_class(ffi_element(element));
+}
+
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-invalid
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-valid
+extern "C" CSS::SelectorFFI::FfiValidityState selector_ffi_element_validity_state(void const* element)
+{
+    auto const& target = ffi_element(element);
+    if (auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(target)) {
+        if (form_associated_element->is_candidate_for_constraint_validation()) {
+            return form_associated_element->satisfies_its_constraints()
+                ? CSS::SelectorFFI::FfiValidityState::Valid
+                : CSS::SelectorFFI::FfiValidityState::Invalid;
+        }
+    }
+
+    auto const* form_element = as_if<HTML::HTMLFormElement>(target);
+    if (!form_element && !is<HTML::HTMLFieldSetElement>(target))
+        return CSS::SelectorFFI::FfiValidityState::NotApplicable;
+
+    bool has_invalid_elements = false;
+    target.for_each_in_subtree([&](auto& node) {
+        auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(&node);
+        if (!form_associated_element)
+            return TraversalDecision::Continue;
+        if (form_element && form_associated_element->form() != form_element)
+            return TraversalDecision::Continue;
+        if (form_associated_element->is_candidate_for_constraint_validation() && !form_associated_element->satisfies_its_constraints()) {
+            has_invalid_elements = true;
+            return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    });
+    return has_invalid_elements
+        ? CSS::SelectorFFI::FfiValidityState::Invalid
+        : CSS::SelectorFFI::FfiValidityState::Valid;
+}
+
+// https://drafts.csswg.org/selectors/#modal-state
+extern "C" bool selector_ffi_element_is_modal(void const* element)
+{
+    auto const* dialog_element = as_if<HTML::HTMLDialogElement>(ffi_element(element));
+    // FIXME: Fullscreen elements are also modal.
+    return dialog_element && dialog_element->is_modal();
+}
+
+extern "C" bool selector_ffi_element_is_open(void const* element)
+{
+    return matches_open_state_pseudo_class(ffi_element(element), true);
+}
+
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-optional
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-required
+extern "C" CSS::SelectorFFI::FfiRequiredState selector_ffi_element_required_state(void const* element)
+{
+    auto const& target = ffi_element(element);
+    if (auto const* input_element = as_if<HTML::HTMLInputElement>(target)) {
+        if (input_element->required_applies())
+            return input_element->has_attribute(HTML::AttributeNames::required)
+                ? CSS::SelectorFFI::FfiRequiredState::Required
+                : CSS::SelectorFFI::FfiRequiredState::Optional;
+        // AD-HOC: Chromium and WebKit also match :optional for hidden inputs.
+        return input_element->type_state() == HTML::HTMLInputElement::TypeAttributeState::Hidden
+            ? CSS::SelectorFFI::FfiRequiredState::Optional
+            : CSS::SelectorFFI::FfiRequiredState::NotApplicable;
+    }
+    if (is<HTML::HTMLSelectElement>(target) || is<HTML::HTMLTextAreaElement>(target))
+        return target.has_attribute(HTML::AttributeNames::required)
+            ? CSS::SelectorFFI::FfiRequiredState::Required
+            : CSS::SelectorFFI::FfiRequiredState::Optional;
+    return CSS::SelectorFFI::FfiRequiredState::NotApplicable;
+}
+
+extern "C" bool selector_ffi_element_is_read_write(void const* element)
+{
+    return matches_read_write_pseudo_class(ffi_element(element));
+}
+
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-valid
+// https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-invalid
+extern "C" CSS::SelectorFFI::FfiValidityState selector_ffi_element_user_validity_state(void const* element)
+{
+    auto const& target = ffi_element(element);
+    bool user_validity = false;
+    if (auto const* input_element = as_if<HTML::HTMLInputElement>(target))
+        user_validity = input_element->user_validity();
+    else if (auto const* select_element = as_if<HTML::HTMLSelectElement>(target))
+        user_validity = select_element->user_validity();
+    else if (auto const* text_area_element = as_if<HTML::HTMLTextAreaElement>(target))
+        user_validity = text_area_element->user_validity();
+    else
+        return CSS::SelectorFFI::FfiValidityState::NotApplicable;
+    if (!user_validity)
+        return CSS::SelectorFFI::FfiValidityState::NotApplicable;
+
+    auto const& form_associated_element = as<HTML::FormAssociatedElement>(target);
+    if (!form_associated_element.is_candidate_for_constraint_validation())
+        return CSS::SelectorFFI::FfiValidityState::NotApplicable;
+    return form_associated_element.satisfies_its_constraints()
+        ? CSS::SelectorFFI::FfiValidityState::Valid
+        : CSS::SelectorFFI::FfiValidityState::Invalid;
+}
+
 extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
 {
     return dom_string_view(ffi_element(element).local_name());
@@ -982,67 +918,6 @@ extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_resolve_namespace(vo
         .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Named,
         .namespace_ = interned_string_identity(*namespace_),
     };
-}
-
-static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
-{
-    return first_is_one_of(
-        pseudo_class,
-        CSS::PseudoClass::Active,
-        CSS::PseudoClass::AnyLink,
-        CSS::PseudoClass::Autofill,
-        CSS::PseudoClass::Buffering,
-        CSS::PseudoClass::Checked,
-        CSS::PseudoClass::Defined,
-        CSS::PseudoClass::Disabled,
-        CSS::PseudoClass::Empty,
-        CSS::PseudoClass::Enabled,
-        CSS::PseudoClass::FirstChild,
-        CSS::PseudoClass::FirstOfType,
-        CSS::PseudoClass::Focus,
-        CSS::PseudoClass::FocusVisible,
-        CSS::PseudoClass::FocusWithin,
-        CSS::PseudoClass::Fullscreen,
-        CSS::PseudoClass::Has,
-        CSS::PseudoClass::Host,
-        CSS::PseudoClass::Is,
-        CSS::PseudoClass::LastChild,
-        CSS::PseudoClass::LastOfType,
-        CSS::PseudoClass::Link,
-        CSS::PseudoClass::LocalLink,
-        CSS::PseudoClass::Muted,
-        CSS::PseudoClass::Not,
-        CSS::PseudoClass::NthChild,
-        CSS::PseudoClass::NthLastChild,
-        CSS::PseudoClass::NthLastOfType,
-        CSS::PseudoClass::NthOfType,
-        CSS::PseudoClass::OnlyChild,
-        CSS::PseudoClass::OnlyOfType,
-        CSS::PseudoClass::Paused,
-        CSS::PseudoClass::PlaceholderShown,
-        CSS::PseudoClass::PopoverOpen,
-        CSS::PseudoClass::Playing,
-        CSS::PseudoClass::Root,
-        CSS::PseudoClass::Scope,
-        CSS::PseudoClass::Seeking,
-        CSS::PseudoClass::Where,
-        CSS::PseudoClass::Dir,
-        CSS::PseudoClass::Heading,
-        CSS::PseudoClass::Lang,
-        CSS::PseudoClass::State,
-        CSS::PseudoClass::Stalled,
-        CSS::PseudoClass::Target,
-        CSS::PseudoClass::Unchecked,
-        CSS::PseudoClass::Visited,
-        CSS::PseudoClass::VolumeLocked);
-}
-
-extern "C" bool selector_ffi_matches_pseudo_class(void const* element, u8 pseudo_class_value)
-{
-    auto pseudo_class = static_cast<CSS::PseudoClass>(pseudo_class_value);
-    VERIFY(pseudo_class < CSS::PseudoClass::__Count);
-    VERIFY(!is_rust_matched_pseudo_class(pseudo_class));
-    return matches_pseudo_class_state(pseudo_class, ffi_element(element));
 }
 
 extern "C" CSS::SelectorFFI::Element selector_ffi_parent_element(void const* element, void const* shadow_host)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -666,10 +666,37 @@ static CSS::SelectorFFI::Element element_to_ffi(DOM::Element const* element)
     auto const& classes = element->class_names();
     return {
         .pointer = element,
+        .local_name = reinterpret_cast<uintptr_t const*>(&element->local_name()),
+        .namespace_ = element->namespace_uri().has_value() ? reinterpret_cast<uintptr_t const*>(&element->namespace_uri().value()) : nullptr,
         .id = element->id().has_value() ? reinterpret_cast<uintptr_t const*>(&element->id().value()) : nullptr,
         .classes = reinterpret_cast<uintptr_t const*>(classes.data()),
         .class_count = classes.size(),
         .class_names_are_case_insensitive = element->document().in_quirks_mode(),
+        .namespace_is_null = !element->namespace_uri().has_value() || element->namespace_uri()->is_empty(),
+        .is_html_element_in_html_document = element->namespace_uri() == Namespace::HTML
+            && element->document().document_type() == DOM::Document::Type::HTML,
+    };
+}
+
+static CSS::SelectorFFI::NamespaceContext namespace_context_to_ffi(MatchContext const& context)
+{
+    if (!context.style_sheet_for_rule || !context.style_sheet_for_rule->default_namespace_rule()) {
+        return {
+            .default_namespace_type = CSS::SelectorFFI::DefaultNamespaceType::Any,
+            .default_namespace = nullptr,
+        };
+    }
+
+    auto const& default_namespace = context.style_sheet_for_rule->default_namespace_rule()->namespace_uri();
+    if (default_namespace.is_empty()) {
+        return {
+            .default_namespace_type = CSS::SelectorFFI::DefaultNamespaceType::None,
+            .default_namespace = nullptr,
+        };
+    }
+    return {
+        .default_namespace_type = CSS::SelectorFFI::DefaultNamespaceType::Named,
+        .default_namespace = reinterpret_cast<uintptr_t const*>(&default_namespace),
     };
 }
 
@@ -684,7 +711,8 @@ bool matches(CSS::Selector const& selector, DOM::AbstractElement const& target, 
         &context,
         scope.ptr(),
         context.collect_per_element_selector_involvement_metadata,
-        context.inside_has_argument_match);
+        context.inside_has_argument_match,
+        namespace_context_to_ffi(context));
 }
 
 bool matches_originating_element_for_pseudo_element(CSS::Selector const& selector, CSS::PseudoElement pseudo_element, DOM::AbstractElement const& target, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, GC::Ptr<DOM::ParentNode const> scope)
@@ -699,7 +727,8 @@ bool matches_originating_element_for_pseudo_element(CSS::Selector const& selecto
         &context,
         scope.ptr(),
         context.collect_per_element_selector_involvement_metadata,
-        context.inside_has_argument_match);
+        context.inside_has_argument_match,
+        namespace_context_to_ffi(context));
 }
 
 static MatchContext& rust_match_context(void* context)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -497,13 +497,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
             return !media_element->paused();
         return false;
-    case CSS::PseudoClass::PopoverOpen:
-        // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open
-        if (auto const* html_element = as_if<HTML::HTMLElement>(element);
-            html_element && html_element->has_attribute(HTML::AttributeNames::popover)) {
-            return html_element->popover_visibility_state() == HTML::HTMLElement::PopoverVisibilityState::Showing;
-        }
-        return false;
     case CSS::PseudoClass::ReadOnly:
         return !matches_read_write_pseudo_class(element);
     case CSS::PseudoClass::ReadWrite:
@@ -618,6 +611,7 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::NthOfType:
     case CSS::PseudoClass::OnlyChild:
     case CSS::PseudoClass::OnlyOfType:
+    case CSS::PseudoClass::PopoverOpen:
     case CSS::PseudoClass::Root:
     case CSS::PseudoClass::Scope:
     case CSS::PseudoClass::State:
@@ -717,6 +711,8 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_link);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_fullscreen);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_heading_level);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_popover_attribute);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_popover_is_showing);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
@@ -846,6 +842,18 @@ extern "C" i64 selector_ffi_element_heading_level(void const* element)
     return heading ? heading->heading_level() : 0;
 }
 
+extern "C" bool selector_ffi_element_has_popover_attribute(void const* element)
+{
+    return ffi_element(element).has_attribute(HTML::AttributeNames::popover);
+}
+
+extern "C" bool selector_ffi_element_popover_is_showing(void const* element)
+{
+    auto const* html_element = as_if<HTML::HTMLElement>(ffi_element(element));
+    return html_element
+        && html_element->popover_visibility_state() == HTML::HTMLElement::PopoverVisibilityState::Showing;
+}
+
 extern "C" bool selector_ffi_element_is_focused(void const* element)
 {
     return ffi_element(element).is_focused();
@@ -972,6 +980,7 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::NthOfType,
         CSS::PseudoClass::OnlyChild,
         CSS::PseudoClass::OnlyOfType,
+        CSS::PseudoClass::PopoverOpen,
         CSS::PseudoClass::Root,
         CSS::PseudoClass::Scope,
         CSS::PseudoClass::Where,

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -407,8 +407,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         return element.matches_enabled_pseudo_class();
     case CSS::PseudoClass::EvenLessGoodValue:
         return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::EvenLessGood);
-    case CSS::PseudoClass::Fullscreen:
-        return element.is_fullscreen_element();
     case CSS::PseudoClass::HighValue:
         if (auto const* meter = as_if<HTML::HTMLMeterElement>(element))
             return meter->value() > meter->high();
@@ -604,6 +602,7 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::Focus:
     case CSS::PseudoClass::FocusVisible:
     case CSS::PseudoClass::FocusWithin:
+    case CSS::PseudoClass::Fullscreen:
     case CSS::PseudoClass::Has:
     case CSS::PseudoClass::Heading:
     case CSS::PseudoClass::Host:
@@ -716,6 +715,7 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_link);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_fullscreen);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
@@ -835,6 +835,11 @@ extern "C" bool selector_ffi_element_is_link(void const* element)
     return ffi_element(element).matches_link_pseudo_class();
 }
 
+extern "C" bool selector_ffi_element_is_fullscreen(void const* element)
+{
+    return ffi_element(element).is_fullscreen_element();
+}
+
 extern "C" bool selector_ffi_element_is_focused(void const* element)
 {
     return ffi_element(element).is_focused();
@@ -947,6 +952,7 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::Focus,
         CSS::PseudoClass::FocusVisible,
         CSS::PseudoClass::FocusWithin,
+        CSS::PseudoClass::Fullscreen,
         CSS::PseudoClass::Has,
         CSS::PseudoClass::Host,
         CSS::PseudoClass::Is,

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -716,6 +716,7 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_docum
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_link);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_fullscreen);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_heading_level);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
@@ -729,7 +730,6 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_direction);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_state);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_heading);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element_in_light_tree);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_previous_element_sibling);
@@ -838,6 +838,12 @@ extern "C" bool selector_ffi_element_is_link(void const* element)
 extern "C" bool selector_ffi_element_is_fullscreen(void const* element)
 {
     return ffi_element(element).is_fullscreen_element();
+}
+
+extern "C" i64 selector_ffi_element_heading_level(void const* element)
+{
+    auto const* heading = as_if<HTML::HTMLHeadingElement>(ffi_element(element));
+    return heading ? heading->heading_level() : 0;
 }
 
 extern "C" bool selector_ffi_element_is_focused(void const* element)
@@ -1011,17 +1017,6 @@ extern "C" bool selector_ffi_matches_state(void const* element, void const* cxx_
     if (auto custom_state_set = target.custom_state_set())
         return custom_state_set->has_state(ffi_simple_selector(cxx_simple_selector).pseudo_class().ident->string_value);
     return false;
-}
-
-extern "C" bool selector_ffi_matches_heading(void const* element, i64 const* levels, size_t level_count)
-{
-    auto const* heading = as_if<HTML::HTMLHeadingElement>(ffi_element(element));
-    if (!heading)
-        return false;
-    if (level_count == 0)
-        return true;
-    VERIFY(levels);
-    return ReadonlySpan<i64> { levels, level_count }.contains_slow(heading->heading_level());
 }
 
 extern "C" CSS::SelectorFFI::Element selector_ffi_parent_element(void const* element, void const* shadow_host)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -653,14 +653,34 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     VERIFY_NOT_REACHED();
 }
 
+static CSS::SelectorFFI::Element element_to_ffi(DOM::Element const* element)
+{
+    if (!element)
+        return {};
+
+    // `Utf16FlyString` is its interned one-word representation. Rust borrows these words directly
+    // while matching; the DOM and selector trees pin their respective strings for the call.
+    static_assert(sizeof(Utf16FlyString) == sizeof(uintptr_t));
+    static_assert(alignof(Utf16FlyString) == alignof(uintptr_t));
+
+    auto const& classes = element->class_names();
+    return {
+        .pointer = element,
+        .id = element->id().has_value() ? reinterpret_cast<uintptr_t const*>(&element->id().value()) : nullptr,
+        .classes = reinterpret_cast<uintptr_t const*>(classes.data()),
+        .class_count = classes.size(),
+        .class_names_are_case_insensitive = element->document().in_quirks_mode(),
+    };
+}
+
 bool matches(CSS::Selector const& selector, DOM::AbstractElement const& target, GC::Ptr<DOM::Element const> shadow_host,
     MatchContext& context, GC::Ptr<DOM::ParentNode const> scope)
 {
     return CSS::SelectorFFI::rust_selector_matches(
         &selector.rust_selector(),
-        &target.element(),
+        element_to_ffi(&target.element()),
         CSS::pseudo_element_to_ffi(target.pseudo_element()),
-        shadow_host.ptr(),
+        element_to_ffi(shadow_host.ptr()),
         &context,
         scope.ptr(),
         context.collect_per_element_selector_involvement_metadata,
@@ -674,8 +694,8 @@ bool matches_originating_element_for_pseudo_element(CSS::Selector const& selecto
     return CSS::SelectorFFI::rust_selector_matches_originating_element(
         &selector.rust_selector(),
         CSS::pseudo_element_to_ffi(pseudo_element),
-        &target.element(),
-        shadow_host.ptr(),
+        element_to_ffi(&target.element()),
+        element_to_ffi(shadow_host.ptr()),
         &context,
         scope.ptr(),
         context.collect_per_element_selector_involvement_metadata,
@@ -768,8 +788,7 @@ using CSS::SelectorFFI::TagNameMatchingMode;
 
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_universal);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_tag_name);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_id);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_class);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_class_quirks);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
@@ -826,16 +845,11 @@ extern "C" bool selector_ffi_matches_tag_name(void* context, void const* element
         && matches_namespace(qualified_name, target, match_context.style_sheet_for_rule);
 }
 
-extern "C" bool selector_ffi_matches_id(void const* element, void const* cxx_simple_selector)
-{
-    return ffi_element(element).id() == ffi_simple_selector(cxx_simple_selector).id_name();
-}
-
-extern "C" bool selector_ffi_matches_class(void const* element, void const* cxx_simple_selector)
+extern "C" bool selector_ffi_matches_class_quirks(void const* element, void const* cxx_simple_selector)
 {
     auto const& target = ffi_element(element);
-    auto case_sensitivity = target.document().in_quirks_mode() ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive;
-    return target.has_class(ffi_simple_selector(cxx_simple_selector).class_name(), case_sensitivity);
+    VERIFY(target.document().in_quirks_mode());
+    return target.has_class(ffi_simple_selector(cxx_simple_selector).class_name(), CaseSensitivity::CaseInsensitive);
 }
 
 static bool matches_attribute_value(CSS::Selector::SimpleSelector::Attribute::MatchType match_type, Utf16View selector_value, Utf16View element_value, CaseSensitivity case_sensitivity)
@@ -1043,54 +1057,54 @@ extern "C" bool selector_ffi_matches_heading(void const* element, i64 const* lev
     return ReadonlySpan<i64> { levels, level_count }.contains_slow(heading->heading_level());
 }
 
-extern "C" void const* selector_ffi_parent_element(void const* element, void const* shadow_host)
+extern "C" CSS::SelectorFFI::Element selector_ffi_parent_element(void const* element, void const* shadow_host)
 {
     auto const& target = ffi_element(element);
     if (!shadow_host)
-        return target.parent_element();
+        return element_to_ffi(target.parent_element());
     if (element == shadow_host)
-        return nullptr;
-    return target.parent_or_shadow_host_element();
+        return {};
+    return element_to_ffi(target.parent_or_shadow_host_element());
 }
 
-extern "C" void const* selector_ffi_parent_element_in_light_tree(void const* element)
+extern "C" CSS::SelectorFFI::Element selector_ffi_parent_element_in_light_tree(void const* element)
 {
-    return ffi_element(element).parent_element();
+    return element_to_ffi(ffi_element(element).parent_element());
 }
 
-extern "C" void const* selector_ffi_previous_element_sibling(void const* element)
+extern "C" CSS::SelectorFFI::Element selector_ffi_previous_element_sibling(void const* element)
 {
-    return ffi_element(element).previous_element_sibling();
+    return element_to_ffi(ffi_element(element).previous_element_sibling());
 }
 
-extern "C" void const* selector_ffi_next_element_sibling(void const* element)
+extern "C" CSS::SelectorFFI::Element selector_ffi_next_element_sibling(void const* element)
 {
-    return ffi_element(element).next_element_sibling();
+    return element_to_ffi(ffi_element(element).next_element_sibling());
 }
 
-extern "C" void const* selector_ffi_first_element_child(void const* element)
+extern "C" CSS::SelectorFFI::Element selector_ffi_first_element_child(void const* element)
 {
-    return ffi_element(element).first_child_of_type<DOM::Element>();
+    return element_to_ffi(ffi_element(element).first_child_of_type<DOM::Element>());
 }
 
-extern "C" void const* selector_ffi_first_element_descendant(void const* element)
+extern "C" CSS::SelectorFFI::Element selector_ffi_first_element_descendant(void const* element)
 {
     auto const& root = ffi_element(element);
     for (auto const* node = root.first_child(); node; node = node->next_in_pre_order(&root)) {
         if (node->is_element())
-            return static_cast<DOM::Element const*>(node);
+            return element_to_ffi(static_cast<DOM::Element const*>(node));
     }
-    return nullptr;
+    return {};
 }
 
-extern "C" void const* selector_ffi_next_element_descendant(void const* element, void const* root)
+extern "C" CSS::SelectorFFI::Element selector_ffi_next_element_descendant(void const* element, void const* root)
 {
     auto const& root_element = ffi_element(root);
     for (auto const* node = static_cast<DOM::Node const*>(&ffi_element(element))->next_in_pre_order(&root_element); node; node = node->next_in_pre_order(&root_element)) {
         if (node->is_element())
-            return static_cast<DOM::Element const*>(node);
+            return element_to_ffi(static_cast<DOM::Element const*>(node));
     }
-    return nullptr;
+    return {};
 }
 
 extern "C" bool selector_ffi_has_no_element_or_nonempty_text_children(void const* element)
@@ -1139,8 +1153,8 @@ extern "C" CSS::SelectorFFI::ElementAndShadowHost selector_ffi_slotted_parent(vo
         if (slot_shadow_root != match_context.rule_shadow_root)
             continue;
         return {
-            .element = slot,
-            .shadow_host = slot_shadow_root ? slot_shadow_root->host() : nullptr,
+            .element = element_to_ffi(slot),
+            .shadow_host = element_to_ffi(slot_shadow_root ? slot_shadow_root->host() : nullptr),
         };
     }
     return {};
@@ -1182,7 +1196,7 @@ extern "C" CSS::SelectorFFI::ElementAndShadowHost selector_ffi_part_parent(void*
             else
                 next_shadow_host = nullptr;
         }
-        return { .element = &host, .shadow_host = next_shadow_host };
+        return { .element = element_to_ffi(&host), .shadow_host = element_to_ffi(next_shadow_host) };
     }
     return {};
 }

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -316,14 +316,10 @@ static bool matches_optimal_value_pseudo_class(DOM::Element const& element, HTML
 static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Element const& element)
 {
     switch (pseudo_class) {
-    case CSS::PseudoClass::Active:
-        return element.is_being_activated();
     case CSS::PseudoClass::Buffering:
         if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
             return media_element->blocked();
         return false;
-    case CSS::PseudoClass::Checked:
-        return element.matches_checked_pseudo_class();
     case CSS::PseudoClass::Default: {
         // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-default
         if (auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(element)) {
@@ -340,12 +336,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         }
         return false;
     }
-    case CSS::PseudoClass::Defined:
-        return element.is_defined();
-    case CSS::PseudoClass::Disabled:
-        return element.matches_disabled_pseudo_class();
-    case CSS::PseudoClass::Enabled:
-        return element.matches_enabled_pseudo_class();
     case CSS::PseudoClass::EvenLessGoodValue:
         return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::EvenLessGood);
     case CSS::PseudoClass::HighValue:
@@ -394,8 +384,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         }
         return false;
     }
-    case CSS::PseudoClass::LocalLink:
-        return element.matches_local_link_pseudo_class();
     case CSS::PseudoClass::LowValue:
         if (auto const* meter = as_if<HTML::HTMLMeterElement>(element))
             return meter->value() < meter->low();
@@ -432,8 +420,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
             return media_element->paused();
         return false;
-    case CSS::PseudoClass::PlaceholderShown:
-        return element.matches_placeholder_shown_pseudo_class();
     case CSS::PseudoClass::Playing:
         if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
             return !media_element->paused();
@@ -461,10 +447,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         return false;
     case CSS::PseudoClass::SuboptimalValue:
         return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::Suboptimal);
-    case CSS::PseudoClass::Target:
-        return element.is_target();
-    case CSS::PseudoClass::Unchecked:
-        return element.matches_unchecked_pseudo_class();
     case CSS::PseudoClass::UserInvalid:
     case CSS::PseudoClass::UserValid: {
         // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-user-valid
@@ -527,10 +509,15 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::Visited:
     case CSS::PseudoClass::VolumeLocked:
     case CSS::PseudoClass::__Count:
+    case CSS::PseudoClass::Active:
     case CSS::PseudoClass::AnyLink:
     case CSS::PseudoClass::Autofill:
+    case CSS::PseudoClass::Checked:
+    case CSS::PseudoClass::Defined:
     case CSS::PseudoClass::Dir:
+    case CSS::PseudoClass::Disabled:
     case CSS::PseudoClass::Empty:
+    case CSS::PseudoClass::Enabled:
     case CSS::PseudoClass::FirstChild:
     case CSS::PseudoClass::FirstOfType:
     case CSS::PseudoClass::Focus:
@@ -545,6 +532,7 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::LastChild:
     case CSS::PseudoClass::LastOfType:
     case CSS::PseudoClass::Link:
+    case CSS::PseudoClass::LocalLink:
     case CSS::PseudoClass::Not:
     case CSS::PseudoClass::NthChild:
     case CSS::PseudoClass::NthLastChild:
@@ -552,10 +540,13 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::NthOfType:
     case CSS::PseudoClass::OnlyChild:
     case CSS::PseudoClass::OnlyOfType:
+    case CSS::PseudoClass::PlaceholderShown:
     case CSS::PseudoClass::PopoverOpen:
     case CSS::PseudoClass::Root:
     case CSS::PseudoClass::Scope:
     case CSS::PseudoClass::State:
+    case CSS::PseudoClass::Target:
+    case CSS::PseudoClass::Unchecked:
     case CSS::PseudoClass::Where:
         VERIFY_NOT_REACHED();
     }
@@ -654,6 +645,15 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_language);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_active);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_checked);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_defined);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_disabled);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_enabled);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_local_link);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_placeholder_shown);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_target);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_unchecked);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute_count);
@@ -831,6 +831,51 @@ extern "C" bool selector_ffi_element_has_focus_within(void const* element)
     return ffi_element(element).matches_focus_within_pseudo_class();
 }
 
+extern "C" bool selector_ffi_element_is_active(void const* element)
+{
+    return ffi_element(element).is_being_activated();
+}
+
+extern "C" bool selector_ffi_element_is_checked(void const* element)
+{
+    return ffi_element(element).matches_checked_pseudo_class();
+}
+
+extern "C" bool selector_ffi_element_is_defined(void const* element)
+{
+    return ffi_element(element).is_defined();
+}
+
+extern "C" bool selector_ffi_element_is_disabled(void const* element)
+{
+    return ffi_element(element).matches_disabled_pseudo_class();
+}
+
+extern "C" bool selector_ffi_element_is_enabled(void const* element)
+{
+    return ffi_element(element).matches_enabled_pseudo_class();
+}
+
+extern "C" bool selector_ffi_element_is_local_link(void const* element)
+{
+    return ffi_element(element).matches_local_link_pseudo_class();
+}
+
+extern "C" bool selector_ffi_element_is_placeholder_shown(void const* element)
+{
+    return ffi_element(element).matches_placeholder_shown_pseudo_class();
+}
+
+extern "C" bool selector_ffi_element_is_target(void const* element)
+{
+    return ffi_element(element).is_target();
+}
+
+extern "C" bool selector_ffi_element_is_unchecked(void const* element)
+{
+    return ffi_element(element).matches_unchecked_pseudo_class();
+}
+
 extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
 {
     return dom_string_view(ffi_element(element).local_name());
@@ -920,9 +965,14 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
 {
     return first_is_one_of(
         pseudo_class,
+        CSS::PseudoClass::Active,
         CSS::PseudoClass::AnyLink,
         CSS::PseudoClass::Autofill,
+        CSS::PseudoClass::Checked,
+        CSS::PseudoClass::Defined,
+        CSS::PseudoClass::Disabled,
         CSS::PseudoClass::Empty,
+        CSS::PseudoClass::Enabled,
         CSS::PseudoClass::FirstChild,
         CSS::PseudoClass::FirstOfType,
         CSS::PseudoClass::Focus,
@@ -935,6 +985,7 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::LastChild,
         CSS::PseudoClass::LastOfType,
         CSS::PseudoClass::Link,
+        CSS::PseudoClass::LocalLink,
         CSS::PseudoClass::Not,
         CSS::PseudoClass::NthChild,
         CSS::PseudoClass::NthLastChild,
@@ -942,6 +993,7 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::NthOfType,
         CSS::PseudoClass::OnlyChild,
         CSS::PseudoClass::OnlyOfType,
+        CSS::PseudoClass::PlaceholderShown,
         CSS::PseudoClass::PopoverOpen,
         CSS::PseudoClass::Root,
         CSS::PseudoClass::Scope,
@@ -950,6 +1002,8 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::Heading,
         CSS::PseudoClass::Lang,
         CSS::PseudoClass::State,
+        CSS::PseudoClass::Target,
+        CSS::PseudoClass::Unchecked,
         CSS::PseudoClass::Visited,
         CSS::PseudoClass::VolumeLocked);
 }

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -316,10 +316,6 @@ static bool matches_optimal_value_pseudo_class(DOM::Element const& element, HTML
 static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Element const& element)
 {
     switch (pseudo_class) {
-    case CSS::PseudoClass::Buffering:
-        if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
-            return media_element->blocked();
-        return false;
     case CSS::PseudoClass::Default: {
         // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-default
         if (auto const* form_associated_element = as_if<HTML::FormAssociatedElement>(element)) {
@@ -394,10 +390,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
             return dialog_element->is_modal();
         // FIXME: fullscreen elements are also modal.
         return false;
-    case CSS::PseudoClass::Muted:
-        if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
-            return media_element->muted();
-        return false;
     case CSS::PseudoClass::Open:
         return matches_open_state_pseudo_class(element, true);
     case CSS::PseudoClass::OptimalValue:
@@ -416,14 +408,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
         if (auto const* textarea_element = as_if<HTML::HTMLTextAreaElement>(element))
             return !textarea_element->has_attribute(HTML::AttributeNames::required);
         return false;
-    case CSS::PseudoClass::Paused:
-        if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
-            return media_element->paused();
-        return false;
-    case CSS::PseudoClass::Playing:
-        if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
-            return !media_element->paused();
-        return false;
     case CSS::PseudoClass::ReadOnly:
         return !matches_read_write_pseudo_class(element);
     case CSS::PseudoClass::ReadWrite:
@@ -436,14 +420,6 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
             return select_element->has_attribute(HTML::AttributeNames::required);
         if (auto const* textarea_element = as_if<HTML::HTMLTextAreaElement>(element))
             return textarea_element->has_attribute(HTML::AttributeNames::required);
-        return false;
-    case CSS::PseudoClass::Seeking:
-        if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
-            return media_element->seeking();
-        return false;
-    case CSS::PseudoClass::Stalled:
-        if (auto const* media_element = as_if<HTML::HTMLMediaElement>(element))
-            return media_element->stalled();
         return false;
     case CSS::PseudoClass::SuboptimalValue:
         return matches_optimal_value_pseudo_class(element, HTML::HTMLMeterElement::ValueState::Suboptimal);
@@ -512,6 +488,7 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::Active:
     case CSS::PseudoClass::AnyLink:
     case CSS::PseudoClass::Autofill:
+    case CSS::PseudoClass::Buffering:
     case CSS::PseudoClass::Checked:
     case CSS::PseudoClass::Defined:
     case CSS::PseudoClass::Dir:
@@ -533,6 +510,7 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::LastOfType:
     case CSS::PseudoClass::Link:
     case CSS::PseudoClass::LocalLink:
+    case CSS::PseudoClass::Muted:
     case CSS::PseudoClass::Not:
     case CSS::PseudoClass::NthChild:
     case CSS::PseudoClass::NthLastChild:
@@ -540,11 +518,15 @@ static bool matches_pseudo_class_state(CSS::PseudoClass pseudo_class, DOM::Eleme
     case CSS::PseudoClass::NthOfType:
     case CSS::PseudoClass::OnlyChild:
     case CSS::PseudoClass::OnlyOfType:
+    case CSS::PseudoClass::Paused:
     case CSS::PseudoClass::PlaceholderShown:
     case CSS::PseudoClass::PopoverOpen:
+    case CSS::PseudoClass::Playing:
     case CSS::PseudoClass::Root:
     case CSS::PseudoClass::Scope:
+    case CSS::PseudoClass::Seeking:
     case CSS::PseudoClass::State:
+    case CSS::PseudoClass::Stalled:
     case CSS::PseudoClass::Target:
     case CSS::PseudoClass::Unchecked:
     case CSS::PseudoClass::Where:
@@ -654,6 +636,12 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_local_link);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_placeholder_shown);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_target);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_unchecked);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_media_element);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_blocked);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_muted);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_paused);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_seeking);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_media_is_stalled);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute_count);
@@ -876,6 +864,41 @@ extern "C" bool selector_ffi_element_is_unchecked(void const* element)
     return ffi_element(element).matches_unchecked_pseudo_class();
 }
 
+extern "C" bool selector_ffi_element_is_media_element(void const* element)
+{
+    return is<HTML::HTMLMediaElement>(ffi_element(element));
+}
+
+extern "C" bool selector_ffi_element_media_is_blocked(void const* element)
+{
+    auto const* media_element = as_if<HTML::HTMLMediaElement>(ffi_element(element));
+    return media_element && media_element->blocked();
+}
+
+extern "C" bool selector_ffi_element_media_is_muted(void const* element)
+{
+    auto const* media_element = as_if<HTML::HTMLMediaElement>(ffi_element(element));
+    return media_element && media_element->muted();
+}
+
+extern "C" bool selector_ffi_element_media_is_paused(void const* element)
+{
+    auto const* media_element = as_if<HTML::HTMLMediaElement>(ffi_element(element));
+    return media_element && media_element->paused();
+}
+
+extern "C" bool selector_ffi_element_media_is_seeking(void const* element)
+{
+    auto const* media_element = as_if<HTML::HTMLMediaElement>(ffi_element(element));
+    return media_element && media_element->seeking();
+}
+
+extern "C" bool selector_ffi_element_media_is_stalled(void const* element)
+{
+    auto const* media_element = as_if<HTML::HTMLMediaElement>(ffi_element(element));
+    return media_element && media_element->stalled();
+}
+
 extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_local_name(void const* element)
 {
     return dom_string_view(ffi_element(element).local_name());
@@ -968,6 +991,7 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::Active,
         CSS::PseudoClass::AnyLink,
         CSS::PseudoClass::Autofill,
+        CSS::PseudoClass::Buffering,
         CSS::PseudoClass::Checked,
         CSS::PseudoClass::Defined,
         CSS::PseudoClass::Disabled,
@@ -986,6 +1010,7 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::LastOfType,
         CSS::PseudoClass::Link,
         CSS::PseudoClass::LocalLink,
+        CSS::PseudoClass::Muted,
         CSS::PseudoClass::Not,
         CSS::PseudoClass::NthChild,
         CSS::PseudoClass::NthLastChild,
@@ -993,15 +1018,19 @@ static bool is_rust_matched_pseudo_class(CSS::PseudoClass pseudo_class)
         CSS::PseudoClass::NthOfType,
         CSS::PseudoClass::OnlyChild,
         CSS::PseudoClass::OnlyOfType,
+        CSS::PseudoClass::Paused,
         CSS::PseudoClass::PlaceholderShown,
         CSS::PseudoClass::PopoverOpen,
+        CSS::PseudoClass::Playing,
         CSS::PseudoClass::Root,
         CSS::PseudoClass::Scope,
+        CSS::PseudoClass::Seeking,
         CSS::PseudoClass::Where,
         CSS::PseudoClass::Dir,
         CSS::PseudoClass::Heading,
         CSS::PseudoClass::Lang,
         CSS::PseudoClass::State,
+        CSS::PseudoClass::Stalled,
         CSS::PseudoClass::Target,
         CSS::PseudoClass::Unchecked,
         CSS::PseudoClass::Visited,

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NumericLimits.h>
 #include <LibWeb/CSS/AncestorFilter.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/PseudoClass.h>
@@ -36,17 +37,6 @@
 #include <LibWeb/SelectorRustFFI.h>
 
 namespace Web::SelectorMatching {
-
-static bool fly_string_equals_utf16(Utf16FlyString const& fly_string, Utf16View utf16_string)
-{
-    return utf16_string == fly_string.view();
-}
-
-template<typename... Names>
-static bool fly_string_is_one_of_utf16(Utf16View utf16_string, Names const&... names)
-{
-    return (fly_string_equals_utf16(names, utf16_string) || ...);
-}
 
 static u32 salted_tag_name_hash(Utf16FlyString const& tag_name)
 {
@@ -724,8 +714,6 @@ static bool is_in_null_namespace(DOM::Element const& element)
     return !element.namespace_uri().has_value() || element.namespace_uri()->is_empty();
 }
 
-using CSS::SelectorFFI::AttributeCaseType;
-using CSS::SelectorFFI::AttributeMatchType;
 using CSS::SelectorFFI::Combinator;
 using CSS::SelectorFFI::Direction;
 using CSS::SelectorFFI::HasCacheResult;
@@ -744,9 +732,10 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_docum
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_local_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_name);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute_count);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_direction);
@@ -864,6 +853,27 @@ extern "C" CSS::SelectorFFI::DomStringView selector_ffi_element_class_name(void 
     return dom_string_view(classes[index]);
 }
 
+extern "C" size_t selector_ffi_element_attribute_count(void const* element)
+{
+    auto count = ffi_element(element).attribute_list_size();
+    VERIFY(count <= NumericLimits<u32>::max());
+    return count;
+}
+
+extern "C" CSS::SelectorFFI::DomAttribute selector_ffi_element_attribute(void const* element, size_t index)
+{
+    auto const& target = ffi_element(element);
+    VERIFY(index < target.attribute_list_size());
+    auto const* attribute = target.attributes()->item(static_cast<u32>(index));
+    VERIFY(attribute);
+    return {
+        .local_name = interned_string_identity(attribute->local_name()),
+        .namespace_ = attribute->namespace_uri().has_value() ? interned_string_identity(*attribute->namespace_uri()) : 0,
+        .has_namespace = attribute->namespace_uri().has_value(),
+        .value = dom_string_view(attribute->value()),
+    };
+}
+
 extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_default_namespace(void* context)
 {
     auto& match_context = rust_match_context(context);
@@ -914,136 +924,6 @@ extern "C" CSS::SelectorFFI::ResolvedNamespace selector_ffi_resolve_namespace(vo
         .namespace_type = CSS::SelectorFFI::ResolvedNamespaceType::Named,
         .namespace_ = interned_string_identity(*namespace_),
     };
-}
-
-static bool matches_attribute_value(CSS::Selector::SimpleSelector::Attribute::MatchType match_type, Utf16View selector_value, Utf16View element_value, CaseSensitivity case_sensitivity)
-{
-    bool const case_insensitive = case_sensitivity == CaseSensitivity::CaseInsensitive;
-    auto values_equal = [&](Utf16View first, Utf16View second) {
-        return case_insensitive ? first.equals_ignoring_ascii_case(second) : first == second;
-    };
-
-    switch (match_type) {
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::HasAttribute:
-        return true;
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch:
-        return values_equal(element_value, selector_value);
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsWord:
-        if (selector_value.is_empty())
-            return false;
-        return element_value.split_view(' ', SplitBehavior::Nothing).contains([&](auto value) { return values_equal(value, selector_value); });
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::ContainsString:
-        return !selector_value.is_empty()
-            && (case_insensitive ? element_value.find_code_unit_offset_ignoring_case(selector_value).has_value() : element_value.contains(selector_value));
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::StartsWithSegment:
-        if (element_value.is_empty())
-            return selector_value.is_empty();
-        if (selector_value.is_empty() || element_value.length_in_code_units() < selector_value.length_in_code_units())
-            return false;
-        if (element_value.length_in_code_units() == selector_value.length_in_code_units())
-            return values_equal(element_value, selector_value);
-        return values_equal(element_value.substring_view(0, selector_value.length_in_code_units()), selector_value)
-            && element_value.code_unit_at(selector_value.length_in_code_units()) == '-';
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::StartsWithString:
-        return !selector_value.is_empty()
-            && selector_value.length_in_code_units() <= element_value.length_in_code_units()
-            && values_equal(element_value.substring_view(0, selector_value.length_in_code_units()), selector_value);
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::EndsWithString:
-        return !selector_value.is_empty()
-            && selector_value.length_in_code_units() <= element_value.length_in_code_units()
-            && values_equal(element_value.substring_view(element_value.length_in_code_units() - selector_value.length_in_code_units()), selector_value);
-    }
-    VERIFY_NOT_REACHED();
-}
-
-extern "C" bool selector_ffi_matches_attribute(void* context, void const* element, void const* cxx_simple_selector)
-{
-    auto& match_context = rust_match_context(context);
-    auto const& target = ffi_element(element);
-    auto const& attribute_selector = ffi_simple_selector(cxx_simple_selector).attribute();
-    auto const& qualified_name = attribute_selector.qualified_name;
-    auto const& attribute_name = qualified_name.name.name;
-    auto const& lowercase_attribute_name = qualified_name.name.lowercase_name;
-    auto const selector_value = attribute_selector.value.utf16_view();
-    auto const match_type = attribute_selector.match_type;
-
-    CaseSensitivity case_sensitivity;
-    switch (attribute_selector.case_type) {
-    case CSS::Selector::SimpleSelector::Attribute::CaseType::CaseSensitiveMatch:
-        case_sensitivity = CaseSensitivity::CaseSensitive;
-        break;
-    case CSS::Selector::SimpleSelector::Attribute::CaseType::CaseInsensitiveMatch:
-        case_sensitivity = CaseSensitivity::CaseInsensitive;
-        break;
-    case CSS::Selector::SimpleSelector::Attribute::CaseType::DefaultMatch:
-        case_sensitivity = target.document().is_html_document()
-                && target.namespace_uri() == Namespace::HTML
-                && qualified_name.namespace_type == CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Default
-                && fly_string_is_one_of_utf16(
-                    attribute_name,
-                    HTML::AttributeNames::accept, HTML::AttributeNames::accept_charset, HTML::AttributeNames::align,
-                    HTML::AttributeNames::alink, HTML::AttributeNames::axis, HTML::AttributeNames::bgcolor, HTML::AttributeNames::charset,
-                    HTML::AttributeNames::checked, HTML::AttributeNames::clear, HTML::AttributeNames::codetype, HTML::AttributeNames::color,
-                    HTML::AttributeNames::compact, HTML::AttributeNames::declare, HTML::AttributeNames::defer, HTML::AttributeNames::dir,
-                    HTML::AttributeNames::direction, HTML::AttributeNames::disabled, HTML::AttributeNames::enctype, HTML::AttributeNames::face,
-                    HTML::AttributeNames::frame, HTML::AttributeNames::hreflang, HTML::AttributeNames::http_equiv, HTML::AttributeNames::lang,
-                    HTML::AttributeNames::language, HTML::AttributeNames::link, HTML::AttributeNames::media, HTML::AttributeNames::method,
-                    HTML::AttributeNames::multiple, HTML::AttributeNames::nohref, HTML::AttributeNames::noresize, HTML::AttributeNames::noshade,
-                    HTML::AttributeNames::nowrap, HTML::AttributeNames::readonly, HTML::AttributeNames::rel, HTML::AttributeNames::rev,
-                    HTML::AttributeNames::rules, HTML::AttributeNames::scope, HTML::AttributeNames::scrolling, HTML::AttributeNames::selected,
-                    HTML::AttributeNames::shape, HTML::AttributeNames::target, HTML::AttributeNames::text, HTML::AttributeNames::type,
-                    HTML::AttributeNames::valign, HTML::AttributeNames::valuetype, HTML::AttributeNames::vlink)
-            ? CaseSensitivity::CaseInsensitive
-            : CaseSensitivity::CaseSensitive;
-        break;
-    }
-
-    auto attribute_matches = [&](DOM::Attr const& attribute) {
-        return matches_attribute_value(match_type, selector_value, attribute.value().utf16_view(), case_sensitivity);
-    };
-
-    switch (qualified_name.namespace_type) {
-    // "In keeping with the Namespaces in the XML recommendation, default namespaces do not apply to attributes,
-    //  therefore attribute selectors without a namespace component apply only to attributes that have no namespace (equivalent to "|attr")"
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Default:
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::None: {
-        auto const& name_to_match = target.document().is_html_document() && target.namespace_uri() == Namespace::HTML
-            ? lowercase_attribute_name
-            : attribute_name;
-        for (u32 i = 0; i < target.attributes()->length(); ++i) {
-            auto const* attribute = target.attributes()->item(i);
-            if (!attribute->namespace_uri().has_value() && attribute->local_name() == name_to_match)
-                return attribute_matches(*attribute);
-        }
-        return false;
-    }
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Any: {
-        bool const use_lowercase_name = target.document().is_html_document() && target.namespace_uri() == Namespace::HTML;
-        auto const& name_to_match = use_lowercase_name ? lowercase_attribute_name : attribute_name;
-        for (u32 i = 0; i < target.attributes()->length(); ++i) {
-            auto const* attribute = target.attributes()->item(i);
-            if (attribute->local_name() == name_to_match && attribute_matches(*attribute))
-                return true;
-        }
-        return false;
-    }
-    case CSS::Selector::SimpleSelector::QualifiedName::NamespaceType::Named: {
-        if (!match_context.style_sheet_for_rule)
-            return false;
-        auto selector_namespace = match_context.style_sheet_for_rule->namespace_uri(qualified_name.namespace_);
-        if (!selector_namespace.has_value())
-            return false;
-        for (u32 i = 0; i < target.attributes()->length(); ++i) {
-            auto const* attribute = target.attributes()->item(i);
-            if (attribute->namespace_uri().has_value()
-                && *selector_namespace == attribute->namespace_uri()->view()
-                && attribute->local_name() == attribute_name)
-                return attribute_matches(*attribute);
-        }
-        return false;
-    }
-    }
-    VERIFY_NOT_REACHED();
 }
 
 static bool is_rust_structural_or_functional_pseudo_class(CSS::PseudoClass pseudo_class)

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -658,24 +658,8 @@ static CSS::SelectorFFI::Element element_to_ffi(DOM::Element const* element)
     if (!element)
         return {};
 
-    // `Utf16FlyString` is its interned one-word representation. Rust borrows these words directly
-    // while matching; the DOM and selector trees pin their respective strings for the call.
-    static_assert(sizeof(Utf16FlyString) == sizeof(uintptr_t));
-    static_assert(alignof(Utf16FlyString) == alignof(uintptr_t));
-
-    auto const& classes = element->class_names();
     return {
         .pointer = element,
-        .local_name = reinterpret_cast<uintptr_t const*>(&element->local_name()),
-        .namespace_ = element->namespace_uri().has_value() ? reinterpret_cast<uintptr_t const*>(&element->namespace_uri().value()) : nullptr,
-        .id = element->id().has_value() ? reinterpret_cast<uintptr_t const*>(&element->id().value()) : nullptr,
-        .classes = reinterpret_cast<uintptr_t const*>(classes.data()),
-        .class_count = classes.size(),
-        .class_names_are_case_insensitive = element->document().in_quirks_mode(),
-        .namespace_is_null = !element->namespace_uri().has_value() || element->namespace_uri()->is_empty(),
-        .is_html_element_in_html_document = element->namespace_uri() == Namespace::HTML
-            && element->document().document_type() == DOM::Document::Type::HTML,
-        .is_document_root = is<HTML::HTMLHtmlElement>(*element),
     };
 }
 
@@ -816,6 +800,13 @@ using CSS::SelectorFFI::TagNameMatchingMode;
 #define DECLARE_SELECTOR_FFI_CALLBACK(function) \
     extern "C" decltype(CSS::SelectorFFI::function) function
 
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_qualified_name);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_id);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_classes);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_class_names_are_case_insensitive);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_namespace_is_null);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_html_element_in_html_document);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_document_root);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_universal);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_tag_name);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_class_quirks);
@@ -848,6 +839,57 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_has_cache_set);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_should_reject_has_argument);
 
 #undef DECLARE_SELECTOR_FFI_CALLBACK
+
+// `Utf16FlyString` is its interned one-word representation. The accessors below expose pointers
+// to live words only for the duration of the synchronous selector-matching call.
+static_assert(sizeof(Utf16FlyString) == sizeof(uintptr_t));
+static_assert(alignof(Utf16FlyString) == alignof(uintptr_t));
+
+extern "C" CSS::SelectorFFI::ElementQualifiedName selector_ffi_element_qualified_name(void const* element)
+{
+    auto const& target = ffi_element(element);
+    return {
+        .local_name = reinterpret_cast<uintptr_t const*>(&target.local_name()),
+        .namespace_ = target.namespace_uri().has_value() ? reinterpret_cast<uintptr_t const*>(&target.namespace_uri().value()) : nullptr,
+    };
+}
+
+extern "C" uintptr_t const* selector_ffi_element_id(void const* element)
+{
+    auto const& id = ffi_element(element).id();
+    return id.has_value() ? reinterpret_cast<uintptr_t const*>(&id.value()) : nullptr;
+}
+
+extern "C" CSS::SelectorFFI::InternedStringList selector_ffi_element_classes(void const* element)
+{
+    auto const& classes = ffi_element(element).class_names();
+    return {
+        .data = reinterpret_cast<uintptr_t const*>(classes.data()),
+        .count = classes.size(),
+    };
+}
+
+extern "C" bool selector_ffi_element_class_names_are_case_insensitive(void const* element)
+{
+    return ffi_element(element).document().in_quirks_mode();
+}
+
+extern "C" bool selector_ffi_element_namespace_is_null(void const* element)
+{
+    return is_in_null_namespace(ffi_element(element));
+}
+
+extern "C" bool selector_ffi_element_is_html_element_in_html_document(void const* element)
+{
+    auto const& target = ffi_element(element);
+    return target.namespace_uri() == Namespace::HTML
+        && target.document().document_type() == DOM::Document::Type::HTML;
+}
+
+extern "C" bool selector_ffi_element_is_document_root(void const* element)
+{
+    return is<HTML::HTMLHtmlElement>(ffi_element(element));
+}
 
 extern "C" bool selector_ffi_matches_universal(void* context, void const* element, void const* cxx_simple_selector)
 {

--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -681,12 +681,6 @@ static Utf16View ffi_string_view(CSS::SelectorFFI::StringView string)
     return { reinterpret_cast<char16_t const*>(string.data), string.length };
 }
 
-static CSS::Selector::SimpleSelector const& ffi_simple_selector(void const* simple_selector)
-{
-    VERIFY(simple_selector);
-    return *static_cast<CSS::Selector::SimpleSelector const*>(simple_selector);
-}
-
 static bool is_in_null_namespace(DOM::Element const& element)
 {
     return !element.namespace_uri().has_value() || element.namespace_uri()->is_empty();
@@ -714,6 +708,7 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_heading_level);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_popover_attribute);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_popover_is_showing);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_direction);
+DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_custom_state);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_is_focused);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_should_indicate_focus);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_element_has_focus_within);
@@ -725,7 +720,6 @@ DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_default_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_resolve_namespace);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_pseudo_class);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_language);
-DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_matches_state);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_parent_element_in_light_tree);
 DECLARE_SELECTOR_FFI_CALLBACK(selector_ffi_previous_element_sibling);
@@ -863,6 +857,16 @@ extern "C" Direction selector_ffi_element_direction(void const* element)
         return Direction::RightToLeft;
     }
     VERIFY_NOT_REACHED();
+}
+
+extern "C" bool selector_ffi_element_has_custom_state(void const* element, uintptr_t state)
+{
+    auto const& target = ffi_element(element);
+    if (!target.is_custom())
+        return false;
+    if (auto custom_state_set = target.custom_state_set())
+        return custom_state_set->has_state(*reinterpret_cast<Utf16FlyString const*>(&state));
+    return false;
 }
 
 extern "C" bool selector_ffi_element_is_focused(void const* element)
@@ -1016,16 +1020,6 @@ extern "C" bool selector_ffi_matches_language(void const* element, StringView la
     auto element_language = ffi_element(element).lang();
     return element_language.has_value()
         && language_range_matches_tag(ffi_string_view(language), *element_language);
-}
-
-extern "C" bool selector_ffi_matches_state(void const* element, void const* cxx_simple_selector)
-{
-    auto const& target = ffi_element(element);
-    if (!target.is_custom())
-        return false;
-    if (auto custom_state_set = target.custom_state_set())
-        return custom_state_set->has_state(ffi_simple_selector(cxx_simple_selector).pseudo_class().ident->string_value);
-    return false;
 }
 
 extern "C" CSS::SelectorFFI::Element selector_ffi_parent_element(void const* element, void const* shadow_host)

--- a/Libraries/LibWeb/CSS/SelectorRustBridge.cpp
+++ b/Libraries/LibWeb/CSS/SelectorRustBridge.cpp
@@ -152,6 +152,8 @@ private:
         output.namespace_ = store_string(qualified_name.namespace_);
         output.name = store_string(qualified_name.name.name);
         output.lowercase_name = store_string(qualified_name.name.lowercase_name);
+        output.interned_name = reinterpret_cast<uintptr_t const*>(&qualified_name.name.name);
+        output.interned_lowercase_name = reinterpret_cast<uintptr_t const*>(&qualified_name.name.lowercase_name);
     }
 
     SelectorFFI::SimpleSelector compile_simple_selector(Selector::SimpleSelector const& simple_selector)

--- a/Libraries/LibWeb/CSS/SelectorRustBridge.cpp
+++ b/Libraries/LibWeb/CSS/SelectorRustBridge.cpp
@@ -173,10 +173,12 @@ private:
         case Selector::SimpleSelector::Type::Id:
             output.selector_type = SelectorFFI::SimpleSelectorType::Id;
             output.name = store_string(simple_selector.id_name());
+            output.interned_name = reinterpret_cast<uintptr_t const*>(&simple_selector.id_name());
             break;
         case Selector::SimpleSelector::Type::Class:
             output.selector_type = SelectorFFI::SimpleSelectorType::Class;
             output.name = store_string(simple_selector.class_name());
+            output.interned_name = reinterpret_cast<uintptr_t const*>(&simple_selector.class_name());
             break;
         case Selector::SimpleSelector::Type::Attribute: {
             output.selector_type = SelectorFFI::SimpleSelectorType::Attribute;

--- a/Libraries/LibWeb/CSS/SelectorRustBridge.cpp
+++ b/Libraries/LibWeb/CSS/SelectorRustBridge.cpp
@@ -159,9 +159,6 @@ private:
     SelectorFFI::SimpleSelector compile_simple_selector(Selector::SimpleSelector const& simple_selector)
     {
         SelectorFFI::SimpleSelector output {};
-        // NB: The C++ simple selector outlives the compiled Rust selector, so matching callbacks
-        //     can use this pointer to compare interned strings without copying them.
-        output.cxx_simple_selector = &simple_selector;
 
         switch (simple_selector.type) {
         case Selector::SimpleSelector::Type::Universal:
@@ -234,6 +231,7 @@ private:
 
         if (pseudo_class.ident.has_value()) {
             output.identifier = store_string(pseudo_class.ident->string_value);
+            output.interned_name = reinterpret_cast<uintptr_t const*>(&pseudo_class.ident->string_value);
             if (pseudo_class.ident->keyword == Keyword::Ltr)
                 output.direction = SelectorFFI::Direction::LeftToRight;
             else if (pseudo_class.ident->keyword == Keyword::Rtl)

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5123,6 +5123,15 @@ Optional<Utf16String> Element::lang() const
     return m_lang_value;
 }
 
+Optional<Utf16View> Element::lang_view() const
+{
+    if (!m_lang_value.has_value())
+        (void)lang();
+    if (m_lang_value->is_empty())
+        return {};
+    return m_lang_value->utf16_view();
+}
+
 void Element::invalidate_lang_value()
 {
     if (m_lang_value.has_value()) {

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -146,6 +146,7 @@ public:
     void follow_the_hyperlink(Optional<Utf16String> hyperlink_suffix, HTML::UserNavigationInvolvement = HTML::UserNavigationInvolvement::None);
 
     Optional<Utf16String> lang() const;
+    Optional<Utf16View> lang_view() const;
     void invalidate_lang_value();
 
     WebIDL::ExceptionOr<void> set_attribute_for_bindings(Utf16FlyString qualified_name, Variant<GC::Ref<TrustedTypes::TrustedHTML>, GC::Ref<TrustedTypes::TrustedScript>, GC::Ref<TrustedTypes::TrustedScriptURL>, Utf16String> const& value);

--- a/Tests/LibWeb/Text/expected/css/live-media-state-selectors.txt
+++ b/Tests/LibWeb/Text/expected/css/live-media-state-selectors.txt
@@ -1,0 +1,13 @@
+video:buffering: true
+video:muted: false
+video:paused: true
+video:playing: false
+video:seeking: false
+video:stalled: false
+video:muted after mutation: true
+div:buffering: false
+div:muted: false
+div:paused: false
+div:playing: false
+div:seeking: false
+div:stalled: false

--- a/Tests/LibWeb/Text/expected/css/live-selector-identifiers.txt
+++ b/Tests/LibWeb/Text/expected/css/live-selector-identifiers.txt
@@ -6,3 +6,5 @@ mutated color: rgb(4, 5, 6)
 disconnected match: true
 shadow initial match: true
 shadow mutated match: true
+document root: true
+disconnected html root: true

--- a/Tests/LibWeb/Text/expected/css/live-selector-identifiers.txt
+++ b/Tests/LibWeb/Text/expected/css/live-selector-identifiers.txt
@@ -1,0 +1,8 @@
+initial match: true
+initial color: rgb(1, 2, 3)
+mutated match: true
+stale match: false
+mutated color: rgb(4, 5, 6)
+disconnected match: true
+shadow initial match: true
+shadow mutated match: true

--- a/Tests/LibWeb/Text/expected/css/selector-engine-characterization.txt
+++ b/Tests/LibWeb/Text/expected/css/selector-engine-characterization.txt
@@ -12,6 +12,7 @@ relative sibling: true
 closest: true
 query selector all: 3
 XML tag case: true/false
+XML slow tag case: true
 XML namespace wildcard: true
 XML attribute namespace wildcard: true
 host: yes

--- a/Tests/LibWeb/Text/expected/css/selector-engine-characterization.txt
+++ b/Tests/LibWeb/Text/expected/css/selector-engine-characterization.txt
@@ -13,7 +13,7 @@ relative sibling: true
 closest: true
 query selector all: 3
 XML tag case: true/false
-XML slow tag case: true
+XML slow tag case: false
 XML namespace wildcard: true
 XML attribute namespace wildcard: true
 host: yes

--- a/Tests/LibWeb/Text/expected/css/selector-engine-characterization.txt
+++ b/Tests/LibWeb/Text/expected/css/selector-engine-characterization.txt
@@ -4,6 +4,7 @@ adjacent sibling: true
 subsequent sibling: true
 attribute insensitive: true
 attribute sensitive: false
+attribute after mutation: true/false
 logical: true
 positional: true
 relative descendant: true

--- a/Tests/LibWeb/Text/expected/non-html-mixed-case-element-name-selector-matching.txt
+++ b/Tests/LibWeb/Text/expected/non-html-mixed-case-element-name-selector-matching.txt
@@ -2,3 +2,4 @@
 ✅ Pass: Selector match for SVG element clipPath.
 ✅ Pass: Selector match for SVG element foreignObject.
 ✅ Pass: Selector match for SVG element radialGradient.
+✅ Pass: Selector matching for SVG element linearGradient is case-sensitive.

--- a/Tests/LibWeb/Text/expected/non-html-mixed-case-element-name-selector-matching.txt
+++ b/Tests/LibWeb/Text/expected/non-html-mixed-case-element-name-selector-matching.txt
@@ -2,4 +2,5 @@
 ✅ Pass: Selector match for SVG element clipPath.
 ✅ Pass: Selector match for SVG element foreignObject.
 ✅ Pass: Selector match for SVG element radialGradient.
+✅ Pass: Exact-case selector match for SVG element linearGradient.
 ✅ Pass: Selector matching for SVG element linearGradient is case-sensitive.

--- a/Tests/LibWeb/Text/expected/quirks-mode-case-insensitive-id-selector.txt
+++ b/Tests/LibWeb/Text/expected/quirks-mode-case-insensitive-id-selector.txt
@@ -1,0 +1,1 @@
+ParentNode.querySelector matches ID selectors case-insensitively in quirks mode: true

--- a/Tests/LibWeb/Text/input/css/live-media-state-selectors.html
+++ b/Tests/LibWeb/Text/input/css/live-media-state-selectors.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<video></video>
+<div></div>
+<script>
+    test(() => {
+        const video = document.querySelector("video");
+        const div = document.querySelector("div");
+
+        for (const pseudoClass of ["buffering", "muted", "paused", "playing", "seeking", "stalled"])
+            println(`video:${pseudoClass}: ${video.matches(`:${pseudoClass}`)}`);
+
+        video.muted = true;
+        println(`video:muted after mutation: ${video.matches(":muted")}`);
+
+        for (const pseudoClass of ["buffering", "muted", "paused", "playing", "seeking", "stalled"])
+            println(`div:${pseudoClass}: ${div.matches(`:${pseudoClass}`)}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/live-selector-identifiers.html
+++ b/Tests/LibWeb/Text/input/css/live-selector-identifiers.html
@@ -43,5 +43,9 @@
         shadow_target.id = "shadow-new";
         shadow_target.className = "shadow-new-class";
         println(`shadow mutated match: ${shadow_target.matches("#shadow-new.shadow-new-class")}`);
+
+        const disconnected_html = document.createElement("html");
+        println(`document root: ${document.documentElement.matches(":root")}`);
+        println(`disconnected html root: ${disconnected_html.matches(":root")}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/live-selector-identifiers.html
+++ b/Tests/LibWeb/Text/input/css/live-selector-identifiers.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #old-parent.old-parent-class #target.old-target-class {
+        color: rgb(1, 2, 3);
+    }
+
+    #new-parent.new-parent-class #target.new-target-class {
+        color: rgb(4, 5, 6);
+    }
+</style>
+<div id="old-parent" class="old-parent-class">
+    <span id="target" class="old-target-class"></span>
+</div>
+<div id="host"></div>
+<script>
+    test(() => {
+        const target = document.querySelector("span");
+        const parent = target.parentElement;
+
+        println(`initial match: ${target.matches("#target.old-target-class")}`);
+        println(`initial color: ${getComputedStyle(target).color}`);
+
+        parent.id = "new-parent";
+        parent.className = "new-parent-class";
+        target.className = "new-target-class";
+
+        println(`mutated match: ${target.matches("#target.new-target-class")}`);
+        println(`stale match: ${target.matches("#target.old-target-class")}`);
+        println(`mutated color: ${getComputedStyle(target).color}`);
+
+        const disconnected = document.createElement("div");
+        disconnected.id = "a-long-disconnected-identifier";
+        disconnected.className = "short a-long-disconnected-class-name";
+        println(`disconnected match: ${disconnected.matches("#a-long-disconnected-identifier.a-long-disconnected-class-name")}`);
+
+        const shadow_root = document.querySelector("#host").attachShadow({ mode: "open" });
+        const shadow_target = document.createElement("span");
+        shadow_target.id = "shadow-old";
+        shadow_target.className = "shadow-old-class";
+        shadow_root.appendChild(shadow_target);
+        println(`shadow initial match: ${shadow_target.matches("#shadow-old.shadow-old-class")}`);
+        shadow_target.id = "shadow-new";
+        shadow_target.className = "shadow-new-class";
+        println(`shadow mutated match: ${shadow_target.matches("#shadow-new.shadow-new-class")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/selector-engine-characterization.html
+++ b/Tests/LibWeb/Text/input/css/selector-engine-characterization.html
@@ -19,6 +19,8 @@
         println(`subsequent sibling: ${document.querySelector(".third").matches(".first ~ .third")}`);
         println(`attribute insensitive: ${outer.matches('[data-mode="mixed" i]')}`);
         println(`attribute sensitive: ${outer.matches('[data-mode="mixed" s]')}`);
+        outer.setAttribute("data-mode", "changed");
+        println(`attribute after mutation: ${outer.matches('[data-mode="changed"]')}/${outer.matches('[data-mode="mixed" i]')}`);
         println(`logical: ${second.matches(":is(.first, .second):not(.third)")}`);
         println(`positional: ${second.matches(":nth-child(2 of .item)")}`);
         println(`relative descendant: ${outer.matches(":has(.second .needle)")}`);
@@ -28,6 +30,7 @@
         println(`query selector all: ${outer.querySelectorAll(":scope > .item").length}`);
         const xml = document.implementation.createDocument("urn:example", "ex:root");
         const child = xml.createElementNS("urn:example", "ex:Child");
+        child.setAttribute("other", "no");
         child.setAttributeNS("urn:attributes", "attr:value", "yes");
         xml.documentElement.appendChild(child);
 

--- a/Tests/LibWeb/Text/input/css/selector-engine-characterization.html
+++ b/Tests/LibWeb/Text/input/css/selector-engine-characterization.html
@@ -32,6 +32,7 @@
         xml.documentElement.appendChild(child);
 
         println(`XML tag case: ${child.matches("Child")}/${child.matches("child")}`);
+        println(`XML slow tag case: ${child.matches("child:not(.missing)")}`);
         println(`XML namespace wildcard: ${child.matches("*|Child")}`);
         println(`XML attribute namespace wildcard: ${child.matches("[*|value]")}`);
         const host = document.createElement("div");

--- a/Tests/LibWeb/Text/input/non-html-mixed-case-element-name-selector-matching.html
+++ b/Tests/LibWeb/Text/input/non-html-mixed-case-element-name-selector-matching.html
@@ -26,6 +26,10 @@
             println("✅ Pass: Selector match for SVG element radialGradient.");
         else
             println("❌ Fail: No selector match for SVG element radialGradient.");
+        if (document.querySelector("linearGradient:not(.missing)"))
+            println("✅ Pass: Exact-case selector match for SVG element linearGradient.");
+        else
+            println("❌ Fail: No exact-case selector match for SVG element linearGradient.");
         if (!document.querySelector("lineargradient:not(.missing)"))
             println("✅ Pass: Selector matching for SVG element linearGradient is case-sensitive.");
         else

--- a/Tests/LibWeb/Text/input/non-html-mixed-case-element-name-selector-matching.html
+++ b/Tests/LibWeb/Text/input/non-html-mixed-case-element-name-selector-matching.html
@@ -26,5 +26,9 @@
             println("✅ Pass: Selector match for SVG element radialGradient.");
         else
             println("❌ Fail: No selector match for SVG element radialGradient.");
+        if (!document.querySelector("lineargradient:not(.missing)"))
+            println("✅ Pass: Selector matching for SVG element linearGradient is case-sensitive.");
+        else
+            println("❌ Fail: Selector matching for SVG element linearGradient is not case-sensitive.");
     });
 </script>

--- a/Tests/LibWeb/Text/input/quirks-mode-case-insensitive-class-selector.html
+++ b/Tests/LibWeb/Text/input/quirks-mode-case-insensitive-class-selector.html
@@ -1,6 +1,6 @@
 <!DOCTYPE quirks>
 <script src="include.js"></script>
-<div class="tEsT"></div>
+<div class="other tEsT"></div>
 <script>
     test(() => {
         let divElement = document.querySelector(".test");

--- a/Tests/LibWeb/Text/input/quirks-mode-case-insensitive-id-selector.html
+++ b/Tests/LibWeb/Text/input/quirks-mode-case-insensitive-id-selector.html
@@ -1,0 +1,9 @@
+<!DOCTYPE quirks>
+<script src="include.js"></script>
+<div id="tEsT"></div>
+<script>
+    test(() => {
+        let divElement = document.querySelector("#test");
+        println(`ParentNode.querySelector matches ID selectors case-insensitively in quirks mode: ${divElement instanceof Element}`);
+    });
+</script>


### PR DESCRIPTION
The Rust selector engine was already the authoritative matcher, but DOM-sensitive selectors still delegated their decisions to C++ callbacks. Replace those callbacks with Stylo-like, lifetime-bound wrappers over the live DOM. Rust now reads current names, namespaces, identifiers, attributes, tree relationships, and element states through small accessors and performs the matching itself.

The wrappers borrow existing interned identifiers and string storage, without copying, caching, or snapshotting DOM state. Live reads are important because focus, validity, media state, attributes, shadow relationships, and other CSS inputs may change independently. This removes the semantic simple-selector and tree-navigation callback surfaces while preserving the existing invalidation and `:has()` bookkeeping. Regression coverage exercises mutations, disconnected elements, shadow trees, XML namespaces, and stateful selectors.
