### PR TITLE
LibWeb: Stop leaking the internal documents of decoded SVG images

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1418,6 +1418,12 @@ void Document::tear_down_layout_tree()
     m_needs_full_layout_tree_update = true;
 }
 
+void Document::tear_down_layout_tree_for_svg_image_document(Badge<SVG::SVGDecodedImageData>)
+{
+    clear_layout_and_paintable_nodes_for_inactive_document();
+    tear_down_layout_tree();
+}
+
 void Document::clear_layout_and_paintable_nodes_for_inactive_document()
 {
     for_each_in_inclusive_subtree([&](auto& node) {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -455,6 +455,8 @@ public:
     void invalidate_layout_tree(InvalidateLayoutTreeReason);
     void invalidate_stacking_context_tree();
 
+    void tear_down_layout_tree_for_svg_image_document(Badge<SVG::SVGDecodedImageData>);
+
     virtual bool is_child_allowed(Node const&) const override;
 
     Layout::Viewport const* layout_node() const;

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -150,6 +150,12 @@ SVGDecodedImageData::SVGDecodedImageData(GC::Ref<Page> page, GC::Ref<SVGPageClie
 
 SVGDecodedImageData::~SVGDecodedImageData() = default;
 
+void SVGDecodedImageData::finalize()
+{
+    Base::finalize();
+    m_document->tear_down_layout_tree_for_svg_image_document({});
+}
+
 void SVGDecodedImageData::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -22,6 +22,8 @@ class SVGDecodedImageData final : public HTML::DecodedImageData {
     GC_DECLARE_ALLOCATOR(SVGDecodedImageData);
 
 public:
+    static constexpr bool OVERRIDES_FINALIZE = true;
+
     class SVGPageClient;
     static ErrorOr<GC::Ref<SVGDecodedImageData>> create(JS::Realm&, GC::Ref<Page>, URL::URL const&, ReadonlyBytes encoded_svg);
     virtual ~SVGDecodedImageData() override;
@@ -39,6 +41,7 @@ public:
     DOM::Document const& svg_document() const { return *m_document; }
 
     virtual void visit_edges(Cell::Visitor& visitor) override;
+    virtual void finalize() override;
     virtual size_t external_memory_size() const override;
 
     virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering) const override;


### PR DESCRIPTION
Out-of-line SVG images are rendered through an internal XMLDocument that builds a layout tree. Every layout node holds a GC::Root to its DOM node while the document owns the layout tree through refcounted pointers, and unlike navigable documents, these internal documents never go through the inactive-document teardown path. Once such a document has built a layout tree, this ownership cycle keeps the document, its DOM subtree, and its realm rooted forever.