### PR TITLE
LibIPC: Propagate transport send errors

### DIFF
--- a/Libraries/LibIPC/Message.cpp
+++ b/Libraries/LibIPC/Message.cpp
@@ -49,7 +49,7 @@ ErrorOr<void> MessageBuffer::transfer_message(Transport& transport)
     VERIFY(m_data.size() <= MAX_MESSAGE_PAYLOAD_SIZE);
     VERIFY(m_attachments.size() <= MAX_MESSAGE_FD_COUNT);
 
-    transport.post_message(take_data(), m_attachments);
+    TRY(transport.post_message(take_data(), m_attachments));
     return {};
 }
 

--- a/Libraries/LibIPC/TransportMachPort.cpp
+++ b/Libraries/LibIPC/TransportMachPort.cpp
@@ -489,13 +489,14 @@ void TransportMachPort::wait_until_readable()
         m_incoming_cv.wait();
 }
 
-void TransportMachPort::post_message(MessageDataType bytes, Vector<Attachment>& attachments)
+ErrorOr<void> TransportMachPort::post_message(MessageDataType bytes, Vector<Attachment>& attachments)
 {
     {
         Sync::MutexLocker locker(m_send_mutex);
         m_pending_send_messages.append(PendingMessage { move(bytes), move(attachments) });
     }
     wake_io_thread();
+    return {};
 }
 
 TransportMachPort::ShouldShutdown TransportMachPort::read_as_many_messages_as_possible_without_blocking(Function<void(Message&&)>&& callback)

--- a/Libraries/LibIPC/TransportMachPort.h
+++ b/Libraries/LibIPC/TransportMachPort.h
@@ -51,7 +51,7 @@ public:
 
     void wait_until_readable();
 
-    void post_message(MessageDataType, Vector<Attachment>& attachments);
+    ErrorOr<void> post_message(MessageDataType, Vector<Attachment>& attachments);
 
     enum class ShouldShutdown {
         No,

--- a/Libraries/LibIPC/TransportSocket.cpp
+++ b/Libraries/LibIPC/TransportSocket.cpp
@@ -338,7 +338,7 @@ static constexpr size_t MAX_UNPROCESSED_BUFFER_SIZE = 128 * MiB;
 // Maximum number of accumulated unprocessed file descriptors before we disconnect the peer
 static constexpr size_t MAX_UNPROCESSED_FDS = 512;
 
-void TransportSocket::post_message(MessageDataType bytes_to_write, Vector<Attachment>& attachments)
+ErrorOr<void> TransportSocket::post_message(MessageDataType bytes_to_write, Vector<Attachment>& attachments)
 {
     auto num_fds_to_transfer = attachments.size();
 
@@ -362,6 +362,7 @@ void TransportSocket::post_message(MessageDataType bytes_to_write, Vector<Attach
 
     m_send_queue->enqueue_message(header, move(bytes_to_write), move(raw_fds));
     wake_io_thread();
+    return {};
 }
 
 ErrorOr<void> TransportSocket::send_message(Core::LocalSocket& socket, ReadonlyBytes& bytes_to_write, Vector<int>& unowned_fds)

--- a/Libraries/LibIPC/TransportSocket.h
+++ b/Libraries/LibIPC/TransportSocket.h
@@ -83,7 +83,7 @@ public:
 
     void wait_until_readable();
 
-    void post_message(MessageDataType, Vector<Attachment>& attachments);
+    ErrorOr<void> post_message(MessageDataType, Vector<Attachment>& attachments);
 
     enum class ShouldShutdown {
         No,

--- a/Libraries/LibIPC/TransportSocketWindows.cpp
+++ b/Libraries/LibIPC/TransportSocketWindows.cpp
@@ -175,17 +175,17 @@ Attachment TransportSocketWindows::deserialize_attachment(ReadonlyBytes& seriali
     VERIFY_NOT_REACHED();
 }
 
-void TransportSocketWindows::post_message(MessageDataType bytes, Vector<Attachment>& attachments)
+ErrorOr<void> TransportSocketWindows::post_message(MessageDataType bytes, Vector<Attachment>& attachments)
 {
     VERIFY(bytes.size() <= MAX_MESSAGE_PAYLOAD_SIZE);
     VERIFY(attachments.size() <= MAX_MESSAGE_FD_COUNT);
 
     auto attachment_count = attachments.size();
-    auto serialized_attachments = MUST(serialize_attachments(attachments));
+    auto serialized_attachments = TRY(serialize_attachments(attachments));
     VERIFY(serialized_attachments.size() <= MAX_ATTACHMENT_DATA_SIZE);
 
     Vector<u8> message_buffer;
-    MUST(message_buffer.try_resize(sizeof(MessageHeader) + serialized_attachments.size() + bytes.size()));
+    TRY(message_buffer.try_resize(sizeof(MessageHeader) + serialized_attachments.size() + bytes.size()));
 
     MessageHeader header {
         .payload_size = static_cast<u32>(bytes.size()),
@@ -202,7 +202,8 @@ void TransportSocketWindows::post_message(MessageDataType bytes, Vector<Attachme
     if (!bytes.is_empty())
         memcpy(payload_storage, bytes.data(), bytes.size());
 
-    MUST(transfer(message_buffer.span()));
+    TRY(transfer(message_buffer.span()));
+    return {};
 }
 
 ErrorOr<void> TransportSocketWindows::transfer(ReadonlyBytes bytes_to_write)

--- a/Libraries/LibIPC/TransportSocketWindows.h
+++ b/Libraries/LibIPC/TransportSocketWindows.h
@@ -38,7 +38,7 @@ public:
 
     void wait_until_readable();
 
-    void post_message(MessageDataType, Vector<Attachment>& attachments);
+    ErrorOr<void> post_message(MessageDataType, Vector<Attachment>& attachments);
 
     enum class ShouldShutdown {
         No,

--- a/Tests/LibIPC/TestTransportSocket.cpp
+++ b/Tests/LibIPC/TestTransportSocket.cpp
@@ -153,7 +153,7 @@ TEST_CASE(message_arriving_just_before_eof_is_not_dropped_on_shutdown)
         IPC::MessageDataType payload;
         payload.append(hello.data(), hello.size());
         Vector<IPC::Attachment> no_attachments;
-        peer.post_message(move(payload), no_attachments);
+        MUST(peer.post_message(move(payload), no_attachments));
         peer.close_after_sending_all_pending_messages();
     }
 
@@ -211,7 +211,7 @@ TEST_CASE(buffered_message_is_drained_when_io_thread_stops_without_reading_it)
         IPC::MessageDataType payload;
         payload.append(hello.data(), hello.size());
         Vector<IPC::Attachment> no_attachments;
-        peer.post_message(move(payload), no_attachments);
+        MUST(peer.post_message(move(payload), no_attachments));
         peer.close_after_sending_all_pending_messages();
     }
 


### PR DESCRIPTION
TransportSocketWindows currently aborts when a synchronous socket write fails. This can happen when a worker exits while WebContent is posting a message to its MessagePort, turning an ordinary peer disconnect into a WebContent crash.

Return ErrorOr<void> from post_message() on each transport and propagate the result through MessageBuffer. This lets the existing ConnectionBase and MessagePort error handling shut down a disconnected channel cleanly.

Also propagate attachment serialization and allocation failures on Windows, and update the socket transport tests for the fallible API.