### PR TITLE
LibWeb/HTML: Invalidate cached canvas commands after 2D draws

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/CanvasRenderingContext2D.h>
 #include <LibWeb/HTML/HTMLCanvasElement.h>
+#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::HTML {
 
@@ -56,6 +57,12 @@ GC::Ref<HTMLCanvasElement> CanvasRenderingContext2D::canvas_for_binding() const
 void CanvasRenderingContext2D::did_draw_hook()
 {
     m_element->set_canvas_content_dirty();
+
+    // NB: Invalidate the cached DrawCanvas command so that if another change causes the display list to be recorded, it
+    // contains the new content generation and damages the canvas. Don't request a display list recording here: the new
+    // content reaches the compositor through the canvas surface registry when the canvas is presented.
+    if (auto paintable = m_element->unsafe_paintable())
+        paintable->invalidate_paint_cache();
     m_element->set_needs_repaint(InvalidateDisplayList::No);
 }
 

--- a/Tests/LibWeb/Text/expected/canvas/2d-draw-invalidates-cached-command.txt
+++ b/Tests/LibWeb/Text/expected/canvas/2d-draw-invalidates-cached-command.txt
@@ -1,0 +1,1 @@
+cached command has new generation: true

--- a/Tests/LibWeb/Text/input/canvas/2d-draw-invalidates-cached-command.html
+++ b/Tests/LibWeb/Text/input/canvas/2d-draw-invalidates-cached-command.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<canvas id="canvas" width="100" height="100"></canvas>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+        const canvasContentGeneration = () => {
+            const match = internals.dumpDisplayList().match(/DrawCanvas@\d+ .*content_generation=(\d+)/);
+            return Number(match[1]);
+        };
+
+        const context = canvas.getContext("2d");
+        context.fillStyle = "red";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        await nextFrame();
+        await nextFrame();
+        const generationBeforeDraw = canvasContentGeneration();
+
+        context.fillStyle = "green";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+
+        // Trigger an unrelated display list recording in the same rendering update. It must not
+        // reuse the DrawCanvas command cached before the canvas content update.
+        document.body.style.backgroundColor = "white";
+        await nextFrame();
+
+        const generationAfterDraw = canvasContentGeneration();
+        println("cached command has new generation: " + (generationAfterDraw > generationBeforeDraw));
+        done();
+    });
+</script>


### PR DESCRIPTION
2D canvas draws marked the element dirty and scheduled a repaint without invalidating its cached DrawCanvas command. If an unrelated page change recorded a display list in the same rendering update, the old command was reused with a stale content generation.

Damage computation then treated the canvas as unchanged and omitted its rectangle. Alternating backing stores retained canvas frames of different ages, making animations appear to jump backward and forward.

Invalidate the canvas paint cache after 2D draws, matching the existing WebGL behavior while retaining the repaint-only fast path. Add coverage for updating a canvas alongside an unrelated display-list invalidation.

This was very visible with chart.js: https://www.chartjs.org/docs/latest/samples/other-charts/pie.html

Before:

[Screencast_20260722_135237.webm](https://github.com/user-attachments/assets/6c7ed976-17db-4798-a3e6-877f2c8a32f3)

After:

[Screencast_20260722_135204.webm](https://github.com/user-attachments/assets/551c3bf1-4705-4ae6-b776-731e696868e8)