### PR TITLE
LibWeb: Move custom properties and style finishing passes into Rust

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1669,6 +1669,7 @@ ComputedProperties::Builder::Builder(ComputedProperties const& style)
     m_data->display_before_box_type_transformation = style.data().display_before_box_type_transformation;
     m_data->pseudo_element_styles = style.data().pseudo_element_styles;
     m_data->line_height = style.data().line_height;
+    m_data->effective_color_scheme = style.data().effective_color_scheme;
     m_data->inheritance_dependent_specified_values = style.data().inheritance_dependent_specified_values;
     m_data->raw_cascaded_font_size = style.data().raw_cascaded_font_size;
     m_depends_on_viewport_metrics = style.depends_on_viewport_metrics();
@@ -2128,6 +2129,11 @@ ColorInterpolation ComputedProperties::color_interpolation_filters() const
 // https://drafts.csswg.org/css-color-adjust-1/#determine-the-used-color-scheme
 PreferredColorScheme ComputedProperties::color_scheme(PreferredColorScheme preferred_scheme, Optional<Vector<Utf16FlyString> const&> document_supported_schemes) const
 {
+    if (!has_animated_property(PropertyID::ColorScheme) && m_data->effective_color_scheme.has_value())
+        return *m_data->effective_color_scheme;
+
+    // NB: Animated color-scheme values keep using this path until animations move
+    //     into the Rust driver.
     // To determine the used color scheme of an element:
     auto const& scheme_value = property(PropertyID::ColorScheme).as_color_scheme();
     auto schemes = scheme_value.schemes();

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -107,6 +107,10 @@ public:
 
         void set_display_before_box_type_transformation(Display);
 
+        bool has_effective_color_scheme() const { return m_data->effective_color_scheme.has_value(); }
+        void set_effective_color_scheme(PreferredColorScheme color_scheme) { m_data->effective_color_scheme = color_scheme; }
+        void clear_effective_color_scheme() { m_data->effective_color_scheme.clear(); }
+
         HashMap<PropertyID, NonnullRefPtr<StyleValue const>> const& inheritance_dependent_specified_values() const { return m_data->inheritance_dependent_specified_values; }
         void add_inheritance_dependent_specified_value(PropertyID property_id, NonnullRefPtr<StyleValue const> value) { m_data->inheritance_dependent_specified_values.set(property_id, move(value)); }
 
@@ -362,6 +366,7 @@ private:
         u64 pseudo_element_styles { 0 };
 
         Optional<CSSPixels> line_height;
+        Optional<PreferredColorScheme> effective_color_scheme;
 
         HashMap<PropertyID, NonnullRefPtr<StyleValue const>> inheritance_dependent_specified_values;
         RefPtr<StyleValue const> raw_cascaded_font_size;

--- a/Libraries/LibWeb/CSS/CustomPropertyData.cpp
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.cpp
@@ -20,11 +20,17 @@ CustomPropertyData::CustomPropertyData(OrderedHashMap<Utf16FlyString, StylePrope
     , m_parent(move(parent))
     , m_ancestor_count(ancestor_count)
 {
+    Vector<String> names;
+    names.ensure_capacity(m_own_values.size());
     Vector<ComputedValuesFFI::FfiCustomPropertyStoreEntry> entries;
     entries.ensure_capacity(m_own_values.size());
     for (auto const& [name, property] : m_own_values) {
+        names.unchecked_append(MUST(name.view().to_utf8()));
+        auto const& name_utf8 = names.last();
         entries.unchecked_append({
             .name_raw = name.to_raw_leaked(),
+            .name_utf8 = name_utf8.bytes().data(),
+            .name_utf8_length = name_utf8.bytes().size(),
             .important = property.important == Important::Yes,
             .shell = property.value.ptr(),
             .data = property.value->rust_style_value_data(),

--- a/Libraries/LibWeb/CSS/CustomPropertyData.cpp
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/CSS/CustomPropertyData.h>
 #include <LibWeb/CSS/CustomPropertyRegistration.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
+#include <LibWeb/ComputedValuesRustFFI.h>
 #include <LibWeb/DOM/Document.h>
 
 namespace Web::CSS {
@@ -19,6 +20,23 @@ CustomPropertyData::CustomPropertyData(OrderedHashMap<Utf16FlyString, StylePrope
     , m_parent(move(parent))
     , m_ancestor_count(ancestor_count)
 {
+    Vector<ComputedValuesFFI::FfiCustomPropertyStoreEntry> entries;
+    entries.ensure_capacity(m_own_values.size());
+    for (auto const& [name, property] : m_own_values) {
+        entries.unchecked_append({
+            .name_raw = name.to_raw_leaked(),
+            .important = property.important == Important::Yes,
+            .shell = property.value.ptr(),
+            .data = property.value->rust_style_value_data(),
+        });
+    }
+    m_rust_store = ComputedValuesFFI::rust_custom_property_store_create(
+        entries.data(), entries.size(), m_parent ? m_parent->rust_store() : nullptr);
+}
+
+CustomPropertyData::~CustomPropertyData()
+{
+    ComputedValuesFFI::rust_custom_property_store_destroy(m_rust_store);
 }
 
 NonnullRefPtr<CustomPropertyData> CustomPropertyData::create(

--- a/Libraries/LibWeb/CSS/CustomPropertyData.h
+++ b/Libraries/LibWeb/CSS/CustomPropertyData.h
@@ -31,6 +31,7 @@ public:
         OrderedHashMap<Utf16FlyString, StyleProperty> own_values,
         RefPtr<CustomPropertyData const> parent,
         AllowParentOwnValueAbsorption allow_parent_own_value_absorption = AllowParentOwnValueAbsorption::Yes);
+    ~CustomPropertyData();
 
     StyleProperty const* get(Utf16FlyString const& name) const;
     RefPtr<CustomPropertyData const> inheritable_impl(RefPtr<CustomPropertyData const> inheritable_parent, AK::Function<Optional<CustomPropertyRegistration const&>(Utf16FlyString const&)> get_custom_property_registration) const;
@@ -44,6 +45,8 @@ public:
 
     bool is_empty() const;
 
+    void const* rust_store() const { return m_rust_store; }
+
 private:
     CustomPropertyData(OrderedHashMap<Utf16FlyString, StyleProperty> own_values, RefPtr<CustomPropertyData const> parent, u8 ancestor_count);
 
@@ -54,6 +57,7 @@ private:
     mutable size_t m_cached_inheritable_generation { NumericLimits<size_t>::max() };
     mutable RefPtr<CustomPropertyData const> m_cached_inheritable_data;
     mutable bool m_cached_inheritable_is_self { false };
+    void const* m_rust_store { nullptr };
 };
 
 }

--- a/Libraries/LibWeb/CSS/Rust/build.rs
+++ b/Libraries/LibWeb/CSS/Rust/build.rs
@@ -627,6 +627,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             manifest_dir.join("src/style_compute.rs"),
             manifest_dir.join("src/css_pixels.rs"),
             manifest_dir.join("src/cascaded_properties.rs"),
+            manifest_dir.join("src/custom_properties.rs"),
         ],
         &out_dir,
         &ffi_out_dir,

--- a/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
@@ -355,6 +355,9 @@ fn apply_declaration_block(
     unset_data: *const c_void,
     is_property_disallowed: &dyn Fn(u16) -> bool,
     resolve_unresolved: &dyn Fn(u16, *const c_void) -> *const c_void,
+    parse_substituted: &dyn Fn(u16, &[u8]) -> *const c_void,
+    custom_property_store: *const c_void,
+    allow_native_var_resolution: bool,
     data_of: &dyn Fn(*const c_void) -> *const c_void,
     create_pending_substitution: &dyn Fn(*const c_void) -> *const c_void,
     mut assign_source_slot: impl FnMut(u32),
@@ -381,8 +384,25 @@ fn apply_declaration_block(
         let mut data = declaration.data;
 
         if declared_is_unresolved {
-            shell = resolve_unresolved(declaration.property_id, shell);
-            data = data_of(shell);
+            let native_resolution = if allow_native_var_resolution {
+                unsafe { crate::custom_properties::resolve_vars(custom_property_store, data) }
+            } else {
+                crate::custom_properties::NativeVarResolution::NotHandled
+            };
+            match native_resolution {
+                crate::custom_properties::NativeVarResolution::Resolved(source) => {
+                    shell = parse_substituted(declaration.property_id, &source);
+                    data = data_of(shell);
+                }
+                crate::custom_properties::NativeVarResolution::Invalid => {
+                    shell = parse_substituted(declaration.property_id, &[]);
+                    data = data_of(shell);
+                }
+                crate::custom_properties::NativeVarResolution::NotHandled => {
+                    shell = resolve_unresolved(declaration.property_id, shell);
+                    data = data_of(shell);
+                }
+            }
         }
 
         if matches!(
@@ -525,6 +545,13 @@ pub struct FfiBulkCascadeCallbacks {
     /// Resolves an unresolved (arbitrary-substitution) value; returns the pinned resolved shell.
     pub resolve_unresolved:
         unsafe extern "C" fn(context: *mut c_void, property_id: u16, shell: *const c_void) -> *const c_void,
+    /// Parses a Rust-substituted UTF-8 token stream as the target property.
+    pub parse_substituted: unsafe extern "C" fn(
+        context: *mut c_void,
+        property_id: u16,
+        source: *const u8,
+        source_length: usize,
+    ) -> *const c_void,
     /// Returns the Rust-owned data of a C++ style value shell.
     pub data_of: unsafe extern "C" fn(context: *mut c_void, shell: *const c_void) -> *const c_void,
     /// Creates and pins a pending-substitution value wrapping the given value; returns its shell.
@@ -536,8 +563,11 @@ pub struct FfiBulkCascadeCallbacks {
     pub assign_source_slots:
         unsafe extern "C" fn(context: *mut c_void, assignments: *const FfiSourceSlotAssignment, count: usize),
     /// Installs the complete custom-property cascade before unresolved longhands are resolved.
-    pub set_custom_properties:
-        unsafe extern "C" fn(context: *mut c_void, properties: *const FfiCascadedCustomProperty, count: usize),
+    pub set_custom_properties: unsafe extern "C" fn(
+        context: *mut c_void,
+        properties: *const FfiCascadedCustomProperty,
+        count: usize,
+    ) -> *const c_void,
 }
 
 /// Runs the whole cascade for one element in css-cascade-5 origin order over
@@ -565,6 +595,7 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
     author_context_count: u32,
     has_pseudo_element: bool,
     cascade_custom_properties: bool,
+    allow_native_var_resolution: bool,
     unset_shell: *const c_void,
     unset_data: *const c_void,
     callbacks: *const FfiBulkCascadeCallbacks,
@@ -658,6 +689,7 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
             application_order.push((index, true, false));
         }
 
+        let mut custom_property_store = std::ptr::null();
         if cascade_custom_properties {
             let mut custom_property_indices = HashMap::new();
             let mut custom_properties: Vec<FfiCascadedCustomProperty> = Vec::new();
@@ -692,7 +724,8 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
             }
             crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CascadeCustomPropertyBatchCallback);
             unsafe {
-                (callbacks.set_custom_properties)(context, custom_properties.as_ptr(), custom_properties.len());
+                custom_property_store =
+                    (callbacks.set_custom_properties)(context, custom_properties.as_ptr(), custom_properties.len());
             }
         }
 
@@ -727,6 +760,12 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
                     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CascadeResolveUnresolvedCallback);
                     unsafe { (callbacks.resolve_unresolved)(context, property_id, shell) }
                 },
+                &|property_id, source| {
+                    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CascadeParseSubstitutedCallback);
+                    unsafe { (callbacks.parse_substituted)(context, property_id, source.as_ptr(), source.len()) }
+                },
+                custom_property_store,
+                allow_native_var_resolution,
                 &|shell| {
                     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CascadeDataOfCallback);
                     unsafe { (callbacks.data_of)(context, shell) }

--- a/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
@@ -354,8 +354,8 @@ fn apply_declaration_block(
     unset_shell: *const c_void,
     unset_data: *const c_void,
     is_property_disallowed: &dyn Fn(u16) -> bool,
-    resolve_unresolved: &dyn Fn(u16, *const c_void) -> *const c_void,
-    parse_substituted: &dyn Fn(u16, &[u8]) -> *const c_void,
+    resolve_unresolved: &dyn Fn(u16, *const c_void) -> FfiResolvedStyleValue,
+    parse_substituted: &dyn Fn(u16, &[u8]) -> FfiResolvedStyleValue,
     custom_property_store: *const c_void,
     custom_property_registry: *const c_void,
     data_of: &dyn Fn(*const c_void) -> *const c_void,
@@ -389,16 +389,19 @@ fn apply_declaration_block(
             };
             match native_resolution {
                 crate::custom_properties::NativeVarResolution::Resolved(source) => {
-                    shell = parse_substituted(declaration.property_id, &source);
-                    data = data_of(shell);
+                    let resolved = parse_substituted(declaration.property_id, &source);
+                    shell = resolved.shell;
+                    data = resolved.data;
                 }
                 crate::custom_properties::NativeVarResolution::Invalid => {
-                    shell = parse_substituted(declaration.property_id, &[]);
-                    data = data_of(shell);
+                    let resolved = parse_substituted(declaration.property_id, &[]);
+                    shell = resolved.shell;
+                    data = resolved.data;
                 }
                 crate::custom_properties::NativeVarResolution::NotHandled => {
-                    shell = resolve_unresolved(declaration.property_id, shell);
-                    data = data_of(shell);
+                    let resolved = resolve_unresolved(declaration.property_id, shell);
+                    shell = resolved.shell;
+                    data = resolved.data;
                 }
             }
         }
@@ -540,16 +543,16 @@ pub struct FfiCascadedCustomProperty {
 #[repr(C)]
 pub struct FfiBulkCascadeCallbacks {
     pub context: *mut c_void,
-    /// Resolves an unresolved (arbitrary-substitution) value; returns the pinned resolved shell.
+    /// Resolves an unresolved value and returns its pinned shell and Rust-owned data.
     pub resolve_unresolved:
-        unsafe extern "C" fn(context: *mut c_void, property_id: u16, shell: *const c_void) -> *const c_void,
-    /// Parses a Rust-substituted UTF-8 token stream as the target property.
+        unsafe extern "C" fn(context: *mut c_void, property_id: u16, shell: *const c_void) -> FfiResolvedStyleValue,
+    /// Parses a substituted token stream and returns its pinned shell and Rust-owned data.
     pub parse_substituted: unsafe extern "C" fn(
         context: *mut c_void,
         property_id: u16,
         source: *const u8,
         source_length: usize,
-    ) -> *const c_void,
+    ) -> FfiResolvedStyleValue,
     /// Returns the Rust-owned data of a C++ style value shell.
     pub data_of: unsafe extern "C" fn(context: *mut c_void, shell: *const c_void) -> *const c_void,
     /// Creates and pins a pending-substitution value wrapping the given value; returns its shell.
@@ -566,6 +569,12 @@ pub struct FfiBulkCascadeCallbacks {
         properties: *const FfiCascadedCustomProperty,
         count: usize,
     ) -> *const c_void,
+}
+
+#[repr(C)]
+pub struct FfiResolvedStyleValue {
+    pub shell: *const c_void,
+    pub data: *const c_void,
 }
 
 /// Runs the whole cascade for one element in css-cascade-5 origin order over

--- a/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
@@ -357,7 +357,7 @@ fn apply_declaration_block(
     resolve_unresolved: &dyn Fn(u16, *const c_void) -> *const c_void,
     parse_substituted: &dyn Fn(u16, &[u8]) -> *const c_void,
     custom_property_store: *const c_void,
-    allow_native_var_resolution: bool,
+    custom_property_registry: *const c_void,
     data_of: &dyn Fn(*const c_void) -> *const c_void,
     create_pending_substitution: &dyn Fn(*const c_void) -> *const c_void,
     mut assign_source_slot: impl FnMut(u32),
@@ -384,10 +384,8 @@ fn apply_declaration_block(
         let mut data = declaration.data;
 
         if declared_is_unresolved {
-            let native_resolution = if allow_native_var_resolution {
-                unsafe { crate::custom_properties::resolve_vars(custom_property_store, data) }
-            } else {
-                crate::custom_properties::NativeVarResolution::NotHandled
+            let native_resolution = unsafe {
+                crate::custom_properties::resolve_vars(custom_property_store, custom_property_registry, data)
             };
             match native_resolution {
                 crate::custom_properties::NativeVarResolution::Resolved(source) => {
@@ -595,7 +593,7 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
     author_context_count: u32,
     has_pseudo_element: bool,
     cascade_custom_properties: bool,
-    allow_native_var_resolution: bool,
+    custom_property_registry: *const c_void,
     unset_shell: *const c_void,
     unset_data: *const c_void,
     callbacks: *const FfiBulkCascadeCallbacks,
@@ -765,7 +763,7 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
                     unsafe { (callbacks.parse_substituted)(context, property_id, source.as_ptr(), source.len()) }
                 },
                 custom_property_store,
-                allow_native_var_resolution,
+                custom_property_registry,
                 &|shell| {
                     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CascadeDataOfCallback);
                     unsafe { (callbacks.data_of)(context, shell) }

--- a/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/cascaded_properties.rs
@@ -328,6 +328,16 @@ pub struct FfiCascadeDeclaration {
     pub data: *const c_void,
 }
 
+/// A custom-property declaration in an `FfiCascadeBlock`. Names cross as retained raw
+/// `Utf16FlyString` identities, which are also sufficient for string equality.
+#[repr(C)]
+pub struct FfiCustomPropertyDeclaration {
+    pub name_raw: usize,
+    pub important: bool,
+    pub is_revert_layer: bool,
+    pub shell: *const c_void,
+}
+
 /// Applies one declaration block to the cascade: filters by importance and applicability,
 /// resolves arbitrary-substitution values through the parser callback, downgrades
 /// invalid-at-computed-value-time declarations to unset, expands shorthands, and routes
@@ -486,6 +496,8 @@ pub struct FfiCascadeBlock {
     pub source_id: u32,
     pub declarations: *const FfiCascadeDeclaration,
     pub declaration_count: usize,
+    pub custom_property_declarations: *const FfiCustomPropertyDeclaration,
+    pub custom_property_declaration_count: usize,
 }
 
 /// One winning store slot and the block source that supplied it, reported in
@@ -494,6 +506,14 @@ pub struct FfiCascadeBlock {
 pub struct FfiSourceSlotAssignment {
     pub slot: u32,
     pub source_id: u32,
+}
+
+/// One winning custom-property declaration, reported in first-declaration order.
+#[repr(C)]
+pub struct FfiCascadedCustomProperty {
+    pub name_raw: usize,
+    pub important: bool,
+    pub shell: *const c_void,
 }
 
 /// Callbacks for the bulk cascade. Values cross as opaque C++ style value
@@ -515,6 +535,9 @@ pub struct FfiBulkCascadeCallbacks {
     /// Receives every winning slot's source assignment in one batch.
     pub assign_source_slots:
         unsafe extern "C" fn(context: *mut c_void, assignments: *const FfiSourceSlotAssignment, count: usize),
+    /// Installs the complete custom-property cascade before unresolved longhands are resolved.
+    pub set_custom_properties:
+        unsafe extern "C" fn(context: *mut c_void, properties: *const FfiCascadedCustomProperty, count: usize),
 }
 
 /// Runs the whole cascade for one element in css-cascade-5 origin order over
@@ -541,6 +564,7 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
     block_count: usize,
     author_context_count: u32,
     has_pseudo_element: bool,
+    cascade_custom_properties: bool,
     unset_shell: *const c_void,
     unset_data: *const c_void,
     callbacks: *const FfiBulkCascadeCallbacks,
@@ -577,6 +601,98 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
                     }
                 }
                 _ => {}
+            }
+        }
+
+        let mut application_order: Vec<(usize, bool, bool)> = Vec::new();
+
+        // Normal user agent, user, and presentational hint declarations.
+        for &index in &user_agent_blocks {
+            application_order.push((index, false, false));
+        }
+        for &index in &user_blocks {
+            application_order.push((index, false, false));
+        }
+        for &index in &presentational_hint_blocks {
+            application_order.push((index, false, false));
+        }
+
+        // Normal author declarations, with inner contexts first so outer contexts win,
+        // layers in declaration order, and inline style after its context's layers.
+        for context_index in (0..author_context_count as usize).rev() {
+            for &index in &author_layer_blocks[context_index] {
+                application_order.push((index, false, true));
+            }
+            if let Some(index) = author_inline_blocks[context_index] {
+                application_order.push((index, false, false));
+            }
+        }
+
+        // Important author declarations, with outer contexts first so inner contexts
+        // win and layers reversed; layer names do not apply in the important pass.
+        for context_index in 0..author_context_count as usize {
+            let layer_blocks = &author_layer_blocks[context_index];
+            let mut boundaries: Vec<(u32, usize, usize)> = Vec::new();
+            for (position, &index) in layer_blocks.iter().enumerate() {
+                let layer = blocks[index].layer_index;
+                match boundaries.last_mut() {
+                    Some((last_layer, _, end)) if *last_layer == layer => *end = position + 1,
+                    _ => boundaries.push((layer, position, position + 1)),
+                }
+            }
+            for &(_, start, end) in boundaries.iter().rev() {
+                for &index in &layer_blocks[start..end] {
+                    application_order.push((index, true, false));
+                }
+            }
+            if let Some(index) = author_inline_blocks[context_index] {
+                application_order.push((index, true, false));
+            }
+        }
+
+        // Important user and user agent declarations.
+        for &index in &user_blocks {
+            application_order.push((index, true, false));
+        }
+        for &index in &user_agent_blocks {
+            application_order.push((index, true, false));
+        }
+
+        if cascade_custom_properties {
+            let mut custom_property_indices = HashMap::new();
+            let mut custom_properties: Vec<FfiCascadedCustomProperty> = Vec::new();
+            for &(block_index, important, _) in &application_order {
+                let block = &blocks[block_index];
+                let declarations = if block.custom_property_declaration_count == 0 {
+                    &[]
+                } else {
+                    unsafe {
+                        std::slice::from_raw_parts(
+                            block.custom_property_declarations,
+                            block.custom_property_declaration_count,
+                        )
+                    }
+                };
+                for declaration in declarations {
+                    if declaration.important != important || declaration.is_revert_layer {
+                        continue;
+                    }
+                    let property = FfiCascadedCustomProperty {
+                        name_raw: declaration.name_raw,
+                        important,
+                        shell: declaration.shell,
+                    };
+                    if let Some(index) = custom_property_indices.get(&declaration.name_raw) {
+                        custom_properties[*index] = property;
+                    } else {
+                        custom_property_indices.insert(declaration.name_raw, custom_properties.len());
+                        custom_properties.push(property);
+                    }
+                }
+            }
+            crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CascadeCustomPropertyBatchCallback);
+            unsafe {
+                (callbacks.set_custom_properties)(context, custom_properties.as_ptr(), custom_properties.len());
             }
         }
 
@@ -628,56 +744,8 @@ pub unsafe extern "C" fn rust_cascade_matched_blocks(
             );
         };
 
-        // Normal user agent, user, and presentational hint declarations.
-        for &index in &user_agent_blocks {
-            apply(index, false, false);
-        }
-        for &index in &user_blocks {
-            apply(index, false, false);
-        }
-        for &index in &presentational_hint_blocks {
-            apply(index, false, false);
-        }
-
-        // Normal author declarations, with inner contexts first so outer contexts win,
-        // layers in declaration order, and inline style after its context's layers.
-        for context_index in (0..author_context_count as usize).rev() {
-            for &index in &author_layer_blocks[context_index] {
-                apply(index, false, true);
-            }
-            if let Some(index) = author_inline_blocks[context_index] {
-                apply(index, false, false);
-            }
-        }
-
-        // Important author declarations, with outer contexts first so inner contexts
-        // win and layers reversed; layer names do not apply in the important pass.
-        for context_index in 0..author_context_count as usize {
-            let layer_blocks = &author_layer_blocks[context_index];
-            let mut boundaries: Vec<(u32, usize, usize)> = Vec::new();
-            for (position, &index) in layer_blocks.iter().enumerate() {
-                let layer = blocks[index].layer_index;
-                match boundaries.last_mut() {
-                    Some((last_layer, _, end)) if *last_layer == layer => *end = position + 1,
-                    _ => boundaries.push((layer, position, position + 1)),
-                }
-            }
-            for &(_, start, end) in boundaries.iter().rev() {
-                for &index in &layer_blocks[start..end] {
-                    apply(index, true, false);
-                }
-            }
-            if let Some(index) = author_inline_blocks[context_index] {
-                apply(index, true, false);
-            }
-        }
-
-        // Important user and user agent declarations.
-        for &index in &user_blocks {
-            apply(index, true, false);
-        }
-        for &index in &user_agent_blocks {
-            apply(index, true, false);
+        for &(block_index, important, use_layer_name) in &application_order {
+            apply(block_index, important, use_layer_name);
         }
 
         if !source_slot_assignments.is_empty() {

--- a/Libraries/LibWeb/CSS/Rust/src/css_tokenizer.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/css_tokenizer.rs
@@ -122,6 +122,72 @@ pub(crate) struct Token {
     range: Range<Position>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum OwnedTokenKind {
+    Ident(String),
+    Function(String),
+    AtKeyword,
+    Hash,
+    Url,
+    BadUrl,
+    Number,
+    Percentage,
+    Dimension,
+    Cdc,
+    Delim(u32),
+    Whitespace,
+    Comma,
+    OpenSquare,
+    CloseSquare,
+    OpenParen,
+    CloseParen,
+    OpenCurly,
+    CloseCurly,
+    Other,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OwnedToken {
+    pub kind: OwnedTokenKind,
+    pub source: Vec<u8>,
+}
+
+pub(crate) fn tokenize_owned(input: &[u8]) -> Vec<OwnedToken> {
+    let mut tokens = Vec::new();
+    tokenize(input, |token, filtered_input| {
+        if matches!(token.token_type, TokenType::EndOfFile) {
+            return;
+        }
+        let kind = match &token.token_type {
+            TokenType::Ident { value } => OwnedTokenKind::Ident(value.clone()),
+            TokenType::Function { name } => OwnedTokenKind::Function(name.clone()),
+            TokenType::AtKeyword { .. } => OwnedTokenKind::AtKeyword,
+            TokenType::Hash { .. } => OwnedTokenKind::Hash,
+            TokenType::Url { .. } => OwnedTokenKind::Url,
+            TokenType::BadUrl => OwnedTokenKind::BadUrl,
+            TokenType::Number { .. } => OwnedTokenKind::Number,
+            TokenType::Percentage { .. } => OwnedTokenKind::Percentage,
+            TokenType::Dimension { .. } => OwnedTokenKind::Dimension,
+            TokenType::Cdc => OwnedTokenKind::Cdc,
+            TokenType::Delim { value } => OwnedTokenKind::Delim(*value),
+            TokenType::Whitespace => OwnedTokenKind::Whitespace,
+            TokenType::Comma => OwnedTokenKind::Comma,
+            TokenType::OpenSquare => OwnedTokenKind::OpenSquare,
+            TokenType::CloseSquare => OwnedTokenKind::CloseSquare,
+            TokenType::OpenParen => OwnedTokenKind::OpenParen,
+            TokenType::CloseParen => OwnedTokenKind::CloseParen,
+            TokenType::OpenCurly => OwnedTokenKind::OpenCurly,
+            TokenType::CloseCurly => OwnedTokenKind::CloseCurly,
+            _ => OwnedTokenKind::Other,
+        };
+        tokens.push(OwnedToken {
+            kind,
+            source: filtered_input.as_bytes()[token.original_source_range.clone()].to_vec(),
+        });
+    });
+    tokens
+}
+
 enum TokenType {
     EndOfFile,
     Ident { value: String },

--- a/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
@@ -80,6 +80,7 @@ impl CustomPropertyStore {
 }
 
 const MAX_SUBSTITUTED_TOKEN_COUNT: usize = 16384;
+const MAX_SUBSTITUTION_RECURSION_DEPTH: u32 = 64;
 
 pub(crate) enum NativeVarResolution {
     Resolved(Vec<u8>),
@@ -90,7 +91,14 @@ pub(crate) enum NativeVarResolution {
 enum TokenResolution {
     Resolved(Vec<OwnedToken>),
     Invalid,
+    Cyclic,
     NotHandled,
+}
+
+#[derive(Default)]
+struct VarResolutionContext {
+    active_names: Vec<String>,
+    cyclic_names: HashSet<String>,
 }
 
 fn matching_close(kind: &OwnedTokenKind) -> Option<OwnedTokenKind> {
@@ -168,7 +176,8 @@ fn resolve_custom_property(
     store: Option<&CustomPropertyStore>,
     registry: Option<&CustomPropertyRegistry>,
     name: &str,
-    guarded_names: &mut HashSet<String>,
+    context: &mut VarResolutionContext,
+    recursion_depth: u32,
 ) -> TokenResolution {
     let registration = registry.and_then(|registry| registry.registrations.get(name));
     if registration.is_some_and(|registration| !registration.syntax_is_universal) {
@@ -193,11 +202,22 @@ fn resolve_custom_property(
         // value and fallback behavior. Keep those on the registered-property computation path.
         return TokenResolution::NotHandled;
     }
-    if !guarded_names.insert(name.to_owned()) {
+    if context.cyclic_names.contains(name) {
         return TokenResolution::Invalid;
     }
-    let result = substitute_tokens(store, registry, &tokenize_owned(source), guarded_names);
-    guarded_names.remove(name);
+    if let Some(cycle_start) = context.active_names.iter().position(|active_name| active_name == name) {
+        // https://drafts.csswg.org/css-variables-1/#cycles
+        // If there is a cycle in the dependency graph, all the custom properties in the cycle
+        // are invalid at computed-value time.
+        context
+            .cyclic_names
+            .extend(context.active_names[cycle_start..].iter().cloned());
+        return TokenResolution::Cyclic;
+    }
+    context.active_names.push(name.to_owned());
+    let result = substitute_tokens(store, registry, &tokenize_owned(source), context, recursion_depth + 1);
+    let active_name = context.active_names.pop().expect("active custom property");
+    debug_assert_eq!(active_name, name);
     if let TokenResolution::Resolved(tokens) = &result
         && is_single_css_wide_keyword(tokens)
     {
@@ -212,7 +232,8 @@ fn replace_var_function(
     store: Option<&CustomPropertyStore>,
     registry: Option<&CustomPropertyRegistry>,
     arguments: &[OwnedToken],
-    guarded_names: &mut HashSet<String>,
+    context: &mut VarResolutionContext,
+    recursion_depth: u32,
 ) -> TokenResolution {
     // https://drafts.csswg.org/css-variables-1/#replace-a-var-function
     // 1. Let el be the element that the style containing the var() function is being applied to.
@@ -236,24 +257,38 @@ fn replace_var_function(
     // 2. Substitute arbitrary substitution functions in first arg, then parse it as a <custom-property-name>.
     //    If parsing returned a <custom-property-name>, let result be the computed value of the corresponding custom
     //    property on el. Otherwise, let result be the guaranteed-invalid value.
-    let result = resolve_custom_property(store, registry, name, guarded_names);
-    if !matches!(result, TokenResolution::Invalid) {
-        return result;
+    match resolve_custom_property(store, registry, name, context, recursion_depth) {
+        TokenResolution::Invalid => {}
+        TokenResolution::Cyclic
+            if context
+                .active_names
+                .last()
+                .is_some_and(|active_name| context.cyclic_names.contains(active_name)) =>
+        {
+            return TokenResolution::Cyclic;
+        }
+        TokenResolution::Cyclic => {}
+        result => return result,
     }
     let Some(comma) = comma else {
         return TokenResolution::Invalid;
     };
     // 4. If result contains the guaranteed-invalid value, and second arg was provided, set result to the result of
     //    substitute arbitrary substitution functions on second arg.
-    substitute_tokens(store, registry, &arguments[comma + 1..], guarded_names)
+    substitute_tokens(store, registry, &arguments[comma + 1..], context, recursion_depth + 1)
 }
 
 fn substitute_tokens(
     store: Option<&CustomPropertyStore>,
     registry: Option<&CustomPropertyRegistry>,
     tokens: &[OwnedToken],
-    guarded_names: &mut HashSet<String>,
+    context: &mut VarResolutionContext,
+    recursion_depth: u32,
 ) -> TokenResolution {
+    if recursion_depth > MAX_SUBSTITUTION_RECURSION_DEPTH {
+        return TokenResolution::Invalid;
+    }
+
     let mut output = Vec::new();
     let mut index = 0;
     while index < tokens.len() {
@@ -267,13 +302,14 @@ fn substitute_tokens(
         let contents = &tokens[index + 1..close_index];
         let resolved = match &tokens[index].kind {
             OwnedTokenKind::Function(name) if name.eq_ignore_ascii_case("var") => {
-                replace_var_function(store, registry, contents, guarded_names)
+                replace_var_function(store, registry, contents, context, recursion_depth)
             }
-            _ => substitute_tokens(store, registry, contents, guarded_names),
+            _ => substitute_tokens(store, registry, contents, context, recursion_depth + 1),
         };
         let resolved = match resolved {
             TokenResolution::Resolved(resolved) => resolved,
             TokenResolution::Invalid => return TokenResolution::Invalid,
+            TokenResolution::Cyclic => return TokenResolution::Cyclic,
             TokenResolution::NotHandled => return TokenResolution::NotHandled,
         };
 
@@ -370,9 +406,15 @@ pub(crate) unsafe fn resolve_vars(
     if !includes_var {
         return NativeVarResolution::NotHandled;
     }
-    match substitute_tokens(store, registry, &tokenize_owned(source), &mut HashSet::new()) {
+    match substitute_tokens(
+        store,
+        registry,
+        &tokenize_owned(source),
+        &mut VarResolutionContext::default(),
+        0,
+    ) {
         TokenResolution::Resolved(tokens) => NativeVarResolution::Resolved(serialize_tokens(&tokens)),
-        TokenResolution::Invalid => NativeVarResolution::Invalid,
+        TokenResolution::Invalid | TokenResolution::Cyclic => NativeVarResolution::Invalid,
         TokenResolution::NotHandled => NativeVarResolution::NotHandled,
     }
 }
@@ -382,7 +424,13 @@ mod tests {
     use super::*;
 
     fn substitute_without_custom_properties(source: &str) -> TokenResolution {
-        substitute_tokens(None, None, &tokenize_owned(source.as_bytes()), &mut HashSet::new())
+        substitute_tokens(
+            None,
+            None,
+            &tokenize_owned(source.as_bytes()),
+            &mut VarResolutionContext::default(),
+            0,
+        )
     }
 
     #[test]
@@ -422,6 +470,20 @@ mod tests {
     fn recognizes_substituted_css_wide_keywords() {
         assert!(is_single_css_wide_keyword(&tokenize_owned(b"  inherit ")));
         assert!(!is_single_css_wide_keyword(&tokenize_owned(b"inherit green")));
+    }
+
+    #[test]
+    fn deeply_nested_functions_are_invalid() {
+        let nesting = MAX_SUBSTITUTION_RECURSION_DEPTH + 1;
+        let source = format!(
+            "{}var(--missing, 1px){}",
+            "calc(".repeat(nesting as usize),
+            ")".repeat(nesting as usize)
+        );
+        assert!(matches!(
+            substitute_without_custom_properties(&source),
+            TokenResolution::Invalid
+        ));
     }
 }
 

--- a/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
@@ -8,10 +8,14 @@
 //! `CustomPropertyData` shell.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ffi::c_void;
 use std::rc::Rc;
 
 use crate::abort_on_panic;
+use crate::css_tokenizer::OwnedToken;
+use crate::css_tokenizer::OwnedTokenKind;
+use crate::css_tokenizer::tokenize_owned;
 use crate::style_value::RetainedStyleValue;
 use crate::style_value::RetainedUtf16FlyString;
 use crate::style_value::StyleValueData;
@@ -19,6 +23,8 @@ use crate::style_value::StyleValueData;
 #[repr(C)]
 pub struct FfiCustomPropertyStoreEntry {
     pub name_raw: usize,
+    pub name_utf8: *const u8,
+    pub name_utf8_length: usize,
     pub important: bool,
     pub shell: *const c_void,
     pub data: *const c_void,
@@ -33,6 +39,7 @@ struct CustomPropertyEntry {
 
 pub struct CustomPropertyStore {
     own_values: HashMap<usize, CustomPropertyEntry>,
+    own_names: HashMap<String, usize>,
     parent: Option<Rc<CustomPropertyStore>>,
 }
 
@@ -41,6 +48,334 @@ impl CustomPropertyStore {
         self.own_values
             .get(&name_raw)
             .or_else(|| self.parent.as_ref()?.get(name_raw))
+    }
+
+    fn get_by_name(&self, name: &str) -> Option<&CustomPropertyEntry> {
+        self.own_names
+            .get(name)
+            .and_then(|name_raw| self.own_values.get(name_raw))
+            .or_else(|| self.parent.as_ref()?.get_by_name(name))
+    }
+}
+
+const MAX_SUBSTITUTED_TOKEN_COUNT: usize = 16384;
+
+pub(crate) enum NativeVarResolution {
+    Resolved(Vec<u8>),
+    Invalid,
+    NotHandled,
+}
+
+enum TokenResolution {
+    Resolved(Vec<OwnedToken>),
+    Invalid,
+    NotHandled,
+}
+
+fn matching_close(kind: &OwnedTokenKind) -> Option<OwnedTokenKind> {
+    match kind {
+        OwnedTokenKind::Function(_) | OwnedTokenKind::OpenParen => Some(OwnedTokenKind::CloseParen),
+        OwnedTokenKind::OpenSquare => Some(OwnedTokenKind::CloseSquare),
+        OwnedTokenKind::OpenCurly => Some(OwnedTokenKind::CloseCurly),
+        _ => None,
+    }
+}
+
+fn find_matching_close(tokens: &[OwnedToken], open_index: usize) -> Option<usize> {
+    let mut expected_closes = vec![matching_close(&tokens[open_index].kind)?];
+    for (index, token) in tokens.iter().enumerate().skip(open_index + 1) {
+        if let Some(close) = matching_close(&token.kind) {
+            expected_closes.push(close);
+            continue;
+        }
+        if expected_closes.last() == Some(&token.kind) {
+            expected_closes.pop();
+            if expected_closes.is_empty() {
+                return Some(index);
+            }
+        }
+    }
+    None
+}
+
+fn find_top_level_comma(tokens: &[OwnedToken]) -> Option<usize> {
+    let mut index = 0;
+    while index < tokens.len() {
+        if matches!(tokens[index].kind, OwnedTokenKind::Comma) {
+            return Some(index);
+        }
+        if matching_close(&tokens[index].kind).is_some() {
+            index = find_matching_close(tokens, index)? + 1;
+        } else {
+            index += 1;
+        }
+    }
+    None
+}
+
+fn trim_whitespace(mut tokens: &[OwnedToken]) -> &[OwnedToken] {
+    while matches!(
+        tokens.first().map(|token| &token.kind),
+        Some(OwnedTokenKind::Whitespace)
+    ) {
+        tokens = &tokens[1..];
+    }
+    while matches!(tokens.last().map(|token| &token.kind), Some(OwnedTokenKind::Whitespace)) {
+        tokens = &tokens[..tokens.len() - 1];
+    }
+    tokens
+}
+
+fn is_single_css_wide_keyword(tokens: &[OwnedToken]) -> bool {
+    let [
+        OwnedToken {
+            kind: OwnedTokenKind::Ident(keyword),
+            ..
+        },
+    ] = trim_whitespace(tokens)
+    else {
+        return false;
+    };
+    keyword.eq_ignore_ascii_case("inherit")
+        || keyword.eq_ignore_ascii_case("initial")
+        || keyword.eq_ignore_ascii_case("unset")
+        || keyword.eq_ignore_ascii_case("revert")
+        || keyword.eq_ignore_ascii_case("revert-layer")
+}
+
+fn resolve_custom_property(
+    store: Option<&CustomPropertyStore>,
+    name: &str,
+    guarded_names: &mut HashSet<String>,
+) -> TokenResolution {
+    let Some(entry) = store.and_then(|store| store.get_by_name(name)) else {
+        return TokenResolution::Invalid;
+    };
+    let data = unsafe { &*entry.data.cast::<StyleValueData>() };
+    if matches!(data, StyleValueData::GuaranteedInvalid) {
+        return TokenResolution::Invalid;
+    }
+    let Some((source, _includes_var)) = data.unresolved_var_source() else {
+        return TokenResolution::NotHandled;
+    };
+    if !guarded_names.insert(name.to_owned()) {
+        return TokenResolution::Invalid;
+    }
+    let result = substitute_tokens(store, &tokenize_owned(source), guarded_names);
+    guarded_names.remove(name);
+    if let TokenResolution::Resolved(tokens) = &result
+        && is_single_css_wide_keyword(tokens)
+    {
+        // NB: A CSS-wide keyword produced by substitution must first take on its custom-property
+        // meaning. Keep this case on the C++ path until custom-property keyword resolution moves.
+        return TokenResolution::NotHandled;
+    }
+    result
+}
+
+fn replace_var_function(
+    store: Option<&CustomPropertyStore>,
+    arguments: &[OwnedToken],
+    guarded_names: &mut HashSet<String>,
+) -> TokenResolution {
+    // https://drafts.csswg.org/css-variables-1/#replace-a-var-function
+    // 1. Let el be the element that the style containing the var() function is being applied to.
+    //    Let first arg be the first <declaration-value> in arguments.
+    //    Let second arg be the <declaration-value>? passed after the comma, or null if there was no comma.
+    let comma = find_top_level_comma(arguments);
+    let first_argument = trim_whitespace(&arguments[..comma.unwrap_or(arguments.len())]);
+    let [
+        OwnedToken {
+            kind: OwnedTokenKind::Ident(name),
+            ..
+        },
+    ] = first_argument
+    else {
+        return TokenResolution::NotHandled;
+    };
+    if !name.starts_with("--") {
+        return TokenResolution::Invalid;
+    }
+
+    // 2. Substitute arbitrary substitution functions in first arg, then parse it as a <custom-property-name>.
+    //    If parsing returned a <custom-property-name>, let result be the computed value of the corresponding custom
+    //    property on el. Otherwise, let result be the guaranteed-invalid value.
+    let result = resolve_custom_property(store, name, guarded_names);
+    if !matches!(result, TokenResolution::Invalid) {
+        return result;
+    }
+    let Some(comma) = comma else {
+        return TokenResolution::Invalid;
+    };
+    // 4. If result contains the guaranteed-invalid value, and second arg was provided, set result to the result of
+    //    substitute arbitrary substitution functions on second arg.
+    substitute_tokens(store, &arguments[comma + 1..], guarded_names)
+}
+
+fn substitute_tokens(
+    store: Option<&CustomPropertyStore>,
+    tokens: &[OwnedToken],
+    guarded_names: &mut HashSet<String>,
+) -> TokenResolution {
+    let mut output = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        let Some(close_index) = matching_close(&tokens[index].kind).and_then(|_| find_matching_close(tokens, index))
+        else {
+            output.push(tokens[index].clone());
+            index += 1;
+            continue;
+        };
+
+        let contents = &tokens[index + 1..close_index];
+        let resolved = match &tokens[index].kind {
+            OwnedTokenKind::Function(name) if name.eq_ignore_ascii_case("var") => {
+                replace_var_function(store, contents, guarded_names)
+            }
+            _ => substitute_tokens(store, contents, guarded_names),
+        };
+        let resolved = match resolved {
+            TokenResolution::Resolved(resolved) => resolved,
+            TokenResolution::Invalid => return TokenResolution::Invalid,
+            TokenResolution::NotHandled => return TokenResolution::NotHandled,
+        };
+
+        if !matches!(tokens[index].kind, OwnedTokenKind::Function(ref name) if name.eq_ignore_ascii_case("var")) {
+            output.push(tokens[index].clone());
+        }
+        output.extend(resolved);
+        if !matches!(tokens[index].kind, OwnedTokenKind::Function(ref name) if name.eq_ignore_ascii_case("var")) {
+            output.push(tokens[close_index].clone());
+        }
+        let remaining_token_count = tokens.len() - close_index - 1;
+        if output.len() + remaining_token_count > MAX_SUBSTITUTED_TOKEN_COUNT {
+            return TokenResolution::Invalid;
+        }
+        index = close_index + 1;
+    }
+    TokenResolution::Resolved(output)
+}
+
+// https://drafts.csswg.org/css-syntax/#serialization
+fn needs_comment_between(first: &OwnedTokenKind, second: &OwnedTokenKind) -> bool {
+    let second_is_common = matches!(
+        second,
+        OwnedTokenKind::Url
+            | OwnedTokenKind::BadUrl
+            | OwnedTokenKind::Number
+            | OwnedTokenKind::Percentage
+            | OwnedTokenKind::Dimension
+            | OwnedTokenKind::Cdc
+    );
+    let second_is_ident = matches!(second, OwnedTokenKind::Ident(_));
+    let second_is_function = matches!(second, OwnedTokenKind::Function(_));
+    let common = second_is_common || second_is_ident;
+
+    match first {
+        OwnedTokenKind::Ident(_) => {
+            second_is_function || matches!(second, OwnedTokenKind::OpenParen | OwnedTokenKind::Delim(45)) || common
+        }
+        OwnedTokenKind::AtKeyword
+        | OwnedTokenKind::Hash
+        | OwnedTokenKind::Dimension
+        | OwnedTokenKind::Delim(35 | 45) => second_is_function || matches!(second, OwnedTokenKind::Delim(45)) || common,
+        OwnedTokenKind::Number => second_is_function || matches!(second, OwnedTokenKind::Delim(37)) || common,
+        OwnedTokenKind::Delim(64) => {
+            second_is_function
+                || matches!(second, OwnedTokenKind::Delim(45))
+                || second_is_ident
+                || matches!(
+                    second,
+                    OwnedTokenKind::Url | OwnedTokenKind::BadUrl | OwnedTokenKind::Cdc
+                )
+        }
+        OwnedTokenKind::Delim(46 | 43) => matches!(
+            second,
+            OwnedTokenKind::Number | OwnedTokenKind::Percentage | OwnedTokenKind::Dimension
+        ),
+        OwnedTokenKind::Delim(47) => matches!(second, OwnedTokenKind::Delim(42)),
+        _ => false,
+    }
+}
+
+fn serialize_tokens(tokens: &[OwnedToken]) -> Vec<u8> {
+    let mut output = Vec::new();
+    for (index, token) in tokens.iter().enumerate() {
+        output.extend_from_slice(&token.source);
+        if let Some(next) = tokens.get(index + 1)
+            && needs_comment_between(&token.kind, &next.kind)
+        {
+            output.extend_from_slice(b"/**/");
+        }
+    }
+    output
+}
+
+pub(crate) unsafe fn resolve_vars(store: *const c_void, value_data: *const c_void) -> NativeVarResolution {
+    let store = if store.is_null() {
+        None
+    } else {
+        Some(unsafe { &*store.cast::<CustomPropertyStore>() })
+    };
+    let value_data = unsafe { &*value_data.cast::<StyleValueData>() };
+    let Some((source, includes_var)) = value_data.unresolved_var_source() else {
+        return NativeVarResolution::NotHandled;
+    };
+    if !includes_var {
+        return NativeVarResolution::NotHandled;
+    }
+    match substitute_tokens(store, &tokenize_owned(source), &mut HashSet::new()) {
+        TokenResolution::Resolved(tokens) => NativeVarResolution::Resolved(serialize_tokens(&tokens)),
+        TokenResolution::Invalid => NativeVarResolution::Invalid,
+        TokenResolution::NotHandled => NativeVarResolution::NotHandled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn substitute_without_custom_properties(source: &str) -> TokenResolution {
+        substitute_tokens(None, &tokenize_owned(source.as_bytes()), &mut HashSet::new())
+    }
+
+    #[test]
+    fn missing_variable_uses_fallback() {
+        let TokenResolution::Resolved(tokens) = substitute_without_custom_properties("calc(var(--missing, 1px) + 2px)")
+        else {
+            panic!("expected fallback substitution");
+        };
+        assert_eq!(serialize_tokens(&tokens), b"calc( 1px + 2px)");
+    }
+
+    #[test]
+    fn empty_fallback_is_valid() {
+        let TokenResolution::Resolved(tokens) = substitute_without_custom_properties("var(--missing,)") else {
+            panic!("expected empty fallback substitution");
+        };
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn missing_variable_without_fallback_is_invalid() {
+        assert!(matches!(
+            substitute_without_custom_properties("var(--missing)"),
+            TokenResolution::Invalid
+        ));
+    }
+
+    #[test]
+    fn serialization_preserves_token_boundaries() {
+        let TokenResolution::Resolved(tokens) = substitute_without_custom_properties("var(--missing, 1)px") else {
+            panic!("expected fallback substitution");
+        };
+        assert_eq!(serialize_tokens(&tokens), b" 1/**/px");
+    }
+
+    #[test]
+    fn recognizes_substituted_css_wide_keywords() {
+        assert!(is_single_css_wide_keyword(&tokenize_owned(b"  inherit ")));
+        assert!(!is_single_css_wide_keyword(&tokenize_owned(b"inherit green")));
     }
 }
 
@@ -70,9 +405,14 @@ pub unsafe extern "C" fn rust_custom_property_store_create(
             unsafe { Rc::increment_strong_count(parent) };
             Some(unsafe { Rc::from_raw(parent) })
         };
+        let mut own_names = HashMap::with_capacity(entries.len());
         let own_values = entries
             .iter()
             .map(|entry| {
+                let name = unsafe { crate::bytes_from_raw(entry.name_utf8, entry.name_utf8_length) }
+                    .and_then(|name| std::str::from_utf8(name).ok())
+                    .expect("invalid custom property name");
+                own_names.insert(name.to_owned(), entry.name_raw);
                 (
                     entry.name_raw,
                     CustomPropertyEntry {
@@ -84,7 +424,12 @@ pub unsafe extern "C" fn rust_custom_property_store_create(
                 )
             })
             .collect();
-        Rc::into_raw(Rc::new(CustomPropertyStore { own_values, parent })).cast()
+        Rc::into_raw(Rc::new(CustomPropertyStore {
+            own_values,
+            own_names,
+            parent,
+        }))
+        .cast()
     })
 }
 

--- a/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Rust-owned custom-property data with the same structurally shared parent shape as the C++
+//! `CustomPropertyData` shell.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::rc::Rc;
+
+use crate::abort_on_panic;
+use crate::style_value::RetainedStyleValue;
+use crate::style_value::RetainedUtf16FlyString;
+
+#[repr(C)]
+pub struct FfiCustomPropertyStoreEntry {
+    pub name_raw: usize,
+    pub important: bool,
+    pub shell: *const c_void,
+    pub data: *const c_void,
+}
+
+struct CustomPropertyEntry {
+    _name: RetainedUtf16FlyString,
+    _value: RetainedStyleValue,
+    important: bool,
+    data: *const c_void,
+}
+
+pub struct CustomPropertyStore {
+    own_values: HashMap<usize, CustomPropertyEntry>,
+    parent: Option<Rc<CustomPropertyStore>>,
+}
+
+impl CustomPropertyStore {
+    fn get(&self, name_raw: usize) -> Option<&CustomPropertyEntry> {
+        self.own_values
+            .get(&name_raw)
+            .or_else(|| self.parent.as_ref()?.get(name_raw))
+    }
+}
+
+/// Creates one Rust store node. Each entry name transfers one leaked fly-string reference;
+/// value shells are borrowed and retained by Rust. The parent is another Rc raw pointer.
+///
+/// # Safety
+/// `entries` must point at `entry_count` valid entries and `parent` must be null or a pointer
+/// returned by this function that remains live for this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_custom_property_store_create(
+    entries: *const FfiCustomPropertyStoreEntry,
+    entry_count: usize,
+    parent: *const c_void,
+) -> *const c_void {
+    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CustomPropertyStoreLifecycleEntry);
+    abort_on_panic(|| {
+        let entries = if entry_count == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(entries, entry_count) }
+        };
+        let parent = if parent.is_null() {
+            None
+        } else {
+            let parent = parent.cast::<CustomPropertyStore>();
+            unsafe { Rc::increment_strong_count(parent) };
+            Some(unsafe { Rc::from_raw(parent) })
+        };
+        let own_values = entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry.name_raw,
+                    CustomPropertyEntry {
+                        _name: unsafe { RetainedUtf16FlyString::from_leaked_raw(entry.name_raw) },
+                        _value: unsafe { RetainedStyleValue::from_borrowed_shell_pointer(entry.shell) },
+                        important: entry.important,
+                        data: entry.data,
+                    },
+                )
+            })
+            .collect();
+        Rc::into_raw(Rc::new(CustomPropertyStore { own_values, parent })).cast()
+    })
+}
+
+/// Releases one store reference returned by `rust_custom_property_store_create`.
+///
+/// # Safety
+/// `store` must be a non-null pointer returned by `rust_custom_property_store_create` that has
+/// not already been released.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_custom_property_store_destroy(store: *const c_void) {
+    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CustomPropertyStoreLifecycleEntry);
+    abort_on_panic(|| drop(unsafe { Rc::from_raw(store.cast::<CustomPropertyStore>()) }));
+}
+
+#[repr(C)]
+pub struct FfiCustomPropertyStoreValue {
+    pub found: bool,
+    pub important: bool,
+    pub shell: *const c_void,
+    pub data: *const c_void,
+}
+
+/// Looks up a custom property through the structurally shared parent chain.
+///
+/// # Safety
+/// `store` must be a live pointer returned by `rust_custom_property_store_create`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_custom_property_store_get(
+    store: *const c_void,
+    name_raw: usize,
+) -> FfiCustomPropertyStoreValue {
+    crate::ffi_stats::bump(crate::ffi_stats::FfiOp::CustomPropertyStoreQueryEntry);
+    abort_on_panic(|| {
+        let store = unsafe { &*store.cast::<CustomPropertyStore>() };
+        let Some(entry) = store.get(name_raw) else {
+            return FfiCustomPropertyStoreValue {
+                found: false,
+                important: false,
+                shell: std::ptr::null(),
+                data: std::ptr::null(),
+            };
+        };
+        FfiCustomPropertyStoreValue {
+            found: true,
+            important: entry.important,
+            shell: entry._value.shell_pointer(),
+            data: entry.data,
+        }
+    })
+}

--- a/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
@@ -43,6 +43,27 @@ pub struct CustomPropertyStore {
     parent: Option<Rc<CustomPropertyStore>>,
 }
 
+pub struct CustomPropertyRegistry {
+    registrations: HashMap<String, RegisteredCustomProperty>,
+}
+
+struct RegisteredCustomProperty {
+    syntax_is_universal: bool,
+    _inherits: bool,
+    initial_source: Option<Vec<u8>>,
+}
+
+#[repr(C)]
+pub struct FfiCustomPropertyRegistration {
+    pub name: *const u8,
+    pub name_length: usize,
+    pub syntax_is_universal: bool,
+    pub inherits: bool,
+    pub has_initial_value: bool,
+    pub initial_value: *const u8,
+    pub initial_value_length: usize,
+}
+
 impl CustomPropertyStore {
     fn get(&self, name_raw: usize) -> Option<&CustomPropertyEntry> {
         self.own_values
@@ -145,23 +166,37 @@ fn is_single_css_wide_keyword(tokens: &[OwnedToken]) -> bool {
 
 fn resolve_custom_property(
     store: Option<&CustomPropertyStore>,
+    registry: Option<&CustomPropertyRegistry>,
     name: &str,
     guarded_names: &mut HashSet<String>,
 ) -> TokenResolution {
+    let registration = registry.and_then(|registry| registry.registrations.get(name));
+    if registration.is_some_and(|registration| !registration.syntax_is_universal) {
+        return TokenResolution::NotHandled;
+    }
     let Some(entry) = store.and_then(|store| store.get_by_name(name)) else {
-        return TokenResolution::Invalid;
+        return registration
+            .and_then(|registration| registration.initial_source.as_ref())
+            .map_or(TokenResolution::Invalid, |source| {
+                TokenResolution::Resolved(tokenize_owned(source))
+            });
     };
     let data = unsafe { &*entry.data.cast::<StyleValueData>() };
     if matches!(data, StyleValueData::GuaranteedInvalid) {
         return TokenResolution::Invalid;
     }
-    let Some((source, _includes_var)) = data.unresolved_var_source() else {
+    let Some((source, includes_var)) = data.unresolved_var_source() else {
         return TokenResolution::NotHandled;
     };
+    if registration.is_some() && includes_var {
+        // NB: Cycles involving registered properties affect the registered property's computed
+        // value and fallback behavior. Keep those on the registered-property computation path.
+        return TokenResolution::NotHandled;
+    }
     if !guarded_names.insert(name.to_owned()) {
         return TokenResolution::Invalid;
     }
-    let result = substitute_tokens(store, &tokenize_owned(source), guarded_names);
+    let result = substitute_tokens(store, registry, &tokenize_owned(source), guarded_names);
     guarded_names.remove(name);
     if let TokenResolution::Resolved(tokens) = &result
         && is_single_css_wide_keyword(tokens)
@@ -175,6 +210,7 @@ fn resolve_custom_property(
 
 fn replace_var_function(
     store: Option<&CustomPropertyStore>,
+    registry: Option<&CustomPropertyRegistry>,
     arguments: &[OwnedToken],
     guarded_names: &mut HashSet<String>,
 ) -> TokenResolution {
@@ -200,7 +236,7 @@ fn replace_var_function(
     // 2. Substitute arbitrary substitution functions in first arg, then parse it as a <custom-property-name>.
     //    If parsing returned a <custom-property-name>, let result be the computed value of the corresponding custom
     //    property on el. Otherwise, let result be the guaranteed-invalid value.
-    let result = resolve_custom_property(store, name, guarded_names);
+    let result = resolve_custom_property(store, registry, name, guarded_names);
     if !matches!(result, TokenResolution::Invalid) {
         return result;
     }
@@ -209,11 +245,12 @@ fn replace_var_function(
     };
     // 4. If result contains the guaranteed-invalid value, and second arg was provided, set result to the result of
     //    substitute arbitrary substitution functions on second arg.
-    substitute_tokens(store, &arguments[comma + 1..], guarded_names)
+    substitute_tokens(store, registry, &arguments[comma + 1..], guarded_names)
 }
 
 fn substitute_tokens(
     store: Option<&CustomPropertyStore>,
+    registry: Option<&CustomPropertyRegistry>,
     tokens: &[OwnedToken],
     guarded_names: &mut HashSet<String>,
 ) -> TokenResolution {
@@ -230,9 +267,9 @@ fn substitute_tokens(
         let contents = &tokens[index + 1..close_index];
         let resolved = match &tokens[index].kind {
             OwnedTokenKind::Function(name) if name.eq_ignore_ascii_case("var") => {
-                replace_var_function(store, contents, guarded_names)
+                replace_var_function(store, registry, contents, guarded_names)
             }
-            _ => substitute_tokens(store, contents, guarded_names),
+            _ => substitute_tokens(store, registry, contents, guarded_names),
         };
         let resolved = match resolved {
             TokenResolution::Resolved(resolved) => resolved,
@@ -311,11 +348,20 @@ fn serialize_tokens(tokens: &[OwnedToken]) -> Vec<u8> {
     output
 }
 
-pub(crate) unsafe fn resolve_vars(store: *const c_void, value_data: *const c_void) -> NativeVarResolution {
+pub(crate) unsafe fn resolve_vars(
+    store: *const c_void,
+    registry: *const c_void,
+    value_data: *const c_void,
+) -> NativeVarResolution {
     let store = if store.is_null() {
         None
     } else {
         Some(unsafe { &*store.cast::<CustomPropertyStore>() })
+    };
+    let registry = if registry.is_null() {
+        None
+    } else {
+        Some(unsafe { &*registry.cast::<CustomPropertyRegistry>() })
     };
     let value_data = unsafe { &*value_data.cast::<StyleValueData>() };
     let Some((source, includes_var)) = value_data.unresolved_var_source() else {
@@ -324,7 +370,7 @@ pub(crate) unsafe fn resolve_vars(store: *const c_void, value_data: *const c_voi
     if !includes_var {
         return NativeVarResolution::NotHandled;
     }
-    match substitute_tokens(store, &tokenize_owned(source), &mut HashSet::new()) {
+    match substitute_tokens(store, registry, &tokenize_owned(source), &mut HashSet::new()) {
         TokenResolution::Resolved(tokens) => NativeVarResolution::Resolved(serialize_tokens(&tokens)),
         TokenResolution::Invalid => NativeVarResolution::Invalid,
         TokenResolution::NotHandled => NativeVarResolution::NotHandled,
@@ -336,7 +382,7 @@ mod tests {
     use super::*;
 
     fn substitute_without_custom_properties(source: &str) -> TokenResolution {
-        substitute_tokens(None, &tokenize_owned(source.as_bytes()), &mut HashSet::new())
+        substitute_tokens(None, None, &tokenize_owned(source.as_bytes()), &mut HashSet::new())
     }
 
     #[test]
@@ -377,6 +423,69 @@ mod tests {
         assert!(is_single_css_wide_keyword(&tokenize_owned(b"  inherit ")));
         assert!(!is_single_css_wide_keyword(&tokenize_owned(b"inherit green")));
     }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_custom_property_registry_create() -> *mut c_void {
+    abort_on_panic(|| {
+        Box::into_raw(Box::new(CustomPropertyRegistry {
+            registrations: HashMap::new(),
+        }))
+        .cast()
+    })
+}
+
+/// Replaces the effective registered custom-property names for one document.
+///
+/// # Safety
+/// `registry` must be a live pointer returned by `rust_custom_property_registry_create`, and
+/// `registrations` must point at `registration_count` valid entries.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_custom_property_registry_update(
+    registry: *mut c_void,
+    registrations: *const FfiCustomPropertyRegistration,
+    registration_count: usize,
+) {
+    abort_on_panic(|| {
+        let registrations = if registration_count == 0 {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(registrations, registration_count) }
+        };
+        let registry = unsafe { &mut *registry.cast::<CustomPropertyRegistry>() };
+        registry.registrations.clear();
+        registry.registrations.reserve(registrations.len());
+        for registration in registrations {
+            let name = unsafe { crate::bytes_from_raw(registration.name, registration.name_length) }
+                .and_then(|name| std::str::from_utf8(name).ok())
+                .expect("invalid registered custom property name");
+            let initial_source = if registration.has_initial_value {
+                Some(
+                    unsafe { crate::bytes_from_raw(registration.initial_value, registration.initial_value_length) }
+                        .expect("invalid registered custom property initial value")
+                        .to_vec(),
+                )
+            } else {
+                None
+            };
+            registry.registrations.insert(
+                name.to_owned(),
+                RegisteredCustomProperty {
+                    syntax_is_universal: registration.syntax_is_universal,
+                    _inherits: registration.inherits,
+                    initial_source,
+                },
+            );
+        }
+    });
+}
+
+/// # Safety
+/// `registry` must be a pointer returned by `rust_custom_property_registry_create` that has not
+/// already been destroyed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_custom_property_registry_destroy(registry: *mut c_void) {
+    abort_on_panic(|| drop(unsafe { Box::from_raw(registry.cast::<CustomPropertyRegistry>()) }));
 }
 
 /// Creates one Rust store node. Each entry name transfers one leaked fly-string reference;

--- a/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/custom_properties.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 use crate::abort_on_panic;
 use crate::style_value::RetainedStyleValue;
 use crate::style_value::RetainedUtf16FlyString;
+use crate::style_value::StyleValueData;
 
 #[repr(C)]
 pub struct FfiCustomPropertyStoreEntry {
@@ -104,6 +105,8 @@ pub struct FfiCustomPropertyStoreValue {
     pub important: bool,
     pub shell: *const c_void,
     pub data: *const c_void,
+    pub token_source: *const u8,
+    pub token_source_length: usize,
 }
 
 /// Looks up a custom property through the structurally shared parent chain.
@@ -124,13 +127,20 @@ pub unsafe extern "C" fn rust_custom_property_store_get(
                 important: false,
                 shell: std::ptr::null(),
                 data: std::ptr::null(),
+                token_source: std::ptr::null(),
+                token_source_length: 0,
             };
         };
+        let token_source = unsafe { &*entry.data.cast::<StyleValueData>() }
+            .unresolved_token_source()
+            .unwrap_or_default();
         FfiCustomPropertyStoreValue {
             found: true,
             important: entry.important,
             shell: entry._value.shell_pointer(),
             data: entry.data,
+            token_source: token_source.as_ptr(),
+            token_source_length: token_source.len(),
         }
     })
 }

--- a/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
@@ -40,6 +40,8 @@ define_ffi_ops! {
     SelectorMatchEntry => "selectorMatchEntries",
     CascadeBulkEntry => "cascadeBulkEntries",
     CascadedStoreQueryEntry => "cascadedStoreQueryEntries",
+    CustomPropertyStoreLifecycleEntry => "customPropertyStoreLifecycleEntries",
+    CustomPropertyStoreQueryEntry => "customPropertyStoreQueryEntries",
     LonghandDriverEntry => "longhandDriverEntries",
     ShorthandExpansionEntry => "shorthandExpansionEntries",
     NestedPropertyComputeEntry => "nestedPropertyComputeEntries",

--- a/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
@@ -59,6 +59,7 @@ define_ffi_ops! {
     SelectorMetadataCallback => "selectorMetadataCallbacks",
     CascadePropertyDisallowedCallback => "cascadePropertyDisallowedCallbacks",
     CascadeResolveUnresolvedCallback => "cascadeResolveUnresolvedCallbacks",
+    CascadeParseSubstitutedCallback => "cascadeParseSubstitutedCallbacks",
     CascadeDataOfCallback => "cascadeDataOfCallbacks",
     CascadePendingSubstitutionCallback => "cascadePendingSubstitutionCallbacks",
     CascadeSourceSlotCallback => "cascadeSourceSlotCallbacks",

--- a/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/ffi_stats.rs
@@ -60,6 +60,7 @@ define_ffi_ops! {
     CascadeDataOfCallback => "cascadeDataOfCallbacks",
     CascadePendingSubstitutionCallback => "cascadePendingSubstitutionCallbacks",
     CascadeSourceSlotCallback => "cascadeSourceSlotCallbacks",
+    CascadeCustomPropertyBatchCallback => "cascadeCustomPropertyBatchCallbacks",
     ShorthandSetLonghandCallback => "shorthandSetLonghandCallbacks",
     LonghandStoreBatchCallback => "longhandStoreBatchCallbacks",
     LonghandCppComputeFallback => "longhandCppComputeFallbacks",

--- a/Libraries/LibWeb/CSS/Rust/src/lib.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cascaded_properties;
 pub mod computed_values;
 pub mod css_pixels;
 mod css_tokenizer;
+pub mod custom_properties;
 pub mod ffi_stats;
 pub mod property_metadata;
 mod selector_engine;

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -1867,8 +1867,9 @@ pub struct FfiLonghandCallbacks {
     /// Stores the used color scheme resolved from the computed color-scheme
     /// value and document preferences.
     pub store_effective_color_scheme: unsafe extern "C" fn(context: *mut c_void, color_scheme: u8),
-    /// Stores the original display and applies the box type transformation
-    /// after the ordinary longhand batch has been flushed.
+    /// Stores the original adjusted properties, applies the post-computation
+    /// changes after the ordinary longhand batch has been flushed, and returns
+    /// the font measurements needed for the input line-height decision.
     pub store_box_type_transformation: unsafe extern "C" fn(
         context: *mut c_void,
         display_before: *const FfiDisplay,
@@ -1879,7 +1880,7 @@ pub struct FfiLonghandCallbacks {
         position_before: u16,
         transformation: *const FfiBoxTypeTransformation,
         element_adjustment: *const FfiElementStyleAdjustment,
-    ) -> bool,
+    ) -> FfiInputLineHeightMetrics,
     /// Rare: fetches the parent's computed value for an explicit `inherit` of
     /// a non-inherited property, which the parent snapshot does not carry.
     /// The C++ side pins the returned shell until the end of the drive, so
@@ -2824,7 +2825,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             clear_longhand_bit(important_words, prop::TEXT_ALIGN);
             clear_longhand_bit(inherited_words, prop::TEXT_ALIGN);
         }
-        let line_height_changed = unsafe {
+        let input_line_height_metrics = unsafe {
             (callbacks.store_box_type_transformation)(
                 context,
                 &raw const display_before,
@@ -2837,6 +2838,22 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                 &raw const element_adjustment,
             )
         };
+        let clamp_input_line_height = should_clamp_input_line_height(&element_adjustment, &input_line_height_metrics);
+        if clamp_input_line_height {
+            let normal = initial_value(prop::LINE_HEIGHT);
+            let entry = FfiComputedStoreEntry {
+                property_id: prop::LINE_HEIGHT,
+                inherited_property_id: prop::LINE_HEIGHT,
+                shell: normal.shell,
+                inheritance_dependent: false,
+                inherited: false,
+                computed_kind: COMPUTED_KIND_KEYWORD,
+                value: keyword::NORMAL as f64,
+            };
+            crate::ffi_stats::bump(crate::ffi_stats::FfiOp::LonghandStoreBatchCallback);
+            unsafe { (callbacks.store_computed_batch)(context, &raw const entry, 1) };
+        }
+        let line_height_changed = element_adjustment.set_line_height_normal || clamp_input_line_height;
         if line_height_changed {
             clear_longhand_bit(important_words, prop::LINE_HEIGHT);
             clear_longhand_bit(inherited_words, prop::LINE_HEIGHT);
@@ -3173,6 +3190,16 @@ pub struct FfiElementStyleAdjustment {
     pub set_position_static: bool,
     pub changed_text_align: bool,
     pub text_align: u16,
+}
+
+#[repr(C)]
+pub struct FfiInputLineHeightMetrics {
+    pub current_line_height: f64,
+    pub minimum_line_height: f64,
+}
+
+fn should_clamp_input_line_height(adjustment: &FfiElementStyleAdjustment, metrics: &FfiInputLineHeightMetrics) -> bool {
+    adjustment.check_input_line_height && metrics.current_line_height < metrics.minimum_line_height
 }
 
 fn adjust_element_style(
@@ -3729,6 +3756,24 @@ mod tests {
         let adjustment = adjust_element_style(&input, FfiDisplay::block(), keyword::_LIBWEB_CENTER);
         assert!(adjustment.changed_text_align);
         assert_eq!(adjustment.text_align, keyword::START);
+
+        input = element_adjustment_input();
+        input.check_input_line_height = true;
+        let adjustment = adjust_element_style(&input, FfiDisplay::inline(), keyword::LEFT);
+        assert!(should_clamp_input_line_height(
+            &adjustment,
+            &FfiInputLineHeightMetrics {
+                current_line_height: 12.0,
+                minimum_line_height: 16.0,
+            }
+        ));
+        assert!(!should_clamp_input_line_height(
+            &adjustment,
+            &FfiInputLineHeightMetrics {
+                current_line_height: 18.0,
+                minimum_line_height: 16.0,
+            }
+        ));
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -1846,6 +1846,8 @@ pub const COMPUTED_KIND_FONT_STYLE: u8 = 6;
 pub const COMPUTED_KIND_COMPUTE_IN_CPP: u8 = 7;
 /// A keyword whose numeric code is carried in `value`.
 pub const COMPUTED_KIND_KEYWORD: u8 = 8;
+/// A display value encoded as tag | first << 8 | second << 16 | third << 24.
+pub const COMPUTED_KIND_DISPLAY: u8 = 9;
 
 /// The leaf callbacks the C++ side provides to the property computation
 /// driver. The driver selects each longhand's cascaded, inherited or initial
@@ -1867,10 +1869,10 @@ pub struct FfiLonghandCallbacks {
     /// Stores the used color scheme resolved from the computed color-scheme
     /// value and document preferences.
     pub store_effective_color_scheme: unsafe extern "C" fn(context: *mut c_void, color_scheme: u8),
-    /// Stores the original adjusted properties, applies the post-computation
-    /// changes after the ordinary longhand batch has been flushed, and returns
-    /// the font measurements needed for the input line-height decision.
-    pub store_box_type_transformation: unsafe extern "C" fn(
+    /// Stores the original adjusted properties for possible animation
+    /// restoration, records the pre-transformation display, and returns the
+    /// font measurements needed for the input line-height decision.
+    pub prepare_post_compute_adjustments: unsafe extern "C" fn(
         context: *mut c_void,
         display_before: *const FfiDisplay,
         float_before: u16,
@@ -1878,8 +1880,7 @@ pub struct FfiLonghandCallbacks {
         overflow_y_before: u16,
         text_align_before: u16,
         position_before: u16,
-        transformation: *const FfiBoxTypeTransformation,
-        element_adjustment: *const FfiElementStyleAdjustment,
+        check_input_line_height: bool,
     ) -> FfiInputLineHeightMetrics,
     /// Rare: fetches the parent's computed value for an explicit `inherit` of
     /// a non-inherited property, which the parent snapshot does not carry.
@@ -2826,7 +2827,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             clear_longhand_bit(inherited_words, prop::TEXT_ALIGN);
         }
         let input_line_height_metrics = unsafe {
-            (callbacks.store_box_type_transformation)(
+            (callbacks.prepare_post_compute_adjustments)(
                 context,
                 &raw const display_before,
                 float_before,
@@ -2834,26 +2835,62 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                 computed_overflow_y.expect("overflow-y must be computed by the longhand driver"),
                 computed_text_align_before_adjustment.expect("text-align must be computed by the longhand driver"),
                 box_type_input.position,
-                &raw const transformation,
-                &raw const element_adjustment,
+                element_adjustment.check_input_line_height,
             )
         };
         let clamp_input_line_height = should_clamp_input_line_height(&element_adjustment, &input_line_height_metrics);
-        if clamp_input_line_height {
-            let normal = initial_value(prop::LINE_HEIGHT);
-            let entry = FfiComputedStoreEntry {
-                property_id: prop::LINE_HEIGHT,
-                inherited_property_id: prop::LINE_HEIGHT,
-                shell: normal.shell,
-                inheritance_dependent: false,
-                inherited: false,
-                computed_kind: COMPUTED_KIND_KEYWORD,
-                value: keyword::NORMAL as f64,
-            };
-            crate::ffi_stats::bump(crate::ffi_stats::FfiOp::LonghandStoreBatchCallback);
-            unsafe { (callbacks.store_computed_batch)(context, &raw const entry, 1) };
+
+        let adjusted_display = if element_adjustment.changed_display {
+            element_adjustment.display
+        } else {
+            display_after_box_type_transformation
+        };
+        let adjusted_entry = |property_id, computed_kind, value| FfiComputedStoreEntry {
+            property_id,
+            inherited_property_id: property_id,
+            shell: initial_value(property_id).shell,
+            inheritance_dependent: false,
+            inherited: false,
+            computed_kind,
+            value,
+        };
+        let mut adjustments = Vec::new();
+        if transformation.set_float_none {
+            adjustments.push(adjusted_entry(prop::FLOAT, COMPUTED_KIND_KEYWORD, keyword::NONE as f64));
+        }
+        if adjusted_display != display_before {
+            adjustments.push(adjusted_entry(
+                prop::DISPLAY,
+                COMPUTED_KIND_DISPLAY,
+                adjusted_display.encoded() as f64,
+            ));
         }
         let line_height_changed = element_adjustment.set_line_height_normal || clamp_input_line_height;
+        if line_height_changed {
+            adjustments.push(adjusted_entry(
+                prop::LINE_HEIGHT,
+                COMPUTED_KIND_KEYWORD,
+                keyword::NORMAL as f64,
+            ));
+        }
+        if element_adjustment.set_position_static {
+            adjustments.push(adjusted_entry(
+                prop::POSITION,
+                COMPUTED_KIND_KEYWORD,
+                keyword::STATIC as f64,
+            ));
+        }
+        if element_adjustment.changed_text_align {
+            adjustments.push(adjusted_entry(
+                prop::TEXT_ALIGN,
+                COMPUTED_KIND_KEYWORD,
+                element_adjustment.text_align as f64,
+            ));
+        }
+        if !adjustments.is_empty() {
+            crate::ffi_stats::bump(crate::ffi_stats::FfiOp::LonghandStoreBatchCallback);
+            unsafe { (callbacks.store_computed_batch)(context, adjustments.as_ptr(), adjustments.len()) };
+        }
         if line_height_changed {
             clear_longhand_bit(important_words, prop::LINE_HEIGHT);
             clear_longhand_bit(inherited_words, prop::LINE_HEIGHT);
@@ -3087,6 +3124,16 @@ impl FfiDisplay {
 
     fn flow_root() -> Self {
         Self::outside_and_inside(display_outside::BLOCK, display_inside::FLOW_ROOT, false)
+    }
+
+    fn encoded(&self) -> u32 {
+        let (first, second, third) = match self.tag {
+            DISPLAY_TAG_OUTSIDE_AND_INSIDE => (self.outside, self.inside, self.list_item as u8),
+            DISPLAY_TAG_INTERNAL => (self.internal, 0, 0),
+            DISPLAY_TAG_BOX => (self.box_value, 0, 0),
+            _ => unreachable!("invalid display tag"),
+        };
+        self.tag as u32 | (first as u32) << 8 | (second as u32) << 16 | (third as u32) << 24
     }
 
     fn none() -> Self {
@@ -3701,6 +3748,27 @@ mod tests {
 
         let none = FfiDisplay::from_raw(u32::from_ne_bytes([DISPLAY_TAG_BOX, display_box::NONE, 0, 0]));
         assert!(none.is_none());
+    }
+
+    #[test]
+    fn display_encodes_for_adjustment_store() {
+        let list_item = FfiDisplay::outside_and_inside(display_outside::BLOCK, display_inside::FLOW, true);
+        assert_eq!(
+            list_item.encoded(),
+            DISPLAY_TAG_OUTSIDE_AND_INSIDE as u32
+                | (display_outside::BLOCK as u32) << 8
+                | (display_inside::FLOW as u32) << 16
+                | 1 << 24
+        );
+
+        assert_eq!(
+            FfiDisplay::internal(display_internal::TABLE_ROW).encoded(),
+            DISPLAY_TAG_INTERNAL as u32 | (display_internal::TABLE_ROW as u32) << 8
+        );
+        assert_eq!(
+            FfiDisplay::none().encoded(),
+            DISPLAY_TAG_BOX as u32 | (display_box::NONE as u32) << 8
+        );
     }
 
     fn element_adjustment_input() -> FfiBoxTypeTransformationInput {

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -1814,7 +1814,7 @@ pub struct FfiComputedStoreEntry {
     pub property_id: u16,
     pub inherited_property_id: u16,
     /// The selected specified value; also the stored value unless a computed
-    /// pixel length replaces it.
+    /// pixel length or keyword replaces it.
     pub shell: *const c_void,
     pub inheritance_dependent: bool,
     pub inherited: bool,
@@ -1844,6 +1844,8 @@ pub const COMPUTED_KIND_FONT_STYLE: u8 = 6;
 /// the reads later computations make, since those reads only happen inside
 /// callbacks the driver invokes after flushing.
 pub const COMPUTED_KIND_COMPUTE_IN_CPP: u8 = 7;
+/// A keyword whose numeric code is carried in `value`.
+pub const COMPUTED_KIND_KEYWORD: u8 = 8;
 
 /// The leaf callbacks the C++ side provides to the property computation
 /// driver. The driver selects each longhand's cascaded, inherited or initial
@@ -2063,8 +2065,8 @@ pub unsafe extern "C" fn rust_drive_property_computation(
     abort_on_panic(|| {
         use crate::property_metadata::{
             FIRST_INHERITED_PROPERTY_ID, NUMBER_OF_LONGHAND_PROPERTIES, REQUIRES_COMPUTATION_ALWAYS,
-            REQUIRES_COMPUTATION_CASCADED, REQUIRES_COMPUTATION_NON_INHERITED, property_is_inherited,
-            property_requires_computation_level,
+            REQUIRES_COMPUTATION_CASCADED, REQUIRES_COMPUTATION_NON_INHERITED, property_id as prop,
+            property_is_inherited, property_requires_computation_level,
         };
 
         let callbacks = unsafe { &*callbacks };
@@ -2143,6 +2145,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
         // both properties only take keywords, whose computed value is the specified one.
         let mut computed_writing_mode: Option<u8> = None;
         let mut computed_direction: Option<u8> = None;
+        let mut computed_overflow_x: Option<u16> = None;
 
         for &property_id in crate::property_metadata::property_computation_order() {
             let mut cascaded_property_id = property_id;
@@ -2624,6 +2627,31 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                     value: 0.0,
                 });
             }
+
+            if property_id == prop::OVERFLOW_X {
+                if let StyleValueData::Keyword { keyword } = value_data {
+                    computed_overflow_x = Some(*keyword);
+                }
+            } else if property_id == prop::OVERFLOW_Y
+                && let (Some(overflow_x), StyleValueData::Keyword { keyword: overflow_y }) =
+                    (computed_overflow_x, value_data)
+            {
+                let effective_overflow = resolve_effective_overflow_keywords(overflow_x, *overflow_y);
+                for entry in pending_stores.iter_mut().rev() {
+                    if entry.property_id == prop::OVERFLOW_X && effective_overflow.changed_x {
+                        debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_SHELL);
+                        entry.computed_kind = COMPUTED_KIND_KEYWORD;
+                        entry.value = effective_overflow.x_keyword as f64;
+                    } else if entry.property_id == prop::OVERFLOW_Y && effective_overflow.changed_y {
+                        debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_SHELL);
+                        entry.computed_kind = COMPUTED_KIND_KEYWORD;
+                        entry.value = effective_overflow.y_keyword as f64;
+                    }
+                    if entry.property_id == prop::OVERFLOW_X {
+                        break;
+                    }
+                }
+            }
         }
 
         flush_pending_stores(callbacks, context, &mut pending_stores);
@@ -3041,37 +3069,39 @@ pub struct FfiEffectiveOverflow {
 /// https://www.w3.org/TR/css-overflow-3/#overflow-control
 /// The visible/clip values of overflow compute to auto/hidden (respectively) if one of overflow-x or
 /// overflow-y is neither visible nor clip.
+fn resolve_effective_overflow_keywords(overflow_x: u16, overflow_y: u16) -> FfiEffectiveOverflow {
+    let is_visible_or_clip = |keyword: u16| keyword == keyword::VISIBLE || keyword == keyword::CLIP;
+    let mut result = FfiEffectiveOverflow {
+        changed_x: false,
+        x_keyword: overflow_x,
+        changed_y: false,
+        y_keyword: overflow_y,
+    };
+    if !is_visible_or_clip(overflow_x) || !is_visible_or_clip(overflow_y) {
+        if overflow_x == keyword::VISIBLE {
+            result.changed_x = true;
+            result.x_keyword = keyword::AUTO;
+        }
+        if overflow_x == keyword::CLIP {
+            result.changed_x = true;
+            result.x_keyword = keyword::HIDDEN;
+        }
+        if overflow_y == keyword::VISIBLE {
+            result.changed_y = true;
+            result.y_keyword = keyword::AUTO;
+        }
+        if overflow_y == keyword::CLIP {
+            result.changed_y = true;
+            result.y_keyword = keyword::HIDDEN;
+        }
+    }
+    result
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_resolve_effective_overflow_keywords(overflow_x: u16, overflow_y: u16) -> FfiEffectiveOverflow {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let is_visible_or_clip = |keyword: u16| keyword == keyword::VISIBLE || keyword == keyword::CLIP;
-        let mut result = FfiEffectiveOverflow {
-            changed_x: false,
-            x_keyword: overflow_x,
-            changed_y: false,
-            y_keyword: overflow_y,
-        };
-        if !is_visible_or_clip(overflow_x) || !is_visible_or_clip(overflow_y) {
-            if overflow_x == keyword::VISIBLE {
-                result.changed_x = true;
-                result.x_keyword = keyword::AUTO;
-            }
-            if overflow_x == keyword::CLIP {
-                result.changed_x = true;
-                result.x_keyword = keyword::HIDDEN;
-            }
-            if overflow_y == keyword::VISIBLE {
-                result.changed_y = true;
-                result.y_keyword = keyword::AUTO;
-            }
-            if overflow_y == keyword::CLIP {
-                result.changed_y = true;
-                result.y_keyword = keyword::HIDDEN;
-            }
-        }
-        result
-    })
+    abort_on_panic(|| resolve_effective_overflow_keywords(overflow_x, overflow_y))
 }
 
 /// Result of the text-align adjustment: the replacement keyword and whether it
@@ -3183,6 +3213,25 @@ mod ffi_test_stubs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn effective_overflow_keywords_compute_together() {
+        let result = resolve_effective_overflow_keywords(keyword::VISIBLE, keyword::AUTO);
+        assert!(result.changed_x);
+        assert_eq!(result.x_keyword, keyword::AUTO);
+        assert!(!result.changed_y);
+        assert_eq!(result.y_keyword, keyword::AUTO);
+
+        let result = resolve_effective_overflow_keywords(keyword::CLIP, keyword::SCROLL);
+        assert!(result.changed_x);
+        assert_eq!(result.x_keyword, keyword::HIDDEN);
+        assert!(!result.changed_y);
+        assert_eq!(result.y_keyword, keyword::SCROLL);
+
+        let result = resolve_effective_overflow_keywords(keyword::VISIBLE, keyword::CLIP);
+        assert!(!result.changed_x);
+        assert!(!result.changed_y);
+    }
 
     fn test_context() -> FfiLengthResolutionContext {
         FfiLengthResolutionContext {

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -2055,6 +2055,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
     callbacks: *const FfiLonghandCallbacks,
     store: *const CascadedPropertyStore,
     parent_snapshot: *const FfiParentSnapshot,
+    is_th_element: bool,
     has_new_font_size: bool,
     device_pixels_per_css_pixel: f64,
     initial_font_size_raw: i32,
@@ -2651,6 +2652,42 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                         break;
                     }
                 }
+            } else if property_id == prop::TEXT_ALIGN
+                && let StyleValueData::Keyword { keyword: text_align } = value_data
+            {
+                let (has_parent_with_computed_values, parent_text_align, parent_direction_is_ltr) =
+                    if let Some(snapshot) = snapshot {
+                        let parent_text_align = match snapshot_entry_data(snapshot, prop::TEXT_ALIGN) {
+                            Some(StyleValueData::Keyword { keyword }) => *keyword,
+                            _ => unreachable!("parent text-align must be a keyword"),
+                        };
+                        let parent_direction_is_ltr = match snapshot_entry_data(snapshot, prop::DIRECTION) {
+                            Some(StyleValueData::Keyword {
+                                keyword: parent_direction,
+                            }) => *parent_direction == keyword::LTR,
+                            _ => unreachable!("parent direction must be a keyword"),
+                        };
+                        (true, parent_text_align, parent_direction_is_ltr)
+                    } else {
+                        (false, 0, true)
+                    };
+                let adjustment = compute_text_align_adjustment(
+                    *text_align,
+                    is_th_element,
+                    has_parent_with_computed_values,
+                    parent_text_align,
+                    parent_direction_is_ltr,
+                );
+                if adjustment.changed {
+                    let entry = pending_stores.last_mut().unwrap();
+                    debug_assert_eq!(entry.property_id, prop::TEXT_ALIGN);
+                    debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_SHELL);
+                    entry.computed_kind = COMPUTED_KIND_KEYWORD;
+                    entry.value = adjustment.keyword as f64;
+                    if adjustment.inherited {
+                        set_longhand_bit(inherited_words, property_id);
+                    }
+                }
             }
         }
 
@@ -3115,6 +3152,58 @@ pub struct FfiTextAlignAdjustment {
 
 /// Decides the text-align adjustments applied after computation. The parent
 /// arguments are only read when `has_parent_with_computed_values` is set.
+fn compute_text_align_adjustment(
+    text_align: u16,
+    is_th_element: bool,
+    has_parent_with_computed_values: bool,
+    parent_text_align: u16,
+    parent_direction_is_ltr: bool,
+) -> FfiTextAlignAdjustment {
+    let unchanged = FfiTextAlignAdjustment {
+        changed: false,
+        keyword: text_align,
+        inherited: false,
+    };
+    let replace = |keyword: u16| FfiTextAlignAdjustment {
+        changed: true,
+        keyword,
+        inherited: false,
+    };
+
+    // https://drafts.csswg.org/css-text-4/#valdef-text-align-match-parent
+    // This value behaves the same as inherit (computes to its parent's computed value) except that an inherited
+    // value of start or end is interpreted against the parent's direction value and results in a computed value of
+    // either left or right. Computes to start when specified on the root element.
+    if text_align == keyword::MATCH_PARENT {
+        if !has_parent_with_computed_values {
+            return replace(keyword::START);
+        }
+        return match parent_text_align {
+            keyword::START if parent_direction_is_ltr => replace(keyword::LEFT),
+            keyword::START => replace(keyword::RIGHT),
+            keyword::END if parent_direction_is_ltr => replace(keyword::RIGHT),
+            keyword::END => replace(keyword::LEFT),
+            _ => replace(parent_text_align),
+        };
+    }
+
+    // AD-HOC: The -libweb-inherit-or-center style defaults to centering, unless the parent element has a
+    //         non-initial computed text-align value. This is used to support the ad-hoc default <th>
+    //         text-align behavior.
+    if text_align == keyword::_LIBWEB_INHERIT_OR_CENTER && is_th_element {
+        if has_parent_with_computed_values && parent_text_align != keyword::START {
+            return FfiTextAlignAdjustment {
+                changed: true,
+                keyword: parent_text_align,
+                inherited: true,
+            };
+        }
+        return replace(keyword::CENTER);
+    }
+
+    unchanged
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_compute_text_align(
     text_align: u16,
@@ -3125,49 +3214,13 @@ pub extern "C" fn rust_compute_text_align(
 ) -> FfiTextAlignAdjustment {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::NestedPropertyComputeEntry);
     abort_on_panic(|| {
-        let unchanged = FfiTextAlignAdjustment {
-            changed: false,
-            keyword: text_align,
-            inherited: false,
-        };
-        let replace = |keyword: u16| FfiTextAlignAdjustment {
-            changed: true,
-            keyword,
-            inherited: false,
-        };
-
-        // https://drafts.csswg.org/css-text-4/#valdef-text-align-match-parent
-        // This value behaves the same as inherit (computes to its parent's computed value) except that an inherited
-        // value of start or end is interpreted against the parent's direction value and results in a computed value of
-        // either left or right. Computes to start when specified on the root element.
-        if text_align == keyword::MATCH_PARENT {
-            if !has_parent_with_computed_values {
-                return replace(keyword::START);
-            }
-            return match parent_text_align {
-                keyword::START if parent_direction_is_ltr => replace(keyword::LEFT),
-                keyword::START => replace(keyword::RIGHT),
-                keyword::END if parent_direction_is_ltr => replace(keyword::RIGHT),
-                keyword::END => replace(keyword::LEFT),
-                _ => replace(parent_text_align),
-            };
-        }
-
-        // AD-HOC: The -libweb-inherit-or-center style defaults to centering, unless the parent element has a
-        //         non-initial computed text-align value. This is used to support the ad-hoc default <th>
-        //         text-align behavior.
-        if text_align == keyword::_LIBWEB_INHERIT_OR_CENTER && is_th_element {
-            if has_parent_with_computed_values && parent_text_align != keyword::START {
-                return FfiTextAlignAdjustment {
-                    changed: true,
-                    keyword: parent_text_align,
-                    inherited: true,
-                };
-            }
-            return replace(keyword::CENTER);
-        }
-
-        unchanged
+        compute_text_align_adjustment(
+            text_align,
+            is_th_element,
+            has_parent_with_computed_values,
+            parent_text_align,
+            parent_direction_is_ltr,
+        )
     })
 }
 
@@ -3231,6 +3284,25 @@ mod tests {
         let result = resolve_effective_overflow_keywords(keyword::VISIBLE, keyword::CLIP);
         assert!(!result.changed_x);
         assert!(!result.changed_y);
+    }
+
+    #[test]
+    fn text_align_adjusts_match_parent_and_table_header_defaults() {
+        let result = compute_text_align_adjustment(keyword::MATCH_PARENT, false, true, keyword::START, false);
+        assert!(result.changed);
+        assert_eq!(result.keyword, keyword::RIGHT);
+        assert!(!result.inherited);
+
+        let result =
+            compute_text_align_adjustment(keyword::_LIBWEB_INHERIT_OR_CENTER, true, true, keyword::JUSTIFY, true);
+        assert!(result.changed);
+        assert_eq!(result.keyword, keyword::JUSTIFY);
+        assert!(result.inherited);
+
+        let result = compute_text_align_adjustment(keyword::_LIBWEB_INHERIT_OR_CENTER, true, false, 0, true);
+        assert!(result.changed);
+        assert_eq!(result.keyword, keyword::CENTER);
+        assert!(!result.inherited);
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -1873,8 +1873,10 @@ pub struct FfiLonghandCallbacks {
         overflow_x_before: u16,
         overflow_y_before: u16,
         text_align_before: u16,
+        position_before: u16,
         transformation: *const FfiBoxTypeTransformation,
-    ),
+        element_adjustment: *const FfiElementStyleAdjustment,
+    ) -> bool,
     /// Rare: fetches the parent's computed value for an explicit `inherit` of
     /// a non-inherited property, which the parent snapshot does not carry.
     /// The C++ side pins the returned shell until the end of the drive, so
@@ -2166,6 +2168,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
         let mut computed_direction: Option<u8> = None;
         let mut computed_overflow_x: Option<u16> = None;
         let mut computed_overflow_y: Option<u16> = None;
+        let mut computed_text_align_before_adjustment: Option<u16> = None;
         let mut computed_text_align: Option<u16> = None;
         let mut computed_display: Option<FfiDisplay> = None;
         let mut computed_float: Option<u16> = None;
@@ -2683,7 +2686,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             } else if property_id == prop::TEXT_ALIGN
                 && let StyleValueData::Keyword { keyword: text_align } = value_data
             {
-                computed_text_align = Some(*text_align);
+                computed_text_align_before_adjustment = Some(*text_align);
                 let (has_parent_with_computed_values, parent_text_align, parent_direction_is_ltr) =
                     if let Some(snapshot) = snapshot {
                         let parent_text_align = match snapshot_entry_data(snapshot, prop::TEXT_ALIGN) {
@@ -2719,6 +2722,11 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                         set_longhand_bit(inherited_words, property_id);
                     }
                 }
+                computed_text_align = Some(if adjustment.changed {
+                    adjustment.keyword
+                } else {
+                    *text_align
+                });
             }
 
             match (property_id, value_data) {
@@ -2743,6 +2751,14 @@ pub unsafe extern "C" fn rust_drive_property_computation(
         box_type_input.float_value = float_before;
         box_type_input.position = computed_position.expect("position must be computed by the longhand driver");
         let transformation = transform_box_type(&box_type_input);
+        let display_after_box_type_transformation = if transformation.changed_display {
+            transformation.display
+        } else {
+            display_before
+        };
+        let text_align = computed_text_align.expect("text-align must be computed by the longhand driver");
+        let element_adjustment =
+            adjust_element_style(&box_type_input, display_after_box_type_transformation, text_align);
         if transformation.set_float_none {
             clear_longhand_bit(important_words, prop::FLOAT);
             clear_longhand_bit(inherited_words, prop::FLOAT);
@@ -2751,16 +2767,34 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             clear_longhand_bit(important_words, prop::DISPLAY);
             clear_longhand_bit(inherited_words, prop::DISPLAY);
         }
-        unsafe {
+        if element_adjustment.changed_display {
+            clear_longhand_bit(important_words, prop::DISPLAY);
+            clear_longhand_bit(inherited_words, prop::DISPLAY);
+        }
+        if element_adjustment.set_position_static {
+            clear_longhand_bit(important_words, prop::POSITION);
+            clear_longhand_bit(inherited_words, prop::POSITION);
+        }
+        if element_adjustment.changed_text_align {
+            clear_longhand_bit(important_words, prop::TEXT_ALIGN);
+            clear_longhand_bit(inherited_words, prop::TEXT_ALIGN);
+        }
+        let line_height_changed = unsafe {
             (callbacks.store_box_type_transformation)(
                 context,
                 &raw const display_before,
                 float_before,
                 computed_overflow_x.expect("overflow-x must be computed by the longhand driver"),
                 computed_overflow_y.expect("overflow-y must be computed by the longhand driver"),
-                computed_text_align.expect("text-align must be computed by the longhand driver"),
+                computed_text_align_before_adjustment.expect("text-align must be computed by the longhand driver"),
+                box_type_input.position,
                 &raw const transformation,
-            );
+                &raw const element_adjustment,
+            )
+        };
+        if line_height_changed {
+            clear_longhand_bit(important_words, prop::LINE_HEIGHT);
+            clear_longhand_bit(inherited_words, prop::LINE_HEIGHT);
         }
     });
 }
@@ -2981,6 +3015,29 @@ impl FfiDisplay {
         Self::outside_and_inside(display_outside::BLOCK, display_inside::FLOW, false)
     }
 
+    fn inline() -> Self {
+        Self::outside_and_inside(display_outside::INLINE, display_inside::FLOW, false)
+    }
+
+    fn inline_block() -> Self {
+        Self::outside_and_inside(display_outside::INLINE, display_inside::FLOW_ROOT, false)
+    }
+
+    fn flow_root() -> Self {
+        Self::outside_and_inside(display_outside::BLOCK, display_inside::FLOW_ROOT, false)
+    }
+
+    fn none() -> Self {
+        Self {
+            tag: DISPLAY_TAG_BOX,
+            outside: 0,
+            inside: 0,
+            list_item: false,
+            internal: 0,
+            box_value: display_box::NONE,
+        }
+    }
+
     fn is_outside_and_inside(&self) -> bool {
         self.tag == DISPLAY_TAG_OUTSIDE_AND_INSIDE
     }
@@ -3039,6 +3096,16 @@ pub struct FfiBoxTypeTransformationInput {
     pub is_mathml_mtd: bool,
     pub has_parent_display: bool,
     pub parent_display: FfiDisplay,
+    pub is_wbr_element: bool,
+    pub disallow_display_contents: bool,
+    pub rewrite_inline_flow: bool,
+    pub is_button_element: bool,
+    pub force_line_height_normal: bool,
+    pub check_input_line_height: bool,
+    pub hide_audio_without_controls: bool,
+    pub is_table_element: bool,
+    pub force_position_static: bool,
+    pub force_symbol_display_inline: bool,
 }
 
 /// Result of the box type transformation: whether float must be reset to none,
@@ -3049,6 +3116,82 @@ pub struct FfiBoxTypeTransformation {
     pub set_float_none: bool,
     pub changed_display: bool,
     pub display: FfiDisplay,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FfiElementStyleAdjustment {
+    pub changed_display: bool,
+    pub display: FfiDisplay,
+    pub set_line_height_normal: bool,
+    pub check_input_line_height: bool,
+    pub set_position_static: bool,
+    pub changed_text_align: bool,
+    pub text_align: u16,
+}
+
+fn adjust_element_style(
+    input: &FfiBoxTypeTransformationInput,
+    display: FfiDisplay,
+    text_align: u16,
+) -> FfiElementStyleAdjustment {
+    let mut new_display = display;
+    if input.is_wbr_element && display.is_contents() {
+        new_display = FfiDisplay::none();
+    }
+    if input.disallow_display_contents && new_display.is_contents() {
+        new_display = FfiDisplay::none();
+    }
+    if input.rewrite_inline_flow && new_display.is_inline_outside() && new_display.inside == display_inside::FLOW {
+        new_display = FfiDisplay::inline_block();
+    }
+    if input.is_button_element
+        && !(new_display.is_flex_inside()
+            || new_display.is_grid_inside()
+            || new_display.is_none()
+            || new_display.is_contents())
+    {
+        new_display = if new_display.is_inline_outside() {
+            FfiDisplay::inline_block()
+        } else {
+            FfiDisplay::flow_root()
+        };
+    }
+    if input.is_br_element {
+        new_display = if new_display.is_contents() {
+            FfiDisplay::none()
+        } else if new_display.is_none() {
+            new_display
+        } else {
+            FfiDisplay::inline()
+        };
+    }
+    if input.hide_audio_without_controls {
+        new_display = FfiDisplay::none();
+    }
+    if input.force_symbol_display_inline {
+        new_display = FfiDisplay::inline();
+    }
+
+    let new_text_align = if input.is_table_element
+        && matches!(
+            text_align,
+            keyword::_LIBWEB_LEFT | keyword::_LIBWEB_CENTER | keyword::_LIBWEB_RIGHT
+        ) {
+        keyword::START
+    } else {
+        text_align
+    };
+
+    FfiElementStyleAdjustment {
+        changed_display: new_display != display,
+        display: new_display,
+        set_line_height_normal: input.force_line_height_normal,
+        check_input_line_height: input.check_input_line_height,
+        set_position_static: input.force_position_static,
+        changed_text_align: new_text_align != text_align,
+        text_align: new_text_align,
+    }
 }
 
 // NB: css-display-3 also defines inlinification, but nothing triggers it yet (the only
@@ -3404,6 +3547,61 @@ mod tests {
 
         let none = FfiDisplay::from_raw(u32::from_ne_bytes([DISPLAY_TAG_BOX, display_box::NONE, 0, 0]));
         assert!(none.is_none());
+    }
+
+    fn element_adjustment_input() -> FfiBoxTypeTransformationInput {
+        FfiBoxTypeTransformationInput {
+            display: FfiDisplay::inline(),
+            position: keyword::STATIC,
+            float_value: keyword::NONE,
+            is_br_element: false,
+            is_document_element: false,
+            is_mathml_element: false,
+            is_mathml_mtable: false,
+            is_mathml_mtr: false,
+            is_mathml_mtd: false,
+            has_parent_display: false,
+            parent_display: FfiDisplay::block(),
+            is_wbr_element: false,
+            disallow_display_contents: false,
+            rewrite_inline_flow: false,
+            is_button_element: false,
+            force_line_height_normal: false,
+            check_input_line_height: false,
+            hide_audio_without_controls: false,
+            is_table_element: false,
+            force_position_static: false,
+            force_symbol_display_inline: false,
+        }
+    }
+
+    #[test]
+    fn element_styles_adjust_from_marshaled_facts() {
+        let mut input = element_adjustment_input();
+        input.disallow_display_contents = true;
+        let contents = FfiDisplay {
+            tag: DISPLAY_TAG_BOX,
+            outside: 0,
+            inside: 0,
+            list_item: false,
+            internal: 0,
+            box_value: display_box::CONTENTS,
+        };
+        let adjustment = adjust_element_style(&input, contents, keyword::LEFT);
+        assert!(adjustment.changed_display);
+        assert!(adjustment.display.is_none());
+
+        input = element_adjustment_input();
+        input.is_button_element = true;
+        let adjustment = adjust_element_style(&input, FfiDisplay::inline(), keyword::LEFT);
+        assert!(adjustment.changed_display);
+        assert!(adjustment.display.is_inline_block());
+
+        input = element_adjustment_input();
+        input.is_table_element = true;
+        let adjustment = adjust_element_style(&input, FfiDisplay::block(), keyword::_LIBWEB_CENTER);
+        assert!(adjustment.changed_text_align);
+        assert_eq!(adjustment.text_align, keyword::START);
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -1864,6 +1864,9 @@ pub struct FfiLonghandCallbacks {
     /// are pinned by the snapshot or the fetch below.
     pub store_computed_batch:
         unsafe extern "C" fn(context: *mut c_void, entries: *const FfiComputedStoreEntry, count: usize),
+    /// Stores the used color scheme resolved from the computed color-scheme
+    /// value and document preferences.
+    pub store_effective_color_scheme: unsafe extern "C" fn(context: *mut c_void, color_scheme: u8),
     /// Stores the original display and applies the box type transformation
     /// after the ordinary longhand batch has been flushed.
     pub store_box_type_transformation: unsafe extern "C" fn(
@@ -1897,6 +1900,36 @@ pub struct FfiLonghandCallbacks {
     /// first, since building a context reads stored values.
     pub length_resolution_context:
         unsafe extern "C" fn(context: *mut c_void, property_id: u16, out: *mut FfiLengthResolutionContext),
+}
+
+/// Document-level inputs to used color-scheme resolution. Scheme values use
+/// the C++ PreferredColorScheme discriminants: auto, dark, and light.
+#[repr(C)]
+pub struct FfiEffectiveColorSchemeInput {
+    pub preferred_color_scheme: u8,
+    pub has_document_supported_schemes: bool,
+    pub document_supported_scheme_codes: *const u8,
+    pub document_supported_scheme_count: usize,
+}
+
+impl FfiEffectiveColorSchemeInput {
+    /// # Safety
+    /// The document-supported scheme storage must be valid for the returned
+    /// slice's lifetime.
+    unsafe fn document_supported_schemes(&self) -> Option<&[u8]> {
+        self.has_document_supported_schemes.then(|| {
+            if self.document_supported_scheme_count == 0 {
+                &[][..]
+            } else {
+                unsafe {
+                    std::slice::from_raw_parts(
+                        self.document_supported_scheme_codes,
+                        self.document_supported_scheme_count,
+                    )
+                }
+            }
+        })
+    }
 }
 
 /// The computation-context kind a property's lengths resolve against,
@@ -2066,15 +2099,17 @@ fn clear_longhand_bit(words: &mut [u64], property_id: u16) {
 /// # Safety
 /// `callbacks` must point at a valid callback table, `store` at a valid
 /// cascaded property store, `parent_snapshot` at a valid snapshot or null,
-/// `box_type_input` at valid element facts, and `results` at a results block
-/// whose bitmap storage covers every longhand; the callbacks must not mutate
-/// the store for the duration of the call.
+/// `box_type_input` and `color_scheme_input` at valid element and document
+/// facts, and `results` at a results block whose bitmap storage covers every
+/// longhand; the callbacks must not mutate the store for the duration of the
+/// call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_drive_property_computation(
     callbacks: *const FfiLonghandCallbacks,
     store: *const CascadedPropertyStore,
     parent_snapshot: *const FfiParentSnapshot,
     box_type_input: *const FfiBoxTypeTransformationInput,
+    color_scheme_input: *const FfiEffectiveColorSchemeInput,
     is_th_element: bool,
     has_new_font_size: bool,
     device_pixels_per_css_pixel: f64,
@@ -2099,6 +2134,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             Some(unsafe { &*parent_snapshot })
         };
         let has_inheritance_parent = snapshot.is_some();
+        let color_scheme_input = unsafe { &*color_scheme_input };
         let results = unsafe { &mut *results };
         assert!(results.word_count * 64 >= NUMBER_OF_LONGHAND_PROPERTIES);
         let important_words = unsafe { std::slice::from_raw_parts_mut(results.important_words, results.word_count) };
@@ -2727,6 +2763,15 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                 } else {
                     *text_align
                 });
+            } else if property_id == prop::COLOR_SCHEME
+                && let StyleValueData::ColorScheme { scheme_codes, .. } = value_data
+            {
+                let color_scheme = resolve_effective_color_scheme(
+                    scheme_codes.as_slice(),
+                    color_scheme_input.preferred_color_scheme,
+                    unsafe { color_scheme_input.document_supported_schemes() },
+                );
+                unsafe { (callbacks.store_effective_color_scheme)(context, color_scheme) };
             }
 
             match (property_id, value_data) {
@@ -3370,6 +3415,71 @@ pub extern "C" fn rust_resolve_effective_overflow_keywords(overflow_x: u16, over
     abort_on_panic(|| resolve_effective_overflow_keywords(overflow_x, overflow_y))
 }
 
+// https://drafts.csswg.org/css-color-adjust-1/#determine-the-used-color-scheme
+fn resolve_effective_color_scheme(
+    schemes: &[u8],
+    preferred_scheme: u8,
+    document_supported_schemes: Option<&[u8]>,
+) -> u8 {
+    const AUTO: u8 = 0;
+    const LIGHT: u8 = 2;
+
+    // To determine the used color scheme of an element:
+
+    // 1. If the user’s preferred color scheme, as indicated by the prefers-color-scheme media feature,
+    //    is present among the listed color schemes, and is supported by the user agent,
+    //    that’s the element’s used color scheme.
+    if preferred_scheme != AUTO && schemes.contains(&preferred_scheme) {
+        return preferred_scheme;
+    }
+
+    // 2. Otherwise, if the user has indicated an overriding preference for their chosen color scheme,
+    //    and the only keyword is not present in color-scheme for the element,
+    //    the user agent must override the color scheme with the user’s preferred color scheme.
+    //    See § 2.3 Overriding the Color Scheme.
+    // FIXME: We don't currently support setting an "overriding preference" for color schemes.
+
+    // 3. Otherwise, if the user agent supports at least one of the listed color schemes,
+    //    the used color scheme is the first supported color scheme in the list.
+    if let Some(first_supported) = schemes.iter().find(|scheme| **scheme != AUTO) {
+        return *first_supported;
+    }
+
+    // 4. Otherwise, the used color scheme is the browser default. (Same as normal.)
+    // `normal` indicates that the element supports the page’s supported color schemes, if they are set
+    if let Some(document_supported_schemes) = document_supported_schemes {
+        if preferred_scheme != AUTO && document_supported_schemes.contains(&preferred_scheme) {
+            return preferred_scheme;
+        }
+        if let Some(first_supported) = document_supported_schemes.iter().find(|scheme| **scheme != AUTO) {
+            return *first_supported;
+        }
+    }
+
+    LIGHT
+}
+
+/// Resolves the used color scheme for a value that required C++ computation.
+///
+/// # Safety
+/// `value` must point at valid ColorScheme StyleValueData and `input` at valid
+/// document inputs for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_resolve_effective_color_scheme(
+    value: *const c_void,
+    input: *const FfiEffectiveColorSchemeInput,
+) -> u8 {
+    abort_on_panic(|| {
+        let StyleValueData::ColorScheme { scheme_codes, .. } = (unsafe { &*(value as *const StyleValueData) }) else {
+            unreachable!("computed color-scheme must have color-scheme data");
+        };
+        let input = unsafe { &*input };
+        resolve_effective_color_scheme(scheme_codes.as_slice(), input.preferred_color_scheme, unsafe {
+            input.document_supported_schemes()
+        })
+    })
+}
+
 /// Result of the text-align adjustment: the replacement keyword and whether it
 /// counts as inherited.
 #[repr(C)]
@@ -3513,6 +3623,23 @@ mod tests {
         let result = resolve_effective_overflow_keywords(keyword::VISIBLE, keyword::CLIP);
         assert!(!result.changed_x);
         assert!(!result.changed_y);
+    }
+
+    #[test]
+    fn effective_color_scheme_follows_element_and_document_preferences() {
+        const AUTO: u8 = 0;
+        const DARK: u8 = 1;
+        const LIGHT: u8 = 2;
+
+        assert_eq!(resolve_effective_color_scheme(&[LIGHT, DARK], DARK, None), DARK);
+        assert_eq!(resolve_effective_color_scheme(&[DARK, LIGHT], LIGHT, None), LIGHT);
+        assert_eq!(resolve_effective_color_scheme(&[DARK, LIGHT], AUTO, None), DARK);
+        assert_eq!(
+            resolve_effective_color_scheme(&[AUTO], DARK, Some(&[LIGHT, DARK])),
+            DARK
+        );
+        assert_eq!(resolve_effective_color_scheme(&[], AUTO, Some(&[DARK])), DARK);
+        assert_eq!(resolve_effective_color_scheme(&[], AUTO, None), LIGHT);
     }
 
     #[test]

--- a/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_compute.rs
@@ -1864,6 +1864,17 @@ pub struct FfiLonghandCallbacks {
     /// are pinned by the snapshot or the fetch below.
     pub store_computed_batch:
         unsafe extern "C" fn(context: *mut c_void, entries: *const FfiComputedStoreEntry, count: usize),
+    /// Stores the original display and applies the box type transformation
+    /// after the ordinary longhand batch has been flushed.
+    pub store_box_type_transformation: unsafe extern "C" fn(
+        context: *mut c_void,
+        display_before: *const FfiDisplay,
+        float_before: u16,
+        overflow_x_before: u16,
+        overflow_y_before: u16,
+        text_align_before: u16,
+        transformation: *const FfiBoxTypeTransformation,
+    ),
     /// Rare: fetches the parent's computed value for an explicit `inherit` of
     /// a non-inherited property, which the parent snapshot does not carry.
     /// The C++ side pins the returned shell until the end of the drive, so
@@ -2036,6 +2047,12 @@ fn set_longhand_bit(words: &mut [u64], property_id: u16) {
     words[index / 64] |= 1 << (index % 64);
 }
 
+fn clear_longhand_bit(words: &mut [u64], property_id: u16) {
+    use crate::property_metadata::FIRST_LONGHAND_PROPERTY_ID;
+    let index = (property_id - FIRST_LONGHAND_PROPERTY_ID) as usize;
+    words[index / 64] &= !(1 << (index % 64));
+}
+
 /// Drives the property computation loop: iterates every longhand in
 /// computation order, resolves logical pairing, reads the winning cascaded
 /// declarations straight from the store, selects between the cascaded,
@@ -2047,14 +2064,15 @@ fn set_longhand_bit(words: &mut [u64], property_id: u16) {
 /// # Safety
 /// `callbacks` must point at a valid callback table, `store` at a valid
 /// cascaded property store, `parent_snapshot` at a valid snapshot or null,
-/// and `results` at a results block whose bitmap storage covers every
-/// longhand; the callbacks must not mutate the store for the duration of the
-/// call.
+/// `box_type_input` at valid element facts, and `results` at a results block
+/// whose bitmap storage covers every longhand; the callbacks must not mutate
+/// the store for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_drive_property_computation(
     callbacks: *const FfiLonghandCallbacks,
     store: *const CascadedPropertyStore,
     parent_snapshot: *const FfiParentSnapshot,
+    box_type_input: *const FfiBoxTypeTransformationInput,
     is_th_element: bool,
     has_new_font_size: bool,
     device_pixels_per_css_pixel: f64,
@@ -2147,6 +2165,11 @@ pub unsafe extern "C" fn rust_drive_property_computation(
         let mut computed_writing_mode: Option<u8> = None;
         let mut computed_direction: Option<u8> = None;
         let mut computed_overflow_x: Option<u16> = None;
+        let mut computed_overflow_y: Option<u16> = None;
+        let mut computed_text_align: Option<u16> = None;
+        let mut computed_display: Option<FfiDisplay> = None;
+        let mut computed_float: Option<u16> = None;
+        let mut computed_position: Option<u16> = None;
 
         for &property_id in crate::property_metadata::property_computation_order() {
             let mut cascaded_property_id = property_id;
@@ -2637,16 +2660,21 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                 && let (Some(overflow_x), StyleValueData::Keyword { keyword: overflow_y }) =
                     (computed_overflow_x, value_data)
             {
+                computed_overflow_y = Some(*overflow_y);
                 let effective_overflow = resolve_effective_overflow_keywords(overflow_x, *overflow_y);
                 for entry in pending_stores.iter_mut().rev() {
                     if entry.property_id == prop::OVERFLOW_X && effective_overflow.changed_x {
                         debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_SHELL);
                         entry.computed_kind = COMPUTED_KIND_KEYWORD;
                         entry.value = effective_overflow.x_keyword as f64;
+                        clear_longhand_bit(important_words, prop::OVERFLOW_X);
+                        clear_longhand_bit(inherited_words, prop::OVERFLOW_X);
                     } else if entry.property_id == prop::OVERFLOW_Y && effective_overflow.changed_y {
                         debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_SHELL);
                         entry.computed_kind = COMPUTED_KIND_KEYWORD;
                         entry.value = effective_overflow.y_keyword as f64;
+                        clear_longhand_bit(important_words, prop::OVERFLOW_Y);
+                        clear_longhand_bit(inherited_words, prop::OVERFLOW_Y);
                     }
                     if entry.property_id == prop::OVERFLOW_X {
                         break;
@@ -2655,6 +2683,7 @@ pub unsafe extern "C" fn rust_drive_property_computation(
             } else if property_id == prop::TEXT_ALIGN
                 && let StyleValueData::Keyword { keyword: text_align } = value_data
             {
+                computed_text_align = Some(*text_align);
                 let (has_parent_with_computed_values, parent_text_align, parent_direction_is_ltr) =
                     if let Some(snapshot) = snapshot {
                         let parent_text_align = match snapshot_entry_data(snapshot, prop::TEXT_ALIGN) {
@@ -2684,14 +2713,55 @@ pub unsafe extern "C" fn rust_drive_property_computation(
                     debug_assert_eq!(entry.computed_kind, COMPUTED_KIND_SHELL);
                     entry.computed_kind = COMPUTED_KIND_KEYWORD;
                     entry.value = adjustment.keyword as f64;
+                    clear_longhand_bit(important_words, property_id);
+                    clear_longhand_bit(inherited_words, property_id);
                     if adjustment.inherited {
                         set_longhand_bit(inherited_words, property_id);
                     }
                 }
             }
+
+            match (property_id, value_data) {
+                (prop::DISPLAY, StyleValueData::Display { raw }) => {
+                    computed_display = Some(FfiDisplay::from_raw(*raw));
+                }
+                (prop::FLOAT, StyleValueData::Keyword { keyword }) => {
+                    computed_float = Some(*keyword);
+                }
+                (prop::POSITION, StyleValueData::Keyword { keyword }) => {
+                    computed_position = Some(*keyword);
+                }
+                _ => {}
+            }
         }
 
         flush_pending_stores(callbacks, context, &mut pending_stores);
+        let display_before = computed_display.expect("display must be computed by the longhand driver");
+        let mut box_type_input = unsafe { *box_type_input };
+        box_type_input.display = display_before;
+        let float_before = computed_float.expect("float must be computed by the longhand driver");
+        box_type_input.float_value = float_before;
+        box_type_input.position = computed_position.expect("position must be computed by the longhand driver");
+        let transformation = transform_box_type(&box_type_input);
+        if transformation.set_float_none {
+            clear_longhand_bit(important_words, prop::FLOAT);
+            clear_longhand_bit(inherited_words, prop::FLOAT);
+        }
+        if transformation.changed_display {
+            clear_longhand_bit(important_words, prop::DISPLAY);
+            clear_longhand_bit(inherited_words, prop::DISPLAY);
+        }
+        unsafe {
+            (callbacks.store_box_type_transformation)(
+                context,
+                &raw const display_before,
+                float_before,
+                computed_overflow_x.expect("overflow-x must be computed by the longhand driver"),
+                computed_overflow_y.expect("overflow-y must be computed by the longhand driver"),
+                computed_text_align.expect("text-align must be computed by the longhand driver"),
+                &raw const transformation,
+            );
+        }
     });
 }
 
@@ -2868,6 +2938,23 @@ const DISPLAY_TAG_INTERNAL: u8 = 1;
 const DISPLAY_TAG_BOX: u8 = 2;
 
 impl FfiDisplay {
+    fn from_raw(raw: u32) -> Self {
+        let [tag, first, second, third] = raw.to_ne_bytes();
+        match tag {
+            DISPLAY_TAG_OUTSIDE_AND_INSIDE => Self::outside_and_inside(first, second, third != 0),
+            DISPLAY_TAG_INTERNAL => Self::internal(first),
+            DISPLAY_TAG_BOX => Self {
+                tag,
+                outside: 0,
+                inside: 0,
+                list_item: false,
+                internal: 0,
+                box_value: first,
+            },
+            _ => unreachable!("invalid display tag"),
+        }
+    }
+
     fn outside_and_inside(outside: u8, inside: u8, list_item: bool) -> Self {
         Self {
             tag: DISPLAY_TAG_OUTSIDE_AND_INSIDE,
@@ -2938,6 +3025,7 @@ impl FfiDisplay {
 /// The element facts the box type transformation needs, marshalled by the C++
 /// side. The parent display is the first non-`display: contents` ancestor's.
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiBoxTypeTransformationInput {
     pub display: FfiDisplay,
     /// Computed position and float keywords.
@@ -2956,6 +3044,7 @@ pub struct FfiBoxTypeTransformationInput {
 /// Result of the box type transformation: whether float must be reset to none,
 /// and the possibly replaced display.
 #[repr(C)]
+#[derive(Clone, Copy)]
 pub struct FfiBoxTypeTransformation {
     pub set_float_none: bool,
     pub changed_display: bool,
@@ -2996,7 +3085,90 @@ fn required_box_type_transformation(input: &FfiBoxTypeTransformationInput) -> Bo
 
 /// https://drafts.csswg.org/css-display/#transformations
 /// 2.7. Automatic Box Type Transformations
-///
+fn transform_box_type(input: &FfiBoxTypeTransformationInput) -> FfiBoxTypeTransformation {
+    let display = input.display;
+    let unchanged = |set_float_none: bool| FfiBoxTypeTransformation {
+        set_float_none,
+        changed_display: false,
+        display,
+    };
+
+    // Some layout effects require blockification or inlinification of the box type,
+    // which sets the box's computed outer display type to block or inline (respectively).
+    // (This has no effect on display types that generate no box at all, such as none or contents.)
+    if display.is_none() || (display.is_contents() && !input.is_document_element) {
+        return unchanged(false);
+    }
+
+    // https://drafts.csswg.org/css-display/#root
+    // The root element's display type is always blockified, and its principal box always establishes an independent formatting context.
+    if input.is_document_element && !display.is_block_outside() {
+        return FfiBoxTypeTransformation {
+            set_float_none: false,
+            changed_display: true,
+            display: FfiDisplay::block(),
+        };
+    }
+
+    let mut new_display = display;
+
+    if display.is_math_inside() {
+        // https://w3c.github.io/mathml-core/#new-display-math-value
+        // For elements that are not MathML elements, if the specified value of display is inline math or block math
+        // then the computed value is block flow and inline flow respectively.
+        if !input.is_mathml_element {
+            new_display = FfiDisplay::outside_and_inside(display.outside, display_inside::FLOW, display.list_item);
+        }
+        // For the mtable element the computed value is block table and inline table respectively.
+        else if input.is_mathml_mtable {
+            new_display = FfiDisplay::outside_and_inside(display.outside, display_inside::TABLE, display.list_item);
+        }
+        // For the mtr element, the computed value is table-row.
+        else if input.is_mathml_mtr {
+            new_display = FfiDisplay::internal(display_internal::TABLE_ROW);
+        }
+        // For the mtd element, the computed value is table-cell.
+        else if input.is_mathml_mtd {
+            new_display = FfiDisplay::internal(display_internal::TABLE_CELL);
+        }
+    }
+
+    // https://www.w3.org/TR/CSS2/visuren.html#dis-pos-flo
+    // If 'position' has the value 'absolute' or 'fixed', [...] 'float' is set to 'none'
+    let set_float_none = input.position == keyword::ABSOLUTE || input.position == keyword::FIXED;
+
+    match required_box_type_transformation(input) {
+        BoxTypeTransformation::None => {}
+        BoxTypeTransformation::Blockify => {
+            if display.is_block_outside() {
+                return unchanged(set_float_none);
+            }
+            // If a layout-internal box is blockified, its inner display type converts to flow so that it becomes a block container.
+            if display.is_internal() {
+                new_display = FfiDisplay::block();
+            } else {
+                assert!(display.is_outside_and_inside());
+
+                // For legacy reasons, if an inline block box (inline flow-root) is blockified, it becomes a block box (losing its flow-root nature).
+                // For consistency, a run-in flow-root box also blockifies to a block box.
+                if display.is_inline_block() {
+                    new_display =
+                        FfiDisplay::outside_and_inside(display_outside::BLOCK, display_inside::FLOW, display.list_item);
+                } else {
+                    new_display =
+                        FfiDisplay::outside_and_inside(display_outside::BLOCK, display.inside, display.list_item);
+                }
+            }
+        }
+    }
+
+    FfiBoxTypeTransformation {
+        set_float_none,
+        changed_display: new_display != display,
+        display: new_display,
+    }
+}
+
 /// # Safety
 /// `input` must be a valid pointer.
 #[unsafe(no_mangle)]
@@ -3004,93 +3176,7 @@ pub unsafe extern "C" fn rust_transform_box_type(
     input: *const FfiBoxTypeTransformationInput,
 ) -> FfiBoxTypeTransformation {
     crate::ffi_stats::bump(crate::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| {
-        let input = unsafe { &*input };
-        let display = input.display;
-        let unchanged = |set_float_none: bool| FfiBoxTypeTransformation {
-            set_float_none,
-            changed_display: false,
-            display,
-        };
-
-        // Some layout effects require blockification or inlinification of the box type,
-        // which sets the box's computed outer display type to block or inline (respectively).
-        // (This has no effect on display types that generate no box at all, such as none or contents.)
-        if display.is_none() || (display.is_contents() && !input.is_document_element) {
-            return unchanged(false);
-        }
-
-        // https://drafts.csswg.org/css-display/#root
-        // The root element's display type is always blockified, and its principal box always establishes an independent formatting context.
-        if input.is_document_element && !display.is_block_outside() {
-            return FfiBoxTypeTransformation {
-                set_float_none: false,
-                changed_display: true,
-                display: FfiDisplay::block(),
-            };
-        }
-
-        let mut new_display = display;
-
-        if display.is_math_inside() {
-            // https://w3c.github.io/mathml-core/#new-display-math-value
-            // For elements that are not MathML elements, if the specified value of display is inline math or block math
-            // then the computed value is block flow and inline flow respectively.
-            if !input.is_mathml_element {
-                new_display = FfiDisplay::outside_and_inside(display.outside, display_inside::FLOW, display.list_item);
-            }
-            // For the mtable element the computed value is block table and inline table respectively.
-            else if input.is_mathml_mtable {
-                new_display = FfiDisplay::outside_and_inside(display.outside, display_inside::TABLE, display.list_item);
-            }
-            // For the mtr element, the computed value is table-row.
-            else if input.is_mathml_mtr {
-                new_display = FfiDisplay::internal(display_internal::TABLE_ROW);
-            }
-            // For the mtd element, the computed value is table-cell.
-            else if input.is_mathml_mtd {
-                new_display = FfiDisplay::internal(display_internal::TABLE_CELL);
-            }
-        }
-
-        // https://www.w3.org/TR/CSS2/visuren.html#dis-pos-flo
-        // If 'position' has the value 'absolute' or 'fixed', [...] 'float' is set to 'none'
-        let set_float_none = input.position == keyword::ABSOLUTE || input.position == keyword::FIXED;
-
-        match required_box_type_transformation(input) {
-            BoxTypeTransformation::None => {}
-            BoxTypeTransformation::Blockify => {
-                if display.is_block_outside() {
-                    return unchanged(set_float_none);
-                }
-                // If a layout-internal box is blockified, its inner display type converts to flow so that it becomes a block container.
-                if display.is_internal() {
-                    new_display = FfiDisplay::block();
-                } else {
-                    assert!(display.is_outside_and_inside());
-
-                    // For legacy reasons, if an inline block box (inline flow-root) is blockified, it becomes a block box (losing its flow-root nature).
-                    // For consistency, a run-in flow-root box also blockifies to a block box.
-                    if display.is_inline_block() {
-                        new_display = FfiDisplay::outside_and_inside(
-                            display_outside::BLOCK,
-                            display_inside::FLOW,
-                            display.list_item,
-                        );
-                    } else {
-                        new_display =
-                            FfiDisplay::outside_and_inside(display_outside::BLOCK, display.inside, display.list_item);
-                    }
-                }
-            }
-        }
-
-        FfiBoxTypeTransformation {
-            set_float_none,
-            changed_display: new_display != display,
-            display: new_display,
-        }
-    })
+    abort_on_panic(|| transform_box_type(unsafe { &*input }))
 }
 
 /// Result of resolving the effective overflow pair: each axis' possibly
@@ -3303,6 +3389,21 @@ mod tests {
         assert!(result.changed);
         assert_eq!(result.keyword, keyword::CENTER);
         assert!(!result.inherited);
+    }
+
+    #[test]
+    fn display_raw_value_decodes_for_box_type_transformation() {
+        let inline_flex = FfiDisplay::from_raw(u32::from_ne_bytes([
+            DISPLAY_TAG_OUTSIDE_AND_INSIDE,
+            display_outside::INLINE,
+            display_inside::FLEX,
+            0,
+        ]));
+        assert!(inline_flex.is_inline_outside());
+        assert!(inline_flex.is_flex_inside());
+
+        let none = FfiDisplay::from_raw(u32::from_ne_bytes([DISPLAY_TAG_BOX, display_box::NONE, 0, 0]));
+        assert!(none.is_none());
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/CSS/Rust/src/style_value.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_value.rs
@@ -1140,14 +1140,19 @@ impl StyleValueData {
             presence_if,
             presence_inherit,
             presence_var,
+            contains_attr_tainted_values,
             ..
         } = self
         else {
             return None;
         };
-        let has_unsupported_substitution_function =
-            *presence_attr || *presence_dashed_function || *presence_env || *presence_if || *presence_inherit;
-        if has_unsupported_substitution_function {
+        let cannot_resolve_natively = *presence_attr
+            || *presence_dashed_function
+            || *presence_env
+            || *presence_if
+            || *presence_inherit
+            || *contains_attr_tainted_values;
+        if cannot_resolve_natively {
             return None;
         }
         Some((self.unresolved_token_source().unwrap_or_default(), *presence_var))

--- a/Libraries/LibWeb/CSS/Rust/src/style_value.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_value.rs
@@ -221,6 +221,53 @@ impl Drop for RetainedString {
     }
 }
 
+/// A retained AK::String accompanied by a Rust-owned copy of its UTF-8 bytes. This is used when
+/// Rust needs to inspect the string instead of only preserving it for C++ access.
+#[repr(C)]
+pub struct RetainedReadableString {
+    raw: usize,
+    bytes: *mut u8,
+    length: usize,
+}
+
+impl RetainedReadableString {
+    /// Takes ownership of a leaked AK::String reference and copies its bytes.
+    ///
+    /// # Safety
+    /// `bytes` must point at `length` readable bytes.
+    unsafe fn from_raw(raw: usize, bytes: *const u8, length: usize) -> Self {
+        let source = unsafe { crate::bytes_from_raw(bytes, length) }.expect("invalid readable string bytes");
+        if source.is_empty() {
+            return Self {
+                raw,
+                bytes: std::ptr::null_mut(),
+                length: 0,
+            };
+        }
+        let owned = source.to_vec().into_boxed_slice();
+        let length = owned.len();
+        let bytes = Box::into_raw(owned).cast::<u8>();
+        Self { raw, bytes, length }
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        if self.bytes.is_null() {
+            return &[];
+        }
+        unsafe { std::slice::from_raw_parts(self.bytes, self.length) }
+    }
+}
+
+impl Drop for RetainedReadableString {
+    fn drop(&mut self) {
+        crate::ffi_stats::bump(crate::ffi_stats::FfiOp::StringRetainReleaseCallback);
+        unsafe { ladybird_string_unref(self.raw) };
+        if !self.bytes.is_null() {
+            drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(self.bytes, self.length)) });
+        }
+    }
+}
+
 /// A retained CSS request URL modifier: the modifier type and either an enum value or a retained
 /// string value (raw 0 when the value is an enum). All enums are C++ `enum class ... : u8`
 /// values, opaque to Rust.
@@ -978,8 +1025,8 @@ pub enum StyleValueData {
     /// source text, an optional normalized comparison text (empty when absent), the presence
     /// flags of each substitution function and the attr-taint flag.
     Unresolved {
-        source_text: RetainedString,
-        value_comparison_text: RetainedString,
+        source_text: RetainedReadableString,
+        value_comparison_text: RetainedReadableString,
         presence_attr: bool,
         presence_dashed_function: bool,
         presence_env: bool,
@@ -1056,6 +1103,24 @@ pub enum StyleValueData {
         color_operation: u8,
         value: RetainedStyleValue,
     },
+}
+
+impl StyleValueData {
+    pub(crate) fn unresolved_token_source(&self) -> Option<&[u8]> {
+        let Self::Unresolved {
+            source_text,
+            value_comparison_text,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        if value_comparison_text.as_bytes().is_empty() {
+            Some(source_text.as_bytes())
+        } else {
+            Some(value_comparison_text.as_bytes())
+        }
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -1799,7 +1864,11 @@ pub unsafe extern "C" fn rust_style_value_create_color_scheme(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_create_unresolved(
     source_text: usize,
+    source_text_bytes: *const u8,
+    source_text_length: usize,
     value_comparison_text: usize,
+    value_comparison_text_bytes: *const u8,
+    value_comparison_text_length: usize,
     presence_attr: bool,
     presence_dashed_function: bool,
     presence_env: bool,
@@ -1810,9 +1879,15 @@ pub unsafe extern "C" fn rust_style_value_create_unresolved(
 ) -> *mut StyleValueData {
     abort_on_panic(|| {
         Box::into_raw(Box::new(StyleValueData::Unresolved {
-            source_text: RetainedString { raw: source_text },
-            value_comparison_text: RetainedString {
-                raw: value_comparison_text,
+            source_text: unsafe {
+                RetainedReadableString::from_raw(source_text, source_text_bytes, source_text_length)
+            },
+            value_comparison_text: unsafe {
+                RetainedReadableString::from_raw(
+                    value_comparison_text,
+                    value_comparison_text_bytes,
+                    value_comparison_text_length,
+                )
             },
             presence_attr,
             presence_dashed_function,

--- a/Libraries/LibWeb/CSS/Rust/src/style_value.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_value.rs
@@ -1121,6 +1121,27 @@ impl StyleValueData {
             Some(value_comparison_text.as_bytes())
         }
     }
+
+    pub(crate) fn unresolved_var_source(&self) -> Option<(&[u8], bool)> {
+        let Self::Unresolved {
+            presence_attr,
+            presence_dashed_function,
+            presence_env,
+            presence_if,
+            presence_inherit,
+            presence_var,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        let has_unsupported_substitution_function =
+            *presence_attr || *presence_dashed_function || *presence_env || *presence_if || *presence_inherit;
+        if has_unsupported_substitution_function {
+            return None;
+        }
+        Some((self.unresolved_token_source().unwrap_or_default(), *presence_var))
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/Libraries/LibWeb/CSS/Rust/src/style_value.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_value.rs
@@ -95,6 +95,11 @@ impl RetainedUtf16FlyString {
         self.raw
     }
 
+    /// Assumes ownership of one leaked reference to the underlying string data.
+    pub(crate) unsafe fn from_leaked_raw(raw: usize) -> Self {
+        Self { raw }
+    }
+
     /// Retains a new reference to the underlying string data.
     ///
     /// # Safety

--- a/Libraries/LibWeb/CSS/Rust/src/style_value.rs
+++ b/Libraries/LibWeb/CSS/Rust/src/style_value.rs
@@ -322,6 +322,15 @@ impl RetainedUtf16FlyStringList {
 
 retained_list_drop!(RetainedUtf16FlyStringList);
 
+impl RetainedByteList {
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        if self.pointer.is_null() {
+            return &[];
+        }
+        unsafe { std::slice::from_raw_parts(self.pointer, self.length) }
+    }
+}
+
 /// A retained counter definition: the counter name, the reversed flag and an optional retained
 /// value (null when absent).
 #[repr(C)]
@@ -1019,6 +1028,7 @@ pub enum StyleValueData {
     /// color-scheme with its retained scheme names and the only keyword flag.
     ColorScheme {
         schemes: RetainedUtf16FlyStringList,
+        scheme_codes: RetainedByteList,
         only: bool,
     },
     /// An unresolved value containing arbitrary substitution functions, kept as its retained
@@ -1870,12 +1880,14 @@ pub unsafe extern "C" fn rust_style_value_create_font_source(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_style_value_create_color_scheme(
     schemes: *const usize,
+    scheme_codes: *const u8,
     scheme_count: usize,
     only: bool,
 ) -> *mut StyleValueData {
     abort_on_panic(|| {
         Box::into_raw(Box::new(StyleValueData::ColorScheme {
             schemes: unsafe { RetainedUtf16FlyStringList::from_raw(schemes, scheme_count) },
+            scheme_codes: unsafe { RetainedByteList::from_raw(scheme_codes, scheme_count) },
             only,
         }))
     })

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3417,6 +3417,9 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
             case ComputedValuesFFI::COMPUTED_KIND_FONT_STYLE:
                 builder.set_property_without_modifying_flags(property_id, FontStyleStyleValue::create(static_cast<FontStyleKeyword>(entry.value)));
                 break;
+            case ComputedValuesFFI::COMPUTED_KIND_KEYWORD:
+                builder.set_property_without_modifying_flags(property_id, KeywordStyleValue::create(static_cast<Keyword>(static_cast<u16>(entry.value))));
+                break;
             case ComputedValuesFFI::COMPUTED_KIND_SUPERELLIPSE: {
                 // NB: The round value is cached since it is the initial value of the corner-*-shape properties.
                 if (entry.value == 1) {
@@ -3529,17 +3532,21 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     // Add or modify CSS-defined animations
     process_animation_definitions(computed_style, cascaded_properties, abstract_element);
 
+    bool animation_values_applied = false;
     auto animations = abstract_element.element().get_animations_internal(
         Animations::Animatable::GetAnimationsSorted::Yes,
         Bindings::GetAnimationsOptions { .subtree = false });
     if (animations.is_exception()) {
+        animation_values_applied = true;
         dbgln("Error getting animations for element {}", abstract_element.debug_description());
     } else {
         for (auto& animation : animations.value()) {
             if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
                 auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());
-                if (keyframe_effect.pseudo_element_type() == abstract_element.pseudo_element())
+                if (keyframe_effect.pseudo_element_type() == abstract_element.pseudo_element()) {
+                    animation_values_applied = true;
                     collect_animation_into(abstract_element, keyframe_effect, builder);
+                }
             }
         }
     }
@@ -3548,7 +3555,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     transform_box_type_if_needed(builder, abstract_element);
 
     // Apply any property-specific computed value logic
-    resolve_effective_overflow_values(builder);
+    if (animation_values_applied)
+        resolve_effective_overflow_values(builder);
     compute_text_align(builder, abstract_element);
 
     // Let the element adjust computed style

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2362,6 +2362,20 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
             bulk_context.pinned_values.append(move(resolved));
             return pointer;
         },
+        .parse_substituted = [](void* context, u16 property_id, u8 const* source, size_t source_length) -> void const* {
+            auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
+            bulk_context.abstract_element.element().set_style_uses_var_css_function();
+            auto parsed = parse_css_value(
+                Parser::ParsingParams { bulk_context.abstract_element.document() },
+                StringView { reinterpret_cast<char const*>(source), source_length },
+                static_cast<PropertyID>(property_id));
+            NonnullRefPtr<StyleValue const> resolved = parsed
+                ? parsed.release_nonnull()
+                : GuaranteedInvalidStyleValue::create();
+            auto const* pointer = resolved.ptr();
+            bulk_context.pinned_values.append(move(resolved));
+            return pointer;
+        },
         .data_of = [](void*, void const* shell) -> void const* {
             return static_cast<StyleValue const*>(shell)->rust_style_value_data();
         },
@@ -2382,7 +2396,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
                 auto const& source = bulk_context.block_sources[assignments[i].source_id];
                 bulk_context.cascaded_properties.assign_source_slot(assignments[i].slot, source.source, source.source_shadow_root);
             } },
-        .set_custom_properties = [](void* context, ComputedValuesFFI::FfiCascadedCustomProperty const* properties, size_t count) {
+        .set_custom_properties = [](void* context, ComputedValuesFFI::FfiCascadedCustomProperty const* properties, size_t count) -> void const* {
             auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
             OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_all;
             cascaded_all.ensure_capacity(count);
@@ -2419,7 +2433,11 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
             } else {
                 bulk_context.abstract_element.set_custom_property_data(
                     CustomPropertyData::create(move(cascaded_own), move(parent_data)));
-            } },
+            }
+
+            auto custom_property_data = bulk_context.abstract_element.custom_property_data();
+            return custom_property_data ? custom_property_data->rust_store() : nullptr;
+        },
     };
 
     auto cascade_custom_properties = !abstract_element.pseudo_element().has_value()
@@ -2432,6 +2450,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
         static_cast<u32>(matching_rule_set.author_contexts.size()),
         abstract_element.pseudo_element().has_value(),
         cascade_custom_properties,
+        abstract_element.document().custom_property_registration_generation() == 0,
         unset_value.ptr(),
         unset_value->rust_style_value_data(),
         &callbacks);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2800,33 +2800,15 @@ static Display from_ffi_display(ComputedValuesFFI::FfiDisplay const& display)
     case Display::Type::Internal:
         return Display { static_cast<DisplayInternal>(display.internal) };
     case Display::Type::Box:
-    default:
-        // The transformation never produces a box-type display.
-        VERIFY_NOT_REACHED();
+        return Display { static_cast<DisplayBox>(display.box_value) };
     }
+    VERIFY_NOT_REACHED();
 }
 
-// https://drafts.csswg.org/css-display/#transformations
-void StyleComputer::transform_box_type_if_needed(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element) const
+static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transformation_input(
+    DOM::AbstractElement abstract_element, Display display, Keyword position, Keyword float_value)
 {
-    auto& style = builder.style();
-    auto display = style.display();
-
-    builder.set_display_before_box_type_transformation(display);
-
-    // The css-display-3 transformation rules live in the Rust style computation core; this
-    // wrapper marshals the element facts they depend on and applies the result.
     auto& element = abstract_element.element();
-    bool is_mathml_element = false;
-    bool is_mathml_mtable = false;
-    bool is_mathml_mtr = false;
-    bool is_mathml_mtd = false;
-    if (display.is_math_inside()) {
-        is_mathml_element = element.namespace_uri() == Namespace::MathML;
-        is_mathml_mtable = element.tag_name().equals_ignoring_ascii_case("mtable"sv);
-        is_mathml_mtr = element.tag_name().equals_ignoring_ascii_case("mtr"sv);
-        is_mathml_mtd = element.tag_name().equals_ignoring_ascii_case("mtd"sv);
-    }
 
     // NOTE: If we're computing style for a pseudo-element, the effective parent will be the originating element itself, not its parent.
     auto parent = abstract_element.element_to_inherit_style_from();
@@ -2837,25 +2819,41 @@ void StyleComputer::transform_box_type_if_needed(ComputedProperties::Builder& bu
 
     bool has_parent_display = parent.has_value() && parent->computed_values();
 
-    ComputedValuesFFI::FfiBoxTypeTransformationInput const input {
+    return {
         .display = to_ffi_display(display),
-        .position = to_underlying(style.property(PropertyID::Position).to_keyword()),
-        .float_value = to_underlying(style.property(PropertyID::Float).to_keyword()),
+        .position = to_underlying(position),
+        .float_value = to_underlying(float_value),
         .is_br_element = !abstract_element.pseudo_element().has_value() && is<HTML::HTMLBRElement>(element),
         .is_document_element = element.is_document_element(),
-        .is_mathml_element = is_mathml_element,
-        .is_mathml_mtable = is_mathml_mtable,
-        .is_mathml_mtr = is_mathml_mtr,
-        .is_mathml_mtd = is_mathml_mtd,
+        .is_mathml_element = element.namespace_uri() == Namespace::MathML,
+        .is_mathml_mtable = element.tag_name().equals_ignoring_ascii_case("mtable"sv),
+        .is_mathml_mtr = element.tag_name().equals_ignoring_ascii_case("mtr"sv),
+        .is_mathml_mtd = element.tag_name().equals_ignoring_ascii_case("mtd"sv),
         .has_parent_display = has_parent_display,
         .parent_display = has_parent_display ? to_ffi_display(parent->computed_values()->display()) : ComputedValuesFFI::FfiDisplay {},
     };
+}
 
-    auto transformation = ComputedValuesFFI::rust_transform_box_type(&input);
+static void apply_box_type_transformation(ComputedProperties::Builder& builder, ComputedValuesFFI::FfiDisplay const& display_before, ComputedValuesFFI::FfiBoxTypeTransformation const& transformation)
+{
+    builder.set_display_before_box_type_transformation(from_ffi_display(display_before));
     if (transformation.set_float_none)
         builder.set_property(PropertyID::Float, KeywordStyleValue::create(Keyword::None));
     if (transformation.changed_display)
         builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(transformation.display)));
+}
+
+// https://drafts.csswg.org/css-display/#transformations
+void StyleComputer::transform_box_type_if_needed(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element) const
+{
+    auto& style = builder.style();
+    auto input = make_box_type_transformation_input(
+        abstract_element,
+        style.display(),
+        style.property(PropertyID::Position).to_keyword(),
+        style.property(PropertyID::Float).to_keyword());
+    auto transformation = ComputedValuesFFI::rust_transform_box_type(&input);
+    apply_box_type_transformation(builder, input.display, transformation);
 }
 
 NonnullRefPtr<ComputedValues const> StyleComputer::create_document_style() const
@@ -3441,18 +3439,30 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     // iterates the longhands in computation order, resolves logical pairing through its
     // mapping tables, and selects the cascaded, inherited or initial value natively.
     struct LonghandLoopContext {
+        ComputedProperties::Builder& builder;
         decltype(store_computed_batch)& store_computed_batch_callback;
         decltype(fetch_length_resolution_context)& fetch_length_resolution_context_callback;
         decltype(get_logical_alias_mapping_context)& get_logical_alias_mapping_context_callback;
         DOM::AbstractElement abstract_element;
+        Optional<ComputedValuesFFI::FfiDisplay> display_before_adjustments;
+        Optional<Keyword> float_before_adjustments;
+        Optional<Keyword> overflow_x_before_adjustments;
+        Optional<Keyword> overflow_y_before_adjustments;
+        Optional<Keyword> text_align_before_adjustments;
         // Pins every parent value handed out by the explicit-inherit fetch until the end
         // of the drive; the driver may queue the shells in deferred store batches.
         Vector<NonnullRefPtr<StyleValue const>> pinned_parent_values;
     } loop_context {
+        .builder = builder,
         .store_computed_batch_callback = store_computed_batch,
         .fetch_length_resolution_context_callback = fetch_length_resolution_context,
         .get_logical_alias_mapping_context_callback = get_logical_alias_mapping_context,
         .abstract_element = abstract_element,
+        .display_before_adjustments = {},
+        .float_before_adjustments = {},
+        .overflow_x_before_adjustments = {},
+        .overflow_y_before_adjustments = {},
+        .text_align_before_adjustments = {},
         .pinned_parent_values = {},
     };
 
@@ -3461,6 +3471,14 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .store_computed_batch = [](void* context, ComputedValuesFFI::FfiComputedStoreEntry const* entries, size_t count) {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.store_computed_batch_callback(entries, count); },
+        .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation) {
+            auto& loop_context = *static_cast<LonghandLoopContext*>(context);
+            loop_context.display_before_adjustments = *display_before;
+            loop_context.float_before_adjustments = static_cast<Keyword>(float_before);
+            loop_context.overflow_x_before_adjustments = static_cast<Keyword>(overflow_x_before);
+            loop_context.overflow_y_before_adjustments = static_cast<Keyword>(overflow_y_before);
+            loop_context.text_align_before_adjustments = static_cast<Keyword>(text_align_before);
+            apply_box_type_transformation(loop_context.builder, *display_before, *transformation); },
         .fetch_non_inherited_parent_value = [](void* context, u16 inherited_property_id) -> ComputedValuesFFI::FfiShellAndData {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             auto value = get_non_animated_inherit_value(static_cast<PropertyID>(inherited_property_id), loop_context.abstract_element);
@@ -3492,7 +3510,9 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .font_metrics_depend_on_viewport_metrics = false,
         .explicitly_inherited_non_inherited_property = false,
     };
-    ComputedValuesFFI::rust_drive_property_computation(&callbacks, cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, abstract_element.element().local_name() == HTML::TagNames::th, new_font_size != nullptr, device_pixels_per_css_pixel, InitialValues::font_size().raw_value(), default_user_font_size().raw_value(), &driver_results);
+    auto box_type_input = make_box_type_transformation_input(
+        abstract_element, InitialValues::display(), Keyword::Static, Keyword::None);
+    ComputedValuesFFI::rust_drive_property_computation(&callbacks, cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, &box_type_input, abstract_element.element().local_name() == HTML::TagNames::th, new_font_size != nullptr, device_pixels_per_css_pixel, InitialValues::font_size().raw_value(), default_user_font_size().raw_value(), &driver_results);
 
     // Apply the driver's bulk results.
     auto longhand_bit_is_set = [](Array<u64, longhand_bitmap_words> const& words, size_t index) {
@@ -3537,13 +3557,24 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         Animations::Animatable::GetAnimationsSorted::Yes,
         Bindings::GetAnimationsOptions { .subtree = false });
     if (animations.is_exception()) {
-        animation_values_applied = true;
         dbgln("Error getting animations for element {}", abstract_element.debug_description());
     } else {
         for (auto& animation : animations.value()) {
             if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
                 auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());
                 if (keyframe_effect.pseudo_element_type() == abstract_element.pseudo_element()) {
+                    if (!animation_values_applied) {
+                        VERIFY(loop_context.display_before_adjustments.has_value());
+                        VERIFY(loop_context.float_before_adjustments.has_value());
+                        VERIFY(loop_context.overflow_x_before_adjustments.has_value());
+                        VERIFY(loop_context.overflow_y_before_adjustments.has_value());
+                        VERIFY(loop_context.text_align_before_adjustments.has_value());
+                        builder.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(*loop_context.display_before_adjustments)));
+                        builder.set_property_without_modifying_flags(PropertyID::Float, KeywordStyleValue::create(*loop_context.float_before_adjustments));
+                        builder.set_property_without_modifying_flags(PropertyID::OverflowX, KeywordStyleValue::create(*loop_context.overflow_x_before_adjustments));
+                        builder.set_property_without_modifying_flags(PropertyID::OverflowY, KeywordStyleValue::create(*loop_context.overflow_y_before_adjustments));
+                        builder.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*loop_context.text_align_before_adjustments));
+                    }
                     animation_values_applied = true;
                     collect_animation_into(abstract_element, keyframe_effect, builder);
                 }
@@ -3551,8 +3582,9 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         }
     }
 
-    // Run automatic box type transformations
-    transform_box_type_if_needed(builder, abstract_element);
+    // Run automatic box type transformations again after animations have been applied.
+    if (animation_values_applied)
+        transform_box_type_if_needed(builder, abstract_element);
 
     // Apply any property-specific computed value logic
     if (animation_values_applied)

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2450,7 +2450,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
         static_cast<u32>(matching_rule_set.author_contexts.size()),
         abstract_element.pseudo_element().has_value(),
         cascade_custom_properties,
-        abstract_element.document().custom_property_registration_generation() == 0,
+        abstract_element.document().rust_custom_property_registry(),
         unset_value.ptr(),
         unset_value->rust_style_value_data(),
         &callbacks);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -96,6 +96,7 @@
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/Layout/Node.h>
@@ -2818,6 +2819,49 @@ static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transforma
         parent = parent->element_to_inherit_style_from();
 
     bool has_parent_display = parent.has_value() && parent->computed_values();
+    bool is_html_element = element.namespace_uri() == Namespace::HTML;
+    bool should_adjust_element = !abstract_element.pseudo_element().has_value();
+    auto local_name = element.local_name();
+
+    bool input_allows_adjustment = false;
+    bool input_is_single_line = false;
+    if (is<HTML::HTMLInputElement>(element)) {
+        auto const& input = static_cast<HTML::HTMLInputElement const&>(element);
+        input_allows_adjustment = !first_is_one_of(
+            input.type_state(),
+            HTML::HTMLInputElement::TypeAttributeState::Hidden,
+            HTML::HTMLInputElement::TypeAttributeState::SubmitButton,
+            HTML::HTMLInputElement::TypeAttributeState::Button,
+            HTML::HTMLInputElement::TypeAttributeState::ResetButton,
+            HTML::HTMLInputElement::TypeAttributeState::ImageButton,
+            HTML::HTMLInputElement::TypeAttributeState::Checkbox,
+            HTML::HTMLInputElement::TypeAttributeState::RadioButton);
+        input_is_single_line = input_allows_adjustment && input.is_single_line();
+    }
+
+    bool force_position_static = false;
+    if (element.namespace_uri() == Namespace::SVG) {
+        force_position_static = true;
+        if (local_name == "svg"sv) {
+            force_position_static = false;
+            for (auto ancestor = element.parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->namespace_uri() == Namespace::SVG && ancestor->local_name() == "foreignObject"sv)
+                    break;
+                if (ancestor->namespace_uri() == Namespace::SVG && ancestor->local_name() == "svg"sv) {
+                    force_position_static = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    bool force_symbol_display_inline = false;
+    if (element.namespace_uri() == Namespace::SVG && local_name == "symbol"sv) {
+        if (auto* shadow_root = as_if<DOM::ShadowRoot>(element.parent())) {
+            auto* host = shadow_root->host();
+            force_symbol_display_inline = host->namespace_uri() == Namespace::SVG && host->local_name() == "use"sv;
+        }
+    }
 
     return {
         .display = to_ffi_display(display),
@@ -2831,6 +2875,16 @@ static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transforma
         .is_mathml_mtd = element.tag_name().equals_ignoring_ascii_case("mtd"sv),
         .has_parent_display = has_parent_display,
         .parent_display = has_parent_display ? to_ffi_display(parent->computed_values()->display()) : ComputedValuesFFI::FfiDisplay {},
+        .is_wbr_element = should_adjust_element && is_html_element && local_name == HTML::TagNames::wbr,
+        .disallow_display_contents = should_adjust_element && (input_allows_adjustment || (is_html_element && first_is_one_of(local_name, HTML::TagNames::textarea, HTML::TagNames::audio, HTML::TagNames::video, HTML::TagNames::canvas, HTML::TagNames::object, HTML::TagNames::iframe, HTML::TagNames::progress, HTML::TagNames::embed, HTML::TagNames::frame, HTML::TagNames::meter, HTML::TagNames::frameset, HTML::TagNames::img))),
+        .rewrite_inline_flow = should_adjust_element && (input_allows_adjustment || (is_html_element && first_is_one_of(local_name, HTML::TagNames::textarea, HTML::TagNames::audio, HTML::TagNames::video, HTML::TagNames::select))),
+        .is_button_element = should_adjust_element && is_html_element && local_name == HTML::TagNames::button,
+        .force_line_height_normal = should_adjust_element && is_html_element && local_name == HTML::TagNames::select,
+        .check_input_line_height = should_adjust_element && input_is_single_line,
+        .hide_audio_without_controls = should_adjust_element && is_html_element && local_name == HTML::TagNames::audio && !element.has_attribute(HTML::AttributeNames::controls),
+        .is_table_element = should_adjust_element && is_html_element && local_name == HTML::TagNames::table,
+        .force_position_static = should_adjust_element && force_position_static,
+        .force_symbol_display_inline = should_adjust_element && force_symbol_display_inline,
     };
 }
 
@@ -2841,6 +2895,30 @@ static void apply_box_type_transformation(ComputedProperties::Builder& builder, 
         builder.set_property(PropertyID::Float, KeywordStyleValue::create(Keyword::None));
     if (transformation.changed_display)
         builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(transformation.display)));
+}
+
+static bool apply_element_style_adjustment(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiElementStyleAdjustment const& adjustment)
+{
+    bool line_height_changed = false;
+    if (adjustment.changed_display)
+        builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(adjustment.display)));
+    if (adjustment.set_line_height_normal) {
+        builder.set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
+        line_height_changed = true;
+    }
+    if (adjustment.check_input_line_height) {
+        auto current_line_height = builder.line_height(abstract_element.element().document().font_computer()).to_double();
+        auto minimum_line_height = ComputedProperties::normal_line_height(builder.first_available_computed_font(abstract_element.element().document().font_computer())->pixel_metrics()).to_double();
+        if (current_line_height < minimum_line_height) {
+            builder.set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
+            line_height_changed = true;
+        }
+    }
+    if (adjustment.set_position_static)
+        builder.set_property(PropertyID::Position, KeywordStyleValue::create(Keyword::Static));
+    if (adjustment.changed_text_align)
+        builder.set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(adjustment.text_align)));
+    return line_height_changed;
 }
 
 // https://drafts.csswg.org/css-display/#transformations
@@ -3449,6 +3527,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         Optional<Keyword> overflow_x_before_adjustments;
         Optional<Keyword> overflow_y_before_adjustments;
         Optional<Keyword> text_align_before_adjustments;
+        Optional<Keyword> position_before_adjustments;
+        RefPtr<StyleValue const> line_height_before_adjustments;
         // Pins every parent value handed out by the explicit-inherit fetch until the end
         // of the drive; the driver may queue the shells in deferred store batches.
         Vector<NonnullRefPtr<StyleValue const>> pinned_parent_values;
@@ -3463,6 +3543,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .overflow_x_before_adjustments = {},
         .overflow_y_before_adjustments = {},
         .text_align_before_adjustments = {},
+        .position_before_adjustments = {},
+        .line_height_before_adjustments = {},
         .pinned_parent_values = {},
     };
 
@@ -3471,14 +3553,17 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .store_computed_batch = [](void* context, ComputedValuesFFI::FfiComputedStoreEntry const* entries, size_t count) {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.store_computed_batch_callback(entries, count); },
-        .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation) {
+        .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, u16 position_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation, ComputedValuesFFI::FfiElementStyleAdjustment const* element_adjustment) -> bool {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.display_before_adjustments = *display_before;
             loop_context.float_before_adjustments = static_cast<Keyword>(float_before);
             loop_context.overflow_x_before_adjustments = static_cast<Keyword>(overflow_x_before);
             loop_context.overflow_y_before_adjustments = static_cast<Keyword>(overflow_y_before);
             loop_context.text_align_before_adjustments = static_cast<Keyword>(text_align_before);
-            apply_box_type_transformation(loop_context.builder, *display_before, *transformation); },
+            loop_context.position_before_adjustments = static_cast<Keyword>(position_before);
+            loop_context.line_height_before_adjustments = loop_context.builder.style().property(PropertyID::LineHeight);
+            apply_box_type_transformation(loop_context.builder, *display_before, *transformation);
+            return apply_element_style_adjustment(loop_context.builder, loop_context.abstract_element, *element_adjustment); },
         .fetch_non_inherited_parent_value = [](void* context, u16 inherited_property_id) -> ComputedValuesFFI::FfiShellAndData {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             auto value = get_non_animated_inherit_value(static_cast<PropertyID>(inherited_property_id), loop_context.abstract_element);
@@ -3569,11 +3654,15 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
                         VERIFY(loop_context.overflow_x_before_adjustments.has_value());
                         VERIFY(loop_context.overflow_y_before_adjustments.has_value());
                         VERIFY(loop_context.text_align_before_adjustments.has_value());
+                        VERIFY(loop_context.position_before_adjustments.has_value());
+                        VERIFY(loop_context.line_height_before_adjustments);
                         builder.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(*loop_context.display_before_adjustments)));
                         builder.set_property_without_modifying_flags(PropertyID::Float, KeywordStyleValue::create(*loop_context.float_before_adjustments));
                         builder.set_property_without_modifying_flags(PropertyID::OverflowX, KeywordStyleValue::create(*loop_context.overflow_x_before_adjustments));
                         builder.set_property_without_modifying_flags(PropertyID::OverflowY, KeywordStyleValue::create(*loop_context.overflow_y_before_adjustments));
                         builder.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*loop_context.text_align_before_adjustments));
+                        builder.set_property_without_modifying_flags(PropertyID::Position, KeywordStyleValue::create(*loop_context.position_before_adjustments));
+                        builder.set_property_without_modifying_flags(PropertyID::LineHeight, *loop_context.line_height_before_adjustments);
                     }
                     animation_values_applied = true;
                     collect_animation_into(abstract_element, keyframe_effect, builder);
@@ -3593,7 +3682,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         compute_text_align(builder, abstract_element);
 
     // Let the element adjust computed style
-    if (!abstract_element.pseudo_element().has_value())
+    if (animation_values_applied && !abstract_element.pseudo_element().has_value())
         abstract_element.element().adjust_computed_style(builder);
 
     bool parent_style_in_display_none_subtree = false;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2897,28 +2897,22 @@ static void apply_box_type_transformation(ComputedProperties::Builder& builder, 
         builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(transformation.display)));
 }
 
-static bool apply_element_style_adjustment(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiElementStyleAdjustment const& adjustment)
+static ComputedValuesFFI::FfiInputLineHeightMetrics apply_element_style_adjustment(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiElementStyleAdjustment const& adjustment)
 {
-    bool line_height_changed = false;
     if (adjustment.changed_display)
         builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(adjustment.display)));
-    if (adjustment.set_line_height_normal) {
+    if (adjustment.set_line_height_normal)
         builder.set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
-        line_height_changed = true;
-    }
+    ComputedValuesFFI::FfiInputLineHeightMetrics line_height_metrics {};
     if (adjustment.check_input_line_height) {
-        auto current_line_height = builder.line_height(abstract_element.element().document().font_computer()).to_double();
-        auto minimum_line_height = ComputedProperties::normal_line_height(builder.first_available_computed_font(abstract_element.element().document().font_computer())->pixel_metrics()).to_double();
-        if (current_line_height < minimum_line_height) {
-            builder.set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
-            line_height_changed = true;
-        }
+        line_height_metrics.current_line_height = builder.line_height(abstract_element.element().document().font_computer()).to_double();
+        line_height_metrics.minimum_line_height = ComputedProperties::normal_line_height(builder.first_available_computed_font(abstract_element.element().document().font_computer())->pixel_metrics()).to_double();
     }
     if (adjustment.set_position_static)
         builder.set_property(PropertyID::Position, KeywordStyleValue::create(Keyword::Static));
     if (adjustment.changed_text_align)
         builder.set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(adjustment.text_align)));
-    return line_height_changed;
+    return line_height_metrics;
 }
 
 // https://drafts.csswg.org/css-display/#transformations
@@ -3575,7 +3569,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .store_effective_color_scheme = [](void* context, u8 color_scheme) {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.builder.set_effective_color_scheme(static_cast<PreferredColorScheme>(color_scheme)); },
-        .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, u16 position_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation, ComputedValuesFFI::FfiElementStyleAdjustment const* element_adjustment) -> bool {
+        .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, u16 position_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation, ComputedValuesFFI::FfiElementStyleAdjustment const* element_adjustment) -> ComputedValuesFFI::FfiInputLineHeightMetrics {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.display_before_adjustments = *display_before;
             loop_context.float_before_adjustments = static_cast<Keyword>(float_before);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3705,6 +3705,18 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         }
     }
 
+    bool parent_text_align_input_is_animated = false;
+    if (computed_values_to_inherit_from) {
+        if (auto const* animated_properties = computed_values_to_inherit_from->animated_properties()) {
+            parent_text_align_input_is_animated = animated_properties->has_property(PropertyID::TextAlign)
+                || animated_properties->has_property(PropertyID::Direction);
+        }
+    }
+    if (parent_text_align_input_is_animated && !animation_values_applied) {
+        VERIFY(loop_context.text_align_before_adjustments.has_value());
+        builder.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*loop_context.text_align_before_adjustments));
+    }
+
     // Run automatic box type transformations again after animations have been applied.
     if (animation_values_applied)
         transform_box_type_if_needed(builder, abstract_element);
@@ -3712,7 +3724,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     // Apply any property-specific computed value logic
     if (animation_values_applied)
         resolve_effective_overflow_values(builder);
-    if (animation_values_applied)
+    if (animation_values_applied || parent_text_align_input_is_animated)
         compute_text_align(builder, abstract_element);
 
     // Let the element adjust computed style

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -876,39 +876,6 @@ void StyleComputer::for_each_property_expanding_shorthands(PropertyID property_i
     ComputedValuesFFI::rust_for_each_property_expanding_shorthands(&callbacks, to_underlying(property_id), &value, value.rust_style_value_data());
 }
 
-static void cascade_custom_properties(DOM::AbstractElement abstract_element, Vector<StyleComputer::ScopedMatchingRule> const& matching_rules, OrderedHashMap<Utf16FlyString, StyleProperty>& custom_properties, Important important, bool include_inline_style)
-{
-    size_t needed_capacity = 0;
-    for (auto const& matching_rule : matching_rules)
-        needed_capacity += matching_rule.rule->declaration().custom_properties().size();
-
-    auto const inline_style = abstract_element.inline_style();
-    if (include_inline_style && inline_style)
-        needed_capacity += inline_style->custom_properties().size();
-
-    custom_properties.ensure_capacity(custom_properties.size() + needed_capacity);
-
-    for (auto const& matching_rule : matching_rules) {
-        for (auto const& it : matching_rule.rule->declaration().custom_properties()) {
-            if (it.value.important != important)
-                continue;
-            auto style_value = it.value.value;
-            if (style_value->is_revert_layer())
-                continue;
-
-            custom_properties.set(it.key, it.value);
-        }
-    }
-
-    if (include_inline_style && inline_style) {
-        for (auto const& it : inline_style->custom_properties()) {
-            if (it.value.important != important)
-                continue;
-            custom_properties.set(it.key, it.value);
-        }
-    }
-}
-
 static RefPtr<CustomPropertyData const> inheritable_custom_property_data(DOM::AbstractElement abstract_element)
 {
     auto data = abstract_element.custom_property_data();
@@ -2228,13 +2195,9 @@ JsonArray StyleComputer::collect_devtools_applied_style_rules(DOM::AbstractEleme
 
 // https://www.w3.org/TR/css-cascade/#cascading
 // https://drafts.csswg.org/css-cascade-5/#layering
-NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::AbstractElement abstract_element, bool did_match_any_pseudo_element_rules, ComputeStyleMode mode, MatchingRuleSet const& matching_rule_set, IncludeInlineStyle include_inline_style) const
+NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::AbstractElement abstract_element, MatchingRuleSet const& matching_rule_set, IncludeInlineStyle include_inline_style) const
 {
     auto cascaded_properties = CascadedProperties::create();
-    if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
-        if (!did_match_any_pseudo_element_rules)
-            return cascaded_properties;
-    }
 
     auto element_context_shadow_root = as_if<DOM::ShadowRoot>(abstract_element.element().root());
 
@@ -2247,15 +2210,18 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
         GC::Ptr<DOM::ShadowRoot const> source_shadow_root;
     };
     Vector<ComputedValuesFFI::FfiCascadeDeclaration> all_declarations;
+    Vector<ComputedValuesFFI::FfiCustomPropertyDeclaration> all_custom_property_declarations;
     struct PendingBlock {
         ComputedValuesFFI::FfiCascadeBlock block;
         size_t declarations_offset { 0 };
+        size_t custom_property_declarations_offset { 0 };
     };
     Vector<PendingBlock> pending_blocks;
     Vector<BlockSource> block_sources;
     Vector<FlatPtr> leaked_layer_names;
+    Vector<FlatPtr> leaked_custom_property_names;
 
-    auto add_block = [&](ReadonlySpan<StyleProperty> properties, CascadeOrigin origin, u32 author_context_index, u32 layer_index, bool is_inline_style, bool bypass_pseudo_element_property_whitelist, Optional<Utf16FlyString> const& layer_name, GC::Ptr<CSSStyleDeclaration const> source, GC::Ptr<DOM::ShadowRoot const> source_shadow_root) {
+    auto add_block = [&](ReadonlySpan<StyleProperty> properties, OrderedHashMap<Utf16FlyString, StyleProperty> const* custom_properties, CascadeOrigin origin, u32 author_context_index, u32 layer_index, bool is_inline_style, bool bypass_pseudo_element_property_whitelist, Optional<Utf16FlyString> const& layer_name, GC::Ptr<CSSStyleDeclaration const> source, GC::Ptr<DOM::ShadowRoot const> source_shadow_root) {
         auto declarations_offset = all_declarations.size();
         all_declarations.ensure_capacity(all_declarations.size() + properties.size());
         for (auto const& property : properties) {
@@ -2265,6 +2231,20 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
                 .shell = property.value.ptr(),
                 .data = property.value->rust_style_value_data(),
             });
+        }
+        auto custom_property_declarations_offset = all_custom_property_declarations.size();
+        if (custom_properties) {
+            all_custom_property_declarations.ensure_capacity(all_custom_property_declarations.size() + custom_properties->size());
+            for (auto const& [name, property] : *custom_properties) {
+                auto name_raw = name.to_raw_leaked();
+                leaked_custom_property_names.append(name_raw);
+                all_custom_property_declarations.unchecked_append({
+                    .name_raw = name_raw,
+                    .important = property.important == Important::Yes,
+                    .is_revert_layer = property.value->is_revert_layer(),
+                    .shell = property.value.ptr(),
+                });
+            }
         }
         FlatPtr layer_name_raw = 0;
         if (layer_name.has_value()) {
@@ -2284,19 +2264,22 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
                 .source_id = static_cast<u32>(block_sources.size()),
                 .declarations = nullptr,
                 .declaration_count = properties.size(),
+                .custom_property_declarations = nullptr,
+                .custom_property_declaration_count = custom_properties ? custom_properties->size() : 0,
             },
             .declarations_offset = declarations_offset,
+            .custom_property_declarations_offset = custom_property_declarations_offset,
         });
         block_sources.append({ source, source_shadow_root });
     };
 
     for (auto const& match : matching_rule_set.user_agent_rules) {
         auto const& declaration = match.rule->declaration();
-        add_block(declaration.properties(), CascadeOrigin::UserAgent, 0, 0, false, false, {}, &declaration, match.shadow_root);
+        add_block(declaration.properties(), nullptr, CascadeOrigin::UserAgent, 0, 0, false, false, {}, &declaration, match.shadow_root);
     }
     for (auto const& match : matching_rule_set.user_rules) {
         auto const& declaration = match.rule->declaration();
-        add_block(declaration.properties(), CascadeOrigin::User, 0, 0, false, false, {}, &declaration, match.shadow_root);
+        add_block(declaration.properties(), nullptr, CascadeOrigin::User, 0, 0, false, false, {}, &declaration, match.shadow_root);
     }
 
     // Author presentational hints
@@ -2317,7 +2300,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
             collect_dimension_attribute(presentational_hint_properties, dimension_source, HTML::AttributeNames::height, CSS::PropertyID::Height);
         }
         if (!presentational_hint_properties.is_empty())
-            add_block(presentational_hint_properties, CascadeOrigin::AuthorPresentationalHint, 0, 0, false, false, {}, nullptr, nullptr);
+            add_block(presentational_hint_properties, nullptr, CascadeOrigin::AuthorPresentationalHint, 0, 0, false, false, {}, nullptr, nullptr);
     }
 
     for (u32 context_index = 0; context_index < matching_rule_set.author_contexts.size(); ++context_index) {
@@ -2329,7 +2312,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
                 Optional<Utf16FlyString> layer_name;
                 if (!layer.qualified_layer_name.is_empty())
                     layer_name = layer.qualified_layer_name;
-                add_block(declaration.properties(), CascadeOrigin::Author, context_index, layer_index, false, false, layer_name, &declaration, match.shadow_root);
+                add_block(declaration.properties(), &declaration.custom_properties(), CascadeOrigin::Author, context_index, layer_index, false, false, layer_name, &declaration, match.shadow_root);
             }
         }
         if (include_inline_style == IncludeInlineStyle::Yes && author_context.shadow_root == element_context_shadow_root) {
@@ -2338,7 +2321,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
             //     properties (e.g. input::placeholder has height set); authors can't set inline style on
             //     pseudo-elements so this doesn't cause any spec compliance issues.
             if (auto const inline_style = abstract_element.inline_style())
-                add_block(inline_style->properties(), CascadeOrigin::Author, context_index, 0, true, true, {}, inline_style, nullptr);
+                add_block(inline_style->properties(), &inline_style->custom_properties(), CascadeOrigin::Author, context_index, 0, true, true, {}, inline_style, nullptr);
         }
     }
 
@@ -2346,6 +2329,8 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
     blocks.ensure_capacity(pending_blocks.size());
     for (auto& pending : pending_blocks) {
         pending.block.declarations = all_declarations.data() + pending.declarations_offset;
+        if (pending.block.custom_property_declaration_count > 0)
+            pending.block.custom_property_declarations = all_custom_property_declarations.data() + pending.custom_property_declarations_offset;
         blocks.unchecked_append(pending.block);
     }
 
@@ -2397,7 +2382,48 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
                 auto const& source = bulk_context.block_sources[assignments[i].source_id];
                 bulk_context.cascaded_properties.assign_source_slot(assignments[i].slot, source.source, source.source_shadow_root);
             } },
+        .set_custom_properties = [](void* context, ComputedValuesFFI::FfiCascadedCustomProperty const* properties, size_t count) {
+            auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
+            OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_all;
+            cascaded_all.ensure_capacity(count);
+            for (size_t i = 0; i < count; ++i) {
+                auto const& property = properties[i];
+                cascaded_all.set(
+                    Utf16FlyString::from_raw(property.name_raw),
+                    StyleProperty {
+                        .important = property.important ? Important::Yes : Important::No,
+                        .property_id = PropertyID::Custom,
+                        .value = *static_cast<StyleValue const*>(property.shell),
+                    });
+            }
+
+            RefPtr<CustomPropertyData const> parent_data;
+            auto inherit_from = bulk_context.abstract_element.element_to_inherit_style_from();
+            if (inherit_from.has_value())
+                parent_data = inheritable_custom_property_data(*inherit_from);
+
+            OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_own;
+            for (auto& [name, property] : cascaded_all) {
+                if (parent_data) {
+                    auto const* parent_property = parent_data->get(name);
+                    if (parent_property && parent_property->value.ptr() == property.value.ptr())
+                        continue;
+                }
+                cascaded_own.set(name, move(property));
+            }
+
+            if (cascaded_own.is_empty() && parent_data) {
+                bulk_context.abstract_element.set_custom_property_data(parent_data);
+            } else if (cascaded_own.is_empty()) {
+                bulk_context.abstract_element.set_custom_property_data(nullptr);
+            } else {
+                bulk_context.abstract_element.set_custom_property_data(
+                    CustomPropertyData::create(move(cascaded_own), move(parent_data)));
+            } },
     };
+
+    auto cascade_custom_properties = !abstract_element.pseudo_element().has_value()
+        || pseudo_element_supports_property(*abstract_element.pseudo_element(), PropertyID::Custom);
 
     ComputedValuesFFI::rust_cascade_matched_blocks(
         cascaded_properties->rust_store(),
@@ -2405,12 +2431,15 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
         blocks.size(),
         static_cast<u32>(matching_rule_set.author_contexts.size()),
         abstract_element.pseudo_element().has_value(),
+        cascade_custom_properties,
         unset_value.ptr(),
         unset_value->rust_style_value_data(),
         &callbacks);
 
     for (auto layer_name_raw : leaked_layer_names)
         Utf16FlyString::unref_raw(layer_name_raw);
+    for (auto custom_property_name_raw : leaked_custom_property_names)
+        Utf16FlyString::unref_raw(custom_property_name_raw);
 
     // Transition declarations [css-transitions-1]
     // Note that we have to do these after finishing computing the style,
@@ -3019,60 +3048,7 @@ RefPtr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElemen
 
     auto old_custom_property_data = abstract_element.custom_property_data();
 
-    // Resolve all the CSS custom properties ("variables") for this element:
-    if (!abstract_element.pseudo_element().has_value() || pseudo_element_supports_property(*abstract_element.pseudo_element(), PropertyID::Custom)) {
-        OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_all;
-
-        auto element_context_shadow_root = as_if<DOM::ShadowRoot>(abstract_element.element().root());
-        auto cascade_inline_style = [&](Important important) {
-            if (include_inline_style == IncludeInlineStyle::No)
-                return;
-            cascade_custom_properties(abstract_element, {}, cascaded_all, important, true);
-        };
-
-        for (auto const& context : matching_rule_set.author_contexts.in_reverse()) {
-            for (auto const& layer : context.author_rules)
-                cascade_custom_properties(abstract_element, layer.rules, cascaded_all, Important::No, false);
-            if (context.shadow_root == element_context_shadow_root)
-                cascade_inline_style(Important::No);
-        }
-
-        for (auto const& context : matching_rule_set.author_contexts) {
-            for (auto const& layer : context.author_rules.in_reverse())
-                cascade_custom_properties(abstract_element, layer.rules, cascaded_all, Important::Yes, false);
-            if (context.shadow_root == element_context_shadow_root)
-                cascade_inline_style(Important::Yes);
-        }
-
-        RefPtr<CustomPropertyData const> parent_data;
-        auto inherit_from = abstract_element.element_to_inherit_style_from();
-        if (inherit_from.has_value())
-            parent_data = inheritable_custom_property_data(*inherit_from);
-
-        // Build own_values with only properties that differ from the parent.
-        // We build a fresh map instead of removing from cascaded_all,
-        // because removing entries doesn't shrink the bucket array.
-        OrderedHashMap<Utf16FlyString, StyleProperty> cascaded_own;
-        for (auto& [name, property] : cascaded_all) {
-            if (parent_data) {
-                auto const* parent_property = parent_data->get(name);
-                if (parent_property && parent_property->value.ptr() == property.value.ptr())
-                    continue;
-            }
-            cascaded_own.set(name, move(property));
-        }
-
-        if (cascaded_own.is_empty() && parent_data) {
-            abstract_element.set_custom_property_data(parent_data);
-        } else if (cascaded_own.is_empty() && !parent_data) {
-            abstract_element.set_custom_property_data(nullptr);
-        } else {
-            abstract_element.set_custom_property_data(
-                CustomPropertyData::create(move(cascaded_own), move(parent_data)));
-        }
-    }
-
-    auto cascaded_properties = compute_cascaded_values(abstract_element, did_match_any_pseudo_element_rules, mode, matching_rule_set, include_inline_style);
+    auto cascaded_properties = compute_cascaded_values(abstract_element, matching_rule_set, include_inline_style);
 
     if (mode == ComputeStyleMode::CreatePseudoElementStyleIfNeeded) {
         // Bail if no pseudo-element would be generated due to...

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3492,7 +3492,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .font_metrics_depend_on_viewport_metrics = false,
         .explicitly_inherited_non_inherited_property = false,
     };
-    ComputedValuesFFI::rust_drive_property_computation(&callbacks, cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, new_font_size != nullptr, device_pixels_per_css_pixel, InitialValues::font_size().raw_value(), default_user_font_size().raw_value(), &driver_results);
+    ComputedValuesFFI::rust_drive_property_computation(&callbacks, cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, abstract_element.element().local_name() == HTML::TagNames::th, new_font_size != nullptr, device_pixels_per_css_pixel, InitialValues::font_size().raw_value(), default_user_font_size().raw_value(), &driver_results);
 
     // Apply the driver's bulk results.
     auto longhand_bit_is_set = [](Array<u64, longhand_bitmap_words> const& words, size_t index) {
@@ -3557,7 +3557,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     // Apply any property-specific computed value logic
     if (animation_values_applied)
         resolve_effective_overflow_values(builder);
-    compute_text_align(builder, abstract_element);
+    if (animation_values_applied)
+        compute_text_align(builder, abstract_element);
 
     // Let the element adjust computed style
     if (!abstract_element.pseudo_element().has_value())

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2350,7 +2350,7 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
 
     ComputedValuesFFI::FfiBulkCascadeCallbacks const callbacks {
         .context = &bulk_context,
-        .resolve_unresolved = [](void* context, u16 property_id, void const* shell) -> void const* {
+        .resolve_unresolved = [](void* context, u16 property_id, void const* shell) -> ComputedValuesFFI::FfiResolvedStyleValue {
             auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
             auto resolved = Parser::Parser::resolve_unresolved_style_value(
                 Parser::ParsingParams { bulk_context.abstract_element.document() },
@@ -2358,11 +2358,14 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
                 {},
                 PropertyNameAndID::from_id(static_cast<PropertyID>(property_id)),
                 static_cast<StyleValue const*>(shell)->as_unresolved());
-            auto const* pointer = resolved.ptr();
+            ComputedValuesFFI::FfiResolvedStyleValue result {
+                .shell = resolved.ptr(),
+                .data = resolved->rust_style_value_data(),
+            };
             bulk_context.pinned_values.append(move(resolved));
-            return pointer;
+            return result;
         },
-        .parse_substituted = [](void* context, u16 property_id, u8 const* source, size_t source_length) -> void const* {
+        .parse_substituted = [](void* context, u16 property_id, u8 const* source, size_t source_length) -> ComputedValuesFFI::FfiResolvedStyleValue {
             auto& bulk_context = *static_cast<BulkCascadeContext*>(context);
             bulk_context.abstract_element.element().set_style_uses_var_css_function();
             auto parsed = parse_css_value(
@@ -2372,9 +2375,12 @@ NonnullRefPtr<CascadedProperties> StyleComputer::compute_cascaded_values(DOM::Ab
             NonnullRefPtr<StyleValue const> resolved = parsed
                 ? parsed.release_nonnull()
                 : GuaranteedInvalidStyleValue::create();
-            auto const* pointer = resolved.ptr();
+            ComputedValuesFFI::FfiResolvedStyleValue result {
+                .shell = resolved.ptr(),
+                .data = resolved->rust_style_value_data(),
+            };
             bulk_context.pinned_values.append(move(resolved));
-            return pointer;
+            return result;
         },
         .data_of = [](void*, void const* shell) -> void const* {
             return static_cast<StyleValue const*>(shell)->rust_style_value_data();

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3446,6 +3446,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         };
     }
 
+    bool animation_values_applied = false;
+
     // Copies the parent's animated value when a longhand inherits, as its store is
     // applied, so later properties' computation contexts observe the animated value.
     // FIXME: Do we need to recompute animated inherited values?
@@ -3461,6 +3463,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
                     ? AnimatedPropertyResultOfTransition::Yes
                     : AnimatedPropertyResultOfTransition::No,
                 ComputedProperties::Inherited::Yes);
+            animation_values_applied = true;
         }
     };
 
@@ -3671,7 +3674,25 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     // Add or modify CSS-defined animations
     process_animation_definitions(computed_style, cascaded_properties, abstract_element);
 
-    bool animation_values_applied = false;
+    auto restore_values_before_post_compute_adjustments = [&] {
+        VERIFY(loop_context.display_before_adjustments.has_value());
+        VERIFY(loop_context.float_before_adjustments.has_value());
+        VERIFY(loop_context.overflow_x_before_adjustments.has_value());
+        VERIFY(loop_context.overflow_y_before_adjustments.has_value());
+        VERIFY(loop_context.text_align_before_adjustments.has_value());
+        VERIFY(loop_context.position_before_adjustments.has_value());
+        VERIFY(loop_context.line_height_before_adjustments);
+        builder.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(*loop_context.display_before_adjustments)));
+        builder.set_property_without_modifying_flags(PropertyID::Float, KeywordStyleValue::create(*loop_context.float_before_adjustments));
+        builder.set_property_without_modifying_flags(PropertyID::OverflowX, KeywordStyleValue::create(*loop_context.overflow_x_before_adjustments));
+        builder.set_property_without_modifying_flags(PropertyID::OverflowY, KeywordStyleValue::create(*loop_context.overflow_y_before_adjustments));
+        builder.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*loop_context.text_align_before_adjustments));
+        builder.set_property_without_modifying_flags(PropertyID::Position, KeywordStyleValue::create(*loop_context.position_before_adjustments));
+        builder.set_property_without_modifying_flags(PropertyID::LineHeight, *loop_context.line_height_before_adjustments);
+    };
+    if (animation_values_applied)
+        restore_values_before_post_compute_adjustments();
+
     auto animations = abstract_element.element().get_animations_internal(
         Animations::Animatable::GetAnimationsSorted::Yes,
         Bindings::GetAnimationsOptions { .subtree = false });
@@ -3682,22 +3703,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
             if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
                 auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());
                 if (keyframe_effect.pseudo_element_type() == abstract_element.pseudo_element()) {
-                    if (!animation_values_applied) {
-                        VERIFY(loop_context.display_before_adjustments.has_value());
-                        VERIFY(loop_context.float_before_adjustments.has_value());
-                        VERIFY(loop_context.overflow_x_before_adjustments.has_value());
-                        VERIFY(loop_context.overflow_y_before_adjustments.has_value());
-                        VERIFY(loop_context.text_align_before_adjustments.has_value());
-                        VERIFY(loop_context.position_before_adjustments.has_value());
-                        VERIFY(loop_context.line_height_before_adjustments);
-                        builder.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(*loop_context.display_before_adjustments)));
-                        builder.set_property_without_modifying_flags(PropertyID::Float, KeywordStyleValue::create(*loop_context.float_before_adjustments));
-                        builder.set_property_without_modifying_flags(PropertyID::OverflowX, KeywordStyleValue::create(*loop_context.overflow_x_before_adjustments));
-                        builder.set_property_without_modifying_flags(PropertyID::OverflowY, KeywordStyleValue::create(*loop_context.overflow_y_before_adjustments));
-                        builder.set_property_without_modifying_flags(PropertyID::TextAlign, KeywordStyleValue::create(*loop_context.text_align_before_adjustments));
-                        builder.set_property_without_modifying_flags(PropertyID::Position, KeywordStyleValue::create(*loop_context.position_before_adjustments));
-                        builder.set_property_without_modifying_flags(PropertyID::LineHeight, *loop_context.line_height_before_adjustments);
-                    }
+                    if (!animation_values_applied)
+                        restore_values_before_post_compute_adjustments();
                     animation_values_applied = true;
                     collect_animation_into(abstract_element, keyframe_effect, builder);
                 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3384,6 +3384,21 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
 
     auto const device_pixels_per_css_pixel = m_document->page().client().device_pixels_per_css_pixel();
 
+    Vector<u8> document_supported_color_scheme_codes;
+    auto document_supported_color_schemes = document().supported_color_schemes();
+    if (document_supported_color_schemes.has_value()) {
+        document_supported_color_scheme_codes.ensure_capacity(document_supported_color_schemes->size());
+        for (auto const& scheme : *document_supported_color_schemes)
+            document_supported_color_scheme_codes.unchecked_append(to_underlying(preferred_color_scheme_from_string(scheme)));
+    }
+    ComputedValuesFFI::FfiEffectiveColorSchemeInput const effective_color_scheme_input {
+        .preferred_color_scheme = static_cast<u8>(to_underlying(document().page().preferred_color_scheme())),
+        .has_document_supported_schemes = document_supported_color_schemes.has_value(),
+        .document_supported_scheme_codes = document_supported_color_scheme_codes.data(),
+        .document_supported_scheme_count = document_supported_color_scheme_codes.size(),
+    };
+    builder.clear_effective_color_scheme();
+
     auto const compute_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> const& style_value, bool& depends_on_viewport_metrics) {
         auto const& computation_context = get_computation_context_for_property(property_id, computed_style, abstract_element);
         computation_context.reset_viewport_metric_dependency_tracking();
@@ -3510,6 +3525,10 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
                 builder.set_property_without_modifying_flags(property_id, value);
                 break;
             }
+            if (property_id == PropertyID::ColorScheme && !builder.has_effective_color_scheme()) {
+                auto effective_color_scheme = ComputedValuesFFI::rust_resolve_effective_color_scheme(builder.property(PropertyID::ColorScheme).rust_style_value_data(), &effective_color_scheme_input);
+                builder.set_effective_color_scheme(static_cast<PreferredColorScheme>(effective_color_scheme));
+            }
         }
     };
 
@@ -3553,6 +3572,9 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .store_computed_batch = [](void* context, ComputedValuesFFI::FfiComputedStoreEntry const* entries, size_t count) {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.store_computed_batch_callback(entries, count); },
+        .store_effective_color_scheme = [](void* context, u8 color_scheme) {
+            auto& loop_context = *static_cast<LonghandLoopContext*>(context);
+            loop_context.builder.set_effective_color_scheme(static_cast<PreferredColorScheme>(color_scheme)); },
         .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, u16 position_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation, ComputedValuesFFI::FfiElementStyleAdjustment const* element_adjustment) -> bool {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.display_before_adjustments = *display_before;
@@ -3597,7 +3619,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
     };
     auto box_type_input = make_box_type_transformation_input(
         abstract_element, InitialValues::display(), Keyword::Static, Keyword::None);
-    ComputedValuesFFI::rust_drive_property_computation(&callbacks, cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, &box_type_input, abstract_element.element().local_name() == HTML::TagNames::th, new_font_size != nullptr, device_pixels_per_css_pixel, InitialValues::font_size().raw_value(), default_user_font_size().raw_value(), &driver_results);
+    ComputedValuesFFI::rust_drive_property_computation(&callbacks, cascaded_properties.rust_store(), parent_snapshot.has_value() ? &*parent_snapshot : nullptr, &box_type_input, &effective_color_scheme_input, abstract_element.element().local_name() == HTML::TagNames::th, new_font_size != nullptr, device_pixels_per_css_pixel, InitialValues::font_size().raw_value(), default_user_font_size().raw_value(), &driver_results);
 
     // Apply the driver's bulk results.
     auto longhand_bit_is_set = [](Array<u64, longhand_bitmap_words> const& words, size_t index) {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2806,6 +2806,29 @@ static Display from_ffi_display(ComputedValuesFFI::FfiDisplay const& display)
     VERIFY_NOT_REACHED();
 }
 
+static ComputedValuesFFI::FfiDisplay decode_ffi_display(u32 encoded)
+{
+    ComputedValuesFFI::FfiDisplay display {};
+    display.tag = encoded & 0xff;
+    auto first = static_cast<u8>((encoded >> 8) & 0xff);
+    auto second = static_cast<u8>((encoded >> 16) & 0xff);
+    auto third = static_cast<u8>((encoded >> 24) & 0xff);
+    switch (static_cast<Display::Type>(display.tag)) {
+    case Display::Type::OutsideAndInside:
+        display.outside = first;
+        display.inside = second;
+        display.list_item = third != 0;
+        break;
+    case Display::Type::Internal:
+        display.internal = first;
+        break;
+    case Display::Type::Box:
+        display.box_value = first;
+        break;
+    }
+    return display;
+}
+
 static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transformation_input(
     DOM::AbstractElement abstract_element, Display display, Keyword position, Keyword float_value)
 {
@@ -2897,21 +2920,13 @@ static void apply_box_type_transformation(ComputedProperties::Builder& builder, 
         builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(transformation.display)));
 }
 
-static ComputedValuesFFI::FfiInputLineHeightMetrics apply_element_style_adjustment(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiElementStyleAdjustment const& adjustment)
+static ComputedValuesFFI::FfiInputLineHeightMetrics input_line_height_metrics(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, bool should_measure)
 {
-    if (adjustment.changed_display)
-        builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(adjustment.display)));
-    if (adjustment.set_line_height_normal)
-        builder.set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
     ComputedValuesFFI::FfiInputLineHeightMetrics line_height_metrics {};
-    if (adjustment.check_input_line_height) {
+    if (should_measure) {
         line_height_metrics.current_line_height = builder.line_height(abstract_element.element().document().font_computer()).to_double();
         line_height_metrics.minimum_line_height = ComputedProperties::normal_line_height(builder.first_available_computed_font(abstract_element.element().document().font_computer())->pixel_metrics()).to_double();
     }
-    if (adjustment.set_position_static)
-        builder.set_property(PropertyID::Position, KeywordStyleValue::create(Keyword::Static));
-    if (adjustment.changed_text_align)
-        builder.set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(adjustment.text_align)));
     return line_height_metrics;
 }
 
@@ -3505,6 +3520,9 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
             case ComputedValuesFFI::COMPUTED_KIND_KEYWORD:
                 builder.set_property_without_modifying_flags(property_id, KeywordStyleValue::create(static_cast<Keyword>(static_cast<u16>(entry.value))));
                 break;
+            case ComputedValuesFFI::COMPUTED_KIND_DISPLAY:
+                builder.set_property_without_modifying_flags(property_id, DisplayStyleValue::create(from_ffi_display(decode_ffi_display(static_cast<u32>(entry.value)))));
+                break;
             case ComputedValuesFFI::COMPUTED_KIND_SUPERELLIPSE: {
                 // NB: The round value is cached since it is the initial value of the corner-*-shape properties.
                 if (entry.value == 1) {
@@ -3569,7 +3587,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         .store_effective_color_scheme = [](void* context, u8 color_scheme) {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.builder.set_effective_color_scheme(static_cast<PreferredColorScheme>(color_scheme)); },
-        .store_box_type_transformation = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, u16 position_before, ComputedValuesFFI::FfiBoxTypeTransformation const* transformation, ComputedValuesFFI::FfiElementStyleAdjustment const* element_adjustment) -> ComputedValuesFFI::FfiInputLineHeightMetrics {
+        .prepare_post_compute_adjustments = [](void* context, ComputedValuesFFI::FfiDisplay const* display_before, u16 float_before, u16 overflow_x_before, u16 overflow_y_before, u16 text_align_before, u16 position_before, bool check_input_line_height) -> ComputedValuesFFI::FfiInputLineHeightMetrics {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             loop_context.display_before_adjustments = *display_before;
             loop_context.float_before_adjustments = static_cast<Keyword>(float_before);
@@ -3578,8 +3596,8 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
             loop_context.text_align_before_adjustments = static_cast<Keyword>(text_align_before);
             loop_context.position_before_adjustments = static_cast<Keyword>(position_before);
             loop_context.line_height_before_adjustments = loop_context.builder.style().property(PropertyID::LineHeight);
-            apply_box_type_transformation(loop_context.builder, *display_before, *transformation);
-            return apply_element_style_adjustment(loop_context.builder, loop_context.abstract_element, *element_adjustment); },
+            loop_context.builder.set_display_before_box_type_transformation(from_ffi_display(*display_before));
+            return input_line_height_metrics(loop_context.builder, loop_context.abstract_element, check_input_line_height); },
         .fetch_non_inherited_parent_value = [](void* context, u16 inherited_property_id) -> ComputedValuesFFI::FfiShellAndData {
             auto& loop_context = *static_cast<LonghandLoopContext*>(context);
             auto value = get_non_animated_inherit_value(static_cast<PropertyID>(inherited_property_id), loop_context.abstract_element);

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -194,7 +194,7 @@ private:
     [[nodiscard]] MatchingRuleSet build_matching_rule_set(DOM::AbstractElement, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
 
     [[nodiscard]] RefPtr<ComputedProperties> compute_style_impl(DOM::AbstractElement, ComputeStyleMode, Optional<bool&> did_change_custom_properties, StyleScope const&, IncludeInlineStyle) const;
-    [[nodiscard]] NonnullRefPtr<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, bool did_match_any_pseudo_element_rules, ComputeStyleMode, MatchingRuleSet const&, IncludeInlineStyle) const;
+    [[nodiscard]] NonnullRefPtr<CascadedProperties> compute_cascaded_values(DOM::AbstractElement, MatchingRuleSet const&, IncludeInlineStyle) const;
     void collect_animation_into(DOM::AbstractElement, GC::Ref<Animations::KeyframeEffect> animation, ComputedProperties&, ComputedProperties::Builder*) const;
     void compute_custom_properties(ComputedProperties&, DOM::AbstractElement) const;
     void start_needed_transitions(ComputedValues const& old_style, ComputedProperties::Builder& new_style, DOM::AbstractElement) const;

--- a/Libraries/LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
 
 namespace Web::CSS {
@@ -46,10 +47,14 @@ private:
     {
         // The Rust allocation takes ownership of one leaked reference to each scheme name.
         Vector<size_t> raws;
+        Vector<u8> scheme_codes;
         raws.ensure_capacity(schemes.size());
-        for (auto const& scheme : schemes)
+        scheme_codes.ensure_capacity(schemes.size());
+        for (auto const& scheme : schemes) {
             raws.unchecked_append(scheme.to_raw_leaked());
-        return StyleValueFFI::rust_style_value_create_color_scheme(raws.data(), raws.size(), only);
+            scheme_codes.unchecked_append(to_underlying(preferred_color_scheme_from_string(scheme)));
+        }
+        return StyleValueFFI::rust_style_value_create_color_scheme(raws.data(), scheme_codes.data(), raws.size(), only);
     }
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
@@ -45,6 +45,28 @@ static void mark_as_attr_tainted(Vector<Parser::ComponentValue>& values)
         value.set_attr_tainted();
 }
 
+static StyleValueFFI::StyleValueData* create_rust_style_value(String source_text, String value_comparison_text, Parser::SubstitutionFunctionsPresence substitution_presence, bool contains_attr_tainted_values)
+{
+    auto source_text_bytes = source_text.bytes();
+    auto value_comparison_text_bytes = value_comparison_text.bytes();
+    auto source_text_raw = source_text.to_raw_leaked();
+    auto value_comparison_text_raw = value_comparison_text.to_raw_leaked();
+    return StyleValueFFI::rust_style_value_create_unresolved(
+        source_text_raw,
+        source_text_bytes.data(),
+        source_text_bytes.size(),
+        value_comparison_text_raw,
+        value_comparison_text_bytes.data(),
+        value_comparison_text_bytes.size(),
+        substitution_presence.attr,
+        substitution_presence.dashed_function,
+        substitution_presence.env,
+        substitution_presence.if_,
+        substitution_presence.inherit,
+        substitution_presence.var,
+        contains_attr_tainted_values);
+}
+
 String UnresolvedStyleValue::comparison_text() const
 {
     auto value_comparison_text = this->value_comparison_text();
@@ -76,7 +98,7 @@ ValueComparingNonnullRefPtr<UnresolvedStyleValue const> UnresolvedStyleValue::cr
 }
 
 UnresolvedStyleValue::UnresolvedStyleValue(String source_text, String value_comparison_text, Parser::SubstitutionFunctionsPresence substitution_presence, bool contains_attr_tainted_values)
-    : StyleValue(Type::Unresolved, StyleValueFFI::rust_style_value_create_unresolved(source_text.to_raw_leaked(), value_comparison_text.to_raw_leaked(), substitution_presence.attr, substitution_presence.dashed_function, substitution_presence.env, substitution_presence.if_, substitution_presence.inherit, substitution_presence.var, contains_attr_tainted_values))
+    : StyleValue(Type::Unresolved, create_rust_style_value(move(source_text), move(value_comparison_text), substitution_presence, contains_attr_tainted_values))
 {
 }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -76,6 +76,7 @@
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/TransitionEvent.h>
 #include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/ComputedValuesRustFFI.h>
 #include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
 #include <LibWeb/ContentSecurityPolicy/Policy.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
@@ -577,6 +578,8 @@ Document::Document(JS::Realm& realm, URL::URL const& url)
     , m_style_invalidator(realm.heap().allocate<CSS::Invalidation::StyleInvalidator>())
     , m_style_scope(*this)
 {
+    m_rust_custom_property_registry = CSS::ComputedValuesFFI::rust_custom_property_registry_create();
+
     m_legacy_platform_object_flags = PlatformObject::LegacyPlatformObjectFlags {
         .supports_named_properties = true,
         .has_legacy_override_built_ins_interface_extended_attribute = true,
@@ -663,6 +666,7 @@ void Document::record_full_style_invalidation() const
 
 void Document::finalize()
 {
+    CSS::ComputedValuesFFI::rust_custom_property_registry_destroy(m_rust_custom_property_registry);
     Base::finalize();
     HTML::main_thread_event_loop().unregister_document({}, *this);
 }
@@ -9573,11 +9577,48 @@ Optional<CSS::CustomPropertyRegistration const&> Document::get_registered_custom
 void Document::did_change_custom_property_registrations()
 {
     ++m_custom_property_registration_generation;
+    sync_custom_property_registrations_to_rust();
 
     // Custom property registration changes can alter inheritance and initial values even when no selector matching
     // changes. Registrations only move when a stylesheet containing an @property rule is added/removed or when
     // CSS.registerProperty() is called, so a full document restyle is cheap enough in practice.
     invalidate_style(DOM::StyleInvalidationReason::CustomPropertyRegistrationChange);
+}
+
+void Document::sync_custom_property_registrations_to_rust()
+{
+    HashMap<Utf16FlyString, CSS::CustomPropertyRegistration const*> effective_registrations;
+    effective_registrations.ensure_capacity(m_registered_property_set.size() + m_cached_registered_properties_from_css_property_rules.size());
+    for (auto const& [name, registration] : m_cached_registered_properties_from_css_property_rules)
+        effective_registrations.set(name, &registration);
+    for (auto const& [name, registration] : m_registered_property_set)
+        effective_registrations.set(name, &registration);
+
+    Vector<String> names;
+    Vector<Optional<String>> initial_values;
+    Vector<CSS::ComputedValuesFFI::FfiCustomPropertyRegistration> registrations;
+    names.ensure_capacity(effective_registrations.size());
+    initial_values.ensure_capacity(effective_registrations.size());
+    registrations.ensure_capacity(effective_registrations.size());
+    for (auto const& [name, registration] : effective_registrations) {
+        names.unchecked_append(MUST(name.view().to_utf8()));
+        initial_values.unchecked_append(registration->initial_value
+                ? Optional<String> { registration->initial_value->to_string(CSS::SerializationMode::Normal) }
+                : Optional<String> {});
+        auto const& name_utf8 = names.last();
+        auto const& initial_value = initial_values.last();
+        registrations.unchecked_append({
+            .name = name_utf8.bytes().data(),
+            .name_length = name_utf8.bytes().size(),
+            .syntax_is_universal = registration->syntax->type() == CSS::Parser::SyntaxNode::NodeType::Universal,
+            .inherits = registration->inherit,
+            .has_initial_value = initial_value.has_value(),
+            .initial_value = initial_value.has_value() ? initial_value->bytes().data() : nullptr,
+            .initial_value_length = initial_value.has_value() ? initial_value->bytes().size() : 0,
+        });
+    }
+    CSS::ComputedValuesFFI::rust_custom_property_registry_update(
+        m_rust_custom_property_registry, registrations.data(), registrations.size());
 }
 
 void Document::build_registered_properties_cache()
@@ -9598,10 +9639,10 @@ void Document::build_registered_properties_cache()
         });
     });
 
-    if (cached_registered_properties_from_css_property_rules != m_cached_registered_properties_from_css_property_rules)
-        did_change_custom_property_registrations();
-
+    auto registrations_changed = cached_registered_properties_from_css_property_rules != m_cached_registered_properties_from_css_property_rules;
     m_cached_registered_properties_from_css_property_rules = move(cached_registered_properties_from_css_property_rules);
+    if (registrations_changed)
+        did_change_custom_property_registrations();
 }
 
 void Document::ensure_cookie_version_index(URL::URL const& new_url, URL::URL const& old_url)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1288,6 +1288,7 @@ public:
     HashMap<Utf16FlyString, CSS::CustomPropertyRegistration>& registered_property_set();
     Optional<CSS::CustomPropertyRegistration const&> get_registered_custom_property(Utf16FlyString const& name) const;
     size_t custom_property_registration_generation() const { return m_custom_property_registration_generation; }
