### PR TITLE
Share GPU backing stores on Windows

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -60,7 +60,7 @@ if (APPLE)
 endif()
 
 if (HAS_DIRECTX)
-    list(APPEND SOURCES Direct3DContext.cpp)
+    list(APPEND SOURCES D3DSharedTexture.cpp Direct3DContext.cpp)
 endif()
 
 if (HAS_VULKAN)

--- a/Libraries/LibGfx/D3DSharedTexture.cpp
+++ b/Libraries/LibGfx/D3DSharedTexture.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/D3DSharedTexture.h>
+#include <LibGfx/Direct3DContext.h>
+
+#ifdef USE_DIRECTX
+
+#    include <AK/Windows.h>
+#    include <d3d12.h>
+
+#    include <wrl/client.h>
+
+namespace Gfx {
+
+using Microsoft::WRL::ComPtr;
+
+D3DSharedTexture::D3DSharedTexture(ID3D12Resource* resource, IPC::File shared_handle, IntSize size)
+    : m_resource(resource)
+    , m_shared_handle(move(shared_handle))
+    , m_size(size)
+{
+}
+
+D3DSharedTexture::~D3DSharedTexture()
+{
+    m_resource->Release();
+}
+
+ErrorOr<NonnullRefPtr<D3DSharedTexture>> D3DSharedTexture::create(Direct3DContext& context, IntSize size)
+{
+    VERIFY(!size.is_empty());
+
+    D3D12_HEAP_PROPERTIES heap_properties {};
+    heap_properties.Type = D3D12_HEAP_TYPE_DEFAULT;
+
+    D3D12_RESOURCE_DESC resource_description {};
+    resource_description.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    resource_description.Width = size.width();
+    resource_description.Height = size.height();
+    resource_description.DepthOrArraySize = 1;
+    resource_description.MipLevels = 1;
+    resource_description.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    resource_description.SampleDesc.Count = 1;
+    resource_description.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    // ALLOW_SIMULTANEOUS_ACCESS is required for the UI process to open this resource on a D3D11 device.
+    resource_description.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
+
+    ComPtr<ID3D12Resource> resource;
+    auto hr = context.device()->CreateCommittedResource(&heap_properties, D3D12_HEAP_FLAG_SHARED, &resource_description,
+        D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&resource));
+    if (FAILED(hr))
+        return Error::from_windows_error(hr);
+
+    HANDLE shared_handle = nullptr;
+    hr = context.device()->CreateSharedHandle(resource.Get(), nullptr, GENERIC_ALL, nullptr, &shared_handle);
+    if (FAILED(hr))
+        return Error::from_windows_error(hr);
+
+    return adopt_ref(*new D3DSharedTexture(resource.Detach(), IPC::File::adopt_fd(to_fd(shared_handle)), size));
+}
+
+}
+
+#endif

--- a/Libraries/LibGfx/D3DSharedTexture.h
+++ b/Libraries/LibGfx/D3DSharedTexture.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#ifdef USE_DIRECTX
+
+#    include <AK/AtomicRefCounted.h>
+#    include <AK/Error.h>
+#    include <AK/NonnullRefPtr.h>
+#    include <LibGfx/Size.h>
+#    include <LibIPC/File.h>
+
+struct ID3D12Resource;
+
+namespace Gfx {
+
+class Direct3DContext;
+
+// A DXGI_FORMAT_R8G8B8A8_UNORM render-target texture allocated on a shared heap so its NT handle
+// can be duplicated into another process and opened there (e.g. by the UI process via
+// ID3D11Device1::OpenSharedResource1).
+class D3DSharedTexture final : public AtomicRefCounted<D3DSharedTexture> {
+public:
+    static ErrorOr<NonnullRefPtr<D3DSharedTexture>> create(Direct3DContext&, IntSize);
+    ~D3DSharedTexture();
+
+    ID3D12Resource* resource() const { return m_resource; }
+    IntSize size() const { return m_size; }
+
+    ErrorOr<IPC::File> clone_handle() const { return IPC::File::clone_fd(m_shared_handle.fd()); }
+
+private:
+    D3DSharedTexture(ID3D12Resource*, IPC::File shared_handle, IntSize);
+
+    ID3D12Resource* m_resource { nullptr };
+    IPC::File m_shared_handle;
+    IntSize m_size;
+};
+
+}
+
+#endif

--- a/Libraries/LibGfx/Direct3DContext.cpp
+++ b/Libraries/LibGfx/Direct3DContext.cpp
@@ -12,6 +12,7 @@
 #ifdef USE_DIRECTX
 
 #    include <AK/Windows.h>
+#    include <LibCore/Environment.h>
 #    include <d3d12.h>
 #    include <dxgi1_4.h>
 
@@ -21,6 +22,11 @@
 namespace Gfx {
 
 using namespace Microsoft::WRL;
+
+static u64 pack_adapter_luid(LUID luid)
+{
+    return (static_cast<u64>(static_cast<u32>(luid.HighPart)) << 32) | static_cast<u32>(luid.LowPart);
+}
 
 struct Direct3DContext::Impl {
     Impl(ComPtr<IDXGIAdapter1> adapter, ComPtr<ID3D12Device> device, ComPtr<ID3D12CommandQueue> queue)
@@ -55,6 +61,11 @@ ID3D12Device* Direct3DContext::device() const
 ID3D12CommandQueue* Direct3DContext::queue() const
 {
     return m_impl->queue.Get();
+}
+
+u64 Direct3DContext::adapter_luid() const
+{
+    return pack_adapter_luid(m_impl->device->GetAdapterLuid());
 }
 
 static ErrorOr<ComPtr<IDXGIAdapter1>> get_hardware_adapter(IDXGIFactory4& factory)
@@ -98,6 +109,33 @@ ErrorOr<NonnullRefPtr<Direct3DContext>> create_direct3d_context()
         return Error::from_windows_error(hr);
 
     return adopt_ref(*new Direct3DContext(make<Direct3DContext::Impl>(move(adapter), move(device), move(queue))));
+}
+
+Optional<u64> default_dxgi_adapter_luid()
+{
+    // The result cannot change within a process lifetime, so compute it once.
+    static Optional<u64> const cached_adapter_luid = []() -> Optional<u64> {
+        ComPtr<IDXGIFactory4> factory;
+        if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&factory))))
+            return {};
+
+        UINT adapter_index = 0;
+        if (auto adapter_index_override = Core::Environment::get("QT_D3D_ADAPTER_INDEX"sv); adapter_index_override.has_value()) {
+            if (auto value = adapter_index_override->to_number<UINT>(); value.has_value())
+                adapter_index = *value;
+        }
+
+        ComPtr<IDXGIAdapter1> adapter;
+        if (FAILED(factory->EnumAdapters1(adapter_index, &adapter)))
+            return {};
+
+        DXGI_ADAPTER_DESC1 description {};
+        if (FAILED(adapter->GetDesc1(&description)))
+            return {};
+
+        return pack_adapter_luid(description.AdapterLuid);
+    }();
+    return cached_adapter_luid;
 }
 
 }

