### PR TITLE
LibWeb: Remove UsedValues copy assignment

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -415,16 +415,14 @@ void GridFormattingContext::for_each_subgrid_item_contributing_to_track_sizing(G
     subgrid_context.resolve_items_box_metrics(dimension);
 
     subgrid_context.for_each_item_contributing_to_track_sizing(dimension, [&](GridItem const& item) {
-        LayoutState::UsedValues used_values_in_parent_grid;
-        used_values_in_parent_grid = item.used_values;
-
         GridItem item_in_parent_grid {
             .box = item.box,
-            .used_values = used_values_in_parent_grid,
+            .used_values = item.used_values,
             .row = item.row,
             .row_span = item.row_span,
             .column = item.column,
             .column_span = item.column_span,
+            .subgrid_extra_margins = item.subgrid_extra_margins,
         };
         subgrid_context.apply_subgrid_edge_extra_margins(item_in_parent_grid, dimension);
 
@@ -508,16 +506,16 @@ void GridFormattingContext::apply_subgrid_edge_extra_margins(GridItem& item, Gri
 
     if (item_start == 0) {
         if (dimension == GridDimension::Column)
-            item.used_values.margin_left += start_extra_margin;
+            item.subgrid_extra_margins.left += start_extra_margin;
         else
-            item.used_values.margin_top += start_extra_margin;
+            item.subgrid_extra_margins.top += start_extra_margin;
     }
 
     if (item_end == static_cast<int>(track_count)) {
         if (dimension == GridDimension::Column)
-            item.used_values.margin_right += end_extra_margin;
+            item.subgrid_extra_margins.right += end_extra_margin;
         else
-            item.used_values.margin_bottom += end_extra_margin;
+            item.subgrid_extra_margins.bottom += end_extra_margin;
     }
 }
 
@@ -785,7 +783,8 @@ void GridFormattingContext::place_item_with_row_and_column_position(Box const& c
         .row = row_start,
         .row_span = row_span,
         .column = column_start,
-        .column_span = column_span });
+        .column_span = column_span,
+        .subgrid_extra_margins = {} });
 }
 
 void GridFormattingContext::place_item_with_row_position(Box const& child_box)
@@ -815,7 +814,8 @@ void GridFormattingContext::place_item_with_row_position(Box const& child_box)
         .row = row_start,
         .row_span = row_span,
         .column = column_start,
-        .column_span = column_span });
+        .column_span = column_span,
+        .subgrid_extra_margins = {} });
 }
 
 void GridFormattingContext::place_item_with_column_position(Box const& child_box, int& auto_placement_cursor_row)
@@ -851,7 +851,8 @@ void GridFormattingContext::place_item_with_column_position(Box const& child_box
         .row = auto_placement_cursor_row,
         .row_span = row_span,
         .column = column_start,
-        .column_span = column_span });
+        .column_span = column_span,
+        .subgrid_extra_margins = {} });
 }
 
 void GridFormattingContext::place_item_with_no_declared_position(Box const& child_box, int& auto_placement_cursor_column, int& auto_placement_cursor_row)
@@ -891,7 +892,8 @@ void GridFormattingContext::place_item_with_no_declared_position(Box const& chil
         .row = row_start,
         .row_span = row_span,
         .column = column_start,
-        .column_span = column_span });
+        .column_span = column_span,
+        .subgrid_extra_margins = {} });
 }
 
 void GridFormattingContext::clamp_grid_area_to_subgrid(GridDimension dimension, int& start, size_t& span) const