+    void const* rust_custom_property_registry() const { return m_rust_custom_property_registry; }
     void did_change_custom_property_registrations();
 
     CSS::StyleScope const& style_scope() const { return m_style_scope; }
@@ -1385,6 +1386,7 @@ private:
     void run_csp_initialization() const;
 
     void build_registered_properties_cache();
+    void sync_custom_property_registrations_to_rust();
     void build_counter_style_cache();
 
     void ensure_cookie_version_index(URL::URL const& new_url, URL::URL const& old_url = {});
@@ -1831,6 +1833,7 @@ private:
     HashMap<Utf16FlyString, CSS::CustomPropertyRegistration> m_cached_registered_properties_from_css_property_rules;
     bool m_needs_registered_properties_cache_update { true };
     size_t m_custom_property_registration_generation { 0 };
+    void* m_rust_custom_property_registry { nullptr };
 
     CSS::StyleScope m_style_scope;
 

--- a/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
@@ -1,0 +1,4 @@
+overflow-x: visible
+overflow-y: visible
+display: inline
+position: static

--- a/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
@@ -2,3 +2,5 @@ overflow-x: visible
 overflow-y: visible
 display: inline
 position: static
+parent text-align: right
+match-parent text-align: right

--- a/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
@@ -4,3 +4,7 @@ display: inline
 position: static
 parent text-align: right
 match-parent text-align: right