--- a/Libraries/LibGfx/Direct3DContext.h
+++ b/Libraries/LibGfx/Direct3DContext.h
@@ -11,6 +11,7 @@
 #    include <AK/Error.h>
 #    include <AK/NonnullOwnPtr.h>
 #    include <AK/NonnullRefPtr.h>
+#    include <AK/Optional.h>
 #    include <AK/RefCounted.h>
 
 struct ID3D12CommandQueue;
@@ -26,6 +27,7 @@ public:
     IDXGIAdapter1* adapter() const;
     ID3D12Device* device() const;
     ID3D12CommandQueue* queue() const;
+    u64 adapter_luid() const;
 
 private:
     struct Impl;
@@ -38,6 +40,11 @@ private:
 };
 
 ErrorOr<NonnullRefPtr<Direct3DContext>> create_direct3d_context();
+
+// LUID of the adapter that Qt's D3D11 backend will pick in the UI process (the first enumerated
+// adapter unless overridden by QT_D3D_ADAPTER_INDEX). Used to check that a texture shared by the
+// Compositor process can be opened by the UI process.
+Optional<u64> default_dxgi_adapter_luid();
 
 }
 

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -25,6 +25,11 @@
 #    include <LibGfx/VulkanImage.h>
 #    include <gpu/ganesh/vk/GrVkBackendSurface.h>
 #    include <gpu/ganesh/vk/GrVkTypes.h>
+#elif defined(USE_DIRECTX)
+#    include <AK/Windows.h>
+#    include <LibGfx/D3DSharedTexture.h>
+#    include <gpu/ganesh/d3d/GrD3DBackendSurface.h>
+#    include <gpu/ganesh/d3d/GrD3DTypes.h>
 #endif
 
 namespace Gfx {
@@ -36,7 +41,7 @@ struct PaintingSurface::Impl {
     RefPtr<Bitmap> bitmap;
 };
 
-#if defined(AK_OS_MACOS) || defined(USE_VULKAN_DMABUF_IMAGES)
+#if defined(AK_OS_MACOS) || defined(USE_VULKAN_DMABUF_IMAGES) || defined(USE_DIRECTX)
 static GrSurfaceOrigin origin_to_sk_origin(PaintingSurface::Origin origin)
 {
     switch (origin) {
@@ -91,6 +96,32 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_from_vkimage(NonnullRefPt
     vulkan_image->ref();
     sk_sp<SkSurface> surface = SkSurfaces::WrapBackendRenderTarget(context->sk_context(), rt, origin_to_sk_origin(origin), vk_format_to_sk_color_type(vulkan_image->info.format),
         SkColorSpace::MakeSRGB(), nullptr, release_vulkan_image, vulkan_image.ptr());
+    return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
+}
+#endif
+
+#ifdef USE_DIRECTX
+static void release_d3d_texture(void* context)
+{
+    auto* texture = static_cast<D3DSharedTexture*>(context);
+    texture->unref();
+}
+
+ErrorOr<NonnullRefPtr<PaintingSurface>> PaintingSurface::create_from_d3d_texture(NonnullRefPtr<SkiaBackendContext> context, NonnullRefPtr<D3DSharedTexture> texture, Origin origin)
+{
+    auto size = texture->size();
+    GrD3DTextureResourceInfo info(nullptr, nullptr, D3D12_RESOURCE_STATE_COMMON, DXGI_FORMAT_R8G8B8A8_UNORM,
+        /* sampleCount */ 1, /* levelCount */ 1, /* sampleQualityLevel */ 0);
+    // NOTE: The positional resource argument of GrD3DTextureResourceInfo would adopt our reference, so attach it with retain() instead.
+    info.fResource.retain(texture->resource());
+    auto render_target = GrBackendRenderTargets::MakeD3D(size.width(), size.height(), info);
+    // Note, we're implicitly giving Skia a reference to the texture. It will eventually be released by the callback function,
+    // which is guaranteed to be invoked even if wrapping fails.
+    texture->ref();
+    sk_sp<SkSurface> surface = SkSurfaces::WrapBackendRenderTarget(context->sk_context(), render_target, origin_to_sk_origin(origin),
+        kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, release_d3d_texture, texture.ptr());
+    if (!surface)
+        return Error::from_string_literal("Failed to wrap shared Direct3D texture in a Skia surface");
     return adopt_ref(*new PaintingSurface(make<Impl>(context, size, surface, nullptr)));
 }
 #endif

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -22,6 +22,16 @@ struct VulkanImage;
 }
 #endif
 
+#ifdef USE_DIRECTX
+#    include <AK/Error.h>
+
+namespace Gfx {
+
+class D3DSharedTexture;
+
+}
+#endif
+
 #ifdef AK_OS_MACOS
 #    include <LibGfx/MetalContext.h>
 #endif
@@ -51,6 +61,10 @@ public:
 
 #ifdef USE_VULKAN_DMABUF_IMAGES
     static NonnullRefPtr<PaintingSurface> create_from_vkimage(NonnullRefPtr<SkiaBackendContext> context, NonnullRefPtr<VulkanImage> vulkan_image, Origin origin);
+#endif
+
+#ifdef USE_DIRECTX
+    static ErrorOr<NonnullRefPtr<PaintingSurface>> create_from_d3d_texture(NonnullRefPtr<SkiaBackendContext>, NonnullRefPtr<D3DSharedTexture>, Origin = Origin::TopLeft);
 #endif
 
     NonnullRefPtr<Bitmap> snapshot_bitmap() const;

--- a/Libraries/LibGfx/SharedImage.cpp
+++ b/Libraries/LibGfx/SharedImage.cpp
@@ -11,6 +11,9 @@
 #ifdef USE_VULKAN_DMABUF_IMAGES
 #    include <LibGfx/VulkanImage.h>
 #endif
+#ifdef USE_DIRECTX
+#    include <LibGfx/D3DSharedTexture.h>
+#endif
 
 #ifdef AK_OS_MACOS
 static Core::MachPort copy_send_right(Core::MachPort const& port)
@@ -39,6 +42,11 @@ SharedImage::SharedImage(LinuxDmaBufHandle&& dmabuf)
 {
 }
 
+SharedImage::SharedImage(WindowsD3DHandle&& d3d_handle)
+    : m_data(move(d3d_handle))
+{
+}
+
 #    ifdef USE_VULKAN_DMABUF_IMAGES
 static constexpr auto shared_image_bitmap_format = BitmapFormat::BGRA8888;
 static constexpr auto shared_image_alpha_type = AlphaType::Premultiplied;
@@ -64,6 +72,21 @@ LinuxDmaBufHandle duplicate_linux_dmabuf_handle(VulkanImage const& vulkan_image)
     };
 }
 #    endif
