### PR TITLE
LibWeb: Capture cached display list ranges directly

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -21,46 +21,6 @@ DisplayListRecorder::DisplayListRecorder(DisplayList& command_list, AccumulatedV
 
 DisplayListRecorder::~DisplayListRecorder() = default;
 
-DisplayListRecorder::CommandCapture::CommandCapture(DisplayListRecorder& recorder)
-    : m_recorder(&recorder)
-{
-}
-
-DisplayListRecorder::CommandCapture::~CommandCapture()
-{
-    if (m_recorder)
-        m_recorder->end_capture();
-}
-
-DisplayListCommandRange DisplayListRecorder::CommandCapture::take()
-{
-    VERIFY(m_recorder);
-    auto capture_start_offset = m_recorder->m_capture_start_command_offset;
-    auto capture_end_offset = m_recorder->m_display_list.command_byte_size();
-    m_recorder->m_is_capturing = false;
-    m_recorder = nullptr;
-    VERIFY(capture_end_offset >= capture_start_offset);
-    VERIFY(capture_end_offset <= NumericLimits<u32>::max());
-    return {
-        static_cast<u32>(capture_start_offset),
-        static_cast<u32>(capture_end_offset - capture_start_offset),
-    };
-}
-
-DisplayListRecorder::CommandCapture DisplayListRecorder::begin_command_capture()
-{
-    VERIFY(!m_is_capturing);
-    m_is_capturing = true;
-    m_capture_start_command_offset = m_display_list.command_byte_size();
-    m_capture_accumulated_visual_context_index = m_accumulated_visual_context_index;
-    return CommandCapture(*this);
-}
-
-void DisplayListRecorder::end_capture()
-{
-    m_is_capturing = false;
-}
-
 template<DisplayListCommand Command>
 class CommandPayloadBuilder {
 public:

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -103,45 +103,15 @@ public:
 
     void translate(Gfx::IntPoint delta);
 
-    void set_accumulated_visual_context(VisualContextIndex index)
-    {
-        // A cached range stores a single recorded context index, so a capture must not span a context switch.
-        VERIFY(!m_is_capturing || index == m_capture_accumulated_visual_context_index);
-        m_accumulated_visual_context_index = index;
-    }
+    void set_accumulated_visual_context(VisualContextIndex index) { m_accumulated_visual_context_index = index; }
     VisualContextIndex accumulated_visual_context() const { return m_accumulated_visual_context_index; }
 
-    void set_context_geometry_only(bool context_geometry_only)
-    {
-        // A cached range is spliced with the context its commands were recorded under, so a capture
-        // must not span a change of context application mode either.
-        VERIFY(!m_is_capturing || context_geometry_only == m_context_geometry_only);
-        m_context_geometry_only = context_geometry_only;
-    }
+    void set_context_geometry_only(bool context_geometry_only) { m_context_geometry_only = context_geometry_only; }
 
     DisplayList const& display_list() const { return m_display_list; }
     AccumulatedVisualContextTree const& visual_context_tree() const { return m_visual_context_tree; }
 
     DisplayListCommandRange append_cached_command_range(DisplayList const& source_display_list, DisplayListCommandRange, VisualContextIndex recorded_context_index);
-
-    class CommandCapture {
-        AK_MAKE_NONCOPYABLE(CommandCapture);
-
-    public:
-        CommandCapture(CommandCapture&& other)
-            : m_recorder(exchange(other.m_recorder, nullptr))
-        {
-        }
-        ~CommandCapture();
-        DisplayListCommandRange take();
-
-    private:
-        friend class DisplayListRecorder;
-        explicit CommandCapture(DisplayListRecorder&);
-        DisplayListRecorder* m_recorder { nullptr };
-    };
-
-    CommandCapture begin_command_capture();
 
     void save();
     void save_layer();
@@ -190,8 +160,6 @@ public:
     int m_save_nesting_level { 0 };
 
 private:
-    void end_capture();
-
     template<DisplayListCommand Command>
     void append_command(Command const& command, ReadonlyBytes inline_data = {})
     {
@@ -204,9 +172,6 @@ private:
     DisplayList& m_display_list;
     AccumulatedVisualContextTree const& m_visual_context_tree;
     DisplayListResourceStorage& m_resource_storage;
-    bool m_is_capturing { false };
-    size_t m_capture_start_command_offset { 0 };
-    VisualContextIndex m_capture_accumulated_visual_context_index { VISUAL_VIEWPORT_NODE_INDEX };
 };
 
 class DisplayListRecorderStateSaver {

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -120,14 +120,18 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
         if (cache_writes_enabled)
             paintable.set_cached_commands(phase, recorder.display_list().id(), destination_range, phase_context_index, phase_has_empty_effective_clip);
     } else {
-        auto capture = !skip_cache && cache_writes_enabled
-            ? Optional<DisplayListRecorder::CommandCapture>(recorder.begin_command_capture())
-            : Optional<DisplayListRecorder::CommandCapture> {};
+        auto const command_range_start = recorder.display_list().command_byte_size();
         if (phase == PaintPhase::Background)
             paintable.record_async_scrolling_metadata(context);
         paintable.paint(context, phase);
-        if (capture.has_value())
-            paintable.set_cached_commands(phase, recorder.display_list().id(), capture->take(), phase_context_index, phase_has_empty_effective_clip);
+        if (!skip_cache && cache_writes_enabled) {
+            auto const command_range_end = recorder.display_list().command_byte_size();
+            DisplayListCommandRange command_range {
+                static_cast<u32>(command_range_start),
+                static_cast<u32>(command_range_end - command_range_start),
+            };
+            paintable.set_cached_commands(phase, recorder.display_list().id(), command_range, phase_context_index, phase_has_empty_effective_clip);
+        }
     }
 
     context.display_list_recorder().set_accumulated_visual_context(VISUAL_VIEWPORT_NODE_INDEX);


### PR DESCRIPTION
CommandCapture retained recorder-owned state to remember the start of a cached command sequence. Since cache entries are byte ranges into the display list, this indirection no longer provides ownership or lifetime management.