### PR TITLE
LibWebView/Base: Improve download progress counters

### DIFF
--- a/Base/res/ladybird/about-pages/downloads.html
+++ b/Base/res/ladybird/about-pages/downloads.html
@@ -193,6 +193,13 @@
             const sizeFormatter = new Intl.NumberFormat([], {
                 maximumFractionDigits: 1,
             });
+            const sizeUnits = [
+                { divisor: 1, suffix: "B" },
+                { divisor: 1024, suffix: "KiB" },
+                { divisor: 1024 ** 2, suffix: "MiB" },
+                { divisor: 1024 ** 3, suffix: "GiB" },
+                { divisor: 1024 ** 4, suffix: "TiB" },
+            ];
 
             let downloads = [];
             const downloadRows = new Map();
@@ -208,18 +215,11 @@
                 return `${count} ${count === 1 ? singular : plural}`;
             }
 
-            function formatSize(size) {
-                if (size < 1024) return `${size} B`;
-
-                const units = ["KiB", "MiB", "GiB", "TiB"];
-                let value = size / 1024;
-                let unitIndex = 0;
-                while (value >= 1024 && unitIndex < units.length - 1) {
-                    value /= 1024;
-                    unitIndex++;
+            function unitForDownloadSize(size) {
+                for (let i = sizeUnits.length - 1; i > 0; --i) {
+                    if (size >= sizeUnits[i].divisor) return sizeUnits[i];
                 }
-
-                return `${sizeFormatter.format(value)} ${units[unitIndex]}`;
+                return sizeUnits[0];
             }
 
             function statusLabel(download) {
@@ -232,9 +232,13 @@
             function detailLabel(download) {
                 if (download.status === "canceled") return "Partial file removed.";
                 if (download.status === "failed") return download.error || "The download failed.";
-                if (download.totalSize !== null && download.totalSize !== undefined)
-                    return `${formatSize(download.downloadedSize)} of ${formatSize(download.totalSize)}`;
-                return formatSize(download.downloadedSize);
+                if (download.status !== "completed" && download.totalSize > 0) {
+                    const unit = unitForDownloadSize(download.totalSize);
+                    return `${sizeFormatter.format(download.downloadedSize / unit.divisor)}/${sizeFormatter.format(download.totalSize / unit.divisor)} ${unit.suffix}`;
+                }
+
+                const unit = unitForDownloadSize(download.downloadedSize);
+                return `${sizeFormatter.format(download.downloadedSize / unit.divisor)} ${unit.suffix}`;
             }
 
             function createActionButton(className, textContent, message, downloadId) {

--- a/Libraries/LibWebView/DownloadPresentation.cpp
+++ b/Libraries/LibWebView/DownloadPresentation.cpp
@@ -28,20 +28,36 @@ static String download_percent_text(double progress)
     return MUST(String::formatted("{}%", static_cast<int>(progress * 100.0)));
 }
 
+struct SizeUnit {
+    u64 divisor;
+    StringView suffix;
+};
+
+static SizeUnit unit_for_download_size(u64 size)
+{
+    if (size < KiB)
+        return { 1, "B"sv };
+    if (size < MiB)
+        return { KiB, "KiB"sv };
+    if (size < GiB)
+        return { MiB, "MiB"sv };
+    if (size < TiB)
+        return { GiB, "GiB"sv };
+    return { TiB, "TiB"sv };
+}
+
+static String unitless_download_size_text(u64 size, SizeUnit unit)
+{
+    if (unit.divisor == 1)
+        return MUST(String::formatted("{}", size));
+
+    return MUST(String::formatted("{:.1f}", static_cast<double>(size) / static_cast<double>(unit.divisor)));
+}
+
 static String download_size_text(u64 size)
 {
-    constexpr double kibibyte = 1024.0;
-    constexpr double mebibyte = kibibyte * 1024.0;
-    constexpr double gibibyte = mebibyte * 1024.0;
-
-    auto size_as_double = static_cast<double>(size);
-    if (size_as_double < kibibyte)
-        return MUST(String::formatted("{} B", size));
-    if (size_as_double < mebibyte)
-        return MUST(String::formatted("{:.1f} KB", size_as_double / kibibyte));
-    if (size_as_double < gibibyte)
-        return MUST(String::formatted("{:.1f} MB", size_as_double / mebibyte));
-    return MUST(String::formatted("{:.1f} GB", size_as_double / gibibyte));
+    auto unit = unit_for_download_size(size);
+    return MUST(String::formatted("{} {}", unitless_download_size_text(size, unit), unit.suffix));
 }
 
 String download_status_text(FileDownloader::Download const& download)
@@ -51,9 +67,11 @@ String download_status_text(FileDownloader::Download const& download)
     switch (download.status) {
     case DownloadStatus::InProgress:
         if (auto progress = download.progress(); progress.has_value()) {
-            return MUST(String::formatted("{} of {} - {}",
-                download_size_text(download.downloaded_size),
-                download_size_text(*download.total_size),
+            auto unit = unit_for_download_size(*download.total_size);
+            return MUST(String::formatted("{}/{} {} - {}",
+                unitless_download_size_text(download.downloaded_size, unit),
+                unitless_download_size_text(*download.total_size, unit),
+                unit.suffix,
                 download_percent_text(*progress)));
         }
         return MUST(String::formatted("{} downloaded", download_size_text(download.downloaded_size)));


### PR DESCRIPTION
We now use consistent units between downloaded and total size (i.e. `0.5/100 MiB` instead of `512 KiB of 100 MiB`) - fixes #10485

We also use `KiB` and friends (up to `TiB`) instead of `KB` in the popover in line with about:downloads.

about:downloads also prints only the total size instead of the progress once the download is complete (i.e. `Completed 100 MiB` instead of `Completed 100/100 MiB`) in line with the popover.