+
+#    ifdef USE_DIRECTX
+SharedImage duplicate_shared_image(D3DSharedTexture const& texture)
+{
+    return SharedImage { duplicate_windows_d3d_handle(texture) };
+}
+
+WindowsD3DHandle duplicate_windows_d3d_handle(D3DSharedTexture const& texture)
+{
+    return WindowsD3DHandle {
+        .size = texture.size(),
+        .file = MUST(texture.clone_handle()),
+    };
+}
+#    endif
 #endif
 
 }
@@ -74,6 +97,7 @@ namespace IPC {
 enum class SharedImageBackingType : u8 {
     ShareableBitmap,
     LinuxDmaBuf,
+    WindowsD3DTexture,
 };
 
 template<>
@@ -102,6 +126,23 @@ ErrorOr<Gfx::LinuxDmaBufHandle> decode(Decoder& decoder)
         .file = TRY(decoder.decode<IPC::File>()),
     };
 }
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Gfx::WindowsD3DHandle const& d3d_handle)
+{
+    TRY(encoder.encode(d3d_handle.size));
+    TRY(encoder.encode(TRY(IPC::File::clone_fd(d3d_handle.file.fd()))));
+    return {};
+}
+
+template<>
+ErrorOr<Gfx::WindowsD3DHandle> decode(Decoder& decoder)
+{
+    return Gfx::WindowsD3DHandle {
+        .size = TRY(decoder.decode<Gfx::IntSize>()),
+        .file = TRY(decoder.decode<IPC::File>()),
+    };
+}
 #endif
 
 template<>
@@ -119,6 +160,11 @@ ErrorOr<void> encode(Encoder& encoder, Gfx::SharedImage const& shared_image)
         [&](Gfx::LinuxDmaBufHandle const& dmabuf) -> ErrorOr<void> {
             TRY(encoder.encode(SharedImageBackingType::LinuxDmaBuf));
             TRY(encoder.encode(dmabuf));
+            return {};
+        },
+        [&](Gfx::WindowsD3DHandle const& d3d_handle) -> ErrorOr<void> {
+            TRY(encoder.encode(SharedImageBackingType::WindowsD3DTexture));
+            TRY(encoder.encode(d3d_handle));
             return {};
         });
 #endif
@@ -138,6 +184,8 @@ ErrorOr<Gfx::SharedImage> decode(Decoder& decoder)
         return Gfx::SharedImage { TRY(decoder.decode<Gfx::ShareableBitmap>()) };
     case SharedImageBackingType::LinuxDmaBuf:
         return Gfx::SharedImage { TRY(decoder.decode<Gfx::LinuxDmaBufHandle>()) };
+    case SharedImageBackingType::WindowsD3DTexture:
+        return Gfx::SharedImage { TRY(decoder.decode<Gfx::WindowsD3DHandle>()) };
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Libraries/LibGfx/SharedImage.h
+++ b/Libraries/LibGfx/SharedImage.h
@@ -33,12 +33,24 @@ struct LinuxDmaBufHandle {
     u64 modifier;
     IPC::File file;
 };
+
+// NOTE: The texture behind the handle is always DXGI_FORMAT_R8G8B8A8_UNORM with premultiplied alpha.
+struct WindowsD3DHandle {
+    IntSize size;
+    IPC::File file;
+};
 #endif
 
 #ifdef USE_VULKAN_DMABUF_IMAGES
 struct VulkanImage;
 SharedImage duplicate_shared_image(VulkanImage const&);
 LinuxDmaBufHandle duplicate_linux_dmabuf_handle(VulkanImage const&);
+#endif
+
+#ifdef USE_DIRECTX
+class D3DSharedTexture;
+SharedImage duplicate_shared_image(D3DSharedTexture const&);
+WindowsD3DHandle duplicate_windows_d3d_handle(D3DSharedTexture const&);
 #endif
 
 class SharedImage {
@@ -54,13 +66,14 @@ public:
 #else
     explicit SharedImage(ShareableBitmap);
     explicit SharedImage(LinuxDmaBufHandle&&);
+    explicit SharedImage(WindowsD3DHandle&&);
 #endif
 
 private:
 #ifdef AK_OS_MACOS
     Core::MachPort m_port;
 #else
-    Variant<ShareableBitmap, LinuxDmaBufHandle> m_data;
+    Variant<ShareableBitmap, LinuxDmaBufHandle, WindowsD3DHandle> m_data;
 #endif
 
     friend class SharedImageBuffer;
@@ -82,6 +95,12 @@ ErrorOr<void> encode(Encoder&, Gfx::LinuxDmaBufHandle const&);
 
 template<>
 ErrorOr<Gfx::LinuxDmaBufHandle> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, Gfx::WindowsD3DHandle const&);
+
+template<>
+ErrorOr<Gfx::WindowsD3DHandle> decode(Decoder&);
 #endif
 
 template<>

--- a/Libraries/LibGfx/SharedImageBuffer.cpp
+++ b/Libraries/LibGfx/SharedImageBuffer.cpp
@@ -63,6 +63,13 @@ SharedImageBuffer::SharedImageBuffer(NonnullRefPtr<Bitmap> bitmap, LinuxDmaBufHa
 {
 }
 #    endif
+
+#    ifdef USE_DIRECTX
+SharedImageBuffer::SharedImageBuffer(WindowsD3DHandle&& d3d_handle)
+    : m_windows_d3d_handle(move(d3d_handle))
+{
+}
+#    endif
 #endif
 
 SharedImageBuffer SharedImageBuffer::create(IntSize size)
@@ -95,6 +102,16 @@ SharedImageBuffer SharedImageBuffer::import_from_shared_image(SharedImage shared
             (void)dmabuf;
             VERIFY_NOT_REACHED();
 #    endif
+        },
+        [](WindowsD3DHandle& d3d_handle) -> SharedImageBuffer {
+#    ifdef USE_DIRECTX
+            // NOTE: D3D12 default-heap textures cannot be mapped for CPU access, so unlike the
+            //       other backing types this buffer has no bitmap view of the pixels.
+            return SharedImageBuffer(move(d3d_handle));
+#    else
+            (void)d3d_handle;
+            VERIFY_NOT_REACHED();
+#    endif
         });
 #endif
 }
@@ -110,7 +127,7 @@ SharedImage SharedImageBuffer::export_shared_image() const
 #ifdef AK_OS_MACOS
     return SharedImage { m_iosurface_handle.create_mach_port() };
 #else
-    return SharedImage { ShareableBitmap { m_bitmap, ShareableBitmap::ConstructWithKnownGoodBitmap } };
+    return SharedImage { ShareableBitmap { bitmap(), ShareableBitmap::ConstructWithKnownGoodBitmap } };
 #endif
 }
 

