### PR TITLE
LibWeb: Notify SVG image clients on a deferred event loop task

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
+#include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 #include <LibWeb/XML/XMLDocumentBuilder.h>
@@ -452,7 +453,19 @@ void SVGDecodedImageData::did_request_frame()
         return;
 
     invalidate_cached_rendering();
-    notify_clients_did_update();
+
+    // NB: Frame requests arrive synchronously from the SVG document, possibly while a client document is in
+    //     the middle of layout or paint; for example, a natural size query during intrinsic size measurement
+    //     flushes style in the SVG document, and applying the resulting invalidation requests a frame.
+    //     Clients respond to the notification by invalidating their own style and layout, which must never
+    //     happen during their layout, so defer (and coalesce) notifications until the event loop spins again.
+    if (m_has_pending_client_notification)
+        return;
+    m_has_pending_client_notification = true;
+    Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [self = GC::Ref { *this }] {
+        self->m_has_pending_client_notification = false;
+        self->notify_clients_did_update();
+    }));
 }
 
 void SVGDecodedImageData::invalidate_cached_rendering()

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -76,6 +76,7 @@ private:
     GC::Ref<SVG::SVGSVGElement> m_root_element;
 
     mutable bool m_is_recording_display_list { false };
+    bool m_has_pending_client_notification { false };
 };
 
 class SVGDecodedImageData::SVGPageClient final : public PageClient {

--- a/Tests/LibWeb/Crash/Layout/reentrant-intrinsic-size-cache-invalidation.html
+++ b/Tests/LibWeb/Crash/Layout/reentrant-intrinsic-size-cache-invalidation.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<script src="../../Text/input/include.js"></script>
+<style>
+    .case {
+        position: absolute;
+    }
+
+    .min-inline {
+        width: min-content;
+    }
+
+    .max-inline {
+        width: max-content;
+    }
+
+    .min-block {
+        display: flex;
+        height: min-content;
+    }
+
+    .max-block {
+        display: flex;
+        height: max-content;
+    }
+
+    /* The SVG images load asynchronously, so their guest documents get their first style
+       flush from the natural-size query inside the intrinsic measurement layout of the
+       absolutely positioned boxes above. The <use> elements matter: their shadow-tree
+       clones lack the insertion-time needs-layout-tree-update marking, so first-time
+       style application on them fires layout tree invalidation in the guest document,
+       which used to escape into the host document mid-measurement. */
+    .min-inline::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3Esvg%7Bwidth:11px;height:11px%7D%3C/style%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h8v8z'/%3E%3C/defs%3E%3Cuse href='%23a'/%3E%3C/svg%3E");
+    }
+
+    .max-inline::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3Esvg%7Bwidth:12px;height:12px%7D%3C/style%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h8v8z'/%3E%3C/defs%3E%3Cuse href='%23a'/%3E%3C/svg%3E");
+    }
+
+    .min-block::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3Esvg%7Bwidth:13px;height:13px%7D%3C/style%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h8v8z'/%3E%3C/defs%3E%3Cuse href='%23a'/%3E%3C/svg%3E");
+    }
+
+    .max-block::before {
+        content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3Esvg%7Bwidth:14px;height:14px%7D%3C/style%3E%3Cdefs%3E%3Cpath id='a' d='M0 0h8v8z'/%3E%3C/defs%3E%3Cuse href='%23a'/%3E%3C/svg%3E");
+    }
+</style>
+<div class="case min-inline"></div>
+<div class="case max-inline"></div>
+<div class="case min-block"></div>
+<div class="case max-block"></div>
+<script>
+    asyncTest(done => {
+        let remainingFrames = 8;
+        function pump() {
+            document.body.offsetHeight;
+            if (--remainingFrames > 0)
+                requestAnimationFrame(pump);
+            else
+                done();
+        }
+        requestAnimationFrame(pump);
+    });
+</script>


### PR DESCRIPTION
SVGPageClient::request_frame() notified clients synchronously, and
frame requests can fire in the middle of host document layout: querying
an SVG image's natural size during intrinsic size measurement flushes
style in the guest SVG document, and the first style pass on a <use>
shadow tree clone applies layout tree invalidation, which requests a
frame. Clients react by invalidating layout, deleting the intrinsic
size cache that the running measurement still holds a reference into.
This use-after-free crashed WebContent on Google Forms.

Layout invalidation must never run during layout, so defer and coalesce
the client notification until the event loop spins again. Add a crash
test that reproduces the reentrant invalidation deterministically.