+inherited overflow-x: scroll
+adjusted overflow-y: auto
+inherited display: block
+inherited position: absolute

--- a/Tests/LibWeb/Text/expected/css/attr-taint-through-unresolved-custom-property.txt
+++ b/Tests/LibWeb/Text/expected/css/attr-taint-through-unresolved-custom-property.txt
@@ -1,1 +1,2 @@
-none
+direct: none
+inherited: none

--- a/Tests/LibWeb/Text/expected/css/custom-property-cascade-order.txt
+++ b/Tests/LibWeb/Text/expected/css/custom-property-cascade-order.txt
@@ -1,0 +1,7 @@
+normal inline: 3px
+normal source order: 5px
+important inline: rgb(255, 0, 255)
+important layer order: rgb(0, 128, 0)
+revert-layer: 10px
+normal outer context: rgb(0, 128, 0)
+important inner context: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/expected/css/effective-color-scheme-resolution.txt
+++ b/Tests/LibWeb/Text/expected/css/effective-color-scheme-resolution.txt
@@ -1,0 +1,5 @@
+preferred: light dark / rgb(235, 235, 235)
+first-supported: custom light / rgb(0, 0, 0)
+normal: normal / rgb(235, 235, 235)
+variable: dark / rgb(235, 235, 235)
+animated: dark / rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/css/input-line-height-clamp.txt
+++ b/Tests/LibWeb/Text/expected/css/input-line-height-clamp.txt
@@ -1,0 +1,4 @@
+small: normal
+large: 40px
+variable: normal
+checkbox: 1px

