### PR TITLE
LibTest+LibCore: Enable the live test display on Windows

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -1400,8 +1400,10 @@ static int initialize_console_settings()
         return 0;
     }
 
-    // Set the output code page to UTF-8 to support Emoji and other Unicode characters
-    (void)SetConsoleOutputCP(CP_UTF8);
+    // Switch the output code page to UTF-8 to support Emoji and other Unicode characters. The shared helper
+    // saves the console's original code page so windows_shutdown() can restore it; this static initializer
+    // runs before windows_init(), so the save must happen here.
+    use_utf8_console_output();
 
     return 0;
 }

--- a/AK/Windows.h
+++ b/AK/Windows.h
@@ -138,14 +138,35 @@ inline void override_crt_invalid_parameter_handler()
     _set_invalid_parameter_handler(invalid_parameter_handler);
 }
 
+inline UINT& saved_console_output_code_page()
+{
+    static UINT code_page = 0;
+    return code_page;
+}
+
+inline void use_utf8_console_output()
+{
+    // All Ladybird output is UTF-8; make consoles interpret it as such. The code page is a property of the console
+    // itself and outlives this process, so the original one is restored in windows_shutdown(). Save it only once:
+    // this runs both from AK/Format.cpp's static initializer and from windows_init(), and a later run would
+    // overwrite the saved value with the already-switched CP_UTF8.
+    if (saved_console_output_code_page() == 0)
+        saved_console_output_code_page() = GetConsoleOutputCP();
+    if (saved_console_output_code_page() != 0)
+        SetConsoleOutputCP(CP_UTF8);
+}
+
 inline void windows_init()
 {
     initiate_wsa();
     override_crt_invalid_parameter_handler();
+    use_utf8_console_output();
 }
 
 inline void windows_shutdown()
 {
+    if (saved_console_output_code_page() != 0 && saved_console_output_code_page() != CP_UTF8)
+        SetConsoleOutputCP(saved_console_output_code_page());
     terminate_wsa();
 }
 #endif

--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -446,6 +446,20 @@ ErrorOr<bool> isatty(int fd)
     return rc == 1;
 }
 
