### PR TITLE
LibWeb: Stop retaining navigation fetch controllers after loading

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4306,6 +4306,8 @@ bool Document::is_completely_loaded() const
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#completely-finish-loading
 void Document::completely_finish_loading()
 {
+    m_ongoing_navigation_fetch_controller = nullptr;
+
     // 2. Set document's completely loaded time to the current time.
     // AD-HOC: Set this unconditionally, even if the document has no navigable yet.
     //         In the async state machine, documents created during populate may complete
@@ -5636,6 +5638,7 @@ void Document::abort()
         m_ongoing_navigation_fetch_controller->stop_fetch();
         canceled_fetch = true;
     }
+    m_ongoing_navigation_fetch_controller = nullptr;
 
     for (auto& fetch_record : relevant_settings_object().fetch_group()) {
         auto controller = fetch_record.fetch_controller();


### PR DESCRIPTION
Every document created by a navigation keeps its main-resource fetch controller, whose fetch params retain the request and, through it, the environment settings object of the document that initiated the navigation. Each navigation therefore chains the previous document, its window, and its realm to the new document, and none of them can ever be garbage-collected. Repeated navigations in one WebContent process grow the heap by roughly a page's worth of cells each.