--- a/Libraries/LibGfx/SharedImageBuffer.h
+++ b/Libraries/LibGfx/SharedImageBuffer.h
@@ -31,12 +31,19 @@ public:
 
     SharedImage export_shared_image() const;
 
-    NonnullRefPtr<Bitmap> bitmap() const { return m_bitmap; }
+    NonnullRefPtr<Bitmap> bitmap() const
+    {
+        VERIFY(m_bitmap);
+        return *m_bitmap;
+    }
+    RefPtr<Bitmap> bitmap_if_present() const { return m_bitmap; }
 
 #ifdef AK_OS_MACOS
     Core::IOSurfaceHandle const& iosurface_handle() const { return m_iosurface_handle; }
 #elif defined(USE_VULKAN_DMABUF_IMAGES)
     LinuxDmaBufHandle const* linux_dmabuf_handle() const { return m_linux_dmabuf_handle.has_value() ? &m_linux_dmabuf_handle.value() : nullptr; }
+#elif defined(USE_DIRECTX)
+    WindowsD3DHandle const* windows_d3d_handle() const { return m_windows_d3d_handle.has_value() ? &m_windows_d3d_handle.value() : nullptr; }
 #endif
 
 private:
@@ -49,8 +56,12 @@ private:
     SharedImageBuffer(NonnullRefPtr<Bitmap>, LinuxDmaBufHandle&&);
     Optional<LinuxDmaBufHandle> m_linux_dmabuf_handle;
 #    endif
+#    ifdef USE_DIRECTX
+    explicit SharedImageBuffer(WindowsD3DHandle&&);
+    Optional<WindowsD3DHandle> m_windows_d3d_handle;
+#    endif
 #endif
-    NonnullRefPtr<Bitmap> m_bitmap;
+    RefPtr<Bitmap> m_bitmap;
 };
 
 }

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -197,6 +197,8 @@ public:
 
     MetalContext& metal_context() override { VERIFY_NOT_REACHED(); }
 
+    Direct3DContext& direct3d_context() override { return m_direct3d_context; }
+
 private:
     sk_sp<GrDirectContext> m_context;
     NonnullRefPtr<Direct3DContext> m_direct3d_context;

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -62,6 +62,7 @@ public:
 
     virtual MetalContext& metal_context() = 0;
     virtual VulkanContext const& vulkan_context() = 0;
+    virtual Direct3DContext& direct3d_context() { VERIFY_NOT_REACHED(); }
 
 protected:
     virtual void flush_and_submit_impl(SkSurface*) = 0;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -52,6 +52,10 @@
 #    include <LibIPC/TransportBootstrapMach.h>
 #endif
 
+#ifdef USE_DIRECTX
+#    include <LibGfx/Direct3DContext.h>
+#endif
+
 #if !defined(AK_OS_WINDOWS)
 #    include <sys/wait.h>
 #endif
@@ -1141,7 +1145,22 @@ ErrorOr<void> Application::launch_compositor_process()
         handle_compositor_process_death();
     };
 
+#ifdef USE_DIRECTX
+    m_reported_compositor_gpu_presentation_unavailable = false;
+    if (auto adapter_luid = Gfx::default_dxgi_adapter_luid(); adapter_luid.has_value())
+        m_compositor_client->async_set_client_gpu_presentation_capability(true, *adapter_luid);
+#endif
+
     return {};
+}
+
+void Application::notify_compositor_gpu_presentation_unavailable()
+{
+    if (m_reported_compositor_gpu_presentation_unavailable)
+        return;
+    m_reported_compositor_gpu_presentation_unavailable = true;
+    if (m_compositor_client)
+        m_compositor_client->async_set_client_gpu_presentation_capability(false, 0);
 }
 
 void Application::handle_compositor_process_death()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -276,6 +276,11 @@ public:
 
     Optional<Core::TimeZoneWatcher&> time_zone_watcher();
 
+    // Called by the UI when it turns out it cannot present GPU textures shared by the Compositor
+    // (e.g. importing a shared Direct3D texture failed), so the Compositor falls back to
+    // CPU-shared backing stores.
+    void notify_compositor_gpu_presentation_unavailable();
+
 protected:
     explicit Application(Optional<ByteString> ladybird_binary_path = {});
 
@@ -424,6 +429,7 @@ private:
     RefPtr<Requests::RequestClient> m_private_request_server_client;
     RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
     RefPtr<CompositorClient> m_compositor_client;
