### PR TITLE
Meta: Report a failure count for every test flakiness concurrency level

### DIFF
--- a/Meta/check-test-flakiness.py
+++ b/Meta/check-test-flakiness.py
@@ -208,13 +208,7 @@ def run_candidate(args, test_web_binary, test_root, candidate, level, deadline, 
 
 
 def format_levels(report, repeat):
-    parts = []
-    for result in report.levels:
-        if result.failures == 0:
-            parts.append(f"-j{result.level}: {repeat}/{repeat} passed")
-        else:
-            parts.append(f"-j{result.level}: {result.failures}/{repeat} failed")
-    return "; ".join(parts)
+    return "; ".join(f"-j{result.level}: {result.failures}/{repeat} failed" for result in report.levels)
 
 
 def write_summary(reports, skipped, levels, repeat):


### PR DESCRIPTION
In `Meta/check-test-flakiness.py`, concurrency levels without failures were previously described as passing while the rest were described as failing, so a single report mixed two phrasings. Always reporting the failure count keeps the levels directly comparable.

Tested using a deliberately failing test file using the change in #10760 that allows you to run against user-supplied test paths.