### PR TITLE
LibWeb: Complete script-created parsers on document.close()

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1086,6 +1086,36 @@ WebIDL::ExceptionOr<Document*> Document::open(Optional<Utf16String> const&, Opti
     // 15. Set document to no-quirks mode.
     set_quirks_mode(QuirksMode::No);
 
+    // INTEROP: The HTML Standard says the document open steps do not affect whether a Document is ready for post-load
+    //          tasks. Blink and WebKit reset their corresponding frame load-completion state, while Gecko marks the
+    //          document loader as opened but not loaded. Reset our load gating flag for the replacement contents too.
+    set_ready_for_post_load_tasks(false);
+
+    // INTEROP: The HTML Standard does not reset the page showing flag in the document open steps. Browsers allow a
+    //          completed Document to be reopened and complete loading again, so mark the replaced contents as no longer
+    //          showing without firing pagehide or otherwise unloading the Document.
+    set_page_showing(false);
+
+    // INTEROP: Cancel completion of the parser that document.open() is about to replace.
+    if (m_html_parser_end_state) {
+        m_html_parser_end_state->cancel();
+        m_html_parser_end_state = nullptr;
+    }
+
+    // INTEROP: The HTML Standard leaves discarding pending scripts unspecified. Blink and WebKit discard their
+    //          parser script runner's pending parsing-blocking and deferred scripts when replacing the parser, and
+    //          Gecko cancels pending parser script loads when terminating the parser. Stop discarded scripts from
+    //          delaying the replacement document's load event before removing them from the parser's queues.
+    if (m_pending_parsing_blocking_script)
+        m_pending_parsing_blocking_script->stop_delaying_document_load_event({});
+    if (m_pending_parsing_blocking_svg_script)
+        m_pending_parsing_blocking_svg_script->stop_delaying_document_load_event({});
+    for (auto& script : m_scripts_to_execute_when_parsing_has_finished)
+        script->stop_delaying_document_load_event({});
+    m_pending_parsing_blocking_script = nullptr;
+    m_pending_parsing_blocking_svg_script = nullptr;
+    m_scripts_to_execute_when_parsing_has_finished.clear();
+
     // 16. Create an HTML parser whose allow declarative shadow roots is document's allow declarative shadow roots, and
     //     associate it with document. This is a script-created parser (meaning that it can be closed by the document.open()
     //     and document.close() methods, and that the tokenizer will wait for an explicit call to document.close() before
@@ -1129,33 +1159,36 @@ WebIDL::ExceptionOr<void> Document::close()
         return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_utf16);
 
     // 3. If there is no script-created parser associated with the document, then return.
-    if (!m_parser || !m_parser->is_script_created())
+    if (!m_parser || !m_parser->is_script_created() || m_parser->tokenizer().is_input_stream_closed())
         return {};
 
-    // 4. Insert an explicit "EOF" character at the end of the parser's input stream.
-    m_parser->tokenizer().insert_eof();
-
     auto parser = m_parser;
-    auto finish_script_created_parser = [parser] {
-        parser->tokenizer().undefine_insertion_point();
-        parser->pop_all_open_elements();
 
-        // AD-HOC: This ensures that a load event is fired if the node navigable's container is an iframe.
-        parser->document().completely_finish_loading();
+    // 4. Insert an explicit "EOF" character at the end of the parser's input stream.
+    parser->tokenizer().insert_eof();
+
+    auto finish_script_created_parser = [parser] {
+        HTML::HTMLParser::the_end(parser->document(), parser);
     };
 
     // 5. If there is a pending parsing-blocking script, then return.
     if (has_pending_parsing_blocking_script()) {
-        m_parser->set_post_parse_action(move(finish_script_created_parser));
+        parser->set_post_parse_action(move(finish_script_created_parser));
         return {};
     }
 
     // 6. Run the tokenizer, processing resulting tokens as they are emitted, and stopping when the tokenizer reaches the explicit "EOF" character or spins the event loop.
-    m_parser->run();
+    parser->run();
+
+    // INTEROP: Running the tokenizer can invoke author code which calls document.open(), replacing the parser.
+    //          Blink, WebKit, and Gecko detach or terminate the old parser in this case, so do not attach its
+    //          completion callback to the replacement parser.
+    if (m_parser != parser)
+        return {};
 
     // run() may have paused on a blocking script (e.g. from document.write inside an inline script).
     if (has_pending_parsing_blocking_script()) {
-        m_parser->set_post_parse_action(move(finish_script_created_parser));
+        parser->set_post_parse_action(move(finish_script_created_parser));
         return {};
     }
 
@@ -4366,8 +4399,8 @@ void Document::completely_finish_loading()
         });
     }
 
-    // AD-HOC: Script-created parsers (iframe document.open/write/close) don't reach set_ready_for_post_load_tasks, so
-    //         the parent's load-event-delay phase wouldn't otherwise be re-evaluated when this iframe finishes loading.
+    // AD-HOC: Finishing a child document can unblock its parent's load-event-delay phase, so wake the parent parser end
+    //         state after queueing the container's load event.
     container->document().schedule_html_parser_end_check();
 }
 
@@ -4828,6 +4861,7 @@ bool Document::allow_focus() const
 
 void Document::set_parser(Badge<HTML::HTMLParser>, HTML::HTMLParser& parser)
 {
+    ++m_parser_generation;
     m_parser = parser;
 }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -705,6 +705,7 @@ public:
     void set_parser(Badge<HTML::HTMLParser>, HTML::HTMLParser&);
     void detach_parser();
     GC::Ptr<HTML::HTMLParser> parser() const { return m_parser; }