--- a/Tests/LibWeb/Text/expected/css/native-var-substitution.txt
+++ b/Tests/LibWeb/Text/expected/css/native-var-substitution.txt
@@ -1,6 +1,8 @@
 width: 10px
 height: 7px
 cycle fallback: 3px
+fallback inside cycle ignored: rgb(255, 0, 0)
+fallback outside cycle used: rgb(0, 0, 255)
 native parse callback used: true
 C++ resolver unused: true
 registered width: 9px

--- a/Tests/LibWeb/Text/expected/css/native-var-substitution.txt
+++ b/Tests/LibWeb/Text/expected/css/native-var-substitution.txt
@@ -1,0 +1,7 @@
+width: 10px
+height: 7px
+cycle fallback: 3px
+native parse callback used: true
+C++ resolver unused: true
+registered width: 9px
+registered value used C++ resolver: true

--- a/Tests/LibWeb/Text/expected/css/native-var-substitution.txt
+++ b/Tests/LibWeb/Text/expected/css/native-var-substitution.txt
@@ -4,4 +4,7 @@ cycle fallback: 3px
 native parse callback used: true
 C++ resolver unused: true
 registered width: 9px
+unregistered height: 11px
+registered universal initial: 13px
 registered value used C++ resolver: true
+unregistered value used native parser: true

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/properties-value-inherit-001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/properties-value-inherit-001.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 560 tests
 
