### PR TITLE
LibWeb: Stop appending unreachable positioned-descendant context nodes

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -459,14 +459,18 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
 
         // Out-of-flow descendants can skip overflow and scroll clips from intermediate ancestors. Keep their visual
         // contexts separate as we descend, and replace them with the normal descendant context only when this box
-        // establishes the relevant containing block.
+        // establishes the relevant containing block. A chain this box replaces below gets no copies appended:
+        // they would be orphaned nodes that nothing in the built tree ever references.
+        auto positioning_containing_blocks = layout_node.establishes_positioning_containing_blocks();
         VisualContextIndex state_for_absolute_position_descendants = inherited_contexts.absolute_position;
         VisualContextIndex state_for_fixed_position_descendants = inherited_contexts.fixed_position;
 
         auto append_to_own_and_positioned_descendant_contexts = [&](auto const& data) {
             own_state = append_node(own_state, data);
-            state_for_absolute_position_descendants = append_node(state_for_absolute_position_descendants, data);
-            state_for_fixed_position_descendants = append_node(state_for_fixed_position_descendants, data);
+            if (!positioning_containing_blocks.absolute)
+                state_for_absolute_position_descendants = append_node(state_for_absolute_position_descendants, data);
+            if (!positioning_containing_blocks.fixed)
+                state_for_fixed_position_descendants = append_node(state_for_fixed_position_descendants, data);
         };
 
         VisualContextIndex sticky_scroll_node_index;
@@ -585,7 +589,6 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
         auto absolute_position_nearest_scroll_nodes = inherited_contexts.absolute_position_nearest_scroll_nodes;
         auto fixed_position_nearest_scroll_nodes = inherited_contexts.fixed_position_nearest_scroll_nodes;
-        auto positioning_containing_blocks = layout_node.establishes_positioning_containing_blocks();
         if (positioning_containing_blocks.absolute) {
             state_for_absolute_position_descendants = state_for_descendants;
             absolute_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;

--- a/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
@@ -4,7 +4,7 @@ AccumulatedVisualContext Tree:
       [2] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (PaintableWithLines(BlockContainer<DIV>.clip-path-ancestor))
       [3] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (PaintableWithLines(BlockContainer<DIV>.abspos))
       [5] clip=[220,0 100x100] (PaintableWithLines(BlockContainer<DIV>.clip-ancestor))
-    [7] clip=[220,0 100x100] (PaintableWithLines(BlockContainer<DIV>.fixed))
+    [6] clip=[220,0 100x100] (PaintableWithLines(BlockContainer<DIV>.fixed))
 
 DisplayList:
 SaveLayer@0
@@ -15,7 +15,7 @@ SaveLayer@0
   CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[0,0 200x200]
   FillRect@3 rect=[0,0 200x200] color=rgb(255, 0, 0)
   CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[220,0 200x200]
-  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[220,0 200x200]
-  FillRect@7 rect=[220,0 200x200] color=rgb(0, 128, 0)
+  CompositorWheelHitTestTarget@6 target_scroll_node_index=0 rect=[220,0 200x200]
+  FillRect@6 rect=[220,0 200x200] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -3,7 +3,7 @@ AccumulatedVisualContext Tree:
     [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 100x100]
         [3] mask=[-2,-2 119x119] kind=luminance origin=svg-mask (SVGForeignObjectPaintable(SVGForeignObjectBox<foreignObject>#fo))
-          [6] clip=[9,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
+          [4] clip=[9,8 100x100] (PaintableWithLines(BlockContainer(anonymous)))
 
 DisplayList:
 SaveLayer@0
@@ -13,13 +13,9 @@ SaveLayer@0
   CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
   CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[9,8 100x100]
-  CompositorWheelHitTestTarget@6 target_scroll_node_index=0 rect=[9,8 100x100]
-  FillRect@6 rect=[9,8 100x100] color=rgb(0, 0, 0)
+  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[9,8 100x100]
+  FillRect@4 rect=[9,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 MaskDisplayList for context 3:
-  FillPath@0 path_bounding_rect=[8,8 100x100]
-MaskDisplayList for context 4:
-  FillPath@0 path_bounding_rect=[8,8 100x100]
-MaskDisplayList for context 5:
   FillPath@0 path_bounding_rect=[8,8 100x100]
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -3,7 +3,7 @@ AccumulatedVisualContext Tree:
     [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
       [2] clip=[8,8 200x200]
         [3] effects=[opacity=0.5]
-          [6] transform=[1,0,0,1,20,20] origin=(8,8) (SVGPathPaintable(SVGGeometryBox<rect>))
+          [4] transform=[1,0,0,1,20,20] origin=(8,8) (SVGPathPaintable(SVGGeometryBox<rect>))
 
 DisplayList:
 SaveLayer@0
@@ -12,6 +12,6 @@ SaveLayer@0
   CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
   CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
   CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
-  FillPath@6 path_bounding_rect=[8,8 100x100]
+  FillPath@4 path_bounding_rect=[8,8 100x100]
 Restore@0
 


### PR DESCRIPTION
A box that establishes an absolute or fixed positioning containing block replaces the corresponding positioned-descendant context with its own descendant context at the end of its build step. The effects, CSS clip, clip-path, and mask copies it appended to that chain earlier were therefore discarded: nodes nothing in the built tree references. Today that only wastes tree slots, but once freed slots start being recycled, unreachable nodes nobody can enumerate become a leak.

Skip the copy onto a chain the box's own containing block establishment is about to replace. Copies onto chains the box does not replace are unaffected: in the clip-positioned-descendants dump the fixed child keeps the CSS clip its abspos ancestor contributes to the fixed chain, and only the ancestor's unreachable absolute-chain copy disappears. All three display list dumps shrink by exactly the formerly orphaned nodes; the foreignObject mask dump also stops registering nested mask content against the two unreachable mask node copies.