### PR TITLE
Compositor: Clear damaged pixels to the canvas color

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8880,8 +8880,11 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
         display_list_recorder.fill_rect(bitmap_rect, CSS::SystemColor::canvas(color_scheme));
 
     auto background_color = this->background_color();
-    if (navigable()->is_top_level_traversable())
-        page().client().page_did_change_background_color(canvas_background_color());
+    if (navigable()->is_top_level_traversable()) {
+        auto canvas_background_color = this->canvas_background_color();
+        display_list->set_surface_clear_color(canvas_background_color);
+        page().client().page_did_change_background_color(canvas_background_color);
+    }
 
     display_list_recorder.fill_rect(bitmap_rect, background_color);
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -35,10 +35,11 @@ DisplayList::DisplayList(u64 compatible_visual_context_tree_version)
 {
 }
 
-DisplayList::DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata> async_scrolling_metadata, HashMap<VisualContextIndex, DisplayListResourceId>&& mask_display_lists)
+DisplayList::DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata> async_scrolling_metadata, HashMap<VisualContextIndex, DisplayListResourceId>&& mask_display_lists)
     : m_compatible_visual_context_tree_version(compatible_visual_context_tree_version)
     , m_id(id)
     , m_command_bytes(move(command_bytes))
+    , m_surface_clear_color(surface_clear_color)
     , m_async_scrolling_metadata(move(async_scrolling_metadata))
     , m_mask_display_lists(move(mask_display_lists))
 {
@@ -473,6 +474,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::DisplayList const& display
     TRY(encoder.encode(display_list.m_id));
     TRY(encoder.encode(display_list.m_command_bytes));
     TRY(encoder.encode(display_list.m_compatible_visual_context_tree_version));
+    TRY(encoder.encode(display_list.m_surface_clear_color));
     TRY(encoder.encode(display_list.m_async_scrolling_metadata));
     TRY(encoder.encode(display_list.m_mask_display_lists));
     return {};
@@ -490,9 +492,10 @@ ErrorOr<NonnullRefPtr<Web::Painting::DisplayList>> decode(Decoder& decoder)
     auto id = TRY(decoder.decode<u64>());
     auto command_bytes = TRY(decoder.decode<ByteBuffer>());
     auto compatible_visual_context_tree_version = TRY(decoder.decode<u64>());
+    auto surface_clear_color = TRY(decoder.decode<Optional<Gfx::Color>>());
     auto async_scrolling_metadata = TRY(decoder.decode<Optional<Web::Painting::DisplayList::AsyncScrollingMetadata>>());
     auto mask_display_lists = TRY(decoder.decode<HashMap<Web::Painting::VisualContextIndex, Web::Painting::DisplayListResourceId>>());
-    return adopt_ref(*new Web::Painting::DisplayList(compatible_visual_context_tree_version, id, move(command_bytes), move(async_scrolling_metadata), move(mask_display_lists)));
+    return adopt_ref(*new Web::Painting::DisplayList(compatible_visual_context_tree_version, id, move(command_bytes), surface_clear_color, move(async_scrolling_metadata), move(mask_display_lists)));
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -123,6 +123,8 @@ public:
     u64 id() const { return m_id; }
 
     ReadonlyBytes command_bytes() const { return m_command_bytes.span(); }
+    void set_surface_clear_color(Gfx::Color color) { m_surface_clear_color = color; }
+    Optional<Gfx::Color> surface_clear_color() const { return m_surface_clear_color; }
     void set_async_scrolling_metadata(AsyncScrollingMetadata metadata) { m_async_scrolling_metadata = metadata; }
     Optional<AsyncScrollingMetadata> const& async_scrolling_metadata() const { return m_async_scrolling_metadata; }
     Optional<DisplayListResourceId> mask_display_list_id(VisualContextIndex context_index) const { return m_mask_display_lists.get(context_index); }
@@ -157,7 +159,7 @@ public:
 
 private:
     explicit DisplayList(u64 compatible_visual_context_tree_version);
-    DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Optional<AsyncScrollingMetadata>, HashMap<VisualContextIndex, DisplayListResourceId>&& mask_display_lists);
+    DisplayList(u64 compatible_visual_context_tree_version, u64 id, ByteBuffer&& command_bytes, Optional<Gfx::Color> surface_clear_color, Optional<AsyncScrollingMetadata>, HashMap<VisualContextIndex, DisplayListResourceId>&& mask_display_lists);
 
     static Optional<Gfx::IntRect> command_bounding_rectangle(auto const& command)
     {
@@ -188,6 +190,7 @@ private:
     u64 m_compatible_visual_context_tree_version { 0 };
     u64 m_id { 0 };
     ByteBuffer m_command_bytes;
+    Optional<Gfx::Color> m_surface_clear_color;
     Optional<AsyncScrollingMetadata> m_async_scrolling_metadata;
     HashMap<VisualContextIndex, DisplayListResourceId> m_mask_display_lists;
 

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibGfx/SkiaUtils.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <core/SkCanvas.h>
@@ -968,6 +969,7 @@ Web::Painting::AccumulatedVisualContextTree const& ContextState::visual_context_
 void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSkia& display_list_player, Gfx::PaintingSurface& surface, CompositedContextResolver const* composited_context_resolver, Optional<Gfx::IntRect> damage_rect)
 {
     VERIFY(m_display_list);
+    auto surface_clear_color = Gfx::to_skia_color(m_display_list->surface_clear_color().value_or(Gfx::Color::Transparent));
     auto paint_display_list = [&](Gfx::PaintingSurface& target_surface) {
         display_list_player.execute(
             *m_display_list,
@@ -987,7 +989,7 @@ void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSk
         }
 
         auto& damage_canvas = m_damage_surface->canvas();
-        damage_canvas.clear(SK_ColorTRANSPARENT);
+        damage_canvas.clear(surface_clear_color);
         damage_canvas.save();
         damage_canvas.translate(-damage_rect->x(), -damage_rect->y());
         paint_display_list(*m_damage_surface);
@@ -1010,8 +1012,7 @@ void ContextState::paint_current_display_list(Web::Painting::DisplayListPlayerSk
     auto save_count = canvas.save();
     if (damage_rect.has_value()) {
         canvas.clipIRect(SkIRect::MakeXYWH(damage_rect->x(), damage_rect->y(), damage_rect->width(), damage_rect->height()));
-        if (!presents_to_client())
-            canvas.clear(SK_ColorTRANSPARENT);
+        canvas.clear(surface_clear_color);
     }
     paint_display_list(surface);
     canvas.restoreToCount(save_count);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_subdirectory(LibXML)
 add_subdirectory(Meta)
 
 if (ENABLE_GUI_TARGETS)
+    add_subdirectory(Compositor)
     add_subdirectory(LibDevTools)
     add_subdirectory(LibGfx)
     add_subdirectory(LibMedia)

--- a/Tests/Compositor/CMakeLists.txt
+++ b/Tests/Compositor/CMakeLists.txt
@@ -1,0 +1,1 @@
+ladybird_test(TestContextState.cpp Compositor LIBS compositorservice LibGfx LibWeb)

--- a/Tests/Compositor/TestContextState.cpp
+++ b/Tests/Compositor/TestContextState.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteBuffer.h>
+#include <AK/Queue.h>
+#include <AK/Stream.h>
+#include <Compositor/CompositorState.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibIPC/Message.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Painting/DisplayListPlayerSkia.h>
+
+struct TestWebContentClient final : public Compositor::CompositorStateWebContentClient {
+    virtual void dispatch_mouse_event_to_web_content(u64, Web::MouseEvent const&) override { }
+    virtual void request_rendering_update() override { }
+};
+
+static NonnullRefPtr<Web::Painting::DisplayList> make_display_list(Web::Painting::AccumulatedVisualContextTree const& visual_context_tree, Optional<Gfx::Color> color, Optional<Gfx::Color> surface_clear_color = {})
+{
+    ByteBuffer command_bytes;
+    if (color.has_value()) {
+        auto command = Web::Painting::FillRect { { 0, 0, 4, 4 }, *color };
+        auto payload = Web::Painting::display_list_object_bytes(command);
+        auto record_size = sizeof(Web::Painting::DisplayListCommandHeader) + payload.size();
+        auto payload_size = align_up_to(record_size, Web::Painting::DisplayList::command_alignment) - sizeof(Web::Painting::DisplayListCommandHeader);
+        Web::Painting::DisplayListCommandHeader header {
+            .type = Web::Painting::FillRect::command_type,
+            .payload_size = static_cast<u32>(payload_size),
+            .context_index = Web::Painting::VISUAL_VIEWPORT_NODE_INDEX,
+            .has_bounding_rect = true,
+            .bounding_rect = command.rect,
+        };
+        command_bytes.append(Web::Painting::display_list_object_bytes(header));
+        command_bytes.append(payload);
+        command_bytes.resize(sizeof(header) + payload_size, ByteBuffer::ZeroFillNewElements::Yes);
+    }
+
+    IPC::MessageBuffer buffer;
+    IPC::Encoder encoder { buffer };
+    MUST(encoder.encode(static_cast<u64>(1)));
+    MUST(encoder.encode(command_bytes));
+    MUST(encoder.encode(visual_context_tree.version()));
+    MUST(encoder.encode(surface_clear_color));
+    MUST(encoder.encode(Optional<Web::Painting::DisplayList::AsyncScrollingMetadata> {}));
+    MUST(encoder.encode(HashMap<Web::Painting::VisualContextIndex, Web::Painting::DisplayListResourceId> {}));
+
+    FixedMemoryStream stream { buffer.data().span() };
+    Queue<IPC::Attachment> attachments;
+    IPC::Decoder decoder { stream, attachments };
+    return MUST(decoder.decode<NonnullRefPtr<Web::Painting::DisplayList>>());
+}
+
+TEST_CASE(rasterization_clears_damaged_pixels_to_the_canvas_color_in_presentation_backing_stores)
+{
+    TestWebContentClient client;
+    Web::Painting::CanvasSurfaceRegistry canvas_surface_registry;
+    Compositor::ContextState context { 0, client, canvas_surface_registry, false };
+    Web::Painting::DisplayListPlayerSkia display_list_player { RefPtr<Gfx::SkiaBackendContext> {} };
+    auto visual_context_tree = Web::Painting::AccumulatedVisualContextTree::create();
+    auto viewport_rect = Gfx::IntRect { 0, 0, 4, 4 };
+
+    context.viewport_size_updated(viewport_rect.size(), Web::Compositor::WindowResizingInProgress::No);
+    auto publication = context.resize_backing_stores_if_needed({});
+    VERIFY(publication.has_value());
+
+    auto paint_frame = [&](NonnullRefPtr<Web::Painting::DisplayList> display_list) {
+        context.install_display_list_update(move(display_list), visual_context_tree, {});
+        context.queue_present_frame({ viewport_rect, viewport_rect });
+        EXPECT(context.present_synchronously(display_list_player, nullptr));
+    };
+
+    // Paint both backing stores red before reusing the first one for a frame with no commands.
+    paint_frame(make_display_list(visual_context_tree, Gfx::Color::Red));
+    EXPECT(context.acknowledge_presented_bitmap(publication->bitmap_ids[0]));
+    paint_frame(make_display_list(visual_context_tree, Gfx::Color::Red));
+    paint_frame(make_display_list(visual_context_tree, {}, Gfx::Color::Green));
+
+    auto bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    EXPECT_EQ(bitmap->get_pixel(0, 0), Gfx::Color::Green);
+
+    paint_frame(make_display_list(visual_context_tree, {}));
+    bitmap = context.latest_rendered_surface()->snapshot_bitmap();
+    EXPECT_EQ(bitmap->get_pixel(0, 0), Gfx::Color::Transparent);
+}


### PR DESCRIPTION
Clear each damaged region before replaying its display list so pixels no longer retain content from earlier frames.

Carry the resolved top-level canvas color with each display list and use it for presentation surfaces. Keep the transparent default for embedded compositor contexts, and cover both behaviors with a compositor test.

Fixes #9913