-280 Pass
-280 Fail
+291 Pass
+269 Fail
 Pass	background-color color(rgba) / values
 Fail	background-color color(rgba) / events
 Pass	background-position-x length(pt) / values
@@ -429,27 +429,27 @@ Fail	font-weight font-weight(keyword) / events
 Pass	font-weight font-weight(numeric) / values
 Fail	font-weight font-weight(numeric) / events
 Pass	line-height number(integer) / values
-Fail	line-height number(integer) / events
+Pass	line-height number(integer) / events
 Pass	line-height number(decimal) / values
-Fail	line-height number(decimal) / events
+Pass	line-height number(decimal) / events
 Pass	line-height length(pt) / values
-Fail	line-height length(pt) / events
+Pass	line-height length(pt) / events
 Pass	line-height length(pc) / values
-Fail	line-height length(pc) / events
+Pass	line-height length(pc) / events
 Pass	line-height length(px) / values
-Fail	line-height length(px) / events
+Pass	line-height length(px) / events
 Pass	line-height length(em) / values
-Fail	line-height length(em) / events
+Pass	line-height length(em) / events
 Pass	line-height length(ex) / values
-Fail	line-height length(ex) / events
+Pass	line-height length(ex) / events
 Pass	line-height length(mm) / values
-Fail	line-height length(mm) / events
+Pass	line-height length(mm) / events
 Pass	line-height length(cm) / values
