### PR TITLE
LibWeb: Resolve FontFaceSet ready with an execution context

### DIFF
--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -443,6 +443,7 @@ void FontFaceSet::switch_to_loaded()
     m_status = Bindings::FontFaceSetLoadStatus::Loaded;
 
     // 4. Fulfill font face set’s [[ReadyPromise]] attribute’s value with font face set.
+    HTML::TemporaryExecutionContext execution_context { realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
     WebIDL::resolve_promise(realm(), m_ready_promise, this);
 
     // 5. Queue a task to perform the following steps synchronously:

--- a/Tests/LibWeb/Text/expected/css/font-face-media-query-change-during-rendering.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-media-query-change-during-rendering.txt
@@ -1,0 +1,5 @@
+Initial media query matches: true
+Initial font face status: loading
+Final media query matches: false
+Font face remains connected: false
+PASS: Media query changed while a CSS font was loading

--- a/Tests/LibWeb/Text/input/css/font-face-media-query-change-during-rendering.html
+++ b/Tests/LibWeb/Text/input/css/font-face-media-query-change-during-rendering.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const token = crypto.randomUUID();
+        const fontURL = await server.createEcho("GET", `/font-face-media-query-change-during-rendering-${token}.woff`, {
+            status: 404,
+            headers: { "Content-Type": "font/woff" },
+            wait_for_unblock: token,
+        });
+
+        const iframe = document.createElement("iframe");
+        iframe.style.width = "300px";
+        iframe.srcdoc = `
+            <!DOCTYPE html>
+            <style>
+                @media (max-width: 400px) {
+                    @font-face {
+                        font-family: PendingFont;
+                        src: url("${fontURL}");
+                    }
+                }
+            </style>
+            <body>Trigger font load</body>
+        `;
+
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const fontFace = [...iframe.contentDocument.fonts][0];
+        const loadPromise = fontFace.load().catch(() => {});
+        println(`Initial media query matches: ${iframe.contentWindow.matchMedia("(max-width: 400px)").matches}`);
+        println(`Initial font face status: ${fontFace.status}`);
+
+        iframe.style.width = "500px";
+        await animationFrame();
+        println(`Final media query matches: ${iframe.contentWindow.matchMedia("(max-width: 400px)").matches}`);
+        println(`Font face remains connected: ${iframe.contentDocument.fonts.has(fontFace)}`);
+        println("PASS: Media query changed while a CSS font was loading");
+
+        await fetch(`${server.baseURL}/unblock/${token}`);
+        await loadPromise;
+    });
+</script>


### PR DESCRIPTION
Media-query evaluation can disconnect a loading CSS font during a rendering update, where no JavaScript execution context is active. Resolving the FontFaceSet ready promise then enters JavaScript and trips the running-execution-context verification.

Establish a temporary callback-enabled execution context around promise resolution. Cover the rendering path with a deterministically blocked font response so the test does not depend on network timing.

Fixes #10804