### PR TITLE
LibMedia+Tests: Recursively parse Matroska SeekHead elements

### DIFF
--- a/Libraries/LibMedia/Containers/Matroska/Reader.cpp
+++ b/Libraries/LibMedia/Containers/Matroska/Reader.cpp
@@ -24,6 +24,8 @@
 
 namespace Media::Matroska {
 
+static constexpr size_t MAX_SEEK_HEADS_TO_PARSE = 8;
+
 DecoderErrorOr<Reader> Reader::from_stream(NonnullRefPtr<MediaStreamCursor> const& stream_cursor)
 {
     Reader reader;
@@ -179,7 +181,7 @@ DecoderErrorOr<void> Reader::parse_initial_data(Streamer& streamer)
     return {};
 }
 
-static DecoderErrorOr<void> parse_seek_head(Streamer& streamer, size_t base_position, HashMap<u32, size_t>& table)
+DecoderErrorOr<void> Reader::parse_seek_head(Streamer& streamer, HashTable<size_t>& parsed_seek_heads)
 {
     TRY(Reader::parse_master_element(streamer, "SeekHead"sv, [&](u64 seek_head_child_id) -> DecoderErrorOr<ElementIterationDecision> {
         if (seek_head_child_id == SEEK_ELEMENT_ID) {
@@ -209,21 +211,57 @@ static DecoderErrorOr<void> parse_seek_head(Streamer& streamer, size_t base_posi
             if (seek_id.value() > NumericLimits<u32>::max())
                 return DecoderError::corrupted("Seek entry's element ID is too large"sv);
 
-            dbgln_if(MATROSKA_TRACE_DEBUG, "Seek entry found with ID {:#010x} and position {} offset from SeekHead at {}", seek_id.value(), seek_position.value(), base_position);
-            // FIXME: SeekHead can reference another SeekHead, we should recursively parse all SeekHeads.
+            auto element_position = m_segment_contents_position + seek_position.value();
+            dbgln_if(MATROSKA_TRACE_DEBUG, "Seek entry found with ID {:#010x} and position {} offset from Segment contents at {}", seek_id.value(), seek_position.value(), m_segment_contents_position);
 
-            if (table.contains(seek_id.value())) {
-                dbgln_if(MATROSKA_DEBUG, "Warning: Duplicate seek entry with ID {:#010x} at position {}", seek_id.value(), seek_position.value());
+            if (seek_id.value() == SEEK_HEAD_ELEMENT_ID) {
+                auto position_after_seek_entry = streamer.position();
+                TRY(parse_seek_head_at_position(streamer, element_position, parsed_seek_heads));
+                TRY(streamer.seek_to_position(position_after_seek_entry));
                 return ElementIterationDecision::Continue;
             }
 
-            DECODER_TRY_ALLOC(table.try_set(seek_id.release_value(), base_position + seek_position.release_value()));
+            auto insertion_result = DECODER_TRY_ALLOC(m_seek_entries.try_set(static_cast<u32>(seek_id.value()), element_position, AK::HashSetExistingEntryBehavior::Keep));
+            if (insertion_result == AK::HashSetResult::KeptExistingEntry)
+                dbgln_if(MATROSKA_DEBUG, "Duplicate seek entry with ID {:#010x} at position {}", seek_id.value(), seek_position.value());
         } else {
             dbgln_if(MATROSKA_TRACE_DEBUG, "Unknown SeekHead child element ID {:#010x}", seek_head_child_id);
         }
 
         return ElementIterationDecision::Continue;
     }));
+    return {};
+}
+
+DecoderErrorOr<void> Reader::parse_seek_head_at_position(Streamer& streamer, size_t seek_head_position, HashTable<size_t>& parsed_seek_heads)
+{
+    if (parsed_seek_heads.contains(seek_head_position))
+        return {};
+
+    if (parsed_seek_heads.size() >= MAX_SEEK_HEADS_TO_PARSE) {
+        dbgln_if(MATROSKA_DEBUG, "SeekHead chain is longer than {}, ignoring SeekHead at position {}", MAX_SEEK_HEADS_TO_PARSE, seek_head_position);
+        return {};
+    }
+
+    DECODER_TRY_ALLOC(parsed_seek_heads.try_set(seek_head_position));
+
+    auto seek_result = streamer.seek_to_position(seek_head_position);
+    if (seek_result.is_error())
+        return {};
+
+    auto element_id = streamer.read_element_id();
+    if (element_id.is_error())
+        return {};
+    if (element_id.value() != SEEK_HEAD_ELEMENT_ID)
+        return {};
+
+    auto parse_result = parse_seek_head(streamer, parsed_seek_heads);
+    if (parse_result.is_error()) {
+        if (parse_result.error().category() == DecoderErrorCategory::Memory)
+            return parse_result.release_error();
+        return {};
+    }
+
     return {};
 }
 
@@ -253,8 +291,9 @@ DecoderErrorOr<Optional<size_t>> Reader::find_first_top_level_element_with_id(St
 
         if (found_element_id == SEEK_HEAD_ELEMENT_ID) {
             dbgln_if(MATROSKA_TRACE_DEBUG, "Found SeekHead, parsing it into the lookup table.");
-            m_seek_entries.clear();
-            TRY(parse_seek_head(streamer, found_element_position, m_seek_entries));
+            HashTable<size_t> parsed_seek_heads;
+            DECODER_TRY_ALLOC(parsed_seek_heads.try_set(found_element_position));
+            TRY(parse_seek_head(streamer, parsed_seek_heads));
             m_last_top_level_element_position = 0;
             if (m_seek_entries.contains(element_id)) {
                 dbgln_if(MATROSKA_TRACE_DEBUG, "SeekHead hit!");

--- a/Libraries/LibMedia/Containers/Matroska/Reader.h
+++ b/Libraries/LibMedia/Containers/Matroska/Reader.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/HashTable.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
@@ -68,6 +69,8 @@ private:
     DecoderErrorOr<void> parse_initial_data(Streamer&);
 
     DecoderErrorOr<Optional<size_t>> find_first_top_level_element_with_id(Streamer&, StringView element_name, u32 element_id);
+    DecoderErrorOr<void> parse_seek_head(Streamer&, HashTable<size_t>& parsed_seek_heads);
+    DecoderErrorOr<void> parse_seek_head_at_position(Streamer&, size_t seek_head_position, HashTable<size_t>& parsed_seek_heads);
 
     DecoderErrorOr<void> parse_segment_information(Streamer&);
 

--- a/Tests/LibMedia/TestParseMatroska.cpp
+++ b/Tests/LibMedia/TestParseMatroska.cpp
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteBuffer.h>
 #include <LibCore/File.h>
+#include <LibMedia/Containers/Matroska/ElementIDs.h>
 #include <LibMedia/Containers/Matroska/MatroskaDemuxer.h>
+#include <LibMedia/IncrementallyPopulatedStream.h>
 #include <LibMedia/ReadonlyBytesCursor.h>
 #include <LibTest/TestCase.h>
 
@@ -14,6 +17,212 @@
 static Media::Matroska::Streamer streamer_from_bytes(ReadonlyBytes bytes)
 {
     return Media::Matroska::Streamer(make_ref_counted<Media::ReadonlyBytesCursor>(bytes));
+}
+
+static void append_ebml_id(ByteBuffer& data, u32 id)
+{
+    bool saw_non_zero_byte = false;
+    for (int shift = 24; shift >= 0; shift -= 8) {
+        auto byte = static_cast<u8>(id >> shift);
+        if (byte != 0)
+            saw_non_zero_byte = true;
+        if (saw_non_zero_byte)
+            data.append(byte);
+    }
+}
+
+static void append_big_endian_uint(ByteBuffer& data, u64 value, size_t value_byte_width)
+{
+    VERIFY(value_byte_width <= sizeof(value));
+    for (auto shift = static_cast<int>((value_byte_width - 1) * 8); shift >= 0; shift -= 8)
+        data.append(static_cast<u8>(value >> shift));
+}
+
+static void patch_big_endian_uint(ByteBuffer& data, size_t offset, u64 value, size_t value_byte_width)
+{
+    VERIFY(offset + value_byte_width <= data.size());
+    for (size_t i = 0; i < value_byte_width; ++i)
+        data[offset + i] = static_cast<u8>(value >> ((value_byte_width - i - 1) * 8));
+}
+
+static void append_ebml_size(ByteBuffer& data, u64 element_data_size, size_t vint_byte_width = 1)
+{
+    VERIFY(vint_byte_width >= 1);
+    VERIFY(vint_byte_width <= 8);
+    VERIFY(element_data_size < (1ull << (vint_byte_width * 7)));
+
+    auto size_payload_offset = data.size();
+    append_big_endian_uint(data, element_data_size, vint_byte_width);
+    data[size_payload_offset] |= 1u << (8 - vint_byte_width);
+}
+
+static void patch_ebml_size(ByteBuffer& data, size_t offset, u64 element_data_size, size_t vint_byte_width)
+{
+    VERIFY(vint_byte_width >= 1);
+    VERIFY(vint_byte_width <= 8);
+    VERIFY(offset + vint_byte_width <= data.size());
+    VERIFY(element_data_size < (1ull << (vint_byte_width * 7)));
+
+    patch_big_endian_uint(data, offset, element_data_size, vint_byte_width);
+    data[offset] |= 1u << (8 - vint_byte_width);
+}
+
+struct EBMLMaster {
+    size_t size_offset { 0 };
+    size_t payload_start { 0 };
+};
+
+static EBMLMaster begin_ebml_master(ByteBuffer& data, u32 id)
+{
+    append_ebml_id(data, id);
+    auto size_offset = data.size();
+    append_ebml_size(data, 0, 8);
+    return { size_offset, data.size() };
+}
+
+static void finish_ebml_master(ByteBuffer& data, EBMLMaster master)
+{
+    patch_ebml_size(data, master.size_offset, data.size() - master.payload_start, 8);
+}
+
+static size_t append_ebml_uint(ByteBuffer& data, u32 id, u64 value, size_t value_byte_width = 0)
+{
+    append_ebml_id(data, id);
+    if (value_byte_width == 0) {
+        value_byte_width = 1;
+        while (value_byte_width < sizeof(value) && value >= (1ull << (value_byte_width * 8)))
+            ++value_byte_width;
+    }
+    append_ebml_size(data, value_byte_width);
+    auto payload_position = data.size();
+    append_big_endian_uint(data, value, value_byte_width);
+    return payload_position;
+}
+
+static void append_ebml_string(ByteBuffer& data, u32 id, StringView value)
+{
+    append_ebml_id(data, id);
+    append_ebml_size(data, value.length());
+    data.append(value.bytes());
+}
+
+static void append_empty_ebml_master(ByteBuffer& data, u32 id)
+{
+    auto master = begin_ebml_master(data, id);
+    finish_ebml_master(data, master);
+}
+
+static size_t append_seek_head(ByteBuffer& data, u32 target_id)
+{
+    auto seek_head = begin_ebml_master(data, Media::Matroska::SEEK_HEAD_ELEMENT_ID);
+    auto seek = begin_ebml_master(data, Media::Matroska::SEEK_ELEMENT_ID);
+    append_ebml_uint(data, Media::Matroska::SEEK_ID_ELEMENT_ID, target_id, 4);
+    auto seek_position_payload_offset = append_ebml_uint(data, Media::Matroska::SEEK_POSITION_ELEMENT_ID, 0, 8);
+    finish_ebml_master(data, seek);
+    finish_ebml_master(data, seek_head);
+    return seek_position_payload_offset;
+}
+
+struct LinkedSeekHeadsTestFile {
+    ByteBuffer data;
+    size_t cluster_end { 0 };
+    size_t cues_position { 0 };
+};
+
+static LinkedSeekHeadsTestFile make_matroska_with_linked_seek_heads(size_t seek_head_count = 3)
+{
+    VERIFY(seek_head_count > 0);
+
+    ByteBuffer data;
+    auto ebml_header = begin_ebml_master(data, Media::Matroska::EBML_MASTER_ELEMENT_ID);
+    append_ebml_string(data, Media::Matroska::DOCTYPE_ELEMENT_ID, "webm"sv);
+    append_ebml_uint(data, Media::Matroska::DOCTYPE_VERSION_ELEMENT_ID, 4);
+    finish_ebml_master(data, ebml_header);
+
+    append_ebml_id(data, Media::Matroska::SEGMENT_ELEMENT_ID);
+    data.append(0xff); // Unknown Segment size.
+    auto segment_contents_position = data.size();
+
+    Vector<size_t> seek_head_positions;
+    Vector<size_t> seek_head_position_patch_offsets;
+
+    MUST(seek_head_positions.try_append(data.size()));
+    MUST(seek_head_position_patch_offsets.try_append(append_seek_head(data, seek_head_count == 1 ? Media::Matroska::CUES_ID : Media::Matroska::SEEK_HEAD_ELEMENT_ID)));
+
+    auto info = begin_ebml_master(data, Media::Matroska::SEGMENT_INFORMATION_ELEMENT_ID);
+    append_ebml_uint(data, Media::Matroska::TIMESTAMP_SCALE_ID, 1000000);
+    finish_ebml_master(data, info);
+
+    auto tracks = begin_ebml_master(data, Media::Matroska::TRACK_ELEMENT_ID);
+    auto track_entry = begin_ebml_master(data, Media::Matroska::TRACK_ENTRY_ID);
+    append_ebml_uint(data, Media::Matroska::TRACK_NUMBER_ID, 1);
+    append_ebml_uint(data, Media::Matroska::TRACK_UID_ID, 1);
+    append_ebml_uint(data, Media::Matroska::TRACK_TYPE_ID, 1);
+    append_ebml_string(data, Media::Matroska::TRACK_CODEC_ID, "V_VP9"sv);
+    auto video = begin_ebml_master(data, Media::Matroska::TRACK_VIDEO_ID);
+    append_ebml_uint(data, Media::Matroska::PIXEL_WIDTH_ID, 1);
+    append_ebml_uint(data, Media::Matroska::PIXEL_HEIGHT_ID, 1);
+    finish_ebml_master(data, video);
+    finish_ebml_master(data, track_entry);
+    finish_ebml_master(data, tracks);
+
+    append_empty_ebml_master(data, Media::Matroska::CLUSTER_ELEMENT_ID);
+    auto cluster_end = data.size();
+
+    data.append(Media::Matroska::EBML_VOID_ELEMENT_ID);
+    data.append(0x8e);
+    for (size_t i = 0; i < 14; ++i)
+        data.append(0);
+
+    auto cues_position = data.size();
+    auto cues = begin_ebml_master(data, Media::Matroska::CUES_ID);
+    auto cue_point = begin_ebml_master(data, Media::Matroska::CUE_POINT_ID);
+    append_ebml_uint(data, Media::Matroska::CUE_TIME_ID, 0);
+    auto cue_track_positions = begin_ebml_master(data, Media::Matroska::CUE_TRACK_POSITIONS_ID);
+    append_ebml_uint(data, Media::Matroska::CUE_TRACK_ID, 1);
+    append_ebml_uint(data, Media::Matroska::CUE_CLUSTER_POSITION_ID, 0);
+    finish_ebml_master(data, cue_track_positions);
+    finish_ebml_master(data, cue_point);
+    finish_ebml_master(data, cues);
+
+    for (size_t i = 1; i < seek_head_count; ++i) {
+        MUST(seek_head_positions.try_append(data.size()));
+        auto target_id = i + 1 == seek_head_count ? Media::Matroska::CUES_ID : Media::Matroska::SEEK_HEAD_ELEMENT_ID;
+        MUST(seek_head_position_patch_offsets.try_append(append_seek_head(data, target_id)));
+    }
+
+    for (size_t i = 0; i < seek_head_count; ++i) {
+        auto target_position = i + 1 == seek_head_count ? cues_position : seek_head_positions[i + 1];
+        patch_big_endian_uint(data, seek_head_position_patch_offsets[i], target_position - segment_contents_position, 8);
+    }
+
+    return { move(data), cluster_end, cues_position };
+}
+
+TEST_CASE(reader_follows_linked_seek_heads)
+{
+    auto file = make_matroska_with_linked_seek_heads();
+    auto stream = Media::IncrementallyPopulatedStream::create_empty();
+    stream->add_chunk_at(0, file.data.span().slice(0, file.cluster_end));
+    stream->add_chunk_at(file.cues_position, file.data.span().slice(file.cues_position));
+    stream->close();
+
+    auto reader = MUST(Media::Matroska::Reader::from_stream(stream->create_cursor()));
+    auto cue_points = reader.cue_points_for_track(1);
+    EXPECT(cue_points.has_value());
+    EXPECT_EQ(cue_points->size(), 1u);
+    EXPECT_EQ(cue_points->first().timestamp, AK::Duration::zero());
+}
+
+TEST_CASE(reader_limits_linked_seek_head_traversal)
+{
+    auto file = make_matroska_with_linked_seek_heads(9);
+    auto stream = Media::IncrementallyPopulatedStream::create_from_buffer(file.data);
+
+    auto reader = MUST(Media::Matroska::Reader::from_stream(stream->create_cursor()));
+    auto cue_points = reader.cue_points_for_track(1);
+    EXPECT(cue_points.has_value());
+    EXPECT_EQ(cue_points->size(), 1u);
 }
 
 TEST_CASE(streamer_read_element_id)


### PR DESCRIPTION
This allows us to stream files with an initial SeekHead pointing to another at the end of the file which then points to the Cues element.