### PR TITLE
LibGfx: Rasterize fonts with FreeType on Windows in test mode

### DIFF
--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -52,6 +52,9 @@ public:
     void for_each_typeface_with_family_name(FlyString const& family_name, Function<void(Typeface const&)>);
     [[nodiscard]] StringView system_font_provider_name() const;
 
+    void set_force_freetype_rasterization(bool force) { m_force_freetype_rasterization = force; }
+    [[nodiscard]] bool force_freetype_rasterization() const { return m_force_freetype_rasterization; }
+
     static ErrorOr<Vector<String>> font_directories();
 
 private:
@@ -59,6 +62,7 @@ private:
     ~FontDatabase() = default;
 
     OwnPtr<SystemFontProvider> m_system_font_provider;
+    bool m_force_freetype_rasterization { false };
 
     struct CodePointFallbackEntry {
         FlyString family_name;

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -21,6 +21,7 @@
 #if defined(AK_OS_ANDROID)
 #    include <ports/SkFontMgr_android.h>
 #elif defined(AK_OS_WINDOWS)
+#    include <ports/SkFontMgr_empty.h>
 #    include <ports/SkTypeface_win.h>
 #else
 #    include <ports/SkFontMgr_fontconfig.h>
@@ -89,7 +90,10 @@ static SkFontMgr& font_manager()
 #if defined(AK_OS_ANDROID)
         font_manager = SkFontMgr_New_Android(nullptr);
 #elif defined(AK_OS_WINDOWS)
-        font_manager = SkFontMgr_New_DirectWrite();
+        if (Gfx::FontDatabase::the().force_freetype_rasterization())
+            font_manager = SkFontMgr_New_Custom_Empty();
+        else
+            font_manager = SkFontMgr_New_DirectWrite();
 #else
         if (!font_manager) {
             font_manager = SkFontMgr_New_FontConfig(nullptr, SkFontScanner_Make_FreeType());

--- a/Services/Compositor/main.cpp
+++ b/Services/Compositor/main.cpp
@@ -49,8 +49,10 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
 
     WebView::platform_init();
     auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
-    if (force_fontconfig)
+    if (force_fontconfig) {
         font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+        Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
+    }
     for (auto const& path : TRY(Gfx::FontDatabase::font_directories()))
         font_provider.load_all_fonts_from_uri(TRY(String::formatted("file://{}", path)));
     font_provider.load_all_fonts_from_uri("resource://fonts"sv);

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -214,6 +214,7 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
     auto& font_provider = static_cast<Gfx::PathFontProvider&>(Gfx::FontDatabase::the().install_system_font_provider(make<Gfx::PathFontProvider>()));
     if (force_fontconfig) {
         font_provider.set_name_but_fixme_should_create_custom_system_font_provider("FontConfig"_string);
+        Gfx::FontDatabase::the().set_force_freetype_rasterization(true);
     }
     font_provider.load_all_fonts_from_uri("resource://fonts"sv);
 


### PR DESCRIPTION
The test harnesses pass --force-fontconfig to get font rendering that is consistent between operating systems, but on Windows the Skia font manager was unconditionally DirectWrite, whose glyph rasterization differs from FreeType's. That failed every Layout test (the layout tree dumps depend on text metrics) and most Screenshot tests.

Skia on Windows is built with FreeType support, so when consistent rendering is requested (--force-fontconfig now sets an explicit force-FreeType-rasterization flag on FontDatabase), use the FreeType-backed custom font manager without system fonts; the fonts bundled with Ladybird are provided through FontDatabase.