+    bool m_reported_compositor_gpu_presentation_unavailable { false };
     size_t m_compositor_restart_count { 0 };
     enum class CompositorRecoveryState {
         Idle,

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2378,18 +2378,22 @@ NonnullRefPtr<Core::Promise<LexicalPath>> ViewImplementation::take_screenshot(Sc
 
     switch (type) {
     case ScreenshotType::Visible: {
-        Gfx::Bitmap const* visible_bitmap = nullptr;
+        RefPtr<Gfx::Bitmap> visible_bitmap;
         if (m_client_state.has_usable_bitmap) {
             VERIFY(m_client_state.front_bitmap.shared_image_buffer);
-            visible_bitmap = m_client_state.front_bitmap.shared_image_buffer->bitmap().ptr();
+            visible_bitmap = m_client_state.front_bitmap.shared_image_buffer->bitmap_if_present();
         } else if (m_backup_shared_image_buffer) {
-            visible_bitmap = m_backup_shared_image_buffer->bitmap().ptr();
+            visible_bitmap = m_backup_shared_image_buffer->bitmap_if_present();
         }
         if (visible_bitmap) {
-            if (auto result = save_screenshot(visible_bitmap); result.is_error())
+            if (auto result = save_screenshot(visible_bitmap.ptr()); result.is_error())
                 promise->reject(result.release_error());
             else
                 promise->resolve(result.release_value());
+        } else {
+            // GPU-shared backing stores have no CPU-visible pixels, so ask WebContent to paint a screenshot for us.
+            m_pending_screenshot = promise;
+            client().async_take_document_screenshot(page_id());
         }
         break;
     }

--- a/Services/Compositor/BackingStoreManager.cpp
+++ b/Services/Compositor/BackingStoreManager.cpp
@@ -16,6 +16,10 @@
 #    include <libdrm/drm_fourcc.h>
 #endif
 
+#ifdef USE_DIRECTX
+#    include <LibGfx/D3DSharedTexture.h>
+#endif
+
 namespace Compositor {
 
 #if defined(USE_DIRECTX) || defined(USE_VULKAN)
@@ -47,21 +51,36 @@ static NonnullRefPtr<Gfx::PaintingSurface> create_shareable_bitmap_backing_store
     return Gfx::PaintingSurface::wrap_bitmap(*buffer.bitmap());
 }
 
-#ifdef USE_VULKAN_DMABUF_IMAGES
-struct DMABufBackingStore {
+#if defined(USE_VULKAN_DMABUF_IMAGES) || defined(USE_DIRECTX)
+struct GpuBackingStore {
     RefPtr<Gfx::PaintingSurface> surface;
     Gfx::SharedImage shared_image;
 };
+#endif
 
-static ErrorOr<DMABufBackingStore> create_linear_dmabuf_backing_store(Gfx::IntSize size, Gfx::SkiaBackendContext& skia_backend_context)
+#ifdef USE_VULKAN_DMABUF_IMAGES
+static ErrorOr<GpuBackingStore> create_shared_gpu_backing_store(Gfx::IntSize size, Gfx::SkiaBackendContext& skia_backend_context)
 {
     auto const& vulkan_context = skia_backend_context.vulkan_context();
     static constexpr Array<u64, 1> linear_modifiers = { DRM_FORMAT_MOD_LINEAR };
     auto image = TRY(Gfx::create_shared_vulkan_image(vulkan_context, size.width(), size.height(), VK_FORMAT_B8G8R8A8_UNORM, linear_modifiers.span()));
     auto shared_image = Gfx::duplicate_shared_image(*image);
 
-    return DMABufBackingStore {
+    return GpuBackingStore {
         .surface = Gfx::PaintingSurface::create_from_vkimage(skia_backend_context, move(image), Gfx::PaintingSurface::Origin::TopLeft),
+        .shared_image = move(shared_image),
+    };
+}
+#endif
+
+#ifdef USE_DIRECTX
+static ErrorOr<GpuBackingStore> create_shared_gpu_backing_store(Gfx::IntSize size, Gfx::SkiaBackendContext& skia_backend_context)
+{
+    auto texture = TRY(Gfx::D3DSharedTexture::create(skia_backend_context.direct3d_context(), size));
+    auto shared_image = Gfx::duplicate_shared_image(*texture);
+
+    return GpuBackingStore {
+        .surface = TRY(Gfx::PaintingSurface::create_from_d3d_texture(skia_backend_context, move(texture))),
         .shared_image = move(shared_image),
     };
 }
@@ -96,7 +115,7 @@ Optional<BackingStoreManager::Allocation> BackingStoreManager::resize_backing_st
     return {};
 }
 
-Optional<BackingStoreManager::Publication> BackingStoreManager::allocate_backing_stores(Allocation const& allocation, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, bool should_publish)
+Optional<BackingStoreManager::Publication> BackingStoreManager::allocate_backing_stores(Allocation const& allocation, RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, bool should_publish, [[maybe_unused]] GpuSharing gpu_sharing)
 {
     m_backing_stores.clear();
     m_rendering_store_index.clear();
@@ -112,14 +131,15 @@ Optional<BackingStoreManager::Publication> BackingStoreManager::allocate_backing
         return should_publish && index == 0 ? BufferState::Presented : BufferState::Available;
     };
 
-#ifdef USE_VULKAN_DMABUF_IMAGES
-    if (skia_backend_context && should_publish) {
+#if defined(USE_VULKAN_DMABUF_IMAGES) || defined(USE_DIRECTX)
+    if (skia_backend_context && should_publish && gpu_sharing == GpuSharing::Allowed) {
         Vector<Gfx::SharedImage> shared_images;
         shared_images.ensure_capacity(buffer_count);
         bool allocation_succeeded = true;
         for (size_t i = 0; i < buffer_count; ++i) {
-            auto backing_store = create_linear_dmabuf_backing_store(allocation.size, *skia_backend_context);
+            auto backing_store = create_shared_gpu_backing_store(allocation.size, *skia_backend_context);
             if (backing_store.is_error()) {
+                dbgln("Failed to allocate shared GPU backing store ({}), falling back to shareable bitmaps", backing_store.error());
                 allocation_succeeded = false;
                 break;
             }

--- a/Services/Compositor/BackingStoreManager.h
+++ b/Services/Compositor/BackingStoreManager.h
@@ -37,11 +37,18 @@ public:
         Gfx::IntRect damage_rect;
     };
 
+    enum class GpuSharing {
+        Disallowed,
+        Allowed,
+    };
+
     BackingStoreManager() = default;
 
     Optional<Allocation> resize_backing_stores_if_needed(
         Gfx::IntSize viewport_size, Web::Compositor::WindowResizingInProgress);
-    Optional<Publication> allocate_backing_stores(Allocation const&, RefPtr<Gfx::SkiaBackendContext> const&, bool should_publish);
+    Optional<Publication> allocate_backing_stores(Allocation const&, RefPtr<Gfx::SkiaBackendContext> const&, bool should_publish, GpuSharing);
+
+    void invalidate() { m_allocated_size = {}; }
 
     bool is_valid() const;
     bool has_available_buffer() const;

--- a/Services/Compositor/CompositorControlServer.ipc
+++ b/Services/Compositor/CompositorControlServer.ipc
@@ -21,5 +21,6 @@ endpoint CompositorControlServer
     handle_pinch_event(Web::Compositor::CompositorContextId context_id, Web::PinchEvent event) => (bool handled)
     async_scroll_by(Web::Compositor::CompositorContextId context_id, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) => (bool handled)
     presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId context_id, i32 bitmap_id) =|
+    set_client_gpu_presentation_capability(bool supported, u64 adapter_luid) =|
     crash() =|
 }

--- a/Services/Compositor/CompositorState.cpp
+++ b/Services/Compositor/CompositorState.cpp
@@ -585,9 +585,38 @@ RefPtr<Gfx::PaintingSurface> CompositorState::resolve_composited_context(Web::Co
 
 void CompositorState::resize_backing_stores_if_needed(Web::Compositor::CompositorContextId context_id, ContextState& context)
 {
-    if (auto publication = context.resize_backing_stores_if_needed(m_skia_backend_context); publication.has_value()) {
+    if (auto publication = context.resize_backing_stores_if_needed(m_skia_backend_context, gpu_sharing_for_client()); publication.has_value()) {
         publish_backing_stores(context_id, context, publication.release_value());
         present_current_frame(context_id, context);
+    }
+}
+
+BackingStoreManager::GpuSharing CompositorState::gpu_sharing_for_client() const
+{
+#ifdef USE_DIRECTX
+    // Shared Direct3D textures can only be opened by the client if it presents on the same adapter.
+    if (!m_skia_backend_context || m_client_gpu_presentation_adapter_luid != m_skia_backend_context->direct3d_context().adapter_luid())
+        return BackingStoreManager::GpuSharing::Disallowed;
+#endif
+    return BackingStoreManager::GpuSharing::Allowed;
+}
+
+void CompositorState::set_client_gpu_presentation_capability(bool supported, u64 adapter_luid)
+{
+    Optional<u64> new_adapter_luid;
+    if (supported)
+        new_adapter_luid = adapter_luid;
+    if (m_client_gpu_presentation_adapter_luid == new_adapter_luid)
+        return;
+    m_client_gpu_presentation_adapter_luid = new_adapter_luid;
+
+    // Reallocate the backing stores of every presenting context so they match the new capability.
+    for (auto& context_entry : m_contexts) {
+        auto& context = *context_entry.value;
+        if (!context.presents_to_client())
+            continue;
+        context.invalidate_backing_stores();
+        resize_backing_stores_if_needed(context_entry.key, context);
     }
 }
 

--- a/Services/Compositor/CompositorState.h
+++ b/Services/Compositor/CompositorState.h
@@ -100,6 +100,7 @@ public:
     void present_frame(Web::Compositor::CompositorContextId, Gfx::IntRect viewport_rect, Gfx::IntRect damage_rect);
     bool request_screenshot(Web::Compositor::CompositorContextId, Gfx::ShareableBitmap&);
     void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id);
+    void set_client_gpu_presentation_capability(bool supported, u64 adapter_luid);
 
 private:
     CompositorState(RefPtr<Gfx::SkiaBackendContext>, bool async_scrolling_enabled);
@@ -143,6 +144,7 @@ private:
     VSyncScheduler& vsync_scheduler_for_display(Optional<u64> display_id);
     void present_pending_frames_on_vsync(Optional<u64> display_id);
     void publish_backing_stores(Web::Compositor::CompositorContextId, ContextState&, BackingStoreManager::Publication&&);
+    BackingStoreManager::GpuSharing gpu_sharing_for_client() const;
     void did_finish_async_present(PendingAsyncPresent&);
     void cancel_pending_async_presents_for_context(Web::Compositor::CompositorContextId);
     void schedule_gpu_completion_check();
@@ -157,6 +159,9 @@ private:
     RefPtr<Core::Timer> m_gpu_completion_timer;
     CompositorStateClient* m_client { nullptr };
     bool m_async_scrolling_enabled { true };
+
+    // LUID of the GPU adapter the client can present shared GPU textures on, if any.
+    Optional<u64> m_client_gpu_presentation_adapter_luid;
 };
 
 }

--- a/Services/Compositor/ConnectionFromClient.cpp
+++ b/Services/Compositor/ConnectionFromClient.cpp
@@ -104,6 +104,11 @@ void ConnectionFromClient::presented_bitmap_ready_to_paint(Web::Compositor::Comp
     m_compositor_state->presented_bitmap_ready_to_paint(context_id, bitmap_id);
 }
 
+void ConnectionFromClient::set_client_gpu_presentation_capability(bool supported, u64 adapter_luid)
+{
+    m_compositor_state->set_client_gpu_presentation_capability(supported, adapter_luid);
+}
+
 void ConnectionFromClient::crash()
 {
     warnln("Crashing Compositor process by request from Browser");

--- a/Services/Compositor/ConnectionFromClient.h
+++ b/Services/Compositor/ConnectionFromClient.h
@@ -45,6 +45,7 @@ private:
     virtual Messages::CompositorControlServer::HandlePinchEventResponse handle_pinch_event(Web::Compositor::CompositorContextId, Web::PinchEvent) override;
     virtual Messages::CompositorControlServer::AsyncScrollByResponse async_scroll_by(Web::Compositor::CompositorContextId, Gfx::FloatPoint position, Gfx::FloatPoint delta_in_device_pixels) override;
     virtual void presented_bitmap_ready_to_paint(Web::Compositor::CompositorContextId, i32 bitmap_id) override;
+    virtual void set_client_gpu_presentation_capability(bool supported, u64 adapter_luid) override;
     virtual void crash() override;
 
     ConnectionFromWebContent* web_content_connection(i32 web_content_connection_id);

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -617,14 +617,19 @@ void ContextState::finish_window_resize()
     m_window_resize_in_progress = Web::Compositor::WindowResizingInProgress::No;
 }
 
-Optional<BackingStoreManager::Publication> ContextState::resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context)
+Optional<BackingStoreManager::Publication> ContextState::resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const& skia_backend_context, BackingStoreManager::GpuSharing gpu_sharing)
 {
     if (m_gpu_present_bitmap_id_awaiting_completion.has_value())
         return {};
     auto allocation = m_backing_store_manager.resize_backing_stores_if_needed(m_viewport_size, m_window_resize_in_progress);
     if (!allocation.has_value())
         return {};
-    return m_backing_store_manager.allocate_backing_stores(*allocation, skia_backend_context, presents_to_client());
+    return m_backing_store_manager.allocate_backing_stores(*allocation, skia_backend_context, presents_to_client(), gpu_sharing);
+}
+
+void ContextState::invalidate_backing_stores()
+{
+    m_backing_store_manager.invalidate();
 }
 
 bool ContextState::set_display_metadata(Optional<u64> display_id, double refresh_rate)

--- a/Services/Compositor/ContextState.h
+++ b/Services/Compositor/ContextState.h
@@ -127,7 +127,8 @@ public:
     bool should_shrink_backing_stores_after_resize() const;
     void schedule_backing_store_shrink(Function<void()>);
     void finish_window_resize();
-    Optional<BackingStoreManager::Publication> resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const&);
+    Optional<BackingStoreManager::Publication> resize_backing_stores_if_needed(RefPtr<Gfx::SkiaBackendContext> const&, BackingStoreManager::GpuSharing);
+    void invalidate_backing_stores();
 
     bool set_display_metadata(Optional<u64> display_id, double refresh_rate);
     Optional<u64> display_id() const { return m_display_id; }

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT APPLE)
     find_package(Qt6 6.9 OPTIONAL_COMPONENTS Positioning)
 endif()
 