-Fail	line-height length(cm) / events
+Pass	line-height length(cm) / events
 Pass	line-height length(in) / values
-Fail	line-height length(in) / events
+Pass	line-height length(in) / events
 Pass	line-height percentage(%) / values
-Fail	line-height percentage(%) / events
+Pass	line-height percentage(%) / events
 Pass	letter-spacing length(pt) / values
 Fail	letter-spacing length(pt) / events
 Pass	letter-spacing length(pc) / values

--- a/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
+++ b/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="overflow" style="overflow-x: visible; overflow-y: auto"></div>
+<div id="position" style="display: inline; position: absolute"></div>
+<script>
+    test(() => {
+        const overflowAnimation = overflow.animate(
+            [{ overflowY: "visible" }, { overflowY: "visible" }],
+            { duration: 1000, fill: "forwards" });
+        overflowAnimation.pause();
+        overflowAnimation.currentTime = 500;
+
+        const overflowStyle = getComputedStyle(overflow);
+        println(`overflow-x: ${overflowStyle.overflowX}`);
+        println(`overflow-y: ${overflowStyle.overflowY}`);
+
+        const positionAnimation = position.animate(
+            [{ position: "static" }, { position: "static" }],
+            { duration: 1000, fill: "forwards" });
+        positionAnimation.pause();
+        positionAnimation.currentTime = 500;
+
+        const positionStyle = getComputedStyle(position);
+        println(`display: ${positionStyle.display}`);
+        println(`position: ${positionStyle.position}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
+++ b/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
@@ -2,13 +2,17 @@
 <script src="../include.js"></script>
 <div id="overflow" style="overflow-x: visible; overflow-y: auto"></div>
 <div id="position" style="display: inline; position: absolute"></div>
+<div id="text-align-parent" style="text-align: left">
+    <div id="text-align-child" style="text-align: match-parent"></div>
+</div>
 <script>
-    test(() => {
+    promiseTest(async () => {
         const overflowAnimation = overflow.animate(
             [{ overflowY: "visible" }, { overflowY: "visible" }],
             { duration: 1000, fill: "forwards" });
         overflowAnimation.pause();
         overflowAnimation.currentTime = 500;
+        await overflowAnimation.ready;
 
         const overflowStyle = getComputedStyle(overflow);
         println(`overflow-x: ${overflowStyle.overflowX}`);
@@ -19,9 +23,24 @@
             { duration: 1000, fill: "forwards" });
         positionAnimation.pause();
         positionAnimation.currentTime = 500;
+        await positionAnimation.ready;
 
         const positionStyle = getComputedStyle(position);
         println(`display: ${positionStyle.display}`);
         println(`position: ${positionStyle.position}`);
+
+        const textAlignParent = document.getElementById("text-align-parent");
+        const textAlignChild = document.getElementById("text-align-child");
+        const textAlignAnimation = textAlignParent.animate(
+            [{ textAlign: "right" }, { textAlign: "right" }],
+            { duration: 1000, fill: "forwards" });
+        textAlignAnimation.pause();
+        textAlignAnimation.currentTime = 500;
+        await textAlignAnimation.ready;
+        await animationFrame();
+
+        println(`parent text-align: ${getComputedStyle(textAlignParent).textAlign}`);
+        await animationFrame();
+        println(`match-parent text-align: ${getComputedStyle(textAlignChild).textAlign}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
+++ b/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
@@ -5,6 +5,12 @@
 <div id="text-align-parent" style="text-align: left">
     <div id="text-align-child" style="text-align: match-parent"></div>
 </div>
+<div id="inherited-overflow-parent" style="overflow-x: visible">
+    <div id="inherited-overflow-child" style="overflow-x: inherit; overflow-y: visible"></div>
+</div>
+<div id="inherited-position-parent" style="position: static">
+    <div id="inherited-position-child" style="display: inline; position: inherit"></div>
+</div>
 <script>
     promiseTest(async () => {
         const overflowAnimation = overflow.animate(
@@ -42,5 +48,31 @@
         println(`parent text-align: ${getComputedStyle(textAlignParent).textAlign}`);
         await animationFrame();
         println(`match-parent text-align: ${getComputedStyle(textAlignChild).textAlign}`);
+
+        const inheritedOverflowParent = document.getElementById("inherited-overflow-parent");
+        const inheritedOverflowChild = document.getElementById("inherited-overflow-child");
+        const inheritedOverflowAnimation = inheritedOverflowParent.animate(
+            [{ overflowX: "scroll" }, { overflowX: "scroll" }],
+            { duration: 1000, fill: "forwards" });
+        inheritedOverflowAnimation.pause();
+        inheritedOverflowAnimation.currentTime = 500;
+        await inheritedOverflowAnimation.ready;
+
+        const inheritedOverflowStyle = getComputedStyle(inheritedOverflowChild);
+        println(`inherited overflow-x: ${inheritedOverflowStyle.overflowX}`);
+        println(`adjusted overflow-y: ${inheritedOverflowStyle.overflowY}`);
+
+        const inheritedPositionParent = document.getElementById("inherited-position-parent");
+        const inheritedPositionChild = document.getElementById("inherited-position-child");
+        const inheritedPositionAnimation = inheritedPositionParent.animate(
+            [{ position: "absolute" }, { position: "absolute" }],
+            { duration: 1000, fill: "forwards" });
+        inheritedPositionAnimation.pause();
+        inheritedPositionAnimation.currentTime = 500;
+        await inheritedPositionAnimation.ready;
+
+        const inheritedPositionStyle = getComputedStyle(inheritedPositionChild);
+        println(`inherited display: ${inheritedPositionStyle.display}`);
+        println(`inherited position: ${inheritedPositionStyle.position}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/attr-taint-through-unresolved-custom-property.html
+++ b/Tests/LibWeb/Text/input/css/attr-taint-through-unresolved-custom-property.html
@@ -1,10 +1,19 @@
 <!doctype html>
 <div id="target" data-url="https://does-not-exist.test/404.png"></div>
+<div id="source" data-url="https://does-not-exist.test/inherited.png">
+    <div id="inherited-target"></div>
+</div>
 <script src="../include.js"></script>
 <script>
     test(() => {
+        const inheritedTarget = document.getElementById("inherited-target");
+
         target.style.setProperty("--x", "attr(data-url)");
         target.style.backgroundImage = "image-set(var(--x))";
-        println(getComputedStyle(target).backgroundImage);
+        println(`direct: ${getComputedStyle(target).backgroundImage}`);
+
+        source.style.setProperty("--x", "attr(data-url)");
+        inheritedTarget.style.backgroundImage = "image-set(var(--x))";
+        println(`inherited: ${getComputedStyle(inheritedTarget).backgroundImage}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/custom-property-cascade-order.html
+++ b/Tests/LibWeb/Text/input/css/custom-property-cascade-order.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    @layer first, second;
+
+    @layer first {
+        #target, #layer-target {
+            --important: rgb(0, 128, 0) !important;
+            --reverted: 10px;
+        }
+    }
+
+    @layer second {
+        #target, #layer-target {
+            --important: rgb(0, 0, 255) !important;
+            --reverted: revert-layer;
+        }
+    }
+
+    #target {
+        --normal: 1px;
+        --normal: 2px;
+        --source-order: 4px;
+        --source-order: 5px;
+        --important: rgb(255, 0, 0) !important;
+        margin-left: var(--normal);
+        margin-right: var(--reverted);
+        padding-left: var(--source-order);
+        color: var(--important);
+    }
+
+    #layer-target {
+        color: var(--important);
+    }
+
+    shadow-cascade-order {
+        --normal-context: rgb(0, 128, 0);
+        --important-context: rgb(255, 0, 0) !important;
+        color: var(--normal-context);
+        background-color: var(--important-context);
+    }
+</style>
+<div id="target" style="--normal: 3px; --important: rgb(255, 0, 255) !important"></div>
+<div id="layer-target"></div>
+<script>
+    test(() => {
+        const style = getComputedStyle(target);
+        println(`normal inline: ${style.marginLeft}`);
+        println(`normal source order: ${style.paddingLeft}`);
+        println(`important inline: ${style.color}`);
+        println(`important layer order: ${getComputedStyle(document.getElementById("layer-target")).color}`);
+        println(`revert-layer: ${style.marginRight}`);
+
+        customElements.define("shadow-cascade-order", class extends HTMLElement {
+            constructor() {
+                super();
+                this.attachShadow({ mode: "open" }).innerHTML = `
+                    <style>
+                        :host {
+                            --normal-context: rgb(255, 0, 0);
+                            --important-context: rgb(0, 0, 255) !important;
+                        }
+                    </style>
+                `;
+            }
+        });
+
+        const host = document.createElement("shadow-cascade-order");
+        document.body.appendChild(host);
+        const hostStyle = getComputedStyle(host);
+        println(`normal outer context: ${hostStyle.color}`);
+        println(`important inner context: ${hostStyle.backgroundColor}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/effective-color-scheme-resolution.html
+++ b/Tests/LibWeb/Text/input/css/effective-color-scheme-resolution.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta name="color-scheme" content="dark light">
+<script src="../include.js"></script>
+<style>
+    div {
+        color: CanvasText;
+    }
+
+    #preferred {
+        color-scheme: light dark;
+    }
+
+    #first-supported {
+        color-scheme: custom light;
+    }
+
+    #variable {
+        --scheme: dark;
+        color-scheme: var(--scheme);
+    }
+
+    #animated {
+        color-scheme: light;
+        animation: scheme 1s -1s paused both;
+    }
+
+    @keyframes scheme {
+        from, to {
+            color-scheme: dark;
+        }
+    }
+</style>
+<div id="preferred"></div>
+<div id="first-supported"></div>
+<div id="normal"></div>
+<div id="variable"></div>
+<div id="animated"></div>
+<script>
+    test(() => {
+        internals.setPreferredColorScheme("dark");
+        internals.updateStyle();
+
+        for (const id of ["preferred", "first-supported", "normal", "variable", "animated"]) {
+            const style = getComputedStyle(document.getElementById(id));
+            println(`${id}: ${style.colorScheme} / ${style.color}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/input-line-height-clamp.html
+++ b/Tests/LibWeb/Text/input/css/input-line-height-clamp.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input id="small" style="font-size: 20px; line-height: 1px">
+<input id="large" style="font-size: 20px; line-height: 40px">
+<input id="variable" style="--height: 1px; font-size: 20px; line-height: var(--height)">
+<input id="checkbox" type="checkbox" style="font-size: 20px; line-height: 1px">
+<script>
+    test(() => {
+        for (const id of ["small", "large", "variable", "checkbox"])
+            println(`${id}: ${getComputedStyle(document.getElementById(id)).lineHeight}`);
+
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/native-var-substitution.html
+++ b/Tests/LibWeb/Text/input/css/native-var-substitution.html
@@ -11,10 +11,15 @@
             --nested: calc(var(--base) * 2);
             --cycle-a: var(--cycle-b);
             --cycle-b: var(--cycle-a);
+            --cycle-fallback-a: var(--cycle-fallback-b, green);
+            --cycle-fallback-b: var(--cycle-fallback-a);
+            --cycle-dependent: var(--cycle-fallback-a, blue);
             --\\78: 7px;
             width: var(--nested);
             height: var(--\\78);
             margin-left: var(--cycle-a, 3px);
+            color: var(--cycle-fallback-a, red);
+            background-color: var(--cycle-dependent, black);
         `;
         document.body.appendChild(element);
 
@@ -22,6 +27,8 @@
         println(`width: ${computed.width}`);
         println(`height: ${computed.height}`);
         println(`cycle fallback: ${computed.marginLeft}`);
+        println(`fallback inside cycle ignored: ${computed.color}`);
+        println(`fallback outside cycle used: ${computed.backgroundColor}`);
 
         const nativeCounters = internals.styleFfiCounters();
         println(`native parse callback used: ${nativeCounters.cascadeParseSubstitutedCallbacks >= 3}`);

--- a/Tests/LibWeb/Text/input/css/native-var-substitution.html
+++ b/Tests/LibWeb/Text/input/css/native-var-substitution.html
@@ -33,17 +33,29 @@
             inherits: false,
             initialValue: "1px",
         });
+        CSS.registerProperty({
+            name: "--registered-universal-native",
+            syntax: "*",
+            inherits: false,
+            initialValue: "13px",
+        });
         internals.resetStyleFfiCounters();
 
         const registered = document.createElement("div");
         registered.style.cssText = `
             --registered-native-fallback: 9px;
+            --unregistered-native-after-registration: 11px;
             width: var(--registered-native-fallback);
+            height: var(--unregistered-native-after-registration);
+            margin-left: var(--registered-universal-native);
         `;
         document.body.appendChild(registered);
         println(`registered width: ${getComputedStyle(registered).width}`);
+        println(`unregistered height: ${getComputedStyle(registered).height}`);
+        println(`registered universal initial: ${getComputedStyle(registered).marginLeft}`);
 
         const registeredCounters = internals.styleFfiCounters();
         println(`registered value used C++ resolver: ${registeredCounters.cascadeResolveUnresolvedCallbacks >= 1}`);
+        println(`unregistered value used native parser: ${registeredCounters.cascadeParseSubstitutedCallbacks >= 1}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/native-var-substitution.html
+++ b/Tests/LibWeb/Text/input/css/native-var-substitution.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        internals.updateStyle();
+        internals.resetStyleFfiCounters();
+
+        const element = document.createElement("div");
+        element.style.cssText = `
+            --base: 5px;
+            --nested: calc(var(--base) * 2);
+            --cycle-a: var(--cycle-b);
+            --cycle-b: var(--cycle-a);
+            --\\78: 7px;
+            width: var(--nested);
+            height: var(--\\78);
+            margin-left: var(--cycle-a, 3px);
+        `;
+        document.body.appendChild(element);
+
+        const computed = getComputedStyle(element);
+        println(`width: ${computed.width}`);
+        println(`height: ${computed.height}`);
+        println(`cycle fallback: ${computed.marginLeft}`);
+
+        const nativeCounters = internals.styleFfiCounters();
+        println(`native parse callback used: ${nativeCounters.cascadeParseSubstitutedCallbacks >= 3}`);
+        println(`C++ resolver unused: ${nativeCounters.cascadeResolveUnresolvedCallbacks === 0}`);
+
+        CSS.registerProperty({
+            name: "--registered-native-fallback",
+            syntax: "<length>",
+            inherits: false,
+            initialValue: "1px",
+        });
+        internals.resetStyleFfiCounters();
+
+        const registered = document.createElement("div");
+        registered.style.cssText = `
+            --registered-native-fallback: 9px;
+            width: var(--registered-native-fallback);
+        `;
+        document.body.appendChild(registered);
+        println(`registered width: ${getComputedStyle(registered).width}`);
+
+        const registeredCounters = internals.styleFfiCounters();
+        println(`registered value used C++ resolver: ${registeredCounters.cascadeResolveUnresolvedCallbacks >= 1}`);
+    });
+</script>


### PR DESCRIPTION
The Rust style core already handles longhand selection, cascading, and much of computed-value construction. This moves the next two stages into the same pipeline: custom-property cascading and `var()` substitution, followed by the adjustments that turn longhand results into a finished computed style.

Custom properties now cascade through the Rust store, with structurally shared inherited data and native handling of nested references, fallbacks, cycles, escaped names, token boundaries, and common registered-property cases. Property grammar parsing remains one coarse C++ callback, while typed registrations and metadata-sensitive values retain the established C++ path.

The Rust driver now also handles overflow pairing, `text-align`, box transformations, element-specific fixups, effective `color-scheme`, and input line-height clamping. These results leave Rust in the driver's final store batch, reducing duplicate C++ work and bringing ordinary style computation closer to one coarse crossing.

Animations remain in C++. Pre-adjustment values are preserved and finishing passes are reapplied against local, inherited, and parent animation overlays, maintaining the previous ordering. Regression coverage includes cascade ordering, native substitution, cycle invalidation, inherited attr taint, and direct and inherited animation adjustments.