+    u64 parser_generation() const { return m_parser_generation; }
 
     void set_temporary_document_for_fragment_parsing(Badge<HTML::HTMLParser>);
     [[nodiscard]] bool is_temporary_document_for_fragment_parsing() const { return m_temporary_document_for_fragment_parsing; }
@@ -1435,6 +1436,7 @@ private:
     Optional<Vector<Utf16FlyString>> m_supported_color_schemes;
 
     GC::Ptr<HTML::HTMLParser> m_parser;
+    u64 m_parser_generation { 0 };
     bool m_active_parser_was_aborted { false };
 
     bool m_has_been_destroyed { false };

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -107,7 +107,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_html_document(HTML::Navi
         TRY(document->populate_with_html_head_and_body());
         if (navigation_params.navigable && navigation_params.navigable->is_top_level_traversable())
             document->set_supported_color_schemes({ "light"_utf16_fly_string, "dark"_utf16_fly_string });
-        HTML::HTMLParser::the_end(document);
+        HTML::HTMLParser::the_end(document, HTML::HTMLParser::parserless_completion_token(document));
     }
 
     // AD-HOC: For about:srcdoc, the body bytes are always immediately available in the response source (the srcdoc
@@ -403,9 +403,10 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_media_document(HTML::Nav
     //        However, if we don't, then we get stuck in HTMLParser::the_end() waiting for the media file to load, which
     //        never happens.
     auto& realm = document->realm();
+    auto completion_token = HTML::HTMLParser::parserless_completion_token(document);
     navigation_params.response->body()->fully_read(
         realm,
-        GC::create_function(document->heap(), [document](ByteBuffer) { HTML::HTMLParser::the_end(document); }),
+        GC::create_function(document->heap(), [document, completion_token](ByteBuffer) { HTML::HTMLParser::the_end(document, completion_token); }),
         GC::create_function(document->heap(), [](JS::Value) {}),
         GC::Ref { realm.global_object() });
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -39,6 +39,7 @@ public:
     void prepare_script(Badge<XMLDocumentBuilder, HTMLParser>) { prepare_script(); }
 
     void execute_script();
+    void stop_delaying_document_load_event(Badge<DOM::Document>) { m_document_load_event_delayer.clear(); }
 
     bool is_parser_inserted() const { return !!m_parser_document; }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -2145,8 +2145,8 @@ void LocalNavigable::populate_session_history_entry_document(
                     // FIXME: Directly calling parser->the_end results in a deadlock, because it waits for the warning image to load.
                     //        However the response is never processed when parser->the_end is called.
                     //        Queuing a global task is a workaround for now.
-                    queue_a_task(Task::Source::Unspecified, HTML::main_thread_event_loop(), document, GC::create_function(heap(), [&document]() {
-                        HTMLParser::the_end(document);
+                    queue_a_task(Task::Source::Unspecified, HTML::main_thread_event_loop(), document, GC::create_function(heap(), [&document, parser] {
+                        HTMLParser::the_end(document, parser);
                     }));
                 });
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -159,9 +159,11 @@ GC::Ref<LocalTraversableNavigable> LocalTraversableNavigable::create_a_fresh_top
     //         Skip the initial navigation as well. This matches the behavior of the window open steps.
 
     if (url_matches_about_blank(initial_navigation_url)) {
-        Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(traversable->heap(), [traversable, initial_navigation_url] {
+        auto document = GC::Ref(*traversable->active_document());
+        auto completion_token = HTML::HTMLParser::parserless_completion_token(document);
+        Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(traversable->heap(), [document, completion_token, initial_navigation_url] {
             // FIXME: We do this other places too when creating a new about:blank document. Perhaps it's worth a spec issue?
-            HTML::HTMLParser::the_end(*traversable->active_document());
+            HTML::HTMLParser::the_end(document, completion_token);
 
             // FIXME: If we perform the URL and history update steps here, we start hanging tests and the UI process will
             //        try to load() the initial URLs passed on the command line before we finish processing the events here.

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -437,7 +437,27 @@ void HTMLParser::run_until_completion(HTMLTokenizer::StopAtInsertionPoint stop_a
 }
 
 // https://html.spec.whatwg.org/multipage/parsing.html#the-end
+HTMLParser::ParserlessCompletionToken HTMLParser::parserless_completion_token(DOM::Document const& document)
+{
+    return { document.parser_generation() };
+}
+
+void HTMLParser::the_end(GC::Ref<DOM::Document> document, ParserlessCompletionToken token)
+{
+    the_end(document, nullptr, token.parser_generation);
+}
+
 void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> parser)
+{
+    the_end(document, parser, document->parser_generation());
+}
+
+static bool parser_was_replaced(DOM::Document const& document, GC::Ptr<HTMLParser> parser, u64 parser_generation)
+{
+    return document.parser_generation() != parser_generation || document.parser() != parser;
+}
+
+void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> parser, u64 parser_generation)
 {
     // Once the user agent stops parsing the document, the user agent must run the following steps:
 
@@ -470,6 +490,12 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
     if (parser && parser->m_parsing_fragment)
         return;
 
+    // INTEROP: Blink and WebKit keep a parser object associated with media documents, so parser identity prevents stale
+    //          completion after document.open(). Ladybird's media documents are parserless, so also compare a generation
+    //          that changes whenever a replacement parser is associated with the Document.
+    if (parser_was_replaced(document, parser, parser_generation))
+        return;
+
     // 1. If the active speculative HTML parser is not null, then stop the speculative HTML parser and return.
     if (parser && parser->m_active_speculative_html_parser) {
         parser->stop_the_speculative_html_parser();
@@ -482,6 +508,10 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
 
     // 3. Update the current document readiness to "interactive".
     document->update_readiness(HTML::DocumentReadyState::Interactive);
+
+    // INTEROP: Step 3 can run a readystatechange event handler which calls document.open(), so recheck after it returns.
+    if (parser_was_replaced(document, parser, parser_generation))
+        return;
 
     // 4. Pop all the nodes off the stack of open elements.
     if (parser)
@@ -497,7 +527,7 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
     }
 
     // Steps 5-11 are handled by the HTMLParserEndState state machine.
-    auto state = HTMLParserEndState::create(document, parser);
+    auto state = HTMLParserEndState::create(document, parser, parser_generation);
     document->set_html_parser_end_state(state);
     state->schedule_progress_check();
 }
@@ -520,16 +550,17 @@ static void perform_pre_progress_microtask_checkpoint()
     vm.restore_execution_context_stack();
 }
 
-GC::Ref<HTMLParserEndState> HTMLParserEndState::create(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> parser)
+GC::Ref<HTMLParserEndState> HTMLParserEndState::create(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> parser, u64 parser_generation)
 {
-    return document->heap().allocate<HTMLParserEndState>(document, parser);
+    return document->heap().allocate<HTMLParserEndState>(document, parser, parser_generation);
 }
 
-HTMLParserEndState::HTMLParserEndState(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> parser)
+HTMLParserEndState::HTMLParserEndState(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> parser, u64 parser_generation)
     : m_document(document)
     , m_parser(parser)
+    , m_parser_generation(parser_generation)
     , m_timeout(Platform::Timer::create_single_shot(heap(), THE_END_TIMEOUT_MS, GC::create_function(heap(), [this] {
-        if (m_phase != Phase::Completed)
+        if (m_phase != Phase::Completed && m_phase != Phase::Cancelled)
             dbgln("HTMLParserEndState: timed out in phase {}", to_underlying(m_phase));
     })))
 {
@@ -544,9 +575,15 @@ void HTMLParserEndState::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_timeout);
 }
 
+void HTMLParserEndState::cancel()
+{
+    m_phase = Phase::Cancelled;
+    m_timeout->stop();
+}
+
 void HTMLParserEndState::schedule_progress_check()
 {
-    if (m_phase == Phase::Completed)
+    if (m_phase == Phase::Completed || m_phase == Phase::Cancelled)
         return;
     if (m_check_pending)
         return;
@@ -560,6 +597,9 @@ void HTMLParserEndState::schedule_progress_check()
 
 void HTMLParserEndState::check_progress()
 {
+    if (m_phase == Phase::Cancelled)
+        return;
+
     // AD-HOC: Bail out if the document is no longer fully active (e.g. navigated away from).
     if (!m_document->is_fully_active()) {
         complete();
@@ -579,6 +619,11 @@ void HTMLParserEndState::check_progress()
 
             // 2. Execute the first script in the list of scripts that will execute when the document has finished parsing.
             first_script.execute_script();
+
+            // INTEROP: The script may have called document.open(), cancelling this parser's completion and clearing
+            //          its list of deferred scripts. Blink, WebKit, and Gecko detach or terminate the old parser here.
+            if (m_phase == Phase::Cancelled)
+                return;
 
             // 3. Remove the first script element from the list of scripts that will execute when the document has finished parsing (i.e. shift out the first entry in the list).
             (void)m_document->scripts_to_execute_when_parsing_has_finished().take_first();
@@ -612,6 +657,8 @@ void HTMLParserEndState::check_progress()
     case Phase::Completed:
         complete();
         return;
+    case Phase::Cancelled:
+        return;
     }
 }
 
@@ -630,6 +677,9 @@ void HTMLParserEndState::advance_to_dom_content_loaded_phase()
 
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
     queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, GC::create_function(m_document->heap(), [state = GC::Ref(*this), document = m_document] {
+        if (state->m_phase != Phase::WaitingForDOMContentLoaded)
+            return;
+
         // 1. Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
@@ -659,11 +709,29 @@ void HTMLParserEndState::advance_to_dom_content_loaded_phase()
 void HTMLParserEndState::complete()
 {
     m_phase = Phase::Completed;
-    m_timeout->stop();
-    m_document->set_html_parser_end_state(nullptr);
 
     // 9. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
-    queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, GC::create_function(m_document->heap(), [document = m_document, parser = m_parser] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, *m_document, GC::create_function(m_document->heap(), [state = GC::Ref(*this), document = m_document, parser = m_parser, parser_generation = m_parser_generation] {
+        if (state->m_phase != Phase::Completed)
+            return;
+
+        // INTEROP: document.open() may have replaced the parser while this task was queued.
+        if (parser_was_replaced(document, parser, parser_generation))
+            return;
+
+        // NB: Step 8 can stop spinning and queue this task before an already-queued task reopens a descendant document.
+        //     Recheck its condition here and resume waiting using the same parser end state.
+        // INTEROP: Blink and WebKit recheck descendant completeness at their final load-completion gate. Gecko's
+        //          document loader likewise remains busy while a child loader is waiting to complete.
+        if (document->is_fully_active() && document->anything_is_delaying_the_load_event()) {
+            state->m_phase = Phase::WaitingForLoadEventDelay;
+            state->schedule_progress_check();
+            return;
+        }
+
+        state->m_timeout->stop();
+        document->set_html_parser_end_state(nullptr);
+
         // 11. The Document is now ready for post-load tasks.
         // NB: The spec sets this synchronously after queueing this task, and relies on "spin the event loop"
         //     continuations being queued tasks to keep an ancestor document's load event behind this document's own
@@ -675,6 +743,10 @@ void HTMLParserEndState::complete()
 
         // 1. Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
+
+        // INTEROP: Step 1 can run a readystatechange event handler which calls document.open(), so recheck after it returns.
+        if (parser_was_replaced(document, parser, parser_generation))
+            return;
 
         // AD-HOC: We need to wait until the document ready state is complete before detaching the parser, otherwise the DOM complete time will not be set correctly.
         if (parser)
@@ -695,6 +767,11 @@ void HTMLParserEndState::complete()
         //        We should reorganize this so that the flag appears explicitly here instead.
         window.dispatch_event(DOM::Event::create(document->realm(), HTML::EventNames::load));
 
+        // INTEROP: A load event handler can call document.open(), which associates a replacement parser after the old
+        //          parser was detached above. Do not let this completion continue into the replacement document.
+        if (document->parser_generation() != parser_generation)
+            return;
+
         // FIXME: 6. Invoke WebDriver BiDi load complete with the Document's browsing context, and a new WebDriver BiDi navigation status whose id is the Document object's navigation id, status is "complete", and url is the Document object's URL.
 
         // FIXME: 7. Set the Document object's navigation id to null.
@@ -710,6 +787,11 @@ void HTMLParserEndState::complete()
 
         // 11. Fire a page transition event named pageshow at window with false.
         window.fire_a_page_transition_event(HTML::EventNames::pageshow, false);
+
+        // INTEROP: Step 11 can run a pageshow event handler which calls document.open(). As with the load event above,
+        //          do not let this completion continue into the replacement document contents.
+        if (document->parser_generation() != parser_generation)
+            return;
 
         // 12. Completely finish loading the Document.
         document->completely_finish_loading();
@@ -861,6 +943,11 @@ void HTMLParser::resume_after_parser_blocking_script()
     if (!m_parser_pause_flag)
         return;
     if (m_aborted || m_stop_parsing)
+        return;
+
+    // INTEROP: Blink and WebKit detach a parser when document.open() replaces it. Do not let resume work from the
+    //          detached parser consume a parsing-blocking script owned by the replacement parser.
+    if (m_document->parser() != this)
         return;
 
     auto pending = document().pending_parsing_blocking_script();

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -54,7 +54,12 @@ public:
     void run_until_completion(HTMLTokenizer::StopAtInsertionPoint = HTMLTokenizer::StopAtInsertionPoint::No);
     void pop_all_open_elements();
 
-    static void the_end(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser> = nullptr);
+    struct ParserlessCompletionToken {
+        u64 parser_generation;
+    };
+    static ParserlessCompletionToken parserless_completion_token(DOM::Document const&);
+    static void the_end(GC::Ref<DOM::Document>, ParserlessCompletionToken);
+    static void the_end(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser>);
 
     DOM::Document& document();
     enum class AllowDeclarativeShadowRoots {
@@ -125,6 +130,7 @@ private:
 
     void resume_after_parser_blocking_script();
     void invoke_post_parse_action();
+    static void the_end(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser>, u64 parser_generation);
 
     HTMLTokenizer m_tokenizer;
     RustFfiHtmlParserHandle* m_rust_parser { nullptr };
@@ -165,8 +171,9 @@ class HTMLParserEndState final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(HTMLParserEndState);
 
 public:
-    static GC::Ref<HTMLParserEndState> create(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser>);
+    static GC::Ref<HTMLParserEndState> create(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser>, u64 parser_generation);
 
+    void cancel();
     void schedule_progress_check();
 
 private:
@@ -176,9 +183,10 @@ private:
         WaitingForASAPScripts,
         WaitingForLoadEventDelay,
         Completed,
+        Cancelled,
     };
 
-    HTMLParserEndState(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser>);
+    HTMLParserEndState(GC::Ref<DOM::Document>, GC::Ptr<HTMLParser>, u64 parser_generation);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -191,6 +199,7 @@ private:
 
     GC::Ref<DOM::Document> m_document;
     GC::Ptr<HTMLParser> m_parser;
+    u64 m_parser_generation { 0 };
     GC::Ref<Platform::Timer> m_timeout;
 };
 

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -310,7 +310,8 @@ WebIDL::ExceptionOr<Window::OpenedWindow> Window::window_open_steps_internal(Utf
         if (url_matches_about_blank(url_record.value())) {
             // AD-HOC: Mark the initial about:blank for the new window as load complete
             // FIXME: We do this other places too when creating a new about:blank document. Perhaps it's worth a spec issue?
-            HTML::HTMLParser::the_end(*target_navigable->active_document());
+            auto document = GC::Ref(*target_navigable->active_document());
+            HTML::HTMLParser::the_end(document, HTML::HTMLParser::parserless_completion_token(document));
 
             perform_url_and_history_update_steps(*target_navigable->active_document(), url_record.release_value());
         }

--- a/Libraries/LibWeb/SVG/SVGScriptElement.h
+++ b/Libraries/LibWeb/SVG/SVGScriptElement.h
@@ -29,6 +29,7 @@ public:
 
     bool is_ready_to_be_parser_executed() const { return m_ready_to_be_parser_executed; }
     void execute_pending_parser_blocking_script(Badge<HTML::HTMLParser>);
+    void stop_delaying_document_load_event(Badge<DOM::Document>) { m_document_load_event_delayer.clear(); }
 
     void set_source_line_number(Badge<HTML::HTMLParser>, size_t source_line_number) { m_source_line_number = source_line_number; }
 

--- a/Tests/LibWeb/Text/expected/HTML/document-close-complete-readystatechange-replaces-parser.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-close-complete-readystatechange-replaces-parser.txt
@@ -1,0 +1,3 @@
+Replaced parser during complete readystatechange event
+Replacement ready state before close: loading
+Iframe load event fired with replacement ready state complete

--- a/Tests/LibWeb/Text/expected/HTML/document-close-iframe-load-event.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-close-iframe-load-event.txt
@@ -1,1 +1,5 @@
-Onload event fired
+Ready state changed to interactive
+DOMContentLoaded event fired
+Ready state changed to complete
+Body onload event fired with ready state complete
+Iframe onload event fired

--- a/Tests/LibWeb/Text/expected/HTML/document-close-readystatechange-replaces-parser.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-close-readystatechange-replaces-parser.txt
@@ -1,0 +1,5 @@
+Replaced parser during interactive readystatechange event
+Ready state after close: loading
+Ready state in first task: loading
+Ready state in second task: loading
+Replacement iframe load event fired after close

--- a/Tests/LibWeb/Text/expected/HTML/document-open-after-completed-script-created-parser.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-after-completed-script-created-parser.txt
@@ -1,0 +1,2 @@
+Iframe load 1 fired with ready state complete
+Iframe load 2 fired with ready state complete

--- a/Tests/LibWeb/Text/expected/HTML/document-open-cancels-delayed-parserless-completion.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-cancels-delayed-parserless-completion.txt
@@ -1,0 +1,3 @@
+Ready state after stale parserless completion: complete
+Replacement load events: 1
+Replacement pageshow events: 1

--- a/Tests/LibWeb/Text/expected/HTML/document-open-cancels-parser-completion.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-cancels-parser-completion.txt
@@ -1,0 +1,2 @@
+Replacement DOMContentLoaded event fired
+Replacement iframe load event fired

--- a/Tests/LibWeb/Text/expected/HTML/document-open-discards-parser-owned-scripts.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-discards-parser-owned-scripts.txt
@@ -1,0 +1,1 @@
+Stale script ran: false

--- a/Tests/LibWeb/Text/expected/HTML/document-open-discards-pending-parsing-blocking-script.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-discards-pending-parsing-blocking-script.txt
@@ -1,0 +1,1 @@
+Stale script ran: false

--- a/Tests/LibWeb/Text/expected/HTML/document-open-during-load-stops-stale-completion.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-during-load-stops-stale-completion.txt
@@ -1,0 +1,3 @@
+Replaced parser during window load event
+Replacement reached complete ready state
+Stale iframe load events: 0

--- a/Tests/LibWeb/Text/expected/HTML/document-open-during-pageshow-stops-stale-completion.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-during-pageshow-stops-stale-completion.txt
@@ -1,0 +1,3 @@
+Replaced parser during pageshow event
+Replacement reached complete ready state
+Stale iframe load events: 0

--- a/Tests/LibWeb/Text/expected/HTML/document-open-from-deferred-script.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-from-deferred-script.txt
@@ -1,0 +1,3 @@
+Deferred script ran: true
+Replacement ready state: complete
+Replacement text: Replacement document

--- a/Tests/LibWeb/Text/expected/HTML/document-open-releases-discarded-script-load-delayers.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-releases-discarded-script-load-delayers.txt
@@ -1,0 +1,4 @@
+Replacement loaded before discarded parsing-blocking script response
+Discarded parsing-blocking script ran: false
+Replacement loaded before discarded deferred script response
+Discarded deferred script ran: false

--- a/Tests/LibWeb/Text/expected/HTML/document-open-reopened-child-delays-parent-load.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-reopened-child-delays-parent-load.txt
@@ -1,0 +1,2 @@
+Parent load events before replacement close: 0
+Replacement child reached complete ready state

--- a/Tests/LibWeb/Text/expected/HTML/document-open-reopened-child-task-delays-parent-load.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-open-reopened-child-task-delays-parent-load.txt
@@ -1,0 +1,2 @@
+Parent load events before replacement close: 0
+Replacement child reached complete ready state

--- a/Tests/LibWeb/Text/input/HTML/document-close-complete-readystatechange-replaces-parser.html
+++ b/Tests/LibWeb/Text/input/HTML/document-close-complete-readystatechange-replaces-parser.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write("<body>First document</body>");
+
+        const checkReplacement = "check-complete-readystatechange-replacement";
+        let didReplaceParser = false;
+        iframeDocument.addEventListener("readystatechange", () => {
+            if (didReplaceParser || iframeDocument.readyState !== "complete")
+                return;
+            didReplaceParser = true;
+            iframeDocument.open().write("<body>Replacement document</body>");
+            println("Replaced parser during complete readystatechange event");
+            window.postMessage(checkReplacement, "*");
+        });
+
+        window.addEventListener("message", event => {
+            if (event.data !== checkReplacement)
+                return;
+            println(`Replacement ready state before close: ${iframeDocument.readyState}`);
+            iframe.onload = () => {
+                println(`Iframe load event fired with replacement ready state ${iframeDocument.readyState}`);
+                iframe.remove();
+                done();
+            };
+            iframeDocument.close();
+        });
+
+        iframeDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-close-iframe-load-event.html
+++ b/Tests/LibWeb/Text/input/HTML/document-close-iframe-load-event.html
@@ -4,12 +4,24 @@
     asyncTest(done => {
         const iframe = document.createElement('iframe');
         document.body.appendChild(iframe);
-        iframe.contentDocument.open();
+
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write('<body onload="window.onBodyLoaded(document)"></body>');
+        iframeDocument.addEventListener("readystatechange", () => {
+            println(`Ready state changed to ${iframeDocument.readyState}`);
+        });
+        iframeDocument.addEventListener("DOMContentLoaded", () => {
+            println("DOMContentLoaded event fired");
+        });
+        iframe.contentWindow.onBodyLoaded = document => {
+            println(`Body onload event fired with ready state ${document.readyState}`);
+        };
         iframe.onload = () => {
-            println("Onload event fired");
+            println("Iframe onload event fired");
             iframe.remove();
             done();
         };
-        iframe.contentDocument.close();
+        iframeDocument.close();
+        iframeDocument.close();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/document-close-readystatechange-replaces-parser.html
+++ b/Tests/LibWeb/Text/input/HTML/document-close-readystatechange-replaces-parser.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write("<body>First document</body>");
+        let didReplaceParser = false;
+        iframeDocument.addEventListener("readystatechange", () => {
+            if (didReplaceParser || iframeDocument.readyState !== "interactive")
+                return;
+            didReplaceParser = true;
+            iframeDocument.open().write("<body>Replacement document</body>");
+            println("Replaced parser during interactive readystatechange event");
+        });
+        iframeDocument.close();
+
+        println(`Ready state after close: ${iframeDocument.readyState}`);
+
+        // Let any stale parser completion work run before closing the replacement parser.
+        const firstCheck = "document-close-replacement-first-check";
+        const secondCheck = "document-close-replacement-second-check";
+        window.addEventListener("message", event => {
+            if (event.data === firstCheck) {
+                println(`Ready state in first task: ${iframeDocument.readyState}`);
+                window.postMessage(secondCheck, "*");
+                return;
+            }
+            if (event.data !== secondCheck)
+                return;
+            println(`Ready state in second task: ${iframeDocument.readyState}`);
+            iframe.onload = () => {
+                println("Replacement iframe load event fired after close");
+                iframe.remove();
+                done();
+            };
+            iframeDocument.close();
+        });
+        window.postMessage(firstCheck, "*");
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-after-completed-script-created-parser.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-after-completed-script-created-parser.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        const iframeDocument = iframe.contentDocument;
+        let loadCount = 0;
+        iframe.addEventListener("load", () => {
+            ++loadCount;
+            println(`Iframe load ${loadCount} fired with ready state ${iframeDocument.readyState}`);
+            if (loadCount === 1) {
+                window.postMessage("replace-completed-script-created-parser", "*");
+                return;
+            }
+
+            iframe.remove();
+            done();
+        });
+
+        window.addEventListener("message", event => {
+            if (event.data !== "replace-completed-script-created-parser")
+                return;
+            iframeDocument.open().write("<body>Second document</body>");
+            iframeDocument.close();
+        });
+
+        iframeDocument.open().write("<body>First document</body>");
+        iframeDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-cancels-delayed-parserless-completion.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-cancels-delayed-parserless-completion.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const popup = window.open();
+        const popupDocument = popup.document;
+
+        popupDocument.open();
+        popupDocument.write("<body>Replacement document</body>");
+
+        let loadCount = 0;
+        let pageshowCount = 0;
+        popup.addEventListener("load", () => ++loadCount);
+        popup.addEventListener("pageshow", () => ++pageshowCount);
+        const replacementLoad = new Promise(resolve => popup.addEventListener("load", resolve, { once: true }));
+        popupDocument.close();
+        await replacementLoad;
+
+        let taskNumber = 0;
+        const nextTask = () => new Promise(resolve => {
+            const message = `document-open-parserless-completion-${++taskNumber}`;
+            const listener = event => {
+                if (event.data !== message)
+                    return;
+                window.removeEventListener("message", listener);
+                resolve();
+            };
+            window.addEventListener("message", listener);
+            window.postMessage(message, "*");
+        });
+        for (let i = 0; i < 5; ++i)
+            await nextTask();
+
+        println(`Ready state after stale parserless completion: ${popupDocument.readyState}`);
+        println(`Replacement load events: ${loadCount}`);
+        println(`Replacement pageshow events: ${pageshowCount}`);
+        popup.close();
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-cancels-parser-completion.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-cancels-parser-completion.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+        const httpServer = httpTestServer();
+        const testID = crypto.randomUUID();
+        const imageToken = `document-open-cancels-parser-completion-${testID}`;
+        const imageURL = await httpServer.createEcho("GET", `/document-open-cancels-parser-completion-${testID}.svg`, {
+            status: 200,
+            headers: {
+                "Content-Type": "image/svg+xml",
+                "Cache-Control": "no-store",
+            },
+            body: '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+            wait_for_unblock: imageToken,
+        });
+
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write("<body>First document</body>");
+        iframeDocument.close();
+
+        // Keep the replacement document's load event delayed until its parser end state is
+        // waiting for the image. A cancelled callback must not clear that replacement state.
+        iframeDocument.open().write(`<body><img src="${imageURL}"></body>`);
+        iframeDocument.addEventListener("DOMContentLoaded", () => {
+            println("Replacement DOMContentLoaded event fired");
+            window.postMessage(imageToken, "*");
+        });
+        iframe.onload = () => {
+            println("Replacement iframe load event fired");
+            iframe.remove();
+            done();
+        };
+        iframeDocument.close();
+
+        window.addEventListener("message", async event => {
+            if (event.data !== imageToken)
+                return;
+            await fetch(new URL(`/unblock/${imageToken}`, imageURL));
+        });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-discards-parser-owned-scripts.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-discards-parser-owned-scripts.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        window.staleScriptRan = false;
+
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write(`
+            <script defer src="data:text/javascript,parent.staleScriptRan%20%3D%20true"><\/script>
+            <body>First document</body>
+        `);
+        iframeDocument.close();
+
+        iframeDocument.open().write("<body>Replacement document</body>");
+        iframeDocument.addEventListener("readystatechange", () => {
+            if (iframeDocument.readyState !== "complete")
+                return;
+            println(`Stale script ran: ${window.staleScriptRan}`);
+            iframe.remove();
+            delete window.staleScriptRan;
+            done();
+        });
+        iframeDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-discards-pending-parsing-blocking-script.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-discards-pending-parsing-blocking-script.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        window.staleScriptRan = false;
+
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write(`
+            <script src="data:text/javascript,parent.staleScriptRan%20%3D%20true"><\/script>
+            <body>First document</body>
+        `);
+
+        iframeDocument.open().write("<body>Replacement document</body>");
+        iframeDocument.addEventListener("readystatechange", () => {
+            if (iframeDocument.readyState !== "complete")
+                return;
+            println(`Stale script ran: ${window.staleScriptRan}`);
+            iframe.remove();
+            delete window.staleScriptRan;
+            done();
+        });
+        iframeDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-during-load-stops-stale-completion.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-during-load-stops-stale-completion.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        const initialLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(iframe);
+        await initialLoad;
+
+        const iframeDocument = iframe.contentDocument;
+        let iframeLoadCount = 0;
+        iframe.addEventListener("load", () => ++iframeLoadCount);
+        iframeDocument.open().write("<body>First document</body>");
+
+        iframe.contentWindow.addEventListener("load", () => {
+            iframeDocument.open().write("<body>Replacement document</body>");
+            println("Replaced parser during window load event");
+            iframeDocument.addEventListener("readystatechange", () => {
+                if (iframeDocument.readyState !== "complete")
+                    return;
+                println("Replacement reached complete ready state");
+                println(`Stale iframe load events: ${iframeLoadCount}`);
+                iframe.remove();
+                done();
+            });
+            iframeDocument.close();
+        }, { once: true });
+
+        iframeDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-during-pageshow-stops-stale-completion.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-during-pageshow-stops-stale-completion.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const iframe = document.createElement("iframe");
+        const initialLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(iframe);
+        await initialLoad;
+
+        const iframeDocument = iframe.contentDocument;
+        let iframeLoadCount = 0;
+        iframe.addEventListener("load", () => ++iframeLoadCount);
+        iframeDocument.open().write("<body>First document</body>");
+
+        iframe.contentWindow.addEventListener("pageshow", () => {
+            iframeDocument.open().write("<body>Replacement document</body>");
+            println("Replaced parser during pageshow event");
+            iframeDocument.addEventListener("readystatechange", () => {
+                if (iframeDocument.readyState !== "complete")
+                    return;
+                println("Replacement reached complete ready state");
+                println(`Stale iframe load events: ${iframeLoadCount}`);
+                iframe.remove();
+                done();
+            });
+            iframeDocument.close();
+        }, { once: true });
+
+        iframeDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-from-deferred-script.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-from-deferred-script.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        window.deferredScriptRan = false;
+
+        const iframe = document.createElement("iframe");
+        const initialLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(iframe);
+        await initialLoad;
+
+        const replacementLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        const iframeDocument = iframe.contentDocument;
+        iframeDocument.open().write(`
+            <script defer src="data:text/javascript,
+                parent.deferredScriptRan%20%3D%20true%3B
+                document.open()%3B
+                document.write('%3Cbody%3EReplacement%20document%3C/body%3E')%3B
+                document.close()%3B
+            "><\/script>
+            <body>First document</body>
+        `);
+        iframeDocument.close();
+
+        await replacementLoad;
+        println(`Deferred script ran: ${window.deferredScriptRan}`);
+        println(`Replacement ready state: ${iframeDocument.readyState}`);
+        println(`Replacement text: ${iframeDocument.body.textContent}`);
+        iframe.remove();
+        delete window.deferredScriptRan;
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-releases-discarded-script-load-delayers.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-releases-discarded-script-load-delayers.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        internals.setTestTimeout(15000);
+        const httpServer = httpTestServer();
+
+        async function verifyReplacementLoadsBeforeDiscardedScript(kind, attributes) {
+            const token = `document-open-discards-${kind}-script`;
+            const scriptURL = await httpServer.createEcho("GET", `/${token}.js`, {
+                status: 200,
+                headers: {
+                    "Content-Type": "text/javascript",
+                    "Cache-Control": "no-store",
+                },
+                body: "parent.discardedScriptRan = true;",
+                wait_for_unblock: token,
+            });
+
+            const iframe = document.createElement("iframe");
+            const initialLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+            document.body.appendChild(iframe);
+            await initialLoad;
+
+            window.discardedScriptRan = false;
+            const iframeDocument = iframe.contentDocument;
+            iframeDocument.open().write(`<script ${attributes} src="${scriptURL}"><\/script><body>Discarded</body>`);
+            if (kind === "deferred")
+                iframeDocument.close();
+
+            const replacementLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+            iframeDocument.open().write("<body>Replacement</body>");
+            iframeDocument.close();
+            await replacementLoad;
+
+            println(`Replacement loaded before discarded ${kind} script response`);
+            println(`Discarded ${kind} script ran: ${discardedScriptRan}`);
+
+            await fetch(new URL(`/unblock/${token}`, scriptURL));
+            iframe.remove();
+        }
+
+        await verifyReplacementLoadsBeforeDiscardedScript("parsing-blocking", "");
+        await verifyReplacementLoadsBeforeDiscardedScript("deferred", "defer");
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-reopened-child-delays-parent-load.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-reopened-child-delays-parent-load.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const parentIframe = document.createElement("iframe");
+        const initialParentLoad = new Promise(resolve => parentIframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(parentIframe);
+        await initialParentLoad;
+
+        let parentLoadCount = 0;
+        parentIframe.addEventListener("load", () => ++parentLoadCount);
+
+        const parentDocument = parentIframe.contentDocument;
+        parentDocument.open().write('<iframe id="child" srcdoc="Initial child document"></iframe>');
+        const childIframe = parentDocument.querySelector("#child");
+        const initialChildLoad = new Promise(resolve => childIframe.addEventListener("load", resolve, { once: true }));
+        await initialChildLoad;
+
+        const childDocument = childIframe.contentDocument;
+        const firstChildLoad = new Promise(resolve => childIframe.addEventListener("load", resolve, { once: true }));
+        childDocument.open().write("<body>First child document</body>");
+        childDocument.close();
+        await firstChildLoad;
+
+        childDocument.open().write("<body>Replacement child document</body>");
+
+        const firstMessage = "reopened-child-parent-load-step-1";
+        const secondMessage = "reopened-child-parent-load-step-2";
+        const checkParent = "reopened-child-parent-load-check";
+        parentDocument.addEventListener("DOMContentLoaded", () => window.postMessage(firstMessage, "*"));
+        window.addEventListener("message", event => {
+            if (event.data === firstMessage) {
+                window.postMessage(secondMessage, "*");
+                return;
+            }
+            if (event.data === secondMessage) {
+                window.postMessage(checkParent, "*");
+                return;
+            }
+            if (event.data !== checkParent)
+                return;
+
+            println(`Parent load events before replacement close: ${parentLoadCount}`);
+            childDocument.addEventListener("readystatechange", () => {
+                if (childDocument.readyState !== "complete")
+                    return;
+                println("Replacement child reached complete ready state");
+                parentIframe.remove();
+                done();
+            });
+            childDocument.close();
+        });
+        parentDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-reopened-child-task-delays-parent-load.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-reopened-child-task-delays-parent-load.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const parentIframe = document.createElement("iframe");
+        const initialParentLoad = new Promise(resolve => parentIframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(parentIframe);
+        await initialParentLoad;
+
+        let parentLoadCount = 0;
+        parentIframe.addEventListener("load", () => ++parentLoadCount);
+
+        const parentDocument = parentIframe.contentDocument;
+        parentDocument.open().write('<iframe id="child" srcdoc="Initial child document"></iframe>');
+        const childIframe = parentDocument.querySelector("#child");
+        const initialChildLoad = new Promise(resolve => childIframe.addEventListener("load", resolve, { once: true }));
+        await initialChildLoad;
+
+        const childDocument = childIframe.contentDocument;
+        const reopenChild = "reopen-child-after-parent-dom-content-loaded";
+        const firstCheck = "reopened-child-parent-load-task-check-1";
+        const secondCheck = "reopened-child-parent-load-task-check-2";
+
+        parentDocument.addEventListener("DOMContentLoaded", () => window.postMessage(reopenChild, "*"));
+        window.addEventListener("message", event => {
+            if (event.data === reopenChild) {
+                childDocument.open().write("<body>Replacement child document</body>");
+                window.postMessage(firstCheck, "*");
+                return;
+            }
+            if (event.data === firstCheck) {
+                window.postMessage(secondCheck, "*");
+                return;
+            }
+            if (event.data !== secondCheck)
+                return;
+
+            println(`Parent load events before replacement close: ${parentLoadCount}`);
+            childDocument.addEventListener("readystatechange", () => {
+                if (childDocument.readyState !== "complete")
+                    return;
+                println("Replacement child reached complete ready state");
+                parentIframe.remove();
+                done();
+            });
+            childDocument.close();
+        });
+        parentDocument.close();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/document-write-after-close.html
+++ b/Tests/LibWeb/Text/input/HTML/document-write-after-close.html
@@ -14,5 +14,6 @@
         let reopened = frameDocument.getElementById("closed") === null
             && frameDocument.getElementById("after") !== null;
         println(`document.write after document.close reopens document: ${reopened}`);
+        frameDocument.close();
     });
 </script>


### PR DESCRIPTION
Run the normal parser completion algorithm after document.close() inserts EOF into a script-created parser. Advance document readiness and dispatch lifecycle events for dynamically written documents.

Treat parser replacement as cancellation of the old parser completion. Reset load gating and showing state for each dynamically reopened document. Discard parser-owned scripts and release their load-event delayers. Reject stale parser-backed completion after document.open(), including from reentrant lifecycle handlers. Track parser generations so delayed parserless completion cannot outlive a replacement parser after it detaches.

Recheck descendant load delays when the queued completion task runs. A child document can be reopened after the preceding progress check.

Add lifecycle and parser-replacement coverage for repeated, deferred, blocking, load-delaying, nested, and reentrant cases.

Fixes an issue where https://dailymotion.com/ never finishes loading :) cc @warpdesign 