### PR TITLE
LibCore: Fix two crashes in the Windows event loop

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -378,15 +378,22 @@ void EventLoopImplementationWindows::wake()
 
 static int notifier_type_to_network_event(NotificationType type)
 {
-    switch (type) {
-    case NotificationType::Read:
-        return FD_READ | FD_CLOSE | FD_ACCEPT;
-    case NotificationType::Write:
-        return FD_WRITE;
-    default:
+    // NotificationType is a bitmask (e.g. HangUp | Error), so translate each set bit.
+    int events = 0;
+    if (has_flag(type, NotificationType::Read))
+        events |= FD_READ | FD_CLOSE | FD_ACCEPT;
+    if (has_flag(type, NotificationType::Write))
+        events |= FD_WRITE | FD_CONNECT;
+    // WSAEventSelect has no separate error event; socket errors surface as FD_CLOSE.
+    if (has_flag(type, NotificationType::HangUp) || has_flag(type, NotificationType::Error))
+        events |= FD_CLOSE;
+
+    if (!events) {
         dbgln("This notification type is not implemented: {}", (int)type);
         VERIFY_NOT_REACHED();
     }
+
+    return events;
 }
 
 void EventLoopManagerWindows::register_notifier(Notifier& notifier)

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -338,8 +338,14 @@ size_t EventLoopImplementationWindows::pump(PumpMode pump_mode)
                     Optional<NonnullOwnPtr<EventLoopProcess>> owned_process = s_processes.with_locked([&](auto& processes) {
                         return processes.take(process_id);
                     });
-                    if (owned_process.has_value())
-                        owned_process.release_value()->exit_handler(process_id);
+                    if (owned_process.has_value()) {
+                        // Run the handler from the event queue rather than inline: it may unregister notifiers whose
+                        // completion packets were dequeued into this very batch and are not yet re-associated, which
+                        // would fail the packet cancellation (and leave dangling pointers in the batch).
+                        deferred_invoke([process = owned_process.release_value(), process_id] {
+                            process->exit_handler(process_id);
+                        });
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
Two crash fixes for the Windows IOCP event loop