+ErrorOr<TerminalSize> terminal_size(int fd)
+{
+    struct winsize ws {};
+    if (::ioctl(fd, TIOCGWINSZ, &ws) < 0)
+        return Error::from_syscall("ioctl"sv, errno);
+    return TerminalSize { ws.ws_col, ws.ws_row };
+}
+
+ErrorOr<void> enable_ansi_escape_sequence_processing(int)
+{
+    // POSIX terminals interpret escape sequences natively.
+    return {};
+}
+
 ErrorOr<void> link(StringView old_path, StringView new_path)
 {
     ByteString old_path_string = old_path;

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -159,6 +159,18 @@ ErrorOr<AddressInfoVector> getaddrinfo(char const* nodename, char const* servnam
 CORE_API ErrorOr<ByteString> getcwd();
 CORE_API ErrorOr<void> chdir(StringView path);
 CORE_API ErrorOr<bool> isatty(int fd);
+
+struct TerminalSize {
+    size_t columns { 0 };
+    size_t rows { 0 };
+};
+
+// Queries the size of the terminal the given fd refers to.
+CORE_API ErrorOr<TerminalSize> terminal_size(int fd);
+
+// Makes the terminal the given fd refers to interpret ANSI escape sequences. This is a no-op on POSIX, where
+// terminals interpret escape sequences natively; on Windows it must be called before writing them to a console.
+CORE_API ErrorOr<void> enable_ansi_escape_sequence_processing(int fd);
 CORE_API unsigned hardware_concurrency();
 CORE_API u64 physical_memory_bytes();
 CORE_API ErrorOr<ByteString> current_executable_path();

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -269,7 +269,10 @@ ErrorOr<Array<int, 2>> pipe2(int flags)
 
 ErrorOr<bool> isatty(int handle)
 {
-    return GetFileType(to_handle(handle)) == FILE_TYPE_CHAR;
+    // GetFileType() cannot answer this: it reports FILE_TYPE_CHAR for every character device, including NUL.
+    // Only real consoles have a console mode.
+    DWORD mode = 0;
+    return GetConsoleMode(to_handle(handle), &mode) != 0;
 }
 
 ErrorOr<TerminalSize> terminal_size(int fd)

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -272,6 +272,27 @@ ErrorOr<bool> isatty(int handle)
     return GetFileType(to_handle(handle)) == FILE_TYPE_CHAR;
 }
 
+ErrorOr<TerminalSize> terminal_size(int fd)
+{
+    CONSOLE_SCREEN_BUFFER_INFO info {};
+    if (!GetConsoleScreenBufferInfo(to_handle(fd), &info))
+        return Error::from_windows_error();
+    return TerminalSize {
+        static_cast<size_t>(info.srWindow.Right - info.srWindow.Left + 1),
+        static_cast<size_t>(info.srWindow.Bottom - info.srWindow.Top + 1),
+    };
+}
+
+ErrorOr<void> enable_ansi_escape_sequence_processing(int fd)
+{
+    DWORD mode = 0;
+    if (!GetConsoleMode(to_handle(fd), &mode))
+        return Error::from_windows_error();
+    if (!SetConsoleMode(to_handle(fd), mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+        return Error::from_windows_error();
+    return {};
+}
+
 ErrorOr<int> socket(int domain, int type, int protocol)
 {
     auto socket = ::socket(domain, type, protocol);

--- a/Libraries/LibTest/LiveDisplay.h
+++ b/Libraries/LibTest/LiveDisplay.h
@@ -13,34 +13,39 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <LibCore/System.h>
 
 #include <fcntl.h>
 #include <stdio.h>
 
-#if !defined(AK_OS_WINDOWS)
-#    include <sys/ioctl.h>
+#if defined(AK_OS_WINDOWS)
+#    include <io.h>
+#else
 #    include <unistd.h>
 #endif
 
 namespace Test {
 
-inline bool stdout_is_tty()
+// Returns the given stdio stream's fd in the form Core::System expects. (The CRT's fileno() namespace differs
+// from the native handle namespace on Windows, so fileno() alone is not usable with Core::System there.)
+inline int system_fd_for_stream(FILE* stream)
 {
 #if defined(AK_OS_WINDOWS)
-    return false;
+    return to_fd(reinterpret_cast<void*>(_get_osfhandle(fileno(stream))));
 #else
-    return isatty(STDOUT_FILENO);
+    return fileno(stream);
 #endif
+}
+
+inline bool stdout_is_tty()
+{
+    return Core::System::isatty(system_fd_for_stream(stdout)).value_or(false);
 }
 
 inline size_t query_terminal_width(int fd, size_t fallback = 80)
 {
-#if !defined(AK_OS_WINDOWS)
-    struct winsize ws;
-    if (ioctl(fd, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0)
-        return ws.ws_col;
-#endif
-    (void)fd;
+    if (auto size = Core::System::terminal_size(fd); !size.is_error() && size.value().columns > 0)
+        return size.value().columns;
     return fallback;
 }
 
@@ -173,23 +178,20 @@ public:
 
     bool begin(Options options)
     {
-#if defined(AK_OS_WINDOWS)
-        (void)options;
-        return false;
-#else
         if (m_active)
             return false;
 
         m_reserved_lines = options.reserved_lines;
         m_log_file_path = move(options.log_file_path);
 
+        // NOTE: This deliberately uses stdio-level fds (fileno() et al), which also exist on Windows as CRT fds.
         if (!m_log_file_path.is_empty()) {
             int log_fd = ::open(m_log_file_path.characters(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
             if (log_fd < 0)
                 return false;
 
-            m_saved_stdout_fd = dup(STDOUT_FILENO);
-            m_saved_stderr_fd = dup(STDERR_FILENO);
+            m_saved_stdout_fd = dup(fileno(stdout));
+            m_saved_stderr_fd = dup(fileno(stderr));
             if (m_saved_stdout_fd < 0 || m_saved_stderr_fd < 0) {
                 close(log_fd);
                 return false;
@@ -197,8 +199,8 @@ public:
 
             (void)fflush(stdout);
             (void)fflush(stderr);
-            (void)dup2(log_fd, STDOUT_FILENO);
-            (void)dup2(log_fd, STDERR_FILENO);
+            (void)dup2(log_fd, fileno(stdout));
+            (void)dup2(log_fd, fileno(stderr));
             close(log_fd);
 
             int display_fd = dup(m_saved_stdout_fd);
@@ -214,6 +216,7 @@ public:
             m_output = stdout;
         }
 
+        (void)Core::System::enable_ansi_escape_sequence_processing(system_fd_for_stream(m_output));
         refresh_terminal_width();
 
         for (size_t i = 0; i < m_reserved_lines; ++i)
@@ -222,12 +225,10 @@ public:
 
         m_active = true;
         return true;
-#endif
     }
 
     void end()
     {
-#if !defined(AK_OS_WINDOWS)
         if (!m_active)
             return;
 
@@ -242,12 +243,12 @@ public:
             (void)fflush(stdout);
             (void)fflush(stderr);
             if (m_saved_stdout_fd >= 0) {
-                (void)dup2(m_saved_stdout_fd, STDOUT_FILENO);
+                (void)dup2(m_saved_stdout_fd, fileno(stdout));
                 close(m_saved_stdout_fd);
                 m_saved_stdout_fd = -1;
             }
             if (m_saved_stderr_fd >= 0) {
-                (void)dup2(m_saved_stderr_fd, STDERR_FILENO);
+                (void)dup2(m_saved_stderr_fd, fileno(stderr));
                 close(m_saved_stderr_fd);
                 m_saved_stderr_fd = -1;
             }
@@ -257,7 +258,6 @@ public:
             m_output = nullptr;
         }
         m_active = false;
-#endif
     }
 
     bool is_active() const { return m_active; }
@@ -270,12 +270,7 @@ public:
 
     void refresh_terminal_width()
     {
-#if !defined(AK_OS_WINDOWS)
-        int fd = m_output ? fileno(m_output) : STDOUT_FILENO;
-#else
-        int fd = 0; // Not actually used.
-#endif
-        m_terminal_width = query_terminal_width(fd);
+        m_terminal_width = query_terminal_width(system_fd_for_stream(m_output ? m_output : stdout));
     }
 
     // Erase the reserved display area, leaving the cursor at the top of it.
@@ -294,6 +289,9 @@ public:
     {
         if (!m_active || !m_output)
             return;
+
+        // Track terminal resizes; unlike POSIX (SIGWINCH), Windows has no resize notification to hook instead.
+        refresh_terminal_width();
 
         StringBuilder builder;
         for (size_t i = 0; i < m_reserved_lines; ++i)
@@ -369,9 +367,7 @@ private:
     size_t m_terminal_width { 80 };
     FILE* m_output { nullptr };
     int m_saved_stdout_fd { -1 };
-#if !defined(AK_OS_WINDOWS)
     int m_saved_stderr_fd { -1 };
-#endif
     ByteString m_log_file_path;
 };
 

--- a/Tests/LibWeb/test-web/Display.cpp
+++ b/Tests/LibWeb/test-web/Display.cpp
@@ -13,6 +13,7 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibDiff/Format.h>
 #include <LibDiff/Generator.h>
@@ -20,7 +21,6 @@
 
 #ifndef AK_OS_WINDOWS
 #    include <signal.h>
-#    include <sys/ioctl.h>
 #    include <unistd.h>
 #endif
 
@@ -52,11 +52,8 @@ void Display::begin_run()
         return;
 
     size_t terminal_rows = 24;
-#ifndef AK_OS_WINDOWS
-    struct winsize ws;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_row > 0)
-        terminal_rows = ws.ws_row;
-#endif
+    if (auto size = Core::System::terminal_size(::Test::system_fd_for_stream(stdout)); !size.is_error() && size.value().rows > 0)
+        terminal_rows = size.value().rows;
     s_display_rows = AK::clamp(
         AK::saturating_sub(terminal_rows, LIVE_DISPLAY_TERMINAL_HEADROOM),
         LIVE_DISPLAY_STATUS_LINES + 1,


### PR DESCRIPTION
The live test display was stubbed out on Windows, but it is plain ANSI rendering, which Windows consoles handle fine once virtual terminal processing is enabled. This adds portable console helpers to LibCore (`terminal_size()`, `enable_ansi_escape_sequence_processing()`, UTF-8 console output), fixes `System::isatty()` to probe `GetConsoleMode()` instead of `GetFileType()` (which misreports `NUL` as a terminal), and routes LiveDisplay through them so test runners show their progress TUI on Windows too.