### PR TITLE
LibWeb: Skip unstyled flat-tree parents in animated style update walk

### DIFF
--- a/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -884,6 +884,17 @@ AnimationUpdateContext::~AnimationUpdateContext()
             auto& element = static_cast<DOM::Element&>(node);
             if (!element.computed_values())
                 return TraversalDecision::SkipChildrenAndContinue;
+            // NB: A styled element can inherit from an unstyled one in the flat tree: per css-shadow-1, a slotted
+            //     element inherits from the slot it's assigned to rather than its light tree parent
+            //     (https://drafts.csswg.org/css-shadow-1/#slots-in-shadow-tree), and that slot may not have computed
+            //     values yet (e.g. a freshly attached shadow tree that hasn't been through a style update).
+            //     Inherited style can't be recomputed against an unstyled parent, so leave the element to the
+            //     regular style pass, which always styles slots before their assigned slottables.
+            if (auto inheritance_parent = DOM::AbstractElement { element }.element_to_inherit_style_from();
+                inheritance_parent.has_value() && !inheritance_parent->computed_values()) {
+                element.set_needs_style_update(true);
+                return TraversalDecision::SkipChildrenAndContinue;
+            }
             auto element_invalidation = element.recompute_inherited_style();
             if (element_invalidation.is_none())
                 return TraversalDecision::SkipChildrenAndContinue;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -5413,6 +5413,11 @@ GC::Ref<WebIDL::Promise> Element::request_pointer_lock(Optional<Bindings::Pointe
 // If a pseudo-element is specified, this will return the element itself.
 // Otherwise, if this element is slotted somewhere, it will return the slot.
 // Otherwise, it will return the parent or shadow host element of this element.
+//
+// The slot case is specified in https://drafts.csswg.org/css-shadow-1/#slots-in-shadow-tree:
+// NOTE: A non-obvious result of assigning elements to slots is that they inherit from the slot they're assigned to.
+//       Their original light tree parent, and any deeper slots that their slot gets assigned to, don't affect
+//       inheritance.
 GC::Ptr<Element const> Element::element_to_inherit_style_from(Optional<CSS::PseudoElement> pseudo_element) const
 {
     if (pseudo_element.has_value())

--- a/Tests/LibWeb/Crash/CSS/animation-subtree-slotted-child-of-unstyled-slot.html
+++ b/Tests/LibWeb/Crash/CSS/animation-subtree-slotted-child-of-unstyled-slot.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<style>
+    @keyframes anim { from { letter-spacing: 0px } to { letter-spacing: 1000px } }
+    #target { animation: anim 10s infinite; }
+</style>
+<div id="target">
+    <div id="host"><span>slotted</span></div>
+</div>
+<script>
+    // Wait a few frames so the animation is running and produces a changed animated value
+    // every frame. Then attach a shadow root whose slot has not been styled yet and force a
+    // style update from within the same animation frame callback, before the regular style
+    // pass has styled the slot. The animated style update walk must not recompute inherited
+    // style for the slotted span against its unstyled assigned slot.
+    let frames = 0;
+    function tick() {
+        if (++frames < 4) {
+            requestAnimationFrame(tick);
+            return;
+        }
+
+        host.attachShadow({ mode: "open" }).innerHTML = "<slot></slot>";
+        target.getBoundingClientRect();
+        requestAnimationFrame(() => {
+            document.documentElement.classList.remove("test-wait");
+        });
+    }
+
+    requestAnimationFrame(tick);
+</script>
+</html>


### PR DESCRIPTION
The animated style update walk in ~AnimationUpdateContext recomputes inherited style for every shadow-including descendant of an animation target that has computed values. Per css-shadow-1, a slotted element inherits from its assigned slot in the flat tree, not from its light tree parent, and that slot can be unstyled: when a shadow root is attached and style is then flushed from a rAF callback, update_style() runs the animated style update before the regular pass has styled the new slot. recompute_inherited_style() then hit VERIFY(computed_values) in Length::ResolutionContext::for_element() while building a computation context from the unstyled slot, crashing WebContent on https://timex.eu collection pages.

Skip such elements in the walk and mark them for a regular style update instead, which always styles slots before their assigned slottables. Also document the css-shadow-1 slot inheritance rule at Element::element_to_inherit_style_from(). Covered by a new crash test.