### PR TITLE
LibWeb: Replay display lists via a transform palette

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -769,23 +769,6 @@ void AccumulatedVisualContextTree::reuse_version_from(AccumulatedVisualContextTr
     m_version = other.m_version;
 }
 
-VisualContextIndex AccumulatedVisualContextTree::find_common_ancestor(VisualContextIndex a, VisualContextIndex b) const
-{
-    VERIFY(a.value() < m_nodes.size());
-    VERIFY(b.value() < m_nodes.size());
-    size_t a_index = a.value();
-    size_t b_index = b.value();
-    while (m_nodes[a_index].depth > m_nodes[b_index].depth)
-        a_index = m_nodes[a_index].parent_index.value();
-    while (m_nodes[b_index].depth > m_nodes[a_index].depth)
-        b_index = m_nodes[b_index].parent_index.value();
-    while (a_index != b_index) {
-        a_index = m_nodes[a_index].parent_index.value();
-        b_index = m_nodes[b_index].parent_index.value();
-    }
-    return a_index;
-}
-
 Vector<size_t, 8> AccumulatedVisualContextTree::build_ancestor_chain(VisualContextIndex index) const
 {
     VERIFY(index.value() < m_nodes.size());

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -72,12 +72,21 @@ AccumulatedVisualContextTree AccumulatedVisualContextTree::create()
 AccumulatedVisualContextTree AccumulatedVisualContextTree::create(TransformData visual_viewport_transform)
 {
     Vector<AccumulatedVisualContextNode> nodes;
-    // Visual viewport transform root. This is identity for trees that are not attached to a document viewport.
+    // Whole-tree transform root: the visual viewport transform for document trees, the content
+    // offset for nested display list trees, identity otherwise.
     nodes.append({ move(visual_viewport_transform), {}, 0, false });
     return AccumulatedVisualContextTree {
         s_next_accumulated_visual_context_tree_version.fetch_add(1, AK::MemoryOrder::memory_order_relaxed),
         move(nodes)
     };
+}
+
+AccumulatedVisualContextTree AccumulatedVisualContextTree::create_with_content_offset(Gfx::IntPoint content_offset)
+{
+    return create(TransformData {
+        Gfx::translation_matrix(Vector3<float>(static_cast<float>(content_offset.x()), static_cast<float>(content_offset.y()), 0)),
+        {},
+    });
 }
 
 static CSSPixelRect effective_css_clip_rect(CSSPixelRect const& css_clip)

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -127,6 +127,10 @@ public:
 
     static WEB_API AccumulatedVisualContextTree create();
     static WEB_API AccumulatedVisualContextTree create(TransformData visual_viewport_transform);
+    // For nested display list trees (masks, patterns, background tiles) whose content is recorded
+    // in outer coordinates but replayed into a list-local surface: the offset becomes the root
+    // transform, keeping the tree the single source of coordinate truth for the list.
+    static WEB_API AccumulatedVisualContextTree create_with_content_offset(Gfx::IntPoint content_offset);
 
     AccumulatedVisualContextTree(AccumulatedVisualContextTree const&) = default;
     AccumulatedVisualContextTree& operator=(AccumulatedVisualContextTree const&) = default;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -149,7 +149,6 @@ public:
     AccumulatedVisualContextNode& node_at(VisualContextIndex index) { return m_nodes[index.value()]; }
     ReadonlySpan<AccumulatedVisualContextNode> nodes() const { return m_nodes.span(); }
 
-    VisualContextIndex find_common_ancestor(VisualContextIndex a, VisualContextIndex b) const;
     Optional<Gfx::FloatPoint> transform_point_for_hit_test(VisualContextIndex, Gfx::FloatPoint, ScrollStateSnapshot const&, ClipBehavior = ClipBehavior::Respect) const;
     Gfx::FloatPoint inverse_transform_point(VisualContextIndex, Gfx::FloatPoint) const;
     Gfx::FloatRect transform_rect_to_viewport(VisualContextIndex, Gfx::FloatRect const&, ScrollStateSnapshot const&, IncludeVisualViewportTransform = IncludeVisualViewportTransform::Yes) const;

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -398,10 +398,9 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
             if (tile_device_rect.height() == 0)
                 tile_device_rect.set_height(1);
 
-            auto visual_context_tree = AccumulatedVisualContextTree::create();
+            auto visual_context_tree = AccumulatedVisualContextTree::create_with_content_offset(-tile_device_rect.location().to_type<int>());
             auto tile_display_list = DisplayList::create(visual_context_tree);
             DisplayListRecorder tile_recorder(*tile_display_list, visual_context_tree, display_list_recorder.resource_storage());
-            tile_recorder.translate(-tile_device_rect.location().to_type<int>());
             auto tile_context = context.clone(tile_recorder);
             image.paint(tile_context, document, tile_device_rect, image_rendering);
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -202,7 +202,7 @@ void DisplayListPlayer::execute_impl(
             nearest_frame_node.unchecked_append(i == 0 ? VISUAL_VIEWPORT_NODE_INDEX : nearest_frame_node[node.parent_index.value()]);
         };
         auto append_spatial_translation = [&](Gfx::IntPoint offset) {
-            // Whole device pixels, matching the Translate ops the per-node application replayed.
+            // Whole device pixels, so scrolled content never lands on subpixel positions.
             append_spatial(Gfx::translation_matrix(Vector3<float>(static_cast<float>(offset.x()), static_cast<float>(offset.y()), 0)));
         };
         auto append_non_spatial = [&] {

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -170,87 +170,112 @@ void DisplayListPlayer::execute_impl(
 
     VERIFY(m_surface);
 
-    auto for_each_node_from_common_ancestor_to_target =
-        [&](this auto const& self,
-            Optional<VisualContextIndex> common_ancestor_index,
-            VisualContextIndex target_index,
-            auto&& callback) -> IterationDecision {
-        if (common_ancestor_index.has_value() && target_index == common_ancestor_index.value())
-            return IterationDecision::Continue;
-        if (target_index != VISUAL_VIEWPORT_NODE_INDEX
-            && self(common_ancestor_index, visual_context_tree.node_at(target_index).parent_index, callback)
-                == IterationDecision::Break) {
-            return IterationDecision::Break;
-        }
-        return callback(target_index, visual_context_tree.node_at(target_index));
+    // Cumulative to-root matrices for every visual context node, resolved against the live scroll
+    // offsets and folded onto the canvas matrix at replay entry, so any node's space can be entered
+    // absolutely with a single set_matrix(). Coordinate-affecting nodes therefore never touch the
+    // canvas save stack; only clips and effects do. Clip and effect nodes inherit their parent's
+    // matrix, so the palette is defined for every node index; nearest_spatial_node canonicalizes
+    // indices whose spaces coincide onto one identity for the current-matrix cache, and
+    // nearest_frame_node links every node to its innermost clip-or-effect ancestor-or-self (root
+    // index 0 doubling as none), letting frame chains hop between frames without visiting the
+    // coordinate-affecting nodes in between. The storage lives on the player so steady-state
+    // replays reuse warm capacity; moving it out for the duration of the replay keeps re-entrant
+    // nested replays from clobbering the outer palette.
+    auto palette_storage = move(m_replay_palette_storage);
+    auto& transform_palette = palette_storage.to_root_matrices;
+    auto& nearest_spatial_node = palette_storage.nearest_spatial_nodes;
+    auto& nearest_frame_node = palette_storage.nearest_frame_nodes;
+    auto const& nodes = visual_context_tree.nodes();
+    transform_palette.clear_with_capacity();
+    transform_palette.ensure_capacity(nodes.size());
+    nearest_spatial_node.clear_with_capacity();
+    nearest_spatial_node.ensure_capacity(nodes.size());
+    nearest_frame_node.clear_with_capacity();
+    nearest_frame_node.ensure_capacity(nodes.size());
+    auto const replay_base_matrix = canvas_matrix();
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        auto const& node = nodes[i];
+        auto append_spatial = [&](Gfx::FloatMatrix4x4 const& local_matrix) {
+            auto const& parent_matrix = i == 0 ? replay_base_matrix : transform_palette[node.parent_index.value()];
+            transform_palette.unchecked_append(parent_matrix * local_matrix);
+            nearest_spatial_node.unchecked_append(VisualContextIndex { i });
+            nearest_frame_node.unchecked_append(i == 0 ? VISUAL_VIEWPORT_NODE_INDEX : nearest_frame_node[node.parent_index.value()]);
+        };
+        auto append_spatial_translation = [&](Gfx::IntPoint offset) {
+            // Whole device pixels, matching the Translate ops the per-node application replayed.
+            append_spatial(Gfx::translation_matrix(Vector3<float>(static_cast<float>(offset.x()), static_cast<float>(offset.y()), 0)));
+        };
+        auto append_non_spatial = [&] {
+            VERIFY(i != 0);
+            transform_palette.unchecked_append(transform_palette[node.parent_index.value()]);
+            nearest_spatial_node.unchecked_append(nearest_spatial_node[node.parent_index.value()]);
+            nearest_frame_node.unchecked_append(VisualContextIndex { i });
+        };
+        node.data.visit(
+            [&](TransformData const& transform) {
+                auto matrix = Gfx::translation_matrix(Vector3<float>(transform.origin.x(), transform.origin.y(), 0));
+                matrix = matrix * transform.matrix;
+                matrix = matrix * Gfx::translation_matrix(Vector3<float>(-transform.origin.x(), -transform.origin.y(), 0));
+                append_spatial(matrix);
+            },
+            [&](PerspectiveData const& perspective) {
+                append_spatial(perspective.matrix);
+            },
+            [&](ScrollData const&) {
+                append_spatial_translation(scroll_state.device_offset_for_index(VisualContextIndex { i }).to_type<int>());
+            },
+            [&](ScrollCompensation const& compensation) {
+                append_spatial_translation((-scroll_state.device_offset_for_index(compensation.scroll_node_index)).to_type<int>());
+            },
+            [&](AnchorScrollShift const& shift) {
+                append_spatial_translation(shift.masked_offset(scroll_state).to_type<int>());
+            },
+            [&](ClipData const&) { append_non_spatial(); },
+            [&](ClipPathData const&) { append_non_spatial(); },
+            [&](EffectsData const&) { append_non_spatial(); });
+    }
+
+    // The palette entry the canvas matrix currently equals, if known; every Restore resets the
+    // matrix to its save point, so unwinding applied frames invalidates it. Recorded streams
+    // contain no matrix-mutating commands, so playing commands never invalidates the cache.
+    Optional<VisualContextIndex> current_ctm_space;
+    auto ensure_ctm_space = [&](VisualContextIndex context_index) {
+        auto space_node_index = nearest_spatial_node[context_index.value()];
+        if (current_ctm_space == space_node_index)
+            return;
+        set_matrix(transform_palette[space_node_index.value()]);
+        current_ctm_space = space_node_index;
     };
 
-    auto apply_accumulated_visual_context =
-        [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node, bool geometry_only) {
-            // Geometry-only application skips nodes that don't affect coordinates, but still pushes a
-            // save so the chain keeps one canvas save per node, which restore_to_depth relies on.
-            if (geometry_only && (node.data.has<ClipData>() || node.data.has<ClipPathData>() || node.data.has<EffectsData>())) {
-                play_command(Save {});
-                return;
-            }
-            node.data.visit(
-                [&](EffectsData const& effects) {
-                    play_command(ApplyEffects {
-                                     .opacity = effects.opacity,
-                                     .compositing_and_blending_operator = effects.blend_mode,
-                                     .has_filter = effects.gfx_filter.has_value(),
-                                     .filter_data = {},
-                                 },
-                        effects.gfx_filter.has_value() ? &effects.gfx_filter.value() : nullptr);
-                },
-                [&](PerspectiveData const& perspective) {
-                    play_command(Save {});
-                    apply_transform({ 0, 0 }, perspective.matrix);
-                },
-                [&](ScrollData const&) {
-                    play_command(Save {});
-                    auto offset = scroll_state.device_offset_for_index(node_index);
-                    if (!offset.is_zero())
-                        play_command(Translate { .delta = offset.to_type<int>() });
-                },
-                [&](ScrollCompensation const& compensation) {
-                    play_command(Save {});
-                    auto offset = -scroll_state.device_offset_for_index(compensation.scroll_node_index);
-                    if (!offset.is_zero())
-                        play_command(Translate { .delta = offset.to_type<int>() });
-                },
-                [&](AnchorScrollShift const& shift) {
-                    play_command(Save {});
-                    auto offset = shift.masked_offset(scroll_state);
-                    if (!offset.is_zero())
-                        play_command(Translate { .delta = offset.to_type<int>() });
-                },
-                [&](TransformData const& transform) {
-                    play_command(Save {});
-                    apply_transform(transform.origin, transform.matrix);
-                },
-                [&](ClipData const& clip) {
-                    play_command(Save {});
-                    if (clip.corner_radii.has_any_radius()) {
-                        play_command(AddRoundedRectClip {
-                            .corner_radii = clip.corner_radii,
-                            .border_rect = clip.rect.to_type<int>(),
-                            .corner_clip = Gfx::CornerClip::Outside,
-                        });
-                    } else {
-                        play_command(AddClipRect { .rect = clip.rect.to_type<int>() });
-                    }
-                },
-                [&](ClipPathData const& clip_path) {
-                    play_command(Save {});
-                    add_clip_path(clip_path.path, clip_path.fill_rule);
-                });
-        };
-
-    VisualContextIndex applied_context_index;
-    bool has_applied_context { false };
+    // One entry of the applied/target context: a clip or effect node on the target's root chain,
+    // each holding exactly one canvas save (a Save for clips, the layer pushed by ApplyEffects for
+    // effects), so unwinding is one Restore per popped frame. Geometry-only commands target an
+    // empty frame list: their coordinates come entirely from the palette.
+    Vector<VisualContextIndex, 16> applied_frames;
+    Vector<VisualContextIndex, 16> target_frames;
+    Optional<VisualContextIndex> applied_context_index;
     bool applied_context_geometry_only { false };
-    size_t applied_depth = 0;
+
+    auto build_target_frames = [&](VisualContextIndex target_index, bool geometry_only) {
+        target_frames.clear_with_capacity();
+        if (geometry_only)
+            return;
+        for (auto index = nearest_frame_node[target_index.value()];
+            index != VISUAL_VIEWPORT_NODE_INDEX;
+            index = nearest_frame_node[visual_context_tree.node_at(index).parent_index.value()]) {
+            target_frames.append(index);
+        }
+        target_frames.reverse();
+    };
+
+    auto restore_to_length = [&](size_t length) {
+        if (applied_frames.size() > length)
+            current_ctm_space = {};
+        while (applied_frames.size() > length) {
+            play_command(Restore {});
+            applied_frames.take_last();
+        }
+    };
 
     // OPTIMIZATION: When walking down to apply effects (opacity, filters, blend modes), check culling before applying
     //               each effect. Effects don't affect clip state, so the culling check is valid before applying them.
@@ -260,74 +285,68 @@ void DisplayListPlayer::execute_impl(
         CulledByEffect,
     };
     auto switch_to_context = [&](VisualContextIndex target_index, bool geometry_only, Optional<Gfx::IntRect> bounding_rect = {}) -> SwitchResult {
-        if (has_applied_context && applied_context_index == target_index && applied_context_geometry_only == geometry_only)
+        if (applied_context_index == target_index && applied_context_geometry_only == geometry_only)
             return SwitchResult::Switched;
 
-        // A chain applied in one mode can't be partially reused in the other: the modes disagree on what
-        // every shared ancestor contributes. Unwind fully and reapply from the root instead.
-        if (has_applied_context && applied_context_geometry_only != geometry_only) {
-            while (applied_depth > 0) {
-                play_command(Restore {});
-                --applied_depth;
-            }
-            has_applied_context = false;
-        }
+        build_target_frames(target_index, geometry_only);
 
-        Optional<VisualContextIndex> common_ancestor_index;
-        if (has_applied_context)
-            common_ancestor_index = visual_context_tree.find_common_ancestor(applied_context_index, target_index);
-        size_t const common_ancestor_depth = common_ancestor_index.has_value() ? visual_context_tree.node_at(common_ancestor_index.value()).depth + 1 : 0;
+        auto common_prefix_length = applied_frames.span().matching_prefix_length(target_frames);
 
-        auto has_coordinate_changing_descendant = [&](Optional<VisualContextIndex> ancestor_index) {
-            for (auto index = target_index;; index = visual_context_tree.node_at(index).parent_index) {
-                if (ancestor_index.has_value() && index == ancestor_index.value())
-                    break;
-                auto const& node = visual_context_tree.node_at(index);
-                if (node.data.has<TransformData>()
-                    || node.data.has<PerspectiveData>()
-                    || node.data.has<ScrollData>()
-                    || node.data.has<ScrollCompensation>()
-                    || node.data.has<AnchorScrollShift>())
-                    return true;
-                if (index == VISUAL_VIEWPORT_NODE_INDEX)
-                    break;
-            }
-            return false;
-        };
+        restore_to_length(common_prefix_length);
 
-        auto restore_to_depth = [&](size_t target_depth) {
-            while (applied_depth > target_depth) {
-                play_command(Restore {});
-                --applied_depth;
-            }
-        };
-        restore_to_depth(common_ancestor_depth);
-
-        auto result = SwitchResult::Switched;
-        for_each_node_from_common_ancestor_to_target(
-            common_ancestor_index,
-            target_index,
-            [&](VisualContextIndex node_index, AccumulatedVisualContextNode const& node) {
-                if (!geometry_only && bounding_rect.has_value() && node.data.has<EffectsData>()) {
-                    auto can_cull_before_effect = !has_coordinate_changing_descendant(Optional<VisualContextIndex> { node_index });
-                    if (bounding_rect->is_empty() || (can_cull_before_effect && would_be_fully_clipped_by_painter(*bounding_rect))) {
-                        result = SwitchResult::CulledByEffect;
-                        return IterationDecision::Break;
+        for (size_t i = common_prefix_length; i < target_frames.size(); ++i) {
+            auto frame_node_index = target_frames[i];
+            auto const& frame_node = visual_context_tree.node_at(frame_node_index);
+            if (auto const* effects = frame_node.data.get_pointer<EffectsData>()) {
+                if (bounding_rect.has_value()) {
+                    bool culled_by_effect = bounding_rect->is_empty();
+                    if (!culled_by_effect) {
+                        ensure_ctm_space(target_index);
+                        culled_by_effect = would_be_fully_clipped_by_painter(*bounding_rect);
+                    }
+                    if (culled_by_effect) {
+                        restore_to_length(common_prefix_length);
+                        // The canvas is unwound to the shared prefix; clearing the applied index
+                        // keeps the fast path from reusing the pre-cull context while the frame
+                        // vector still enables prefix reuse on the next switch.
+                        applied_context_index = {};
+                        return SwitchResult::CulledByEffect;
                     }
                 }
-                apply_accumulated_visual_context(node_index, node, geometry_only);
-                applied_depth++;
-                return IterationDecision::Continue;
-            });
-
-        if (result == SwitchResult::Switched) {
-            applied_context_index = target_index;
-            applied_context_geometry_only = geometry_only;
-            has_applied_context = true;
-        } else {
-            restore_to_depth(common_ancestor_depth);
+                ensure_ctm_space(frame_node_index);
+                play_command(ApplyEffects {
+                                 .opacity = effects->opacity,
+                                 .compositing_and_blending_operator = effects->blend_mode,
+                                 .has_filter = effects->gfx_filter.has_value(),
+                                 .filter_data = {},
+                             },
+                    effects->gfx_filter.has_value() ? &effects->gfx_filter.value() : nullptr);
+            } else {
+                play_command(Save {});
+                ensure_ctm_space(frame_node_index);
+                frame_node.data.visit(
+                    [&](ClipData const& clip) {
+                        if (clip.corner_radii.has_any_radius()) {
+                            play_command(AddRoundedRectClip {
+                                .corner_radii = clip.corner_radii,
+                                .border_rect = clip.rect.to_type<int>(),
+                                .corner_clip = Gfx::CornerClip::Outside,
+                            });
+                        } else {
+                            play_command(AddClipRect { .rect = clip.rect.to_type<int>() });
+                        }
+                    },
+                    [&](ClipPathData const& clip_path) {
+                        add_clip_path(clip_path.path, clip_path.fill_rule);
+                    },
+                    [&](auto const&) { VERIFY_NOT_REACHED(); });
+            }
+            applied_frames.append(frame_node_index);
         }
-        return result;
+
+        applied_context_index = target_index;
+        applied_context_geometry_only = geometry_only;
+        return SwitchResult::Switched;
     };
 
     DisplayList::for_each_command_header(commands, [&](DisplayListCommandHeader const& header, ReadonlyBytes payload) {
@@ -340,6 +359,8 @@ void DisplayListPlayer::execute_impl(
 
         if (switch_to_context(header.context_index, header.context_geometry_only, bounding_rect) == SwitchResult::CulledByEffect)
             return;
+
+        ensure_ctm_space(header.context_index);
 
         if (bounding_rect.has_value() && (bounding_rect->is_empty() || would_be_fully_clipped_by_painter(*bounding_rect))) {
             // Any clip that's located outside of the visible region is equivalent to a simple clip-rect,
@@ -378,10 +399,12 @@ void DisplayListPlayer::execute_impl(
         }
     });
 
-    while (applied_depth > 0) {
-        play_command(Restore {});
-        applied_depth--;
-    }
+    restore_to_length(0);
+    // Node spaces were entered by setting the canvas matrix absolutely, outside any save, so the
+    // matrix the replay entered with must be handed back explicitly.
+    set_matrix(replay_base_matrix);
+
+    m_replay_palette_storage = move(palette_storage);
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -67,7 +67,8 @@ private:
     ENUMERATE_DISPLAY_LIST_COMMANDS(DECLARE_PLAY_COMMAND)
 #undef DECLARE_PLAY_COMMAND
     virtual void play_command(ApplyEffects const&, Gfx::Filter const*) = 0;
-    virtual void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) = 0;
+    virtual void set_matrix(Gfx::FloatMatrix4x4 const&) = 0;
+    virtual Gfx::FloatMatrix4x4 canvas_matrix() const = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 
     virtual void add_clip_path(Gfx::Path const&, Gfx::WindingRule) = 0;
@@ -78,6 +79,16 @@ private:
     CanvasSurfaceRegistry const* m_canvas_surface_registry { nullptr };
     RefPtr<Gfx::PaintingSurface> m_surface;
     ReadonlyBytes m_current_command_payload;
+
+    // Scratch for the per-replay transform palette, retained so steady-state replays reuse warm
+    // capacity; execute_impl moves it out for the duration of a replay, letting re-entrant nested
+    // replays build their own palettes without clobbering the outer one.
+    struct ReplayPaletteStorage {
+        Vector<Gfx::FloatMatrix4x4> to_root_matrices;
+        Vector<VisualContextIndex> nearest_spatial_nodes;
+        Vector<VisualContextIndex> nearest_frame_nodes;
+    };
+    ReplayPaletteStorage m_replay_palette_storage;
 };
 
 class DisplayList : public AtomicRefCounted<DisplayList> {

--- a/Libraries/LibWeb/Painting/DisplayListCommand.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.cpp
@@ -110,11 +110,6 @@ void Restore::dump(StringBuilder&) const
 {
 }
 
-void Translate::dump(StringBuilder& builder) const
-{
-    builder.appendff(" delta={}", delta);
-}
-
 void AddClipRect::dump(StringBuilder& builder) const
 {
     builder.appendff(" rect={}", rect);

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -47,7 +47,6 @@ class DisplayList;
     V(Save, save)                                                                      \
     V(SaveLayer, save_layer)                                                           \
     V(Restore, restore)                                                                \
-    V(Translate, translate)                                                            \
     V(AddClipRect, add_clip_rect)                                                      \
     V(PaintLinearGradient, paint_linear_gradient)                                      \
     V(PaintRadialGradient, paint_radial_gradient)                                      \
@@ -300,15 +299,6 @@ struct Restore {
     static constexpr StringView command_name = "Restore"sv;
     static constexpr DisplayListCommandType command_type = DisplayListCommandType::Restore;
     static constexpr int nesting_level_change = -1;
-
-    void dump(StringBuilder&) const;
-};
-
-struct Translate {
-    static constexpr StringView command_name = "Translate"sv;
-    static constexpr DisplayListCommandType command_type = DisplayListCommandType::Translate;
-
-    Gfx::IntPoint delta;
 
     void dump(StringBuilder&) const;
 };

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -527,12 +527,6 @@ void DisplayListPlayerSkia::play_command(Restore const&)
     canvas.restore();
 }
 
-void DisplayListPlayerSkia::play_command(Translate const& command)
-{
-    auto& canvas = surface().canvas();
-    canvas.translate(command.delta.x(), command.delta.y());
-}
-
 static SkGradient::Interpolation to_skia_interpolation(Gfx::GradientInterpolationMethod interpolation_method)
 {
     SkGradient::Interpolation interpolation;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -124,6 +124,16 @@ static SkM44 to_skia_matrix4x4(Gfx::FloatMatrix4x4 const& matrix)
         matrix[3, 3]);
 }
 
+static Gfx::FloatMatrix4x4 to_gfx_matrix4x4(SkM44 const& matrix)
+{
+    Gfx::FloatMatrix4x4 result;
+    for (int row = 0; row < 4; ++row) {
+        for (int column = 0; column < 4; ++column)
+            result[row, column] = matrix.rc(row, column);
+    }
+    return result;
+}
+
 void DisplayListPlayerSkia::flush(Gfx::PaintingSurface& surface)
 {
     if (auto context = surface.skia_backend_context())
@@ -1189,13 +1199,14 @@ void DisplayListPlayerSkia::play_command(ApplyEffects const& command, Gfx::Filte
     canvas.saveLayer(nullptr, &paint);
 }
 
-void DisplayListPlayerSkia::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const& matrix)
+void DisplayListPlayerSkia::set_matrix(Gfx::FloatMatrix4x4 const& matrix)
 {
-    auto new_transform = Gfx::translation_matrix(Vector3<float>(origin.x(), origin.y(), 0));
-    new_transform = new_transform * matrix;
-    new_transform = new_transform * Gfx::translation_matrix(Vector3<float>(-origin.x(), -origin.y(), 0));
-    auto skia_matrix = to_skia_matrix4x4(new_transform);
-    surface().canvas().concat(skia_matrix);
+    surface().canvas().setMatrix(to_skia_matrix4x4(matrix));
+}
+
+Gfx::FloatMatrix4x4 DisplayListPlayerSkia::canvas_matrix() const
+{
+    return to_gfx_matrix4x4(surface().canvas().getLocalToDevice());
 }
 
 void DisplayListPlayerSkia::add_clip_path(Gfx::Path const& path, Gfx::WindingRule winding_rule)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -47,7 +47,8 @@ private:
     ENUMERATE_DISPLAY_LIST_COMMANDS(DECLARE_PLAY_COMMAND)
 #undef DECLARE_PLAY_COMMAND
     void play_command(ApplyEffects const&, Gfx::Filter const*) override;
-    void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 const&) override;
+    void set_matrix(Gfx::FloatMatrix4x4 const&) override;
+    Gfx::FloatMatrix4x4 canvas_matrix() const override;
 
     void add_clip_path(Gfx::Path const&, Gfx::WindingRule) override;
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -652,11 +652,6 @@ void DisplayListRecorder::add_clip_rect(Gfx::IntRect const& rect)
     append_command(AddClipRect { rect });
 }
 
-void DisplayListRecorder::translate(Gfx::IntPoint delta)
-{
-    append_command(Translate { delta });
-}
-
 void DisplayListRecorder::save()
 {
     append_command(Save {});

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -101,8 +101,6 @@ public:
 
     void add_clip_rect(Gfx::IntRect const& rect);
 
-    void translate(Gfx::IntPoint delta);
-
     void set_accumulated_visual_context(VisualContextIndex index) { m_accumulated_visual_context_index = index; }
     VisualContextIndex accumulated_visual_context() const { return m_accumulated_visual_context_index; }
 

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -100,9 +100,9 @@ static void build_nested_svg_visual_context_tree_for_subtree(AccumulatedVisualCo
     });
 }
 
-static AccumulatedVisualContextTree build_nested_svg_visual_context_tree(Paintable& root_paintable)
+static AccumulatedVisualContextTree build_nested_svg_visual_context_tree(Paintable& root_paintable, Gfx::IntPoint content_offset)
 {
-    auto visual_context_tree = AccumulatedVisualContextTree::create();
+    auto visual_context_tree = AccumulatedVisualContextTree::create_with_content_offset(content_offset);
     auto pixel_ratio = root_paintable.document().page().client().device_pixels_per_css_pixel();
     build_nested_svg_visual_context_tree_for_subtree(visual_context_tree, root_paintable, {}, pixel_ratio);
 
@@ -125,10 +125,9 @@ static Optional<DisplayListResource> paint_mask_or_clip_to_display_list(
     bool is_clip_path)
 {
     auto mask_rect = context.enclosing_device_rect(area);
-    auto visual_context_tree = build_nested_svg_visual_context_tree(const_cast<Paintable&>(paintable));
+    auto visual_context_tree = build_nested_svg_visual_context_tree(const_cast<Paintable&>(paintable), -mask_rect.location().to_type<int>());
     auto display_list = DisplayList::create(visual_context_tree);
     DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, context.display_list_recorder().resource_storage());
-    display_list_recorder.translate(-mask_rect.location().to_type<int>());
     auto paint_context = context.clone(display_list_recorder);
     auto const& mask_element = as<SVG::SVGGraphicsElement const>(*paintable.dom_node());
     // Layout computes transforms only within the mask/clip subtree, so prepend the target's accumulated transform here.

--- a/Libraries/LibWeb/SVG/SVGPatternElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPatternElement.cpp
@@ -291,11 +291,10 @@ Optional<Painting::PaintStyle> SVGPatternElement::to_gfx_paint_style(SVGPaintCon
     auto svg_offset = recording_context.rounded_device_point(svg_element_rect.location()).to_type<int>().to_type<float>();
     tile_rect.translate_by(svg_offset);
 
-    auto visual_context_tree = Painting::AccumulatedVisualContextTree::create();
+    auto content_origin = paint_context.paint_transform.map(Gfx::FloatPoint { 0, 0 }) + svg_offset;
+    auto visual_context_tree = Painting::AccumulatedVisualContextTree::create_with_content_offset(-Gfx::IntPoint(content_origin.to_type<int>()));
     auto display_list = Painting::DisplayList::create(visual_context_tree);
     Painting::DisplayListRecorder display_list_recorder(*display_list, visual_context_tree, recording_context.display_list_recorder().resource_storage());
-    auto content_origin = paint_context.paint_transform.map(Gfx::FloatPoint { 0, 0 }) + svg_offset;
-    display_list_recorder.translate(-Gfx::IntPoint(content_origin.to_type<int>()));
     auto paint_context_copy = recording_context.clone(display_list_recorder);
 
     Gfx::AffineTransform target_svg_transform;

--- a/Tests/LibWeb/Ref/expected/svg-mask-with-effect-group-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-mask-with-effect-group-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<style>* { margin: 0; }</style>
+<svg width="400" height="300">
+  <rect x="100" y="100" width="100" height="100" fill="green"/>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg-mask-with-effect-group.html
+++ b/Tests/LibWeb/Ref/input/svg-mask-with-effect-group.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-mask-with-effect-group-ref.html" />
+<style>* { margin: 0; }</style>
+<svg width="400" height="300">
+  <mask id="m">
+    <!-- The group needs a layer during mask replay, so the commands after it re-enter the
+         mask's root context; the full-coverage white rect must still land on the target. -->
+    <g opacity="0.5"><rect x="110" y="110" width="10" height="10" fill="white"/></g>
+    <rect x="100" y="100" width="100" height="100" fill="white"/>
+  </mask>
+  <rect x="100" y="100" width="100" height="100" fill="green" mask="url(#m)"/>
+</svg>

--- a/Tests/LibWeb/TestDisplayListDamage.cpp
+++ b/Tests/LibWeb/TestDisplayListDamage.cpp
@@ -129,8 +129,18 @@ TEST_CASE(damage_contains_old_and_new_command_bounds)
 TEST_CASE(changed_unbounded_commands_require_full_repaint)
 {
     auto visual_context_tree = AccumulatedVisualContextTree::create();
-    auto old_display_list = command_bytes(Translate { { 1, 1 } });
-    auto new_display_list = command_bytes(Translate { { 2, 2 } });
+    auto old_display_list = command_bytes(ApplyEffects {
+        .opacity = 0.5f,
+        .compositing_and_blending_operator = Gfx::CompositingAndBlendingOperator::Normal,
+        .has_filter = false,
+        .filter_data = {},
+    });
+    auto new_display_list = command_bytes(ApplyEffects {
+        .opacity = 0.6f,
+        .compositing_and_blending_operator = Gfx::CompositingAndBlendingOperator::Normal,
+        .has_filter = false,
+        .filter_data = {},
+    });
     ScrollStateSnapshot scroll_state;
 
     auto damage = compute_display_list_damage(old_display_list, visual_context_tree, scroll_state, new_display_list, visual_context_tree, scroll_state, { 0, 0, 100, 100 });

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -16,7 +16,6 @@ SaveLayer@0
     SaveLayer@2
       ApplyEffects@3 opacity=1 has_filter=false
         PaintNestedDisplayList@3 rect=[-2,-2 119x119]
-          Translate@0 delta=[2,2]
           FillPath@0 path_bounding_rect=[8,8 100x100]
       Restore@3
     Restore@3
@@ -29,7 +28,6 @@ SaveLayer@0
       FillRect@3 rect=[9,8 100x100] color=rgb(0, 0, 0)
       ApplyEffects@2 opacity=1 has_filter=false
         PaintNestedDisplayList@2 rect=[-2,-2 119x119]
-          Translate@0 delta=[2,2]
           FillPath@0 path_bounding_rect=[8,8 100x100]
       Restore@2
     Restore@2

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -22,7 +22,6 @@ SaveLayer@0
           FillPath@1 path_bounding_rect=[1,50 55x55]
           ApplyEffects@1 opacity=1 has_filter=false
             PaintNestedDisplayList@1 rect=[4,10 55x55]
-              Translate@0 delta=[-4,-10]
               FillPath@0 path_bounding_rect=[4,10 55x56]
           Restore@1
         Restore@1


### PR DESCRIPTION
The display list player entered a command's coordinate space by replaying its
visual context chain onto the canvas stack: one save plus a translate or concat
per transform, perspective, scroll, scroll-compensation, and anchor-shift node,
then more saves for clips and effects. Deep chains cost a save per node on every
context switch, and each switch re-walked the tree to find the common ancestor
and to decide whether an effect may cull.

Replay now resolves a palette of cumulative to-root matrices for all visual
context nodes once per replay (folding in live scroll offsets and the canvas
matrix at entry) and enters any node's space with a single setMatrix. The canvas
save stack holds only clip and effect frames, so save depth shrinks from chain
length to clip+effect count; context switches diff frame lists instead of
walking the tree; geometry-only (inspector overlay) commands stop pushing
placeholder saves; and effect culling becomes exact, since the bounding rect is
checked in the command's own space before any layer is pushed.