-if (APPLE)
+if (APPLE OR HAS_DIRECTX)
     # The native presentation paths use platform GPU buffer handles directly instead of copying frames through CPU memory.
     set(QT_NO_PRIVATE_MODULE_WARNING ON)
     find_package(Qt6 6.9 REQUIRED COMPONENTS GuiPrivate)
@@ -103,6 +103,11 @@ if (NOT APPLE AND USE_VULKAN_DMABUF_IMAGES AND Qt6_VERSION VERSION_GREATER_EQUAL
     target_include_directories(ladybird PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
     target_link_libraries(ladybird PRIVATE Vulkan::Vulkan)
     add_dependencies(ladybird generate_web_content_view_linux_shaders)
+endif()
+
+if (HAS_DIRECTX)
+    target_sources(ladybird PRIVATE WebContentViewWindows.cpp)
+    target_link_libraries(ladybird PRIVATE Qt::GuiPrivate d3d11)
 endif()
 
 create_ladybird_bundle(ladybird)

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -61,7 +61,7 @@ bool is_using_dark_system_theme(QWidget&);
 
 static QWidget* initial_web_content_view_parent([[maybe_unused]] QWidget* window)
 {
-#ifdef AK_OS_MACOS
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
     return nullptr;
 #else
     return window;
@@ -72,14 +72,18 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     : WebContentViewBase(initial_web_content_view_parent(window))
     , WebView::ViewImplementation(initial_state.is_private)
 {
-#ifdef LADYBIRD_QT_USE_METAL_RHI_WIDGET
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
     // Keep the QRhiWidget out of the top-level QWidget backing store. If it is
     // parented before becoming native, Qt propagates its RHI config to the whole
     // browser window and uploads the full backing store texture on chrome repaints.
     setAttribute(Qt::WA_DontCreateNativeAncestors);
     setAttribute(Qt::WA_NativeWindow);
     setParent(window);
+#    ifdef LADYBIRD_QT_USE_METAL_RHI_WIDGET
     setApi(QRhiWidget::Api::Metal);
+#    else
+    setApi(QRhiWidget::Api::Direct3D11);
+#    endif
 #endif
 
     m_client_state.client = parent_client;
@@ -902,20 +906,26 @@ void WebContentView::paintEvent(QPaintEvent*)
 Optional<QPixmap> WebContentView::tab_preview_pixmap(QSize const& maximum_size) const
 {
     auto paintable = current_paintable();
-    if (!paintable.has_value())
+    if (!paintable.has_value() || maximum_size.isEmpty())
         return {};
 
-    auto const* bitmap = paintable->shared_image_buffer->bitmap().ptr();
-    if (!bitmap)
-        return {};
+    QImage snapshot;
+    if (auto bitmap = paintable->shared_image_buffer->bitmap_if_present()) {
+        auto width = min(bitmap->width(), paintable->bitmap_size.width());
+        auto height = min(bitmap->height(), paintable->bitmap_size.height());
+        if (width <= 0 || height <= 0)
+            return {};
 
-    auto width = min(bitmap->width(), paintable->bitmap_size.width());
-    auto height = min(bitmap->height(), paintable->bitmap_size.height());
-    if (width <= 0 || height <= 0 || maximum_size.isEmpty())
-        return {};
+        QImage image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), bitmap->pitch(), QImage::Format_RGB32);
+        snapshot = image.copy(0, 0, width, height);
+    }
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
+    else {
+        // GPU-shared backing stores have no CPU-visible pixels, so grab the rendered widget instead.
+        snapshot = const_cast<WebContentView*>(this)->grabFramebuffer();
+    }
+#endif
 
-    QImage image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), bitmap->pitch(), QImage::Format_RGB32);
-    auto snapshot = image.copy(0, 0, width, height);
     if (snapshot.isNull())
         return {};
 

--- a/UI/Qt/WebContentView.h
+++ b/UI/Qt/WebContentView.h
@@ -11,6 +11,7 @@
 #include <AK/Function.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
+#include <AK/Vector.h>
 #include <LibGfx/Cursor.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
@@ -27,6 +28,9 @@
 #ifdef AK_OS_MACOS
 #    define LADYBIRD_QT_USE_METAL_RHI_WIDGET 1
 #    define LADYBIRD_QT_USE_RHI_WIDGET 1
+#elif defined(USE_DIRECTX)
+#    define LADYBIRD_QT_USE_D3D_RHI_WIDGET 1
+#    define LADYBIRD_QT_USE_RHI_WIDGET 1
 #elif defined(USE_VULKAN_DMABUF_IMAGES)
 #    define LADYBIRD_QT_USE_VULKAN_WINDOW 1
 #endif
@@ -40,6 +44,16 @@
 class QKeyEvent;
 class QSinglePointEvent;
 class QCursor;
+
+#ifdef LADYBIRD_QT_USE_D3D_RHI_WIDGET
+struct ID3D11Texture2D;
+
+namespace Gfx {
+
+struct WindowsD3DHandle;
+
+}
+#endif
 
 namespace Ladybird {
 
@@ -184,10 +198,30 @@ private:
     Gfx::SharedImageBuffer const* m_imported_shared_image_buffer { nullptr };
     unsigned long m_render_target_pixel_format { 0 };
 
+    bool m_repaint_retry_scheduled { false };
+#endif
+
+#ifdef LADYBIRD_QT_USE_RHI_WIDGET
     bool m_force_full_repaint { true };
     bool m_has_pending_frame_damage { false };
-    bool m_repaint_retry_scheduled { false };
     Gfx::IntRect m_pending_frame_damage;
+#endif
+
+#ifdef LADYBIRD_QT_USE_D3D_RHI_WIDGET
+    // The front and back backing stores alternate every frame, so imported textures are cached
+    // per shared image buffer to avoid re-opening the shared handle on every present. Entries
+    // with a null qrhi_texture record failed imports so they are not retried every frame.
+    struct ImportedD3DTexture {
+        Gfx::SharedImageBuffer const* shared_image_buffer { nullptr };
+        int handle_value { -1 };
+        ID3D11Texture2D* d3d11_texture { nullptr };
+        QRhiTexture* qrhi_texture { nullptr };
+    };
+
+    QRhiTexture* imported_d3d_texture_for(Gfx::SharedImageBuffer const&, Gfx::WindowsD3DHandle const&);
+    void release_imported_d3d_textures();
+
+    Vector<ImportedD3DTexture> m_imported_d3d_textures;
 #endif
 
 #ifdef LADYBIRD_QT_USE_VULKAN_WINDOW

--- a/UI/Qt/WebContentViewWindows.cpp
+++ b/UI/Qt/WebContentViewWindows.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/SharedImageBuffer.h>
+#include <LibWebView/Application.h>
+#include <UI/Qt/WebContentView.h>
+
+#include <QColor>
+#include <QImage>
+#include <rhi/qrhi.h>
+#include <rhi/qrhi_platform.h>
+
+#include <AK/Windows.h>
+#include <d3d11_1.h>
+
+#include <wrl/client.h>
+
+namespace Ladybird {
+
+using Microsoft::WRL::ComPtr;
+
+// Front, back, and backup backing stores can be alive at the same time; anything above that means
+// the cached buffer pointers are stale (e.g. after a reallocation), so the cache is reset.
+static constexpr size_t max_cached_imported_d3d_textures = 4;
+
+void WebContentView::release_imported_d3d_textures()
+{
+    for (auto& texture : m_imported_d3d_textures) {
+        // The QRhiTexture wraps the D3D texture without owning it, so it has to go first.
+        delete texture.qrhi_texture;
+        if (texture.d3d11_texture)
+            texture.d3d11_texture->Release();
+    }
+    m_imported_d3d_textures.clear();
+}
+
+QRhiTexture* WebContentView::imported_d3d_texture_for(Gfx::SharedImageBuffer const& shared_image_buffer, Gfx::WindowsD3DHandle const& d3d_handle)
+{
+    for (auto& texture : m_imported_d3d_textures) {
+        if (texture.shared_image_buffer == &shared_image_buffer && texture.handle_value == d3d_handle.file.fd())
+            return texture.qrhi_texture;
+    }
+
+    if (!rhi() || rhi()->backend() != QRhi::D3D11)
+        return nullptr;
+
+    auto const* rhi_native_handles = static_cast<QRhiD3D11NativeHandles const*>(rhi()->nativeHandles());
+    if (!rhi_native_handles || !rhi_native_handles->dev)
+        return nullptr;
+
+    ComPtr<ID3D11Device1> device;
+    if (FAILED(static_cast<ID3D11Device*>(rhi_native_handles->dev)->QueryInterface(IID_PPV_ARGS(&device))))
+        return nullptr;
+
+    if (m_imported_d3d_textures.size() >= max_cached_imported_d3d_textures)
+        release_imported_d3d_textures();
+
+    ID3D11Texture2D* texture = nullptr;
+    QRhiTexture* qrhi_texture = nullptr;
+    auto hr = device->OpenSharedResource1(to_handle(d3d_handle.file.fd()), IID_PPV_ARGS(&texture));
+    if (SUCCEEDED(hr)) {
+        qrhi_texture = rhi()->newTexture(QRhiTexture::RGBA8, QSize(d3d_handle.size.width(), d3d_handle.size.height()), 1, QRhiTexture::UsedAsTransferSource);
+        if (qrhi_texture && !qrhi_texture->createFrom({ reinterpret_cast<quint64>(texture), 0 })) {
+            delete qrhi_texture;
+            qrhi_texture = nullptr;
+        }
+        if (!qrhi_texture) {
+            texture->Release();
+            texture = nullptr;
+        }
+    } else {
+        dbgln("Failed to open shared Direct3D texture in the UI process: {}", Error::from_windows_error(hr));
+    }
+
+    // Failed imports are cached as well (with a null texture) so they are not retried every frame
+    // while the Compositor downgrades to CPU-shared backing stores.
+    m_imported_d3d_textures.append({ &shared_image_buffer, d3d_handle.file.fd(), texture, qrhi_texture });
+    return qrhi_texture;
+}
+
+void WebContentView::initialize(QRhiCommandBuffer*)
+{
+    release_imported_d3d_textures();
+}
+
+void WebContentView::releaseResources()
+{
+    release_imported_d3d_textures();
+}
+
+void WebContentView::render(QRhiCommandBuffer* command_buffer)
+{
+    auto background_color = page_background_color();
+    auto clear_color = QColor(background_color.red(), background_color.green(), background_color.blue());
+
+    // The clear covers the part of the render target that the (possibly padded or stale-sized)
+    // backing store does not.
+    command_buffer->beginPass(renderTarget(), clear_color, { 1.0f, 0 });
+    command_buffer->endPass();
+
+    auto paintable = current_paintable();
+    if (!paintable.has_value() || paintable->bitmap_size.is_empty() || !rhi() || !colorTexture())
+        return;
+
+    auto target_size = colorTexture()->pixelSize();
+    auto content_width = min(paintable->bitmap_size.width(), target_size.width());
+    auto content_height = min(paintable->bitmap_size.height(), target_size.height());
+    if (content_width <= 0 || content_height <= 0)
+        return;
+
+    if (auto const* d3d_handle = paintable->shared_image_buffer->windows_d3d_handle()) {
+        auto* imported_texture = imported_d3d_texture_for(*paintable->shared_image_buffer, *d3d_handle);
+        if (!imported_texture) {
+            WebView::Application::the().notify_compositor_gpu_presentation_unavailable();
+            return;
+        }
+
+        QRhiTextureCopyDescription copy_description;
+        copy_description.setPixelSize(QSize(
+            min(content_width, d3d_handle->size.width()),
+            min(content_height, d3d_handle->size.height())));
+
+        auto* batch = rhi()->nextResourceUpdateBatch();
+        batch->copyTexture(colorTexture(), imported_texture, copy_description);
+        command_buffer->resourceUpdate(batch);
+        m_force_full_repaint = false;
+        m_has_pending_frame_damage = false;
+        m_pending_frame_damage = {};
+        return;
+    }
+
+    // CPU-shared backing store (e.g. --force-cpu-painting, or the Compositor could not share GPU
+    // textures): upload the visible part of the bitmap into the render target.
+    auto bitmap = paintable->shared_image_buffer->bitmap_if_present();
+    if (!bitmap)
+        return;
+
+    auto image = QImage(bitmap->scanline_u8(0), min(content_width, bitmap->width()), min(content_height, bitmap->height()), bitmap->pitch(), QImage::Format_RGB32)
+                     .convertToFormat(QImage::Format_RGBA8888);
+    if (image.isNull())
+        return;
+
+    QRhiTextureSubresourceUploadDescription subresource_description(image);
+    subresource_description.setSourceSize(image.size());
+
+    auto* batch = rhi()->nextResourceUpdateBatch();
+    batch->uploadTexture(colorTexture(), QRhiTextureUploadDescription({ 0, 0, subresource_description }));
+    command_buffer->resourceUpdate(batch);
+    m_force_full_repaint = false;
+    m_has_pending_frame_damage = false;
+    m_pending_frame_damage = {};
+}
+
+}


### PR DESCRIPTION
Previously, when Skia's Direct3D 12 backend was active, the Compositor rendered each frame into a GPU surface and then read it back into a CPU-shared bitmap that the Qt UI blitted with QPainter. This adds zero-copy GPU backing store sharing on Windows, matching what macOS (IOSurface) and Linux (dma-buf) already do:

- The Compositor allocates backing stores as shared committed D3D12 textures (D3D12_HEAP_FLAG_SHARED, RGBA8888) and Skia renders straight into them; the per-frame GPU->CPU readback is gone. Only the NT shared handle crosses the process boundary, riding the existing DuplicateHandle attachment transport.
- Gfx::SharedImage gains a WindowsD3DHandle backing type, and SharedImageBuffer supports buffers without a CPU bitmap view (D3D12 default-heap textures cannot be mapped).
- The Qt view becomes a QRhiWidget on Windows with the D3D11 backend: it opens the shared texture with ID3D11Device1::OpenSharedResource1 (which is why the resource is created with ALLOW_SIMULTANEOUS_ACCESS) and presents it with a shader-less copyTexture into the widget's backing texture. Imports are cached per backing store.
- The UI advertises GPU presentation capability (with its DXGI adapter LUID) to the Compositor after launching it; on adapter mismatch or a failed import the Compositor falls back to the existing CPU-shared bitmap path, which also remains in use for --force-cpu-painting and Skia builds without SK_DIRECT3D.
- Tab previews grab the rendered widget and visible screenshots go through WebContent when the backing store has no CPU pixels.

No new synchronization is needed: did_present_frame is only sent after Skia's finished-proc observes GPU completion, and buffer reuse is already gated by the presented_bitmap_ready_to_paint acknowledgement.