@@ -3011,7 +3013,7 @@ AbsposContainingBlockInfo GridFormattingContext::resolve_abspos_containing_block
 
     auto grid_area = [&] -> LogicalRect {
         auto const& computed_values = box.computed_values();
-        GridItem item { box, abspos_box_state, {}, {}, {}, {} };
+        GridItem item { box, abspos_box_state, {}, {}, {}, {}, {} };
         auto row_placement_position = resolve_grid_position(box, GridDimension::Row);
         auto column_placement_position = resolve_grid_position(box, GridDimension::Column);
         if (!is_auto_positioned_track(computed_values.grid_row_start(), computed_values.grid_row_end())) {

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -36,6 +36,15 @@ struct GridItem {
     Optional<int> column;
     Optional<size_t> column_span;
 
+    // Accumulated while projecting a nested subgrid item into an ancestor's track
+    // sizing without modifying the UsedValues owned by the nested grid context.
+    struct SubgridExtraMargins {
+        CSSPixels top { 0 };
+        CSSPixels right { 0 };
+        CSSPixels bottom { 0 };
+        CSSPixels left { 0 };
+    } subgrid_extra_margins;
+
     [[nodiscard]] size_t span(GridDimension dimension) const
     {
         return dimension == GridDimension::Column ? column_span.value() : row_span.value();
@@ -49,8 +58,8 @@ struct GridItem {
     [[nodiscard]] CSSPixels add_margin_box_sizes(CSSPixels content_size, GridDimension dimension) const
     {
         if (dimension == GridDimension::Column)
-            return used_values.margin_box_left() + content_size + used_values.margin_box_right();
-        return used_values.margin_box_top() + content_size + used_values.margin_box_bottom();
+            return used_values.margin_box_left() + subgrid_extra_margins.left + content_size + used_values.margin_box_right() + subgrid_extra_margins.right;
+        return used_values.margin_box_top() + subgrid_extra_margins.top + content_size + used_values.margin_box_bottom() + subgrid_extra_margins.bottom;
     }
 
     [[nodiscard]] int gap_adjusted_position(GridDimension dimension) const
@@ -93,22 +102,30 @@ struct GridItem {
 
     CSSPixels used_margin_box_start(GridDimension dimension) const
     {
-        return dimension == GridDimension::Column ? used_values.margin_box_left() : used_values.margin_box_top();
+        if (dimension == GridDimension::Column)
+            return used_values.margin_box_left() + subgrid_extra_margins.left;
+        return used_values.margin_box_top() + subgrid_extra_margins.top;
     }
 
     CSSPixels used_margin_box_end(GridDimension dimension) const
     {
-        return dimension == GridDimension::Column ? used_values.margin_box_right() : used_values.margin_box_bottom();
+        if (dimension == GridDimension::Column)
+            return used_values.margin_box_right() + subgrid_extra_margins.right;
+        return used_values.margin_box_bottom() + subgrid_extra_margins.bottom;
     }
 
     CSSPixels used_margin_start(GridDimension dimension) const
     {
-        return dimension == GridDimension::Column ? used_values.margin_left : used_values.margin_top;
+        if (dimension == GridDimension::Column)
+            return used_values.margin_left + subgrid_extra_margins.left;
+        return used_values.margin_top + subgrid_extra_margins.top;
     }
 
     CSSPixels used_margin_end(GridDimension dimension) const
     {
-        return dimension == GridDimension::Column ? used_values.margin_right : used_values.margin_bottom;
+        if (dimension == GridDimension::Column)
+            return used_values.margin_right + subgrid_extra_margins.right;
+        return used_values.margin_bottom + subgrid_extra_margins.bottom;
     }
 
     AvailableSpace available_space() const

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -442,50 +442,6 @@ void LayoutState::commit_used_values_and_build_paint_tree(Box& root, RefPtr<Pain
     resolve_relative_positions_and_assign_inline_box_geometry();
 }
 
-LayoutState::UsedValues& LayoutState::UsedValues::operator=(UsedValues const& other)
-{
-    if (this == &other)
-        return *this;
-
-    m_content_offset = other.m_content_offset;
-    inline_size_constraint = other.inline_size_constraint;
-    block_size_constraint = other.block_size_constraint;
-    margin_left = other.margin_left;
-    margin_right = other.margin_right;
-    margin_top = other.margin_top;
-    margin_bottom = other.margin_bottom;
-    border_left = other.border_left;
-    border_right = other.border_right;
-    border_top = other.border_top;
-    border_bottom = other.border_bottom;
-    padding_left = other.padding_left;
-    padding_right = other.padding_right;
-    padding_top = other.padding_top;
-    padding_bottom = other.padding_bottom;
-    inset_left = other.inset_left;
-    inset_right = other.inset_right;
-    inset_top = other.inset_top;
-    inset_bottom = other.inset_bottom;
-    line_boxes = other.line_boxes;
-    inline_box_pieces = other.inline_box_pieces;
-    first_baseline = other.first_baseline;
-    last_baseline = other.last_baseline;
-    containing_line_box_fragment = other.containing_line_box_fragment;
-
-    m_node = other.m_node;
-    m_content_inline_size = other.m_content_inline_size;
-    m_content_block_size = other.m_content_block_size;
-    m_has_definite_inline_size = other.m_has_definite_inline_size;
-    m_has_definite_block_size = other.m_has_definite_block_size;
-    m_materialized_from_paintable = other.m_materialized_from_paintable;
-    if (other.m_rare)
-        m_rare = make<RareData>(*other.m_rare);
-    else
-        m_rare = nullptr;
-
-    return *this;
-}
-
 void LayoutState::UsedValues::set_node(NodeWithStyle const& node, Optional<CSSPixels> percentage_basis_inline_size, Optional<CSSPixels> percentage_basis_block_size)
 {
     m_node = &node;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -109,11 +109,6 @@ struct LayoutState {
     AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
 
     struct UsedValues {
-        UsedValues() = default;
-        UsedValues(UsedValues&&) = default;
-        UsedValues& operator=(UsedValues&&) = default;
-        UsedValues& operator=(UsedValues const& other);
-
         NodeWithStyle const& node() const { return *m_node; }
         NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
         void set_node(NodeWithStyle const&, Optional<CSSPixels> percentage_basis_inline_size = {}, Optional<CSSPixels> percentage_basis_block_size = {});
@@ -311,23 +306,6 @@ struct LayoutState {
 
         struct RareData {
             AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
-
-            RareData() = default;
-            RareData(RareData const& other)
-                : lowest_floating_descendant_bottom_margin_edge(other.lowest_floating_descendant_bottom_margin_edge)
-                , table_cell_coordinates(other.table_cell_coordinates)
-                , computed_svg_path(other.computed_svg_path)
-                , grid_template_columns(other.grid_template_columns)
-                , grid_template_rows(other.grid_template_rows)
-                , override_borders_data(other.override_borders_data)
-                , computed_svg_transforms(other.computed_svg_transforms)
-                , abspos_layout_inputs(other.abspos_layout_inputs)
-            {
-                if (other.grid_layout_data)
-                    grid_layout_data = make<GridLayoutData>(*other.grid_layout_data);
-                if (other.flex_layout_data)
-                    flex_layout_data = make<FlexLayoutData>(*other.flex_layout_data);
-            }
 
             Optional<CSSPixels> lowest_floating_descendant_bottom_margin_edge;
             Optional<Painting::Paintable::TableCellCoordinates> table_cell_coordinates;

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -995,7 +995,33 @@ Optional<TableFormattingContext::MeasuredCellContent> TableFormattingContext::me
 
     LayoutState throwaway_state(cell_box, LayoutState::Purpose::Measurement);
     auto& throwaway_cell_used_values = throwaway_state.create(cell_box, {}, {});
-    throwaway_cell_used_values = cell_used_values;
+
+    // The table formatting context owns the cell's outer geometry. Seed the inputs
+    // needed to lay out its contents without copying placement or layout outputs.
+    throwaway_cell_used_values.inline_size_constraint = cell_used_values.inline_size_constraint;
+    throwaway_cell_used_values.block_size_constraint = cell_used_values.block_size_constraint;
+    throwaway_cell_used_values.set_content_inline_size(cell_used_values.content_inline_size());
+    throwaway_cell_used_values.set_content_block_size(cell_used_values.content_block_size());
+    throwaway_cell_used_values.set_has_definite_inline_size(cell_used_values.has_definite_inline_size());
+    throwaway_cell_used_values.set_has_definite_block_size(cell_used_values.has_definite_block_size());
+
+    throwaway_cell_used_values.margin_left = cell_used_values.margin_left;
+    throwaway_cell_used_values.margin_right = cell_used_values.margin_right;
+    throwaway_cell_used_values.margin_top = cell_used_values.margin_top;
+    throwaway_cell_used_values.margin_bottom = cell_used_values.margin_bottom;
+
+    throwaway_cell_used_values.border_left = cell_used_values.border_left;
+    throwaway_cell_used_values.border_right = cell_used_values.border_right;
+    throwaway_cell_used_values.border_top = cell_used_values.border_top;
+    throwaway_cell_used_values.border_bottom = cell_used_values.border_bottom;
+
+    throwaway_cell_used_values.padding_left = cell_used_values.padding_left;
+    throwaway_cell_used_values.padding_right = cell_used_values.padding_right;
+    throwaway_cell_used_values.padding_top = cell_used_values.padding_top;
+    throwaway_cell_used_values.padding_bottom = cell_used_values.padding_bottom;
+
+    if (auto const& override_borders_data = cell_used_values.override_borders_data(); override_borders_data.has_value())
+        throwaway_cell_used_values.set_override_borders_data(override_borders_data.value());
 
     auto measuring_context = create_independent_formatting_context_if_needed(throwaway_state, m_layout_mode, cell_box, this);
     if (!measuring_context)


### PR DESCRIPTION
UsedValues retained a general-purpose deep-copy assignment from the old copy-on-write LayoutState design. Its two remaining users copied much more state than their algorithms needed. The copies included layout outputs and rare state owned by another formatting context.

Seed table-cell measurement states with only the sizing and box-model inputs consumed by their child formatting context. Represent subgrid edge-margin adjustments separately on GridItem as contributions bubble into the parent, so track sizing does not clone UsedValues from another formatting context or mutate its margins during contribution sizing.

This removes the copy assignment and the RareData deep-copy constructor, leaving each call site with a purpose-specific data flow.