### PR TITLE
LibWeb: Port layout tree construction to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "libweb_layout_rust"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+]
+
+[[package]]
 name = "libweb_rust"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "Libraries/LibWeb/CSS/Rust",
     "Libraries/LibWeb/Rust",
     "Libraries/LibWeb/HTML/Parser/Rust",
+    "Libraries/LibWeb/Layout/Rust",
 ]
 exclude = [
     "Libraries/LibJS/AsmIntGen",

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -1341,6 +1341,17 @@ import_rust_crate(
     FFI_HEADERS HTML/Parser/RustFFI.h
 )
 
+set(layout_rust_features "")
+if (NOT BUILD_SHARED_LIBS)
+    set(layout_rust_features FEATURES allocator)
+endif()
+import_rust_crate(
+    MANIFEST_PATH Layout/Rust/Cargo.toml
+    CRATE_NAME libweb_layout_rust
+    ${layout_rust_features}
+    FFI_HEADERS Layout/TreeBuilderRustFFI.h
+)
+
 set(css_rust_features "")
 if (NOT BUILD_SHARED_LIBS)
     set(css_rust_features FEATURES allocator)
@@ -1357,8 +1368,9 @@ if (NOT BUILD_SHARED_LIBS)
     set(content_blocker_rust_features FEATURES allocator)
 endif()
 import_rust_crate(MANIFEST_PATH ContentBlocker/Rust/Cargo.toml CRATE_NAME libweb_content_blocker_rust ${content_blocker_rust_features} FFI_HEADER ContentBlockerRustFFI.h)
-target_link_libraries(LibWeb PRIVATE libweb_rust libweb_css_rust libweb_content_blocker_rust)
+target_link_libraries(LibWeb PRIVATE libweb_rust libweb_layout_rust libweb_css_rust libweb_content_blocker_rust)
 get_target_property(_libweb_rust_lib libweb_rust IMPORTED_LOCATION)
+get_target_property(_libweb_layout_rust_lib libweb_layout_rust IMPORTED_LOCATION)
 get_target_property(_libweb_css_rust_lib libweb_css_rust IMPORTED_LOCATION)
 get_target_property(_libweb_content_blocker_rust_lib libweb_content_blocker_rust IMPORTED_LOCATION)
 set_property(SOURCE HTML/Parser/HTMLTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
@@ -1371,6 +1383,7 @@ endif()
 if(NOT BUILD_SHARED_LIBS)
     add_custom_command(TARGET LibWeb POST_BUILD
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_rust>
+        COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_layout_rust>
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_css_rust>
         COMMAND ${CMAKE_AR} -x $<TARGET_FILE:libweb_content_blocker_rust>
         COMMAND ${CMAKE_AR} -qS $<TARGET_FILE:LibWeb> *.o
@@ -1388,6 +1401,7 @@ if(NOT BUILD_SHARED_LIBS)
     # re-merges the fresh Rust objects.
     set_property(SOURCE CSS/Parser/RustTokenizer.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_css_rust_lib})
     set_property(SOURCE HTML/Parser/HTMLEncodingDetection.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_rust_lib})
+    set_property(SOURCE Layout/TreeBuilder.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_layout_rust_lib})
     set_property(SOURCE Loader/ContentBlocker.cpp APPEND PROPERTY OBJECT_DEPENDS ${_libweb_content_blocker_rust_lib})
 endif()
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2011,15 +2011,15 @@ Document::PartialRelayoutResult Document::try_partial_relayout(HashTable<WeakPtr
     Vector<Layout::Node*> rebuilt_subtree_roots;
     if (needs_layout_tree_rebuild) {
         auto tree_build_timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
-        Layout::TreeBuilder tree_builder;
-        m_layout_root = as<Layout::Viewport>(*tree_builder.build(*this));
-        record_layout_tree_build(tree_builder.rebuilt_subtree_roots().size(), tree_builder.layout_tree_update_escaped_rebuild_roots());
+        auto tree_build_result = Layout::build_layout_tree(*this);
+        m_layout_root = as<Layout::Viewport>(*tree_build_result.root);
+        record_layout_tree_build(tree_build_result.rebuilt_subtree_roots.size(), tree_build_result.layout_tree_update_escaped_rebuild_roots);
         needs_layout_tree_rebuild = false;
         layout_tree_was_built_in_partial_branch = true;
         pending_updates_escaped_during_partial_build = m_partial_relayout_invalidation.escapes()
-            || tree_builder.layout_tree_update_escaped_rebuild_roots();
+            || tree_build_result.layout_tree_update_escaped_rebuild_roots;
         m_partial_relayout_invalidation.clear_escape(PartialRelayoutEscapeClearReason::PartialLayoutTreeBuild);
-        rebuilt_subtree_roots = tree_builder.rebuilt_subtree_roots();
+        rebuilt_subtree_roots = move(tree_build_result.rebuilt_subtree_roots);
 
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             dbgln("TREEBUILD {} µs", tree_build_timer.elapsed_time().to_microseconds());
@@ -2179,9 +2179,9 @@ void Document::update_layout(UpdateLayoutReason reason)
         auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
 
         if (needs_layout_tree_rebuild) {
-            Layout::TreeBuilder tree_builder;
-            m_layout_root = as<Layout::Viewport>(*tree_builder.build(*this));
-            record_layout_tree_build(tree_builder.rebuilt_subtree_roots().size(), tree_builder.layout_tree_update_escaped_rebuild_roots());
+            auto tree_build_result = Layout::build_layout_tree(*this);
+            m_layout_root = as<Layout::Viewport>(*tree_build_result.root);
+            record_layout_tree_build(tree_build_result.rebuilt_subtree_roots.size(), tree_build_result.layout_tree_update_escaped_rebuild_roots);
 
             // NB: Called during layout update.
             if (document_element && document_element->unsafe_layout_node())
@@ -8100,7 +8100,7 @@ void Document::process_pending_top_layer_layout_changes()
                 invalidate_layout_tree(InvalidateLayoutTreeReason::TopLayerElementStillRenderedAfterRemoval);
                 return;
             }
-            Layout::TreeBuilder::detach_top_layer_element_layout_subtree(element);
+            Layout::detach_top_layer_element_layout_subtree(element);
             if (element->is_connected())
                 elements_to_mark_for_layout_tree_update.append(element);
         }
@@ -8109,7 +8109,7 @@ void Document::process_pending_top_layer_layout_changes()
     for (auto const& member : m_top_layer_elements) {
         if (!member->rendered_in_top_layer())
             continue;
-        Layout::TreeBuilder::detach_top_layer_element_layout_subtree(member);
+        Layout::detach_top_layer_element_layout_subtree(member);
         elements_to_mark_for_layout_tree_update.append(member);
     }
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2242,7 +2242,7 @@ void Element::children_changed(ChildrenChangedMetadata const& metadata)
     }
 }
 
-void Element::set_synthetic_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::PseudoElement pseudo_element, Layout::NodeWithStyle* pseudo_element_node)
+void Element::set_synthetic_pseudo_element_node(Badge<Layout::LayoutTreeBuilderAccess>, CSS::PseudoElement pseudo_element, Layout::NodeWithStyle* pseudo_element_node)
 {
     auto existing_pseudo_element = get_synthetic_pseudo_element(pseudo_element);
     if (!existing_pseudo_element.has_value() && !pseudo_element_node)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -404,13 +404,13 @@ public:
             m_removed_attributes_for_style_invalidation.append(attribute_name);
     }
 
-    void set_synthetic_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::PseudoElement, Layout::NodeWithStyle*);
+    void set_synthetic_pseudo_element_node(Badge<Layout::LayoutTreeBuilderAccess>, CSS::PseudoElement, Layout::NodeWithStyle*);
 
     Layout::NodeWithStyle* pseudo_element_layout_node(CSS::PseudoElement) const;
     Layout::NodeWithStyle* pseudo_element_unsafe_layout_node(CSS::PseudoElement) const;
 
     bool has_synthetic_pseudo_elements() const;
-    void clear_synthetic_pseudo_element_layout_nodes(Badge<Layout::TreeBuilder, Node>) { clear_synthetic_pseudo_element_layout_nodes(); }
+    void clear_synthetic_pseudo_element_layout_nodes(Badge<Layout::LayoutTreeBuilderAccess, Node>) { clear_synthetic_pseudo_element_layout_nodes(); }
 
     void serialize_children_as_json(JsonObjectSerializer<Utf16StringBuilder>&) const;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1775,7 +1775,7 @@ void Node::clear_layout_node_and_paintable(Badge<Document>)
     m_paintable = nullptr;
 }
 
-void Node::detach_layout_node(Badge<Layout::TreeBuilder>)
+void Node::detach_layout_node(Badge<Layout::LayoutTreeBuilderAccess>)
 {
     if (m_layout_node)
         m_layout_node->prepare_for_detach_from_layout_tree();

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -371,7 +371,7 @@ public:
 
     void clear_layout_node_and_paintable(Badge<Document>);
     void set_layout_node(Badge<Layout::Node>, Layout::Node&);
-    void detach_layout_node(Badge<Layout::TreeBuilder>);
+    void detach_layout_node(Badge<Layout::LayoutTreeBuilderAccess>);
 
     virtual bool is_child_allowed(Node const&) const { return true; }
 

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -994,7 +994,7 @@ class SVGSVGBox;
 class TableWrapper;
 class TextNode;
 class TextOffsetMapping;
-class TreeBuilder;
+class LayoutTreeBuilderAccess;
 class VideoBox;
 class Viewport;
 

--- a/Libraries/LibWeb/Layout/Rust/Cargo.toml
+++ b/Libraries/LibWeb/Layout/Rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libweb_layout_rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["staticlib"]
+
+[features]
+default = []
+allocator = []
+
+[build-dependencies]
+cbindgen = "0.29"
+
+[lints]
+workspace = true

--- a/Libraries/LibWeb/Layout/Rust/build.rs
+++ b/Libraries/LibWeb/Layout/Rust/build.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::env;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-env-changed=FFI_OUTPUT_DIR");
+    println!("cargo:rerun-if-changed=src");
+
+    let ffi_out_dir = env::var("FFI_OUTPUT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| out_dir.clone());
+    let config = cbindgen::Config::from_file(manifest_dir.join("cbindgen.toml"))?;
+    let header = Path::new("Layout/TreeBuilderRustFFI.h");
+    let builder = cbindgen::Builder::new().with_config(config).with_crate(&manifest_dir);
+
+    builder.generate().map_or_else(
+        |error| match error {
+            cbindgen::Error::ParseSyntaxError { .. } => {}
+            other => panic!("{other:?}"),
+        },
+        |bindings| {
+            let output_header = out_dir.join(header);
+            std::fs::create_dir_all(output_header.parent().unwrap()).unwrap();
+            bindings.write_to_file(output_header);
+            if ffi_out_dir != out_dir {
+                let ffi_header = ffi_out_dir.join(header);
+                std::fs::create_dir_all(ffi_header.parent().unwrap()).unwrap();
+                bindings.write_to_file(ffi_header);
+            }
+        },
+    );
+
+    Ok(())
+}

--- a/Libraries/LibWeb/Layout/Rust/cbindgen.toml
+++ b/Libraries/LibWeb/Layout/Rust/cbindgen.toml
@@ -1,0 +1,23 @@
+language = "C++"
+header = """/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */"""
+pragma_once = true
+include_version = true
+namespaces = ["Web", "Layout", "RustFFI"]
+line_length = 120
+tab_width = 4
+no_includes = true
+sys_includes = ["stdint.h", "stddef.h"]
+usize_is_size_t = true
+
+[parse]
+parse_deps = false
+
+[parse.expand]
+all_features = false
+
+[export.mangle]
+rename_types = "PascalCase"

--- a/Libraries/LibWeb/Layout/Rust/src/lib.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/lib.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#[cfg(feature = "allocator")]
+#[path = "../../../../RustAllocator.rs"]
+mod rust_allocator;
+
+mod tree_builder;
+
+use std::panic::AssertUnwindSafe;
+use std::panic::catch_unwind;
+
+fn abort_on_panic<F: FnOnce() -> R, R>(f: F) -> R {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = if let Some(message) = payload.downcast_ref::<&str>() {
+                (*message).to_string()
+            } else if let Some(message) = payload.downcast_ref::<String>() {
+                message.clone()
+            } else {
+                "unknown panic".to_string()
+            };
+            eprintln!("Rust panic at FFI boundary: {message}");
+            std::process::abort();
+        }
+    }
+}

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -76,6 +76,17 @@ pub struct FfiLayoutNodeFacts {
     pub is_table_wrapper: bool,
     pub has_been_wrapped_in_table_wrapper: bool,
     pub has_replaced_element_table_display_adjustment: bool,
+    pub is_inline: bool,
+    pub is_in_flow: bool,
+    pub is_inline_node: bool,
+    pub is_field_set_box: bool,
+    pub is_svg_foreign_object_box: bool,
+    pub is_svg_box: bool,
+    pub is_svg_svg_box: bool,
+    pub is_generated_for_pseudo_element: bool,
+    pub display_is_flow_inside: bool,
+    pub display_is_flex_inside: bool,
+    pub display_is_grid_inside: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -87,6 +98,15 @@ pub enum FfiAnonymousTableBoxKind {
     InlineTable,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+// NB: `Prepend` is constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiInsertionMode {
+    Append,
+    Prepend,
+}
+
 #[repr(C)]
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
@@ -95,6 +115,7 @@ pub struct FfiTreeBuilderCallbacks {
     pub first_child: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub next_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub previous_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub last_child: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub remove_nodes: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize),
     pub wrap_in_anonymous:
         unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, *mut c_void, FfiAnonymousTableBoxKind),
@@ -105,6 +126,11 @@ pub struct FfiTreeBuilderCallbacks {
     pub table_grid_column_count: unsafe extern "C" fn(*mut c_void, *mut c_void) -> usize,
     pub table_grid_is_occupied: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, usize) -> bool,
     pub append_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub create_and_append_anonymous_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub wrap_children_in_anonymous: unsafe extern "C" fn(*mut c_void, *mut c_void, *const *mut c_void, usize),
+    pub insert_child: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
+    pub set_children_are_inline: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
+    pub note_tree_restructuring: unsafe extern "C" fn(*mut c_void, *mut c_void),
 }
 
 type LayoutNode = *mut c_void;
@@ -145,6 +171,11 @@ impl TreeBuilderHost<'_> {
     fn previous_sibling(&self, node: LayoutNode) -> LayoutNode {
         // SAFETY: The entry point's callback contract guarantees that `node` is live.
         unsafe { (self.callbacks.previous_sibling)(self.callbacks.context, node) }
+    }
+
+    fn last_child(&self, node: LayoutNode) -> LayoutNode {
+        // SAFETY: The entry point's callback contract guarantees that `node` is live.
+        unsafe { (self.callbacks.last_child)(self.callbacks.context, node) }
     }
 
     fn for_each_in_inclusive_subtree(
@@ -207,6 +238,241 @@ impl TreeBuilderHost<'_> {
     }
 }
 
+fn has_inline_or_in_flow_block_children(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
+    let mut child = host.first_child(node);
+    while !child.is_null() {
+        let facts = host.facts(child);
+        if facts.is_inline || facts.is_in_flow {
+            return true;
+        }
+        child = host.next_sibling(child);
+    }
+    false
+}
+
+fn has_in_flow_block_children(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
+    if host.facts(node).children_are_inline {
+        return false;
+    }
+    let mut child = host.first_child(node);
+    while !child.is_null() {
+        let facts = host.facts(child);
+        if !facts.is_inline && facts.is_in_flow {
+            return true;
+        }
+        child = host.next_sibling(child);
+    }
+    false
+}
+
+fn is_out_of_flow_table_internal_child_of_table_root(
+    host: &TreeBuilderHost<'_>,
+    parent: LayoutNode,
+    child: LayoutNode,
+) -> bool {
+    let parent_facts = host.facts(parent);
+    let child_facts = host.facts(child);
+    parent_facts.current_display == FfiTableDisplay::TableRoot
+        && child_facts.has_style
+        && !child_facts.is_anonymous
+        && child_facts.is_out_of_flow
+        && !child_facts.has_replaced_element_table_display_adjustment
+        && is_table_non_root_box_with_display(child_facts.display_before_box_type_transformation)
+}
+
+fn create_anonymous_wrapper(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
+    // SAFETY: `parent` is a live NodeWithStyle. The callback appends and returns a live anonymous wrapper.
+    let wrapper = unsafe { (host.callbacks.create_and_append_anonymous_wrapper)(host.callbacks.context, parent) };
+    assert!(!wrapper.is_null());
+    wrapper
+}
+
+fn last_child_creating_anonymous_wrapper_if_needed(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
+    let last_child = host.last_child(parent);
+    if last_child.is_null() {
+        return create_anonymous_wrapper(host, parent);
+    }
+    let facts = host.facts(last_child);
+    if !facts.is_anonymous || !facts.children_are_inline || facts.is_generated_for_pseudo_element {
+        return create_anonymous_wrapper(host, parent);
+    }
+    last_child
+}
+
+// The insertion_parent_for_*() functions maintain the invariant that the in-flow children of
+// block-level boxes must be either all block-level or all inline-level.
+fn insertion_parent_for_inline_node(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
+    let facts = host.facts(parent);
+    if facts.is_field_set_box || facts.is_svg_foreign_object_box {
+        return last_child_creating_anonymous_wrapper_if_needed(host, parent);
+    }
+
+    // SVG layout ignores the inline/block distinction, and an anonymous wrapper would only hide
+    // the child from SVGFormattingContext (e.g. a shape with a foreignObject sibling).
+    if facts.is_svg_box || facts.is_svg_svg_box {
+        return parent;
+    }
+
+    if facts.is_inline && facts.display_is_flow_inside {
+        return parent;
+    }
+
+    if facts.display_is_flex_inside || facts.display_is_grid_inside {
+        return last_child_creating_anonymous_wrapper_if_needed(host, parent);
+    }
+
+    if !has_in_flow_block_children(host, parent) || facts.children_are_inline {
+        return parent;
+    }
+
+    // Parent has block-level children, insert into an anonymous wrapper block (and create it first if needed)
+    last_child_creating_anonymous_wrapper_if_needed(host, parent)
+}
+
+fn insertion_parent_for_block_node(
+    host: &TreeBuilderHost<'_>,
+    parent: LayoutNode,
+    node: LayoutNode,
+    mode: FfiInsertionMode,
+) -> LayoutNode {
+    let parent_facts = host.facts(parent);
+
+    // Inline is fine for in-flow block children (interrupting blocks) and for out-of-flow children;
+    // the inline formatting context emits items for both.
+    if !host.facts(node).is_anonymous && parent_facts.is_inline && parent_facts.display_is_flow_inside {
+        return parent;
+    }
+
+    // SVG layout ignores the inline/block distinction; wrapping existing inline-level siblings
+    // (e.g. shapes next to a foreignObject) would only hide them from SVGFormattingContext.
+    if parent_facts.is_svg_box || parent_facts.is_svg_svg_box {
+        return parent;
+    }
+
+    // Make sure we're not inserting into an inline node, since those do not support block nodes.
+    let mut new_parent = parent;
+    while host.facts(new_parent).is_inline_node {
+        new_parent = host.parent(new_parent);
+        assert!(!new_parent.is_null());
+    }
+
+    // If the parent block has no children, insert this block into parent.
+    if !has_inline_or_in_flow_block_children(host, new_parent) {
+        return new_parent;
+    }
+
+    // Table-internal boxes may have been blockified before insertion, but table fixup still needs to see them as
+    // direct table children instead of grouping them with neighboring table whitespace.
+    if is_out_of_flow_table_internal_child_of_table_root(host, new_parent, node) {
+        return new_parent;
+    }
+
+    let node_facts = host.facts(node);
+    let new_parent_facts = host.facts(new_parent);
+
+    // If the block is out-of-flow,
+    if node_facts.is_out_of_flow {
+        let last_child = host.last_child(new_parent);
+        assert!(!last_child.is_null());
+        let last_child_facts = host.facts(last_child);
+
+        // And we're appending while the parent's last child is an anonymous block, join that
+        // anonymous block. Prepended boxes (e.g. an absolutely positioned ::before) belong at the
+        // very start of the parent, not at the start of its trailing inline run.
+        if mode == FfiInsertionMode::Append
+            && !new_parent_facts.display_is_flex_inside
+            && !new_parent_facts.display_is_grid_inside
+            && !last_child_facts.is_generated_for_pseudo_element
+            && last_child_facts.is_anonymous
+            && last_child_facts.children_are_inline
+        {
+            return last_child;
+        }
+
+        // Otherwise, insert this block into parent.
+        return new_parent;
+    }
+
+    // If the parent block has block-level children, insert this block into parent.
+    if !new_parent_facts.children_are_inline {
+        return new_parent;
+    }
+
+    // Parent block has inline-level children (our siblings); wrap these siblings into an anonymous wrapper block.
+    // SAFETY: `new_parent` is live for the duration of this call.
+    unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, new_parent) };
+    let mut children_to_wrap = Vec::new();
+    let mut child = host.first_child(new_parent);
+    while !child.is_null() {
+        if !is_out_of_flow_table_internal_child_of_table_root(host, new_parent, child) {
+            children_to_wrap.push(child);
+        }
+        child = host.next_sibling(child);
+    }
+    // SAFETY: The callback retains the children before moving them and leaves `new_parent` live.
+    unsafe {
+        (host.callbacks.wrap_children_in_anonymous)(
+            host.callbacks.context,
+            new_parent,
+            children_to_wrap.as_ptr(),
+            children_to_wrap.len(),
+        );
+    };
+
+    // Then it's safe to insert this block into parent.
+    new_parent
+}
+
+/// Inserts a layout node while maintaining the inline/block child invariant.
+///
+/// # Safety
+///
+/// `callbacks`, `nearest_insertion_ancestor`, and `node` must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_insert_node_into_inline_or_block_ancestor(
+    callbacks: *const FfiTreeBuilderCallbacks,
+    nearest_insertion_ancestor: *mut c_void,
+    node: *mut c_void,
+    is_inline_outside: bool,
+    mode: FfiInsertionMode,
+) {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!nearest_insertion_ancestor.is_null());
+        assert!(!node.is_null());
+        // SAFETY: The caller guarantees that `callbacks` remains valid for the duration of this call.
+        let host = TreeBuilderHost {
+            callbacks: unsafe { &*callbacks },
+        };
+
+        let insertion_point = if is_inline_outside {
+            insertion_parent_for_inline_node(&host, nearest_insertion_ancestor)
+        } else {
+            insertion_parent_for_block_node(&host, nearest_insertion_ancestor, node, mode)
+        };
+
+        // Insertion parents can be above the subtree being rebuilt in place: inline ancestors are
+        // skipped, and out-of-flow boxes can join a trailing anonymous sibling.
+        // SAFETY: `insertion_point` is live for the duration of this call.
+        unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, insertion_point) };
+        // SAFETY: The callback retains `node` while inserting it into the live insertion point.
+        unsafe { (host.callbacks.insert_child)(host.callbacks.context, insertion_point, node, mode) };
+
+        if is_inline_outside {
+            // After inserting an inline-level box into a parent, mark the parent as having inline children.
+            // SAFETY: `insertion_point` remains live and attached.
+            unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, true) };
+        } else if host.facts(node).is_in_flow {
+            let insertion_point_facts = host.facts(insertion_point);
+            // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
+            if !insertion_point_facts.is_inline || !insertion_point_facts.display_is_flow_inside {
+                // SAFETY: `insertion_point` remains live and attached.
+                unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, false) };
+            }
+        }
+    });
+}
+
 fn is_table_track(display: FfiTableDisplay) -> bool {
     matches!(display, FfiTableDisplay::TableRow | FfiTableDisplay::TableColumn)
 }
@@ -242,9 +508,9 @@ fn is_proper_table_child(facts: FfiLayoutNodeFacts) -> bool {
     is_table_track_group(display) || is_table_track(display) || display == FfiTableDisplay::TableCaption
 }
 
-fn is_table_non_root_box(facts: FfiLayoutNodeFacts) -> bool {
+fn is_table_non_root_box_with_display(display: FfiTableDisplay) -> bool {
     matches!(
-        facts.current_display,
+        display,
         FfiTableDisplay::TableRow
             | FfiTableDisplay::TableColumn
             | FfiTableDisplay::TableRowGroup
@@ -254,6 +520,10 @@ fn is_table_non_root_box(facts: FfiLayoutNodeFacts) -> bool {
             | FfiTableDisplay::TableCell
             | FfiTableDisplay::TableCaption
     )
+}
+
+fn is_table_non_root_box(facts: FfiLayoutNodeFacts) -> bool {
+    is_table_non_root_box_with_display(facts.current_display)
 }
 
 fn is_tabular_container(facts: FfiLayoutNodeFacts) -> bool {

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -118,8 +118,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
-    pub update_before_children: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, bool),
-    pub update_after_children: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, bool),
+    pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+    pub wrap_fieldset_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub wrap_button_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub clear_stale_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub push_layout_parent: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -133,6 +133,13 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub quote_nesting_level: unsafe extern "C" fn(*mut c_void) -> u32,
     pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
     pub clear_dom_update_flags: unsafe extern "C" fn(*mut c_void),
+    pub svg_pattern_content_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub register_svg_resource_reference: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub ancestor_count: unsafe extern "C" fn(*mut c_void) -> usize,
+    pub ancestor_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
+    pub layout_node_dom_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub set_context_layout_svg_mask_or_clip_path: unsafe extern "C" fn(*mut c_void, bool),
+    pub set_context_layout_svg_pattern: unsafe extern "C" fn(*mut c_void, bool),
 }
 
 #[derive(Clone, Copy)]
@@ -158,12 +165,21 @@ pub struct FfiPrincipalDescendantFacts {
     pub child_needs_layout_tree_update: bool,
     pub layout_node_can_have_children: bool,
     pub layout_node_is_replaced_box_with_children: bool,
+    pub layout_node_is_list_item_box: bool,
+    pub layout_node_is_block_container: bool,
     pub is_svg_switch_element: bool,
     pub is_document: bool,
     pub has_style_containment: bool,
     pub dom_children_parent: *mut c_void,
     pub shadow_root: *mut c_void,
     pub slot_element: *mut c_void,
+    pub svg_graphics_element: *mut c_void,
+    pub svg_mask: *mut c_void,
+    pub svg_clip_path: *mut c_void,
+    pub svg_fill_pattern: *mut c_void,
+    pub svg_stroke_pattern: *mut c_void,
+    pub context_layout_svg_mask_or_clip_path: bool,
+    pub context_layout_svg_pattern: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -632,6 +648,85 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
     });
 }
 
+fn ancestor_stack_contains_dom_node(host: &DomTreeBuilderHost<'_>, dom_node: *mut c_void) -> bool {
+    // SAFETY: The builder and its ancestor stack remain live throughout tree construction.
+    let count = unsafe { (host.callbacks.ancestor_count)(host.callbacks.builder) };
+    for index in 0..count {
+        // SAFETY: `index` is below the stable ancestor count and the returned layout node is live.
+        let ancestor = unsafe { (host.callbacks.ancestor_at)(host.callbacks.builder, index) };
+        assert!(!ancestor.is_null());
+        // SAFETY: `ancestor` is a live layout node.
+        if unsafe { (host.callbacks.layout_node_dom_node)(ancestor) } == dom_node {
+            return true;
+        }
+    }
+    false
+}
+
+fn update_svg_resource(
+    host: &DomTreeBuilderHost<'_>,
+    resource: *mut c_void,
+    graphics_element: *mut c_void,
+    layout_node: *mut c_void,
+    context: *mut c_void,
+    prior_context_value: bool,
+) {
+    // SAFETY: The traversal context and layout node remain live throughout resource construction.
+    unsafe {
+        (host.callbacks.set_context_layout_svg_mask_or_clip_path)(context, true);
+        (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
+    }
+
+    if !ancestor_stack_contains_dom_node(host, resource) {
+        host.update_layout_tree(resource, context, true);
+        // SAFETY: Both pointers denote live SVG elements held by the graphics element.
+        unsafe { (host.callbacks.register_svg_resource_reference)(resource, graphics_element) };
+    } else {
+        // FIXME: Somehow either remove ancestor from the layout tree or mark it as invalid.
+    }
+
+    // SAFETY: Balance the parent push and restore the context's entry value.
+    unsafe {
+        (host.callbacks.pop_layout_parent)(host.callbacks.builder);
+        (host.callbacks.set_context_layout_svg_mask_or_clip_path)(context, prior_context_value);
+    }
+}
+
+fn update_svg_pattern(
+    host: &DomTreeBuilderHost<'_>,
+    pattern: *mut c_void,
+    content_element: *mut c_void,
+    graphics_element: *mut c_void,
+    layout_node: *mut c_void,
+    context: *mut c_void,
+    prior_context_value: bool,
+) {
+    // SAFETY: The traversal context and layout node remain live throughout resource construction.
+    unsafe {
+        (host.callbacks.set_context_layout_svg_pattern)(context, true);
+        (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
+    }
+
+    if !ancestor_stack_contains_dom_node(host, content_element) {
+        host.update_layout_tree(content_element, context, true);
+        // The referenced pattern may inherit its content from another pattern via href. Removing either element
+        // invalidates the attached resource box, so register the referencer with both.
+        // SAFETY: All pointers denote live SVG elements held by the graphics element or pattern chain.
+        unsafe {
+            (host.callbacks.register_svg_resource_reference)(content_element, graphics_element);
+            if pattern != content_element {
+                (host.callbacks.register_svg_resource_reference)(pattern, graphics_element);
+            }
+        }
+    }
+
+    // SAFETY: Balance the parent push and restore the context's entry value.
+    unsafe {
+        (host.callbacks.pop_layout_parent)(host.callbacks.builder);
+        (host.callbacks.set_context_layout_svg_pattern)(context, prior_context_value);
+    }
+}
+
 /// Updates the descendants and post-child state of a node with a principal layout box.
 ///
 /// # Safety
@@ -665,15 +760,20 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                 // SAFETY: `dom_node` is a live Element when this fact is set.
                 unsafe { (host.callbacks.resolve_counters)(dom_node) };
             }
-            // SAFETY: All pointers remain live throughout the call.
-            unsafe {
-                (host.callbacks.update_before_children)(
-                    host.callbacks.builder,
-                    dom_node,
-                    layout_node,
-                    context,
-                    facts.content_visibility_hidden,
-                );
+
+            // Add the ::before pseudo-element before walking normal children.
+            if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
+                // SAFETY: The builder, element, and layout node remain live throughout pseudo-element creation.
+                unsafe {
+                    (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
+                    (host.callbacks.create_pseudo_element)(
+                        host.callbacks.builder,
+                        dom_node,
+                        FfiPseudoElement::Before,
+                        FfiInsertionMode::Prepend,
+                    );
+                    (host.callbacks.pop_layout_parent)(host.callbacks.builder);
+                }
             }
         }
 
@@ -800,15 +900,76 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
         }
 
         if should_create_layout_node {
-            // SAFETY: All pointers remain live throughout the call.
+            if !facts.svg_graphics_element.is_null() {
+                for resource in [facts.svg_mask, facts.svg_clip_path] {
+                    if !resource.is_null() {
+                        update_svg_resource(
+                            &host,
+                            resource,
+                            facts.svg_graphics_element,
+                            layout_node,
+                            context,
+                            facts.context_layout_svg_mask_or_clip_path,
+                        );
+                    }
+                }
+
+                let mut seen_content_elements = Vec::with_capacity(2);
+                for pattern in [facts.svg_fill_pattern, facts.svg_stroke_pattern] {
+                    if pattern.is_null() {
+                        continue;
+                    }
+                    // SAFETY: `pattern` is a live SVGPatternElement.
+                    let content_element = unsafe { (host.callbacks.svg_pattern_content_element)(pattern) };
+                    if content_element.is_null() || seen_content_elements.contains(&content_element) {
+                        continue;
+                    }
+                    seen_content_elements.push(content_element);
+                    update_svg_pattern(
+                        &host,
+                        pattern,
+                        content_element,
+                        facts.svg_graphics_element,
+                        layout_node,
+                        context,
+                        facts.context_layout_svg_pattern,
+                    );
+                }
+            }
+
+            // Add ::marker and ::after once normal and SVG resource children are complete.
+            if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
+                // SAFETY: The builder, element, and layout node remain live throughout pseudo-element creation.
+                unsafe {
+                    (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
+                    if facts.layout_node_is_list_item_box {
+                        (host.callbacks.create_pseudo_element)(
+                            host.callbacks.builder,
+                            dom_node,
+                            FfiPseudoElement::Marker,
+                            FfiInsertionMode::Prepend,
+                        );
+                    }
+                    (host.callbacks.create_pseudo_element)(
+                        host.callbacks.builder,
+                        dom_node,
+                        FfiPseudoElement::After,
+                        FfiInsertionMode::Append,
+                    );
+                    (host.callbacks.pop_layout_parent)(host.callbacks.builder);
+                }
+
+                if facts.layout_node_is_block_container {
+                    // SAFETY: `dom_node` is an Element and `layout_node` is a BlockContainer when these facts are set.
+                    unsafe {
+                        (host.callbacks.create_first_letter_wrapper)(host.callbacks.builder, dom_node, layout_node);
+                    }
+                }
+            }
+
+            // SAFETY: All pointers remain live throughout the calls.
             unsafe {
-                (host.callbacks.update_after_children)(
-                    host.callbacks.builder,
-                    dom_node,
-                    layout_node,
-                    context,
-                    facts.content_visibility_hidden,
-                );
+                (host.callbacks.wrap_fieldset_layout)(host.callbacks.builder, layout_node);
                 (host.callbacks.wrap_button_layout)(host.callbacks.builder, dom_node, layout_node);
             }
         }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -97,6 +97,187 @@ pub extern "C" fn rust_tree_builder_set_quote_nesting_level(state: *mut c_void, 
     });
 }
 
+#[repr(C)]
+pub struct FfiDomTreeBuilderCallbacks {
+    pub builder: *mut c_void,
+    pub first_child: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub next_sibling: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub update_layout_tree: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool),
+    pub clear_update_flags: unsafe extern "C" fn(*mut c_void),
+    pub needs_layout_tree_update: unsafe extern "C" fn(*mut c_void) -> bool,
+    pub assigned_node_count: unsafe extern "C" fn(*mut c_void) -> usize,
+    pub assigned_node_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
+    pub is_svg_element: unsafe extern "C" fn(*mut c_void) -> bool,
+    pub clear_stale_layout_and_paint_node: unsafe extern "C" fn(*mut c_void, *mut c_void),
+}
+
+struct DomTreeBuilderHost<'a> {
+    callbacks: &'a FfiDomTreeBuilderCallbacks,
+}
+
+impl DomTreeBuilderHost<'_> {
+    fn first_child(&self, parent: *mut c_void) -> *mut c_void {
+        // SAFETY: Entry points guarantee that `parent` is a live ParentNode.
+        unsafe { (self.callbacks.first_child)(parent) }
+    }
+
+    fn next_sibling(&self, node: *mut c_void) -> *mut c_void {
+        // SAFETY: Callers only pass live DOM nodes.
+        unsafe { (self.callbacks.next_sibling)(node) }
+    }
+
+    fn update_layout_tree(&self, node: *mut c_void, context: *mut c_void, must_create_subtree: bool) {
+        // SAFETY: The builder, DOM node, and traversal context remain live throughout recursive construction.
+        unsafe {
+            (self.callbacks.update_layout_tree)(self.callbacks.builder, node, context, must_create_subtree);
+        }
+    }
+}
+
+unsafe fn dom_tree_builder_host<'a>(callbacks: *const FfiDomTreeBuilderCallbacks) -> DomTreeBuilderHost<'a> {
+    assert!(!callbacks.is_null());
+    // SAFETY: Each exported entry point requires the callback table to remain live for the duration of its call.
+    DomTreeBuilderHost {
+        callbacks: unsafe { &*callbacks },
+    }
+}
+
+/// Updates every direct DOM child in tree order.
+///
+/// # Safety
+///
+/// The callback table, parent, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_layout_tree_for_dom_children(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    parent: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!parent.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        let mut node = host.first_child(parent);
+        while !node.is_null() {
+            host.update_layout_tree(node, context, must_create_subtree);
+            node = host.next_sibling(node);
+        }
+    });
+}
+
+/// Updates every shadow-root child in tree order and clears the root's update flags.
+///
+/// # Safety
+///
+/// The callback table, shadow root, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_layout_tree_for_shadow_root_children(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    shadow_root: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!shadow_root.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        let mut node = host.first_child(shadow_root);
+        while !node.is_null() {
+            host.update_layout_tree(node, context, must_create_subtree);
+            node = host.next_sibling(node);
+        }
+        // SAFETY: `shadow_root` remains live throughout the call.
+        unsafe { (host.callbacks.clear_update_flags)(shadow_root) };
+    });
+}
+
+/// Updates a slot's assigned nodes in flat-tree order.
+///
+/// # Safety
+///
+/// The callback table, slot element, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_layout_tree_for_assigned_slottables(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    slot_element: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!slot_element.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        // SAFETY: `slot_element` remains live throughout the call.
+        let slot_needs_layout_tree_update = unsafe { (host.callbacks.needs_layout_tree_update)(slot_element) };
+        let must_create_subtree = must_create_subtree || slot_needs_layout_tree_update;
+        // SAFETY: `slot_element` remains live throughout the call.
+        let assigned_node_count = unsafe { (host.callbacks.assigned_node_count)(slot_element) };
+        for index in 0..assigned_node_count {
+            // SAFETY: `index` is below the count reported for this unchanged assigned-node list.
+            let node = unsafe { (host.callbacks.assigned_node_at)(slot_element, index) };
+            assert!(!node.is_null());
+            host.update_layout_tree(node, context, must_create_subtree);
+        }
+    });
+}
+
+/// Applies SVG `<switch>` child selection and updates its rendered child.
+///
+/// # Safety
+///
+/// The callback table, switch element, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_layout_tree_for_svg_switch_children(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    switch_element: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!switch_element.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+
+        // https://svgwg.org/svg2-draft/struct.html#SwitchElement
+        // The ‘switch’ element evaluates the ‘requiredExtensions’ and ‘systemLanguage’ attributes on its direct child
+        // elements in order, and then processes and renders the first child for which these attributes evaluate to
+        // true. All others will be bypassed and therefore not rendered. If the child element is a container element
+        // such as a ‘g’, then the entire subtree is either processed/rendered or bypassed/not rendered.
+        let mut rendered_child = std::ptr::null_mut();
+        let mut child = host.first_child(switch_element);
+        while !child.is_null() {
+            // FIXME: Evaluate the requiredExtensions and systemLanguage attributes.
+            // SAFETY: `child` is a live DOM node.
+            if unsafe { (host.callbacks.is_svg_element)(child) } {
+                rendered_child = child;
+                break;
+            }
+            child = host.next_sibling(child);
+        }
+
+        // NB: Clean up any stale children that should no longer be rendered.
+        let mut child = host.first_child(switch_element);
+        while !child.is_null() {
+            if child != rendered_child {
+                // SAFETY: The builder and `child` remain live throughout the call.
+                unsafe {
+                    (host.callbacks.clear_stale_layout_and_paint_node)(host.callbacks.builder, child);
+                }
+            }
+            child = host.next_sibling(child);
+        }
+
+        if !rendered_child.is_null() {
+            host.update_layout_tree(rendered_child, context, must_create_subtree);
+        }
+    });
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum FfiReplacedElementDisplayAdjustment {

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -286,6 +286,117 @@ pub enum FfiReplacedElementDisplayAdjustment {
     Block,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+// NB: `Other` is constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiPseudoElement {
+    Before,
+    After,
+    Marker,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+// NB: `List` is constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiComputedContentType {
+    Normal,
+    None,
+    List,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiPseudoElementDecision {
+    None,
+    NormalMarker,
+    ContentReplacement,
+    Contents,
+    Box,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPseudoElementFacts {
+    pub pseudo_element: FfiPseudoElement,
+    pub content_type: FfiComputedContentType,
+    pub display_is_none: bool,
+    pub display_is_contents: bool,
+    pub display_is_list_item: bool,
+    pub has_content_replacement: bool,
+    pub originating_layout_node_is_list_item: bool,
+    pub normal_marker_has_content: bool,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
+    abort_on_panic(|| {
+        // https://drafts.csswg.org/css-display-3/#box-generation
+        // The element and its descendants generate no boxes or text sequences.
+        if facts.display_is_none {
+            return FfiPseudoElementDecision::None;
+        }
+
+        // ::before and ::after only exist if they have content. `content: normal` computes to `none` for them.
+        if matches!(facts.pseudo_element, FfiPseudoElement::Before | FfiPseudoElement::After)
+            && matches!(
+                facts.content_type,
+                FfiComputedContentType::Normal | FfiComputedContentType::None
+            )
+        {
+            return FfiPseudoElementDecision::None;
+        }
+
+        // For ::marker with content 'none' -- do nothing.
+        if facts.pseudo_element == FfiPseudoElement::Marker && facts.content_type == FfiComputedContentType::None {
+            return FfiPseudoElementDecision::None;
+        }
+
+        if facts.pseudo_element == FfiPseudoElement::Marker
+            && facts.content_type == FfiComputedContentType::Normal
+            && facts.originating_layout_node_is_list_item
+        {
+            // https://www.w3.org/TR/css-lists-3/#content-property
+            // "::marker does not generate a box" when list-style-type is 'none' and there's no marker image. Custom
+            // ::marker content is already excluded by the outer condition checking for Type::Normal.
+            return if facts.normal_marker_has_content {
+                FfiPseudoElementDecision::NormalMarker
+            } else {
+                FfiPseudoElementDecision::None
+            };
+        }
+
+        // https://drafts.csswg.org/css-content-3/#content-property
+        // Note: If the value of <content-list> is a single <image>, it must instead be interpreted as a
+        // <content-replacement>.
+        // Makes the element or pseudo-element a replaced element, filled with the specified <image>.
+        let mut is_content_replacement = facts.has_content_replacement;
+
+        // INTEROP: Blink, WebKit, and Gecko keep generated images as children of pseudo-element boxes. Preserve that
+        //          behavior for list items because our marker layout currently requires a ListItemBox.
+        if facts.display_is_list_item {
+            is_content_replacement = false;
+        }
+
+        // https://drafts.csswg.org/css-display-3/#box-generation
+        // This value computes to 'display: none' on replaced elements.
+        // INTEROP: Blink, WebKit, and Gecko preserve image content on 'display: contents' pseudo-elements instead.
+        if facts.display_is_contents {
+            is_content_replacement = false;
+        }
+
+        if is_content_replacement {
+            FfiPseudoElementDecision::ContentReplacement
+        } else if facts.display_is_contents {
+            FfiPseudoElementDecision::Contents
+        } else {
+            FfiPseudoElementDecision::Box
+        }
+    })
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_adjusted_table_display_for_replaced_element(
     is_table_inside: bool,
@@ -1475,8 +1586,9 @@ pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallb
 #[cfg(test)]
 mod tests {
     use super::{
-        FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks, FfiReplacedElementDisplayAdjustment,
-        FirstLetterTextHost, find_first_letter_in_text, rust_adjusted_table_display_for_replaced_element,
+        FfiComputedContentType, FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks, FfiPseudoElement,
+        FfiPseudoElementDecision, FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment, FirstLetterTextHost,
+        find_first_letter_in_text, rust_adjusted_table_display_for_replaced_element, rust_pseudo_element_decision,
     };
     use std::ffi::c_void;
 
@@ -1580,5 +1692,94 @@ mod tests {
         assert_eq!(super::rust_tree_builder_ancestor_count(state), 0);
         // SAFETY: `state` was returned by the matching create function and has not been destroyed yet.
         unsafe { super::rust_tree_builder_state_destroy(state) };
+    }
+
+    #[test]
+    fn pseudo_element_box_generation_decisions() {
+        let decide = |pseudo_element,
+                      content_type,
+                      display_is_none,
+                      display_is_contents,
+                      display_is_list_item,
+                      has_content_replacement,
+                      originating_layout_node_is_list_item,
+                      normal_marker_has_content| {
+            rust_pseudo_element_decision(FfiPseudoElementFacts {
+                pseudo_element,
+                content_type,
+                display_is_none,
+                display_is_contents,
+                display_is_list_item,
+                has_content_replacement,
+                originating_layout_node_is_list_item,
+                normal_marker_has_content,
+            })
+        };
+
+        assert_eq!(
+            decide(
+                FfiPseudoElement::Before,
+                FfiComputedContentType::Normal,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+            ),
+            FfiPseudoElementDecision::None
+        );
+        assert_eq!(
+            decide(
+                FfiPseudoElement::Marker,
+                FfiComputedContentType::Normal,
+                false,
+                false,
+                false,
+                false,
+                true,
+                true
+            ),
+            FfiPseudoElementDecision::NormalMarker
+        );
+        assert_eq!(
+            decide(
+                FfiPseudoElement::Other,
+                FfiComputedContentType::List,
+                false,
+                false,
+                false,
+                true,
+                false,
+                false
+            ),
+            FfiPseudoElementDecision::ContentReplacement
+        );
+        assert_eq!(
+            decide(
+                FfiPseudoElement::Other,
+                FfiComputedContentType::List,
+                false,
+                true,
+                false,
+                true,
+                false,
+                false
+            ),
+            FfiPseudoElementDecision::Contents
+        );
+        assert_eq!(
+            decide(
+                FfiPseudoElement::Other,
+                FfiComputedContentType::List,
+                false,
+                false,
+                true,
+                true,
+                false,
+                false
+            ),
+            FfiPseudoElementDecision::Box
+        );
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -45,7 +45,7 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_synthetic_pseudo_element_layout_nodes: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub clear_stale_inclusive_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void),
-    pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
+    pub clear_stale_assigned_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
     pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiFirstLetterTarget),
@@ -325,7 +325,9 @@ pub struct FfiTopLayerDetachCallbacks {
     pub remove_layout_node: unsafe extern "C" fn(*mut c_void),
     pub clear_element_subtree: unsafe extern "C" fn(*mut c_void),
     pub slot_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
-    pub clear_assigned_slottables: unsafe extern "C" fn(*mut c_void),
+    pub assigned_node_count: unsafe extern "C" fn(*mut c_void) -> usize,
+    pub assigned_node_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
+    pub clear_assigned_subtree: unsafe extern "C" fn(*mut c_void),
 }
 
 /// Detaches a top-layer element's layout placement and clears every stale projected subtree.
@@ -369,44 +371,29 @@ pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
         // SAFETY: The callback returns the element's adjusted HTMLSlotElement pointer, if any.
         let slot_element = unsafe { (callbacks.slot_element)(element) };
         if !slot_element.is_null() {
-            // SAFETY: The slot element remains live throughout assigned-node cleanup.
-            unsafe { (callbacks.clear_assigned_slottables)(slot_element) };
+            clear_stale_assigned_slottables(
+                slot_element,
+                |slot| unsafe { (callbacks.assigned_node_count)(slot) },
+                |slot, index| unsafe { (callbacks.assigned_node_at)(slot, index) },
+                |root| unsafe { (callbacks.clear_assigned_subtree)(root) },
+            );
         }
     });
 }
 
-#[repr(C)]
-pub struct FfiAssignedCleanupCallbacks {
-    pub assigned_node_count: unsafe extern "C" fn(*mut c_void) -> usize,
-    pub assigned_node_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
-    pub clear_assigned_subtree: unsafe extern "C" fn(*mut c_void),
-}
-
-/// Clears stale layout state for every flat-tree child assigned to a slot.
-///
-/// # Safety
-///
-/// The callback table and slot element must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_clear_stale_assigned_slottables(
-    callbacks: *const FfiAssignedCleanupCallbacks,
+fn clear_stale_assigned_slottables(
     slot_element: *mut c_void,
+    assigned_node_count: impl Fn(*mut c_void) -> usize,
+    assigned_node_at: impl Fn(*mut c_void, usize) -> *mut c_void,
+    clear_assigned_subtree: impl Fn(*mut c_void),
 ) {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!slot_element.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let callbacks = unsafe { &*callbacks };
-        // SAFETY: The slot and assigned-node list remain live throughout cleanup.
-        let count = unsafe { (callbacks.assigned_node_count)(slot_element) };
-        for index in 0..count {
-            // SAFETY: `index` is below the stable assigned-node count.
-            let root = unsafe { (callbacks.assigned_node_at)(slot_element, index) };
-            assert!(!root.is_null());
-            // SAFETY: The assigned subtree root remains live throughout cleanup.
-            unsafe { (callbacks.clear_assigned_subtree)(root) };
-        }
-    });
+    assert!(!slot_element.is_null());
+    let count = assigned_node_count(slot_element);
+    for index in 0..count {
+        let root = assigned_node_at(slot_element, index);
+        assert!(!root.is_null());
+        clear_assigned_subtree(root);
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -778,8 +765,12 @@ unsafe fn update_layout_tree_for_display_contents(
                     );
                 }
             } else {
-                // SAFETY: `slot_element` remains live throughout this call.
-                unsafe { (host.callbacks.clear_stale_assigned_slottables)(facts.slot_element) };
+                clear_stale_assigned_slottables(
+                    facts.slot_element,
+                    |slot| unsafe { (host.callbacks.assigned_node_count)(slot) },
+                    |slot, index| unsafe { (host.callbacks.assigned_node_at)(slot, index) },
+                    |root| unsafe { (host.callbacks.clear_stale_assigned_subtree)(host.callbacks.builder, root) },
+                );
             }
         }
 
@@ -1033,8 +1024,12 @@ unsafe fn update_principal_node_descendants(
                 }
                 assert!(state.ancestor_stack.pop().is_some());
             } else {
-                // SAFETY: `slot_element` remains live throughout cleanup.
-                unsafe { (host.callbacks.clear_stale_assigned_slottables)(facts.slot_element) };
+                clear_stale_assigned_slottables(
+                    facts.slot_element,
+                    |slot| unsafe { (host.callbacks.assigned_node_count)(slot) },
+                    |slot, index| unsafe { (host.callbacks.assigned_node_at)(slot, index) },
+                    |root| unsafe { (host.callbacks.clear_stale_assigned_subtree)(host.callbacks.builder, root) },
+                );
             }
         }
 

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -171,6 +171,10 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub set_context_has_svg_root: unsafe extern "C" fn(*mut c_void, bool),
+    pub reset_style_ancestor_filter: unsafe extern "C" fn(*mut c_void),
+    pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub fixup_tables: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub layout_root: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
 }
 
 #[derive(Clone, Copy)]
@@ -1289,6 +1293,49 @@ pub unsafe extern "C" fn rust_update_layout_tree(
             unsafe { (host.callbacks.pop_style_ancestor)(dom_node) };
         }
     });
+}
+
+/// Builds or incrementally updates a document's layout tree and applies table fixup.
+///
+/// # Safety
+///
+/// The callback table, frame storage, document, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_build_layout_tree(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    frame: *mut c_void,
+    document: *mut c_void,
+    context: *mut c_void,
+) -> *mut c_void {
+    abort_on_panic(|| {
+        assert!(!frame.is_null());
+        assert!(!document.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        // SAFETY: All pointers remain live throughout the build.
+        let entry_facts =
+            unsafe { (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, document, context, false) };
+        assert!(entry_facts.is_document);
+
+        // SAFETY: The document and builder remain live throughout the build.
+        unsafe {
+            (host.callbacks.reset_style_ancestor_filter)(document);
+            (host.callbacks.set_quote_nesting_level)(host.callbacks.builder, 0);
+            rust_update_layout_tree(callbacks, frame, document, context, false);
+        }
+
+        // NB: Called during layout tree construction.
+        // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
+        let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
+        if !document_layout_node.is_null() {
+            // SAFETY: The builder and layout root remain live throughout table fixup.
+            unsafe { (host.callbacks.fixup_tables)(host.callbacks.builder, document_layout_node) };
+        }
+
+        // SAFETY: The builder remains live and owns the returned root.
+        unsafe { (host.callbacks.layout_root)(host.callbacks.builder) }
+    })
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -73,7 +73,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub create_principal_element_layout:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind),
     pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub principal_text_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiTextLayoutFacts,
+    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
@@ -104,6 +105,15 @@ pub struct FfiDisplayContentsFacts {
     pub dom_children_parent: *mut c_void,
     pub shadow_root: *mut c_void,
     pub slot_element: *mut c_void,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiTextLayoutFacts {
+    pub has_style_parent: bool,
+    pub parent_display_is_contents: bool,
+    pub text_is_ascii_whitespace: bool,
+    pub parent_collapses_whitespace: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -259,8 +269,7 @@ fn principal_box_generation_decision(
     })
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_display_contents_text_needs_style_wrapper(
+fn display_contents_text_needs_style_wrapper(
     has_style_parent: bool,
     parent_display_is_contents: bool,
     text_is_ascii_whitespace: bool,
@@ -1204,8 +1213,16 @@ fn construct_principal_layout_node(
             // SAFETY: The frame and DOM document remain live throughout construction.
             unsafe { (host.callbacks.create_principal_document_layout)(frame, dom_node) };
         } else if entry_facts.is_text {
+            // SAFETY: The DOM text node remains live throughout the fact query.
+            let facts = unsafe { (host.callbacks.principal_text_layout_facts)(dom_node) };
+            let needs_style_wrapper = display_contents_text_needs_style_wrapper(
+                facts.has_style_parent,
+                facts.parent_display_is_contents,
+                facts.text_is_ascii_whitespace,
+                facts.parent_collapses_whitespace,
+            );
             // SAFETY: The frame and DOM text node remain live throughout construction.
-            unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node) };
+            unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node, needs_style_wrapper) };
         }
     } else {
         // SAFETY: The frame and DOM node remain live throughout the call.
@@ -2946,9 +2963,10 @@ mod tests {
         FfiFirstLetterTextCallbacks, FfiPrincipalBoxPlacement, FfiPrincipalBoxPlacementFacts,
         FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts,
         FfiReplacedElementDisplayAdjustment, FirstLetterTextHost, PrincipalBoxGenerationDecision, SvgEntryDecision,
-        TopLayerEntryDecision, TreeBuilderContext, adjusted_table_display_for_replaced_element, element_layout_kind,
-        find_first_letter_in_text, principal_box_generation_decision, principal_box_placement_decision,
-        principal_node_entry_decision, pseudo_element_decision, rust_display_contents_text_needs_style_wrapper,
+        TopLayerEntryDecision, TreeBuilderContext, adjusted_table_display_for_replaced_element,
+        display_contents_text_needs_style_wrapper, element_layout_kind, find_first_letter_in_text,
+        principal_box_generation_decision, principal_box_placement_decision, principal_node_entry_decision,
+        pseudo_element_decision,
     };
     use std::ffi::c_void;
 
@@ -3251,11 +3269,9 @@ mod tests {
 
     #[test]
     fn display_contents_text_style_wrapper_decisions() {
-        assert!(!rust_display_contents_text_needs_style_wrapper(
-            false, true, false, false
-        ));
-        assert!(rust_display_contents_text_needs_style_wrapper(true, true, false, true));
-        assert!(!rust_display_contents_text_needs_style_wrapper(true, true, true, true));
-        assert!(rust_display_contents_text_needs_style_wrapper(true, true, true, false));
+        assert!(!display_contents_text_needs_style_wrapper(false, true, false, false));
+        assert!(display_contents_text_needs_style_wrapper(true, true, false, true));
+        assert!(!display_contents_text_needs_style_wrapper(true, true, true, true));
+        assert!(display_contents_text_needs_style_wrapper(true, true, true, false));
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -50,9 +50,7 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
-    pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
-    pub wrap_fieldset_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub wrap_button_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+    pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiFirstLetterTarget),
     pub clear_stale_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void,
     pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
@@ -95,8 +93,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub reset_style_ancestor_filter: unsafe extern "C" fn(*mut c_void),
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
-    pub fixup_tables: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub layout_root: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub layout: FfiTreeBuilderCallbacks,
 }
 
 #[derive(Clone, Copy)]
@@ -134,6 +132,7 @@ pub struct FfiPrincipalDescendantFacts {
     pub is_svg_switch_element: bool,
     pub is_document: bool,
     pub has_style_containment: bool,
+    pub uses_button_layout: bool,
     pub dom_children_parent: *mut c_void,
     pub shadow_root: *mut c_void,
     pub slot_element: *mut c_void,
@@ -536,6 +535,12 @@ impl DomTreeBuilderHost<'_> {
     fn next_sibling(&self, node: *mut c_void) -> *mut c_void {
         // SAFETY: Callers only pass live DOM nodes.
         unsafe { (self.callbacks.next_sibling)(node) }
+    }
+
+    fn layout(&self) -> TreeBuilderHost<'_> {
+        TreeBuilderHost {
+            callbacks: &self.callbacks.layout,
+        }
     }
 }
 
@@ -1109,18 +1114,19 @@ unsafe fn update_principal_node_descendants(
                 assert!(state.ancestor_stack.pop().is_some());
 
                 if facts.layout_node_is_block_container && facts.has_first_letter_style {
-                    // SAFETY: `dom_node` is an Element and `layout_node` is a BlockContainer when these facts are set.
-                    unsafe {
-                        (host.callbacks.create_first_letter_wrapper)(host.callbacks.builder, dom_node, layout_node);
+                    let target = find_first_letter_in_block(&host.layout(), layout_node);
+                    if target.found {
+                        // SAFETY: `dom_node` is an Element and `target` identifies a live descendant text node.
+                        unsafe {
+                            (host.callbacks.create_first_letter_wrapper)(host.callbacks.builder, dom_node, target);
+                        }
                     }
                 }
             }
 
-            // SAFETY: All pointers remain live throughout the calls.
-            unsafe {
-                (host.callbacks.wrap_fieldset_layout)(host.callbacks.builder, layout_node);
-                (host.callbacks.wrap_button_layout)(host.callbacks.builder, dom_node, layout_node);
-            }
+            let layout_host = host.layout();
+            wrap_fieldset_contents_if_needed(&layout_host, layout_node);
+            wrap_button_contents_if_needed(&layout_host, layout_node, facts.uses_button_layout);
         }
 
         // https://www.w3.org/TR/css-contain-2/#containment-style
@@ -1447,8 +1453,7 @@ pub unsafe extern "C" fn rust_build_layout_tree(
         // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
         let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
         if !document_layout_node.is_null() {
-            // SAFETY: The builder and layout root remain live throughout table fixup.
-            unsafe { (host.callbacks.fixup_tables)(host.callbacks.builder, document_layout_node) };
+            fixup_tables(&host.layout(), document_layout_node);
         }
 
         // SAFETY: The builder remains live and owns the returned root.
@@ -2420,137 +2425,77 @@ fn find_first_letter_in_block(host: &TreeBuilderHost<'_>, block: LayoutNode) -> 
     FfiFirstLetterTarget::not_found()
 }
 
-/// Finds the text range claimed by a block's `::first-letter` pseudo-element.
-///
-/// # Safety
-///
-/// `callbacks` must remain valid for the duration of the call and `block` must be a live BlockContainer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_find_first_letter_in_block(
-    callbacks: *const FfiTreeBuilderCallbacks,
-    block: *mut c_void,
-) -> FfiFirstLetterTarget {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!block.is_null());
-        // SAFETY: The caller guarantees that `callbacks` remains valid for the duration of this call.
-        let host = TreeBuilderHost {
-            callbacks: unsafe { &*callbacks },
-        };
-        find_first_letter_in_block(&host, block)
-    })
-}
+fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: *mut c_void, uses_button_layout: bool) {
+    assert!(!layout_node.is_null());
+    if !uses_button_layout {
+        return;
+    }
 
-/// Creates the anonymous layout structure required for button rendering.
-///
-/// # Safety
-///
-/// `callbacks` must remain valid for the call and `layout_node` must be a live NodeWithStyle.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_wrap_button_contents_if_needed(
-    callbacks: *const FfiTreeBuilderCallbacks,
-    layout_node: *mut c_void,
-    uses_button_layout: bool,
-) {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!layout_node.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = TreeBuilderHost {
-            callbacks: unsafe { &*callbacks },
-        };
-        if !uses_button_layout {
-            return;
+    // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
+    // If the element is an input element, or if it is a button element and its computed value for 'display' is not
+    // 'inline-grid', 'grid', 'inline-flex', or 'flex', then the element's box has a child anonymous button content
+    // box with the following behaviors:
+    let facts = host.facts(layout_node);
+    if !facts.display_is_grid_inside && !facts.display_is_flex_inside {
+        let mut children = Vec::new();
+        let mut child = host.first_child(layout_node);
+        while !child.is_null() {
+            children.push(child);
+            child = host.next_sibling(child);
         }
 
-        // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
-        // If the element is an input element, or if it is a button element and its computed value for 'display' is not
-        // 'inline-grid', 'grid', 'inline-flex', or 'flex', then the element's box has a child anonymous button content
-        // box with the following behaviors:
-        let facts = host.facts(layout_node);
-        if !facts.display_is_grid_inside && !facts.display_is_flex_inside {
-            let mut children = Vec::new();
-            let mut child = host.first_child(layout_node);
-            while !child.is_null() {
+        // SAFETY: `layout_node` remains live and owns the returned content wrapper through its flex wrapper.
+        let content_wrapper =
+            unsafe { (host.callbacks.create_button_content_wrapper)(host.callbacks.context, layout_node) };
+        assert!(!content_wrapper.is_null());
+        // SAFETY: The parent and content wrapper remain live, and the callback retains all nodes while moving them.
+        unsafe {
+            (host.callbacks.set_children_are_inline)(
+                host.callbacks.context,
+                content_wrapper,
+                facts.children_are_inline,
+            );
+            (host.callbacks.move_nodes_to_parent)(
+                host.callbacks.context,
+                content_wrapper,
+                children.as_ptr(),
+                children.len(),
+            );
+            (host.callbacks.set_children_are_inline)(host.callbacks.context, layout_node, false);
+        }
+    }
+}
+
+fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: *mut c_void) {
+    assert!(!layout_node.is_null());
+
+    // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+    // The anonymous fieldset content box is expected to appear after the rendered legend and is expected to contain
+    // the content (including the '::before' and '::after' pseudo-elements) of the fieldset element except for the
+    // rendered legend, if there is one.
+    let facts = host.facts(layout_node);
+    if facts.is_field_set_box && facts.has_rendered_legend {
+        // SAFETY: `layout_node` is a live FieldSetBox with a rendered legend.
+        let legend = unsafe { (host.callbacks.rendered_legend)(host.callbacks.context, layout_node) };
+        assert!(!legend.is_null());
+
+        let mut children = Vec::new();
+        let mut child = host.first_child(layout_node);
+        while !child.is_null() {
+            if child != legend {
                 children.push(child);
-                child = host.next_sibling(child);
             }
-
-            // SAFETY: `layout_node` remains live and owns the returned content wrapper through its flex wrapper.
-            let content_wrapper =
-                unsafe { (host.callbacks.create_button_content_wrapper)(host.callbacks.context, layout_node) };
-            assert!(!content_wrapper.is_null());
-            // SAFETY: The parent and content wrapper remain live, and the callback retains all nodes while moving them.
-            unsafe {
-                (host.callbacks.set_children_are_inline)(
-                    host.callbacks.context,
-                    content_wrapper,
-                    facts.children_are_inline,
-                );
-                (host.callbacks.move_nodes_to_parent)(
-                    host.callbacks.context,
-                    content_wrapper,
-                    children.as_ptr(),
-                    children.len(),
-                );
-                (host.callbacks.set_children_are_inline)(host.callbacks.context, layout_node, false);
-            }
+            child = host.next_sibling(child);
         }
-    });
-}
 
-/// Creates the anonymous fieldset content box around non-legend children.
-///
-/// # Safety
-///
-/// `callbacks` must remain valid for the call and `layout_node` must be a live layout node.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_wrap_fieldset_contents_if_needed(
-    callbacks: *const FfiTreeBuilderCallbacks,
-    layout_node: *mut c_void,
-) {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!layout_node.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = TreeBuilderHost {
-            callbacks: unsafe { &*callbacks },
-        };
-
-        // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-        // The anonymous fieldset content box is expected to appear after the rendered legend and is expected to contain
-        // the content (including the '::before' and '::after' pseudo-elements) of the fieldset element except for the
-        // rendered legend, if there is one.
-        let facts = host.facts(layout_node);
-        if facts.is_field_set_box && facts.has_rendered_legend {
-            // SAFETY: `layout_node` is a live FieldSetBox with a rendered legend.
-            let legend = unsafe { (host.callbacks.rendered_legend)(host.callbacks.context, layout_node) };
-            assert!(!legend.is_null());
-
-            let mut children = Vec::new();
-            let mut child = host.first_child(layout_node);
-            while !child.is_null() {
-                if child != legend {
-                    children.push(child);
-                }
-                child = host.next_sibling(child);
-            }
-
-            // SAFETY: The fieldset remains live and owns the returned wrapper.
-            let wrapper =
-                unsafe { (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, layout_node) };
-            assert!(!wrapper.is_null());
-            // SAFETY: The wrapper remains attached and the callback retains all nodes while moving them.
-            unsafe {
-                (host.callbacks.move_nodes_to_parent)(
-                    host.callbacks.context,
-                    wrapper,
-                    children.as_ptr(),
-                    children.len(),
-                );
-            }
+        // SAFETY: The fieldset remains live and owns the returned wrapper.
+        let wrapper = unsafe { (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, layout_node) };
+        assert!(!wrapper.is_null());
+        // SAFETY: The wrapper remains attached and the callback retains all nodes while moving them.
+        unsafe {
+            (host.callbacks.move_nodes_to_parent)(host.callbacks.context, wrapper, children.as_ptr(), children.len());
         }
-    });
+    }
 }
 
 fn is_table_track(display: FfiTableDisplay) -> bool {
@@ -2987,26 +2932,12 @@ fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
     }
 }
 
-/// Runs the CSS table-model fixup over an already constructed layout subtree.
-///
-/// # Safety
-///
-/// `callbacks` must point to a valid callback table for the duration of the call. `root` must be a live
-/// NodeWithStyle, and every callback-returned node must remain live for as long as it stays attached to that root.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallbacks, root: *mut c_void) {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!root.is_null());
-        // SAFETY: Guaranteed by the entry point's contract and checked for null above.
-        let host = TreeBuilderHost {
-            callbacks: unsafe { &*callbacks },
-        };
-        remove_irrelevant_boxes(&host, root);
-        generate_missing_child_wrappers(&host, root);
-        let table_roots = generate_missing_parents(&host, root);
-        missing_cells_fixup(&host, &table_roots);
-    });
+fn fixup_tables(host: &TreeBuilderHost<'_>, root: *mut c_void) {
+    assert!(!root.is_null());
+    remove_irrelevant_boxes(host, root);
+    generate_missing_child_wrappers(host, root);
+    let table_roots = generate_missing_parents(host, root);
+    missing_cells_fixup(host, &table_roots);
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -307,50 +307,45 @@ fn element_layout_kind(facts: FfiElementLayoutFacts) -> FfiElementLayoutKind {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FfiTopLayerEntryDecision {
+enum TopLayerEntryDecision {
     Continue,
     Skip,
     SkipAndRequestZoneRebuild,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FfiSvgEntryDecision {
+enum SvgEntryDecision {
     Continue,
     EnterSvgRoot,
     Skip,
 }
 
 #[derive(Clone, Copy)]
-#[repr(C)]
-pub struct FfiPrincipalNodeEntryDecision {
-    pub should_create_layout_node: bool,
-    pub top_layer: FfiTopLayerEntryDecision,
-    pub svg: FfiSvgEntryDecision,
+struct PrincipalNodeEntryDecision {
+    should_create_layout_node: bool,
+    top_layer: TopLayerEntryDecision,
+    svg: SvgEntryDecision,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FfiPrincipalBoxGenerationDecision {
+enum PrincipalBoxGenerationDecision {
     Suppress,
     DisplayContents,
     PrincipalBox,
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_principal_box_generation_decision(
+fn principal_box_generation_decision(
     is_element: bool,
     display_is_none: bool,
     display_is_contents: bool,
-) -> FfiPrincipalBoxGenerationDecision {
+) -> PrincipalBoxGenerationDecision {
     abort_on_panic(|| {
         if is_element && display_is_none {
-            FfiPrincipalBoxGenerationDecision::Suppress
+            PrincipalBoxGenerationDecision::Suppress
         } else if is_element && display_is_contents {
-            FfiPrincipalBoxGenerationDecision::DisplayContents
+            PrincipalBoxGenerationDecision::DisplayContents
         } else {
-            FfiPrincipalBoxGenerationDecision::PrincipalBox
+            PrincipalBoxGenerationDecision::PrincipalBox
         }
     })
 }
@@ -532,20 +527,16 @@ pub enum FfiPrincipalBoxPlacement {
 }
 
 #[derive(Clone, Copy)]
-#[repr(C)]
-pub struct FfiPrincipalBoxPlacementDecision {
-    pub placement: FfiPrincipalBoxPlacement,
-    pub may_replace_existing_layout_node: bool,
-    pub start_rebuild_root: bool,
-    pub mark_update_escaped_rebuild_roots: bool,
-    pub create_backdrop: bool,
-    pub clear_layout_top_layer_for_descendants: bool,
+struct PrincipalBoxPlacementDecision {
+    placement: FfiPrincipalBoxPlacement,
+    may_replace_existing_layout_node: bool,
+    start_rebuild_root: bool,
+    mark_update_escaped_rebuild_roots: bool,
+    create_backdrop: bool,
+    clear_layout_top_layer_for_descendants: bool,
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_principal_box_placement_decision(
-    facts: FfiPrincipalBoxPlacementFacts,
-) -> FfiPrincipalBoxPlacementDecision {
+fn principal_box_placement_decision(facts: FfiPrincipalBoxPlacementFacts) -> PrincipalBoxPlacementDecision {
     abort_on_panic(|| {
         let may_replace_existing_layout_node = !facts.must_create_subtree
             && facts.has_old_layout_node
@@ -571,7 +562,7 @@ pub extern "C" fn rust_principal_box_placement_decision(
 
         let is_active_top_layer_member =
             facts.is_element && facts.rendered_in_top_layer && facts.context_layout_top_layer;
-        FfiPrincipalBoxPlacementDecision {
+        PrincipalBoxPlacementDecision {
             placement,
             may_replace_existing_layout_node,
             start_rebuild_root,
@@ -582,10 +573,7 @@ pub extern "C" fn rust_principal_box_placement_decision(
     })
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_principal_node_entry_decision(
-    facts: FfiPrincipalNodeEntryFacts,
-) -> FfiPrincipalNodeEntryDecision {
+fn principal_node_entry_decision(facts: FfiPrincipalNodeEntryFacts) -> PrincipalNodeEntryDecision {
     abort_on_panic(|| {
         let should_create_layout_node = facts.must_create_subtree
             || facts.needs_layout_tree_update
@@ -594,23 +582,23 @@ pub extern "C" fn rust_principal_node_entry_decision(
 
         let top_layer = if facts.is_element && facts.rendered_in_top_layer && !facts.context_layout_top_layer {
             if !facts.layout_node_is_attached && !facts.needs_layout_tree_update {
-                FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild
+                TopLayerEntryDecision::SkipAndRequestZoneRebuild
             } else {
-                FfiTopLayerEntryDecision::Skip
+                TopLayerEntryDecision::Skip
             }
         } else {
-            FfiTopLayerEntryDecision::Continue
+            TopLayerEntryDecision::Continue
         };
 
         let svg = if facts.is_svg_container {
-            FfiSvgEntryDecision::EnterSvgRoot
+            SvgEntryDecision::EnterSvgRoot
         } else if facts.requires_svg_container && !facts.context_has_svg_root {
-            FfiSvgEntryDecision::Skip
+            SvgEntryDecision::Skip
         } else {
-            FfiSvgEntryDecision::Continue
+            SvgEntryDecision::Continue
         };
 
-        FfiPrincipalNodeEntryDecision {
+        PrincipalNodeEntryDecision {
             should_create_layout_node,
             top_layer,
             svg,
@@ -670,8 +658,7 @@ unsafe fn dom_tree_builder_host<'a>(callbacks: *const FfiDomTreeBuilderCallbacks
 /// # Safety
 ///
 /// The callback table, parent, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_layout_tree_for_dom_children(
+unsafe fn update_layout_tree_for_dom_children(
     callbacks: *const FfiDomTreeBuilderCallbacks,
     parent: *mut c_void,
     context: *mut c_void,
@@ -695,8 +682,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_dom_children(
 /// # Safety
 ///
 /// The callback table, shadow root, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_layout_tree_for_shadow_root_children(
+unsafe fn update_layout_tree_for_shadow_root_children(
     callbacks: *const FfiDomTreeBuilderCallbacks,
     shadow_root: *mut c_void,
     context: *mut c_void,
@@ -722,8 +708,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_shadow_root_children(
 /// # Safety
 ///
 /// The callback table, slot element, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_layout_tree_for_assigned_slottables(
+unsafe fn update_layout_tree_for_assigned_slottables(
     callbacks: *const FfiDomTreeBuilderCallbacks,
     slot_element: *mut c_void,
     context: *mut c_void,
@@ -753,8 +738,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_assigned_slottables(
 /// # Safety
 ///
 /// The callback table, switch element, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_layout_tree_for_svg_switch_children(
+unsafe fn update_layout_tree_for_svg_switch_children(
     callbacks: *const FfiDomTreeBuilderCallbacks,
     switch_element: *mut c_void,
     context: *mut c_void,
@@ -806,8 +790,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_svg_switch_children(
 /// # Safety
 ///
 /// The callback table, element, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
+unsafe fn update_layout_tree_for_display_contents(
     callbacks: *const FfiDomTreeBuilderCallbacks,
     element: *mut c_void,
     context: *mut c_void,
@@ -860,7 +843,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
             if !facts.shadow_root.is_null() {
                 // SAFETY: The callback table, shadow root, and context remain valid.
                 unsafe {
-                    rust_update_layout_tree_for_shadow_root_children(
+                    update_layout_tree_for_shadow_root_children(
                         callbacks,
                         facts.shadow_root,
                         context,
@@ -871,7 +854,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
                 assert!(!facts.dom_children_parent.is_null());
                 // SAFETY: The callback table, parent, and context remain valid.
                 unsafe {
-                    rust_update_layout_tree_for_dom_children(
+                    update_layout_tree_for_dom_children(
                         callbacks,
                         facts.dom_children_parent,
                         context,
@@ -885,7 +868,7 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
             if !facts.content_visibility_hidden {
                 // SAFETY: The callback table, slot element, and context remain valid.
                 unsafe {
-                    rust_update_layout_tree_for_assigned_slottables(
+                    update_layout_tree_for_assigned_slottables(
                         callbacks,
                         facts.slot_element,
                         context,
@@ -1005,8 +988,7 @@ fn update_svg_pattern(
 /// # Safety
 ///
 /// The callback table, DOM node, layout node, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_principal_node_descendants(
+unsafe fn update_principal_node_descendants(
     callbacks: *const FfiDomTreeBuilderCallbacks,
     dom_node: *mut c_void,
     layout_node: *mut c_void,
@@ -1079,7 +1061,7 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                 }
                 // SAFETY: The callback table, shadow root, and context remain valid.
                 unsafe {
-                    rust_update_layout_tree_for_shadow_root_children(
+                    update_layout_tree_for_shadow_root_children(
                         callbacks,
                         facts.shadow_root,
                         context,
@@ -1095,7 +1077,7 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                 if facts.is_svg_switch_element {
                     // SAFETY: The callback table, parent, and context remain valid.
                     unsafe {
-                        rust_update_layout_tree_for_svg_switch_children(
+                        update_layout_tree_for_svg_switch_children(
                             callbacks,
                             facts.dom_children_parent,
                             context,
@@ -1105,7 +1087,7 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                 } else {
                     // SAFETY: The callback table, parent, and context remain valid.
                     unsafe {
-                        rust_update_layout_tree_for_dom_children(
+                        update_layout_tree_for_dom_children(
                             callbacks,
                             facts.dom_children_parent,
                             context,
@@ -1157,7 +1139,7 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                 unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
                 // SAFETY: The callback table, slot element, and context remain valid.
                 unsafe {
-                    rust_update_layout_tree_for_assigned_slottables(
+                    update_layout_tree_for_assigned_slottables(
                         callbacks,
                         facts.slot_element,
                         context,
@@ -1291,18 +1273,18 @@ fn construct_principal_layout_node(
                 should_create_layout_node,
             )
         };
-        let generation = rust_principal_box_generation_decision(
+        let generation = principal_box_generation_decision(
             true,
             should_create_layout_node && display.display_is_none,
             display.display_is_contents,
         );
-        if generation == FfiPrincipalBoxGenerationDecision::Suppress {
+        if generation == PrincipalBoxGenerationDecision::Suppress {
             return (false, false);
         }
-        if generation == FfiPrincipalBoxGenerationDecision::DisplayContents {
+        if generation == PrincipalBoxGenerationDecision::DisplayContents {
             // SAFETY: The callback table, DOM element, and context remain valid throughout the recursive walk.
             unsafe {
-                rust_update_layout_tree_for_display_contents(
+                update_layout_tree_for_display_contents(
                     update.callbacks,
                     dom_node,
                     context,
@@ -1359,7 +1341,7 @@ fn construct_principal_layout_node(
 fn update_principal_node_after_entry(
     update: &PrincipalNodeUpdate<'_, '_>,
     entry_facts: FfiPrincipalNodeEntryFacts,
-    entry_decision: FfiPrincipalNodeEntryDecision,
+    entry_decision: PrincipalNodeEntryDecision,
 ) {
     let host = update.host;
     let frame = update.frame;
@@ -1368,12 +1350,12 @@ fn update_principal_node_after_entry(
     // SAFETY: The frame and DOM node remain live throughout this update.
     unsafe { (host.callbacks.initialize_principal_frame)(frame, dom_node) };
 
-    if entry_decision.svg == FfiSvgEntryDecision::EnterSvgRoot {
+    if entry_decision.svg == SvgEntryDecision::EnterSvgRoot {
         // SAFETY: The traversal context remains live throughout this update.
         unsafe { (host.callbacks.set_context_has_svg_root)(context, true) };
     }
 
-    let (has_layout_node, handled_display_contents) = if entry_decision.svg == FfiSvgEntryDecision::Skip {
+    let (has_layout_node, handled_display_contents) = if entry_decision.svg == SvgEntryDecision::Skip {
         (false, false)
     } else {
         construct_principal_layout_node(update, entry_facts, entry_decision.should_create_layout_node)
@@ -1388,7 +1370,7 @@ fn update_principal_node_after_entry(
         // SAFETY: The frame owns the live principal layout node and its display.
         let layout_facts = unsafe { (host.callbacks.principal_layout_facts)(frame) };
         if layout_facts.is_replaced_element {
-            let adjustment = rust_adjusted_table_display_for_replaced_element(
+            let adjustment = adjusted_table_display_for_replaced_element(
                 layout_facts.display.display_is_table_inside,
                 layout_facts.display.display_is_block_outside,
                 layout_facts.display.display_is_internal_table,
@@ -1411,7 +1393,7 @@ fn update_principal_node_after_entry(
                 entry_decision.should_create_layout_node,
             )
         };
-        let placement = rust_principal_box_placement_decision(placement_facts);
+        let placement = principal_box_placement_decision(placement_facts);
 
         let mut prior_rebuild_root = std::ptr::null_mut();
         if placement.start_rebuild_root {
@@ -1452,7 +1434,7 @@ fn update_principal_node_after_entry(
         unsafe { (host.callbacks.place_principal_layout)(host.callbacks.builder, frame, placement.placement) };
         // SAFETY: The callback table, DOM node, layout node, and context remain live throughout the call.
         unsafe {
-            rust_update_principal_node_descendants(
+            update_principal_node_descendants(
                 update.callbacks,
                 dom_node,
                 (host.callbacks.principal_layout_node)(frame),
@@ -1476,7 +1458,7 @@ fn update_principal_node_after_entry(
         unsafe { (host.callbacks.clear_stale_inclusive_subtree)(host.callbacks.builder, dom_node) };
     }
 
-    if entry_decision.svg == FfiSvgEntryDecision::EnterSvgRoot {
+    if entry_decision.svg == SvgEntryDecision::EnterSvgRoot {
         // SAFETY: Restore the traversal context's entry value.
         unsafe { (host.callbacks.set_context_has_svg_root)(context, entry_facts.context_has_svg_root) };
     }
@@ -1505,9 +1487,9 @@ pub unsafe extern "C" fn rust_update_layout_tree(
         let entry_facts = unsafe {
             (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, dom_node, context, must_create_subtree)
         };
-        let entry_decision = rust_principal_node_entry_decision(entry_facts);
-        if entry_decision.top_layer != FfiTopLayerEntryDecision::Continue {
-            if entry_decision.top_layer == FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild {
+        let entry_decision = principal_node_entry_decision(entry_facts);
+        if entry_decision.top_layer != TopLayerEntryDecision::Continue {
+            if entry_decision.top_layer == TopLayerEntryDecision::SkipAndRequestZoneRebuild {
                 // A member found here without an attached box was cleared together with a hidden ancestor subtree, and
                 // nothing is scheduled to rebuild it. Request another top-layer zone pass instead of stranding dirty
                 // flags below ancestors whose walks already finished.
@@ -1667,8 +1649,7 @@ pub struct FfiPseudoTreeBuilderCallbacks {
     pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
+fn pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
     abort_on_panic(|| {
         if !facts.has_style {
             return FfiPseudoElementDecision::None;
@@ -1760,7 +1741,7 @@ pub unsafe extern "C" fn rust_create_pseudo_element(
         let callbacks = unsafe { &*callbacks };
         // SAFETY: The frame and element remain live throughout initialization.
         let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
-        let decision = rust_pseudo_element_decision(facts);
+        let decision = pseudo_element_decision(facts);
         if decision == FfiPseudoElementDecision::None {
             return std::ptr::null_mut();
         }
@@ -1780,7 +1761,7 @@ pub unsafe extern "C" fn rust_create_pseudo_element(
         if decision == FfiPseudoElementDecision::ContentReplacement {
             // SAFETY: The frame owns the live replacement node and its display.
             let layout_facts = unsafe { (callbacks.layout_facts)(frame) };
-            let adjustment = rust_adjusted_table_display_for_replaced_element(
+            let adjustment = adjusted_table_display_for_replaced_element(
                 layout_facts.display.display_is_table_inside,
                 layout_facts.display.display_is_block_outside,
                 layout_facts.display.display_is_internal_table,
@@ -1838,8 +1819,7 @@ pub unsafe extern "C" fn rust_create_pseudo_element(
     })
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_adjusted_table_display_for_replaced_element(
+fn adjusted_table_display_for_replaced_element(
     is_table_inside: bool,
     is_block_outside: bool,
     is_internal_table: bool,
@@ -3095,13 +3075,12 @@ pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallb
 mod tests {
     use super::{
         FfiComputedContentType, FfiElementLayoutFacts, FfiElementLayoutKind, FfiFirstLetterCodePointFacts,
-        FfiFirstLetterTextCallbacks, FfiPrincipalBoxGenerationDecision, FfiPrincipalBoxPlacement,
-        FfiPrincipalBoxPlacementFacts, FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision,
-        FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment, FfiSvgEntryDecision, FfiTopLayerEntryDecision,
-        FirstLetterTextHost, element_layout_kind, find_first_letter_in_text,
-        rust_adjusted_table_display_for_replaced_element, rust_display_contents_text_needs_style_wrapper,
-        rust_principal_box_generation_decision, rust_principal_box_placement_decision,
-        rust_principal_node_entry_decision, rust_pseudo_element_decision,
+        FfiFirstLetterTextCallbacks, FfiPrincipalBoxPlacement, FfiPrincipalBoxPlacementFacts,
+        FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts,
+        FfiReplacedElementDisplayAdjustment, FirstLetterTextHost, PrincipalBoxGenerationDecision, SvgEntryDecision,
+        TopLayerEntryDecision, adjusted_table_display_for_replaced_element, element_layout_kind,
+        find_first_letter_in_text, principal_box_generation_decision, principal_box_placement_decision,
+        principal_node_entry_decision, pseudo_element_decision, rust_display_contents_text_needs_style_wrapper,
     };
     use std::ffi::c_void;
 
@@ -3146,23 +3125,23 @@ mod tests {
     #[test]
     fn replaced_table_display_adjustments() {
         assert_eq!(
-            rust_adjusted_table_display_for_replaced_element(true, true, false, false),
+            adjusted_table_display_for_replaced_element(true, true, false, false),
             FfiReplacedElementDisplayAdjustment::Block
         );
         assert_eq!(
-            rust_adjusted_table_display_for_replaced_element(true, false, false, false),
+            adjusted_table_display_for_replaced_element(true, false, false, false),
             FfiReplacedElementDisplayAdjustment::Inline
         );
         assert_eq!(
-            rust_adjusted_table_display_for_replaced_element(false, false, true, false),
+            adjusted_table_display_for_replaced_element(false, false, true, false),
             FfiReplacedElementDisplayAdjustment::Inline
         );
         assert_eq!(
-            rust_adjusted_table_display_for_replaced_element(false, false, false, true),
+            adjusted_table_display_for_replaced_element(false, false, false, true),
             FfiReplacedElementDisplayAdjustment::Inline
         );
         assert_eq!(
-            rust_adjusted_table_display_for_replaced_element(false, false, false, false),
+            adjusted_table_display_for_replaced_element(false, false, false, false),
             FfiReplacedElementDisplayAdjustment::None
         );
     }
@@ -3217,7 +3196,7 @@ mod tests {
                       has_content_replacement,
                       originating_layout_node_is_list_item,
                       normal_marker_has_content| {
-            rust_pseudo_element_decision(FfiPseudoElementFacts {
+            pseudo_element_decision(FfiPseudoElementFacts {
                 has_style: true,
                 pseudo_element,
                 content_type,
@@ -3314,26 +3293,26 @@ mod tests {
             requires_svg_container: false,
             context_has_svg_root: false,
         };
-        let decision = rust_principal_node_entry_decision(facts);
+        let decision = principal_node_entry_decision(facts);
         assert!(!decision.should_create_layout_node);
-        assert_eq!(decision.top_layer, FfiTopLayerEntryDecision::Continue);
-        assert_eq!(decision.svg, FfiSvgEntryDecision::Continue);
+        assert_eq!(decision.top_layer, TopLayerEntryDecision::Continue);
+        assert_eq!(decision.svg, SvgEntryDecision::Continue);
 
         facts.rendered_in_top_layer = true;
         facts.layout_node_is_attached = false;
-        let decision = rust_principal_node_entry_decision(facts);
-        assert_eq!(decision.top_layer, FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild);
+        let decision = principal_node_entry_decision(facts);
+        assert_eq!(decision.top_layer, TopLayerEntryDecision::SkipAndRequestZoneRebuild);
 
         facts.rendered_in_top_layer = false;
         facts.requires_svg_container = true;
-        let decision = rust_principal_node_entry_decision(facts);
-        assert_eq!(decision.svg, FfiSvgEntryDecision::Skip);
+        let decision = principal_node_entry_decision(facts);
+        assert_eq!(decision.svg, SvgEntryDecision::Skip);
 
         facts.must_create_subtree = true;
         facts.is_svg_container = true;
-        let decision = rust_principal_node_entry_decision(facts);
+        let decision = principal_node_entry_decision(facts);
         assert!(decision.should_create_layout_node);
-        assert_eq!(decision.svg, FfiSvgEntryDecision::EnterSvgRoot);
+        assert_eq!(decision.svg, SvgEntryDecision::EnterSvgRoot);
     }
 
     #[test]
@@ -3365,16 +3344,16 @@ mod tests {
     #[test]
     fn principal_box_generation_and_placement_decisions() {
         assert_eq!(
-            rust_principal_box_generation_decision(true, true, false),
-            FfiPrincipalBoxGenerationDecision::Suppress
+            principal_box_generation_decision(true, true, false),
+            PrincipalBoxGenerationDecision::Suppress
         );
         assert_eq!(
-            rust_principal_box_generation_decision(true, false, true),
-            FfiPrincipalBoxGenerationDecision::DisplayContents
+            principal_box_generation_decision(true, false, true),
+            PrincipalBoxGenerationDecision::DisplayContents
         );
         assert_eq!(
-            rust_principal_box_generation_decision(false, false, false),
-            FfiPrincipalBoxGenerationDecision::PrincipalBox
+            principal_box_generation_decision(false, false, false),
+            PrincipalBoxGenerationDecision::PrincipalBox
         );
 
         let mut facts = FfiPrincipalBoxPlacementFacts {
@@ -3390,7 +3369,7 @@ mod tests {
             context_layout_top_layer: true,
             layout_node_is_svg_box: false,
         };
-        let decision = rust_principal_box_placement_decision(facts);
+        let decision = principal_box_placement_decision(facts);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::ReplaceExisting);
         assert!(decision.start_rebuild_root);
         assert!(decision.create_backdrop);
@@ -3399,7 +3378,7 @@ mod tests {
         facts.has_old_layout_node = false;
         facts.old_layout_node_is_attached = false;
         facts.layout_node_is_svg_box = true;
-        let decision = rust_principal_box_placement_decision(facts);
+        let decision = principal_box_placement_decision(facts);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::AppendSvg);
         assert!(decision.mark_update_escaped_rebuild_roots);
     }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -131,6 +131,83 @@ pub struct FfiDisplayContentsFacts {
     pub slot_element: *mut c_void,
 }
 
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalNodeEntryFacts {
+    pub must_create_subtree: bool,
+    pub needs_layout_tree_update: bool,
+    pub document_needs_full_layout_tree_update: bool,
+    pub is_document: bool,
+    pub has_layout_node: bool,
+    pub is_element: bool,
+    pub rendered_in_top_layer: bool,
+    pub context_layout_top_layer: bool,
+    pub layout_node_is_attached: bool,
+    pub is_svg_container: bool,
+    pub requires_svg_container: bool,
+    pub context_has_svg_root: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiTopLayerEntryDecision {
+    Continue,
+    Skip,
+    SkipAndRequestZoneRebuild,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiSvgEntryDecision {
+    Continue,
+    EnterSvgRoot,
+    Skip,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalNodeEntryDecision {
+    pub should_create_layout_node: bool,
+    pub top_layer: FfiTopLayerEntryDecision,
+    pub svg: FfiSvgEntryDecision,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_principal_node_entry_decision(
+    facts: FfiPrincipalNodeEntryFacts,
+) -> FfiPrincipalNodeEntryDecision {
+    abort_on_panic(|| {
+        let should_create_layout_node = facts.must_create_subtree
+            || facts.needs_layout_tree_update
+            || facts.document_needs_full_layout_tree_update
+            || (facts.is_document && !facts.has_layout_node);
+
+        let top_layer = if facts.is_element && facts.rendered_in_top_layer && !facts.context_layout_top_layer {
+            if !facts.layout_node_is_attached && !facts.needs_layout_tree_update {
+                FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild
+            } else {
+                FfiTopLayerEntryDecision::Skip
+            }
+        } else {
+            FfiTopLayerEntryDecision::Continue
+        };
+
+        let svg = if facts.is_svg_container {
+            FfiSvgEntryDecision::EnterSvgRoot
+        } else if facts.requires_svg_container && !facts.context_has_svg_root {
+            FfiSvgEntryDecision::Skip
+        } else {
+            FfiSvgEntryDecision::Continue
+        };
+
+        FfiPrincipalNodeEntryDecision {
+            should_create_layout_node,
+            top_layer,
+            svg,
+        }
+    })
+}
+
 struct DomTreeBuilderHost<'a> {
     callbacks: &'a FfiDomTreeBuilderCallbacks,
 }
@@ -1793,9 +1870,11 @@ pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallb
 #[cfg(test)]
 mod tests {
     use super::{
-        FfiComputedContentType, FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks, FfiPseudoElement,
-        FfiPseudoElementDecision, FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment, FirstLetterTextHost,
-        find_first_letter_in_text, rust_adjusted_table_display_for_replaced_element, rust_pseudo_element_decision,
+        FfiComputedContentType, FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks, FfiPrincipalNodeEntryFacts,
+        FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment,
+        FfiSvgEntryDecision, FfiTopLayerEntryDecision, FirstLetterTextHost, find_first_letter_in_text,
+        rust_adjusted_table_display_for_replaced_element, rust_principal_node_entry_decision,
+        rust_pseudo_element_decision,
     };
     use std::ffi::c_void;
 
@@ -1988,5 +2067,43 @@ mod tests {
             ),
             FfiPseudoElementDecision::Box
         );
+    }
+
+    #[test]
+    fn principal_node_entry_decisions() {
+        let mut facts = FfiPrincipalNodeEntryFacts {
+            must_create_subtree: false,
+            needs_layout_tree_update: false,
+            document_needs_full_layout_tree_update: false,
+            is_document: false,
+            has_layout_node: true,
+            is_element: true,
+            rendered_in_top_layer: false,
+            context_layout_top_layer: false,
+            layout_node_is_attached: true,
+            is_svg_container: false,
+            requires_svg_container: false,
+            context_has_svg_root: false,
+        };
+        let decision = rust_principal_node_entry_decision(facts);
+        assert!(!decision.should_create_layout_node);
+        assert_eq!(decision.top_layer, FfiTopLayerEntryDecision::Continue);
+        assert_eq!(decision.svg, FfiSvgEntryDecision::Continue);
+
+        facts.rendered_in_top_layer = true;
+        facts.layout_node_is_attached = false;
+        let decision = rust_principal_node_entry_decision(facts);
+        assert_eq!(decision.top_layer, FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild);
+
+        facts.rendered_in_top_layer = false;
+        facts.requires_svg_container = true;
+        let decision = rust_principal_node_entry_decision(facts);
+        assert_eq!(decision.svg, FfiSvgEntryDecision::Skip);
+
+        facts.must_create_subtree = true;
+        facts.is_svg_container = true;
+        let decision = rust_principal_node_entry_decision(facts);
+        assert!(decision.should_create_layout_node);
+        assert_eq!(decision.svg, FfiSvgEntryDecision::EnterSvgRoot);
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -45,8 +45,6 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_synthetic_pseudo_element_layout_nodes: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub clear_stale_inclusive_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void),
-    pub create_pseudo_element:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement, FfiInsertionMode),
     pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
@@ -86,8 +84,6 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub start_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub restore_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub mark_update_escaped_rebuild_roots: unsafe extern "C" fn(*mut c_void),
-    pub create_principal_backdrop:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, bool) -> *mut c_void,
     pub insert_principal_backdrop_before_old: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -95,6 +91,7 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub layout_root: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub layout: FfiTreeBuilderCallbacks,
+    pub pseudo: FfiPseudoTreeBuilderCallbacks,
 }
 
 #[derive(Clone, Copy)]
@@ -731,16 +728,13 @@ unsafe fn update_layout_tree_for_display_contents(
         }
 
         if !facts.content_visibility_hidden {
-            // SAFETY: The builder and element remain live throughout this call.
-            unsafe {
-                (host.callbacks.create_pseudo_element)(
-                    host.callbacks.builder,
-                    state as *mut TreeBuilderState as *mut c_void,
-                    element,
-                    FfiPseudoElement::Before,
-                    FfiInsertionMode::Append,
-                );
-            }
+            create_pseudo_element(
+                host,
+                state,
+                element,
+                FfiPseudoElement::Before,
+                Some(FfiInsertionMode::Append),
+            );
         }
 
         if !facts.content_visibility_hidden && (should_create_layout_node || facts.child_needs_layout_tree_update) {
@@ -790,16 +784,13 @@ unsafe fn update_layout_tree_for_display_contents(
         }
 
         if !facts.content_visibility_hidden {
-            // SAFETY: The builder and element remain live throughout this call.
-            unsafe {
-                (host.callbacks.create_pseudo_element)(
-                    host.callbacks.builder,
-                    state as *mut TreeBuilderState as *mut c_void,
-                    element,
-                    FfiPseudoElement::After,
-                    FfiInsertionMode::Append,
-                );
-            }
+            create_pseudo_element(
+                host,
+                state,
+                element,
+                FfiPseudoElement::After,
+                Some(FfiInsertionMode::Append),
+            );
         }
 
         assert!(!facts.dom_children_parent.is_null());
@@ -913,16 +904,13 @@ unsafe fn update_principal_node_descendants(
             // Add the ::before pseudo-element before walking normal children.
             if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
                 state.ancestor_stack.push(layout_node);
-                // SAFETY: The builder, state, element, and layout node remain live throughout pseudo-element creation.
-                unsafe {
-                    (host.callbacks.create_pseudo_element)(
-                        host.callbacks.builder,
-                        state as *mut TreeBuilderState as *mut c_void,
-                        dom_node,
-                        FfiPseudoElement::Before,
-                        FfiInsertionMode::Prepend,
-                    );
-                }
+                create_pseudo_element(
+                    host,
+                    state,
+                    dom_node,
+                    FfiPseudoElement::Before,
+                    Some(FfiInsertionMode::Prepend),
+                );
                 assert!(state.ancestor_stack.pop().is_some());
             }
         }
@@ -1092,25 +1080,22 @@ unsafe fn update_principal_node_descendants(
             // Add ::marker and ::after once normal and SVG resource children are complete.
             if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
                 state.ancestor_stack.push(layout_node);
-                // SAFETY: The builder, state, element, and layout node remain live throughout pseudo-element creation.
-                unsafe {
-                    if facts.layout_node_is_list_item_box {
-                        (host.callbacks.create_pseudo_element)(
-                            host.callbacks.builder,
-                            state as *mut TreeBuilderState as *mut c_void,
-                            dom_node,
-                            FfiPseudoElement::Marker,
-                            FfiInsertionMode::Prepend,
-                        );
-                    }
-                    (host.callbacks.create_pseudo_element)(
-                        host.callbacks.builder,
-                        state as *mut TreeBuilderState as *mut c_void,
+                if facts.layout_node_is_list_item_box {
+                    create_pseudo_element(
+                        host,
+                        state,
                         dom_node,
-                        FfiPseudoElement::After,
-                        FfiInsertionMode::Append,
+                        FfiPseudoElement::Marker,
+                        Some(FfiInsertionMode::Prepend),
                     );
                 }
+                create_pseudo_element(
+                    host,
+                    state,
+                    dom_node,
+                    FfiPseudoElement::After,
+                    Some(FfiInsertionMode::Append),
+                );
                 assert!(state.ancestor_stack.pop().is_some());
 
                 if facts.layout_node_is_block_container && facts.has_first_letter_style {
@@ -1307,16 +1292,13 @@ fn update_principal_node_after_entry(
         if placement.create_backdrop {
             // A backdrop is a sibling of its originating top-layer element. Append it normally, but insert it before
             // an old box that will be replaced in place so the backdrop remains behind the element.
-            // SAFETY: The builder and DOM element remain live throughout pseudo-element construction.
-            let backdrop = unsafe {
-                (host.callbacks.create_principal_backdrop)(
-                    host.callbacks.builder,
-                    frame,
-                    update.state as *mut TreeBuilderState as *mut c_void,
-                    dom_node,
-                    !placement.may_replace_existing_layout_node,
-                )
+            let insertion_mode = if placement.may_replace_existing_layout_node {
+                None
+            } else {
+                Some(FfiInsertionMode::Append)
             };
+            let backdrop =
+                create_pseudo_element(host, update.state, dom_node, FfiPseudoElement::Backdrop, insertion_mode);
             if placement.may_replace_existing_layout_node && !backdrop.is_null() {
                 // SAFETY: The frame retains the attached old layout node and `backdrop` is owned by the element.
                 unsafe {
@@ -1335,9 +1317,26 @@ fn update_principal_node_after_entry(
         } else {
             update.state.current_parent()
         };
-        unsafe {
-            (host.callbacks.place_principal_layout)(host.callbacks.builder, frame, current_parent, placement.placement);
-        };
+        if placement.placement == FfiPrincipalBoxPlacement::NormalInsertion {
+            let layout_node = unsafe { (host.callbacks.principal_layout_node)(frame) };
+            let layout_host = host.layout();
+            insert_node_into_inline_or_block_ancestor(
+                &layout_host,
+                current_parent,
+                layout_node,
+                layout_host.is_inline_outside(layout_node),
+                FfiInsertionMode::Append,
+            );
+        } else {
+            unsafe {
+                (host.callbacks.place_principal_layout)(
+                    host.callbacks.builder,
+                    frame,
+                    current_parent,
+                    placement.placement,
+                );
+            };
+        }
         // SAFETY: The callback table, DOM node, layout node, and context remain live throughout the call.
         unsafe {
             update_principal_node_descendants(
@@ -1526,6 +1525,8 @@ pub struct FfiResolvedPseudoContentFacts {
 #[repr(C)]
 pub struct FfiPseudoTreeBuilderCallbacks {
     pub builder: *mut c_void,
+    pub push_frame: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub pop_frame: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub initialize: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement) -> FfiPseudoElementFacts,
     pub create_layout_node:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement, FfiPseudoElementDecision),
@@ -1536,12 +1537,10 @@ pub struct FfiPseudoTreeBuilderCallbacks {
     pub layout_node_is_list_item: unsafe extern "C" fn(*mut c_void) -> bool,
     pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub configure_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32),
-    pub insert_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void, FfiPseudoElement),
     pub resolve_content:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32) -> FfiResolvedPseudoContentFacts,
     pub create_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, usize) -> *mut c_void,
-    pub insert_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
 }
 
 fn pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
@@ -1614,102 +1613,117 @@ fn pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDeci
     })
 }
 
-/// Creates a generated pseudo-element layout subtree when its style and content require one.
-///
-/// # Safety
-///
-/// The callback table, frame storage, and originating element must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_create_pseudo_element(
-    callbacks: *const FfiPseudoTreeBuilderCallbacks,
-    frame: *mut c_void,
-    state: *mut c_void,
+fn create_pseudo_element(
+    host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
-    has_insertion_mode: bool,
-    insertion_mode: FfiInsertionMode,
+    insertion_mode: Option<FfiInsertionMode>,
 ) -> *mut c_void {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!frame.is_null());
-        assert!(!state.is_null());
-        assert!(!element.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let callbacks = unsafe { &*callbacks };
-        // SAFETY: The caller passes the state for the active Rust layout-tree build.
-        let state = unsafe { &mut *state.cast::<TreeBuilderState>() };
-        // SAFETY: The frame and element remain live throughout initialization.
-        let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
-        let decision = pseudo_element_decision(facts);
-        if decision == FfiPseudoElementDecision::None {
-            return std::ptr::null_mut();
-        }
+    assert!(!element.is_null());
+    let callbacks = &host.callbacks.pseudo;
+    // SAFETY: The builder owns frame storage that remains live throughout the build.
+    let frame = unsafe { (callbacks.push_frame)(callbacks.builder) };
+    assert!(!frame.is_null());
+    let layout_node = create_pseudo_element_with_frame(host, state, frame, element, pseudo_element, insertion_mode);
+    // SAFETY: `frame` is the most recently pushed pseudo-element frame and Rust no longer uses it.
+    unsafe { (callbacks.pop_frame)(callbacks.builder, frame) };
+    layout_node
+}
 
-        // SAFETY: The builder, frame, and element remain live throughout construction.
-        unsafe {
-            (callbacks.create_layout_node)(callbacks.builder, frame, element, pseudo_element, decision);
-        }
-        // SAFETY: The frame remains live throughout the call.
-        let layout_node = unsafe { (callbacks.layout_node)(frame) };
-        if layout_node.is_null() || decision == FfiPseudoElementDecision::NormalMarker {
-            return layout_node;
-        }
+fn create_pseudo_element_with_frame(
+    host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
+    frame: *mut c_void,
+    element: *mut c_void,
+    pseudo_element: FfiPseudoElement,
+    insertion_mode: Option<FfiInsertionMode>,
+) -> *mut c_void {
+    let callbacks = &host.callbacks.pseudo;
+    // SAFETY: The frame and element remain live throughout initialization.
+    let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
+    let decision = pseudo_element_decision(facts);
+    if decision == FfiPseudoElementDecision::None {
+        return std::ptr::null_mut();
+    }
 
-        // SAFETY: The frame owns a live pseudo-element layout node.
-        unsafe { (callbacks.attach_style_resources)(frame) };
-        if decision == FfiPseudoElementDecision::ContentReplacement {
-            // SAFETY: The frame owns the live replacement node and its display.
-            let layout_facts = unsafe { (callbacks.layout_facts)(frame) };
-            let adjustment = adjusted_table_display_for_replaced_element(
-                layout_facts.display.display_is_table_inside,
-                layout_facts.display.display_is_block_outside,
-                layout_facts.display.display_is_internal_table,
-                layout_facts.display.display_is_table_caption,
+    // SAFETY: The builder, frame, and element remain live throughout construction.
+    unsafe {
+        (callbacks.create_layout_node)(callbacks.builder, frame, element, pseudo_element, decision);
+    }
+    // SAFETY: The frame remains live throughout the call.
+    let layout_node = unsafe { (callbacks.layout_node)(frame) };
+    if layout_node.is_null() || decision == FfiPseudoElementDecision::NormalMarker {
+        return layout_node;
+    }
+
+    // SAFETY: The frame owns a live pseudo-element layout node.
+    unsafe { (callbacks.attach_style_resources)(frame) };
+    if decision == FfiPseudoElementDecision::ContentReplacement {
+        // SAFETY: The frame owns the live replacement node and its display.
+        let layout_facts = unsafe { (callbacks.layout_facts)(frame) };
+        let adjustment = adjusted_table_display_for_replaced_element(
+            layout_facts.display.display_is_table_inside,
+            layout_facts.display.display_is_block_outside,
+            layout_facts.display.display_is_internal_table,
+            layout_facts.display.display_is_table_caption,
+        );
+        if adjustment != FfiReplacedElementDisplayAdjustment::None {
+            // SAFETY: The frame owns a live NodeWithStyle.
+            unsafe { (callbacks.apply_replaced_display_adjustment)(frame, adjustment) };
+        }
+    }
+
+    // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker.
+    // SAFETY: The frame owns a live pseudo-element layout node.
+    if unsafe { (callbacks.layout_node_is_list_item)(frame) } {
+        // SAFETY: The builder, frame, and element remain live throughout marker creation.
+        unsafe { (callbacks.create_nested_list_marker)(callbacks.builder, frame, element) };
+        // FIXME: Support counters on element::pseudo::marker.
+    }
+
+    let initial_quote_nesting_level = state.quote_nesting_level;
+    // SAFETY: The frame and element remain live throughout configuration.
+    unsafe { (callbacks.configure_layout_node)(frame, element, pseudo_element, initial_quote_nesting_level) };
+    if let Some(insertion_mode) = insertion_mode {
+        let layout_host = host.layout();
+        insert_node_into_inline_or_block_ancestor(
+            &layout_host,
+            state.current_parent(),
+            layout_node,
+            layout_host.is_inline_outside(layout_node),
+            insertion_mode,
+        );
+    }
+    // SAFETY: The element remains live and its pseudo-element layout node is attached when requested.
+    unsafe { (callbacks.resolve_counters)(element, pseudo_element) };
+
+    // Resolve content after insertion because counter() and counters() items read the counters established by this
+    // pseudo-element's box.
+    // SAFETY: The frame and element remain live throughout content resolution.
+    let resolved_content =
+        unsafe { (callbacks.resolve_content)(frame, element, pseudo_element, initial_quote_nesting_level) };
+    state.quote_nesting_level = resolved_content.final_quote_nesting_level;
+
+    if resolved_content.content_is_list && decision != FfiPseudoElementDecision::ContentReplacement {
+        state.ancestor_stack.push(layout_node);
+        for index in 0..resolved_content.content_item_count {
+            // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
+            let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
+            assert!(!content_item.is_null());
+            let layout_host = host.layout();
+            insert_node_into_inline_or_block_ancestor(
+                &layout_host,
+                state.current_parent(),
+                content_item,
+                layout_host.is_inline_outside(content_item),
+                FfiInsertionMode::Append,
             );
-            if adjustment != FfiReplacedElementDisplayAdjustment::None {
-                // SAFETY: The frame owns a live NodeWithStyle.
-                unsafe { (callbacks.apply_replaced_display_adjustment)(frame, adjustment) };
-            }
         }
+        assert!(state.ancestor_stack.pop().is_some());
+    }
 
-        // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker.
-        // SAFETY: The frame owns a live pseudo-element layout node.
-        if unsafe { (callbacks.layout_node_is_list_item)(frame) } {
-            // SAFETY: The builder, frame, and element remain live throughout marker creation.
-            unsafe { (callbacks.create_nested_list_marker)(callbacks.builder, frame, element) };
-            // FIXME: Support counters on element::pseudo::marker.
-        }
-
-        let initial_quote_nesting_level = state.quote_nesting_level;
-        unsafe {
-            (callbacks.configure_layout_node)(frame, element, pseudo_element, initial_quote_nesting_level);
-            if has_insertion_mode {
-                (callbacks.insert_layout_node)(callbacks.builder, frame, state.current_parent(), insertion_mode);
-            }
-            (callbacks.resolve_counters)(element, pseudo_element);
-        }
-
-        // Resolve content after insertion because counter() and counters() items read the counters established by this
-        // pseudo-element's box.
-        // SAFETY: The frame and element remain live throughout content resolution.
-        let resolved_content =
-            unsafe { (callbacks.resolve_content)(frame, element, pseudo_element, initial_quote_nesting_level) };
-        state.quote_nesting_level = resolved_content.final_quote_nesting_level;
-
-        if resolved_content.content_is_list && decision != FfiPseudoElementDecision::ContentReplacement {
-            state.ancestor_stack.push(layout_node);
-            for index in 0..resolved_content.content_item_count {
-                // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
-                let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
-                assert!(!content_item.is_null());
-                // SAFETY: The builder and generated content item remain live throughout insertion.
-                unsafe { (callbacks.insert_content_item)(callbacks.builder, content_item, state.current_parent()) };
-            }
-            assert!(state.ancestor_stack.pop().is_some());
-        }
-
-        layout_node
-    })
+    layout_node
 }
 
 fn adjusted_table_display_for_replaced_element(
@@ -1853,6 +1867,7 @@ pub enum FfiInsertionMode {
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
     pub layout_node_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiLayoutNodeFacts,
+    pub is_inline_outside: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub parent: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub first_child: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub next_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
@@ -1898,6 +1913,12 @@ impl TreeBuilderHost<'_> {
         assert!(!node.is_null());
         // SAFETY: The entry point's callback contract guarantees that every node passed to a callback is live.
         unsafe { (self.callbacks.layout_node_facts)(self.callbacks.context, node) }
+    }
+
+    fn is_inline_outside(&self, node: LayoutNode) -> bool {
+        assert!(!node.is_null());
+        // SAFETY: The entry point's callback contract guarantees that `node` is live.
+        unsafe { (self.callbacks.is_inline_outside)(self.callbacks.context, node) }
     }
 
     fn parent(&self, node: LayoutNode) -> LayoutNode {
@@ -2170,54 +2191,41 @@ fn insertion_parent_for_block_node(
     new_parent
 }
 
-/// Inserts a layout node while maintaining the inline/block child invariant.
-///
-/// # Safety
-///
-/// `callbacks`, `nearest_insertion_ancestor`, and `node` must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_insert_node_into_inline_or_block_ancestor(
-    callbacks: *const FfiTreeBuilderCallbacks,
+fn insert_node_into_inline_or_block_ancestor(
+    host: &TreeBuilderHost<'_>,
     nearest_insertion_ancestor: *mut c_void,
     node: *mut c_void,
     is_inline_outside: bool,
     mode: FfiInsertionMode,
 ) {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        assert!(!nearest_insertion_ancestor.is_null());
-        assert!(!node.is_null());
-        // SAFETY: The caller guarantees that `callbacks` remains valid for the duration of this call.
-        let host = TreeBuilderHost {
-            callbacks: unsafe { &*callbacks },
-        };
+    assert!(!nearest_insertion_ancestor.is_null());
+    assert!(!node.is_null());
 
-        let insertion_point = if is_inline_outside {
-            insertion_parent_for_inline_node(&host, nearest_insertion_ancestor)
-        } else {
-            insertion_parent_for_block_node(&host, nearest_insertion_ancestor, node, mode)
-        };
+    let insertion_point = if is_inline_outside {
+        insertion_parent_for_inline_node(host, nearest_insertion_ancestor)
+    } else {
+        insertion_parent_for_block_node(host, nearest_insertion_ancestor, node, mode)
+    };
 
-        // Insertion parents can be above the subtree being rebuilt in place: inline ancestors are
-        // skipped, and out-of-flow boxes can join a trailing anonymous sibling.
-        // SAFETY: `insertion_point` is live for the duration of this call.
-        unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, insertion_point) };
-        // SAFETY: The callback retains `node` while inserting it into the live insertion point.
-        unsafe { (host.callbacks.insert_child)(host.callbacks.context, insertion_point, node, mode) };
+    // Insertion parents can be above the subtree being rebuilt in place: inline ancestors are
+    // skipped, and out-of-flow boxes can join a trailing anonymous sibling.
+    // SAFETY: `insertion_point` is live for the duration of this call.
+    unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, insertion_point) };
+    // SAFETY: The callback retains `node` while inserting it into the live insertion point.
+    unsafe { (host.callbacks.insert_child)(host.callbacks.context, insertion_point, node, mode) };
 
-        if is_inline_outside {
-            // After inserting an inline-level box into a parent, mark the parent as having inline children.
+    if is_inline_outside {
+        // After inserting an inline-level box into a parent, mark the parent as having inline children.
+        // SAFETY: `insertion_point` remains live and attached.
+        unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, true) };
+    } else if host.facts(node).is_in_flow {
+        let insertion_point_facts = host.facts(insertion_point);
+        // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
+        if !insertion_point_facts.is_inline || !insertion_point_facts.display_is_flow_inside {
             // SAFETY: `insertion_point` remains live and attached.
-            unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, true) };
-        } else if host.facts(node).is_in_flow {
-            let insertion_point_facts = host.facts(insertion_point);
-            // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
-            if !insertion_point_facts.is_inline || !insertion_point_facts.display_is_flow_inside {
-                // SAFETY: `insertion_point` remains live and attached.
-                unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, false) };
-            }
+            unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, false) };
         }
-    });
+    }
 }
 
 struct FirstLetterTextHost<'a> {

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -1981,8 +1981,10 @@ pub struct FfiTreeBuilderCallbacks {
     pub set_children_are_inline: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub note_tree_restructuring: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub find_first_letter_in_text: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiFirstLetterTarget,
-    pub wrap_button_contents: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub wrap_fieldset_contents: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub create_button_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub rendered_legend: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub create_fieldset_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub move_nodes_to_parent: unsafe extern "C" fn(*mut c_void, *mut c_void, *const *mut c_void, usize),
 }
 
 type LayoutNode = *mut c_void;
@@ -2579,8 +2581,32 @@ pub unsafe extern "C" fn rust_wrap_button_contents_if_needed(
         // box with the following behaviors:
         let facts = host.facts(layout_node);
         if !facts.display_is_grid_inside && !facts.display_is_flex_inside {
-            // SAFETY: `layout_node` remains live and the callback performs the ownership-sensitive wrapper mutation.
-            unsafe { (host.callbacks.wrap_button_contents)(host.callbacks.context, layout_node) };
+            let mut children = Vec::new();
+            let mut child = host.first_child(layout_node);
+            while !child.is_null() {
+                children.push(child);
+                child = host.next_sibling(child);
+            }
+
+            // SAFETY: `layout_node` remains live and owns the returned content wrapper through its flex wrapper.
+            let content_wrapper =
+                unsafe { (host.callbacks.create_button_content_wrapper)(host.callbacks.context, layout_node) };
+            assert!(!content_wrapper.is_null());
+            // SAFETY: The parent and content wrapper remain live, and the callback retains all nodes while moving them.
+            unsafe {
+                (host.callbacks.set_children_are_inline)(
+                    host.callbacks.context,
+                    content_wrapper,
+                    facts.children_are_inline,
+                );
+                (host.callbacks.move_nodes_to_parent)(
+                    host.callbacks.context,
+                    content_wrapper,
+                    children.as_ptr(),
+                    children.len(),
+                );
+                (host.callbacks.set_children_are_inline)(host.callbacks.context, layout_node, false);
+            }
         }
     });
 }
@@ -2610,7 +2636,31 @@ pub unsafe extern "C" fn rust_wrap_fieldset_contents_if_needed(
         let facts = host.facts(layout_node);
         if facts.is_field_set_box && facts.has_rendered_legend {
             // SAFETY: `layout_node` is a live FieldSetBox with a rendered legend.
-            unsafe { (host.callbacks.wrap_fieldset_contents)(host.callbacks.context, layout_node) };
+            let legend = unsafe { (host.callbacks.rendered_legend)(host.callbacks.context, layout_node) };
+            assert!(!legend.is_null());
+
+            let mut children = Vec::new();
+            let mut child = host.first_child(layout_node);
+            while !child.is_null() {
+                if child != legend {
+                    children.push(child);
+                }
+                child = host.next_sibling(child);
+            }
+
+            // SAFETY: The fieldset remains live and owns the returned wrapper.
+            let wrapper =
+                unsafe { (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, layout_node) };
+            assert!(!wrapper.is_null());
+            // SAFETY: The wrapper remains attached and the callback retains all nodes while moving them.
+            unsafe {
+                (host.callbacks.move_nodes_to_parent)(
+                    host.callbacks.context,
+                    wrapper,
+                    children.as_ptr(),
+                    children.len(),
+                );
+            }
         }
     });
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -140,6 +140,37 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub layout_node_dom_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub set_context_layout_svg_mask_or_clip_path: unsafe extern "C" fn(*mut c_void, bool),
     pub set_context_layout_svg_pattern: unsafe extern "C" fn(*mut c_void, bool),
+    pub principal_node_entry_facts:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> FfiPrincipalNodeEntryFacts,
+    pub request_top_layer_zone_rebuild: unsafe extern "C" fn(*mut c_void),
+    pub push_style_ancestor: unsafe extern "C" fn(*mut c_void),
+    pub pop_style_ancestor: unsafe extern "C" fn(*mut c_void),
+    pub initialize_principal_frame: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub prepare_principal_element:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> FfiPrincipalDisplayFacts,
+    pub create_principal_element_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void),
+    pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
+    pub principal_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiPrincipalLayoutFacts,
+    pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
+    pub principal_placement_facts: unsafe extern "C" fn(
+        *mut c_void,
+        *mut c_void,
+        *mut c_void,
+        *mut c_void,
+        bool,
+        bool,
+    ) -> FfiPrincipalBoxPlacementFacts,
+    pub start_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub restore_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub mark_update_escaped_rebuild_roots: unsafe extern "C" fn(*mut c_void),
+    pub create_principal_backdrop: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool),
+    pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
+    pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub set_context_has_svg_root: unsafe extern "C" fn(*mut c_void, bool),
 }
 
 #[derive(Clone, Copy)]
@@ -191,12 +222,31 @@ pub struct FfiPrincipalNodeEntryFacts {
     pub is_document: bool,
     pub has_layout_node: bool,
     pub is_element: bool,
+    pub is_text: bool,
     pub rendered_in_top_layer: bool,
     pub context_layout_top_layer: bool,
     pub layout_node_is_attached: bool,
     pub is_svg_container: bool,
     pub requires_svg_container: bool,
     pub context_has_svg_root: bool,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalDisplayFacts {
+    pub display_is_none: bool,
+    pub display_is_contents: bool,
+    pub display_is_table_inside: bool,
+    pub display_is_block_outside: bool,
+    pub display_is_internal_table: bool,
+    pub display_is_table_caption: bool,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalLayoutFacts {
+    pub is_replaced_element: bool,
+    pub display: FfiPrincipalDisplayFacts,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -987,6 +1037,257 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
 
         // SAFETY: `dom_node` remains live throughout the call.
         unsafe { (host.callbacks.clear_dom_update_flags)(dom_node) };
+    });
+}
+
+struct PrincipalNodeUpdate<'host, 'callbacks> {
+    host: &'host DomTreeBuilderHost<'callbacks>,
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    frame: *mut c_void,
+    dom_node: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+}
+
+fn construct_principal_layout_node(
+    update: &PrincipalNodeUpdate<'_, '_>,
+    entry_facts: FfiPrincipalNodeEntryFacts,
+    should_create_layout_node: bool,
+) -> (bool, bool) {
+    let host = update.host;
+    let frame = update.frame;
+    let dom_node = update.dom_node;
+    let context = update.context;
+    if entry_facts.is_element {
+        // SAFETY: The frame, builder, and DOM element remain live throughout the call.
+        let display = unsafe {
+            (host.callbacks.prepare_principal_element)(
+                host.callbacks.builder,
+                frame,
+                dom_node,
+                should_create_layout_node,
+            )
+        };
+        let generation = rust_principal_box_generation_decision(
+            true,
+            should_create_layout_node && display.display_is_none,
+            display.display_is_contents,
+        );
+        if generation == FfiPrincipalBoxGenerationDecision::Suppress {
+            return (false, false);
+        }
+        if generation == FfiPrincipalBoxGenerationDecision::DisplayContents {
+            // SAFETY: The callback table, DOM element, and context remain valid throughout the recursive walk.
+            unsafe {
+                rust_update_layout_tree_for_display_contents(
+                    update.callbacks,
+                    dom_node,
+                    context,
+                    update.must_create_subtree,
+                    should_create_layout_node,
+                );
+            }
+            return (false, true);
+        }
+        if should_create_layout_node {
+            // SAFETY: The builder, frame, element, and context remain live throughout construction.
+            unsafe {
+                (host.callbacks.create_principal_element_layout)(host.callbacks.builder, frame, dom_node, context);
+            }
+        } else {
+            // SAFETY: The frame and DOM node remain live throughout the call.
+            unsafe { (host.callbacks.reuse_principal_layout)(frame, dom_node) };
+        }
+    } else if should_create_layout_node {
+        if entry_facts.is_document {
+            // SAFETY: The frame and DOM document remain live throughout construction.
+            unsafe { (host.callbacks.create_principal_document_layout)(frame, dom_node) };
+        } else if entry_facts.is_text {
+            // SAFETY: The frame and DOM text node remain live throughout construction.
+            unsafe { (host.callbacks.create_principal_text_layout)(frame, dom_node) };
+        }
+    } else {
+        // SAFETY: The frame and DOM node remain live throughout the call.
+        unsafe { (host.callbacks.reuse_principal_layout)(frame, dom_node) };
+    }
+
+    // SAFETY: The frame remains live throughout the call.
+    (
+        !unsafe { (host.callbacks.principal_layout_node)(frame) }.is_null(),
+        false,
+    )
+}
+
+fn update_principal_node_after_entry(
+    update: &PrincipalNodeUpdate<'_, '_>,
+    entry_facts: FfiPrincipalNodeEntryFacts,
+    entry_decision: FfiPrincipalNodeEntryDecision,
+) {
+    let host = update.host;
+    let frame = update.frame;
+    let dom_node = update.dom_node;
+    let context = update.context;
+    // SAFETY: The frame and DOM node remain live throughout this update.
+    unsafe { (host.callbacks.initialize_principal_frame)(frame, dom_node) };
+
+    if entry_decision.svg == FfiSvgEntryDecision::EnterSvgRoot {
+        // SAFETY: The traversal context remains live throughout this update.
+        unsafe { (host.callbacks.set_context_has_svg_root)(context, true) };
+    }
+
+    let (has_layout_node, handled_display_contents) = if entry_decision.svg == FfiSvgEntryDecision::Skip {
+        (false, false)
+    } else {
+        construct_principal_layout_node(update, entry_facts, entry_decision.should_create_layout_node)
+    };
+
+    if has_layout_node {
+        if entry_facts.is_element || entry_facts.is_document {
+            // SAFETY: The frame owns a live NodeWithStyle for elements and documents.
+            unsafe { (host.callbacks.attach_principal_style_resources)(frame) };
+        }
+
+        // SAFETY: The frame owns the live principal layout node and its display.
+        let layout_facts = unsafe { (host.callbacks.principal_layout_facts)(frame) };
+        if layout_facts.is_replaced_element {
+            let adjustment = rust_adjusted_table_display_for_replaced_element(
+                layout_facts.display.display_is_table_inside,
+                layout_facts.display.display_is_block_outside,
+                layout_facts.display.display_is_internal_table,
+                layout_facts.display.display_is_table_caption,
+            );
+            if adjustment != FfiReplacedElementDisplayAdjustment::None {
+                // SAFETY: The frame owns a live NodeWithStyle.
+                unsafe { (host.callbacks.apply_replaced_display_adjustment)(frame, adjustment) };
+            }
+        }
+
+        // SAFETY: All pointers remain live and the frame owns both old and new layout nodes.
+        let placement_facts = unsafe {
+            (host.callbacks.principal_placement_facts)(
+                host.callbacks.builder,
+                frame,
+                dom_node,
+                context,
+                update.must_create_subtree,
+                entry_decision.should_create_layout_node,
+            )
+        };
+        let placement = rust_principal_box_placement_decision(placement_facts);
+
+        let mut prior_rebuild_root = std::ptr::null_mut();
+        if placement.start_rebuild_root {
+            // SAFETY: The builder and frame remain live throughout descendant construction.
+            prior_rebuild_root =
+                unsafe { (host.callbacks.start_principal_rebuild_root)(host.callbacks.builder, frame) };
+        } else if placement.mark_update_escaped_rebuild_roots {
+            // SAFETY: The builder remains live throughout the call.
+            unsafe { (host.callbacks.mark_update_escaped_rebuild_roots)(host.callbacks.builder) };
+        }
+
+        if placement.create_backdrop {
+            // SAFETY: The builder, frame, and DOM element remain live throughout creation.
+            unsafe {
+                (host.callbacks.create_principal_backdrop)(
+                    host.callbacks.builder,
+                    frame,
+                    dom_node,
+                    placement.may_replace_existing_layout_node,
+                );
+            }
+        }
+
+        if placement.clear_layout_top_layer_for_descendants {
+            // SAFETY: The traversal context remains live throughout descendant construction.
+            unsafe { (host.callbacks.set_context_layout_top_layer)(context, false) };
+        }
+
+        // SAFETY: The builder and frame remain live, and Rust selected the placement mode.
+        unsafe { (host.callbacks.place_principal_layout)(host.callbacks.builder, frame, placement.placement) };
+        // SAFETY: The callback table, DOM node, layout node, and context remain live throughout the call.
+        unsafe {
+            rust_update_principal_node_descendants(
+                update.callbacks,
+                dom_node,
+                (host.callbacks.principal_layout_node)(frame),
+                context,
+                entry_decision.should_create_layout_node,
+                update.must_create_subtree,
+            );
+        }
+
+        if placement.clear_layout_top_layer_for_descendants {
+            // SAFETY: Restore the context value captured in the placement facts.
+            unsafe { (host.callbacks.set_context_layout_top_layer)(context, placement_facts.context_layout_top_layer) };
+        }
+        if placement.start_rebuild_root {
+            // SAFETY: Restore the builder's previous rebuild root after descendant construction.
+            unsafe { (host.callbacks.restore_principal_rebuild_root)(host.callbacks.builder, prior_rebuild_root) };
+        }
+    } else if !handled_display_contents {
+        // If no layout node was created, remove every stale layout and paint node from the shadow-including subtree.
+        // SAFETY: The builder and DOM node remain live throughout cleanup.
+        unsafe { (host.callbacks.clear_stale_inclusive_subtree)(host.callbacks.builder, dom_node) };
+    }
+
+    if entry_decision.svg == FfiSvgEntryDecision::EnterSvgRoot {
+        // SAFETY: Restore the traversal context's entry value.
+        unsafe { (host.callbacks.set_context_has_svg_root)(context, entry_facts.context_has_svg_root) };
+    }
+}
+
+/// Updates one DOM node and its layout-tree subtree.
+///
+/// # Safety
+///
+/// The callback table, frame storage, DOM node, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_layout_tree(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    frame: *mut c_void,
+    dom_node: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!frame.is_null());
+        assert!(!dom_node.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        // SAFETY: The builder, DOM node, and context remain live throughout the call.
+        let entry_facts = unsafe {
+            (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, dom_node, context, must_create_subtree)
+        };
+        let entry_decision = rust_principal_node_entry_decision(entry_facts);
+        if entry_decision.top_layer != FfiTopLayerEntryDecision::Continue {
+            if entry_decision.top_layer == FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild {
+                // A member found here without an attached box was cleared together with a hidden ancestor subtree, and
+                // nothing is scheduled to rebuild it. Request another top-layer zone pass instead of stranding dirty
+                // flags below ancestors whose walks already finished.
+                // SAFETY: `dom_node` remains live throughout the call.
+                unsafe { (host.callbacks.request_top_layer_zone_rebuild)(dom_node) };
+            }
+            return;
+        }
+
+        if entry_facts.is_element {
+            // SAFETY: `dom_node` is a live Element when this fact is set.
+            unsafe { (host.callbacks.push_style_ancestor)(dom_node) };
+        }
+        let update = PrincipalNodeUpdate {
+            host: &host,
+            callbacks,
+            frame,
+            dom_node,
+            context,
+            must_create_subtree,
+        };
+        update_principal_node_after_entry(&update, entry_facts, entry_decision);
+        if entry_facts.is_element {
+            // SAFETY: Balances the style ancestor push above.
+            unsafe { (host.callbacks.pop_style_ancestor)(dom_node) };
+        }
     });
 }
 
@@ -2575,6 +2876,7 @@ mod tests {
             is_document: false,
             has_layout_node: true,
             is_element: true,
+            is_text: false,
             rendered_in_top_layer: false,
             context_layout_top_layer: false,
             layout_node_is_attached: true,

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -128,7 +128,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub copy_top_layer_elements: unsafe extern "C" fn(*mut c_void, *mut *mut c_void, usize),
     pub rendered_in_top_layer: unsafe extern "C" fn(*mut c_void) -> bool,
-    pub has_unrendered_flat_tree_ancestor: unsafe extern "C" fn(*mut c_void) -> bool,
+    pub flat_tree_parent: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub flat_tree_render_facts: unsafe extern "C" fn(*mut c_void) -> FfiFlatTreeRenderFacts,
     pub clear_stale_top_layer_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub quote_nesting_level: unsafe extern "C" fn(*mut c_void) -> u32,
     pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
@@ -170,7 +171,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub start_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub restore_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub mark_update_escaped_rebuild_roots: unsafe extern "C" fn(*mut c_void),
-    pub create_principal_backdrop: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool),
+    pub create_principal_backdrop: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> *mut c_void,
+    pub insert_principal_backdrop_before_old: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub set_context_has_svg_root: unsafe extern "C" fn(*mut c_void, bool),
@@ -195,6 +197,14 @@ pub struct FfiDisplayContentsFacts {
 
 #[derive(Clone, Copy)]
 #[repr(C)]
+pub struct FfiFlatTreeRenderFacts {
+    pub is_element: bool,
+    pub has_computed_style: bool,
+    pub display_is_none: bool,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
 pub struct FfiPrincipalDescendantFacts {
     pub is_element: bool,
     pub context_layout_top_layer: bool,
@@ -205,6 +215,7 @@ pub struct FfiPrincipalDescendantFacts {
     pub layout_node_is_replaced_box_with_children: bool,
     pub layout_node_is_list_item_box: bool,
     pub layout_node_is_block_container: bool,
+    pub has_first_letter_style: bool,
     pub is_svg_switch_element: bool,
     pub is_document: bool,
     pub has_style_containment: bool,
@@ -344,6 +355,156 @@ pub extern "C" fn rust_principal_box_generation_decision(
     })
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_display_contents_text_needs_style_wrapper(
+    has_style_parent: bool,
+    parent_display_is_contents: bool,
+    text_is_ascii_whitespace: bool,
+    parent_collapses_whitespace: bool,
+) -> bool {
+    abort_on_panic(|| {
+        has_style_parent && parent_display_is_contents && (!text_is_ascii_whitespace || !parent_collapses_whitespace)
+    })
+}
+
+#[repr(C)]
+pub struct FfiStaleNodeCallbacks {
+    pub layout_parent: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub layout_dom_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub dom_is_shadow_including_inclusive_descendant: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
+}
+
+/// Returns whether an SVG resource layout node must survive cleanup of a DOM subtree.
+///
+/// # Safety
+///
+/// The callback table, layout node, and optional cleared subtree root must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
+    callbacks: *const FfiStaleNodeCallbacks,
+    layout_node: *mut c_void,
+    cleared_subtree_root: *mut c_void,
+) -> bool {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!layout_node.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let callbacks = unsafe { &*callbacks };
+        if cleared_subtree_root.is_null() {
+            return true;
+        }
+
+        // SAFETY: The layout node remains live throughout the ancestor walk.
+        let mut ancestor = unsafe { (callbacks.layout_parent)(layout_node) };
+        while !ancestor.is_null() {
+            // SAFETY: `ancestor` is a live layout node.
+            let dom_node = unsafe { (callbacks.layout_dom_node)(ancestor) };
+            // SAFETY: Both DOM pointers remain live throughout cleanup.
+            if !dom_node.is_null()
+                && unsafe { (callbacks.dom_is_shadow_including_inclusive_descendant)(dom_node, cleared_subtree_root) }
+            {
+                return false;
+            }
+            // SAFETY: `ancestor` remains live throughout the walk.
+            ancestor = unsafe { (callbacks.layout_parent)(ancestor) };
+        }
+        true
+    })
+}
+
+#[repr(C)]
+pub struct FfiTopLayerDetachCallbacks {
+    pub element_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub topmost_placement_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void),
+    pub layout_parent: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub remove_layout_node: unsafe extern "C" fn(*mut c_void),
+    pub clear_element_subtree: unsafe extern "C" fn(*mut c_void),
+    pub slot_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub clear_assigned_slottables: unsafe extern "C" fn(*mut c_void),
+}
+
+/// Detaches a top-layer element's layout placement and clears every stale projected subtree.
+///
+/// # Safety
+///
+/// The callback table and element must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
+    callbacks: *const FfiTopLayerDetachCallbacks,
+    element: *mut c_void,
+) {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!element.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let callbacks = unsafe { &*callbacks };
+        // SAFETY: The element remains live throughout the call.
+        let element_layout_node = unsafe { (callbacks.element_layout_node)(element) };
+        if !element_layout_node.is_null() {
+            // Take along any anonymous table-fixup wrapper around the box. Leaving an empty table wrapper as a
+            // viewport child would violate layout invariants.
+            // SAFETY: The element layout node remains live throughout detachment.
+            let topmost = unsafe { (callbacks.topmost_placement_node)(element_layout_node) };
+            let layout_node_to_detach = if topmost.is_null() {
+                element_layout_node
+            } else {
+                topmost
+            };
+            // SAFETY: The chosen layout subtree remains live throughout detachment.
+            unsafe {
+                (callbacks.prepare_subtree_for_detach)(layout_node_to_detach);
+                if !(callbacks.layout_parent)(layout_node_to_detach).is_null() {
+                    (callbacks.remove_layout_node)(layout_node_to_detach);
+                }
+            }
+        }
+
+        // SAFETY: The element remains live throughout subtree cleanup.
+        unsafe { (callbacks.clear_element_subtree)(element) };
+        // SAFETY: The callback returns the element's adjusted HTMLSlotElement pointer, if any.
+        let slot_element = unsafe { (callbacks.slot_element)(element) };
+        if !slot_element.is_null() {
+            // SAFETY: The slot element remains live throughout assigned-node cleanup.
+            unsafe { (callbacks.clear_assigned_slottables)(slot_element) };
+        }
+    });
+}
+
+#[repr(C)]
+pub struct FfiAssignedCleanupCallbacks {
+    pub assigned_node_count: unsafe extern "C" fn(*mut c_void) -> usize,
+    pub assigned_node_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
+    pub clear_assigned_subtree: unsafe extern "C" fn(*mut c_void),
+}
+
+/// Clears stale layout state for every flat-tree child assigned to a slot.
+///
+/// # Safety
+///
+/// The callback table and slot element must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_clear_stale_assigned_slottables(
+    callbacks: *const FfiAssignedCleanupCallbacks,
+    slot_element: *mut c_void,
+) {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!slot_element.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let callbacks = unsafe { &*callbacks };
+        // SAFETY: The slot and assigned-node list remain live throughout cleanup.
+        let count = unsafe { (callbacks.assigned_node_count)(slot_element) };
+        for index in 0..count {
+            // SAFETY: `index` is below the stable assigned-node count.
+            let root = unsafe { (callbacks.assigned_node_at)(slot_element, index) };
+            assert!(!root.is_null());
+            // SAFETY: The assigned subtree root remains live throughout cleanup.
+            unsafe { (callbacks.clear_assigned_subtree)(root) };
+        }
+    });
+}
+
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiPrincipalBoxPlacementFacts {
@@ -478,6 +639,22 @@ impl DomTreeBuilderHost<'_> {
             (self.callbacks.update_layout_tree)(self.callbacks.builder, node, context, must_create_subtree);
         }
     }
+}
+
+fn has_unrendered_flat_tree_ancestor(host: &DomTreeBuilderHost<'_>, element: *mut c_void) -> bool {
+    // SAFETY: `element` and every returned flat-tree ancestor remain live throughout layout-tree construction.
+    let mut ancestor = unsafe { (host.callbacks.flat_tree_parent)(element) };
+    while !ancestor.is_null() {
+        // SAFETY: `ancestor` is a live DOM node.
+        let facts = unsafe { (host.callbacks.flat_tree_render_facts)(ancestor) };
+        // Null style means the style update pass skipped a display:none subtree.
+        if facts.is_element && (!facts.has_computed_style || facts.display_is_none) {
+            return true;
+        }
+        // SAFETY: `ancestor` remains live throughout the walk.
+        ancestor = unsafe { (host.callbacks.flat_tree_parent)(ancestor) };
+    }
+    false
 }
 
 unsafe fn dom_tree_builder_host<'a>(callbacks: *const FfiDomTreeBuilderCallbacks) -> DomTreeBuilderHost<'a> {
@@ -957,7 +1134,7 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                         continue;
                     }
                     // SAFETY: `element` is a live DOM Element.
-                    if unsafe { (host.callbacks.has_unrendered_flat_tree_ancestor)(element) } {
+                    if has_unrendered_flat_tree_ancestor(&host, element) {
                         // SAFETY: The builder and element remain live throughout cleanup.
                         unsafe {
                             (host.callbacks.clear_stale_top_layer_subtree)(host.callbacks.builder, element);
@@ -1055,7 +1232,7 @@ pub unsafe extern "C" fn rust_update_principal_node_descendants(
                     (host.callbacks.pop_layout_parent)(host.callbacks.builder);
                 }
 
-                if facts.layout_node_is_block_container {
+                if facts.layout_node_is_block_container && facts.has_first_letter_style {
                     // SAFETY: `dom_node` is an Element and `layout_node` is a BlockContainer when these facts are set.
                     unsafe {
                         (host.callbacks.create_first_letter_wrapper)(host.callbacks.builder, dom_node, layout_node);
@@ -1247,14 +1424,22 @@ fn update_principal_node_after_entry(
         }
 
         if placement.create_backdrop {
-            // SAFETY: The builder, frame, and DOM element remain live throughout creation.
-            unsafe {
+            // A backdrop is a sibling of its originating top-layer element. Append it normally, but insert it before
+            // an old box that will be replaced in place so the backdrop remains behind the element.
+            // SAFETY: The builder and DOM element remain live throughout pseudo-element construction.
+            let backdrop = unsafe {
                 (host.callbacks.create_principal_backdrop)(
                     host.callbacks.builder,
                     frame,
                     dom_node,
-                    placement.may_replace_existing_layout_node,
-                );
+                    !placement.may_replace_existing_layout_node,
+                )
+            };
+            if placement.may_replace_existing_layout_node && !backdrop.is_null() {
+                // SAFETY: The frame retains the attached old layout node and `backdrop` is owned by the element.
+                unsafe {
+                    (host.callbacks.insert_principal_backdrop_before_old)(host.callbacks.builder, frame, backdrop);
+                }
             }
         }
 
@@ -2914,8 +3099,9 @@ mod tests {
         FfiPrincipalBoxPlacementFacts, FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision,
         FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment, FfiSvgEntryDecision, FfiTopLayerEntryDecision,
         FirstLetterTextHost, element_layout_kind, find_first_letter_in_text,
-        rust_adjusted_table_display_for_replaced_element, rust_principal_box_generation_decision,
-        rust_principal_box_placement_decision, rust_principal_node_entry_decision, rust_pseudo_element_decision,
+        rust_adjusted_table_display_for_replaced_element, rust_display_contents_text_needs_style_wrapper,
+        rust_principal_box_generation_decision, rust_principal_box_placement_decision,
+        rust_principal_node_entry_decision, rust_pseudo_element_decision,
     };
     use std::ffi::c_void;
 
@@ -3216,5 +3402,15 @@ mod tests {
         let decision = rust_principal_box_placement_decision(facts);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::AppendSvg);
         assert!(decision.mark_update_escaped_rebuild_roots);
+    }
+
+    #[test]
+    fn display_contents_text_style_wrapper_decisions() {
+        assert!(!rust_display_contents_text_needs_style_wrapper(
+            false, true, false, false
+        ));
+        assert!(rust_display_contents_text_needs_style_wrapper(true, true, false, true));
+        assert!(!rust_display_contents_text_needs_style_wrapper(true, true, true, true));
+        assert!(rust_display_contents_text_needs_style_wrapper(true, true, true, false));
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -172,6 +172,108 @@ pub struct FfiPrincipalNodeEntryDecision {
     pub svg: FfiSvgEntryDecision,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiPrincipalBoxGenerationDecision {
+    Suppress,
+    DisplayContents,
+    PrincipalBox,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_principal_box_generation_decision(
+    is_element: bool,
+    display_is_none: bool,
+    display_is_contents: bool,
+) -> FfiPrincipalBoxGenerationDecision {
+    abort_on_panic(|| {
+        if is_element && display_is_none {
+            FfiPrincipalBoxGenerationDecision::Suppress
+        } else if is_element && display_is_contents {
+            FfiPrincipalBoxGenerationDecision::DisplayContents
+        } else {
+            FfiPrincipalBoxGenerationDecision::PrincipalBox
+        }
+    })
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalBoxPlacementFacts {
+    pub must_create_subtree: bool,
+    pub should_create_layout_node: bool,
+    pub has_old_layout_node: bool,
+    pub old_layout_node_is_attached: bool,
+    pub old_and_new_layout_nodes_are_same: bool,
+    pub has_current_rebuild_root: bool,
+    pub is_document: bool,
+    pub is_element: bool,
+    pub rendered_in_top_layer: bool,
+    pub context_layout_top_layer: bool,
+    pub layout_node_is_svg_box: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiPrincipalBoxPlacement {
+    None,
+    DocumentRoot,
+    ReplaceExisting,
+    AppendSvg,
+    NormalInsertion,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalBoxPlacementDecision {
+    pub placement: FfiPrincipalBoxPlacement,
+    pub may_replace_existing_layout_node: bool,
+    pub start_rebuild_root: bool,
+    pub mark_update_escaped_rebuild_roots: bool,
+    pub create_backdrop: bool,
+    pub clear_layout_top_layer_for_descendants: bool,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_principal_box_placement_decision(
+    facts: FfiPrincipalBoxPlacementFacts,
+) -> FfiPrincipalBoxPlacementDecision {
+    abort_on_panic(|| {
+        let may_replace_existing_layout_node = !facts.must_create_subtree
+            && facts.has_old_layout_node
+            && facts.old_layout_node_is_attached
+            && !facts.old_and_new_layout_nodes_are_same;
+        let start_rebuild_root = may_replace_existing_layout_node && !facts.has_current_rebuild_root;
+        let mark_update_escaped_rebuild_roots = facts.should_create_layout_node
+            && !facts.has_old_layout_node
+            && !facts.has_current_rebuild_root
+            && !facts.is_document;
+
+        let placement = if facts.is_document {
+            FfiPrincipalBoxPlacement::DocumentRoot
+        } else if !facts.should_create_layout_node {
+            FfiPrincipalBoxPlacement::None
+        } else if may_replace_existing_layout_node {
+            FfiPrincipalBoxPlacement::ReplaceExisting
+        } else if facts.layout_node_is_svg_box {
+            FfiPrincipalBoxPlacement::AppendSvg
+        } else {
+            FfiPrincipalBoxPlacement::NormalInsertion
+        };
+
+        let is_active_top_layer_member =
+            facts.is_element && facts.rendered_in_top_layer && facts.context_layout_top_layer;
+        FfiPrincipalBoxPlacementDecision {
+            placement,
+            may_replace_existing_layout_node,
+            start_rebuild_root,
+            mark_update_escaped_rebuild_roots,
+            create_backdrop: facts.should_create_layout_node && is_active_top_layer_member,
+            clear_layout_top_layer_for_descendants: is_active_top_layer_member,
+        }
+    })
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_principal_node_entry_decision(
     facts: FfiPrincipalNodeEntryFacts,
@@ -1870,11 +1972,13 @@ pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallb
 #[cfg(test)]
 mod tests {
     use super::{
-        FfiComputedContentType, FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks, FfiPrincipalNodeEntryFacts,
-        FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment,
-        FfiSvgEntryDecision, FfiTopLayerEntryDecision, FirstLetterTextHost, find_first_letter_in_text,
-        rust_adjusted_table_display_for_replaced_element, rust_principal_node_entry_decision,
-        rust_pseudo_element_decision,
+        FfiComputedContentType, FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks,
+        FfiPrincipalBoxGenerationDecision, FfiPrincipalBoxPlacement, FfiPrincipalBoxPlacementFacts,
+        FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts,
+        FfiReplacedElementDisplayAdjustment, FfiSvgEntryDecision, FfiTopLayerEntryDecision, FirstLetterTextHost,
+        find_first_letter_in_text, rust_adjusted_table_display_for_replaced_element,
+        rust_principal_box_generation_decision, rust_principal_box_placement_decision,
+        rust_principal_node_entry_decision, rust_pseudo_element_decision,
     };
     use std::ffi::c_void;
 
@@ -2105,5 +2209,47 @@ mod tests {
         let decision = rust_principal_node_entry_decision(facts);
         assert!(decision.should_create_layout_node);
         assert_eq!(decision.svg, FfiSvgEntryDecision::EnterSvgRoot);
+    }
+
+    #[test]
+    fn principal_box_generation_and_placement_decisions() {
+        assert_eq!(
+            rust_principal_box_generation_decision(true, true, false),
+            FfiPrincipalBoxGenerationDecision::Suppress
+        );
+        assert_eq!(
+            rust_principal_box_generation_decision(true, false, true),
+            FfiPrincipalBoxGenerationDecision::DisplayContents
+        );
+        assert_eq!(
+            rust_principal_box_generation_decision(false, false, false),
+            FfiPrincipalBoxGenerationDecision::PrincipalBox
+        );
+
+        let mut facts = FfiPrincipalBoxPlacementFacts {
+            must_create_subtree: false,
+            should_create_layout_node: true,
+            has_old_layout_node: true,
+            old_layout_node_is_attached: true,
+            old_and_new_layout_nodes_are_same: false,
+            has_current_rebuild_root: false,
+            is_document: false,
+            is_element: true,
+            rendered_in_top_layer: true,
+            context_layout_top_layer: true,
+            layout_node_is_svg_box: false,
+        };
+        let decision = rust_principal_box_placement_decision(facts);
+        assert_eq!(decision.placement, FfiPrincipalBoxPlacement::ReplaceExisting);
+        assert!(decision.start_rebuild_root);
+        assert!(decision.create_backdrop);
+        assert!(decision.clear_layout_top_layer_for_descendants);
+
+        facts.has_old_layout_node = false;
+        facts.old_layout_node_is_attached = false;
+        facts.layout_node_is_svg_box = true;
+        let decision = rust_principal_box_placement_decision(facts);
+        assert_eq!(decision.placement, FfiPrincipalBoxPlacement::AppendSvg);
+        assert!(decision.mark_update_escaped_rebuild_roots);
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -7,6 +7,7 @@
 use crate::abort_on_panic;
 use std::ffi::c_void;
 
+#[derive(Default)]
 struct TreeBuilderState {
     ancestor_stack: Vec<LayoutNode>,
     quote_nesting_level: u32,
@@ -20,89 +21,13 @@ struct TreeBuilderContext {
     layout_svg_pattern: bool,
 }
 
-/// Creates the Rust-owned state for one layout tree builder.
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_state_create() -> *mut c_void {
-    abort_on_panic(|| {
-        Box::into_raw(Box::new(TreeBuilderState {
-            ancestor_stack: Vec::new(),
-            quote_nesting_level: 0,
-        }))
-        .cast()
-    })
-}
-
-/// Destroys state returned by `rust_tree_builder_state_create`.
-///
-/// # Safety
-///
-/// `state` must have been returned by `rust_tree_builder_state_create` and must not have been destroyed already.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_tree_builder_state_destroy(state: *mut c_void) {
-    abort_on_panic(|| {
-        assert!(!state.is_null());
-        // SAFETY: Guaranteed by the entry point's contract and checked for null above.
-        drop(unsafe { Box::from_raw(state.cast::<TreeBuilderState>()) });
-    });
-}
-
-fn tree_builder_state(state: *mut c_void) -> &'static TreeBuilderState {
-    assert!(!state.is_null());
-    // SAFETY: Every caller passes live state created by `rust_tree_builder_state_create`.
-    unsafe { &*state.cast::<TreeBuilderState>() }
-}
-
-fn tree_builder_state_mut(state: *mut c_void) -> &'static mut TreeBuilderState {
-    assert!(!state.is_null());
-    // SAFETY: FFI calls are serialized by the owning C++ TreeBuilder.
-    unsafe { &mut *state.cast::<TreeBuilderState>() }
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_push_parent(state: *mut c_void, parent: *mut c_void) {
-    abort_on_panic(|| {
-        assert!(!parent.is_null());
-        tree_builder_state_mut(state).ancestor_stack.push(parent);
-    });
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_pop_parent(state: *mut c_void) {
-    abort_on_panic(|| {
-        assert!(tree_builder_state_mut(state).ancestor_stack.pop().is_some());
-    });
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_ancestor_count(state: *mut c_void) -> usize {
-    abort_on_panic(|| tree_builder_state(state).ancestor_stack.len())
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_ancestor_at(state: *mut c_void, index: usize) -> *mut c_void {
-    abort_on_panic(|| tree_builder_state(state).ancestor_stack[index])
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_current_parent(state: *mut c_void) -> *mut c_void {
-    abort_on_panic(|| {
-        *tree_builder_state(state)
+impl TreeBuilderState {
+    fn current_parent(&self) -> LayoutNode {
+        *self
             .ancestor_stack
             .last()
             .expect("layout tree builder must have an insertion ancestor")
-    })
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_quote_nesting_level(state: *mut c_void) -> u32 {
-    abort_on_panic(|| tree_builder_state(state).quote_nesting_level)
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn rust_tree_builder_set_quote_nesting_level(state: *mut c_void, quote_nesting_level: u32) {
-    abort_on_panic(|| {
-        tree_builder_state_mut(state).quote_nesting_level = quote_nesting_level;
-    });
+    }
 }
 
 #[repr(C)]
@@ -120,7 +45,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_synthetic_pseudo_element_layout_nodes: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub clear_stale_inclusive_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void),
-    pub create_pseudo_element: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, FfiInsertionMode),
+    pub create_pseudo_element:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement, FfiInsertionMode),
     pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
@@ -128,22 +54,16 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub wrap_fieldset_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub wrap_button_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub clear_stale_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub push_layout_parent: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub pop_layout_parent: unsafe extern "C" fn(*mut c_void),
-    pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void,
     pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub copy_top_layer_elements: unsafe extern "C" fn(*mut c_void, *mut *mut c_void, usize),
     pub rendered_in_top_layer: unsafe extern "C" fn(*mut c_void) -> bool,
     pub flat_tree_parent: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub flat_tree_render_facts: unsafe extern "C" fn(*mut c_void) -> FfiFlatTreeRenderFacts,
     pub clear_stale_top_layer_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub quote_nesting_level: unsafe extern "C" fn(*mut c_void) -> u32,
-    pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
     pub clear_dom_update_flags: unsafe extern "C" fn(*mut c_void),
     pub svg_pattern_content_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub register_svg_resource_reference: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub ancestor_count: unsafe extern "C" fn(*mut c_void) -> usize,
-    pub ancestor_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
     pub layout_node_dom_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub principal_node_entry_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> FfiPrincipalNodeEntryFacts,
     pub request_top_layer_zone_rebuild: unsafe extern "C" fn(*mut c_void),
@@ -168,9 +88,10 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub start_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub restore_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub mark_update_escaped_rebuild_roots: unsafe extern "C" fn(*mut c_void),
-    pub create_principal_backdrop: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> *mut c_void,
+    pub create_principal_backdrop:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, bool) -> *mut c_void,
     pub insert_principal_backdrop_before_old: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
-    pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
+    pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub reset_style_ancestor_filter: unsafe extern "C" fn(*mut c_void),
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
@@ -649,6 +570,7 @@ unsafe fn dom_tree_builder_host<'a>(callbacks: *const FfiDomTreeBuilderCallbacks
 /// The callback table, parent, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_dom_children(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     parent: *mut c_void,
     context: &mut TreeBuilderContext,
     must_create_subtree: bool,
@@ -657,7 +579,7 @@ unsafe fn update_layout_tree_for_dom_children(
         assert!(!parent.is_null());
         let mut node = host.first_child(parent);
         while !node.is_null() {
-            update_layout_tree(host, node, context, must_create_subtree);
+            update_layout_tree(host, state, node, context, must_create_subtree);
             node = host.next_sibling(node);
         }
     });
@@ -670,6 +592,7 @@ unsafe fn update_layout_tree_for_dom_children(
 /// The callback table, shadow root, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_shadow_root_children(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     shadow_root: *mut c_void,
     context: &mut TreeBuilderContext,
     must_create_subtree: bool,
@@ -678,7 +601,7 @@ unsafe fn update_layout_tree_for_shadow_root_children(
         assert!(!shadow_root.is_null());
         let mut node = host.first_child(shadow_root);
         while !node.is_null() {
-            update_layout_tree(host, node, context, must_create_subtree);
+            update_layout_tree(host, state, node, context, must_create_subtree);
             node = host.next_sibling(node);
         }
         // SAFETY: `shadow_root` remains live throughout the call.
@@ -693,6 +616,7 @@ unsafe fn update_layout_tree_for_shadow_root_children(
 /// The callback table, slot element, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_assigned_slottables(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     slot_element: *mut c_void,
     context: &mut TreeBuilderContext,
     must_create_subtree: bool,
@@ -708,7 +632,7 @@ unsafe fn update_layout_tree_for_assigned_slottables(
             // SAFETY: `index` is below the count reported for this unchanged assigned-node list.
             let node = unsafe { (host.callbacks.assigned_node_at)(slot_element, index) };
             assert!(!node.is_null());
-            update_layout_tree(host, node, context, must_create_subtree);
+            update_layout_tree(host, state, node, context, must_create_subtree);
         }
     });
 }
@@ -720,6 +644,7 @@ unsafe fn update_layout_tree_for_assigned_slottables(
 /// The callback table, switch element, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_svg_switch_children(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     switch_element: *mut c_void,
     context: &mut TreeBuilderContext,
     must_create_subtree: bool,
@@ -757,7 +682,7 @@ unsafe fn update_layout_tree_for_svg_switch_children(
         }
 
         if !rendered_child.is_null() {
-            update_layout_tree(host, rendered_child, context, must_create_subtree);
+            update_layout_tree(host, state, rendered_child, context, must_create_subtree);
         }
     });
 }
@@ -769,6 +694,7 @@ unsafe fn update_layout_tree_for_svg_switch_children(
 /// The callback table, element, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_display_contents(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     element: *mut c_void,
     context: &mut TreeBuilderContext,
     must_create_subtree: bool,
@@ -804,6 +730,7 @@ unsafe fn update_layout_tree_for_display_contents(
             unsafe {
                 (host.callbacks.create_pseudo_element)(
                     host.callbacks.builder,
+                    state as *mut TreeBuilderState as *mut c_void,
                     element,
                     FfiPseudoElement::Before,
                     FfiInsertionMode::Append,
@@ -816,13 +743,25 @@ unsafe fn update_layout_tree_for_display_contents(
             if !facts.shadow_root.is_null() {
                 // SAFETY: The callback table, shadow root, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_shadow_root_children(host, facts.shadow_root, context, must_create_children);
+                    update_layout_tree_for_shadow_root_children(
+                        host,
+                        state,
+                        facts.shadow_root,
+                        context,
+                        must_create_children,
+                    );
                 }
             } else if facts.should_layout_dom_children {
                 assert!(!facts.dom_children_parent.is_null());
                 // SAFETY: The callback table, parent, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_dom_children(host, facts.dom_children_parent, context, must_create_children);
+                    update_layout_tree_for_dom_children(
+                        host,
+                        state,
+                        facts.dom_children_parent,
+                        context,
+                        must_create_children,
+                    );
                 }
             }
         }
@@ -831,7 +770,13 @@ unsafe fn update_layout_tree_for_display_contents(
             if !facts.content_visibility_hidden {
                 // SAFETY: The callback table, slot element, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_assigned_slottables(host, facts.slot_element, context, must_create_subtree);
+                    update_layout_tree_for_assigned_slottables(
+                        host,
+                        state,
+                        facts.slot_element,
+                        context,
+                        must_create_subtree,
+                    );
                 }
             } else {
                 // SAFETY: `slot_element` remains live throughout this call.
@@ -844,6 +789,7 @@ unsafe fn update_layout_tree_for_display_contents(
             unsafe {
                 (host.callbacks.create_pseudo_element)(
                     host.callbacks.builder,
+                    state as *mut TreeBuilderState as *mut c_void,
                     element,
                     FfiPseudoElement::After,
                     FfiInsertionMode::Append,
@@ -861,12 +807,12 @@ unsafe fn update_layout_tree_for_display_contents(
     });
 }
 
-fn ancestor_stack_contains_dom_node(host: &DomTreeBuilderHost<'_>, dom_node: *mut c_void) -> bool {
-    // SAFETY: The builder and its ancestor stack remain live throughout tree construction.
-    let count = unsafe { (host.callbacks.ancestor_count)(host.callbacks.builder) };
-    for index in 0..count {
-        // SAFETY: `index` is below the stable ancestor count and the returned layout node is live.
-        let ancestor = unsafe { (host.callbacks.ancestor_at)(host.callbacks.builder, index) };
+fn ancestor_stack_contains_dom_node(
+    host: &DomTreeBuilderHost<'_>,
+    state: &TreeBuilderState,
+    dom_node: *mut c_void,
+) -> bool {
+    for &ancestor in &state.ancestor_stack {
         assert!(!ancestor.is_null());
         // SAFETY: `ancestor` is a live layout node.
         if unsafe { (host.callbacks.layout_node_dom_node)(ancestor) } == dom_node {
@@ -878,6 +824,7 @@ fn ancestor_stack_contains_dom_node(host: &DomTreeBuilderHost<'_>, dom_node: *mu
 
 fn update_svg_resource(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     resource: *mut c_void,
     graphics_element: *mut c_void,
     layout_node: *mut c_void,
@@ -885,37 +832,35 @@ fn update_svg_resource(
     prior_context_value: bool,
 ) {
     context.layout_svg_mask_or_clip_path = true;
-    // SAFETY: The layout node remains live throughout resource construction.
-    unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
+    state.ancestor_stack.push(layout_node);
 
-    if !ancestor_stack_contains_dom_node(host, resource) {
-        update_layout_tree(host, resource, context, true);
+    if !ancestor_stack_contains_dom_node(host, state, resource) {
+        update_layout_tree(host, state, resource, context, true);
         // SAFETY: Both pointers denote live SVG elements held by the graphics element.
         unsafe { (host.callbacks.register_svg_resource_reference)(resource, graphics_element) };
     } else {
         // FIXME: Somehow either remove ancestor from the layout tree or mark it as invalid.
     }
 
-    // SAFETY: Balance the parent push.
-    unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+    assert!(state.ancestor_stack.pop().is_some());
     context.layout_svg_mask_or_clip_path = prior_context_value;
 }
 
 fn update_svg_pattern(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     pattern: *mut c_void,
     content_element: *mut c_void,
     graphics_element: *mut c_void,
     layout_node: *mut c_void,
     context: &mut TreeBuilderContext,
-    prior_context_value: bool,
 ) {
+    let prior_context_value = context.layout_svg_pattern;
     context.layout_svg_pattern = true;
-    // SAFETY: The layout node remains live throughout resource construction.
-    unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
+    state.ancestor_stack.push(layout_node);
 
-    if !ancestor_stack_contains_dom_node(host, content_element) {
-        update_layout_tree(host, content_element, context, true);
+    if !ancestor_stack_contains_dom_node(host, state, content_element) {
+        update_layout_tree(host, state, content_element, context, true);
         // The referenced pattern may inherit its content from another pattern via href. Removing either element
         // invalidates the attached resource box, so register the referencer with both.
         // SAFETY: All pointers denote live SVG elements held by the graphics element or pattern chain.
@@ -927,8 +872,7 @@ fn update_svg_pattern(
         }
     }
 
-    // SAFETY: Balance the parent push.
-    unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+    assert!(state.ancestor_stack.pop().is_some());
     context.layout_svg_pattern = prior_context_value;
 }
 
@@ -939,6 +883,7 @@ fn update_svg_pattern(
 /// The callback table, DOM node, layout node, and context must remain valid for the duration of the call.
 unsafe fn update_principal_node_descendants(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     dom_node: *mut c_void,
     layout_node: *mut c_void,
     context: &mut TreeBuilderContext,
@@ -951,8 +896,7 @@ unsafe fn update_principal_node_descendants(
         // SAFETY: All pointers remain live throughout the call.
         let facts =
             unsafe { (host.callbacks.principal_descendant_facts)(host.callbacks.builder, dom_node, layout_node) };
-        // SAFETY: The builder remains live throughout the call.
-        let prior_quote_nesting_level = unsafe { (host.callbacks.quote_nesting_level)(host.callbacks.builder) };
+        let prior_quote_nesting_level = state.quote_nesting_level;
 
         if should_create_layout_node {
             // Resolve counters now that we exist in the layout tree.
@@ -963,17 +907,18 @@ unsafe fn update_principal_node_descendants(
 
             // Add the ::before pseudo-element before walking normal children.
             if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
-                // SAFETY: The builder, element, and layout node remain live throughout pseudo-element creation.
+                state.ancestor_stack.push(layout_node);
+                // SAFETY: The builder, state, element, and layout node remain live throughout pseudo-element creation.
                 unsafe {
-                    (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
                     (host.callbacks.create_pseudo_element)(
                         host.callbacks.builder,
+                        state as *mut TreeBuilderState as *mut c_void,
                         dom_node,
                         FfiPseudoElement::Before,
                         FfiInsertionMode::Prepend,
                     );
-                    (host.callbacks.pop_layout_parent)(host.callbacks.builder);
                 }
+                assert!(state.ancestor_stack.pop().is_some());
             }
         }
 
@@ -989,8 +934,7 @@ unsafe fn update_principal_node_descendants(
             && facts.layout_node_can_have_children
             && !facts.content_visibility_hidden
         {
-            // SAFETY: `layout_node` remains live throughout descendant construction.
-            unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
+            state.ancestor_stack.push(layout_node);
 
             if !facts.shadow_root.is_null() {
                 if facts.layout_node_is_replaced_box_with_children {
@@ -998,24 +942,27 @@ unsafe fn update_principal_node_descendants(
                     // anonymous BlockContainer so that a BFC handles their layout.
                     // SAFETY: The callback returns the live first-child wrapper.
                     let wrapper = unsafe {
-                        (host.callbacks.ensure_replaced_children_wrapper)(host.callbacks.builder, layout_node)
+                        (host.callbacks.ensure_replaced_children_wrapper)(
+                            host.callbacks.builder,
+                            layout_node,
+                            state.current_parent(),
+                        )
                     };
                     assert!(!wrapper.is_null());
-                    // SAFETY: `wrapper` remains live and attached throughout the recursive call.
-                    unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, wrapper) };
+                    state.ancestor_stack.push(wrapper);
                 }
                 // SAFETY: The callback table, shadow root, and context remain valid.
                 unsafe {
                     update_layout_tree_for_shadow_root_children(
                         host,
+                        state,
                         facts.shadow_root,
                         context,
                         should_create_layout_node,
                     );
                 }
                 if facts.layout_node_is_replaced_box_with_children {
-                    // SAFETY: Balances the wrapper push above.
-                    unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+                    assert!(state.ancestor_stack.pop().is_some());
                 }
             } else if facts.should_layout_dom_children {
                 assert!(!facts.dom_children_parent.is_null());
@@ -1024,6 +971,7 @@ unsafe fn update_principal_node_descendants(
                     unsafe {
                         update_layout_tree_for_svg_switch_children(
                             host,
+                            state,
                             facts.dom_children_parent,
                             context,
                             should_create_layout_node,
@@ -1034,6 +982,7 @@ unsafe fn update_principal_node_descendants(
                     unsafe {
                         update_layout_tree_for_dom_children(
                             host,
+                            state,
                             facts.dom_children_parent,
                             context,
                             should_create_layout_node,
@@ -1068,25 +1017,28 @@ unsafe fn update_principal_node_descendants(
                         }
                         continue;
                     }
-                    update_layout_tree(host, element, context, should_create_layout_node);
+                    update_layout_tree(host, state, element, context, should_create_layout_node);
                 }
                 context.layout_top_layer = prior_layout_top_layer;
             }
 
-            // SAFETY: Balances the principal layout-node push above.
-            unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+            assert!(state.ancestor_stack.pop().is_some());
         }
 
         if !facts.slot_element.is_null() {
             if !facts.content_visibility_hidden {
-                // SAFETY: `layout_node` remains live throughout assigned-node construction.
-                unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
+                state.ancestor_stack.push(layout_node);
                 // SAFETY: The callback table, slot element, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_assigned_slottables(host, facts.slot_element, context, must_create_subtree);
+                    update_layout_tree_for_assigned_slottables(
+                        host,
+                        state,
+                        facts.slot_element,
+                        context,
+                        must_create_subtree,
+                    );
                 }
-                // SAFETY: Balances the assigned-node parent push above.
-                unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+                assert!(state.ancestor_stack.pop().is_some());
             } else {
                 // SAFETY: `slot_element` remains live throughout cleanup.
                 unsafe { (host.callbacks.clear_stale_assigned_slottables)(facts.slot_element) };
@@ -1099,6 +1051,7 @@ unsafe fn update_principal_node_descendants(
                     if !resource.is_null() {
                         update_svg_resource(
                             host,
+                            state,
                             resource,
                             facts.svg_graphics_element,
                             layout_node,
@@ -1121,24 +1074,25 @@ unsafe fn update_principal_node_descendants(
                     seen_content_elements.push(content_element);
                     update_svg_pattern(
                         host,
+                        state,
                         pattern,
                         content_element,
                         facts.svg_graphics_element,
                         layout_node,
                         context,
-                        context.layout_svg_pattern,
                     );
                 }
             }
 
             // Add ::marker and ::after once normal and SVG resource children are complete.
             if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
-                // SAFETY: The builder, element, and layout node remain live throughout pseudo-element creation.
+                state.ancestor_stack.push(layout_node);
+                // SAFETY: The builder, state, element, and layout node remain live throughout pseudo-element creation.
                 unsafe {
-                    (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
                     if facts.layout_node_is_list_item_box {
                         (host.callbacks.create_pseudo_element)(
                             host.callbacks.builder,
+                            state as *mut TreeBuilderState as *mut c_void,
                             dom_node,
                             FfiPseudoElement::Marker,
                             FfiInsertionMode::Prepend,
@@ -1146,12 +1100,13 @@ unsafe fn update_principal_node_descendants(
                     }
                     (host.callbacks.create_pseudo_element)(
                         host.callbacks.builder,
+                        state as *mut TreeBuilderState as *mut c_void,
                         dom_node,
                         FfiPseudoElement::After,
                         FfiInsertionMode::Append,
                     );
-                    (host.callbacks.pop_layout_parent)(host.callbacks.builder);
                 }
+                assert!(state.ancestor_stack.pop().is_some());
 
                 if facts.layout_node_is_block_container && facts.has_first_letter_style {
                     // SAFETY: `dom_node` is an Element and `layout_node` is a BlockContainer when these facts are set.
@@ -1173,10 +1128,7 @@ unsafe fn update_principal_node_descendants(
         // 2. The effects of the 'content' property’s 'open-quote', 'close-quote', 'no-open-quote' and 'no-close-quote'
         //    must be scoped to the element’s sub-tree.
         if facts.has_style_containment {
-            // SAFETY: The builder remains live throughout the call.
-            unsafe {
-                (host.callbacks.set_quote_nesting_level)(host.callbacks.builder, prior_quote_nesting_level);
-            }
+            state.quote_nesting_level = prior_quote_nesting_level;
         }
 
         // SAFETY: `dom_node` remains live throughout the call.
@@ -1184,8 +1136,9 @@ unsafe fn update_principal_node_descendants(
     });
 }
 
-struct PrincipalNodeUpdate<'host, 'callbacks, 'context> {
+struct PrincipalNodeUpdate<'host, 'callbacks, 'state, 'context> {
     host: &'host DomTreeBuilderHost<'callbacks>,
+    state: &'state mut TreeBuilderState,
     frame: *mut c_void,
     dom_node: *mut c_void,
     context: &'context mut TreeBuilderContext,
@@ -1193,7 +1146,7 @@ struct PrincipalNodeUpdate<'host, 'callbacks, 'context> {
 }
 
 fn construct_principal_layout_node(
-    update: &mut PrincipalNodeUpdate<'_, '_, '_>,
+    update: &mut PrincipalNodeUpdate<'_, '_, '_, '_>,
     entry_facts: FfiPrincipalNodeEntryFacts,
     should_create_layout_node: bool,
 ) -> (bool, bool) {
@@ -1225,6 +1178,7 @@ fn construct_principal_layout_node(
             unsafe {
                 update_layout_tree_for_display_contents(
                     host,
+                    update.state,
                     dom_node,
                     context,
                     must_create_subtree,
@@ -1280,7 +1234,7 @@ fn construct_principal_layout_node(
 }
 
 fn update_principal_node_after_entry(
-    update: &mut PrincipalNodeUpdate<'_, '_, '_>,
+    update: &mut PrincipalNodeUpdate<'_, '_, '_, '_>,
     entry_facts: FfiPrincipalNodeEntryFacts,
     entry_decision: PrincipalNodeEntryDecision,
 ) {
@@ -1352,6 +1306,7 @@ fn update_principal_node_after_entry(
                 (host.callbacks.create_principal_backdrop)(
                     host.callbacks.builder,
                     frame,
+                    update.state as *mut TreeBuilderState as *mut c_void,
                     dom_node,
                     !placement.may_replace_existing_layout_node,
                 )
@@ -1369,11 +1324,19 @@ fn update_principal_node_after_entry(
         }
 
         // SAFETY: The builder and frame remain live, and Rust selected the placement mode.
-        unsafe { (host.callbacks.place_principal_layout)(host.callbacks.builder, frame, placement.placement) };
+        let current_parent = if update.state.ancestor_stack.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            update.state.current_parent()
+        };
+        unsafe {
+            (host.callbacks.place_principal_layout)(host.callbacks.builder, frame, current_parent, placement.placement);
+        };
         // SAFETY: The callback table, DOM node, layout node, and context remain live throughout the call.
         unsafe {
             update_principal_node_descendants(
                 host,
+                update.state,
                 dom_node,
                 (host.callbacks.principal_layout_node)(frame),
                 context,
@@ -1407,6 +1370,7 @@ fn update_principal_node_after_entry(
 /// The callback table and DOM node must remain valid for the duration of the call.
 fn update_layout_tree(
     host: &DomTreeBuilderHost<'_>,
+    state: &mut TreeBuilderState,
     dom_node: *mut c_void,
     context: &mut TreeBuilderContext,
     must_create_subtree: bool,
@@ -1438,6 +1402,7 @@ fn update_layout_tree(
         assert!(!frame.is_null());
         let mut update = PrincipalNodeUpdate {
             host,
+            state,
             frame,
             dom_node,
             context,
@@ -1467,18 +1432,16 @@ pub unsafe extern "C" fn rust_build_layout_tree(
         assert!(!document.is_null());
         // SAFETY: Guaranteed by the entry point's contract.
         let host = unsafe { dom_tree_builder_host(callbacks) };
+        let mut state = TreeBuilderState::default();
         let mut context = TreeBuilderContext::default();
         // SAFETY: All pointers remain live throughout the build.
         let entry_facts =
             unsafe { (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, document, false) };
         assert!(entry_facts.is_document);
 
-        // SAFETY: The document and builder remain live throughout the build.
-        unsafe {
-            (host.callbacks.reset_style_ancestor_filter)(document);
-            (host.callbacks.set_quote_nesting_level)(host.callbacks.builder, 0);
-        }
-        update_layout_tree(&host, document, &mut context, false);
+        // SAFETY: The document remains live throughout the build.
+        unsafe { (host.callbacks.reset_style_ancestor_filter)(document) };
+        update_layout_tree(&host, &mut state, document, &mut context, false);
 
         // NB: Called during layout tree construction.
         // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
@@ -1568,16 +1531,12 @@ pub struct FfiPseudoTreeBuilderCallbacks {
     pub layout_node_is_list_item: unsafe extern "C" fn(*mut c_void) -> bool,
     pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub configure_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32),
-    pub insert_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiInsertionMode),
+    pub insert_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void, FfiPseudoElement),
     pub resolve_content:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32) -> FfiResolvedPseudoContentFacts,
     pub create_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, usize) -> *mut c_void,
-    pub insert_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub push_layout_parent: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub pop_layout_parent: unsafe extern "C" fn(*mut c_void),
-    pub quote_nesting_level: unsafe extern "C" fn(*mut c_void) -> u32,
-    pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
+    pub insert_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
 }
 
 fn pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
@@ -1659,6 +1618,7 @@ fn pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDeci
 pub unsafe extern "C" fn rust_create_pseudo_element(
     callbacks: *const FfiPseudoTreeBuilderCallbacks,
     frame: *mut c_void,
+    state: *mut c_void,
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     has_insertion_mode: bool,
@@ -1667,9 +1627,12 @@ pub unsafe extern "C" fn rust_create_pseudo_element(
     abort_on_panic(|| {
         assert!(!callbacks.is_null());
         assert!(!frame.is_null());
+        assert!(!state.is_null());
         assert!(!element.is_null());
         // SAFETY: Guaranteed by the entry point's contract.
         let callbacks = unsafe { &*callbacks };
+        // SAFETY: The caller passes the state for the active Rust layout-tree build.
+        let state = unsafe { &mut *state.cast::<TreeBuilderState>() };
         // SAFETY: The frame and element remain live throughout initialization.
         let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
         let decision = pseudo_element_decision(facts);
@@ -1712,12 +1675,11 @@ pub unsafe extern "C" fn rust_create_pseudo_element(
             // FIXME: Support counters on element::pseudo::marker.
         }
 
-        // SAFETY: The builder and frame remain live throughout configuration and insertion.
-        let initial_quote_nesting_level = unsafe { (callbacks.quote_nesting_level)(callbacks.builder) };
+        let initial_quote_nesting_level = state.quote_nesting_level;
         unsafe {
             (callbacks.configure_layout_node)(frame, element, pseudo_element, initial_quote_nesting_level);
             if has_insertion_mode {
-                (callbacks.insert_layout_node)(callbacks.builder, frame, insertion_mode);
+                (callbacks.insert_layout_node)(callbacks.builder, frame, state.current_parent(), insertion_mode);
             }
             (callbacks.resolve_counters)(element, pseudo_element);
         }
@@ -1727,23 +1689,18 @@ pub unsafe extern "C" fn rust_create_pseudo_element(
         // SAFETY: The frame and element remain live throughout content resolution.
         let resolved_content =
             unsafe { (callbacks.resolve_content)(frame, element, pseudo_element, initial_quote_nesting_level) };
-        // SAFETY: The builder remains live throughout the call.
-        unsafe {
-            (callbacks.set_quote_nesting_level)(callbacks.builder, resolved_content.final_quote_nesting_level);
-        }
+        state.quote_nesting_level = resolved_content.final_quote_nesting_level;
 
         if resolved_content.content_is_list && decision != FfiPseudoElementDecision::ContentReplacement {
-            // SAFETY: The pseudo-element node remains live throughout child construction.
-            unsafe { (callbacks.push_layout_parent)(callbacks.builder, layout_node) };
+            state.ancestor_stack.push(layout_node);
             for index in 0..resolved_content.content_item_count {
                 // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
                 let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
                 assert!(!content_item.is_null());
                 // SAFETY: The builder and generated content item remain live throughout insertion.
-                unsafe { (callbacks.insert_content_item)(callbacks.builder, content_item) };
+                unsafe { (callbacks.insert_content_item)(callbacks.builder, content_item, state.current_parent()) };
             }
-            // SAFETY: Balances the pseudo-element parent push above.
-            unsafe { (callbacks.pop_layout_parent)(callbacks.builder) };
+            assert!(state.ancestor_stack.pop().is_some());
         }
 
         layout_node
@@ -3150,21 +3107,19 @@ mod tests {
 
     #[test]
     fn tree_builder_state_tracks_ancestors_and_quotes() {
-        let state = super::rust_tree_builder_state_create();
+        let mut state = super::TreeBuilderState::default();
         let mut parent = 0_u8;
         let parent_pointer = (&raw mut parent).cast::<c_void>();
-        super::rust_tree_builder_push_parent(state, parent_pointer);
-        assert_eq!(super::rust_tree_builder_ancestor_count(state), 1);
-        assert_eq!(super::rust_tree_builder_current_parent(state), parent_pointer);
-        assert_eq!(super::rust_tree_builder_ancestor_at(state, 0), parent_pointer);
+        state.ancestor_stack.push(parent_pointer);
+        assert_eq!(state.ancestor_stack.len(), 1);
+        assert_eq!(state.current_parent(), parent_pointer);
+        assert_eq!(state.ancestor_stack[0], parent_pointer);
 
-        super::rust_tree_builder_set_quote_nesting_level(state, 3);
-        assert_eq!(super::rust_tree_builder_quote_nesting_level(state), 3);
+        state.quote_nesting_level = 3;
+        assert_eq!(state.quote_nesting_level, 3);
 
-        super::rust_tree_builder_pop_parent(state);
-        assert_eq!(super::rust_tree_builder_ancestor_count(state), 0);
-        // SAFETY: `state` was returned by the matching create function and has not been destroyed yet.
-        unsafe { super::rust_tree_builder_state_destroy(state) };
+        assert!(state.ancestor_stack.pop().is_some());
+        assert_eq!(state.ancestor_stack.len(), 0);
     }
 
     #[test]

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -7,6 +7,96 @@
 use crate::abort_on_panic;
 use std::ffi::c_void;
 
+struct TreeBuilderState {
+    ancestor_stack: Vec<LayoutNode>,
+    quote_nesting_level: u32,
+}
+
+/// Creates the Rust-owned state for one layout tree builder.
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_state_create() -> *mut c_void {
+    abort_on_panic(|| {
+        Box::into_raw(Box::new(TreeBuilderState {
+            ancestor_stack: Vec::new(),
+            quote_nesting_level: 0,
+        }))
+        .cast()
+    })
+}
+
+/// Destroys state returned by `rust_tree_builder_state_create`.
+///
+/// # Safety
+///
+/// `state` must have been returned by `rust_tree_builder_state_create` and must not have been destroyed already.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_tree_builder_state_destroy(state: *mut c_void) {
+    abort_on_panic(|| {
+        assert!(!state.is_null());
+        // SAFETY: Guaranteed by the entry point's contract and checked for null above.
+        drop(unsafe { Box::from_raw(state.cast::<TreeBuilderState>()) });
+    });
+}
+
+fn tree_builder_state(state: *mut c_void) -> &'static TreeBuilderState {
+    assert!(!state.is_null());
+    // SAFETY: Every caller passes live state created by `rust_tree_builder_state_create`.
+    unsafe { &*state.cast::<TreeBuilderState>() }
+}
+
+fn tree_builder_state_mut(state: *mut c_void) -> &'static mut TreeBuilderState {
+    assert!(!state.is_null());
+    // SAFETY: FFI calls are serialized by the owning C++ TreeBuilder.
+    unsafe { &mut *state.cast::<TreeBuilderState>() }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_push_parent(state: *mut c_void, parent: *mut c_void) {
+    abort_on_panic(|| {
+        assert!(!parent.is_null());
+        tree_builder_state_mut(state).ancestor_stack.push(parent);
+    });
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_pop_parent(state: *mut c_void) {
+    abort_on_panic(|| {
+        assert!(tree_builder_state_mut(state).ancestor_stack.pop().is_some());
+    });
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_ancestor_count(state: *mut c_void) -> usize {
+    abort_on_panic(|| tree_builder_state(state).ancestor_stack.len())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_ancestor_at(state: *mut c_void, index: usize) -> *mut c_void {
+    abort_on_panic(|| tree_builder_state(state).ancestor_stack[index])
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_current_parent(state: *mut c_void) -> *mut c_void {
+    abort_on_panic(|| {
+        *tree_builder_state(state)
+            .ancestor_stack
+            .last()
+            .expect("layout tree builder must have an insertion ancestor")
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_quote_nesting_level(state: *mut c_void) -> u32 {
+    abort_on_panic(|| tree_builder_state(state).quote_nesting_level)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tree_builder_set_quote_nesting_level(state: *mut c_void, quote_nesting_level: u32) {
+    abort_on_panic(|| {
+        tree_builder_state_mut(state).quote_nesting_level = quote_nesting_level;
+    });
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum FfiReplacedElementDisplayAdjustment {
@@ -1290,5 +1380,24 @@ mod tests {
         assert_eq!((target.letter_start, target.letter_end), (0, 1));
 
         assert!(!first_letter_target("\nHello", true).found);
+    }
+
+    #[test]
+    fn tree_builder_state_tracks_ancestors_and_quotes() {
+        let state = super::rust_tree_builder_state_create();
+        let mut parent = 0_u8;
+        let parent_pointer = (&raw mut parent).cast::<c_void>();
+        super::rust_tree_builder_push_parent(state, parent_pointer);
+        assert_eq!(super::rust_tree_builder_ancestor_count(state), 1);
+        assert_eq!(super::rust_tree_builder_current_parent(state), parent_pointer);
+        assert_eq!(super::rust_tree_builder_ancestor_at(state, 0), parent_pointer);
+
+        super::rust_tree_builder_set_quote_nesting_level(state, 3);
+        assert_eq!(super::rust_tree_builder_quote_nesting_level(state), 3);
+
+        super::rust_tree_builder_pop_parent(state);
+        assert_eq!(super::rust_tree_builder_ancestor_count(state), 0);
+        // SAFETY: `state` was returned by the matching create function and has not been destroyed yet.
+        unsafe { super::rust_tree_builder_state_destroy(state) };
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -116,6 +116,23 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub resolve_counters: unsafe extern "C" fn(*mut c_void),
     pub create_pseudo_element: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, FfiInsertionMode),
     pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
+    pub principal_descendant_facts:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
+    pub update_before_children: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, bool),
+    pub update_after_children: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, bool),
+    pub wrap_button_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+    pub clear_stale_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub push_layout_parent: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub pop_layout_parent: unsafe extern "C" fn(*mut c_void),
+    pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
+    pub copy_top_layer_elements: unsafe extern "C" fn(*mut c_void, *mut *mut c_void, usize),
+    pub rendered_in_top_layer: unsafe extern "C" fn(*mut c_void) -> bool,
+    pub has_unrendered_flat_tree_ancestor: unsafe extern "C" fn(*mut c_void) -> bool,
+    pub clear_stale_top_layer_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub quote_nesting_level: unsafe extern "C" fn(*mut c_void) -> u32,
+    pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
+    pub clear_dom_update_flags: unsafe extern "C" fn(*mut c_void),
 }
 
 #[derive(Clone, Copy)]
@@ -126,6 +143,24 @@ pub struct FfiDisplayContentsFacts {
     pub content_visibility_hidden: bool,
     pub should_layout_dom_children: bool,
     pub child_needs_layout_tree_update: bool,
+    pub dom_children_parent: *mut c_void,
+    pub shadow_root: *mut c_void,
+    pub slot_element: *mut c_void,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiPrincipalDescendantFacts {
+    pub is_element: bool,
+    pub context_layout_top_layer: bool,
+    pub content_visibility_hidden: bool,
+    pub should_layout_dom_children: bool,
+    pub child_needs_layout_tree_update: bool,
+    pub layout_node_can_have_children: bool,
+    pub layout_node_is_replaced_box_with_children: bool,
+    pub is_svg_switch_element: bool,
+    pub is_document: bool,
+    pub has_style_containment: bool,
     pub dom_children_parent: *mut c_void,
     pub shadow_root: *mut c_void,
     pub slot_element: *mut c_void,
@@ -594,6 +629,203 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
             // SAFETY: Restore the live traversal context to its entry value.
             unsafe { (host.callbacks.set_context_layout_top_layer)(context, true) };
         }
+    });
+}
+
+/// Updates the descendants and post-child state of a node with a principal layout box.
+///
+/// # Safety
+///
+/// The callback table, DOM node, layout node, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_principal_node_descendants(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    dom_node: *mut c_void,
+    layout_node: *mut c_void,
+    context: *mut c_void,
+    should_create_layout_node: bool,
+    must_create_subtree: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!dom_node.is_null());
+        assert!(!layout_node.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        // SAFETY: All pointers remain live throughout the call.
+        let facts = unsafe {
+            (host.callbacks.principal_descendant_facts)(host.callbacks.builder, dom_node, layout_node, context)
+        };
+        // SAFETY: The builder remains live throughout the call.
+        let prior_quote_nesting_level = unsafe { (host.callbacks.quote_nesting_level)(host.callbacks.builder) };
+
+        if should_create_layout_node {
+            // Resolve counters now that we exist in the layout tree.
+            if facts.is_element {
+                // SAFETY: `dom_node` is a live Element when this fact is set.
+                unsafe { (host.callbacks.resolve_counters)(dom_node) };
+            }
+            // SAFETY: All pointers remain live throughout the call.
+            unsafe {
+                (host.callbacks.update_before_children)(
+                    host.callbacks.builder,
+                    dom_node,
+                    layout_node,
+                    context,
+                    facts.content_visibility_hidden,
+                );
+            }
+        }
+
+        if facts.content_visibility_hidden {
+            // SAFETY: The builder and DOM node remain live throughout the call.
+            unsafe {
+                (host.callbacks.clear_stale_descendants)(host.callbacks.builder, dom_node);
+            }
+        }
+
+        if (should_create_layout_node || facts.child_needs_layout_tree_update)
+            && (!facts.shadow_root.is_null() || facts.should_layout_dom_children)
+            && facts.layout_node_can_have_children
+            && !facts.content_visibility_hidden
+        {
+            // SAFETY: `layout_node` remains live throughout descendant construction.
+            unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
+
+            if !facts.shadow_root.is_null() {
+                if facts.layout_node_is_replaced_box_with_children {
+                    // For replaced elements with shadow DOM children, wrap the children in an
+                    // anonymous BlockContainer so that a BFC handles their layout.
+                    // SAFETY: The callback returns the live first-child wrapper.
+                    let wrapper = unsafe {
+                        (host.callbacks.ensure_replaced_children_wrapper)(host.callbacks.builder, layout_node)
+                    };
+                    assert!(!wrapper.is_null());
+                    // SAFETY: `wrapper` remains live and attached throughout the recursive call.
+                    unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, wrapper) };
+                }
+                // SAFETY: The callback table, shadow root, and context remain valid.
+                unsafe {
+                    rust_update_layout_tree_for_shadow_root_children(
+                        callbacks,
+                        facts.shadow_root,
+                        context,
+                        should_create_layout_node,
+                    );
+                }
+                if facts.layout_node_is_replaced_box_with_children {
+                    // SAFETY: Balances the wrapper push above.
+                    unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+                }
+            } else if facts.should_layout_dom_children {
+                assert!(!facts.dom_children_parent.is_null());
+                if facts.is_svg_switch_element {
+                    // SAFETY: The callback table, parent, and context remain valid.
+                    unsafe {
+                        rust_update_layout_tree_for_svg_switch_children(
+                            callbacks,
+                            facts.dom_children_parent,
+                            context,
+                            should_create_layout_node,
+                        );
+                    }
+                } else {
+                    // SAFETY: The callback table, parent, and context remain valid.
+                    unsafe {
+                        rust_update_layout_tree_for_dom_children(
+                            callbacks,
+                            facts.dom_children_parent,
+                            context,
+                            should_create_layout_node,
+                        );
+                    }
+                }
+            }
+
+            if facts.is_document {
+                // Elements in the top layer do not lay out normally based on their position in the document; instead
+                // they generate boxes as if they were siblings of the root element.
+                // SAFETY: The traversal context remains live and is restored before this function returns.
+                unsafe { (host.callbacks.set_context_layout_top_layer)(context, true) };
+                // SAFETY: The DOM document remains live and owns a stable top-layer list during this pass.
+                let count = unsafe { (host.callbacks.top_layer_element_count)(dom_node) };
+                let mut top_layer_elements = vec![std::ptr::null_mut(); count];
+                // SAFETY: The output slice has room for the stable top-layer list reported above.
+                unsafe {
+                    (host.callbacks.copy_top_layer_elements)(dom_node, top_layer_elements.as_mut_ptr(), count);
+                }
+                for element in top_layer_elements {
+                    assert!(!element.is_null());
+                    // SAFETY: `element` is a live DOM Element.
+                    if !unsafe { (host.callbacks.rendered_in_top_layer)(element) } {
+                        continue;
+                    }
+                    // SAFETY: `element` is a live DOM Element.
+                    if unsafe { (host.callbacks.has_unrendered_flat_tree_ancestor)(element) } {
+                        // SAFETY: The builder and element remain live throughout cleanup.
+                        unsafe {
+                            (host.callbacks.clear_stale_top_layer_subtree)(host.callbacks.builder, element);
+                        }
+                        continue;
+                    }
+                    host.update_layout_tree(element, context, should_create_layout_node);
+                }
+                // SAFETY: Restore the traversal context's entry value for the document walk.
+                unsafe { (host.callbacks.set_context_layout_top_layer)(context, facts.context_layout_top_layer) };
+            }
+
+            // SAFETY: Balances the principal layout-node push above.
+            unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+        }
+
+        if !facts.slot_element.is_null() {
+            if !facts.content_visibility_hidden {
+                // SAFETY: `layout_node` remains live throughout assigned-node construction.
+                unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
+                // SAFETY: The callback table, slot element, and context remain valid.
+                unsafe {
+                    rust_update_layout_tree_for_assigned_slottables(
+                        callbacks,
+                        facts.slot_element,
+                        context,
+                        must_create_subtree,
+                    );
+                }
+                // SAFETY: Balances the assigned-node parent push above.
+                unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+            } else {
+                // SAFETY: `slot_element` remains live throughout cleanup.
+                unsafe { (host.callbacks.clear_stale_assigned_slottables)(facts.slot_element) };
+            }
+        }
+
+        if should_create_layout_node {
+            // SAFETY: All pointers remain live throughout the call.
+            unsafe {
+                (host.callbacks.update_after_children)(
+                    host.callbacks.builder,
+                    dom_node,
+                    layout_node,
+                    context,
+                    facts.content_visibility_hidden,
+                );
+                (host.callbacks.wrap_button_layout)(host.callbacks.builder, dom_node, layout_node);
+            }
+        }
+
+        // https://www.w3.org/TR/css-contain-2/#containment-style
+        // Giving an element style containment has the following effects:
+        // 2. The effects of the 'content' property’s 'open-quote', 'close-quote', 'no-open-quote' and 'no-close-quote'
+        //    must be scoped to the element’s sub-tree.
+        if facts.has_style_containment {
+            // SAFETY: The builder remains live throughout the call.
+            unsafe {
+                (host.callbacks.set_quote_nesting_level)(host.callbacks.builder, prior_quote_nesting_level);
+            }
+        }
+
+        // SAFETY: `dom_node` remains live throughout the call.
+        unsafe { (host.callbacks.clear_dom_update_flags)(dom_node) };
     });
 }
 

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -1354,6 +1354,7 @@ pub enum FfiPseudoElement {
     Before,
     After,
     Marker,
+    Backdrop,
     Other,
 }
 
@@ -1380,6 +1381,7 @@ pub enum FfiPseudoElementDecision {
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiPseudoElementFacts {
+    pub has_style: bool,
     pub pseudo_element: FfiPseudoElement,
     pub content_type: FfiComputedContentType,
     pub display_is_none: bool,
@@ -1390,9 +1392,46 @@ pub struct FfiPseudoElementFacts {
     pub normal_marker_has_content: bool,
 }
 
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiResolvedPseudoContentFacts {
+    pub final_quote_nesting_level: u32,
+    pub content_is_list: bool,
+    pub content_item_count: usize,
+}
+
+#[repr(C)]
+pub struct FfiPseudoTreeBuilderCallbacks {
+    pub builder: *mut c_void,
+    pub initialize: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement) -> FfiPseudoElementFacts,
+    pub create_layout_node:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement, FfiPseudoElementDecision),
+    pub layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub attach_style_resources: unsafe extern "C" fn(*mut c_void),
+    pub layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiPrincipalLayoutFacts,
+    pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
+    pub layout_node_is_list_item: unsafe extern "C" fn(*mut c_void) -> bool,
+    pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+    pub configure_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32),
+    pub insert_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiInsertionMode),
+    pub resolve_counters: unsafe extern "C" fn(*mut c_void, FfiPseudoElement),
+    pub resolve_content:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32) -> FfiResolvedPseudoContentFacts,
+    pub create_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, usize) -> *mut c_void,
+    pub insert_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub push_layout_parent: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub pop_layout_parent: unsafe extern "C" fn(*mut c_void),
+    pub quote_nesting_level: unsafe extern "C" fn(*mut c_void) -> u32,
+    pub set_quote_nesting_level: unsafe extern "C" fn(*mut c_void, u32),
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
     abort_on_panic(|| {
+        if !facts.has_style {
+            return FfiPseudoElementDecision::None;
+        }
+
         // https://drafts.csswg.org/css-display-3/#box-generation
         // The element and its descendants generate no boxes or text sequences.
         if facts.display_is_none {
@@ -1454,6 +1493,106 @@ pub extern "C" fn rust_pseudo_element_decision(facts: FfiPseudoElementFacts) -> 
         } else {
             FfiPseudoElementDecision::Box
         }
+    })
+}
+
+/// Creates a generated pseudo-element layout subtree when its style and content require one.
+///
+/// # Safety
+///
+/// The callback table, frame storage, and originating element must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_create_pseudo_element(
+    callbacks: *const FfiPseudoTreeBuilderCallbacks,
+    frame: *mut c_void,
+    element: *mut c_void,
+    pseudo_element: FfiPseudoElement,
+    has_insertion_mode: bool,
+    insertion_mode: FfiInsertionMode,
+) -> *mut c_void {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!frame.is_null());
+        assert!(!element.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let callbacks = unsafe { &*callbacks };
+        // SAFETY: The frame and element remain live throughout initialization.
+        let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
+        let decision = rust_pseudo_element_decision(facts);
+        if decision == FfiPseudoElementDecision::None {
+            return std::ptr::null_mut();
+        }
+
+        // SAFETY: The builder, frame, and element remain live throughout construction.
+        unsafe {
+            (callbacks.create_layout_node)(callbacks.builder, frame, element, pseudo_element, decision);
+        }
+        // SAFETY: The frame remains live throughout the call.
+        let layout_node = unsafe { (callbacks.layout_node)(frame) };
+        if layout_node.is_null() || decision == FfiPseudoElementDecision::NormalMarker {
+            return layout_node;
+        }
+
+        // SAFETY: The frame owns a live pseudo-element layout node.
+        unsafe { (callbacks.attach_style_resources)(frame) };
+        if decision == FfiPseudoElementDecision::ContentReplacement {
+            // SAFETY: The frame owns the live replacement node and its display.
+            let layout_facts = unsafe { (callbacks.layout_facts)(frame) };
+            let adjustment = rust_adjusted_table_display_for_replaced_element(
+                layout_facts.display.display_is_table_inside,
+                layout_facts.display.display_is_block_outside,
+                layout_facts.display.display_is_internal_table,
+                layout_facts.display.display_is_table_caption,
+            );
+            if adjustment != FfiReplacedElementDisplayAdjustment::None {
+                // SAFETY: The frame owns a live NodeWithStyle.
+                unsafe { (callbacks.apply_replaced_display_adjustment)(frame, adjustment) };
+            }
+        }
+
+        // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker.
+        // SAFETY: The frame owns a live pseudo-element layout node.
+        if unsafe { (callbacks.layout_node_is_list_item)(frame) } {
+            // SAFETY: The builder, frame, and element remain live throughout marker creation.
+            unsafe { (callbacks.create_nested_list_marker)(callbacks.builder, frame, element) };
+            // FIXME: Support counters on element::pseudo::marker.
+        }
+
+        // SAFETY: The builder and frame remain live throughout configuration and insertion.
+        let initial_quote_nesting_level = unsafe { (callbacks.quote_nesting_level)(callbacks.builder) };
+        unsafe {
+            (callbacks.configure_layout_node)(frame, element, pseudo_element, initial_quote_nesting_level);
+            if has_insertion_mode {
+                (callbacks.insert_layout_node)(callbacks.builder, frame, insertion_mode);
+            }
+            (callbacks.resolve_counters)(element, pseudo_element);
+        }
+
+        // Resolve content after insertion because counter() and counters() items read the counters established by this
+        // pseudo-element's box.
+        // SAFETY: The frame and element remain live throughout content resolution.
+        let resolved_content =
+            unsafe { (callbacks.resolve_content)(frame, element, pseudo_element, initial_quote_nesting_level) };
+        // SAFETY: The builder remains live throughout the call.
+        unsafe {
+            (callbacks.set_quote_nesting_level)(callbacks.builder, resolved_content.final_quote_nesting_level);
+        }
+
+        if resolved_content.content_is_list && decision != FfiPseudoElementDecision::ContentReplacement {
+            // SAFETY: The pseudo-element node remains live throughout child construction.
+            unsafe { (callbacks.push_layout_parent)(callbacks.builder, layout_node) };
+            for index in 0..resolved_content.content_item_count {
+                // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
+                let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
+                assert!(!content_item.is_null());
+                // SAFETY: The builder and generated content item remain live throughout insertion.
+                unsafe { (callbacks.insert_content_item)(callbacks.builder, content_item) };
+            }
+            // SAFETY: Balances the pseudo-element parent push above.
+            unsafe { (callbacks.pop_layout_parent)(callbacks.builder) };
+        }
+
+        layout_node
     })
 }
 
@@ -2836,6 +2975,7 @@ mod tests {
                       originating_layout_node_is_list_item,
                       normal_marker_has_content| {
             rust_pseudo_element_decision(FfiPseudoElementFacts {
+                has_style: true,
                 pseudo_element,
                 content_type,
                 display_is_none,

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::abort_on_panic;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiReplacedElementDisplayAdjustment {
+    None,
+    Inline,
+    Block,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_adjusted_table_display_for_replaced_element(
+    is_table_inside: bool,
+    is_block_outside: bool,
+    is_internal_table: bool,
+    is_table_caption: bool,
+) -> FfiReplacedElementDisplayAdjustment {
+    abort_on_panic(|| {
+        // https://drafts.csswg.org/css-display-3/#outer-role
+        // Note: Outer display types do affect replaced elements.
+        if is_table_inside {
+            if is_block_outside {
+                return FfiReplacedElementDisplayAdjustment::Block;
+            }
+            return FfiReplacedElementDisplayAdjustment::Inline;
+        }
+
+        // https://drafts.csswg.org/css-display-3/#layout-specific-display
+        // When the 'display' property of a replaced element computes to one of the layout-internal values, it is
+        // handled as having a used value of 'display: inline'.
+        if is_internal_table || is_table_caption {
+            return FfiReplacedElementDisplayAdjustment::Inline;
+        }
+        FfiReplacedElementDisplayAdjustment::None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FfiReplacedElementDisplayAdjustment, rust_adjusted_table_display_for_replaced_element};
+
+    #[test]
+    fn replaced_table_display_adjustments() {
+        assert_eq!(
+            rust_adjusted_table_display_for_replaced_element(true, true, false, false),
+            FfiReplacedElementDisplayAdjustment::Block
+        );
+        assert_eq!(
+            rust_adjusted_table_display_for_replaced_element(true, false, false, false),
+            FfiReplacedElementDisplayAdjustment::Inline
+        );
+        assert_eq!(
+            rust_adjusted_table_display_for_replaced_element(false, false, true, false),
+            FfiReplacedElementDisplayAdjustment::Inline
+        );
+        assert_eq!(
+            rust_adjusted_table_display_for_replaced_element(false, false, false, true),
+            FfiReplacedElementDisplayAdjustment::Inline
+        );
+        assert_eq!(
+            rust_adjusted_table_display_for_replaced_element(false, false, false, false),
+            FfiReplacedElementDisplayAdjustment::None
+        );
+    }
+}

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::abort_on_panic;
+use std::ffi::c_void;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -39,6 +40,623 @@ pub extern "C" fn rust_adjusted_table_display_for_replaced_element(
         }
         FfiReplacedElementDisplayAdjustment::None
     })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+// NB: Some variants are only constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiTableDisplay {
+    Other,
+    TableRoot,
+    TableRowGroup,
+    TableHeaderGroup,
+    TableFooterGroup,
+    TableColumnGroup,
+    TableColumn,
+    TableRow,
+    TableCell,
+    TableCaption,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiLayoutNodeFacts {
+    pub current_display: FfiTableDisplay,
+    pub display_before_box_type_transformation: FfiTableDisplay,
+    pub is_box: bool,
+    pub has_style: bool,
+    pub is_anonymous: bool,
+    pub is_block_container: bool,
+    pub children_are_inline: bool,
+    pub is_out_of_flow: bool,
+    pub is_text: bool,
+    pub text_is_ascii_whitespace: bool,
+    pub is_inline_outside: bool,
+    pub is_table_wrapper: bool,
+    pub has_been_wrapped_in_table_wrapper: bool,
+    pub has_replaced_element_table_display_adjustment: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiAnonymousTableBoxKind {
+    TableRow,
+    TableCell,
+    Table,
+    InlineTable,
+}
+
+#[repr(C)]
+pub struct FfiTreeBuilderCallbacks {
+    pub context: *mut c_void,
+    pub layout_node_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiLayoutNodeFacts,
+    pub parent: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub first_child: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub next_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub previous_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub remove_nodes: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize),
+    pub wrap_in_anonymous:
+        unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, *mut c_void, FfiAnonymousTableBoxKind),
+    pub update_existing_table_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+    pub wrap_table_root: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
+    pub create_table_grid: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub destroy_table_grid: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub table_grid_column_count: unsafe extern "C" fn(*mut c_void, *mut c_void) -> usize,
+    pub table_grid_is_occupied: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, usize) -> bool,
+    pub append_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void),
+}
+
+type LayoutNode = *mut c_void;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TraversalDecision {
+    Continue,
+    SkipChildrenAndContinue,
+    Break,
+}
+
+struct TreeBuilderHost<'a> {
+    callbacks: &'a FfiTreeBuilderCallbacks,
+}
+
+impl TreeBuilderHost<'_> {
+    fn facts(&self, node: LayoutNode) -> FfiLayoutNodeFacts {
+        assert!(!node.is_null());
+        // SAFETY: The entry point's callback contract guarantees that every node passed to a callback is live.
+        unsafe { (self.callbacks.layout_node_facts)(self.callbacks.context, node) }
+    }
+
+    fn parent(&self, node: LayoutNode) -> LayoutNode {
+        // SAFETY: The entry point's callback contract guarantees that `node` is live.
+        unsafe { (self.callbacks.parent)(self.callbacks.context, node) }
+    }
+
+    fn first_child(&self, node: LayoutNode) -> LayoutNode {
+        // SAFETY: The entry point's callback contract guarantees that `node` is live.
+        unsafe { (self.callbacks.first_child)(self.callbacks.context, node) }
+    }
+
+    fn next_sibling(&self, node: LayoutNode) -> LayoutNode {
+        // SAFETY: The entry point's callback contract guarantees that `node` is live.
+        unsafe { (self.callbacks.next_sibling)(self.callbacks.context, node) }
+    }
+
+    fn previous_sibling(&self, node: LayoutNode) -> LayoutNode {
+        // SAFETY: The entry point's callback contract guarantees that `node` is live.
+        unsafe { (self.callbacks.previous_sibling)(self.callbacks.context, node) }
+    }
+
+    fn for_each_in_inclusive_subtree(
+        &self,
+        root: LayoutNode,
+        mut callback: impl FnMut(LayoutNode) -> TraversalDecision,
+    ) {
+        let mut current = root;
+        while !current.is_null() {
+            let decision = callback(current);
+            if decision == TraversalDecision::Break {
+                return;
+            }
+
+            if decision != TraversalDecision::SkipChildrenAndContinue {
+                let first_child = self.first_child(current);
+                if !first_child.is_null() {
+                    current = first_child;
+                    continue;
+                }
+            }
+            if current == root {
+                break;
+            }
+
+            let next_sibling = self.next_sibling(current);
+            if !next_sibling.is_null() {
+                current = next_sibling;
+                continue;
+            }
+
+            while current != root && self.next_sibling(current).is_null() {
+                current = self.parent(current);
+            }
+            if current == root {
+                break;
+            }
+
+            current = self.next_sibling(current);
+        }
+    }
+
+    fn remove_nodes(&self, nodes: &[LayoutNode]) {
+        // SAFETY: All nodes remain tree-owned until the callback first retains the complete slice.
+        unsafe { (self.callbacks.remove_nodes)(self.callbacks.context, nodes.as_ptr(), nodes.len()) };
+    }
+
+    fn wrap_in_anonymous(&self, nodes: &[LayoutNode], nearest_sibling: LayoutNode, kind: FfiAnonymousTableBoxKind) {
+        assert!(!nodes.is_empty());
+        // SAFETY: The nodes are live siblings and `nearest_sibling` is either null or their live next sibling.
+        unsafe {
+            (self.callbacks.wrap_in_anonymous)(
+                self.callbacks.context,
+                nodes.as_ptr(),
+                nodes.len(),
+                nearest_sibling,
+                kind,
+            );
+        };
+    }
+}
+
+fn is_table_track(display: FfiTableDisplay) -> bool {
+    matches!(display, FfiTableDisplay::TableRow | FfiTableDisplay::TableColumn)
+}
+
+fn is_table_track_group(display: FfiTableDisplay) -> bool {
+    // Unless explicitly mentioned otherwise, mentions of table-row-groups in this spec also encompass the specialized
+    // table-header-groups and table-footer-groups.
+    matches!(
+        display,
+        FfiTableDisplay::TableRowGroup
+            | FfiTableDisplay::TableHeaderGroup
+            | FfiTableDisplay::TableFooterGroup
+            | FfiTableDisplay::TableColumnGroup
+    )
+}
+
+fn display_for_table_fixup(facts: FfiLayoutNodeFacts) -> FfiTableDisplay {
+    // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
+    // For the purposes of these rules, out-of-flow elements are represented as inline elements of zero width and
+    // height. Their containing blocks are chosen accordingly.
+    //
+    // AD-HOC: Table-internal boxes can be blockified before fixup. Use the pre-transformation display for authored
+    // boxes so an out-of-flow table-header-group is still recognized as a proper table child during fixup.
+    if facts.has_replaced_element_table_display_adjustment || facts.is_anonymous {
+        facts.current_display
+    } else {
+        facts.display_before_box_type_transformation
+    }
+}
+
+fn is_proper_table_child(facts: FfiLayoutNodeFacts) -> bool {
+    let display = display_for_table_fixup(facts);
+    is_table_track_group(display) || is_table_track(display) || display == FfiTableDisplay::TableCaption
+}
+
+fn is_table_non_root_box(facts: FfiLayoutNodeFacts) -> bool {
+    matches!(
+        facts.current_display,
+        FfiTableDisplay::TableRow
+            | FfiTableDisplay::TableColumn
+            | FfiTableDisplay::TableRowGroup
+            | FfiTableDisplay::TableHeaderGroup
+            | FfiTableDisplay::TableFooterGroup
+            | FfiTableDisplay::TableColumnGroup
+            | FfiTableDisplay::TableCell
+            | FfiTableDisplay::TableCaption
+    )
+}
+
+fn is_tabular_container(facts: FfiLayoutNodeFacts) -> bool {
+    // https://drafts.csswg.org/css-tables-3/#tabular-container
+    matches!(
+        facts.current_display,
+        FfiTableDisplay::TableRoot
+            | FfiTableDisplay::TableRow
+            | FfiTableDisplay::TableRowGroup
+            | FfiTableDisplay::TableHeaderGroup
+            | FfiTableDisplay::TableFooterGroup
+    )
+}
+
+fn is_ignorable_whitespace(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
+    let facts = host.facts(node);
+    if facts.is_text && facts.text_is_ascii_whitespace {
+        return true;
+    }
+
+    if facts.is_anonymous && facts.is_block_container && facts.children_are_inline {
+        let mut contains_only_whitespace = true;
+        host.for_each_in_inclusive_subtree(node, |descendant| {
+            let descendant_facts = host.facts(descendant);
+            if descendant_facts.is_text {
+                if !descendant_facts.text_is_ascii_whitespace {
+                    contains_only_whitespace = false;
+                    return TraversalDecision::Break;
+                }
+            } else if descendant_facts.is_out_of_flow || !descendant_facts.is_anonymous {
+                contains_only_whitespace = false;
+                return TraversalDecision::Break;
+            }
+            TraversalDecision::Continue
+        });
+        return contains_only_whitespace;
+    }
+
+    false
+}
+
+fn is_first_or_last_child_with_table_non_root_sibling_if_any(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
+    let previous_sibling = host.previous_sibling(node);
+    let next_sibling = host.next_sibling(node);
+    if !previous_sibling.is_null() && !next_sibling.is_null() {
+        return false;
+    }
+    if !previous_sibling.is_null() && !is_table_non_root_box(host.facts(previous_sibling)) {
+        return false;
+    }
+    if !next_sibling.is_null() && !is_table_non_root_box(host.facts(next_sibling)) {
+        return false;
+    }
+    true
+}
+
+fn for_each_sequence_of_consecutive_children_matching(
+    host: &TreeBuilderHost<'_>,
+    parent: LayoutNode,
+    matcher: impl Fn(FfiLayoutNodeFacts) -> bool,
+    mut callback: impl FnMut(&[LayoutNode], LayoutNode),
+) {
+    let mut sequence = Vec::new();
+    let mut child = host.first_child(parent);
+    while !child.is_null() {
+        if matcher(host.facts(child)) || (!sequence.is_empty() && is_ignorable_whitespace(host, child)) {
+            sequence.push(child);
+        } else if !sequence.is_empty() {
+            if !sequence.iter().all(|&node| is_ignorable_whitespace(host, node)) {
+                callback(&sequence, child);
+            }
+            sequence.clear();
+        }
+        child = host.next_sibling(child);
+    }
+    if !sequence.is_empty() && !sequence.iter().all(|&node| is_ignorable_whitespace(host, node)) {
+        callback(&sequence, std::ptr::null_mut());
+    }
+}
+
+fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
+    // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
+    // 1. Remove irrelevant boxes:
+    // The following boxes are discarded as if they were display:none:
+    let mut to_remove = Vec::new();
+    host.for_each_in_inclusive_subtree(root, |node| {
+        let facts = host.facts(node);
+
+        // 1. Children of a table-column.
+        if facts.is_box && facts.current_display == FfiTableDisplay::TableColumn {
+            let mut child = host.first_child(node);
+            while !child.is_null() {
+                to_remove.push(child);
+                child = host.next_sibling(child);
+            }
+        }
+
+        // 2. Children of a table-column-group which are not a table-column.
+        if facts.is_box && facts.current_display == FfiTableDisplay::TableColumnGroup {
+            let mut child = host.first_child(node);
+            while !child.is_null() {
+                if host.facts(child).current_display != FfiTableDisplay::TableColumn {
+                    to_remove.push(child);
+                }
+                child = host.next_sibling(child);
+            }
+        }
+
+        // FIXME: 3. Anonymous inline boxes which contain only white space and are between two immediate siblings each
+        //           of which is a table-non-root box.
+
+        // 4. Anonymous inline boxes which meet all of the following criteria:
+        //    - they contain only white space
+        //    - they are the first and/or last child of a tabular container
+        //    - whose immediate sibling, if any, is a table-non-root box
+        let parent = host.parent(node);
+        if facts.is_box
+            && !parent.is_null()
+            && is_tabular_container(host.facts(parent))
+            && is_first_or_last_child_with_table_non_root_sibling_if_any(host, node)
+            && is_ignorable_whitespace(host, node)
+        {
+            to_remove.push(node);
+            return TraversalDecision::SkipChildrenAndContinue;
+        }
+        TraversalDecision::Continue
+    });
+    host.remove_nodes(&to_remove);
+}
+
+fn generate_missing_child_wrappers(host: &TreeBuilderHost<'_>, root: LayoutNode) {
+    // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
+    // 2. Generate missing child wrappers:
+    host.for_each_in_inclusive_subtree(root, |parent| {
+        let facts = host.facts(parent);
+        if !facts.is_box {
+            return TraversalDecision::Continue;
+        }
+
+        match facts.current_display {
+            FfiTableDisplay::TableRoot => {
+                // 1. An anonymous table-row box must be generated around each sequence of consecutive children of a
+                //    table-root box which are not proper table child boxes.
+                for_each_sequence_of_consecutive_children_matching(
+                    host,
+                    parent,
+                    |child| !child.has_style || !is_proper_table_child(child),
+                    |sequence, nearest_sibling| {
+                        host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
+                    },
+                );
+            }
+            FfiTableDisplay::TableRowGroup | FfiTableDisplay::TableHeaderGroup | FfiTableDisplay::TableFooterGroup => {
+                // 2. An anonymous table-row box must be generated around each sequence of consecutive children of a
+                //    table-row-group box which are not table-row boxes.
+                for_each_sequence_of_consecutive_children_matching(
+                    host,
+                    parent,
+                    |child| !child.has_style || child.current_display != FfiTableDisplay::TableRow,
+                    |sequence, nearest_sibling| {
+                        host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
+                    },
+                );
+            }
+            FfiTableDisplay::TableRow => {
+                // 3. An anonymous table-cell box must be generated around each sequence of consecutive children of a
+                //    table-row box which are not table-cell boxes.
+                for_each_sequence_of_consecutive_children_matching(
+                    host,
+                    parent,
+                    |child| !child.has_style || child.current_display != FfiTableDisplay::TableCell,
+                    |sequence, nearest_sibling| {
+                        host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableCell);
+                    },
+                );
+            }
+            _ => {}
+        }
+        TraversalDecision::Continue
+    });
+}
+
+fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec<LayoutNode> {
+    // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
+    // 3. Generate missing parents:
+    let mut table_roots_to_wrap = Vec::new();
+    host.for_each_in_inclusive_subtree(root, |parent| {
+        let facts = host.facts(parent);
+        if !facts.has_style {
+            return TraversalDecision::Continue;
+        }
+
+        // 1. An anonymous table-row box must be generated around each sequence of consecutive table-cell boxes whose
+        //    parent is not a table-row.
+        if facts.current_display != FfiTableDisplay::TableRow {
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| child.has_style && child.current_display == FfiTableDisplay::TableCell,
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
+                },
+            );
+        }
+
+        // 2. An anonymous table or inline-table box must be generated around each sequence of consecutive proper table
+        //    child boxes which are misparented.
+        // If the box’s parent is an inline, run-in, or ruby box (or any box that would perform inlinification of its
+        // children), then an inline-table box must be generated; otherwise it must be a table box.
+        // FIXME: run-in and ruby boxes
+        let anonymous_table_kind = if facts.is_inline_outside {
+            FfiAnonymousTableBoxKind::InlineTable
+        } else {
+            FfiAnonymousTableBoxKind::Table
+        };
+
+        let is_table_row_group = matches!(
+            facts.current_display,
+            FfiTableDisplay::TableRowGroup | FfiTableDisplay::TableHeaderGroup | FfiTableDisplay::TableFooterGroup
+        );
+        // A table-row is misparented if its parent is neither a table-row-group nor a table-root box.
+        if !is_table_row_group && facts.current_display != FfiTableDisplay::TableRoot {
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| child.has_style && child.current_display == FfiTableDisplay::TableRow,
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
+                },
+            );
+        }
+
+        // A table-column box is misparented if its parent is neither a table-column-group box nor a table-root box.
+        if facts.current_display != FfiTableDisplay::TableColumnGroup
+            && facts.current_display != FfiTableDisplay::TableRoot
+        {
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| child.has_style && child.current_display == FfiTableDisplay::TableColumn,
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
+                },
+            );
+        }
+
+        // A table-row-group, table-column-group, or table-caption box is misparented if its parent is not a table-root
+        // box.
+        if facts.current_display != FfiTableDisplay::TableRoot {
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| {
+                    if !child.has_style {
+                        return false;
+                    }
+                    let display = display_for_table_fixup(child);
+                    is_table_track_group(display) || display == FfiTableDisplay::TableCaption
+                },
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
+                },
+            );
+        }
+
+        // 3. An anonymous table-wrapper box must be generated around each table-root.
+        if facts.is_box && facts.current_display == FfiTableDisplay::TableRoot {
+            if facts.has_been_wrapped_in_table_wrapper {
+                let parent = host.parent(parent);
+                assert!(!parent.is_null());
+                assert!(host.facts(parent).is_table_wrapper);
+                return TraversalDecision::Continue;
+            }
+            table_roots_to_wrap.push(parent);
+        }
+
+        TraversalDecision::Continue
+    });
+
+    for &table_root in &table_roots_to_wrap {
+        let nearest_sibling = host.next_sibling(table_root);
+        let parent = host.parent(table_root);
+        assert!(!parent.is_null());
+        if host.facts(parent).is_table_wrapper {
+            // SAFETY: Both nodes are live and `parent` is a TableWrapper.
+            unsafe { (host.callbacks.update_existing_table_wrapper)(host.callbacks.context, table_root, parent) };
+        } else {
+            // SAFETY: `table_root` is attached and `nearest_sibling` is either null or its live next sibling.
+            unsafe { (host.callbacks.wrap_table_root)(host.callbacks.context, table_root, nearest_sibling) };
+        }
+    }
+    table_roots_to_wrap
+}
+
+struct TableGrid<'a> {
+    host: &'a TreeBuilderHost<'a>,
+    grid: *mut c_void,
+}
+
+impl TableGrid<'_> {
+    fn column_count(&self) -> usize {
+        // SAFETY: `grid` is live until this wrapper is dropped.
+        unsafe { (self.host.callbacks.table_grid_column_count)(self.host.callbacks.context, self.grid) }
+    }
+
+    fn is_occupied(&self, column_index: usize, row_index: usize) -> bool {
+        // SAFETY: `grid` is live until this wrapper is dropped.
+        unsafe {
+            (self.host.callbacks.table_grid_is_occupied)(
+                self.host.callbacks.context,
+                self.grid,
+                column_index,
+                row_index,
+            )
+        }
+    }
+}
+
+impl Drop for TableGrid<'_> {
+    fn drop(&mut self) {
+        // SAFETY: This wrapper owns the grid returned by `create_table_grid` and drops it exactly once.
+        unsafe { (self.host.callbacks.destroy_table_grid)(self.host.callbacks.context, self.grid) };
+    }
+}
+
+fn fixup_row(host: &TreeBuilderHost<'_>, row: LayoutNode, table_grid: &TableGrid<'_>, row_index: usize) {
+    for column_index in 0..table_grid.column_count() {
+        if table_grid.is_occupied(column_index, row_index) {
+            continue;
+        }
+        // SAFETY: `row` is a live table-row box.
+        unsafe { (host.callbacks.append_missing_table_cell)(host.callbacks.context, row) };
+    }
+}
+
+fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
+    // https://drafts.csswg.org/css-tables-3/#missing-cells-fixup
+    // Once the amount of columns in a table is known, any table-row box must be modified such that it owns enough
+    // cells to fill all the columns of the table, when taking spans into account. New table-cell anonymous boxes must
+    // be appended to its rows content until this condition is met.
+    for &table_root in table_roots {
+        // SAFETY: `table_root` is a live table-root box and the callback returns a newly owned grid.
+        let grid = unsafe { (host.callbacks.create_table_grid)(host.callbacks.context, table_root) };
+        assert!(!grid.is_null());
+        let grid = TableGrid { host, grid };
+        let mut row_index = 0;
+
+        let mut child = host.first_child(table_root);
+        while !child.is_null() {
+            let child_facts = host.facts(child);
+            if child_facts.is_box
+                && matches!(
+                    child_facts.current_display,
+                    FfiTableDisplay::TableRowGroup
+                        | FfiTableDisplay::TableHeaderGroup
+                        | FfiTableDisplay::TableFooterGroup
+                )
+            {
+                let mut row = host.first_child(child);
+                while !row.is_null() {
+                    let row_facts = host.facts(row);
+                    if row_facts.is_box && row_facts.current_display == FfiTableDisplay::TableRow {
+                        fixup_row(host, row, &grid, row_index);
+                        row_index += 1;
+                    }
+                    row = host.next_sibling(row);
+                }
+            }
+            child = host.next_sibling(child);
+        }
+
+        let mut child = host.first_child(table_root);
+        while !child.is_null() {
+            let child_facts = host.facts(child);
+            if child_facts.is_box && child_facts.current_display == FfiTableDisplay::TableRow {
+                fixup_row(host, child, &grid, row_index);
+                row_index += 1;
+            }
+            child = host.next_sibling(child);
+        }
+    }
+}
+
+/// Runs the CSS table-model fixup over an already constructed layout subtree.
+///
+/// # Safety
+///
+/// `callbacks` must point to a valid callback table for the duration of the call. `root` must be a live
+/// NodeWithStyle, and every callback-returned node must remain live for as long as it stays attached to that root.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallbacks, root: *mut c_void) {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!root.is_null());
+        // SAFETY: Guaranteed by the entry point's contract and checked for null above.
+        let host = TreeBuilderHost {
+            callbacks: unsafe { &*callbacks },
+        };
+        remove_irrelevant_boxes(&host, root);
+        generate_missing_child_wrappers(&host, root);
+        let table_roots = generate_missing_parents(&host, root);
+        missing_cells_fixup(&host, &table_roots);
+    });
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -148,7 +148,10 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub initialize_principal_frame: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub prepare_principal_element:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> FfiPrincipalDisplayFacts,
-    pub create_principal_element_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void),
+    pub principal_element_layout_facts:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiElementLayoutFacts,
+    pub create_principal_element_layout:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind),
     pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -251,6 +254,45 @@ pub struct FfiPrincipalDisplayFacts {
 pub struct FfiPrincipalLayoutFacts {
     pub is_replaced_element: bool,
     pub display: FfiPrincipalDisplayFacts,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiElementLayoutFacts {
+    pub has_content_replacement: bool,
+    pub context_layout_svg_mask_or_clip_path: bool,
+    pub context_layout_svg_pattern: bool,
+    pub is_svg_mask_element: bool,
+    pub is_svg_clip_path_element: bool,
+    pub is_svg_pattern_element: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FfiElementLayoutKind {
+    ContentReplacement,
+    SvgMask,
+    SvgClipPath,
+    SvgPattern,
+    Normal,
+}
+
+fn element_layout_kind(facts: FfiElementLayoutFacts) -> FfiElementLayoutKind {
+    if facts.has_content_replacement {
+        FfiElementLayoutKind::ContentReplacement
+    } else if facts.context_layout_svg_mask_or_clip_path {
+        if facts.is_svg_mask_element {
+            FfiElementLayoutKind::SvgMask
+        } else {
+            assert!(facts.is_svg_clip_path_element);
+            FfiElementLayoutKind::SvgClipPath
+        }
+    } else if facts.context_layout_svg_pattern {
+        assert!(facts.is_svg_pattern_element);
+        FfiElementLayoutKind::SvgPattern
+    } else {
+        FfiElementLayoutKind::Normal
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1094,9 +1136,24 @@ fn construct_principal_layout_node(
             return (false, true);
         }
         if should_create_layout_node {
-            // SAFETY: The builder, frame, element, and context remain live throughout construction.
+            // SAFETY: The frame, element, and context remain live throughout construction.
+            let layout_facts = unsafe { (host.callbacks.principal_element_layout_facts)(frame, dom_node, context) };
+            let layout_kind = element_layout_kind(layout_facts);
+            // SAFETY: The builder, frame, and element remain live throughout construction.
             unsafe {
-                (host.callbacks.create_principal_element_layout)(host.callbacks.builder, frame, dom_node, context);
+                (host.callbacks.create_principal_element_layout)(host.callbacks.builder, frame, dom_node, layout_kind);
+            }
+            if matches!(
+                layout_kind,
+                FfiElementLayoutKind::SvgMask | FfiElementLayoutKind::SvgClipPath
+            ) {
+                // Only direct mask and clip-path uses inherit this construction mode.
+                // SAFETY: The traversal context remains live throughout the call.
+                unsafe { (host.callbacks.set_context_layout_svg_mask_or_clip_path)(context, false) };
+            } else if layout_kind == FfiElementLayoutKind::SvgPattern {
+                // Only the directly referenced pattern inherits this construction mode.
+                // SAFETY: The traversal context remains live throughout the call.
+                unsafe { (host.callbacks.set_context_layout_svg_pattern)(context, false) };
             }
         } else {
             // SAFETY: The frame and DOM node remain live throughout the call.
@@ -2852,13 +2909,13 @@ pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallb
 #[cfg(test)]
 mod tests {
     use super::{
-        FfiComputedContentType, FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks,
-        FfiPrincipalBoxGenerationDecision, FfiPrincipalBoxPlacement, FfiPrincipalBoxPlacementFacts,
-        FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts,
-        FfiReplacedElementDisplayAdjustment, FfiSvgEntryDecision, FfiTopLayerEntryDecision, FirstLetterTextHost,
-        find_first_letter_in_text, rust_adjusted_table_display_for_replaced_element,
-        rust_principal_box_generation_decision, rust_principal_box_placement_decision,
-        rust_principal_node_entry_decision, rust_pseudo_element_decision,
+        FfiComputedContentType, FfiElementLayoutFacts, FfiElementLayoutKind, FfiFirstLetterCodePointFacts,
+        FfiFirstLetterTextCallbacks, FfiPrincipalBoxGenerationDecision, FfiPrincipalBoxPlacement,
+        FfiPrincipalBoxPlacementFacts, FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision,
+        FfiPseudoElementFacts, FfiReplacedElementDisplayAdjustment, FfiSvgEntryDecision, FfiTopLayerEntryDecision,
+        FirstLetterTextHost, element_layout_kind, find_first_letter_in_text,
+        rust_adjusted_table_display_for_replaced_element, rust_principal_box_generation_decision,
+        rust_principal_box_placement_decision, rust_principal_node_entry_decision, rust_pseudo_element_decision,
     };
     use std::ffi::c_void;
 
@@ -3091,6 +3148,32 @@ mod tests {
         let decision = rust_principal_node_entry_decision(facts);
         assert!(decision.should_create_layout_node);
         assert_eq!(decision.svg, FfiSvgEntryDecision::EnterSvgRoot);
+    }
+
+    #[test]
+    fn specialized_element_layout_kinds() {
+        let mut facts = FfiElementLayoutFacts {
+            has_content_replacement: false,
+            context_layout_svg_mask_or_clip_path: false,
+            context_layout_svg_pattern: false,
+            is_svg_mask_element: false,
+            is_svg_clip_path_element: false,
+            is_svg_pattern_element: false,
+        };
+        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::Normal);
+
+        facts.has_content_replacement = true;
+        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::ContentReplacement);
+        facts.has_content_replacement = false;
+        facts.context_layout_svg_mask_or_clip_path = true;
+        facts.is_svg_mask_element = true;
+        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::SvgMask);
+
+        facts.context_layout_svg_mask_or_clip_path = false;
+        facts.is_svg_mask_element = false;
+        facts.context_layout_svg_pattern = true;
+        facts.is_svg_pattern_element = true;
+        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::SvgPattern);
     }
 
     #[test]

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -473,6 +473,7 @@ pub struct FfiLayoutNodeFacts {
     pub is_generated_for_marker: bool,
     pub is_fragmented_inline: bool,
     pub has_first_letter_style: bool,
+    pub has_rendered_legend: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -559,6 +560,8 @@ pub struct FfiTreeBuilderCallbacks {
     pub set_children_are_inline: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub note_tree_restructuring: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub find_first_letter_in_text: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiFirstLetterTarget,
+    pub wrap_button_contents: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub wrap_fieldset_contents: unsafe extern "C" fn(*mut c_void, *mut c_void),
 }
 
 type LayoutNode = *mut c_void;
@@ -1125,6 +1128,70 @@ pub unsafe extern "C" fn rust_find_first_letter_in_block(
         };
         find_first_letter_in_block(&host, block)
     })
+}
+
+/// Creates the anonymous layout structure required for button rendering.
+///
+/// # Safety
+///
+/// `callbacks` must remain valid for the call and `layout_node` must be a live NodeWithStyle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_wrap_button_contents_if_needed(
+    callbacks: *const FfiTreeBuilderCallbacks,
+    layout_node: *mut c_void,
+    uses_button_layout: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!layout_node.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = TreeBuilderHost {
+            callbacks: unsafe { &*callbacks },
+        };
+        if !uses_button_layout {
+            return;
+        }
+
+        // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
+        // If the element is an input element, or if it is a button element and its computed value for 'display' is not
+        // 'inline-grid', 'grid', 'inline-flex', or 'flex', then the element's box has a child anonymous button content
+        // box with the following behaviors:
+        let facts = host.facts(layout_node);
+        if !facts.display_is_grid_inside && !facts.display_is_flex_inside {
+            // SAFETY: `layout_node` remains live and the callback performs the ownership-sensitive wrapper mutation.
+            unsafe { (host.callbacks.wrap_button_contents)(host.callbacks.context, layout_node) };
+        }
+    });
+}
+
+/// Creates the anonymous fieldset content box around non-legend children.
+///
+/// # Safety
+///
+/// `callbacks` must remain valid for the call and `layout_node` must be a live layout node.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_wrap_fieldset_contents_if_needed(
+    callbacks: *const FfiTreeBuilderCallbacks,
+    layout_node: *mut c_void,
+) {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!layout_node.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = TreeBuilderHost {
+            callbacks: unsafe { &*callbacks },
+        };
+
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+        // The anonymous fieldset content box is expected to appear after the rendered legend and is expected to contain
+        // the content (including the '::before' and '::after' pseudo-elements) of the fieldset element except for the
+        // rendered legend, if there is one.
+        let facts = host.facts(layout_node);
+        if facts.is_field_set_box && facts.has_rendered_legend {
+            // SAFETY: `layout_node` is a live FieldSetBox with a rendered legend.
+            unsafe { (host.callbacks.wrap_fieldset_contents)(host.callbacks.context, layout_node) };
+        }
+    });
 }
 
 fn is_table_track(display: FfiTableDisplay) -> bool {

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -1883,7 +1883,8 @@ pub struct FfiTreeBuilderCallbacks {
     pub insert_child: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
     pub set_children_are_inline: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub note_tree_restructuring: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub find_first_letter_in_text: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiFirstLetterTarget,
+    pub prepare_first_letter_text:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiFirstLetterTextCallbacks) -> bool,
     pub create_button_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub rendered_legend: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub create_fieldset_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
@@ -2342,24 +2343,20 @@ fn find_first_letter_in_text(host: &FirstLetterTextHost<'_>, preserves_segment_b
     FfiFirstLetterTarget::not_found()
 }
 
-/// Finds the first-letter text pattern within one layout text node.
-///
-/// # Safety
-///
-/// `callbacks` must point to a valid callback table whose context remains live for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_find_first_letter_in_text(
-    callbacks: *const FfiFirstLetterTextCallbacks,
-    preserves_segment_breaks: bool,
-) -> FfiFirstLetterTarget {
-    abort_on_panic(|| {
-        assert!(!callbacks.is_null());
-        // SAFETY: The caller guarantees that `callbacks` remains valid for the duration of this call.
-        let host = FirstLetterTextHost {
-            callbacks: unsafe { &*callbacks },
-        };
-        find_first_letter_in_text(&host, preserves_segment_breaks)
-    })
+fn find_first_letter_in_layout_text(host: &TreeBuilderHost<'_>, node: LayoutNode) -> FfiFirstLetterTarget {
+    let mut callbacks = std::mem::MaybeUninit::<FfiFirstLetterTextCallbacks>::uninit();
+    // SAFETY: `node` is a live TextNode and the callback initializes the output table with a context that remains live
+    // until the next call.
+    let preserves_segment_breaks =
+        unsafe { (host.callbacks.prepare_first_letter_text)(host.callbacks.context, node, callbacks.as_mut_ptr()) };
+    // SAFETY: The callback contract guarantees that the output table was initialized.
+    let callbacks = unsafe { callbacks.assume_init() };
+    let text_host = FirstLetterTextHost { callbacks: &callbacks };
+    let mut target = find_first_letter_in_text(&text_host, preserves_segment_breaks);
+    if target.found {
+        target.text_node = node;
+    }
+    target
 }
 
 fn is_marker_content(facts: FfiLayoutNodeFacts) -> bool {
@@ -2383,8 +2380,7 @@ fn find_first_letter_in_block(host: &TreeBuilderHost<'_>, block: LayoutNode) -> 
                 return TraversalDecision::SkipChildrenAndContinue;
             }
             if facts.is_text {
-                // SAFETY: `node` is a live TextNode.
-                result = unsafe { (host.callbacks.find_first_letter_in_text)(host.callbacks.context, node) };
+                result = find_first_letter_in_layout_text(host, node);
                 return if result.found {
                     TraversalDecision::Break
                 } else {

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -12,6 +12,14 @@ struct TreeBuilderState {
     quote_nesting_level: u32,
 }
 
+#[derive(Default)]
+struct TreeBuilderContext {
+    has_svg_root: bool,
+    layout_top_layer: bool,
+    layout_svg_mask_or_clip_path: bool,
+    layout_svg_pattern: bool,
+}
+
 /// Creates the Rust-owned state for one layout tree builder.
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_tree_builder_state_create() -> *mut c_void {
@@ -102,22 +110,20 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub builder: *mut c_void,
     pub first_child: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub next_sibling: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
-    pub update_layout_tree: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool),
     pub clear_update_flags: unsafe extern "C" fn(*mut c_void),
     pub needs_layout_tree_update: unsafe extern "C" fn(*mut c_void) -> bool,
     pub assigned_node_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub assigned_node_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
     pub is_svg_element: unsafe extern "C" fn(*mut c_void) -> bool,
     pub clear_stale_layout_and_paint_node: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub display_contents_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiDisplayContentsFacts,
-    pub set_context_layout_top_layer: unsafe extern "C" fn(*mut c_void, bool),
+    pub display_contents_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiDisplayContentsFacts,
     pub clear_synthetic_pseudo_element_layout_nodes: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub clear_stale_inclusive_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void),
     pub create_pseudo_element: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, FfiInsertionMode),
     pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
     pub principal_descendant_facts:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
     pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub wrap_fieldset_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub wrap_button_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
@@ -139,18 +145,15 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub ancestor_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub ancestor_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
     pub layout_node_dom_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
-    pub set_context_layout_svg_mask_or_clip_path: unsafe extern "C" fn(*mut c_void, bool),
-    pub set_context_layout_svg_pattern: unsafe extern "C" fn(*mut c_void, bool),
-    pub principal_node_entry_facts:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> FfiPrincipalNodeEntryFacts,
+    pub principal_node_entry_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, bool) -> FfiPrincipalNodeEntryFacts,
     pub request_top_layer_zone_rebuild: unsafe extern "C" fn(*mut c_void),
     pub push_style_ancestor: unsafe extern "C" fn(*mut c_void),
     pub pop_style_ancestor: unsafe extern "C" fn(*mut c_void),
-    pub initialize_principal_frame: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub push_principal_frame: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub pop_principal_frame: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub prepare_principal_element:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool) -> FfiPrincipalDisplayFacts,
-    pub principal_element_layout_facts:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiElementLayoutFacts,
+    pub principal_element_layout_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiElementLayoutFacts,
     pub create_principal_element_layout:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiElementLayoutKind),
     pub create_principal_document_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -160,14 +163,8 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
     pub principal_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiPrincipalLayoutFacts,
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
-    pub principal_placement_facts: unsafe extern "C" fn(
-        *mut c_void,
-        *mut c_void,
-        *mut c_void,
-        *mut c_void,
-        bool,
-        bool,
-    ) -> FfiPrincipalBoxPlacementFacts,
+    pub principal_placement_facts:
+        unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool, bool) -> FfiPrincipalBoxPlacementFacts,
     pub start_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub restore_principal_rebuild_root: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub mark_update_escaped_rebuild_roots: unsafe extern "C" fn(*mut c_void),
@@ -175,7 +172,6 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub insert_principal_backdrop_before_old: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub set_context_has_svg_root: unsafe extern "C" fn(*mut c_void, bool),
     pub reset_style_ancestor_filter: unsafe extern "C" fn(*mut c_void),
     pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub fixup_tables: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -186,7 +182,6 @@ pub struct FfiDomTreeBuilderCallbacks {
 #[repr(C)]
 pub struct FfiDisplayContentsFacts {
     pub rendered_in_top_layer: bool,
-    pub context_layout_top_layer: bool,
     pub content_visibility_hidden: bool,
     pub should_layout_dom_children: bool,
     pub child_needs_layout_tree_update: bool,
@@ -207,7 +202,6 @@ pub struct FfiFlatTreeRenderFacts {
 #[repr(C)]
 pub struct FfiPrincipalDescendantFacts {
     pub is_element: bool,
-    pub context_layout_top_layer: bool,
     pub content_visibility_hidden: bool,
     pub should_layout_dom_children: bool,
     pub child_needs_layout_tree_update: bool,
@@ -227,8 +221,6 @@ pub struct FfiPrincipalDescendantFacts {
     pub svg_clip_path: *mut c_void,
     pub svg_fill_pattern: *mut c_void,
     pub svg_stroke_pattern: *mut c_void,
-    pub context_layout_svg_mask_or_clip_path: bool,
-    pub context_layout_svg_pattern: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -242,11 +234,9 @@ pub struct FfiPrincipalNodeEntryFacts {
     pub is_element: bool,
     pub is_text: bool,
     pub rendered_in_top_layer: bool,
-    pub context_layout_top_layer: bool,
     pub layout_node_is_attached: bool,
     pub is_svg_container: bool,
     pub requires_svg_container: bool,
-    pub context_has_svg_root: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -271,8 +261,6 @@ pub struct FfiPrincipalLayoutFacts {
 #[repr(C)]
 pub struct FfiElementLayoutFacts {
     pub has_content_replacement: bool,
-    pub context_layout_svg_mask_or_clip_path: bool,
-    pub context_layout_svg_pattern: bool,
     pub is_svg_mask_element: bool,
     pub is_svg_clip_path_element: bool,
     pub is_svg_pattern_element: bool,
@@ -288,17 +276,21 @@ pub enum FfiElementLayoutKind {
     Normal,
 }
 
-fn element_layout_kind(facts: FfiElementLayoutFacts) -> FfiElementLayoutKind {
+fn element_layout_kind(
+    facts: FfiElementLayoutFacts,
+    layout_svg_mask_or_clip_path: bool,
+    layout_svg_pattern: bool,
+) -> FfiElementLayoutKind {
     if facts.has_content_replacement {
         FfiElementLayoutKind::ContentReplacement
-    } else if facts.context_layout_svg_mask_or_clip_path {
+    } else if layout_svg_mask_or_clip_path {
         if facts.is_svg_mask_element {
             FfiElementLayoutKind::SvgMask
         } else {
             assert!(facts.is_svg_clip_path_element);
             FfiElementLayoutKind::SvgClipPath
         }
-    } else if facts.context_layout_svg_pattern {
+    } else if layout_svg_pattern {
         assert!(facts.is_svg_pattern_element);
         FfiElementLayoutKind::SvgPattern
     } else {
@@ -512,7 +504,6 @@ pub struct FfiPrincipalBoxPlacementFacts {
     pub is_document: bool,
     pub is_element: bool,
     pub rendered_in_top_layer: bool,
-    pub context_layout_top_layer: bool,
     pub layout_node_is_svg_box: bool,
 }
 
@@ -536,7 +527,10 @@ struct PrincipalBoxPlacementDecision {
     clear_layout_top_layer_for_descendants: bool,
 }
 
-fn principal_box_placement_decision(facts: FfiPrincipalBoxPlacementFacts) -> PrincipalBoxPlacementDecision {
+fn principal_box_placement_decision(
+    facts: FfiPrincipalBoxPlacementFacts,
+    layout_top_layer: bool,
+) -> PrincipalBoxPlacementDecision {
     abort_on_panic(|| {
         let may_replace_existing_layout_node = !facts.must_create_subtree
             && facts.has_old_layout_node
@@ -560,8 +554,7 @@ fn principal_box_placement_decision(facts: FfiPrincipalBoxPlacementFacts) -> Pri
             FfiPrincipalBoxPlacement::NormalInsertion
         };
 
-        let is_active_top_layer_member =
-            facts.is_element && facts.rendered_in_top_layer && facts.context_layout_top_layer;
+        let is_active_top_layer_member = facts.is_element && facts.rendered_in_top_layer && layout_top_layer;
         PrincipalBoxPlacementDecision {
             placement,
             may_replace_existing_layout_node,
@@ -573,14 +566,17 @@ fn principal_box_placement_decision(facts: FfiPrincipalBoxPlacementFacts) -> Pri
     })
 }
 
-fn principal_node_entry_decision(facts: FfiPrincipalNodeEntryFacts) -> PrincipalNodeEntryDecision {
+fn principal_node_entry_decision(
+    facts: FfiPrincipalNodeEntryFacts,
+    context: &TreeBuilderContext,
+) -> PrincipalNodeEntryDecision {
     abort_on_panic(|| {
         let should_create_layout_node = facts.must_create_subtree
             || facts.needs_layout_tree_update
             || facts.document_needs_full_layout_tree_update
             || (facts.is_document && !facts.has_layout_node);
 
-        let top_layer = if facts.is_element && facts.rendered_in_top_layer && !facts.context_layout_top_layer {
+        let top_layer = if facts.is_element && facts.rendered_in_top_layer && !context.layout_top_layer {
             if !facts.layout_node_is_attached && !facts.needs_layout_tree_update {
                 TopLayerEntryDecision::SkipAndRequestZoneRebuild
             } else {
@@ -592,7 +588,7 @@ fn principal_node_entry_decision(facts: FfiPrincipalNodeEntryFacts) -> Principal
 
         let svg = if facts.is_svg_container {
             SvgEntryDecision::EnterSvgRoot
-        } else if facts.requires_svg_container && !facts.context_has_svg_root {
+        } else if facts.requires_svg_container && !context.has_svg_root {
             SvgEntryDecision::Skip
         } else {
             SvgEntryDecision::Continue
@@ -619,13 +615,6 @@ impl DomTreeBuilderHost<'_> {
     fn next_sibling(&self, node: *mut c_void) -> *mut c_void {
         // SAFETY: Callers only pass live DOM nodes.
         unsafe { (self.callbacks.next_sibling)(node) }
-    }
-
-    fn update_layout_tree(&self, node: *mut c_void, context: *mut c_void, must_create_subtree: bool) {
-        // SAFETY: The builder, DOM node, and traversal context remain live throughout recursive construction.
-        unsafe {
-            (self.callbacks.update_layout_tree)(self.callbacks.builder, node, context, must_create_subtree);
-        }
     }
 }
 
@@ -659,19 +648,16 @@ unsafe fn dom_tree_builder_host<'a>(callbacks: *const FfiDomTreeBuilderCallbacks
 ///
 /// The callback table, parent, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_dom_children(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
+    host: &DomTreeBuilderHost<'_>,
     parent: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
         assert!(!parent.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
         let mut node = host.first_child(parent);
         while !node.is_null() {
-            host.update_layout_tree(node, context, must_create_subtree);
+            update_layout_tree(host, node, context, must_create_subtree);
             node = host.next_sibling(node);
         }
     });
@@ -683,19 +669,16 @@ unsafe fn update_layout_tree_for_dom_children(
 ///
 /// The callback table, shadow root, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_shadow_root_children(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
+    host: &DomTreeBuilderHost<'_>,
     shadow_root: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
         assert!(!shadow_root.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
         let mut node = host.first_child(shadow_root);
         while !node.is_null() {
-            host.update_layout_tree(node, context, must_create_subtree);
+            update_layout_tree(host, node, context, must_create_subtree);
             node = host.next_sibling(node);
         }
         // SAFETY: `shadow_root` remains live throughout the call.
@@ -709,16 +692,13 @@ unsafe fn update_layout_tree_for_shadow_root_children(
 ///
 /// The callback table, slot element, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_assigned_slottables(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
+    host: &DomTreeBuilderHost<'_>,
     slot_element: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
         assert!(!slot_element.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
         // SAFETY: `slot_element` remains live throughout the call.
         let slot_needs_layout_tree_update = unsafe { (host.callbacks.needs_layout_tree_update)(slot_element) };
         let must_create_subtree = must_create_subtree || slot_needs_layout_tree_update;
@@ -728,7 +708,7 @@ unsafe fn update_layout_tree_for_assigned_slottables(
             // SAFETY: `index` is below the count reported for this unchanged assigned-node list.
             let node = unsafe { (host.callbacks.assigned_node_at)(slot_element, index) };
             assert!(!node.is_null());
-            host.update_layout_tree(node, context, must_create_subtree);
+            update_layout_tree(host, node, context, must_create_subtree);
         }
     });
 }
@@ -739,16 +719,13 @@ unsafe fn update_layout_tree_for_assigned_slottables(
 ///
 /// The callback table, switch element, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_svg_switch_children(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
+    host: &DomTreeBuilderHost<'_>,
     switch_element: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
         assert!(!switch_element.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
 
         // https://svgwg.org/svg2-draft/struct.html#SwitchElement
         // The ‘switch’ element evaluates the ‘requiredExtensions’ and ‘systemLanguage’ attributes on its direct child
@@ -780,7 +757,7 @@ unsafe fn update_layout_tree_for_svg_switch_children(
         }
 
         if !rendered_child.is_null() {
-            host.update_layout_tree(rendered_child, context, must_create_subtree);
+            update_layout_tree(host, rendered_child, context, must_create_subtree);
         }
     });
 }
@@ -791,26 +768,22 @@ unsafe fn update_layout_tree_for_svg_switch_children(
 ///
 /// The callback table, element, and context must remain valid for the duration of the call.
 unsafe fn update_layout_tree_for_display_contents(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
+    host: &DomTreeBuilderHost<'_>,
     element: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     must_create_subtree: bool,
     should_create_layout_node: bool,
 ) {
     abort_on_panic(|| {
         assert!(!element.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
-        // SAFETY: The element and context remain live for the duration of the call.
-        let facts = unsafe { (host.callbacks.display_contents_facts)(host.callbacks.builder, element, context) };
+        // SAFETY: The element remains live for the duration of the call.
+        let facts = unsafe { (host.callbacks.display_contents_facts)(host.callbacks.builder, element) };
 
         // A display:contents member builds its children through this path, so the top layer flag
         // is consumed here the same way update_layout_tree does for members with a box.
-        let clear_layout_top_layer_for_descendants = facts.rendered_in_top_layer && facts.context_layout_top_layer;
+        let clear_layout_top_layer_for_descendants = facts.rendered_in_top_layer && context.layout_top_layer;
         if clear_layout_top_layer_for_descendants {
-            // SAFETY: `context` remains live throughout this call.
-            unsafe { (host.callbacks.set_context_layout_top_layer)(context, false) };
+            context.layout_top_layer = false;
         }
 
         // SAFETY: The builder and element remain live throughout this call.
@@ -843,23 +816,13 @@ unsafe fn update_layout_tree_for_display_contents(
             if !facts.shadow_root.is_null() {
                 // SAFETY: The callback table, shadow root, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_shadow_root_children(
-                        callbacks,
-                        facts.shadow_root,
-                        context,
-                        must_create_children,
-                    );
+                    update_layout_tree_for_shadow_root_children(host, facts.shadow_root, context, must_create_children);
                 }
             } else if facts.should_layout_dom_children {
                 assert!(!facts.dom_children_parent.is_null());
                 // SAFETY: The callback table, parent, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_dom_children(
-                        callbacks,
-                        facts.dom_children_parent,
-                        context,
-                        must_create_children,
-                    );
+                    update_layout_tree_for_dom_children(host, facts.dom_children_parent, context, must_create_children);
                 }
             }
         }
@@ -868,12 +831,7 @@ unsafe fn update_layout_tree_for_display_contents(
             if !facts.content_visibility_hidden {
                 // SAFETY: The callback table, slot element, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_assigned_slottables(
-                        callbacks,
-                        facts.slot_element,
-                        context,
-                        must_create_subtree,
-                    );
+                    update_layout_tree_for_assigned_slottables(host, facts.slot_element, context, must_create_subtree);
                 }
             } else {
                 // SAFETY: `slot_element` remains live throughout this call.
@@ -898,8 +856,7 @@ unsafe fn update_layout_tree_for_display_contents(
         unsafe { (host.callbacks.clear_update_flags)(facts.dom_children_parent) };
 
         if clear_layout_top_layer_for_descendants {
-            // SAFETY: Restore the live traversal context to its entry value.
-            unsafe { (host.callbacks.set_context_layout_top_layer)(context, true) };
+            context.layout_top_layer = true;
         }
     });
 }
@@ -924,28 +881,24 @@ fn update_svg_resource(
     resource: *mut c_void,
     graphics_element: *mut c_void,
     layout_node: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     prior_context_value: bool,
 ) {
-    // SAFETY: The traversal context and layout node remain live throughout resource construction.
-    unsafe {
-        (host.callbacks.set_context_layout_svg_mask_or_clip_path)(context, true);
-        (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
-    }
+    context.layout_svg_mask_or_clip_path = true;
+    // SAFETY: The layout node remains live throughout resource construction.
+    unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
 
     if !ancestor_stack_contains_dom_node(host, resource) {
-        host.update_layout_tree(resource, context, true);
+        update_layout_tree(host, resource, context, true);
         // SAFETY: Both pointers denote live SVG elements held by the graphics element.
         unsafe { (host.callbacks.register_svg_resource_reference)(resource, graphics_element) };
     } else {
         // FIXME: Somehow either remove ancestor from the layout tree or mark it as invalid.
     }
 
-    // SAFETY: Balance the parent push and restore the context's entry value.
-    unsafe {
-        (host.callbacks.pop_layout_parent)(host.callbacks.builder);
-        (host.callbacks.set_context_layout_svg_mask_or_clip_path)(context, prior_context_value);
-    }
+    // SAFETY: Balance the parent push.
+    unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+    context.layout_svg_mask_or_clip_path = prior_context_value;
 }
 
 fn update_svg_pattern(
@@ -954,17 +907,15 @@ fn update_svg_pattern(
     content_element: *mut c_void,
     graphics_element: *mut c_void,
     layout_node: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     prior_context_value: bool,
 ) {
-    // SAFETY: The traversal context and layout node remain live throughout resource construction.
-    unsafe {
-        (host.callbacks.set_context_layout_svg_pattern)(context, true);
-        (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node);
-    }
+    context.layout_svg_pattern = true;
+    // SAFETY: The layout node remains live throughout resource construction.
+    unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
 
     if !ancestor_stack_contains_dom_node(host, content_element) {
-        host.update_layout_tree(content_element, context, true);
+        update_layout_tree(host, content_element, context, true);
         // The referenced pattern may inherit its content from another pattern via href. Removing either element
         // invalidates the attached resource box, so register the referencer with both.
         // SAFETY: All pointers denote live SVG elements held by the graphics element or pattern chain.
@@ -976,11 +927,9 @@ fn update_svg_pattern(
         }
     }
 
-    // SAFETY: Balance the parent push and restore the context's entry value.
-    unsafe {
-        (host.callbacks.pop_layout_parent)(host.callbacks.builder);
-        (host.callbacks.set_context_layout_svg_pattern)(context, prior_context_value);
-    }
+    // SAFETY: Balance the parent push.
+    unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
+    context.layout_svg_pattern = prior_context_value;
 }
 
 /// Updates the descendants and post-child state of a node with a principal layout box.
@@ -989,23 +938,19 @@ fn update_svg_pattern(
 ///
 /// The callback table, DOM node, layout node, and context must remain valid for the duration of the call.
 unsafe fn update_principal_node_descendants(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
+    host: &DomTreeBuilderHost<'_>,
     dom_node: *mut c_void,
     layout_node: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     should_create_layout_node: bool,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
         assert!(!dom_node.is_null());
         assert!(!layout_node.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
         // SAFETY: All pointers remain live throughout the call.
-        let facts = unsafe {
-            (host.callbacks.principal_descendant_facts)(host.callbacks.builder, dom_node, layout_node, context)
-        };
+        let facts =
+            unsafe { (host.callbacks.principal_descendant_facts)(host.callbacks.builder, dom_node, layout_node) };
         // SAFETY: The builder remains live throughout the call.
         let prior_quote_nesting_level = unsafe { (host.callbacks.quote_nesting_level)(host.callbacks.builder) };
 
@@ -1062,7 +1007,7 @@ unsafe fn update_principal_node_descendants(
                 // SAFETY: The callback table, shadow root, and context remain valid.
                 unsafe {
                     update_layout_tree_for_shadow_root_children(
-                        callbacks,
+                        host,
                         facts.shadow_root,
                         context,
                         should_create_layout_node,
@@ -1078,7 +1023,7 @@ unsafe fn update_principal_node_descendants(
                     // SAFETY: The callback table, parent, and context remain valid.
                     unsafe {
                         update_layout_tree_for_svg_switch_children(
-                            callbacks,
+                            host,
                             facts.dom_children_parent,
                             context,
                             should_create_layout_node,
@@ -1088,7 +1033,7 @@ unsafe fn update_principal_node_descendants(
                     // SAFETY: The callback table, parent, and context remain valid.
                     unsafe {
                         update_layout_tree_for_dom_children(
-                            callbacks,
+                            host,
                             facts.dom_children_parent,
                             context,
                             should_create_layout_node,
@@ -1100,8 +1045,8 @@ unsafe fn update_principal_node_descendants(
             if facts.is_document {
                 // Elements in the top layer do not lay out normally based on their position in the document; instead
                 // they generate boxes as if they were siblings of the root element.
-                // SAFETY: The traversal context remains live and is restored before this function returns.
-                unsafe { (host.callbacks.set_context_layout_top_layer)(context, true) };
+                let prior_layout_top_layer = context.layout_top_layer;
+                context.layout_top_layer = true;
                 // SAFETY: The DOM document remains live and owns a stable top-layer list during this pass.
                 let count = unsafe { (host.callbacks.top_layer_element_count)(dom_node) };
                 let mut top_layer_elements = vec![std::ptr::null_mut(); count];
@@ -1116,17 +1061,16 @@ unsafe fn update_principal_node_descendants(
                         continue;
                     }
                     // SAFETY: `element` is a live DOM Element.
-                    if has_unrendered_flat_tree_ancestor(&host, element) {
+                    if has_unrendered_flat_tree_ancestor(host, element) {
                         // SAFETY: The builder and element remain live throughout cleanup.
                         unsafe {
                             (host.callbacks.clear_stale_top_layer_subtree)(host.callbacks.builder, element);
                         }
                         continue;
                     }
-                    host.update_layout_tree(element, context, should_create_layout_node);
+                    update_layout_tree(host, element, context, should_create_layout_node);
                 }
-                // SAFETY: Restore the traversal context's entry value for the document walk.
-                unsafe { (host.callbacks.set_context_layout_top_layer)(context, facts.context_layout_top_layer) };
+                context.layout_top_layer = prior_layout_top_layer;
             }
 
             // SAFETY: Balances the principal layout-node push above.
@@ -1139,12 +1083,7 @@ unsafe fn update_principal_node_descendants(
                 unsafe { (host.callbacks.push_layout_parent)(host.callbacks.builder, layout_node) };
                 // SAFETY: The callback table, slot element, and context remain valid.
                 unsafe {
-                    update_layout_tree_for_assigned_slottables(
-                        callbacks,
-                        facts.slot_element,
-                        context,
-                        must_create_subtree,
-                    );
+                    update_layout_tree_for_assigned_slottables(host, facts.slot_element, context, must_create_subtree);
                 }
                 // SAFETY: Balances the assigned-node parent push above.
                 unsafe { (host.callbacks.pop_layout_parent)(host.callbacks.builder) };
@@ -1159,12 +1098,12 @@ unsafe fn update_principal_node_descendants(
                 for resource in [facts.svg_mask, facts.svg_clip_path] {
                     if !resource.is_null() {
                         update_svg_resource(
-                            &host,
+                            host,
                             resource,
                             facts.svg_graphics_element,
                             layout_node,
                             context,
-                            facts.context_layout_svg_mask_or_clip_path,
+                            context.layout_svg_mask_or_clip_path,
                         );
                     }
                 }
@@ -1181,13 +1120,13 @@ unsafe fn update_principal_node_descendants(
                     }
                     seen_content_elements.push(content_element);
                     update_svg_pattern(
-                        &host,
+                        host,
                         pattern,
                         content_element,
                         facts.svg_graphics_element,
                         layout_node,
                         context,
-                        facts.context_layout_svg_pattern,
+                        context.layout_svg_pattern,
                     );
                 }
             }
@@ -1245,24 +1184,24 @@ unsafe fn update_principal_node_descendants(
     });
 }
 
-struct PrincipalNodeUpdate<'host, 'callbacks> {
+struct PrincipalNodeUpdate<'host, 'callbacks, 'context> {
     host: &'host DomTreeBuilderHost<'callbacks>,
-    callbacks: *const FfiDomTreeBuilderCallbacks,
     frame: *mut c_void,
     dom_node: *mut c_void,
-    context: *mut c_void,
+    context: &'context mut TreeBuilderContext,
     must_create_subtree: bool,
 }
 
 fn construct_principal_layout_node(
-    update: &PrincipalNodeUpdate<'_, '_>,
+    update: &mut PrincipalNodeUpdate<'_, '_, '_>,
     entry_facts: FfiPrincipalNodeEntryFacts,
     should_create_layout_node: bool,
 ) -> (bool, bool) {
     let host = update.host;
     let frame = update.frame;
     let dom_node = update.dom_node;
-    let context = update.context;
+    let must_create_subtree = update.must_create_subtree;
+    let context = &mut *update.context;
     if entry_facts.is_element {
         // SAFETY: The frame, builder, and DOM element remain live throughout the call.
         let display = unsafe {
@@ -1285,19 +1224,23 @@ fn construct_principal_layout_node(
             // SAFETY: The callback table, DOM element, and context remain valid throughout the recursive walk.
             unsafe {
                 update_layout_tree_for_display_contents(
-                    update.callbacks,
+                    host,
                     dom_node,
                     context,
-                    update.must_create_subtree,
+                    must_create_subtree,
                     should_create_layout_node,
                 );
             }
             return (false, true);
         }
         if should_create_layout_node {
-            // SAFETY: The frame, element, and context remain live throughout construction.
-            let layout_facts = unsafe { (host.callbacks.principal_element_layout_facts)(frame, dom_node, context) };
-            let layout_kind = element_layout_kind(layout_facts);
+            // SAFETY: The frame and element remain live throughout construction.
+            let layout_facts = unsafe { (host.callbacks.principal_element_layout_facts)(frame, dom_node) };
+            let layout_kind = element_layout_kind(
+                layout_facts,
+                context.layout_svg_mask_or_clip_path,
+                context.layout_svg_pattern,
+            );
             // SAFETY: The builder, frame, and element remain live throughout construction.
             unsafe {
                 (host.callbacks.create_principal_element_layout)(host.callbacks.builder, frame, dom_node, layout_kind);
@@ -1307,12 +1250,10 @@ fn construct_principal_layout_node(
                 FfiElementLayoutKind::SvgMask | FfiElementLayoutKind::SvgClipPath
             ) {
                 // Only direct mask and clip-path uses inherit this construction mode.
-                // SAFETY: The traversal context remains live throughout the call.
-                unsafe { (host.callbacks.set_context_layout_svg_mask_or_clip_path)(context, false) };
+                context.layout_svg_mask_or_clip_path = false;
             } else if layout_kind == FfiElementLayoutKind::SvgPattern {
                 // Only the directly referenced pattern inherits this construction mode.
-                // SAFETY: The traversal context remains live throughout the call.
-                unsafe { (host.callbacks.set_context_layout_svg_pattern)(context, false) };
+                context.layout_svg_pattern = false;
             }
         } else {
             // SAFETY: The frame and DOM node remain live throughout the call.
@@ -1339,20 +1280,17 @@ fn construct_principal_layout_node(
 }
 
 fn update_principal_node_after_entry(
-    update: &PrincipalNodeUpdate<'_, '_>,
+    update: &mut PrincipalNodeUpdate<'_, '_, '_>,
     entry_facts: FfiPrincipalNodeEntryFacts,
     entry_decision: PrincipalNodeEntryDecision,
 ) {
     let host = update.host;
     let frame = update.frame;
     let dom_node = update.dom_node;
-    let context = update.context;
-    // SAFETY: The frame and DOM node remain live throughout this update.
-    unsafe { (host.callbacks.initialize_principal_frame)(frame, dom_node) };
 
+    let prior_has_svg_root = update.context.has_svg_root;
     if entry_decision.svg == SvgEntryDecision::EnterSvgRoot {
-        // SAFETY: The traversal context remains live throughout this update.
-        unsafe { (host.callbacks.set_context_has_svg_root)(context, true) };
+        update.context.has_svg_root = true;
     }
 
     let (has_layout_node, handled_display_contents) = if entry_decision.svg == SvgEntryDecision::Skip {
@@ -1360,6 +1298,7 @@ fn update_principal_node_after_entry(
     } else {
         construct_principal_layout_node(update, entry_facts, entry_decision.should_create_layout_node)
     };
+    let context = &mut *update.context;
 
     if has_layout_node {
         if entry_facts.is_element || entry_facts.is_document {
@@ -1388,12 +1327,12 @@ fn update_principal_node_after_entry(
                 host.callbacks.builder,
                 frame,
                 dom_node,
-                context,
                 update.must_create_subtree,
                 entry_decision.should_create_layout_node,
             )
         };
-        let placement = principal_box_placement_decision(placement_facts);
+        let prior_layout_top_layer = context.layout_top_layer;
+        let placement = principal_box_placement_decision(placement_facts, prior_layout_top_layer);
 
         let mut prior_rebuild_root = std::ptr::null_mut();
         if placement.start_rebuild_root {
@@ -1426,8 +1365,7 @@ fn update_principal_node_after_entry(
         }
 
         if placement.clear_layout_top_layer_for_descendants {
-            // SAFETY: The traversal context remains live throughout descendant construction.
-            unsafe { (host.callbacks.set_context_layout_top_layer)(context, false) };
+            context.layout_top_layer = false;
         }
 
         // SAFETY: The builder and frame remain live, and Rust selected the placement mode.
@@ -1435,7 +1373,7 @@ fn update_principal_node_after_entry(
         // SAFETY: The callback table, DOM node, layout node, and context remain live throughout the call.
         unsafe {
             update_principal_node_descendants(
-                update.callbacks,
+                host,
                 dom_node,
                 (host.callbacks.principal_layout_node)(frame),
                 context,
@@ -1445,8 +1383,7 @@ fn update_principal_node_after_entry(
         }
 
         if placement.clear_layout_top_layer_for_descendants {
-            // SAFETY: Restore the context value captured in the placement facts.
-            unsafe { (host.callbacks.set_context_layout_top_layer)(context, placement_facts.context_layout_top_layer) };
+            context.layout_top_layer = prior_layout_top_layer;
         }
         if placement.start_rebuild_root {
             // SAFETY: Restore the builder's previous rebuild root after descendant construction.
@@ -1459,8 +1396,7 @@ fn update_principal_node_after_entry(
     }
 
     if entry_decision.svg == SvgEntryDecision::EnterSvgRoot {
-        // SAFETY: Restore the traversal context's entry value.
-        unsafe { (host.callbacks.set_context_has_svg_root)(context, entry_facts.context_has_svg_root) };
+        context.has_svg_root = prior_has_svg_root;
     }
 }
 
@@ -1468,26 +1404,20 @@ fn update_principal_node_after_entry(
 ///
 /// # Safety
 ///
-/// The callback table, frame storage, DOM node, and context must remain valid for the duration of the call.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_update_layout_tree(
-    callbacks: *const FfiDomTreeBuilderCallbacks,
-    frame: *mut c_void,
+/// The callback table and DOM node must remain valid for the duration of the call.
+fn update_layout_tree(
+    host: &DomTreeBuilderHost<'_>,
     dom_node: *mut c_void,
-    context: *mut c_void,
+    context: &mut TreeBuilderContext,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
-        assert!(!frame.is_null());
         assert!(!dom_node.is_null());
-        assert!(!context.is_null());
-        // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
-        // SAFETY: The builder, DOM node, and context remain live throughout the call.
+        // SAFETY: The builder and DOM node remain live throughout the call.
         let entry_facts = unsafe {
-            (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, dom_node, context, must_create_subtree)
+            (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, dom_node, must_create_subtree)
         };
-        let entry_decision = principal_node_entry_decision(entry_facts);
+        let entry_decision = principal_node_entry_decision(entry_facts, context);
         if entry_decision.top_layer != TopLayerEntryDecision::Continue {
             if entry_decision.top_layer == TopLayerEntryDecision::SkipAndRequestZoneRebuild {
                 // A member found here without an attached box was cleared together with a hidden ancestor subtree, and
@@ -1503,19 +1433,23 @@ pub unsafe extern "C" fn rust_update_layout_tree(
             // SAFETY: `dom_node` is a live Element when this fact is set.
             unsafe { (host.callbacks.push_style_ancestor)(dom_node) };
         }
-        let update = PrincipalNodeUpdate {
-            host: &host,
-            callbacks,
+        // SAFETY: The builder and DOM node remain live, and the callback retains frame-owned C++ objects.
+        let frame = unsafe { (host.callbacks.push_principal_frame)(host.callbacks.builder, dom_node) };
+        assert!(!frame.is_null());
+        let mut update = PrincipalNodeUpdate {
+            host,
             frame,
             dom_node,
             context,
             must_create_subtree,
         };
-        update_principal_node_after_entry(&update, entry_facts, entry_decision);
+        update_principal_node_after_entry(&mut update, entry_facts, entry_decision);
         if entry_facts.is_element {
             // SAFETY: Balances the style ancestor push above.
             unsafe { (host.callbacks.pop_style_ancestor)(dom_node) };
         }
+        // SAFETY: `frame` is the most recently pushed principal frame and is no longer used by Rust.
+        unsafe { (host.callbacks.pop_principal_frame)(host.callbacks.builder, frame) };
     });
 }
 
@@ -1523,31 +1457,28 @@ pub unsafe extern "C" fn rust_update_layout_tree(
 ///
 /// # Safety
 ///
-/// The callback table, frame storage, document, and context must remain valid for the duration of the call.
+/// The callback table and document must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_build_layout_tree(
     callbacks: *const FfiDomTreeBuilderCallbacks,
-    frame: *mut c_void,
     document: *mut c_void,
-    context: *mut c_void,
 ) -> *mut c_void {
     abort_on_panic(|| {
-        assert!(!frame.is_null());
         assert!(!document.is_null());
-        assert!(!context.is_null());
         // SAFETY: Guaranteed by the entry point's contract.
         let host = unsafe { dom_tree_builder_host(callbacks) };
+        let mut context = TreeBuilderContext::default();
         // SAFETY: All pointers remain live throughout the build.
         let entry_facts =
-            unsafe { (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, document, context, false) };
+            unsafe { (host.callbacks.principal_node_entry_facts)(host.callbacks.builder, document, false) };
         assert!(entry_facts.is_document);
 
         // SAFETY: The document and builder remain live throughout the build.
         unsafe {
             (host.callbacks.reset_style_ancestor_filter)(document);
             (host.callbacks.set_quote_nesting_level)(host.callbacks.builder, 0);
-            rust_update_layout_tree(callbacks, frame, document, context, false);
         }
+        update_layout_tree(&host, document, &mut context, false);
 
         // NB: Called during layout tree construction.
         // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
@@ -3128,7 +3059,7 @@ mod tests {
         FfiFirstLetterTextCallbacks, FfiPrincipalBoxPlacement, FfiPrincipalBoxPlacementFacts,
         FfiPrincipalNodeEntryFacts, FfiPseudoElement, FfiPseudoElementDecision, FfiPseudoElementFacts,
         FfiReplacedElementDisplayAdjustment, FirstLetterTextHost, PrincipalBoxGenerationDecision, SvgEntryDecision,
-        TopLayerEntryDecision, adjusted_table_display_for_replaced_element, element_layout_kind,
+        TopLayerEntryDecision, TreeBuilderContext, adjusted_table_display_for_replaced_element, element_layout_kind,
         find_first_letter_in_text, principal_box_generation_decision, principal_box_placement_decision,
         principal_node_entry_decision, pseudo_element_decision, rust_display_contents_text_needs_style_wrapper,
     };
@@ -3337,30 +3268,30 @@ mod tests {
             is_element: true,
             is_text: false,
             rendered_in_top_layer: false,
-            context_layout_top_layer: false,
             layout_node_is_attached: true,
             is_svg_container: false,
             requires_svg_container: false,
-            context_has_svg_root: false,
         };
-        let decision = principal_node_entry_decision(facts);
+        let mut context = TreeBuilderContext::default();
+        let decision = principal_node_entry_decision(facts, &context);
         assert!(!decision.should_create_layout_node);
         assert_eq!(decision.top_layer, TopLayerEntryDecision::Continue);
         assert_eq!(decision.svg, SvgEntryDecision::Continue);
 
         facts.rendered_in_top_layer = true;
         facts.layout_node_is_attached = false;
-        let decision = principal_node_entry_decision(facts);
+        let decision = principal_node_entry_decision(facts, &context);
         assert_eq!(decision.top_layer, TopLayerEntryDecision::SkipAndRequestZoneRebuild);
 
         facts.rendered_in_top_layer = false;
         facts.requires_svg_container = true;
-        let decision = principal_node_entry_decision(facts);
+        let decision = principal_node_entry_decision(facts, &context);
         assert_eq!(decision.svg, SvgEntryDecision::Skip);
 
         facts.must_create_subtree = true;
         facts.is_svg_container = true;
-        let decision = principal_node_entry_decision(facts);
+        context.has_svg_root = false;
+        let decision = principal_node_entry_decision(facts, &context);
         assert!(decision.should_create_layout_node);
         assert_eq!(decision.svg, SvgEntryDecision::EnterSvgRoot);
     }
@@ -3369,26 +3300,27 @@ mod tests {
     fn specialized_element_layout_kinds() {
         let mut facts = FfiElementLayoutFacts {
             has_content_replacement: false,
-            context_layout_svg_mask_or_clip_path: false,
-            context_layout_svg_pattern: false,
             is_svg_mask_element: false,
             is_svg_clip_path_element: false,
             is_svg_pattern_element: false,
         };
-        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::Normal);
+        assert_eq!(element_layout_kind(facts, false, false), FfiElementLayoutKind::Normal);
 
         facts.has_content_replacement = true;
-        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::ContentReplacement);
+        assert_eq!(
+            element_layout_kind(facts, false, false),
+            FfiElementLayoutKind::ContentReplacement
+        );
         facts.has_content_replacement = false;
-        facts.context_layout_svg_mask_or_clip_path = true;
         facts.is_svg_mask_element = true;
-        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::SvgMask);
+        assert_eq!(element_layout_kind(facts, true, false), FfiElementLayoutKind::SvgMask);
 
-        facts.context_layout_svg_mask_or_clip_path = false;
         facts.is_svg_mask_element = false;
-        facts.context_layout_svg_pattern = true;
         facts.is_svg_pattern_element = true;
-        assert_eq!(element_layout_kind(facts), FfiElementLayoutKind::SvgPattern);
+        assert_eq!(
+            element_layout_kind(facts, false, true),
+            FfiElementLayoutKind::SvgPattern
+        );
     }
 
     #[test]
@@ -3416,10 +3348,9 @@ mod tests {
             is_document: false,
             is_element: true,
             rendered_in_top_layer: true,
-            context_layout_top_layer: true,
             layout_node_is_svg_box: false,
         };
-        let decision = principal_box_placement_decision(facts);
+        let decision = principal_box_placement_decision(facts, true);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::ReplaceExisting);
         assert!(decision.start_rebuild_root);
         assert!(decision.create_backdrop);
@@ -3428,7 +3359,7 @@ mod tests {
         facts.has_old_layout_node = false;
         facts.old_layout_node_is_attached = false;
         facts.layout_node_is_svg_box = true;
-        let decision = principal_box_placement_decision(facts);
+        let decision = principal_box_placement_decision(facts, true);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::AppendSvg);
         assert!(decision.mark_update_escaped_rebuild_roots);
     }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -109,6 +109,26 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub assigned_node_at: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void,
     pub is_svg_element: unsafe extern "C" fn(*mut c_void) -> bool,
     pub clear_stale_layout_and_paint_node: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub display_contents_facts: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiDisplayContentsFacts,
+    pub set_context_layout_top_layer: unsafe extern "C" fn(*mut c_void, bool),
+    pub clear_synthetic_pseudo_element_layout_nodes: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub clear_stale_inclusive_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub resolve_counters: unsafe extern "C" fn(*mut c_void),
+    pub create_pseudo_element: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, FfiInsertionMode),
+    pub clear_stale_assigned_slottables: unsafe extern "C" fn(*mut c_void),
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiDisplayContentsFacts {
+    pub rendered_in_top_layer: bool,
+    pub context_layout_top_layer: bool,
+    pub content_visibility_hidden: bool,
+    pub should_layout_dom_children: bool,
+    pub child_needs_layout_tree_update: bool,
+    pub dom_children_parent: *mut c_void,
+    pub shadow_root: *mut c_void,
+    pub slot_element: *mut c_void,
 }
 
 struct DomTreeBuilderHost<'a> {
@@ -274,6 +294,126 @@ pub unsafe extern "C" fn rust_update_layout_tree_for_svg_switch_children(
 
         if !rendered_child.is_null() {
             host.update_layout_tree(rendered_child, context, must_create_subtree);
+        }
+    });
+}
+
+/// Updates an element that generates no principal box because it has `display: contents`.
+///
+/// # Safety
+///
+/// The callback table, element, and context must remain valid for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_update_layout_tree_for_display_contents(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    element: *mut c_void,
+    context: *mut c_void,
+    must_create_subtree: bool,
+    should_create_layout_node: bool,
+) {
+    abort_on_panic(|| {
+        assert!(!element.is_null());
+        assert!(!context.is_null());
+        // SAFETY: Guaranteed by the entry point's contract.
+        let host = unsafe { dom_tree_builder_host(callbacks) };
+        // SAFETY: The element and context remain live for the duration of the call.
+        let facts = unsafe { (host.callbacks.display_contents_facts)(host.callbacks.builder, element, context) };
+
+        // A display:contents member builds its children through this path, so the top layer flag
+        // is consumed here the same way update_layout_tree does for members with a box.
+        let clear_layout_top_layer_for_descendants = facts.rendered_in_top_layer && facts.context_layout_top_layer;
+        if clear_layout_top_layer_for_descendants {
+            // SAFETY: `context` remains live throughout this call.
+            unsafe { (host.callbacks.set_context_layout_top_layer)(context, false) };
+        }
+
+        // SAFETY: The builder and element remain live throughout this call.
+        unsafe {
+            (host.callbacks.clear_synthetic_pseudo_element_layout_nodes)(host.callbacks.builder, element);
+        }
+
+        if should_create_layout_node {
+            // SAFETY: The builder and element remain live throughout this call.
+            unsafe {
+                (host.callbacks.clear_stale_inclusive_descendants)(host.callbacks.builder, element);
+                (host.callbacks.resolve_counters)(element);
+            }
+        }
+
+        if !facts.content_visibility_hidden {
+            // SAFETY: The builder and element remain live throughout this call.
+            unsafe {
+                (host.callbacks.create_pseudo_element)(
+                    host.callbacks.builder,
+                    element,
+                    FfiPseudoElement::Before,
+                    FfiInsertionMode::Append,
+                );
+            }
+        }
+
+        if !facts.content_visibility_hidden && (should_create_layout_node || facts.child_needs_layout_tree_update) {
+            let must_create_children = should_create_layout_node;
+            if !facts.shadow_root.is_null() {
+                // SAFETY: The callback table, shadow root, and context remain valid.
+                unsafe {
+                    rust_update_layout_tree_for_shadow_root_children(
+                        callbacks,
+                        facts.shadow_root,
+                        context,
+                        must_create_children,
+                    );
+                }
+            } else if facts.should_layout_dom_children {
+                assert!(!facts.dom_children_parent.is_null());
+                // SAFETY: The callback table, parent, and context remain valid.
+                unsafe {
+                    rust_update_layout_tree_for_dom_children(
+                        callbacks,
+                        facts.dom_children_parent,
+                        context,
+                        must_create_children,
+                    );
+                }
+            }
+        }
+
+        if !facts.slot_element.is_null() {
+            if !facts.content_visibility_hidden {
+                // SAFETY: The callback table, slot element, and context remain valid.
+                unsafe {
+                    rust_update_layout_tree_for_assigned_slottables(
+                        callbacks,
+                        facts.slot_element,
+                        context,
+                        must_create_subtree,
+                    );
+                }
+            } else {
+                // SAFETY: `slot_element` remains live throughout this call.
+                unsafe { (host.callbacks.clear_stale_assigned_slottables)(facts.slot_element) };
+            }
+        }
+
+        if !facts.content_visibility_hidden {
+            // SAFETY: The builder and element remain live throughout this call.
+            unsafe {
+                (host.callbacks.create_pseudo_element)(
+                    host.callbacks.builder,
+                    element,
+                    FfiPseudoElement::After,
+                    FfiInsertionMode::Append,
+                );
+            }
+        }
+
+        assert!(!facts.dom_children_parent.is_null());
+        // SAFETY: The element's ParentNode subobject remains live throughout this call.
+        unsafe { (host.callbacks.clear_update_flags)(facts.dom_children_parent) };
+
+        if clear_layout_top_layer_for_descendants {
+            // SAFETY: Restore the live traversal context to its entry value.
+            unsafe { (host.callbacks.set_context_layout_top_layer)(context, true) };
         }
     });
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -87,6 +87,51 @@ pub struct FfiLayoutNodeFacts {
     pub display_is_flow_inside: bool,
     pub display_is_flex_inside: bool,
     pub display_is_grid_inside: bool,
+    pub is_list_item_marker_box: bool,
+    pub is_generated_for_marker: bool,
+    pub is_fragmented_inline: bool,
+    pub has_first_letter_style: bool,
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiFirstLetterTarget {
+    pub text_node: *mut c_void,
+    pub letter_start: usize,
+    pub letter_end: usize,
+    pub found: bool,
+}
+
+impl FfiFirstLetterTarget {
+    fn not_found() -> Self {
+        Self {
+            text_node: std::ptr::null_mut(),
+            letter_start: 0,
+            letter_end: 0,
+            found: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct FfiFirstLetterCodePointFacts {
+    pub is_space_separator: bool,
+    pub is_punctuation: bool,
+    pub is_letter: bool,
+    pub is_number: bool,
+    pub is_symbol: bool,
+    pub is_open_punctuation: bool,
+    pub is_dash_punctuation: bool,
+}
+
+#[repr(C)]
+pub struct FfiFirstLetterTextCallbacks {
+    pub context: *mut c_void,
+    pub code_unit_length: unsafe extern "C" fn(*mut c_void) -> usize,
+    pub code_point_at: unsafe extern "C" fn(*mut c_void, usize) -> u32,
+    pub next_grapheme_boundary: unsafe extern "C" fn(*mut c_void, usize) -> usize,
+    pub code_point_facts: unsafe extern "C" fn(*mut c_void, u32) -> FfiFirstLetterCodePointFacts,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -131,6 +176,7 @@ pub struct FfiTreeBuilderCallbacks {
     pub insert_child: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
     pub set_children_are_inline: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub note_tree_restructuring: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub find_first_letter_in_text: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiFirstLetterTarget,
 }
 
 type LayoutNode = *mut c_void;
@@ -471,6 +517,232 @@ pub unsafe extern "C" fn rust_insert_node_into_inline_or_block_ancestor(
             }
         }
     });
+}
+
+struct FirstLetterTextHost<'a> {
+    callbacks: &'a FfiFirstLetterTextCallbacks,
+}
+
+impl FirstLetterTextHost<'_> {
+    fn code_unit_length(&self) -> usize {
+        // SAFETY: The entry point's callback contract guarantees that the text context is live.
+        unsafe { (self.callbacks.code_unit_length)(self.callbacks.context) }
+    }
+
+    fn code_point_at(&self, index: usize) -> u32 {
+        // SAFETY: Callers only pass indices below `code_unit_length`.
+        unsafe { (self.callbacks.code_point_at)(self.callbacks.context, index) }
+    }
+
+    fn next_grapheme_boundary(&self, index: usize) -> usize {
+        // SAFETY: Callers only pass indices at or below `code_unit_length`.
+        unsafe { (self.callbacks.next_grapheme_boundary)(self.callbacks.context, index) }
+    }
+
+    fn code_point_facts(&self, code_point: u32) -> FfiFirstLetterCodePointFacts {
+        // SAFETY: The callback accepts every Unicode scalar value and lone surrogate value supplied by the text view.
+        unsafe { (self.callbacks.code_point_facts)(self.callbacks.context, code_point) }
+    }
+}
+
+fn code_unit_length_for_code_point(code_point: u32) -> usize {
+    if code_point > 0xffff { 2 } else { 1 }
+}
+
+// https://drafts.csswg.org/css-pseudo-4/#first-letter-pattern
+fn find_first_letter_in_text(host: &FirstLetterTextHost<'_>, preserves_segment_breaks: bool) -> FfiFirstLetterTarget {
+    // NB: Matches the first-letter text pattern: (P (Zs|P)*)? (L|N|S) ((Zs|P-(Ps|Pd))* (P-(Ps|Pd))?)?
+
+    let code_units = host.code_unit_length();
+    let mut match_start = 0;
+    while match_start < code_units {
+        let mut cursor = match_start;
+        let starting_code_point = host.code_point_at(cursor);
+
+        // When white-space preserves segment breaks, a newline before any letter puts the letter on a later line, so
+        // the first formatted line is empty and ::first-letter must not match.
+        if preserves_segment_breaks && (starting_code_point == b'\n' as u32 || starting_code_point == b'\r' as u32) {
+            return FfiFirstLetterTarget::not_found();
+        }
+
+        let starting_facts = host.code_point_facts(starting_code_point);
+
+        // A valid match starts with either a P, or the letter itself.
+        let has_preceding = starting_facts.is_punctuation;
+        if !(has_preceding || starting_facts.is_letter || starting_facts.is_number || starting_facts.is_symbol) {
+            match_start += code_unit_length_for_code_point(starting_code_point);
+            continue;
+        }
+
+        if has_preceding {
+            // Preceding group: P followed by (Zs|P)*.
+            cursor = host.next_grapheme_boundary(cursor);
+            while cursor < code_units {
+                let code_point = host.code_point_at(cursor);
+                let facts = host.code_point_facts(code_point);
+                // For the preceding run: Zs excluding U+3000 IDEOGRAPHIC SPACE.
+                let is_preceding_intervening_space = code_point != 0x3000 && facts.is_space_separator;
+                if !facts.is_punctuation && !is_preceding_intervening_space {
+                    break;
+                }
+                cursor = host.next_grapheme_boundary(cursor);
+            }
+        }
+
+        // The letter (L|N|S) must follow the preceding group. If the preceding punctuation consumed the entire text
+        // node, accept it as the first-letter.
+        if cursor >= code_units {
+            return FfiFirstLetterTarget {
+                text_node: std::ptr::null_mut(),
+                letter_start: match_start,
+                letter_end: cursor,
+                found: true,
+            };
+        }
+        let letter_facts = host.code_point_facts(host.code_point_at(cursor));
+        if !(letter_facts.is_letter || letter_facts.is_number || letter_facts.is_symbol) {
+            match_start += code_unit_length_for_code_point(starting_code_point);
+            continue;
+        }
+
+        let mut letter_end = host.next_grapheme_boundary(cursor);
+
+        // Trailing group: greedy match of (Zs|P-(Ps|Pd))*.
+        while letter_end < code_units {
+            let code_point = host.code_point_at(letter_end);
+            let facts = host.code_point_facts(code_point);
+            // For the trailing run: Zs excluding U+3000 IDEOGRAPHIC SPACE and word separators.
+            // NB: css-text-4 defines word separators as a non-exhaustive list, but of the seven code
+            //     points it names only U+0020 SPACE and U+00A0 NO-BREAK SPACE are in the Zs category;
+            //     the rest are in Po and would never reach this check. Fixed-width spaces are explicitly
+            //     not word separators per the spec's note, so they remain valid intervening Zs here.
+            let is_trailing_intervening_space =
+                !matches!(code_point, 0x0020 | 0x00a0 | 0x3000) && facts.is_space_separator;
+            // NB: The css-pseudo specification excludes Ps and Pd classes (closing punctuation and dashes) from the
+            //     trailing run, whereas CSS 2.1 allowed all classes in both the preceding and trailing runs.
+            let is_trailing_punctuation =
+                facts.is_punctuation && !facts.is_open_punctuation && !facts.is_dash_punctuation;
+            if !is_trailing_intervening_space && !is_trailing_punctuation {
+                break;
+            }
+            letter_end = host.next_grapheme_boundary(letter_end);
+        }
+
+        return FfiFirstLetterTarget {
+            text_node: std::ptr::null_mut(),
+            letter_start: match_start,
+            letter_end,
+            found: true,
+        };
+    }
+    FfiFirstLetterTarget::not_found()
+}
+
+/// Finds the first-letter text pattern within one layout text node.
+///
+/// # Safety
+///
+/// `callbacks` must point to a valid callback table whose context remains live for the duration of the call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_find_first_letter_in_text(
+    callbacks: *const FfiFirstLetterTextCallbacks,
+    preserves_segment_breaks: bool,
+) -> FfiFirstLetterTarget {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        // SAFETY: The caller guarantees that `callbacks` remains valid for the duration of this call.
+        let host = FirstLetterTextHost {
+            callbacks: unsafe { &*callbacks },
+        };
+        find_first_letter_in_text(&host, preserves_segment_breaks)
+    })
+}
+
+fn is_marker_content(facts: FfiLayoutNodeFacts) -> bool {
+    facts.is_list_item_marker_box || facts.is_generated_for_marker
+}
+
+// https://drafts.csswg.org/css-pseudo-4/#first-letter-application
+fn find_first_letter_in_block(host: &TreeBuilderHost<'_>, block: LayoutNode) -> FfiFirstLetterTarget {
+    // NB: This walks a block container's inline descendants looking for the first-letter text. If the block has block
+    //     children instead of inline, recurses into each in-flow block child in turn.
+    if host.facts(block).children_are_inline {
+        let mut result = FfiFirstLetterTarget::not_found();
+        let mut is_root = true;
+        host.for_each_in_inclusive_subtree(block, |node| {
+            if is_root {
+                is_root = false;
+                return TraversalDecision::Continue;
+            }
+            let facts = host.facts(node);
+            if is_marker_content(facts) || facts.is_out_of_flow {
+                return TraversalDecision::SkipChildrenAndContinue;
+            }
+            if facts.is_text {
+                // SAFETY: `node` is a live TextNode.
+                result = unsafe { (host.callbacks.find_first_letter_in_text)(host.callbacks.context, node) };
+                return if result.found {
+                    TraversalDecision::Break
+                } else {
+                    TraversalDecision::Continue
+                };
+            }
+            if facts.is_fragmented_inline {
+                return TraversalDecision::Continue;
+            }
+            TraversalDecision::Break
+        });
+        return result;
+    }
+
+    // We have no inline content of our own but ::first-letter can still apply to text in an in-flow block descendant,
+    // so walk into each in-flow block child in document order until one yields a letter.
+    let mut child = host.first_child(block);
+    while !child.is_null() {
+        let facts = host.facts(child);
+        if is_marker_content(facts) || facts.is_out_of_flow {
+            child = host.next_sibling(child);
+            continue;
+        }
+        if !facts.is_block_container {
+            break;
+        }
+        // Stop descending if this child block defines its own ::first-letter: the child will style the first letter
+        // inside it, so the ancestor's ::first-letter must not also claim the same letter.
+        if facts.has_first_letter_style {
+            break;
+        }
+        let target = find_first_letter_in_block(host, child);
+        if target.found {
+            return target;
+        }
+        if !facts.is_anonymous {
+            break;
+        }
+        child = host.next_sibling(child);
+    }
+    FfiFirstLetterTarget::not_found()
+}
+
+/// Finds the text range claimed by a block's `::first-letter` pseudo-element.
+///
+/// # Safety
+///
+/// `callbacks` must remain valid for the duration of the call and `block` must be a live BlockContainer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_find_first_letter_in_block(
+    callbacks: *const FfiTreeBuilderCallbacks,
+    block: *mut c_void,
+) -> FfiFirstLetterTarget {
+    abort_on_panic(|| {
+        assert!(!callbacks.is_null());
+        assert!(!block.is_null());
+        // SAFETY: The caller guarantees that `callbacks` remains valid for the duration of this call.
+        let host = TreeBuilderHost {
+            callbacks: unsafe { &*callbacks },
+        };
+        find_first_letter_in_block(&host, block)
+    })
 }
 
 fn is_table_track(display: FfiTableDisplay) -> bool {
@@ -931,7 +1203,49 @@ pub unsafe extern "C" fn rust_fixup_tables(callbacks: *const FfiTreeBuilderCallb
 
 #[cfg(test)]
 mod tests {
-    use super::{FfiReplacedElementDisplayAdjustment, rust_adjusted_table_display_for_replaced_element};
+    use super::{
+        FfiFirstLetterCodePointFacts, FfiFirstLetterTextCallbacks, FfiReplacedElementDisplayAdjustment,
+        FirstLetterTextHost, find_first_letter_in_text, rust_adjusted_table_display_for_replaced_element,
+    };
+    use std::ffi::c_void;
+
+    unsafe extern "C" fn text_length(context: *mut c_void) -> usize {
+        // SAFETY: Test callers pass a valid `Vec<u16>` as the callback context.
+        unsafe { (&*context.cast::<Vec<u16>>()).len() }
+    }
+
+    unsafe extern "C" fn code_point_at(context: *mut c_void, index: usize) -> u32 {
+        // SAFETY: Test callers pass a valid `Vec<u16>` and an in-bounds index.
+        unsafe { (&*context.cast::<Vec<u16>>())[index] as u32 }
+    }
+
+    unsafe extern "C" fn next_grapheme_boundary(_: *mut c_void, index: usize) -> usize {
+        index + 1
+    }
+
+    unsafe extern "C" fn code_point_facts(_: *mut c_void, code_point: u32) -> FfiFirstLetterCodePointFacts {
+        FfiFirstLetterCodePointFacts {
+            is_space_separator: code_point == b' ' as u32,
+            is_punctuation: matches!(code_point, 0x21 | 0x22 | 0x27..=0x2f | 0x3a | 0x3b | 0x3f | 0x40),
+            is_letter: matches!(code_point, 0x41..=0x5a | 0x61..=0x7a),
+            is_number: matches!(code_point, 0x30..=0x39),
+            is_symbol: matches!(code_point, 0x24 | 0x2b | 0x3c..=0x3e | 0x5e | 0x60 | 0x7c | 0x7e),
+            is_open_punctuation: matches!(code_point, 0x28 | 0x5b | 0x7b),
+            is_dash_punctuation: code_point == 0x2d,
+        }
+    }
+
+    fn first_letter_target(text: &str, preserves_segment_breaks: bool) -> super::FfiFirstLetterTarget {
+        let mut text = text.encode_utf16().collect::<Vec<_>>();
+        let callbacks = FfiFirstLetterTextCallbacks {
+            context: (&raw mut text).cast(),
+            code_unit_length: text_length,
+            code_point_at,
+            next_grapheme_boundary,
+            code_point_facts,
+        };
+        find_first_letter_in_text(&FirstLetterTextHost { callbacks: &callbacks }, preserves_segment_breaks)
+    }
 
     #[test]
     fn replaced_table_display_adjustments() {
@@ -955,5 +1269,26 @@ mod tests {
             rust_adjusted_table_display_for_replaced_element(false, false, false, false),
             FfiReplacedElementDisplayAdjustment::None
         );
+    }
+
+    #[test]
+    fn first_letter_text_pattern() {
+        let target = first_letter_target("  Hello", false);
+        assert!(target.found);
+        assert_eq!((target.letter_start, target.letter_end), (2, 3));
+
+        let target = first_letter_target("\") A", false);
+        assert!(target.found);
+        assert_eq!((target.letter_start, target.letter_end), (0, 4));
+
+        let target = first_letter_target("H!ello", false);
+        assert!(target.found);
+        assert_eq!((target.letter_start, target.letter_end), (0, 2));
+
+        let target = first_letter_target("H-ello", false);
+        assert!(target.found);
+        assert_eq!((target.letter_start, target.letter_end), (0, 1));
+
+        assert!(!first_letter_target("\nHello", true).found);
     }
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -64,6 +64,8 @@ public:
     void note_tree_restructuring_at(Layout::Node const&);
     static void detach_top_layer_element_layout_subtree(DOM::Element&);
 
+    struct FirstLetterTextContext;
+
 private:
     struct PrincipalNodeFrameStorage;
     struct PseudoElementFrameStorage;
@@ -71,6 +73,7 @@ private:
 
     RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
     RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
+    RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks();
 
     static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
     static void create_first_letter_wrapper(DOM::Element&, RustFFI::FfiFirstLetterTarget);
@@ -78,6 +81,7 @@ private:
     RefPtr<Layout::Node> m_layout_root;
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
     OwnPtr<PseudoElementFrameStorage> m_pseudo_element_frames;
+    OwnPtr<FirstLetterTextContext> m_first_letter_text_context;
 
     Layout::Node* m_current_rebuild_root { nullptr };
     Vector<Layout::Node*> m_rebuilt_subtree_roots;
@@ -104,7 +108,6 @@ void LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(DOM::Element& el
     element.set_synthetic_pseudo_element_node({}, pseudo_element, layout_node);
 }
 
-static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTreeBuildBridge*);
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
 static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&);
@@ -366,6 +369,17 @@ struct PseudoElementFrame {
 struct LayoutTreeBuildBridge::PseudoElementFrameStorage {
     Vector<NonnullOwnPtr<PseudoElementFrame>> frames;
     size_t active_frame_count { 0 };
+};
+
+struct LayoutTreeBuildBridge::FirstLetterTextContext {
+    FirstLetterTextContext(Utf16View text, NonnullOwnPtr<Unicode::Segmenter> grapheme_segmenter)
+        : text(text)
+        , grapheme_segmenter(move(grapheme_segmenter))
+    {
+    }
+
+    Utf16View text;
+    NonnullOwnPtr<Unicode::Segmenter> grapheme_segmenter;
 };
 
 RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tree_builder_callbacks()
@@ -1123,7 +1137,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
         .layout_root = [](void* builder_pointer) -> void* {
             VERIFY(builder_pointer);
             return static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_root.ptr(); },
-        .layout = make_ffi_tree_builder_callbacks(this),
+        .layout = make_ffi_tree_builder_callbacks(),
         .pseudo = make_ffi_pseudo_tree_builder_callbacks(),
     };
 }
@@ -1285,21 +1299,16 @@ static bool ffi_layout_node_is_inline_outside(void*, void* node_pointer)
     return node_with_style && node_with_style->display().is_inline_outside();
 }
 
-struct FfiFirstLetterTextContext {
-    Utf16View text;
-    NonnullOwnPtr<Unicode::Segmenter> grapheme_segmenter;
-};
-
 static size_t ffi_first_letter_code_unit_length(void* context_pointer)
 {
     VERIFY(context_pointer);
-    return static_cast<FfiFirstLetterTextContext*>(context_pointer)->text.length_in_code_units();
+    return static_cast<LayoutTreeBuildBridge::FirstLetterTextContext*>(context_pointer)->text.length_in_code_units();
 }
 
 static u32 ffi_first_letter_code_point_at(void* context_pointer, size_t index)
 {
     VERIFY(context_pointer);
-    auto& context = *static_cast<FfiFirstLetterTextContext*>(context_pointer);
+    auto& context = *static_cast<LayoutTreeBuildBridge::FirstLetterTextContext*>(context_pointer);
     VERIFY(index < context.text.length_in_code_units());
     return context.text.code_point_at(index);
 }
@@ -1307,7 +1316,7 @@ static u32 ffi_first_letter_code_point_at(void* context_pointer, size_t index)
 static size_t ffi_first_letter_next_grapheme_boundary(void* context_pointer, size_t index)
 {
     VERIFY(context_pointer);
-    auto& context = *static_cast<FfiFirstLetterTextContext*>(context_pointer);
+    auto& context = *static_cast<LayoutTreeBuildBridge::FirstLetterTextContext*>(context_pointer);
     VERIFY(index <= context.text.length_in_code_units());
     return context.grapheme_segmenter->next_boundary(index).value_or(context.text.length_in_code_units());
 }
@@ -1325,31 +1334,6 @@ static RustFFI::FfiFirstLetterCodePointFacts ffi_first_letter_code_point_facts(v
         .is_open_punctuation = Unicode::code_point_has_general_category(code_point, ps),
         .is_dash_punctuation = Unicode::code_point_has_general_category(code_point, pd),
     };
-}
-
-static RustFFI::FfiFirstLetterTarget ffi_find_first_letter_in_text(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    auto& text_node = as<TextNode>(*static_cast<Node*>(node_pointer));
-    auto text = text_node.text().utf16_view();
-    auto grapheme_segmenter = text_node.document().grapheme_segmenter().clone();
-    grapheme_segmenter->set_segmented_text(text);
-    FfiFirstLetterTextContext context { text, move(grapheme_segmenter) };
-    RustFFI::FfiFirstLetterTextCallbacks callbacks {
-        .context = &context,
-        .code_unit_length = ffi_first_letter_code_unit_length,
-        .code_point_at = ffi_first_letter_code_point_at,
-        .next_grapheme_boundary = ffi_first_letter_next_grapheme_boundary,
-        .code_point_facts = ffi_first_letter_code_point_facts,
-    };
-
-    auto const white_space_collapse = text_node.parent()->computed_values().white_space_collapse();
-    auto const preserves_segment_breaks = first_is_one_of(white_space_collapse,
-        CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces);
-    auto target = RustFFI::rust_find_first_letter_in_text(&callbacks, preserves_segment_breaks);
-    if (target.found)
-        target.text_node = &text_node;
-    return target;
 }
 
 static void* ffi_layout_node_parent(void*, void* node_pointer)
@@ -1610,10 +1594,10 @@ static void ffi_move_nodes_to_parent(void*, void* parent_pointer, void* const* n
     }
 }
 
-static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTreeBuildBridge* bridge)
+RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_callbacks()
 {
     return {
-        .context = bridge,
+        .context = this,
         .layout_node_facts = ffi_layout_node_facts,
         .is_inline_outside = ffi_layout_node_is_inline_outside,
         .parent = ffi_layout_node_parent,
@@ -1635,7 +1619,27 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTr
         .insert_child = ffi_insert_child,
         .set_children_are_inline = ffi_set_children_are_inline,
         .note_tree_restructuring = ffi_note_tree_restructuring,
-        .find_first_letter_in_text = ffi_find_first_letter_in_text,
+        .prepare_first_letter_text = [](void* builder_pointer, void* node_pointer, RustFFI::FfiFirstLetterTextCallbacks* callbacks) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            VERIFY(callbacks);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
+            auto& text_node = as<TextNode>(*static_cast<Node*>(node_pointer));
+            auto text = text_node.text().utf16_view();
+            auto grapheme_segmenter = text_node.document().grapheme_segmenter().clone();
+            grapheme_segmenter->set_segmented_text(text);
+            builder.m_first_letter_text_context = make<FirstLetterTextContext>(text, move(grapheme_segmenter));
+            *callbacks = {
+                .context = builder.m_first_letter_text_context.ptr(),
+                .code_unit_length = ffi_first_letter_code_unit_length,
+                .code_point_at = ffi_first_letter_code_point_at,
+                .next_grapheme_boundary = ffi_first_letter_next_grapheme_boundary,
+                .code_point_facts = ffi_first_letter_code_point_facts,
+            };
+
+            auto const white_space_collapse = text_node.parent()->computed_values().white_space_collapse();
+            return first_is_one_of(white_space_collapse,
+                CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces); },
         .create_button_content_wrapper = ffi_create_button_content_wrapper,
         .rendered_legend = ffi_rendered_legend,
         .create_fieldset_content_wrapper = ffi_create_fieldset_content_wrapper,

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -829,28 +829,34 @@ void TreeBuilder::create_backdrop_for_top_layer_element_if_needed(DOM::Element& 
 void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree)
 {
     // NB: Called during layout tree construction.
-    bool should_create_layout_node = must_create_subtree == MustCreateSubtree::Yes
-        || dom_node.needs_layout_tree_update()
-        || dom_node.document().needs_full_layout_tree_update()
-        || (dom_node.is_document() && !dom_node.unsafe_layout_node());
-
-    if (dom_node.is_element()) {
-        auto& element = static_cast<DOM::Element&>(dom_node);
-        if (element.rendered_in_top_layer() && !context.layout_top_layer) {
+    auto* existing_layout_node = dom_node.unsafe_layout_node();
+    auto entry_decision = RustFFI::rust_principal_node_entry_decision({
+        .must_create_subtree = must_create_subtree == MustCreateSubtree::Yes,
+        .needs_layout_tree_update = dom_node.needs_layout_tree_update(),
+        .document_needs_full_layout_tree_update = dom_node.document().needs_full_layout_tree_update(),
+        .is_document = dom_node.is_document(),
+        .has_layout_node = existing_layout_node != nullptr,
+        .is_element = dom_node.is_element(),
+        .rendered_in_top_layer = dom_node.is_element() && static_cast<DOM::Element&>(dom_node).rendered_in_top_layer(),
+        .context_layout_top_layer = context.layout_top_layer,
+        .layout_node_is_attached = existing_layout_node && existing_layout_node->parent(),
+        .is_svg_container = dom_node.is_svg_container(),
+        .requires_svg_container = dom_node.requires_svg_container(),
+        .context_has_svg_root = context.has_svg_root,
+    });
+    if (entry_decision.top_layer != RustFFI::FfiTopLayerEntryDecision::Continue) {
+        if (entry_decision.top_layer == RustFFI::FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild) {
             // A member found here without an attached box was cleared together with a hidden
             // ancestor subtree, and nothing is scheduled to rebuild it: request a top layer
             // zone rebuild, which runs as another update_layout pass and re-marks every member
             // itself. Marking the member here instead would strand dirty flags under ancestors
             // whose walks already finished, and a later update_layout would then treat the
             // detached member boxes as up to date.
-            // NB: Called during layout tree construction.
-            auto* element_layout_node = element.unsafe_layout_node();
-            bool element_box_is_missing_or_detached = !element_layout_node || !element_layout_node->parent();
-            if (element_box_is_missing_or_detached && !element.needs_layout_tree_update())
-                element.document().set_top_layer_needs_layout_zone_rebuild();
-            return;
+            dom_node.document().set_top_layer_needs_layout_zone_rebuild();
         }
+        return;
     }
+    bool should_create_layout_node = entry_decision.should_create_layout_node;
     if (dom_node.is_element())
         dom_node.document().style_computer().push_ancestor(static_cast<DOM::Element const&>(dom_node));
 
@@ -876,9 +882,9 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         }
     };
 
-    if (dom_node.is_svg_container()) {
+    if (entry_decision.svg == RustFFI::FfiSvgEntryDecision::EnterSvgRoot) {
         has_svg_root_change.emplace(context.has_svg_root, true);
-    } else if (dom_node.requires_svg_container() && !context.has_svg_root) {
+    } else if (entry_decision.svg == RustFFI::FfiSvgEntryDecision::Skip) {
         return;
     }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -55,7 +55,51 @@
 
 namespace Web::Layout {
 
-TreeBuilder::TreeBuilder() = default;
+TreeBuilder::TreeBuilder()
+    : m_rust_state(RustFFI::rust_tree_builder_state_create())
+{
+    VERIFY(m_rust_state);
+}
+
+TreeBuilder::~TreeBuilder()
+{
+    RustFFI::rust_tree_builder_state_destroy(m_rust_state);
+}
+
+void TreeBuilder::push_parent(Layout::NodeWithStyle& parent)
+{
+    RustFFI::rust_tree_builder_push_parent(m_rust_state, &parent);
+}
+
+void TreeBuilder::pop_parent()
+{
+    RustFFI::rust_tree_builder_pop_parent(m_rust_state);
+}
+
+Layout::NodeWithStyle& TreeBuilder::current_parent() const
+{
+    return *static_cast<Layout::NodeWithStyle*>(RustFFI::rust_tree_builder_current_parent(m_rust_state));
+}
+
+size_t TreeBuilder::ancestor_count() const
+{
+    return RustFFI::rust_tree_builder_ancestor_count(m_rust_state);
+}
+
+Layout::NodeWithStyle& TreeBuilder::ancestor_at(size_t index) const
+{
+    return *static_cast<Layout::NodeWithStyle*>(RustFFI::rust_tree_builder_ancestor_at(m_rust_state, index));
+}
+
+u32 TreeBuilder::quote_nesting_level() const
+{
+    return RustFFI::rust_tree_builder_quote_nesting_level(m_rust_state);
+}
+
+void TreeBuilder::set_quote_nesting_level(u32 quote_nesting_level)
+{
+    RustFFI::rust_tree_builder_set_quote_nesting_level(m_rust_state, quote_nesting_level);
+}
 
 static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder*);
 
@@ -84,7 +128,7 @@ void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, 
     auto callbacks = make_ffi_tree_builder_callbacks(this);
     RustFFI::rust_insert_node_into_inline_or_block_ancestor(
         &callbacks,
-        m_ancestor_stack.last(),
+        &current_parent(),
         &node,
         display.is_inline_outside(),
         mode == AppendOrPrepend::Append ? RustFFI::FfiInsertionMode::Append : RustFFI::FfiInsertionMode::Prepend);
@@ -308,7 +352,7 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
     if (pseudo_element_display.is_none())
         return {};
 
-    auto initial_quote_nesting_level = m_quote_nesting_level;
+    auto initial_quote_nesting_level = quote_nesting_level();
 
     // NB: Whether this pseudo-element generates a box depends only on the shape of its computed
     //     content value, so the full resolution (which reads counters that do not exist until
@@ -398,7 +442,7 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
     CSS::resolve_counters(element_reference);
 
     auto [pseudo_element_content, final_quote_nesting_level] = pseudo_element_values->resolved_content(element_reference, initial_quote_nesting_level);
-    m_quote_nesting_level = final_quote_nesting_level;
+    set_quote_nesting_level(final_quote_nesting_level);
     pseudo_element_node->set_content(pseudo_element_content);
 
     // FIXME: Handle images, and multiple values
@@ -827,7 +871,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             old_layout_node->prepare_subtree_for_detach_from_layout_tree();
             old_layout_node->parent()->replace_child(*layout_node, *old_layout_node);
         } else if (layout_node->is_svg_box()) {
-            m_ancestor_stack.last()->append_child(*layout_node);
+            current_parent().append_child(*layout_node);
         } else {
             insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
         }
@@ -844,7 +888,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         return false;
     }();
 
-    auto prior_quote_nesting_level = m_quote_nesting_level;
+    auto prior_quote_nesting_level = quote_nesting_level();
 
     if (should_create_layout_node) {
         // Resolve counters now that we exist in the layout tree.
@@ -877,7 +921,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                 if (layout_node->is_replaced_box_with_children()) {
                     if (!layout_node->first_child() || !layout_node->first_child()->is_anonymous()) {
                         auto wrapper = as<NodeWithStyle>(*layout_node).create_anonymous_wrapper();
-                        m_ancestor_stack.last()->append_child(wrapper);
+                        current_parent().append_child(wrapper);
                     }
                     push_parent(as<NodeWithStyle>(*layout_node->first_child()));
                 }
@@ -934,7 +978,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     // 2. The effects of the 'content' property’s 'open-quote', 'close-quote', 'no-open-quote' and 'no-close-quote' must
     //    be scoped to the element’s sub-tree.
     if (auto const* node_with_style = as_if<NodeWithStyle>(*layout_node); node_with_style && node_with_style->has_style_containment()) {
-        m_quote_nesting_level = prior_quote_nesting_level;
+        set_quote_nesting_level(prior_quote_nesting_level);
     }
 
     dom_node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
@@ -1105,8 +1149,8 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, Layout:
             push_parent(as<NodeWithStyle>(layout_node));
 
             // Check for reference cycle
-            for (auto* ancestor : m_ancestor_stack) {
-                if (ancestor->dom_node() == mask_or_clip_path) {
+            for (size_t index = 0; index < ancestor_count(); ++index) {
+                if (ancestor_at(index).dom_node() == mask_or_clip_path) {
                     // FIXME: Somehow either remove ancestor from the layout tree or mark it as invalid.
                     pop_parent();
                     return;
@@ -1132,8 +1176,8 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, Layout:
                 return;
             TemporaryChange<bool> layout_flag(context.layout_svg_pattern, true);
             push_parent(as<NodeWithStyle>(layout_node));
-            for (auto* ancestor : m_ancestor_stack) {
-                if (ancestor->dom_node() == content_element.ptr()) {
+            for (size_t index = 0; index < ancestor_count(); ++index) {
+                if (ancestor_at(index).dom_node() == content_element.ptr()) {
                     pop_parent();
                     return;
                 }
@@ -1212,7 +1256,7 @@ RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)
     dom_node.document().style_computer().reset_ancestor_filter();
 
     Context context;
-    m_quote_nesting_level = 0;
+    set_quote_nesting_level(0);
     update_layout_tree(dom_node, context, MustCreateSubtree::No);
 
     // NB: Called during layout tree construction.

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1131,38 +1131,8 @@ static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithSt
 void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, Layout::Node& layout_node)
 {
     auto const* html_element = as_if<HTML::HTMLElement>(dom_node);
-    if (!html_element || !html_element->uses_button_layout())
-        return;
-
-    // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
-    // If the element is an input element, or if it is a button element and its computed value for 'display' is not
-    // 'inline-grid', 'grid', 'inline-flex', or 'flex', then the element's box has a child anonymous button content box
-    // with the following behaviors:
-    auto display = as<NodeWithStyle>(layout_node).display();
-    if (!display.is_grid_inside() && !display.is_flex_inside()) {
-        auto& parent = as<NodeWithStyle>(layout_node);
-
-        // If the box does not overflow in the vertical axis, then it is centered vertically.
-        // FIXME: Only apply alignment when box overflows
-        auto flex_wrapper = create_button_flex_wrapper(parent);
-
-        auto content_box_wrapper = create_button_content_box_wrapper(parent);
-        content_box_wrapper->set_children_are_inline(parent.children_are_inline());
-
-        Vector<NonnullRefPtr<Node>> sequence;
-        for (auto child = parent.first_child(); child; child = child->next_sibling())
-            sequence.append(*child);
-
-        for (auto& node : sequence) {
-            parent.remove_child(*node);
-            content_box_wrapper->append_child(*node);
-        }
-
-        flex_wrapper->append_child(*content_box_wrapper);
-
-        parent.append_child(*flex_wrapper);
-        parent.set_children_are_inline(false);
-    }
+    auto callbacks = make_ffi_tree_builder_callbacks(this);
+    RustFFI::rust_wrap_button_contents_if_needed(&callbacks, &layout_node, html_element && html_element->uses_button_layout());
 }
 
 void TreeBuilder::update_layout_tree_before_children(DOM::Node& dom_node, Layout::Node& layout_node, TreeBuilder::Context&, bool element_has_content_visibility_hidden)
@@ -1258,36 +1228,8 @@ void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, Layout:
             create_first_letter_wrapper_if_needed(element, *block_container);
     }
 
-    // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-    // The anonymous fieldset content box is expected to appear after the rendered legend and is expected to contain the
-    // content (including the '::before' and '::after' pseudo-elements) of the fieldset element except for the rendered
-    // legend, if there is one.
-    if (auto* fieldset_box = as_if<FieldSetBox>(layout_node)) {
-        if (auto legend = fieldset_box->rendered_legend()) {
-            auto wrapper = fieldset_box->create_anonymous_wrapper();
-            wrapper->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
-
-            // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
-            // The following properties are expected to inherit from the fieldset element:
-            //     align-content, align-items, border-radius, column-count, column-fill, column-gap, column-rule,
-            //     column-width, flex-direction, flex-wrap, grid (grid-auto-columns, grid-auto-flow, grid-auto-rows,
-            //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
-            //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
-            // FIXME: Transfer all of these properties, not just overflow.
-            wrapper->set_overflow(fieldset_box->computed_values().overflow_x(), fieldset_box->computed_values().overflow_y());
-            fieldset_box->set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
-
-            for (auto child = fieldset_box->first_child(); child;) {
-                auto next = child->next_sibling();
-                if (child != legend) {
-                    fieldset_box->remove_child(*child);
-                    wrapper->append_child(*child);
-                }
-                child = next;
-            }
-            fieldset_box->append_child(*wrapper);
-        }
-    }
+    auto callbacks = make_ffi_tree_builder_callbacks(this);
+    RustFFI::rust_wrap_fieldset_contents_if_needed(&callbacks, &layout_node);
 }
 
 RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)
@@ -1369,6 +1311,7 @@ static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_point
             auto* dom_element = as_if<DOM::Element>(node.dom_node());
             return dom_element && dom_element->computed_values(CSS::PseudoElement::FirstLetter);
         }(),
+        .has_rendered_legend = is<FieldSetBox>(node) && static_cast<FieldSetBox&>(node).rendered_legend(),
     };
 }
 
@@ -1642,6 +1585,62 @@ static void ffi_note_tree_restructuring(void* context, void* node_pointer)
     static_cast<TreeBuilder*>(context)->note_tree_restructuring_at(*static_cast<Node*>(node_pointer));
 }
 
+static void ffi_wrap_button_contents(void*, void* layout_node_pointer)
+{
+    VERIFY(layout_node_pointer);
+    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(layout_node_pointer));
+
+    // If the box does not overflow in the vertical axis, then it is centered vertically.
+    // FIXME: Only apply alignment when box overflows
+    auto flex_wrapper = create_button_flex_wrapper(parent);
+
+    auto content_box_wrapper = create_button_content_box_wrapper(parent);
+    content_box_wrapper->set_children_are_inline(parent.children_are_inline());
+
+    Vector<NonnullRefPtr<Node>> sequence;
+    for (auto child = parent.first_child(); child; child = child->next_sibling())
+        sequence.append(*child);
+
+    for (auto& node : sequence) {
+        parent.remove_child(*node);
+        content_box_wrapper->append_child(*node);
+    }
+
+    flex_wrapper->append_child(*content_box_wrapper);
+    parent.append_child(*flex_wrapper);
+    parent.set_children_are_inline(false);
+}
+
+static void ffi_wrap_fieldset_contents(void*, void* layout_node_pointer)
+{
+    VERIFY(layout_node_pointer);
+    auto& fieldset_box = as<FieldSetBox>(*static_cast<Node*>(layout_node_pointer));
+    auto legend = fieldset_box.rendered_legend();
+    VERIFY(legend);
+    auto wrapper = fieldset_box.create_anonymous_wrapper();
+    wrapper->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
+
+    // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
+    // The following properties are expected to inherit from the fieldset element:
+    //     align-content, align-items, border-radius, column-count, column-fill, column-gap, column-rule,
+    //     column-width, flex-direction, flex-wrap, grid (grid-auto-columns, grid-auto-flow, grid-auto-rows,
+    //     grid-column-gap, grid-row-gap, grid-template-areas, grid-template-columns, grid-template-rows),
+    //     justify-content, justify-items, overflow, padding, text-overflow, unicode-bidi
+    // FIXME: Transfer all of these properties, not just overflow.
+    wrapper->set_overflow(fieldset_box.computed_values().overflow_x(), fieldset_box.computed_values().overflow_y());
+    fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
+
+    for (auto child = fieldset_box.first_child(); child;) {
+        auto next = child->next_sibling();
+        if (child != legend) {
+            fieldset_box.remove_child(*child);
+            wrapper->append_child(*child);
+        }
+        child = next;
+    }
+    fieldset_box.append_child(*wrapper);
+}
+
 static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder* tree_builder)
 {
     return {
@@ -1667,6 +1666,8 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuil
         .set_children_are_inline = ffi_set_children_are_inline,
         .note_tree_restructuring = ffi_note_tree_restructuring,
         .find_first_letter_in_text = ffi_find_first_letter_in_text,
+        .wrap_button_contents = ffi_wrap_button_contents,
+        .wrap_fieldset_contents = ffi_wrap_fieldset_contents,
     };
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -705,6 +705,120 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
             VERIFY(slot_element_pointer);
             clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
+        .principal_descendant_facts = [](void*, void* node_pointer, void* layout_node_pointer, void* context_pointer) -> RustFFI::FfiPrincipalDescendantFacts {
+            VERIFY(node_pointer);
+            VERIFY(layout_node_pointer);
+            VERIFY(context_pointer);
+            auto& node = *static_cast<DOM::Node*>(node_pointer);
+            auto& layout_node = *static_cast<Layout::Node*>(layout_node_pointer);
+            auto& context = *static_cast<Context*>(context_pointer);
+            auto* element = as_if<DOM::Element>(node);
+            auto* slot_element = as_if<HTML::HTMLSlotElement>(node);
+            auto* parent_node = as_if<DOM::ParentNode>(node);
+            auto shadow_root = element ? element->shadow_root() : nullptr;
+            return {
+                .is_element = element != nullptr,
+                .context_layout_top_layer = context.layout_top_layer,
+                .content_visibility_hidden = element && element->computed_values()->content_visibility() == CSS::ContentVisibility::Hidden,
+                .should_layout_dom_children = slot_element ? slot_element->assigned_nodes_internal().is_empty() && node.has_children() : node.has_children(),
+                .child_needs_layout_tree_update = node.child_needs_layout_tree_update(),
+                .layout_node_can_have_children = layout_node.can_have_children(),
+                .layout_node_is_replaced_box_with_children = layout_node.is_replaced_box_with_children(),
+                .is_svg_switch_element = is<SVG::SVGSwitchElement>(node),
+                .is_document = node.is_document(),
+                .has_style_containment = is<NodeWithStyle>(layout_node) && static_cast<NodeWithStyle&>(layout_node).has_style_containment(),
+                .dom_children_parent = parent_node,
+                .shadow_root = shadow_root ? static_cast<DOM::ParentNode*>(shadow_root.ptr()) : nullptr,
+                .slot_element = slot_element,
+            }; },
+        .update_before_children = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer, void* context_pointer, bool content_visibility_hidden) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            VERIFY(layout_node_pointer);
+            VERIFY(context_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->update_layout_tree_before_children(
+                *static_cast<DOM::Node*>(node_pointer),
+                *static_cast<Layout::Node*>(layout_node_pointer),
+                *static_cast<Context*>(context_pointer),
+                content_visibility_hidden); },
+        .update_after_children = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer, void* context_pointer, bool content_visibility_hidden) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            VERIFY(layout_node_pointer);
+            VERIFY(context_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->update_layout_tree_after_children(
+                *static_cast<DOM::Node*>(node_pointer),
+                *static_cast<Layout::Node*>(layout_node_pointer),
+                *static_cast<Context*>(context_pointer),
+                content_visibility_hidden); },
+        .wrap_button_layout = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            VERIFY(layout_node_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->wrap_in_button_layout_tree_if_needed(
+                *static_cast<DOM::Node*>(node_pointer),
+                *static_cast<Layout::Node*>(layout_node_pointer)); },
+        .clear_stale_descendants = [](void* builder_pointer, void* node_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& node = *static_cast<DOM::Node*>(node_pointer);
+            node.for_each_shadow_including_descendant([&](auto& descendant) {
+                return builder.clear_stale_layout_and_paint_node(descendant, &node);
+            }); },
+        .push_layout_parent = [](void* builder_pointer, void* layout_node_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(layout_node_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->push_parent(as<NodeWithStyle>(*static_cast<Layout::Node*>(layout_node_pointer))); },
+        .pop_layout_parent = [](void* builder_pointer) {
+            VERIFY(builder_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->pop_parent(); },
+        .ensure_replaced_children_wrapper = [](void* builder_pointer, void* layout_node_pointer) -> void* {
+            VERIFY(builder_pointer);
+            VERIFY(layout_node_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& layout_node = *static_cast<Layout::Node*>(layout_node_pointer);
+            if (!layout_node.first_child() || !layout_node.first_child()->is_anonymous()) {
+                auto wrapper = as<NodeWithStyle>(layout_node).create_anonymous_wrapper();
+                builder.current_parent().append_child(wrapper);
+            }
+            return layout_node.first_child().ptr(); },
+        .top_layer_element_count = [](void* document_pointer) {
+            VERIFY(document_pointer);
+            return static_cast<DOM::Document*>(document_pointer)->top_layer_elements().size(); },
+        .copy_top_layer_elements = [](void* document_pointer, void** output, size_t count) {
+            VERIFY(document_pointer);
+            VERIFY(output || count == 0);
+            auto const& elements = static_cast<DOM::Document*>(document_pointer)->top_layer_elements();
+            VERIFY(count == elements.size());
+            size_t index = 0;
+            for (auto const& element : elements)
+                output[index++] = element.ptr(); },
+        .rendered_in_top_layer = [](void* element_pointer) {
+            VERIFY(element_pointer);
+            return static_cast<DOM::Element*>(element_pointer)->rendered_in_top_layer(); },
+        .has_unrendered_flat_tree_ancestor = [](void* element_pointer) {
+            VERIFY(element_pointer);
+            return element_has_an_unrendered_flat_tree_ancestor(*static_cast<DOM::Element*>(element_pointer)); },
+        .clear_stale_top_layer_subtree = [](void* builder_pointer, void* element_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(element_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return builder.clear_stale_layout_and_paint_node(node, &element);
+            }); },
+        .quote_nesting_level = [](void* builder_pointer) {
+            VERIFY(builder_pointer);
+            return static_cast<TreeBuilder*>(builder_pointer)->quote_nesting_level(); },
+        .set_quote_nesting_level = [](void* builder_pointer, u32 quote_nesting_level) {
+            VERIFY(builder_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->set_quote_nesting_level(quote_nesting_level); },
+        .clear_dom_update_flags = [](void* node_pointer) {
+            VERIFY(node_pointer);
+            auto& node = *static_cast<DOM::Node*>(node_pointer);
+            node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
+            node.set_child_needs_layout_tree_update(false); },
     };
 }
 
@@ -1001,111 +1115,14 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
     }
 
-    auto shadow_root = dom_element ? dom_element->shadow_root() : nullptr;
-
-    auto element_has_content_visibility_hidden = [&dom_node]() {
-        if (is<DOM::Element>(dom_node)) {
-            auto& element = static_cast<DOM::Element&>(dom_node);
-            return element.computed_values()->content_visibility() == CSS::ContentVisibility::Hidden;
-        }
-        return false;
-    }();
-
-    auto prior_quote_nesting_level = quote_nesting_level();
-
-    if (should_create_layout_node) {
-        // Resolve counters now that we exist in the layout tree.
-        if (auto* element = as_if<DOM::Element>(dom_node)) {
-            DOM::AbstractElement element_reference { *element };
-            CSS::resolve_counters(element_reference);
-        }
-
-        update_layout_tree_before_children(dom_node, *layout_node, context, element_has_content_visibility_hidden);
-    }
-
-    if (element_has_content_visibility_hidden) {
-        dom_node.for_each_shadow_including_descendant([&](auto& node) {
-            return clear_stale_layout_and_paint_node(node, &dom_node);
-        });
-    }
-
-    auto should_layout_dom_children = [&]() {
-        if (auto const* slot_element = as_if<HTML::HTMLSlotElement>(dom_node))
-            return slot_element->assigned_nodes_internal().is_empty() && dom_node.has_children();
-        return dom_node.has_children();
-    }();
-
-    if (should_create_layout_node || dom_node.child_needs_layout_tree_update()) {
-        if ((should_layout_dom_children || shadow_root) && layout_node->can_have_children() && !element_has_content_visibility_hidden) {
-            push_parent(as<NodeWithStyle>(*layout_node));
-            if (shadow_root) {
-                // For replaced elements with shadow DOM children, wrap the children in an
-                // anonymous BlockContainer so that a BFC handles their layout.
-                if (layout_node->is_replaced_box_with_children()) {
-                    if (!layout_node->first_child() || !layout_node->first_child()->is_anonymous()) {
-                        auto wrapper = as<NodeWithStyle>(*layout_node).create_anonymous_wrapper();
-                        current_parent().append_child(wrapper);
-                    }
-                    push_parent(as<NodeWithStyle>(*layout_node->first_child()));
-                }
-                update_layout_tree_for_shadow_root_children(*shadow_root, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
-                if (layout_node->is_replaced_box_with_children())
-                    pop_parent();
-            } else if (should_layout_dom_children) {
-                if (auto* switch_element = as_if<SVG::SVGSwitchElement>(dom_node)) {
-                    update_layout_tree_for_svg_switch_children(*switch_element, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
-                } else {
-                    update_layout_tree_for_dom_children(as<DOM::ParentNode>(dom_node), context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
-                }
-            }
-
-            if (dom_node.is_document()) {
-                // Elements in the top layer do not lay out normally based on their position in the document; instead they
-                // generate boxes as if they were siblings of the root element.
-                TemporaryChange<bool> layout_mask(context.layout_top_layer, true);
-                for (auto const& top_layer_element : document.top_layer_elements()) {
-                    if (!top_layer_element->rendered_in_top_layer())
-                        continue;
-                    if (element_has_an_unrendered_flat_tree_ancestor(top_layer_element)) {
-                        top_layer_element->for_each_shadow_including_inclusive_descendant([&](auto& node) {
-                            return clear_stale_layout_and_paint_node(node, top_layer_element.ptr());
-                        });
-                        continue;
-                    }
-                    update_layout_tree(top_layer_element, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
-                }
-            }
-            pop_parent();
-        }
-    }
-
-    if (is<HTML::HTMLSlotElement>(dom_node)) {
-        auto& slot_element = static_cast<HTML::HTMLSlotElement&>(dom_node);
-
-        if (slot_element.computed_values()->content_visibility() != CSS::ContentVisibility::Hidden) {
-            push_parent(as<NodeWithStyle>(*layout_node));
-            update_layout_tree_for_assigned_slottables(slot_element, context, must_create_subtree);
-            pop_parent();
-        } else {
-            clear_stale_layout_nodes_for_assigned_slottables(slot_element);
-        }
-    }
-
-    if (should_create_layout_node) {
-        update_layout_tree_after_children(dom_node, *layout_node, context, element_has_content_visibility_hidden);
-        wrap_in_button_layout_tree_if_needed(dom_node, *layout_node);
-    }
-
-    // https://www.w3.org/TR/css-contain-2/#containment-style
-    // Giving an element style containment has the following effects:
-    // 2. The effects of the 'content' property’s 'open-quote', 'close-quote', 'no-open-quote' and 'no-close-quote' must
-    //    be scoped to the element’s sub-tree.
-    if (auto const* node_with_style = as_if<NodeWithStyle>(*layout_node); node_with_style && node_with_style->has_style_containment()) {
-        set_quote_nesting_level(prior_quote_nesting_level);
-    }
-
-    dom_node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
-    dom_node.set_child_needs_layout_tree_update(false);
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    RustFFI::rust_update_principal_node_descendants(
+        &callbacks,
+        &dom_node,
+        layout_node.ptr(),
+        &context,
+        should_create_layout_node,
+        must_create_subtree == MustCreateSubtree::Yes);
 }
 
 void TreeBuilder::update_layout_tree_for_display_contents(DOM::Element& element, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree, bool should_create_layout_node)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -60,11 +60,6 @@ TreeBuilder::TreeBuilder()
     VERIFY(m_rust_state);
 }
 
-TreeBuilder::~TreeBuilder()
-{
-    RustFFI::rust_tree_builder_state_destroy(m_rust_state);
-}
-
 void TreeBuilder::push_parent(Layout::NodeWithStyle& parent)
 {
     RustFFI::rust_tree_builder_push_parent(m_rust_state, &parent);
@@ -705,6 +700,16 @@ struct PrincipalNodeFrame {
     CSS::Display display;
 };
 
+struct TreeBuilder::PrincipalNodeFrameStorage {
+    Vector<NonnullOwnPtr<PrincipalNodeFrame>> frames;
+    size_t active_frame_count { 0 };
+};
+
+TreeBuilder::~TreeBuilder()
+{
+    RustFFI::rust_tree_builder_state_destroy(m_rust_state);
+}
+
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display display)
 {
     return {
@@ -729,14 +734,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(node_pointer);
             return static_cast<DOM::Node*>(node_pointer)->next_sibling();
         },
-        .update_layout_tree = [](void* builder_pointer, void* node_pointer, void* context_pointer, bool must_create_subtree) {
-            VERIFY(builder_pointer);
-            VERIFY(node_pointer);
-            VERIFY(context_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->update_layout_tree(
-                *static_cast<DOM::Node*>(node_pointer),
-                *static_cast<Context*>(context_pointer),
-                must_create_subtree ? MustCreateSubtree::Yes : MustCreateSubtree::No); },
         .clear_update_flags = [](void* node_pointer) {
             VERIFY(node_pointer);
             auto& node = *static_cast<DOM::ParentNode*>(node_pointer);
@@ -763,16 +760,13 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
             (void)static_cast<TreeBuilder*>(builder_pointer)->clear_stale_layout_and_paint_node(*static_cast<DOM::Node*>(node_pointer)); },
-        .display_contents_facts = [](void*, void* element_pointer, void* context_pointer) -> RustFFI::FfiDisplayContentsFacts {
+        .display_contents_facts = [](void*, void* element_pointer) -> RustFFI::FfiDisplayContentsFacts {
             VERIFY(element_pointer);
-            VERIFY(context_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
-            auto& context = *static_cast<Context*>(context_pointer);
             auto* slot_element = as_if<HTML::HTMLSlotElement>(element);
             auto shadow_root = element.shadow_root();
             return {
                 .rendered_in_top_layer = element.rendered_in_top_layer(),
-                .context_layout_top_layer = context.layout_top_layer,
                 .content_visibility_hidden = element.computed_values()->content_visibility() == CSS::ContentVisibility::Hidden,
                 .should_layout_dom_children = slot_element ? slot_element->assigned_nodes_internal().is_empty() && element.has_children() : element.has_children(),
                 .child_needs_layout_tree_update = element.child_needs_layout_tree_update(),
@@ -781,9 +775,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 .slot_element = slot_element,
             };
         },
-        .set_context_layout_top_layer = [](void* context_pointer, bool layout_top_layer) {
-            VERIFY(context_pointer);
-            static_cast<Context*>(context_pointer)->layout_top_layer = layout_top_layer; },
         .clear_synthetic_pseudo_element_layout_nodes = [](void*, void* element_pointer) {
             VERIFY(element_pointer);
             static_cast<DOM::Element*>(element_pointer)->clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {}); },
@@ -818,13 +809,11 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
             VERIFY(slot_element_pointer);
             clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
-        .principal_descendant_facts = [](void*, void* node_pointer, void* layout_node_pointer, void* context_pointer) -> RustFFI::FfiPrincipalDescendantFacts {
+        .principal_descendant_facts = [](void*, void* node_pointer, void* layout_node_pointer) -> RustFFI::FfiPrincipalDescendantFacts {
             VERIFY(node_pointer);
             VERIFY(layout_node_pointer);
-            VERIFY(context_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
             auto& layout_node = *static_cast<Layout::Node*>(layout_node_pointer);
-            auto& context = *static_cast<Context*>(context_pointer);
             auto* element = as_if<DOM::Element>(node);
             auto* slot_element = as_if<HTML::HTMLSlotElement>(node);
             auto* parent_node = as_if<DOM::ParentNode>(node);
@@ -836,7 +825,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             auto stroke_pattern = graphics_element ? graphics_element->stroke_pattern() : nullptr;
             return {
                 .is_element = element != nullptr,
-                .context_layout_top_layer = context.layout_top_layer,
                 .content_visibility_hidden = element && element->computed_values()->content_visibility() == CSS::ContentVisibility::Hidden,
                 .should_layout_dom_children = slot_element ? slot_element->assigned_nodes_internal().is_empty() && node.has_children() : node.has_children(),
                 .child_needs_layout_tree_update = node.child_needs_layout_tree_update(),
@@ -856,8 +844,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 .svg_clip_path = const_cast<SVG::SVGClipPathElement*>(clip_path.ptr()),
                 .svg_fill_pattern = const_cast<SVG::SVGPatternElement*>(fill_pattern.ptr()),
                 .svg_stroke_pattern = const_cast<SVG::SVGPatternElement*>(stroke_pattern.ptr()),
-                .context_layout_svg_mask_or_clip_path = context.layout_svg_mask_or_clip_path,
-                .context_layout_svg_pattern = context.layout_svg_pattern,
             }; },
         .create_first_letter_wrapper = [](void*, void* element_pointer, void* layout_node_pointer) {
             VERIFY(element_pointer);
@@ -967,17 +953,9 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .layout_node_dom_node = [](void* layout_node_pointer) -> void* {
             VERIFY(layout_node_pointer);
             return static_cast<Layout::Node*>(layout_node_pointer)->dom_node(); },
-        .set_context_layout_svg_mask_or_clip_path = [](void* context_pointer, bool layout_svg_mask_or_clip_path) {
-            VERIFY(context_pointer);
-            static_cast<Context*>(context_pointer)->layout_svg_mask_or_clip_path = layout_svg_mask_or_clip_path; },
-        .set_context_layout_svg_pattern = [](void* context_pointer, bool layout_svg_pattern) {
-            VERIFY(context_pointer);
-            static_cast<Context*>(context_pointer)->layout_svg_pattern = layout_svg_pattern; },
-        .principal_node_entry_facts = [](void*, void* node_pointer, void* context_pointer, bool must_create_subtree) -> RustFFI::FfiPrincipalNodeEntryFacts {
+        .principal_node_entry_facts = [](void*, void* node_pointer, bool must_create_subtree) -> RustFFI::FfiPrincipalNodeEntryFacts {
             VERIFY(node_pointer);
-            VERIFY(context_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
-            auto& context = *static_cast<Context*>(context_pointer);
             // NB: Called during layout tree construction.
             auto* existing_layout_node = node.unsafe_layout_node();
             auto* element = as_if<DOM::Element>(node);
@@ -990,11 +968,9 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 .is_element = element != nullptr,
                 .is_text = is<DOM::Text>(node),
                 .rendered_in_top_layer = element && element->rendered_in_top_layer(),
-                .context_layout_top_layer = context.layout_top_layer,
                 .layout_node_is_attached = existing_layout_node && existing_layout_node->parent(),
                 .is_svg_container = node.is_svg_container(),
                 .requires_svg_container = node.requires_svg_container(),
-                .context_has_svg_root = context.has_svg_root,
             }; },
         .request_top_layer_zone_rebuild = [](void* node_pointer) {
             VERIFY(node_pointer);
@@ -1007,16 +983,37 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(element_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
             element.document().style_computer().pop_ancestor(element); },
-        .initialize_principal_frame = [](void* frame_pointer, void* node_pointer) {
-            VERIFY(frame_pointer);
+        .push_principal_frame = [](void* builder_pointer, void* node_pointer) -> void* {
+            VERIFY(builder_pointer);
             VERIFY(node_pointer);
-            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            if (!builder.m_principal_frames)
+                builder.m_principal_frames = make<PrincipalNodeFrameStorage>();
+            auto& storage = *builder.m_principal_frames;
+            if (storage.active_frame_count == storage.frames.size())
+                storage.frames.append(make<PrincipalNodeFrame>());
+            auto& frame = *storage.frames[storage.active_frame_count++];
             auto& node = *static_cast<DOM::Node*>(node_pointer);
             // NB: Called during layout tree construction.
             frame.old_layout_node = node.unsafe_layout_node();
             frame.layout_node = nullptr;
             frame.backdrop_node = nullptr;
-            frame.computed_values = nullptr; },
+            frame.computed_values = nullptr;
+            return &frame; },
+        .pop_principal_frame = [](void* builder_pointer, void* frame_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            VERIFY(builder.m_principal_frames);
+            auto& storage = *builder.m_principal_frames;
+            VERIFY(storage.active_frame_count > 0);
+            VERIFY(storage.frames[storage.active_frame_count - 1].ptr() == frame_pointer);
+            auto& frame = *storage.frames[storage.active_frame_count - 1];
+            frame.old_layout_node = nullptr;
+            frame.layout_node = nullptr;
+            frame.backdrop_node = nullptr;
+            frame.computed_values = nullptr;
+            --storage.active_frame_count; },
         .prepare_principal_element = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool should_create_layout_node) -> RustFFI::FfiPrincipalDisplayFacts {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
@@ -1037,18 +1034,14 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             frame.computed_values = element.computed_values();
             frame.display = frame.computed_values->display();
             return ffi_principal_display_facts(frame.display); },
-        .principal_element_layout_facts = [](void* frame_pointer, void* element_pointer, void* context_pointer) -> RustFFI::FfiElementLayoutFacts {
+        .principal_element_layout_facts = [](void* frame_pointer, void* element_pointer) -> RustFFI::FfiElementLayoutFacts {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
-            VERIFY(context_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
-            auto& context = *static_cast<Context*>(context_pointer);
             VERIFY(frame.computed_values);
             return {
                 .has_content_replacement = content_replacement_image(frame.computed_values->computed_content()) != nullptr,
-                .context_layout_svg_mask_or_clip_path = context.layout_svg_mask_or_clip_path,
-                .context_layout_svg_pattern = context.layout_svg_pattern,
                 .is_svg_mask_element = is<SVG::SVGMaskElement>(element),
                 .is_svg_clip_path_element = is<SVG::SVGClipPathElement>(element),
                 .is_svg_pattern_element = is<SVG::SVGPatternElement>(element),
@@ -1127,15 +1120,13 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             else
                 VERIFY_NOT_REACHED();
             as<NodeWithStyle>(*frame.layout_node).set_display(frame.display); },
-        .principal_placement_facts = [](void* builder_pointer, void* frame_pointer, void* node_pointer, void* context_pointer, bool must_create_subtree, bool should_create_layout_node) -> RustFFI::FfiPrincipalBoxPlacementFacts {
+        .principal_placement_facts = [](void* builder_pointer, void* frame_pointer, void* node_pointer, bool must_create_subtree, bool should_create_layout_node) -> RustFFI::FfiPrincipalBoxPlacementFacts {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(node_pointer);
-            VERIFY(context_pointer);
             auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
-            auto& context = *static_cast<Context*>(context_pointer);
             VERIFY(frame.layout_node);
             auto* element = as_if<DOM::Element>(node);
             return {
@@ -1148,7 +1139,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 .is_document = node.is_document(),
                 .is_element = element != nullptr,
                 .rendered_in_top_layer = element && element->rendered_in_top_layer(),
-                .context_layout_top_layer = context.layout_top_layer,
                 .layout_node_is_svg_box = frame.layout_node->is_svg_box(),
             }; },
         .start_principal_rebuild_root = [](void* builder_pointer, void* frame_pointer) -> void* {
@@ -1221,9 +1211,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             static_cast<DOM::Node*>(node_pointer)->for_each_shadow_including_inclusive_descendant([&](auto& node) {
                 return builder.clear_stale_layout_and_paint_node(node);
             }); },
-        .set_context_has_svg_root = [](void* context_pointer, bool has_svg_root) {
-            VERIFY(context_pointer);
-            static_cast<Context*>(context_pointer)->has_svg_root = has_svg_root; },
         .reset_style_ancestor_filter = [](void* document_pointer) {
             VERIFY(document_pointer);
             static_cast<DOM::Document*>(document_pointer)->style_computer().reset_ancestor_filter(); },
@@ -1302,18 +1289,6 @@ static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node)
     return layout_node;
 }
 
-void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree)
-{
-    PrincipalNodeFrame frame;
-    auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_layout_tree(
-        &callbacks,
-        &frame,
-        &dom_node,
-        &context,
-        must_create_subtree == MustCreateSubtree::Yes);
-}
-
 // A full-height flex column that centers the button contents vertically.
 static NonnullRefPtr<NodeWithStyle> create_button_flex_wrapper(NodeWithStyle& parent)
 {
@@ -1340,10 +1315,8 @@ static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithSt
 
 LayoutTreeBuildResult TreeBuilder::build(DOM::Node& dom_node)
 {
-    Context context;
-    PrincipalNodeFrame frame;
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    m_layout_root = static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &frame, &dom_node, &context));
+    m_layout_root = static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &dom_node));
     return {
         .root = move(m_layout_root),
         .rebuilt_subtree_roots = move(m_rebuilt_subtree_roots),

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -696,6 +696,8 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                     return CSS::PseudoElement::Before;
                 case RustFFI::FfiPseudoElement::After:
                     return CSS::PseudoElement::After;
+                case RustFFI::FfiPseudoElement::Marker:
+                    return CSS::PseudoElement::Marker;
                 default:
                     VERIFY_NOT_REACHED();
                 }
@@ -716,6 +718,11 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             auto* slot_element = as_if<HTML::HTMLSlotElement>(node);
             auto* parent_node = as_if<DOM::ParentNode>(node);
             auto shadow_root = element ? element->shadow_root() : nullptr;
+            auto* graphics_element = as_if<SVG::SVGGraphicsElement>(node);
+            auto mask = graphics_element ? graphics_element->mask() : nullptr;
+            auto clip_path = graphics_element ? graphics_element->clip_path() : nullptr;
+            auto fill_pattern = graphics_element ? graphics_element->fill_pattern() : nullptr;
+            auto stroke_pattern = graphics_element ? graphics_element->stroke_pattern() : nullptr;
             return {
                 .is_element = element != nullptr,
                 .context_layout_top_layer = context.layout_top_layer,
@@ -724,33 +731,33 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 .child_needs_layout_tree_update = node.child_needs_layout_tree_update(),
                 .layout_node_can_have_children = layout_node.can_have_children(),
                 .layout_node_is_replaced_box_with_children = layout_node.is_replaced_box_with_children(),
+                .layout_node_is_list_item_box = layout_node.is_list_item_box(),
+                .layout_node_is_block_container = is<BlockContainer>(layout_node),
                 .is_svg_switch_element = is<SVG::SVGSwitchElement>(node),
                 .is_document = node.is_document(),
                 .has_style_containment = is<NodeWithStyle>(layout_node) && static_cast<NodeWithStyle&>(layout_node).has_style_containment(),
                 .dom_children_parent = parent_node,
                 .shadow_root = shadow_root ? static_cast<DOM::ParentNode*>(shadow_root.ptr()) : nullptr,
                 .slot_element = slot_element,
+                .svg_graphics_element = graphics_element,
+                .svg_mask = const_cast<SVG::SVGMaskElement*>(mask.ptr()),
+                .svg_clip_path = const_cast<SVG::SVGClipPathElement*>(clip_path.ptr()),
+                .svg_fill_pattern = const_cast<SVG::SVGPatternElement*>(fill_pattern.ptr()),
+                .svg_stroke_pattern = const_cast<SVG::SVGPatternElement*>(stroke_pattern.ptr()),
+                .context_layout_svg_mask_or_clip_path = context.layout_svg_mask_or_clip_path,
+                .context_layout_svg_pattern = context.layout_svg_pattern,
             }; },
-        .update_before_children = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer, void* context_pointer, bool content_visibility_hidden) {
-            VERIFY(builder_pointer);
-            VERIFY(node_pointer);
+        .create_first_letter_wrapper = [](void*, void* element_pointer, void* layout_node_pointer) {
+            VERIFY(element_pointer);
             VERIFY(layout_node_pointer);
-            VERIFY(context_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->update_layout_tree_before_children(
-                *static_cast<DOM::Node*>(node_pointer),
-                *static_cast<Layout::Node*>(layout_node_pointer),
-                *static_cast<Context*>(context_pointer),
-                content_visibility_hidden); },
-        .update_after_children = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer, void* context_pointer, bool content_visibility_hidden) {
+            create_first_letter_wrapper_if_needed(
+                *static_cast<DOM::Element*>(element_pointer),
+                as<BlockContainer>(*static_cast<Layout::Node*>(layout_node_pointer))); },
+        .wrap_fieldset_layout = [](void* builder_pointer, void* layout_node_pointer) {
             VERIFY(builder_pointer);
-            VERIFY(node_pointer);
             VERIFY(layout_node_pointer);
-            VERIFY(context_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->update_layout_tree_after_children(
-                *static_cast<DOM::Node*>(node_pointer),
-                *static_cast<Layout::Node*>(layout_node_pointer),
-                *static_cast<Context*>(context_pointer),
-                content_visibility_hidden); },
+            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<TreeBuilder*>(builder_pointer));
+            RustFFI::rust_wrap_fieldset_contents_if_needed(&callbacks, layout_node_pointer); },
         .wrap_button_layout = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
@@ -819,6 +826,29 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             auto& node = *static_cast<DOM::Node*>(node_pointer);
             node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
             node.set_child_needs_layout_tree_update(false); },
+        .svg_pattern_content_element = [](void* pattern_pointer) -> void* {
+            VERIFY(pattern_pointer);
+            return const_cast<SVG::SVGPatternElement*>(static_cast<SVG::SVGPatternElement*>(pattern_pointer)->pattern_content_element().ptr()); },
+        .register_svg_resource_reference = [](void* resource_pointer, void* graphics_element_pointer) {
+            VERIFY(resource_pointer);
+            VERIFY(graphics_element_pointer);
+            static_cast<SVG::SVGElement*>(resource_pointer)->register_resource_box_referencing_element(
+                {}, *static_cast<SVG::SVGGraphicsElement*>(graphics_element_pointer)); },
+        .ancestor_count = [](void* builder_pointer) {
+            VERIFY(builder_pointer);
+            return static_cast<TreeBuilder*>(builder_pointer)->ancestor_count(); },
+        .ancestor_at = [](void* builder_pointer, size_t index) -> void* {
+            VERIFY(builder_pointer);
+            return &static_cast<TreeBuilder*>(builder_pointer)->ancestor_at(index); },
+        .layout_node_dom_node = [](void* layout_node_pointer) -> void* {
+            VERIFY(layout_node_pointer);
+            return static_cast<Layout::Node*>(layout_node_pointer)->dom_node(); },
+        .set_context_layout_svg_mask_or_clip_path = [](void* context_pointer, bool layout_svg_mask_or_clip_path) {
+            VERIFY(context_pointer);
+            static_cast<Context*>(context_pointer)->layout_svg_mask_or_clip_path = layout_svg_mask_or_clip_path; },
+        .set_context_layout_svg_pattern = [](void* context_pointer, bool layout_svg_pattern) {
+            VERIFY(context_pointer);
+            static_cast<Context*>(context_pointer)->layout_svg_pattern = layout_svg_pattern; },
     };
 }
 
@@ -1175,103 +1205,6 @@ void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, Layo
     auto const* html_element = as_if<HTML::HTMLElement>(dom_node);
     auto callbacks = make_ffi_tree_builder_callbacks(this);
     RustFFI::rust_wrap_button_contents_if_needed(&callbacks, &layout_node, html_element && html_element->uses_button_layout());
-}
-
-void TreeBuilder::update_layout_tree_before_children(DOM::Node& dom_node, Layout::Node& layout_node, TreeBuilder::Context&, bool element_has_content_visibility_hidden)
-{
-    // Add node for the ::before pseudo-element.
-    if (is<DOM::Element>(dom_node) && layout_node.can_have_children() && !element_has_content_visibility_hidden) {
-        auto& element = static_cast<DOM::Element&>(dom_node);
-        push_parent(as<NodeWithStyle>(layout_node));
-        (void)create_pseudo_element_if_needed(element, CSS::PseudoElement::Before, AppendOrPrepend::Prepend);
-
-        pop_parent();
-    }
-}
-
-void TreeBuilder::update_layout_tree_after_children(DOM::Node& dom_node, Layout::Node& layout_node, TreeBuilder::Context& context, bool element_has_content_visibility_hidden)
-{
-    if (is<SVG::SVGGraphicsElement>(dom_node)) {
-        auto& graphics_element = static_cast<SVG::SVGGraphicsElement&>(dom_node);
-        // Create the layout tree for the SVG mask/clip paths as a child of the masked element.
-        // Note: This will create a new subtree for each use of the mask (so there's  not a 1-to-1 mapping
-        // from DOM node to mask layout node). Each use of a mask may be laid out differently so this
-        // duplication is necessary.
-        auto layout_mask_or_clip_path = [&](GC::Ptr<SVG::SVGElement const> mask_or_clip_path) {
-            TemporaryChange<bool> layout_mask(context.layout_svg_mask_or_clip_path, true);
-            push_parent(as<NodeWithStyle>(layout_node));
-
-            // Check for reference cycle
-            for (size_t index = 0; index < ancestor_count(); ++index) {
-                if (ancestor_at(index).dom_node() == mask_or_clip_path) {
-                    // FIXME: Somehow either remove ancestor from the layout tree or mark it as invalid.
-                    pop_parent();
-                    return;
-                }
-            }
-            update_layout_tree(const_cast<SVG::SVGElement&>(*mask_or_clip_path), context, MustCreateSubtree::Yes);
-            const_cast<SVG::SVGElement&>(*mask_or_clip_path).register_resource_box_referencing_element({}, graphics_element);
-            pop_parent();
-        };
-        if (auto mask = graphics_element.mask())
-            layout_mask_or_clip_path(mask);
-        if (auto clip_path = graphics_element.clip_path())
-            layout_mask_or_clip_path(clip_path);
-
-        HashTable<SVG::SVGPatternElement const*> seen_content_elements;
-        auto layout_pattern = [&](GC::Ptr<SVG::SVGPatternElement const> pattern) {
-            if (!pattern)
-                return;
-            auto content_element = pattern->pattern_content_element();
-            if (!content_element)
-                return;
-            if (seen_content_elements.set(content_element.ptr()) != AK::HashSetResult::InsertedNewEntry)
-                return;
-            TemporaryChange<bool> layout_flag(context.layout_svg_pattern, true);
-            push_parent(as<NodeWithStyle>(layout_node));
-            for (size_t index = 0; index < ancestor_count(); ++index) {
-                if (ancestor_at(index).dom_node() == content_element.ptr()) {
-                    pop_parent();
-                    return;
-                }
-            }
-            update_layout_tree(const_cast<SVG::SVGPatternElement&>(*content_element), context, MustCreateSubtree::Yes);
-            // NB: The referenced pattern may inherit its content from another pattern via href. Removing either
-            //     element invalidates the attached resource box, so register the referencer with both.
-            const_cast<SVG::SVGPatternElement&>(*content_element).register_resource_box_referencing_element({}, graphics_element);
-            if (pattern != content_element)
-                const_cast<SVG::SVGPatternElement&>(*pattern).register_resource_box_referencing_element({}, graphics_element);
-            pop_parent();
-        };
-        if (auto fill = graphics_element.fill_pattern())
-            layout_pattern(fill);
-        if (auto stroke = graphics_element.stroke_pattern())
-            layout_pattern(stroke);
-    }
-
-    // Add nodes for the ::after pseudo-element.
-    if (is<DOM::Element>(dom_node) && layout_node.can_have_children() && !element_has_content_visibility_hidden) {
-        auto& element = static_cast<DOM::Element&>(dom_node);
-        push_parent(as<NodeWithStyle>(layout_node));
-
-        // https://drafts.csswg.org/css-lists-3/#marker-pseudo
-        // The marker box is generated by the ::marker pseudo-element of a list item as the list item’s first child,
-        // before the ::before pseudo-element (if it exists on the element). It is filled with content as defined
-        // in § 3.2 Generating Marker Contents.
-        // NOTE: This happens in update_layout_tree_after_children (and not in ..._before_...), since potential
-        //       block container wrapper children are created after update_layout_tree_before_children.
-        if (layout_node.is_list_item_box())
-            (void)create_pseudo_element_if_needed(element, CSS::PseudoElement::Marker, AppendOrPrepend::Prepend);
-
-        (void)create_pseudo_element_if_needed(element, CSS::PseudoElement::After, AppendOrPrepend::Append);
-        pop_parent();
-
-        if (auto* block_container = as_if<BlockContainer>(layout_node))
-            create_first_letter_wrapper_if_needed(element, *block_container);
-    }
-
-    auto callbacks = make_ffi_tree_builder_callbacks(this);
-    RustFFI::rust_wrap_fieldset_contents_if_needed(&callbacks, &layout_node);
 }
 
 RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1682,7 +1682,7 @@ static void ffi_note_tree_restructuring(void* context, void* node_pointer)
     static_cast<TreeBuilder*>(context)->note_tree_restructuring_at(*static_cast<Node*>(node_pointer));
 }
 
-static void ffi_wrap_button_contents(void*, void* layout_node_pointer)
+static void* ffi_create_button_content_wrapper(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(layout_node_pointer));
@@ -1692,28 +1692,22 @@ static void ffi_wrap_button_contents(void*, void* layout_node_pointer)
     auto flex_wrapper = create_button_flex_wrapper(parent);
 
     auto content_box_wrapper = create_button_content_box_wrapper(parent);
-    content_box_wrapper->set_children_are_inline(parent.children_are_inline());
-
-    Vector<NonnullRefPtr<Node>> sequence;
-    for (auto child = parent.first_child(); child; child = child->next_sibling())
-        sequence.append(*child);
-
-    for (auto& node : sequence) {
-        parent.remove_child(*node);
-        content_box_wrapper->append_child(*node);
-    }
-
     flex_wrapper->append_child(*content_box_wrapper);
     parent.append_child(*flex_wrapper);
-    parent.set_children_are_inline(false);
+    return content_box_wrapper.ptr();
 }
 
-static void ffi_wrap_fieldset_contents(void*, void* layout_node_pointer)
+static void* ffi_rendered_legend(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
     auto& fieldset_box = as<FieldSetBox>(*static_cast<Node*>(layout_node_pointer));
-    auto legend = fieldset_box.rendered_legend();
-    VERIFY(legend);
+    return const_cast<Node*>(static_cast<Node const*>(fieldset_box.rendered_legend().ptr()));
+}
+
+static void* ffi_create_fieldset_content_wrapper(void*, void* layout_node_pointer)
+{
+    VERIFY(layout_node_pointer);
+    auto& fieldset_box = as<FieldSetBox>(*static_cast<Node*>(layout_node_pointer));
     auto wrapper = fieldset_box.create_anonymous_wrapper();
     wrapper->set_display(CSS::Display::from_short(CSS::Display::Short::FlowRoot));
 
@@ -1727,15 +1721,20 @@ static void ffi_wrap_fieldset_contents(void*, void* layout_node_pointer)
     wrapper->set_overflow(fieldset_box.computed_values().overflow_x(), fieldset_box.computed_values().overflow_y());
     fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
 
-    for (auto child = fieldset_box.first_child(); child;) {
-        auto next = child->next_sibling();
-        if (child != legend) {
-            fieldset_box.remove_child(*child);
-            wrapper->append_child(*child);
-        }
-        child = next;
-    }
     fieldset_box.append_child(*wrapper);
+    return wrapper.ptr();
+}
+
+static void ffi_move_nodes_to_parent(void*, void* parent_pointer, void* const* node_pointers, size_t node_count)
+{
+    VERIFY(parent_pointer);
+    auto& parent = *static_cast<Node*>(parent_pointer);
+    auto nodes = retain_ffi_layout_nodes(node_pointers, node_count);
+    for (auto& node : nodes) {
+        VERIFY(node->parent());
+        node->parent()->remove_child(*node);
+        parent.append_child(*node);
+    }
 }
 
 static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder* tree_builder)
@@ -1763,8 +1762,10 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuil
         .set_children_are_inline = ffi_set_children_are_inline,
         .note_tree_restructuring = ffi_note_tree_restructuring,
         .find_first_letter_in_text = ffi_find_first_letter_in_text,
-        .wrap_button_contents = ffi_wrap_button_contents,
-        .wrap_fieldset_contents = ffi_wrap_fieldset_contents,
+        .create_button_content_wrapper = ffi_create_button_content_wrapper,
+        .rendered_legend = ffi_rendered_legend,
+        .create_fieldset_content_wrapper = ffi_create_fieldset_content_wrapper,
+        .move_nodes_to_parent = ffi_move_nodes_to_parent,
     };
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -11,6 +11,7 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/Optional.h>
+#include <AK/OwnPtr.h>
 #include <AK/Utf16String.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibUnicode/CharacterTypes.h>
@@ -54,18 +55,73 @@
 
 namespace Web::Layout {
 
-static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder*);
+class LayoutTreeBuildBridge {
+public:
+    ~LayoutTreeBuildBridge();
+
+    LayoutTreeBuildResult build(DOM::Node&);
+
+    enum class AppendOrPrepend {
+        Append,
+        Prepend,
+    };
+
+    void note_tree_restructuring_at(Layout::Node const&);
+    static void detach_top_layer_element_layout_subtree(DOM::Element&);
+
+private:
+    struct PrincipalNodeFrameStorage;
+    static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
+    static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
+
+    RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
+    RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
+
+    void insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle&, Layout::Node&, CSS::Display, AppendOrPrepend);
+    static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
+    RefPtr<NodeWithStyle> create_pseudo_element_if_needed(void* rust_state, DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
+    static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
+
+    RefPtr<Layout::Node> m_layout_root;
+    OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
+
+    Layout::Node* m_current_rebuild_root { nullptr };
+    Vector<Layout::Node*> m_rebuilt_subtree_roots;
+    bool m_layout_tree_update_escaped_rebuild_roots { false };
+};
+
+void LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(DOM::Element& element)
+{
+    element.clear_synthetic_pseudo_element_layout_nodes({});
+}
+
+void LayoutTreeBuilderAccess::detach_layout_node(DOM::Node& node)
+{
+    node.detach_layout_node({});
+}
+
+void LayoutTreeBuilderAccess::register_svg_resource_reference(SVG::SVGElement& resource, DOM::Element& referencing_element)
+{
+    resource.register_resource_box_referencing_element({}, referencing_element);
+}
+
+void LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(DOM::Element& element, CSS::PseudoElement pseudo_element, Layout::NodeWithStyle* layout_node)
+{
+    element.set_synthetic_pseudo_element_node({}, pseudo_element, layout_node);
+}
+
+static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTreeBuildBridge*);
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
 static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&);
 
-void TreeBuilder::note_tree_restructuring_at(Layout::Node const& node)
+void LayoutTreeBuildBridge::note_tree_restructuring_at(Layout::Node const& node)
 {
     if (m_current_rebuild_root && !m_current_rebuild_root->is_inclusive_ancestor_of(node))
         m_layout_tree_update_escaped_rebuild_roots = true;
 }
 
-void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle& parent, Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
+void LayoutTreeBuildBridge::insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle& parent, Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
 {
     auto callbacks = make_ffi_tree_builder_callbacks(this);
     RustFFI::rust_insert_node_into_inline_or_block_ancestor(
@@ -226,7 +282,7 @@ static FirstLetterTextSlices create_first_letter_text_slices(DOM::Document& docu
     };
 }
 
-void TreeBuilder::create_first_letter_wrapper_if_needed(DOM::Element& element, BlockContainer& block_container)
+void LayoutTreeBuildBridge::create_first_letter_wrapper_if_needed(DOM::Element& element, BlockContainer& block_container)
 {
     auto callbacks = make_ffi_tree_builder_callbacks(nullptr);
     auto target = RustFFI::rust_find_first_letter_in_block(&callbacks, &block_container);
@@ -248,7 +304,7 @@ void TreeBuilder::create_first_letter_wrapper_if_needed(DOM::Element& element, B
     first_letter_wrapper->set_generated_for(CSS::PseudoElement::FirstLetter, element);
     first_letter_wrapper->set_children_are_inline(true);
     first_letter_wrapper->append_child(*first_letter_slice);
-    element.set_synthetic_pseudo_element_node({}, CSS::PseudoElement::FirstLetter, first_letter_wrapper);
+    LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::FirstLetter, first_letter_wrapper);
 
     auto* parent = text_node.parent();
     VERIFY(parent);
@@ -257,7 +313,7 @@ void TreeBuilder::create_first_letter_wrapper_if_needed(DOM::Element& element, B
     parent->remove_child(text_node);
 }
 
-NonnullRefPtr<ListItemMarkerBox> TreeBuilder::create_and_attach_list_item_marker(ListItemBox& list_box, DOM::Element& element, NonnullRefPtr<CSS::ComputedValues const> marker_style)
+NonnullRefPtr<ListItemMarkerBox> LayoutTreeBuildBridge::create_and_attach_list_item_marker(ListItemBox& list_box, DOM::Element& element, NonnullRefPtr<CSS::ComputedValues const> marker_style)
 {
     auto list_item_marker = make_ref_counted<ListItemMarkerBox>(
         list_box.document(),
@@ -267,7 +323,7 @@ NonnullRefPtr<ListItemMarkerBox> TreeBuilder::create_and_attach_list_item_marker
         move(marker_style));
     list_item_marker->attach_style_resources();
     list_box.set_marker(list_item_marker);
-    element.set_synthetic_pseudo_element_node({}, CSS::PseudoElement::Marker, list_item_marker);
+    LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, CSS::PseudoElement::Marker, list_item_marker);
     list_box.prepend_child(*list_item_marker);
     return list_item_marker;
 }
@@ -328,7 +384,7 @@ struct PseudoElementFrame {
     RefPtr<Layout::Node> content_item;
 };
 
-RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(void* rust_state, DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
+RefPtr<NodeWithStyle> LayoutTreeBuildBridge::create_pseudo_element_if_needed(void* rust_state, DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
 {
     PseudoElementFrame frame;
     auto callbacks = make_ffi_pseudo_tree_builder_callbacks();
@@ -345,7 +401,7 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(void* rust_st
     return static_cast<NodeWithStyle*>(layout_node);
 }
 
-RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder_callbacks()
+RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tree_builder_callbacks()
 {
     return {
         .builder = this,
@@ -456,7 +512,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
             VERIFY(frame.layout_node);
@@ -471,14 +527,14 @@ RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder
             VERIFY(frame.layout_node);
             frame.layout_node->set_generated_for(pseudo_element, element);
             frame.layout_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
-            element.set_synthetic_pseudo_element_node({}, pseudo_element, frame.layout_node); },
+            LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, pseudo_element, frame.layout_node); },
         .insert_layout_node = [](void* builder_pointer, void* frame_pointer, void* parent_pointer, RustFFI::FfiInsertionMode insertion_mode) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(parent_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
-            static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
+            static_cast<LayoutTreeBuildBridge*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
                 as<NodeWithStyle>(*static_cast<Layout::Node*>(parent_pointer)),
                 *frame.layout_node,
                 frame.layout_node->display(),
@@ -531,7 +587,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder
             auto display = content_item.is_text_node()
                 ? CSS::Display::from_short(CSS::Display::Short::Inline)
                 : as<NodeWithStyle>(content_item).display();
-            static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
+            static_cast<LayoutTreeBuildBridge*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
                 as<NodeWithStyle>(*static_cast<Layout::Node*>(parent_pointer)),
                 content_item,
                 display,
@@ -571,7 +627,7 @@ static void transfer_saved_layout_state_to_replacement_box(Layout::Node& old_lay
     }
 }
 
-TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* cleared_subtree_root)
+TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* cleared_subtree_root)
 {
     node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
     node.set_child_needs_layout_tree_update(false);
@@ -602,16 +658,16 @@ TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node
     if (layout_node && layout_node->parent())
         layout_node->remove();
 
-    node.detach_layout_node({});
+    LayoutTreeBuilderAccess::detach_layout_node(node);
     node.clear_paintable();
 
     if (is<DOM::Element>(node))
-        static_cast<DOM::Element&>(node).clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
+        LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(static_cast<DOM::Element&>(node));
 
     return TraversalDecision::Continue;
 }
 
-void TreeBuilder::detach_top_layer_element_layout_subtree(DOM::Element& element)
+void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element& element)
 {
     RustFFI::FfiTopLayerDetachCallbacks callbacks {
         .element_layout_node = [](void* element_pointer) -> void* {
@@ -654,12 +710,12 @@ struct PrincipalNodeFrame {
     CSS::Display display;
 };
 
-struct TreeBuilder::PrincipalNodeFrameStorage {
+struct LayoutTreeBuildBridge::PrincipalNodeFrameStorage {
     Vector<NonnullOwnPtr<PrincipalNodeFrame>> frames;
     size_t active_frame_count { 0 };
 };
 
-TreeBuilder::~TreeBuilder()
+LayoutTreeBuildBridge::~LayoutTreeBuildBridge()
 {
 }
 
@@ -675,7 +731,7 @@ static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Displa
     };
 }
 
-RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callbacks()
+RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_builder_callbacks()
 {
     return {
         .builder = this,
@@ -712,7 +768,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .clear_stale_layout_and_paint_node = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
-            (void)static_cast<TreeBuilder*>(builder_pointer)->clear_stale_layout_and_paint_node(*static_cast<DOM::Node*>(node_pointer)); },
+            (void)static_cast<LayoutTreeBuildBridge*>(builder_pointer)->clear_stale_layout_and_paint_node(*static_cast<DOM::Node*>(node_pointer)); },
         .display_contents_facts = [](void*, void* element_pointer) -> RustFFI::FfiDisplayContentsFacts {
             VERIFY(element_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
@@ -730,11 +786,11 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         },
         .clear_synthetic_pseudo_element_layout_nodes = [](void*, void* element_pointer) {
             VERIFY(element_pointer);
-            static_cast<DOM::Element*>(element_pointer)->clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {}); },
+            LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(*static_cast<DOM::Element*>(element_pointer)); },
         .clear_stale_inclusive_descendants = [](void* builder_pointer, void* element_pointer) {
             VERIFY(builder_pointer);
             VERIFY(element_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             static_cast<DOM::Element*>(element_pointer)->for_each_shadow_including_inclusive_descendant([&](auto& node) {
                 return builder.clear_stale_layout_and_paint_node(node);
             }); },
@@ -759,7 +815,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 }
             }();
             auto mode = insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend;
-            (void)static_cast<TreeBuilder*>(builder_pointer)->create_pseudo_element_if_needed(rust_state, *static_cast<DOM::Element*>(element_pointer), css_pseudo_element, mode); },
+            (void)static_cast<LayoutTreeBuildBridge*>(builder_pointer)->create_pseudo_element_if_needed(rust_state, *static_cast<DOM::Element*>(element_pointer), css_pseudo_element, mode); },
         .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
             VERIFY(slot_element_pointer);
             clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
@@ -808,14 +864,14 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .wrap_fieldset_layout = [](void* builder_pointer, void* layout_node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(layout_node_pointer);
-            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<TreeBuilder*>(builder_pointer));
+            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<LayoutTreeBuildBridge*>(builder_pointer));
             RustFFI::rust_wrap_fieldset_contents_if_needed(&callbacks, layout_node_pointer); },
         .wrap_button_layout = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
             VERIFY(layout_node_pointer);
             auto* html_element = as_if<HTML::HTMLElement>(*static_cast<DOM::Node*>(node_pointer));
-            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<TreeBuilder*>(builder_pointer));
+            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<LayoutTreeBuildBridge*>(builder_pointer));
             RustFFI::rust_wrap_button_contents_if_needed(
                 &callbacks,
                 layout_node_pointer,
@@ -823,7 +879,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .clear_stale_descendants = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
             node.for_each_shadow_including_descendant([&](auto& descendant) {
                 return builder.clear_stale_layout_and_paint_node(descendant, &node);
@@ -867,7 +923,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .clear_stale_top_layer_subtree = [](void* builder_pointer, void* element_pointer) {
             VERIFY(builder_pointer);
             VERIFY(element_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
             element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
                 return builder.clear_stale_layout_and_paint_node(node, &element);
@@ -883,8 +939,9 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .register_svg_resource_reference = [](void* resource_pointer, void* graphics_element_pointer) {
             VERIFY(resource_pointer);
             VERIFY(graphics_element_pointer);
-            static_cast<SVG::SVGElement*>(resource_pointer)->register_resource_box_referencing_element(
-                {}, *static_cast<SVG::SVGGraphicsElement*>(graphics_element_pointer)); },
+            LayoutTreeBuilderAccess::register_svg_resource_reference(
+                *static_cast<SVG::SVGElement*>(resource_pointer),
+                *static_cast<SVG::SVGGraphicsElement*>(graphics_element_pointer)); },
         .layout_node_dom_node = [](void* layout_node_pointer) -> void* {
             VERIFY(layout_node_pointer);
             return static_cast<Layout::Node*>(layout_node_pointer)->dom_node(); },
@@ -921,7 +978,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .push_principal_frame = [](void* builder_pointer, void* node_pointer) -> void* {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             if (!builder.m_principal_frames)
                 builder.m_principal_frames = make<PrincipalNodeFrameStorage>();
             auto& storage = *builder.m_principal_frames;
@@ -938,7 +995,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .pop_principal_frame = [](void* builder_pointer, void* frame_pointer) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             VERIFY(builder.m_principal_frames);
             auto& storage = *builder.m_principal_frames;
             VERIFY(storage.active_frame_count > 0);
@@ -953,7 +1010,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& element = *static_cast<DOM::Element*>(element_pointer);
             if (should_create_layout_node) {
@@ -963,7 +1020,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                     builder.m_layout_tree_update_escaped_rebuild_roots = true;
                     old_backdrop_node->remove();
                 }
-                element.clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
+                LayoutTreeBuilderAccess::clear_synthetic_pseudo_element_layout_nodes(element);
                 update_style_if_needed_for_layout_tree_bypass_path(element);
             }
             frame.computed_values = element.computed_values();
@@ -1059,7 +1116,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(node_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
             VERIFY(frame.layout_node);
@@ -1079,7 +1136,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .start_principal_rebuild_root = [](void* builder_pointer, void* frame_pointer) -> void* {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
             auto* prior_rebuild_root = builder.m_current_rebuild_root;
@@ -1088,16 +1145,16 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             return prior_rebuild_root; },
         .restore_principal_rebuild_root = [](void* builder_pointer, void* rebuild_root_pointer) {
             VERIFY(builder_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->m_current_rebuild_root = static_cast<Layout::Node*>(rebuild_root_pointer); },
+            static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_current_rebuild_root = static_cast<Layout::Node*>(rebuild_root_pointer); },
         .mark_update_escaped_rebuild_roots = [](void* builder_pointer) {
             VERIFY(builder_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->m_layout_tree_update_escaped_rebuild_roots = true; },
+            static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_tree_update_escaped_rebuild_roots = true; },
         .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* rust_state, void* element_pointer, bool append) -> void* {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(rust_state);
             VERIFY(element_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             frame.backdrop_node = builder.create_pseudo_element_if_needed(
                 rust_state,
@@ -1109,7 +1166,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(backdrop_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             VERIFY(frame.old_layout_node);
             VERIFY(frame.old_layout_node->parent());
@@ -1119,7 +1176,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .place_principal_layout = [](void* builder_pointer, void* frame_pointer, void* parent_pointer, RustFFI::FfiPrincipalBoxPlacement placement) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
             switch (placement) {
@@ -1150,7 +1207,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .clear_stale_inclusive_subtree = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
             static_cast<DOM::Node*>(node_pointer)->for_each_shadow_including_inclusive_descendant([&](auto& node) {
                 return builder.clear_stale_layout_and_paint_node(node);
             }); },
@@ -1164,15 +1221,15 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .fixup_tables = [](void* builder_pointer, void* root_pointer) {
             VERIFY(builder_pointer);
             VERIFY(root_pointer);
-            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<TreeBuilder*>(builder_pointer));
+            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<LayoutTreeBuildBridge*>(builder_pointer));
             RustFFI::rust_fixup_tables(&callbacks, root_pointer); },
         .layout_root = [](void* builder_pointer) -> void* {
             VERIFY(builder_pointer);
-            return static_cast<TreeBuilder*>(builder_pointer)->m_layout_root.ptr(); },
+            return static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_root.ptr(); },
     };
 }
 
-void TreeBuilder::clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement& slot_element)
+void LayoutTreeBuildBridge::clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement& slot_element)
 {
     // Assigned slottables are flat tree children of a slot, not DOM descendants, so subtree
     // cleanup of the slot does not reach them.
@@ -1256,7 +1313,7 @@ static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithSt
     return content_box_wrapper;
 }
 
-LayoutTreeBuildResult TreeBuilder::build(DOM::Node& dom_node)
+LayoutTreeBuildResult LayoutTreeBuildBridge::build(DOM::Node& dom_node)
 {
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
     m_layout_root = static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &dom_node));
@@ -1269,13 +1326,13 @@ LayoutTreeBuildResult TreeBuilder::build(DOM::Node& dom_node)
 
 LayoutTreeBuildResult build_layout_tree(DOM::Node& dom_node)
 {
-    TreeBuilder tree_builder;
-    return tree_builder.build(dom_node);
+    LayoutTreeBuildBridge bridge;
+    return bridge.build(dom_node);
 }
 
 void detach_top_layer_element_layout_subtree(DOM::Element& element)
 {
-    TreeBuilder::detach_top_layer_element_layout_subtree(element);
+    LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(element);
 }
 
 static RustFFI::FfiTableDisplay ffi_table_display(CSS::Display display)
@@ -1611,7 +1668,7 @@ static void ffi_note_tree_restructuring(void* context, void* node_pointer)
 {
     VERIFY(context);
     VERIFY(node_pointer);
-    static_cast<TreeBuilder*>(context)->note_tree_restructuring_at(*static_cast<Node*>(node_pointer));
+    static_cast<LayoutTreeBuildBridge*>(context)->note_tree_restructuring_at(*static_cast<Node*>(node_pointer));
 }
 
 static void* ffi_create_button_content_wrapper(void*, void* layout_node_pointer)
@@ -1669,10 +1726,10 @@ static void ffi_move_nodes_to_parent(void*, void* parent_pointer, void* const* n
     }
 }
 
-static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder* tree_builder)
+static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTreeBuildBridge* bridge)
 {
     return {
-        .context = tree_builder,
+        .context = bridge,
         .layout_node_facts = ffi_layout_node_facts,
         .parent = ffi_layout_node_parent,
         .first_child = ffi_layout_node_first_child,

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -897,7 +897,8 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             auto& element = static_cast<DOM::Element&>(dom_node);
             computed_values = element.computed_values();
             display = computed_values->display();
-            if (display.is_contents()) {
+            auto box_generation = RustFFI::rust_principal_box_generation_decision(true, false, display.is_contents());
+            if (box_generation == RustFFI::FfiPrincipalBoxGenerationDecision::DisplayContents) {
                 should_clear_stale_layout_subtree_if_no_layout_node = false;
                 update_layout_tree_for_display_contents(element, context, must_create_subtree, should_create_layout_node);
                 return;
@@ -920,9 +921,10 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             update_style_if_needed_for_layout_tree_bypass_path(element);
             computed_values = element.computed_values();
             display = computed_values->display();
-            if (display.is_none())
+            auto box_generation = RustFFI::rust_principal_box_generation_decision(true, display.is_none(), display.is_contents());
+            if (box_generation == RustFFI::FfiPrincipalBoxGenerationDecision::Suppress)
                 return;
-            if (display.is_contents()) {
+            if (box_generation == RustFFI::FfiPrincipalBoxGenerationDecision::DisplayContents) {
                 should_clear_stale_layout_subtree_if_no_layout_node = false;
                 update_layout_tree_for_display_contents(element, context, must_create_subtree, should_create_layout_node);
                 return;
@@ -952,49 +954,53 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         }
     }
 
-    // Decide whether to replace an existing node (partial tree update) or insert a new one appropriately.
-    bool const may_replace_existing_layout_node = must_create_subtree == MustCreateSubtree::No
-        && old_layout_node
-        && old_layout_node->parent()
-        && old_layout_node != layout_node;
+    auto* dom_element = as_if<DOM::Element>(dom_node);
+    auto placement_decision = RustFFI::rust_principal_box_placement_decision({
+        .must_create_subtree = must_create_subtree == MustCreateSubtree::Yes,
+        .should_create_layout_node = should_create_layout_node,
+        .has_old_layout_node = old_layout_node != nullptr,
+        .old_layout_node_is_attached = old_layout_node && old_layout_node->parent(),
+        .old_and_new_layout_nodes_are_same = old_layout_node == layout_node,
+        .has_current_rebuild_root = m_current_rebuild_root != nullptr,
+        .is_document = dom_node.is_document(),
+        .is_element = dom_element != nullptr,
+        .rendered_in_top_layer = dom_element && dom_element->rendered_in_top_layer(),
+        .context_layout_top_layer = context.layout_top_layer,
+        .layout_node_is_svg_box = layout_node->is_svg_box(),
+    });
+
     Optional<TemporaryChange<Layout::Node*>> current_rebuild_root_change;
-    if (may_replace_existing_layout_node && !m_current_rebuild_root) {
+    if (placement_decision.start_rebuild_root) {
         current_rebuild_root_change.emplace(m_current_rebuild_root, layout_node.ptr());
         m_rebuilt_subtree_roots.append(layout_node.ptr());
-    } else if (should_create_layout_node && !old_layout_node && !m_current_rebuild_root && !dom_node.is_document()) {
+    } else if (placement_decision.mark_update_escaped_rebuild_roots) {
         // A fresh subtree that replaces no box in place (a ShadowRoot direct child, or a
         // top-layer element revealed from display:none) belongs to no rebuild root, so nothing
         // would lay its new boxes out on the partial path.
         m_layout_tree_update_escaped_rebuild_roots = true;
     }
 
-    if (dom_node.is_element() && should_create_layout_node) {
-        auto& element = static_cast<DOM::Element&>(dom_node);
-        if (element.rendered_in_top_layer() && context.layout_top_layer)
-            create_backdrop_for_top_layer_element_if_needed(element, old_layout_node, may_replace_existing_layout_node);
-    }
+    if (placement_decision.create_backdrop)
+        create_backdrop_for_top_layer_element_if_needed(*dom_element, old_layout_node, placement_decision.may_replace_existing_layout_node);
 
     // A top layer member nested inside this member must be skipped at its normal position
     // like anywhere else in the walk, so its own turn of the pass builds its viewport box.
     Optional<TemporaryChange<bool>> layout_top_layer_cleared_for_member_descendants;
-    if (auto* element = as_if<DOM::Element>(dom_node); element && element->rendered_in_top_layer() && context.layout_top_layer)
+    if (placement_decision.clear_layout_top_layer_for_descendants)
         layout_top_layer_cleared_for_member_descendants.emplace(context.layout_top_layer, false);
 
-    if (dom_node.is_document()) {
+    if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::DocumentRoot) {
         m_layout_root = layout_node;
-    } else if (should_create_layout_node) {
-        if (may_replace_existing_layout_node) {
-            transfer_saved_layout_state_to_replacement_box(*old_layout_node, *layout_node);
-            old_layout_node->prepare_subtree_for_detach_from_layout_tree();
-            old_layout_node->parent()->replace_child(*layout_node, *old_layout_node);
-        } else if (layout_node->is_svg_box()) {
-            current_parent().append_child(*layout_node);
-        } else {
-            insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
-        }
+    } else if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::ReplaceExisting) {
+        transfer_saved_layout_state_to_replacement_box(*old_layout_node, *layout_node);
+        old_layout_node->prepare_subtree_for_detach_from_layout_tree();
+        old_layout_node->parent()->replace_child(*layout_node, *old_layout_node);
+    } else if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::AppendSvg) {
+        current_parent().append_child(*layout_node);
+    } else if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::NormalInsertion) {
+        insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
     }
 
-    auto* dom_element = as_if<DOM::Element>(dom_node);
     auto shadow_root = dom_element ? dom_element->shadow_root() : nullptr;
 
     auto element_has_content_visibility_hidden = [&dom_node]() {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -603,28 +603,83 @@ static bool element_has_an_unrendered_flat_tree_ancestor(DOM::Element const& ele
     return false;
 }
 
+RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callbacks()
+{
+    return {
+        .builder = this,
+        .first_child = [](void* parent_pointer) -> void* {
+            VERIFY(parent_pointer);
+            return static_cast<DOM::ParentNode*>(parent_pointer)->first_child();
+        },
+        .next_sibling = [](void* node_pointer) -> void* {
+            VERIFY(node_pointer);
+            return static_cast<DOM::Node*>(node_pointer)->next_sibling();
+        },
+        .update_layout_tree = [](void* builder_pointer, void* node_pointer, void* context_pointer, bool must_create_subtree) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            VERIFY(context_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->update_layout_tree(
+                *static_cast<DOM::Node*>(node_pointer),
+                *static_cast<Context*>(context_pointer),
+                must_create_subtree ? MustCreateSubtree::Yes : MustCreateSubtree::No); },
+        .clear_update_flags = [](void* node_pointer) {
+            VERIFY(node_pointer);
+            auto& node = *static_cast<DOM::ParentNode*>(node_pointer);
+            node.set_child_needs_layout_tree_update(false);
+            node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None); },
+        .needs_layout_tree_update = [](void* node_pointer) {
+            VERIFY(node_pointer);
+            return static_cast<DOM::Node*>(node_pointer)->needs_layout_tree_update(); },
+        .assigned_node_count = [](void* slot_element_pointer) {
+            VERIFY(slot_element_pointer);
+            return static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal().size(); },
+        .assigned_node_at = [](void* slot_element_pointer, size_t index) -> void* {
+            VERIFY(slot_element_pointer);
+            auto assigned_nodes = static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal();
+            VERIFY(index < assigned_nodes.size());
+            DOM::Node* node = nullptr;
+            assigned_nodes[index].visit([&](auto& assigned_node) { node = assigned_node.ptr(); });
+            return node;
+        },
+        .is_svg_element = [](void* node_pointer) {
+            VERIFY(node_pointer);
+            return is<SVG::SVGElement>(*static_cast<DOM::Node*>(node_pointer)); },
+        .clear_stale_layout_and_paint_node = [](void* builder_pointer, void* node_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            (void)static_cast<TreeBuilder*>(builder_pointer)->clear_stale_layout_and_paint_node(*static_cast<DOM::Node*>(node_pointer)); },
+    };
+}
+
 void TreeBuilder::update_layout_tree_for_shadow_root_children(DOM::ShadowRoot& shadow_root, Context& context, MustCreateSubtree must_create_subtree)
 {
-    for (auto* node = shadow_root.first_child(); node; node = node->next_sibling())
-        update_layout_tree(*node, context, must_create_subtree);
-    shadow_root.set_child_needs_layout_tree_update(false);
-    shadow_root.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    RustFFI::rust_update_layout_tree_for_shadow_root_children(
+        &callbacks,
+        static_cast<DOM::ParentNode*>(&shadow_root),
+        &context,
+        must_create_subtree == MustCreateSubtree::Yes);
 }
 
 void TreeBuilder::update_layout_tree_for_dom_children(DOM::ParentNode& parent, Context& context, MustCreateSubtree must_create_subtree)
 {
-    for (auto* node = parent.first_child(); node; node = node->next_sibling())
-        update_layout_tree(*node, context, must_create_subtree);
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    RustFFI::rust_update_layout_tree_for_dom_children(
+        &callbacks,
+        &parent,
+        &context,
+        must_create_subtree == MustCreateSubtree::Yes);
 }
 
 void TreeBuilder::update_layout_tree_for_assigned_slottables(HTML::HTMLSlotElement& slot_element, Context& context, MustCreateSubtree must_create_subtree)
 {
-    auto must_create_subtree_for_slottable = must_create_subtree;
-    if (slot_element.needs_layout_tree_update())
-        must_create_subtree_for_slottable = MustCreateSubtree::Yes;
-
-    for (auto const& slottable : slot_element.assigned_nodes_internal())
-        slottable.visit([&](auto& node) { update_layout_tree(node, context, must_create_subtree_for_slottable); });
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    RustFFI::rust_update_layout_tree_for_assigned_slottables(
+        &callbacks,
+        &slot_element,
+        &context,
+        must_create_subtree == MustCreateSubtree::Yes);
 }
 
 void TreeBuilder::clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement& slot_element)
@@ -1038,29 +1093,12 @@ void TreeBuilder::update_layout_tree_for_display_contents(DOM::Element& element,
 
 void TreeBuilder::update_layout_tree_for_svg_switch_children(SVG::SVGSwitchElement& switch_element, Context& context, MustCreateSubtree must_create_subtree)
 {
-    // https://svgwg.org/svg2-draft/struct.html#SwitchElement
-    // The ‘switch’ element evaluates the ‘requiredExtensions’ and ‘systemLanguage’ attributes on its direct child
-    // elements in order, and then processes and renders the first child for which these attributes evaluate to true.
-    // All others will be bypassed and therefore not rendered. If the child element is a container element such as a
-    // ‘g’, then the entire subtree is either processed/rendered or bypassed/not rendered.
-
-    auto* rendered_child = [&] -> DOM::Node* {
-        for (auto* node = switch_element.first_child_of_type<SVG::SVGElement>(); node; node = node->next_sibling_of_type<SVG::SVGElement>()) {
-            // FIXME: Evaluate the requiredExtensions and systemLanguage attributes.
-            return node;
-        }
-        return nullptr;
-    }();
-
-    // NB: Clean up any stale children that should no longer be rendered.
-    switch_element.for_each_child([&](DOM::Node& child_node) {
-        if (&child_node != rendered_child)
-            clear_stale_layout_and_paint_node(child_node);
-        return IterationDecision::Continue;
-    });
-
-    if (rendered_child)
-        update_layout_tree(*rendered_child, context, must_create_subtree);
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    RustFFI::rust_update_layout_tree_for_svg_switch_children(
+        &callbacks,
+        static_cast<DOM::ParentNode*>(&switch_element),
+        &context,
+        must_create_subtree == MustCreateSubtree::Yes);
 }
 
 // A full-height flex column that centers the button contents vertically.

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -67,7 +67,6 @@ public:
 private:
     struct PrincipalNodeFrameStorage;
     struct PseudoElementFrameStorage;
-    static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
     static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
     RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
@@ -109,6 +108,22 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTr
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
 static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&);
+
+static size_t ffi_assigned_node_count(void* slot_element_pointer)
+{
+    VERIFY(slot_element_pointer);
+    return static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal().size();
+}
+
+static void* ffi_assigned_node_at(void* slot_element_pointer, size_t index)
+{
+    VERIFY(slot_element_pointer);
+    auto assigned_nodes = static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal();
+    VERIFY(index < assigned_nodes.size());
+    DOM::Node* node = nullptr;
+    assigned_nodes[index].visit([&](auto& assigned_node) { node = assigned_node.ptr(); });
+    return node;
+}
 
 void LayoutTreeBuildBridge::note_tree_restructuring_at(Layout::Node const& node)
 {
@@ -639,9 +654,14 @@ void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element
         .slot_element = [](void* element_pointer) -> void* {
             VERIFY(element_pointer);
             return as_if<HTML::HTMLSlotElement>(*static_cast<DOM::Element*>(element_pointer)); },
-        .clear_assigned_slottables = [](void* slot_element_pointer) {
-            VERIFY(slot_element_pointer);
-            clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
+        .assigned_node_count = ffi_assigned_node_count,
+        .assigned_node_at = ffi_assigned_node_at,
+        .clear_assigned_subtree = [](void* root_pointer) {
+            VERIFY(root_pointer);
+            auto& root = *static_cast<DOM::Node*>(root_pointer);
+            root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return clear_stale_layout_and_paint_node(node, &root);
+            }); },
     };
     RustFFI::rust_detach_top_layer_element_layout_subtree(&callbacks, &element);
 }
@@ -694,17 +714,8 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
         .needs_layout_tree_update = [](void* node_pointer) {
             VERIFY(node_pointer);
             return static_cast<DOM::Node*>(node_pointer)->needs_layout_tree_update(); },
-        .assigned_node_count = [](void* slot_element_pointer) {
-            VERIFY(slot_element_pointer);
-            return static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal().size(); },
-        .assigned_node_at = [](void* slot_element_pointer, size_t index) -> void* {
-            VERIFY(slot_element_pointer);
-            auto assigned_nodes = static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal();
-            VERIFY(index < assigned_nodes.size());
-            DOM::Node* node = nullptr;
-            assigned_nodes[index].visit([&](auto& assigned_node) { node = assigned_node.ptr(); });
-            return node;
-        },
+        .assigned_node_count = ffi_assigned_node_count,
+        .assigned_node_at = ffi_assigned_node_at,
         .is_svg_element = [](void* node_pointer) {
             VERIFY(node_pointer);
             return is<SVG::SVGElement>(*static_cast<DOM::Node*>(node_pointer)); },
@@ -741,9 +752,13 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(element_pointer);
             DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer) };
             CSS::resolve_counters(element_reference); },
-        .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
-            VERIFY(slot_element_pointer);
-            clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
+        .clear_stale_assigned_subtree = [](void* builder_pointer, void* root_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(root_pointer);
+            auto& root = *static_cast<DOM::Node*>(root_pointer);
+            root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return static_cast<LayoutTreeBuildBridge*>(builder_pointer)->clear_stale_layout_and_paint_node(node, &root);
+            }); },
         .principal_descendant_facts = [](void*, void* node_pointer, void* layout_node_pointer) -> RustFFI::FfiPrincipalDescendantFacts {
             VERIFY(node_pointer);
             VERIFY(layout_node_pointer);
@@ -1111,31 +1126,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
         .layout = make_ffi_tree_builder_callbacks(this),
         .pseudo = make_ffi_pseudo_tree_builder_callbacks(),
     };
-}
-
-void LayoutTreeBuildBridge::clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement& slot_element)
-{
-    // Assigned slottables are flat tree children of a slot, not DOM descendants, so subtree
-    // cleanup of the slot does not reach them.
-    RustFFI::FfiAssignedCleanupCallbacks callbacks {
-        .assigned_node_count = [](void* slot_element_pointer) {
-            VERIFY(slot_element_pointer);
-            return static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal().size(); },
-        .assigned_node_at = [](void* slot_element_pointer, size_t index) -> void* {
-            VERIFY(slot_element_pointer);
-            auto assigned_nodes = static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal();
-            VERIFY(index < assigned_nodes.size());
-            DOM::Node* node = nullptr;
-            assigned_nodes[index].visit([&](auto& assigned_node) { node = assigned_node.ptr(); });
-            return node; },
-        .clear_assigned_subtree = [](void* root_pointer) {
-            VERIFY(root_pointer);
-            auto& root = *static_cast<DOM::Node*>(root_pointer);
-            root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
-                return clear_stale_layout_and_paint_node(node, &root);
-            }); },
-    };
-    RustFFI::rust_clear_stale_assigned_slottables(&callbacks, &slot_element);
 }
 
 // Elements inside a `display:none` subtree are skipped by `Document::update_style_recursively`,

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -80,7 +80,7 @@ private:
     void insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle&, Layout::Node&, CSS::Display, AppendOrPrepend);
     static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
     RefPtr<NodeWithStyle> create_pseudo_element_if_needed(void* rust_state, DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
-    static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
+    static void create_first_letter_wrapper(DOM::Element&, RustFFI::FfiFirstLetterTarget);
 
     RefPtr<Layout::Node> m_layout_root;
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
@@ -282,13 +282,9 @@ static FirstLetterTextSlices create_first_letter_text_slices(DOM::Document& docu
     };
 }
 
-void LayoutTreeBuildBridge::create_first_letter_wrapper_if_needed(DOM::Element& element, BlockContainer& block_container)
+void LayoutTreeBuildBridge::create_first_letter_wrapper(DOM::Element& element, RustFFI::FfiFirstLetterTarget target)
 {
-    auto callbacks = make_ffi_tree_builder_callbacks(nullptr);
-    auto target = RustFFI::rust_find_first_letter_in_block(&callbacks, &block_container);
-    if (!target.found)
-        return;
-
+    VERIFY(target.found);
     auto& text_node = as<TextNode>(*static_cast<Node*>(target.text_node));
     auto& document = element.document();
 
@@ -846,6 +842,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .is_svg_switch_element = is<SVG::SVGSwitchElement>(node),
                 .is_document = node.is_document(),
                 .has_style_containment = is<NodeWithStyle>(layout_node) && static_cast<NodeWithStyle&>(layout_node).has_style_containment(),
+                .uses_button_layout = element && is<HTML::HTMLElement>(*element) && static_cast<HTML::HTMLElement&>(*element).uses_button_layout(),
                 .dom_children_parent = parent_node,
                 .shadow_root = shadow_root ? static_cast<DOM::ParentNode*>(shadow_root.ptr()) : nullptr,
                 .slot_element = slot_element,
@@ -855,27 +852,9 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .svg_fill_pattern = const_cast<SVG::SVGPatternElement*>(fill_pattern.ptr()),
                 .svg_stroke_pattern = const_cast<SVG::SVGPatternElement*>(stroke_pattern.ptr()),
             }; },
-        .create_first_letter_wrapper = [](void*, void* element_pointer, void* layout_node_pointer) {
+        .create_first_letter_wrapper = [](void*, void* element_pointer, RustFFI::FfiFirstLetterTarget target) {
             VERIFY(element_pointer);
-            VERIFY(layout_node_pointer);
-            create_first_letter_wrapper_if_needed(
-                *static_cast<DOM::Element*>(element_pointer),
-                as<BlockContainer>(*static_cast<Layout::Node*>(layout_node_pointer))); },
-        .wrap_fieldset_layout = [](void* builder_pointer, void* layout_node_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(layout_node_pointer);
-            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<LayoutTreeBuildBridge*>(builder_pointer));
-            RustFFI::rust_wrap_fieldset_contents_if_needed(&callbacks, layout_node_pointer); },
-        .wrap_button_layout = [](void* builder_pointer, void* node_pointer, void* layout_node_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(node_pointer);
-            VERIFY(layout_node_pointer);
-            auto* html_element = as_if<HTML::HTMLElement>(*static_cast<DOM::Node*>(node_pointer));
-            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<LayoutTreeBuildBridge*>(builder_pointer));
-            RustFFI::rust_wrap_button_contents_if_needed(
-                &callbacks,
-                layout_node_pointer,
-                html_element && html_element->uses_button_layout()); },
+            create_first_letter_wrapper(*static_cast<DOM::Element*>(element_pointer), target); },
         .clear_stale_descendants = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
@@ -1218,14 +1197,10 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(document_pointer);
             // NB: Called during layout tree construction.
             return static_cast<DOM::Document*>(document_pointer)->unsafe_layout_node(); },
-        .fixup_tables = [](void* builder_pointer, void* root_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(root_pointer);
-            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<LayoutTreeBuildBridge*>(builder_pointer));
-            RustFFI::rust_fixup_tables(&callbacks, root_pointer); },
         .layout_root = [](void* builder_pointer) -> void* {
             VERIFY(builder_pointer);
             return static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_root.ptr(); },
+        .layout = make_ffi_tree_builder_callbacks(this),
     };
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1072,37 +1072,22 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .set_context_has_svg_root = [](void* context_pointer, bool has_svg_root) {
             VERIFY(context_pointer);
             static_cast<Context*>(context_pointer)->has_svg_root = has_svg_root; },
+        .reset_style_ancestor_filter = [](void* document_pointer) {
+            VERIFY(document_pointer);
+            static_cast<DOM::Document*>(document_pointer)->style_computer().reset_ancestor_filter(); },
+        .document_layout_node = [](void* document_pointer) -> void* {
+            VERIFY(document_pointer);
+            // NB: Called during layout tree construction.
+            return static_cast<DOM::Document*>(document_pointer)->unsafe_layout_node(); },
+        .fixup_tables = [](void* builder_pointer, void* root_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(root_pointer);
+            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<TreeBuilder*>(builder_pointer));
+            RustFFI::rust_fixup_tables(&callbacks, root_pointer); },
+        .layout_root = [](void* builder_pointer) -> void* {
+            VERIFY(builder_pointer);
+            return static_cast<TreeBuilder*>(builder_pointer)->m_layout_root.ptr(); },
     };
-}
-
-void TreeBuilder::update_layout_tree_for_shadow_root_children(DOM::ShadowRoot& shadow_root, Context& context, MustCreateSubtree must_create_subtree)
-{
-    auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_layout_tree_for_shadow_root_children(
-        &callbacks,
-        static_cast<DOM::ParentNode*>(&shadow_root),
-        &context,
-        must_create_subtree == MustCreateSubtree::Yes);
-}
-
-void TreeBuilder::update_layout_tree_for_dom_children(DOM::ParentNode& parent, Context& context, MustCreateSubtree must_create_subtree)
-{
-    auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_layout_tree_for_dom_children(
-        &callbacks,
-        &parent,
-        &context,
-        must_create_subtree == MustCreateSubtree::Yes);
-}
-
-void TreeBuilder::update_layout_tree_for_assigned_slottables(HTML::HTMLSlotElement& slot_element, Context& context, MustCreateSubtree must_create_subtree)
-{
-    auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_layout_tree_for_assigned_slottables(
-        &callbacks,
-        &slot_element,
-        &context,
-        must_create_subtree == MustCreateSubtree::Yes);
 }
 
 void TreeBuilder::clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement& slot_element)
@@ -1205,27 +1190,6 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         must_create_subtree == MustCreateSubtree::Yes);
 }
 
-void TreeBuilder::update_layout_tree_for_display_contents(DOM::Element& element, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree, bool should_create_layout_node)
-{
-    auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_layout_tree_for_display_contents(
-        &callbacks,
-        &element,
-        &context,
-        must_create_subtree == MustCreateSubtree::Yes,
-        should_create_layout_node);
-}
-
-void TreeBuilder::update_layout_tree_for_svg_switch_children(SVG::SVGSwitchElement& switch_element, Context& context, MustCreateSubtree must_create_subtree)
-{
-    auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_layout_tree_for_svg_switch_children(
-        &callbacks,
-        static_cast<DOM::ParentNode*>(&switch_element),
-        &context,
-        must_create_subtree == MustCreateSubtree::Yes);
-}
-
 // A full-height flex column that centers the button contents vertically.
 static NonnullRefPtr<NodeWithStyle> create_button_flex_wrapper(NodeWithStyle& parent)
 {
@@ -1259,19 +1223,10 @@ void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, Layo
 
 RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)
 {
-    VERIFY(dom_node.is_document());
-
-    dom_node.document().style_computer().reset_ancestor_filter();
-
     Context context;
-    set_quote_nesting_level(0);
-    update_layout_tree(dom_node, context, MustCreateSubtree::No);
-
-    // NB: Called during layout tree construction.
-    if (auto* root = dom_node.document().unsafe_layout_node())
-        fixup_tables(*root);
-
-    return m_layout_root;
+    PrincipalNodeFrame frame;
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    return static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &frame, &dom_node, &context));
 }
 
 static RustFFI::FfiTableDisplay ffi_table_display(CSS::Display display)
@@ -1697,10 +1652,5 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuil
 }
 
 // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-void TreeBuilder::fixup_tables(NodeWithStyle& root)
-{
-    auto callbacks = make_ffi_tree_builder_callbacks(this);
-    RustFFI::rust_fixup_tables(&callbacks, &root);
-}
 
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -54,47 +54,6 @@
 
 namespace Web::Layout {
 
-TreeBuilder::TreeBuilder()
-    : m_rust_state(RustFFI::rust_tree_builder_state_create())
-{
-    VERIFY(m_rust_state);
-}
-
-void TreeBuilder::push_parent(Layout::NodeWithStyle& parent)
-{
-    RustFFI::rust_tree_builder_push_parent(m_rust_state, &parent);
-}
-
-void TreeBuilder::pop_parent()
-{
-    RustFFI::rust_tree_builder_pop_parent(m_rust_state);
-}
-
-Layout::NodeWithStyle& TreeBuilder::current_parent() const
-{
-    return *static_cast<Layout::NodeWithStyle*>(RustFFI::rust_tree_builder_current_parent(m_rust_state));
-}
-
-size_t TreeBuilder::ancestor_count() const
-{
-    return RustFFI::rust_tree_builder_ancestor_count(m_rust_state);
-}
-
-Layout::NodeWithStyle& TreeBuilder::ancestor_at(size_t index) const
-{
-    return *static_cast<Layout::NodeWithStyle*>(RustFFI::rust_tree_builder_ancestor_at(m_rust_state, index));
-}
-
-u32 TreeBuilder::quote_nesting_level() const
-{
-    return RustFFI::rust_tree_builder_quote_nesting_level(m_rust_state);
-}
-
-void TreeBuilder::set_quote_nesting_level(u32 quote_nesting_level)
-{
-    RustFFI::rust_tree_builder_set_quote_nesting_level(m_rust_state, quote_nesting_level);
-}
-
 static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder*);
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
@@ -106,12 +65,12 @@ void TreeBuilder::note_tree_restructuring_at(Layout::Node const& node)
         m_layout_tree_update_escaped_rebuild_roots = true;
 }
 
-void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
+void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle& parent, Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
 {
     auto callbacks = make_ffi_tree_builder_callbacks(this);
     RustFFI::rust_insert_node_into_inline_or_block_ancestor(
         &callbacks,
-        &current_parent(),
+        &parent,
         &node,
         display.is_inline_outside(),
         mode == AppendOrPrepend::Append ? RustFFI::FfiInsertionMode::Append : RustFFI::FfiInsertionMode::Prepend);
@@ -369,13 +328,14 @@ struct PseudoElementFrame {
     RefPtr<Layout::Node> content_item;
 };
 
-RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
+RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(void* rust_state, DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
 {
     PseudoElementFrame frame;
     auto callbacks = make_ffi_pseudo_tree_builder_callbacks();
     auto* layout_node = RustFFI::rust_create_pseudo_element(
         &callbacks,
         &frame,
+        rust_state,
         &element,
         ffi_pseudo_element(pseudo_element),
         insertion_mode.has_value(),
@@ -512,12 +472,14 @@ RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder
             frame.layout_node->set_generated_for(pseudo_element, element);
             frame.layout_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
             element.set_synthetic_pseudo_element_node({}, pseudo_element, frame.layout_node); },
-        .insert_layout_node = [](void* builder_pointer, void* frame_pointer, RustFFI::FfiInsertionMode insertion_mode) {
+        .insert_layout_node = [](void* builder_pointer, void* frame_pointer, void* parent_pointer, RustFFI::FfiInsertionMode insertion_mode) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
+            VERIFY(parent_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
             VERIFY(frame.layout_node);
             static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
+                as<NodeWithStyle>(*static_cast<Layout::Node*>(parent_pointer)),
                 *frame.layout_node,
                 frame.layout_node->display(),
                 insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend); },
@@ -561,27 +523,19 @@ RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder
             }
             frame.content_item->set_generated_for(css_pseudo_element(ffi_pseudo), element);
             return frame.content_item.ptr(); },
-        .insert_content_item = [](void* builder_pointer, void* content_item_pointer) {
+        .insert_content_item = [](void* builder_pointer, void* content_item_pointer, void* parent_pointer) {
             VERIFY(builder_pointer);
             VERIFY(content_item_pointer);
+            VERIFY(parent_pointer);
             auto& content_item = *static_cast<Layout::Node*>(content_item_pointer);
             auto display = content_item.is_text_node()
                 ? CSS::Display::from_short(CSS::Display::Short::Inline)
                 : as<NodeWithStyle>(content_item).display();
-            static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(content_item, display, AppendOrPrepend::Append); },
-        .push_layout_parent = [](void* builder_pointer, void* layout_node_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(layout_node_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->push_parent(as<NodeWithStyle>(*static_cast<Layout::Node*>(layout_node_pointer))); },
-        .pop_layout_parent = [](void* builder_pointer) {
-            VERIFY(builder_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->pop_parent(); },
-        .quote_nesting_level = [](void* builder_pointer) {
-            VERIFY(builder_pointer);
-            return static_cast<TreeBuilder*>(builder_pointer)->quote_nesting_level(); },
-        .set_quote_nesting_level = [](void* builder_pointer, u32 quote_nesting_level) {
-            VERIFY(builder_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->set_quote_nesting_level(quote_nesting_level); },
+            static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
+                as<NodeWithStyle>(*static_cast<Layout::Node*>(parent_pointer)),
+                content_item,
+                display,
+                AppendOrPrepend::Append); },
     };
 }
 
@@ -707,7 +661,6 @@ struct TreeBuilder::PrincipalNodeFrameStorage {
 
 TreeBuilder::~TreeBuilder()
 {
-    RustFFI::rust_tree_builder_state_destroy(m_rust_state);
 }
 
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display display)
@@ -789,8 +742,9 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(element_pointer);
             DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer) };
             CSS::resolve_counters(element_reference); },
-        .create_pseudo_element = [](void* builder_pointer, void* element_pointer, RustFFI::FfiPseudoElement pseudo_element, RustFFI::FfiInsertionMode insertion_mode) {
+        .create_pseudo_element = [](void* builder_pointer, void* rust_state, void* element_pointer, RustFFI::FfiPseudoElement pseudo_element, RustFFI::FfiInsertionMode insertion_mode) {
             VERIFY(builder_pointer);
+            VERIFY(rust_state);
             VERIFY(element_pointer);
             auto css_pseudo_element = [&] {
                 switch (pseudo_element) {
@@ -805,7 +759,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 }
             }();
             auto mode = insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend;
-            (void)static_cast<TreeBuilder*>(builder_pointer)->create_pseudo_element_if_needed(*static_cast<DOM::Element*>(element_pointer), css_pseudo_element, mode); },
+            (void)static_cast<TreeBuilder*>(builder_pointer)->create_pseudo_element_if_needed(rust_state, *static_cast<DOM::Element*>(element_pointer), css_pseudo_element, mode); },
         .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
             VERIFY(slot_element_pointer);
             clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
@@ -874,21 +828,14 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             node.for_each_shadow_including_descendant([&](auto& descendant) {
                 return builder.clear_stale_layout_and_paint_node(descendant, &node);
             }); },
-        .push_layout_parent = [](void* builder_pointer, void* layout_node_pointer) {
+        .ensure_replaced_children_wrapper = [](void* builder_pointer, void* layout_node_pointer, void* parent_pointer) -> void* {
             VERIFY(builder_pointer);
             VERIFY(layout_node_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->push_parent(as<NodeWithStyle>(*static_cast<Layout::Node*>(layout_node_pointer))); },
-        .pop_layout_parent = [](void* builder_pointer) {
-            VERIFY(builder_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->pop_parent(); },
-        .ensure_replaced_children_wrapper = [](void* builder_pointer, void* layout_node_pointer) -> void* {
-            VERIFY(builder_pointer);
-            VERIFY(layout_node_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            VERIFY(parent_pointer);
             auto& layout_node = *static_cast<Layout::Node*>(layout_node_pointer);
             if (!layout_node.first_child() || !layout_node.first_child()->is_anonymous()) {
                 auto wrapper = as<NodeWithStyle>(layout_node).create_anonymous_wrapper();
-                builder.current_parent().append_child(wrapper);
+                static_cast<Layout::NodeWithStyle*>(parent_pointer)->append_child(wrapper);
             }
             return layout_node.first_child().ptr(); },
         .top_layer_element_count = [](void* document_pointer) {
@@ -925,12 +872,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
                 return builder.clear_stale_layout_and_paint_node(node, &element);
             }); },
-        .quote_nesting_level = [](void* builder_pointer) {
-            VERIFY(builder_pointer);
-            return static_cast<TreeBuilder*>(builder_pointer)->quote_nesting_level(); },
-        .set_quote_nesting_level = [](void* builder_pointer, u32 quote_nesting_level) {
-            VERIFY(builder_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->set_quote_nesting_level(quote_nesting_level); },
         .clear_dom_update_flags = [](void* node_pointer) {
             VERIFY(node_pointer);
             auto& node = *static_cast<DOM::Node*>(node_pointer);
@@ -944,12 +885,6 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(graphics_element_pointer);
             static_cast<SVG::SVGElement*>(resource_pointer)->register_resource_box_referencing_element(
                 {}, *static_cast<SVG::SVGGraphicsElement*>(graphics_element_pointer)); },
-        .ancestor_count = [](void* builder_pointer) {
-            VERIFY(builder_pointer);
-            return static_cast<TreeBuilder*>(builder_pointer)->ancestor_count(); },
-        .ancestor_at = [](void* builder_pointer, size_t index) -> void* {
-            VERIFY(builder_pointer);
-            return &static_cast<TreeBuilder*>(builder_pointer)->ancestor_at(index); },
         .layout_node_dom_node = [](void* layout_node_pointer) -> void* {
             VERIFY(layout_node_pointer);
             return static_cast<Layout::Node*>(layout_node_pointer)->dom_node(); },
@@ -1157,13 +1092,15 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .mark_update_escaped_rebuild_roots = [](void* builder_pointer) {
             VERIFY(builder_pointer);
             static_cast<TreeBuilder*>(builder_pointer)->m_layout_tree_update_escaped_rebuild_roots = true; },
-        .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool append) -> void* {
+        .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* rust_state, void* element_pointer, bool append) -> void* {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
+            VERIFY(rust_state);
             VERIFY(element_pointer);
             auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
             frame.backdrop_node = builder.create_pseudo_element_if_needed(
+                rust_state,
                 *static_cast<DOM::Element*>(element_pointer),
                 CSS::PseudoElement::Backdrop,
                 append ? Optional<AppendOrPrepend> { AppendOrPrepend::Append } : Optional<AppendOrPrepend> {});
@@ -1179,7 +1116,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             auto& backdrop = *static_cast<Layout::Node*>(backdrop_pointer);
             builder.note_tree_restructuring_at(*frame.old_layout_node->parent());
             frame.old_layout_node->parent()->insert_before(backdrop, frame.old_layout_node); },
-        .place_principal_layout = [](void* builder_pointer, void* frame_pointer, RustFFI::FfiPrincipalBoxPlacement placement) {
+        .place_principal_layout = [](void* builder_pointer, void* frame_pointer, void* parent_pointer, RustFFI::FfiPrincipalBoxPlacement placement) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
@@ -1198,10 +1135,16 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 frame.old_layout_node->parent()->replace_child(*frame.layout_node, *frame.old_layout_node);
                 break;
             case RustFFI::FfiPrincipalBoxPlacement::AppendSvg:
-                builder.current_parent().append_child(*frame.layout_node);
+                VERIFY(parent_pointer);
+                static_cast<Layout::NodeWithStyle*>(parent_pointer)->append_child(*frame.layout_node);
                 break;
             case RustFFI::FfiPrincipalBoxPlacement::NormalInsertion:
-                builder.insert_node_into_inline_or_block_ancestor(*frame.layout_node, frame.display, AppendOrPrepend::Append);
+                VERIFY(parent_pointer);
+                builder.insert_node_into_inline_or_block_ancestor(
+                    *static_cast<Layout::NodeWithStyle*>(parent_pointer),
+                    *frame.layout_node,
+                    frame.display,
+                    AppendOrPrepend::Append);
                 break;
             } },
         .clear_stale_inclusive_subtree = [](void* builder_pointer, void* node_pointer) {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -101,6 +101,7 @@ void TreeBuilder::set_quote_nesting_level(u32 quote_nesting_level)
 }
 
 static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder*);
+static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
 static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&);
 
@@ -108,20 +109,6 @@ void TreeBuilder::note_tree_restructuring_at(Layout::Node const& node)
 {
     if (m_current_rebuild_root && !m_current_rebuild_root->is_inclusive_ancestor_of(node))
         m_layout_tree_update_escaped_rebuild_roots = true;
-}
-
-static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::Display display)
-{
-    auto adjustment = RustFFI::rust_adjusted_table_display_for_replaced_element(
-        display.is_table_inside(),
-        display.is_block_outside(),
-        display.is_internal_table(),
-        display.is_table_caption());
-    if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Block)
-        return CSS::Display::from_short(CSS::Display::Short::Block);
-    if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Inline)
-        return CSS::Display::from_short(CSS::Display::Short::Inline);
-    return {};
 }
 
 void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
@@ -343,9 +330,28 @@ static RustFFI::FfiPseudoElement ffi_pseudo_element(CSS::PseudoElement pseudo_el
         return RustFFI::FfiPseudoElement::After;
     case CSS::PseudoElement::Marker:
         return RustFFI::FfiPseudoElement::Marker;
+    case CSS::PseudoElement::Backdrop:
+        return RustFFI::FfiPseudoElement::Backdrop;
     default:
         return RustFFI::FfiPseudoElement::Other;
     }
+}
+
+static CSS::PseudoElement css_pseudo_element(RustFFI::FfiPseudoElement pseudo_element)
+{
+    switch (pseudo_element) {
+    case RustFFI::FfiPseudoElement::Before:
+        return CSS::PseudoElement::Before;
+    case RustFFI::FfiPseudoElement::After:
+        return CSS::PseudoElement::After;
+    case RustFFI::FfiPseudoElement::Marker:
+        return CSS::PseudoElement::Marker;
+    case RustFFI::FfiPseudoElement::Backdrop:
+        return CSS::PseudoElement::Backdrop;
+    case RustFFI::FfiPseudoElement::Other:
+        VERIFY_NOT_REACHED();
+    }
+    VERIFY_NOT_REACHED();
 }
 
 static RustFFI::FfiComputedContentType ffi_computed_content_type(CSS::ComputedContentData::Type content_type)
@@ -361,118 +367,230 @@ static RustFFI::FfiComputedContentType ffi_computed_content_type(CSS::ComputedCo
     VERIFY_NOT_REACHED();
 }
 
+struct PseudoElementFrame {
+    RefPtr<CSS::ComputedValues const> computed_values;
+    CSS::Display display;
+    CSS::AbstractImageStyleValue const* replacement_image { nullptr };
+    ListItemBox* originating_list_box { nullptr };
+    RefPtr<NodeWithStyle> layout_node;
+    CSS::ContentData resolved_content;
+    RefPtr<Layout::Node> content_item;
+};
+
 RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
 {
-    auto& document = element.document();
+    PseudoElementFrame frame;
+    auto callbacks = make_ffi_pseudo_tree_builder_callbacks();
+    auto* layout_node = RustFFI::rust_create_pseudo_element(
+        &callbacks,
+        &frame,
+        &element,
+        ffi_pseudo_element(pseudo_element),
+        insertion_mode.has_value(),
+        insertion_mode.value_or(AppendOrPrepend::Append) == AppendOrPrepend::Append
+            ? RustFFI::FfiInsertionMode::Append
+            : RustFFI::FfiInsertionMode::Prepend);
+    return static_cast<NodeWithStyle*>(layout_node);
+}
 
-    // Clear stale layout nodes before deciding if this pseudo-element still generates one.
-    if (auto existing_pseudo = element.get_synthetic_pseudo_element(pseudo_element); existing_pseudo.has_value() && existing_pseudo->layout_node())
-        existing_pseudo->set_layout_node(nullptr);
-
-    auto pseudo_element_values = element.computed_values(pseudo_element);
-    if (!pseudo_element_values)
-        return {};
-
-    auto pseudo_element_display = pseudo_element_values->display();
-
-    auto initial_quote_nesting_level = quote_nesting_level();
-
-    // NB: Whether this pseudo-element generates a box depends only on the shape of its computed
-    //     content value, so the full resolution (which reads counters that do not exist until
-    //     the box is inserted) can wait until after insertion.
-    auto const computed_content_type = pseudo_element_values->computed_content().type;
-    auto const* replacement_image = content_replacement_image(pseudo_element_values->computed_content());
-    ListItemBox* originating_list_box = nullptr;
-    if (pseudo_element == CSS::PseudoElement::Marker && computed_content_type == CSS::ComputedContentData::Type::Normal)
-        originating_list_box = as_if<ListItemBox>(*element.unsafe_layout_node());
-    auto const normal_marker_has_content = originating_list_box
-        && (!originating_list_box->computed_values().list_style_type().has<Empty>() || originating_list_box->list_style_image());
-    auto const decision = RustFFI::rust_pseudo_element_decision({
-        .pseudo_element = ffi_pseudo_element(pseudo_element),
-        .content_type = ffi_computed_content_type(computed_content_type),
-        .display_is_none = pseudo_element_display.is_none(),
-        .display_is_contents = pseudo_element_display.is_contents(),
-        .display_is_list_item = pseudo_element_display.is_list_item(),
-        .has_content_replacement = replacement_image != nullptr,
-        .originating_layout_node_is_list_item = originating_list_box != nullptr,
-        .normal_marker_has_content = normal_marker_has_content,
-    });
-    if (decision == RustFFI::FfiPseudoElementDecision::None)
-        return {};
-
-    // For ::marker with content 'normal', create the marker pseudo-element from a ListItemMarkerBox
-    // FIXME: This + ListItemBox + ListItemMarkerBox will disappear once ::marker pseudo-elements with 'normal' content
-    //        are rendered using the special list-item counter.
-    //        See: https://github.com/LadybirdBrowser/ladybird/issues/4782
-    // NB: Called during layout tree construction.
-    if (decision == RustFFI::FfiPseudoElementDecision::NormalMarker)
-        return create_and_attach_list_item_marker(*originating_list_box, element, NonnullRefPtr { *pseudo_element_values });
-
-    RefPtr<NodeWithStyle> pseudo_element_node;
-    auto const is_content_replacement = decision == RustFFI::FfiPseudoElementDecision::ContentReplacement;
-
-    if (is_content_replacement) {
-        pseudo_element_node = create_content_image_box(document, nullptr, NonnullRefPtr { *pseudo_element_values }, const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
-        if (auto adjusted_display = adjusted_table_display_for_replaced_element(pseudo_element_display); adjusted_display.has_value())
-            pseudo_element_node->set_display(*adjusted_display);
-    } else if (decision == RustFFI::FfiPseudoElementDecision::Contents) {
-        pseudo_element_node = make_ref_counted<InlineNode>(document, nullptr, NonnullRefPtr { *pseudo_element_values });
-        pseudo_element_node->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
-    } else {
-        pseudo_element_node = DOM::Element::create_layout_node_for_display_type(document, pseudo_element_display, NonnullRefPtr { *pseudo_element_values }, nullptr);
-        if (!pseudo_element_node)
-            return {};
-    }
-    pseudo_element_node->attach_style_resources();
-
-    // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker
-    if (auto* list_box = as_if<ListItemBox>(*pseudo_element_node)) {
-        auto marker_style = document.style_computer().compute_style({ element, CSS::PseudoElement::Marker });
-        (void)create_and_attach_list_item_marker(*list_box, element, move(marker_style));
-
-        // FIXME: Support counters on element::pseudo::marker
-    }
-
-    pseudo_element_node->set_generated_for(pseudo_element, element);
-    pseudo_element_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
-
-    element.set_synthetic_pseudo_element_node({}, pseudo_element, pseudo_element_node);
-    if (insertion_mode.has_value())
-        insert_node_into_inline_or_block_ancestor(*pseudo_element_node, pseudo_element_node->display(), insertion_mode.value());
-
-    // Resolve counters before content: counter() and counters() items in the content list read
-    // the counters established for this pseudo-element's box.
-    DOM::AbstractElement element_reference { element, pseudo_element };
-    CSS::resolve_counters(element_reference);
-
-    auto [pseudo_element_content, final_quote_nesting_level] = pseudo_element_values->resolved_content(element_reference, initial_quote_nesting_level);
-    set_quote_nesting_level(final_quote_nesting_level);
-    pseudo_element_node->set_content(pseudo_element_content);
-
-    // FIXME: Handle images, and multiple values
-    if (pseudo_element_content.type == CSS::ContentData::Type::List && !is_content_replacement) {
-        push_parent(*pseudo_element_node);
-        for (auto& item : pseudo_element_content.data) {
-            RefPtr<Layout::Node> layout_node;
+RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder_callbacks()
+{
+    return {
+        .builder = this,
+        .initialize = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo) -> RustFFI::FfiPseudoElementFacts {
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            auto pseudo_element = css_pseudo_element(ffi_pseudo);
+            if (auto existing_pseudo = element.get_synthetic_pseudo_element(pseudo_element); existing_pseudo.has_value() && existing_pseudo->layout_node())
+                existing_pseudo->set_layout_node(nullptr);
+            frame.computed_values = element.computed_values(pseudo_element);
+            frame.replacement_image = nullptr;
+            frame.originating_list_box = nullptr;
+            frame.layout_node = nullptr;
+            frame.content_item = nullptr;
+            if (!frame.computed_values) {
+                return {
+                    .has_style = false,
+                    .pseudo_element = ffi_pseudo,
+                    .content_type = RustFFI::FfiComputedContentType::None,
+                    .display_is_none = false,
+                    .display_is_contents = false,
+                    .display_is_list_item = false,
+                    .has_content_replacement = false,
+                    .originating_layout_node_is_list_item = false,
+                    .normal_marker_has_content = false,
+                };
+            }
+            frame.display = frame.computed_values->display();
+            auto const computed_content_type = frame.computed_values->computed_content().type;
+            frame.replacement_image = content_replacement_image(frame.computed_values->computed_content());
+            if (pseudo_element == CSS::PseudoElement::Marker && computed_content_type == CSS::ComputedContentData::Type::Normal)
+                frame.originating_list_box = as_if<ListItemBox>(*element.unsafe_layout_node());
+            auto const normal_marker_has_content = frame.originating_list_box
+                && (!frame.originating_list_box->computed_values().list_style_type().has<Empty>() || frame.originating_list_box->list_style_image());
+            return {
+                .has_style = true,
+                .pseudo_element = ffi_pseudo,
+                .content_type = ffi_computed_content_type(computed_content_type),
+                .display_is_none = frame.display.is_none(),
+                .display_is_contents = frame.display.is_contents(),
+                .display_is_list_item = frame.display.is_list_item(),
+                .has_content_replacement = frame.replacement_image != nullptr,
+                .originating_layout_node_is_list_item = frame.originating_list_box != nullptr,
+                .normal_marker_has_content = normal_marker_has_content,
+            }; },
+        .create_layout_node = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement, RustFFI::FfiPseudoElementDecision decision) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            VERIFY(frame.computed_values);
+            auto& document = element.document();
+            switch (decision) {
+            case RustFFI::FfiPseudoElementDecision::None:
+                VERIFY_NOT_REACHED();
+            case RustFFI::FfiPseudoElementDecision::NormalMarker:
+                VERIFY(frame.originating_list_box);
+                frame.layout_node = create_and_attach_list_item_marker(*frame.originating_list_box, element, NonnullRefPtr { *frame.computed_values });
+                break;
+            case RustFFI::FfiPseudoElementDecision::ContentReplacement:
+                VERIFY(frame.replacement_image);
+                frame.layout_node = create_content_image_box(document, nullptr, NonnullRefPtr { *frame.computed_values }, const_cast<CSS::AbstractImageStyleValue&>(*frame.replacement_image));
+                break;
+            case RustFFI::FfiPseudoElementDecision::Contents:
+                frame.layout_node = make_ref_counted<InlineNode>(document, nullptr, NonnullRefPtr { *frame.computed_values });
+                frame.layout_node->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
+                break;
+            case RustFFI::FfiPseudoElementDecision::Box:
+                frame.layout_node = DOM::Element::create_layout_node_for_display_type(document, frame.display, NonnullRefPtr { *frame.computed_values }, nullptr);
+                break;
+            } },
+        .layout_node = [](void* frame_pointer) -> void* {
+            VERIFY(frame_pointer);
+            return static_cast<PseudoElementFrame*>(frame_pointer)->layout_node.ptr(); },
+        .attach_style_resources = [](void* frame_pointer) {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            frame.layout_node->attach_style_resources(); },
+        .layout_facts = [](void* frame_pointer) -> RustFFI::FfiPrincipalLayoutFacts {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            return {
+                .is_replaced_element = frame.layout_node->is_replaced_element(),
+                .display = ffi_principal_display_facts(frame.display),
+            }; },
+        .apply_replaced_display_adjustment = [](void* frame_pointer, RustFFI::FfiReplacedElementDisplayAdjustment adjustment) {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Block)
+                frame.display = CSS::Display::from_short(CSS::Display::Short::Block);
+            else if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Inline)
+                frame.display = CSS::Display::from_short(CSS::Display::Short::Inline);
+            else
+                VERIFY_NOT_REACHED();
+            frame.layout_node->set_display(frame.display); },
+        .layout_node_is_list_item = [](void* frame_pointer) {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            return is<ListItemBox>(*frame.layout_node); },
+        .create_nested_list_marker = [](void* builder_pointer, void* frame_pointer, void* element_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            VERIFY(frame.layout_node);
+            auto marker_style = element.document().style_computer().compute_style({ element, CSS::PseudoElement::Marker });
+            (void)builder.create_and_attach_list_item_marker(as<ListItemBox>(*frame.layout_node), element, move(marker_style)); },
+        .configure_layout_node = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo, u32 initial_quote_nesting_level) {
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            auto pseudo_element = css_pseudo_element(ffi_pseudo);
+            VERIFY(frame.layout_node);
+            frame.layout_node->set_generated_for(pseudo_element, element);
+            frame.layout_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
+            element.set_synthetic_pseudo_element_node({}, pseudo_element, frame.layout_node); },
+        .insert_layout_node = [](void* builder_pointer, void* frame_pointer, RustFFI::FfiInsertionMode insertion_mode) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
+                *frame.layout_node,
+                frame.layout_node->display(),
+                insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend); },
+        .resolve_counters = [](void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo) {
+            VERIFY(element_pointer);
+            DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer), css_pseudo_element(ffi_pseudo) };
+            CSS::resolve_counters(element_reference); },
+        .resolve_content = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo, u32 initial_quote_nesting_level) -> RustFFI::FfiResolvedPseudoContentFacts {
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            VERIFY(frame.computed_values);
+            VERIFY(frame.layout_node);
+            DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer), css_pseudo_element(ffi_pseudo) };
+            auto [content, final_quote_nesting_level] = frame.computed_values->resolved_content(element_reference, initial_quote_nesting_level);
+            frame.resolved_content = move(content);
+            frame.layout_node->set_content(frame.resolved_content);
+            return {
+                .final_quote_nesting_level = final_quote_nesting_level,
+                .content_is_list = frame.resolved_content.type == CSS::ContentData::Type::List,
+                .content_item_count = frame.resolved_content.data.size(),
+            }; },
+        .create_content_item = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo, size_t index) -> void* {
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            VERIFY(frame.layout_node);
+            VERIFY(index < frame.resolved_content.data.size());
+            auto& item = frame.resolved_content.data[index];
             if (auto const* string = item.get_pointer<Utf16String>()) {
-                layout_node = make_ref_counted<GeneratedTextNode>(document, *string);
+                frame.content_item = make_ref_counted<GeneratedTextNode>(element.document(), *string);
             } else {
                 auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();
-                auto image_box = create_content_image_box(document, nullptr, NonnullRefPtr { pseudo_element_node->computed_values() }, image);
+                auto image_box = create_content_image_box(element.document(), nullptr, NonnullRefPtr { frame.layout_node->computed_values() }, image);
                 // https://drafts.csswg.org/css-content-3/#content-property
                 // For <image>, this is an inline anonymous replaced element.
                 image_box->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
                 image_box->attach_style_resources();
-                layout_node = move(image_box);
+                frame.content_item = move(image_box);
             }
-            layout_node->set_generated_for(pseudo_element, element);
-            auto display = layout_node->is_text_node() ? CSS::Display::from_short(CSS::Display::Short::Inline) : as<NodeWithStyle>(*layout_node).display();
-            insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
-        }
-        pop_parent();
-    }
-
-    return pseudo_element_node;
+            frame.content_item->set_generated_for(css_pseudo_element(ffi_pseudo), element);
+            return frame.content_item.ptr(); },
+        .insert_content_item = [](void* builder_pointer, void* content_item_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(content_item_pointer);
+            auto& content_item = *static_cast<Layout::Node*>(content_item_pointer);
+            auto display = content_item.is_text_node()
+                ? CSS::Display::from_short(CSS::Display::Short::Inline)
+                : as<NodeWithStyle>(content_item).display();
+            static_cast<TreeBuilder*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(content_item, display, AppendOrPrepend::Append); },
+        .push_layout_parent = [](void* builder_pointer, void* layout_node_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(layout_node_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->push_parent(as<NodeWithStyle>(*static_cast<Layout::Node*>(layout_node_pointer))); },
+        .pop_layout_parent = [](void* builder_pointer) {
+            VERIFY(builder_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->pop_parent(); },
+        .quote_nesting_level = [](void* builder_pointer) {
+            VERIFY(builder_pointer);
+            return static_cast<TreeBuilder*>(builder_pointer)->quote_nesting_level(); },
+        .set_quote_nesting_level = [](void* builder_pointer, u32 quote_nesting_level) {
+            VERIFY(builder_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->set_quote_nesting_level(quote_nesting_level); },
+    };
 }
 
 RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Element& element, NonnullRefPtr<CSS::ComputedValues const> computed_values) const

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1338,12 +1338,28 @@ static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithSt
     return content_box_wrapper;
 }
 
-RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)
+LayoutTreeBuildResult TreeBuilder::build(DOM::Node& dom_node)
 {
     Context context;
     PrincipalNodeFrame frame;
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    return static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &frame, &dom_node, &context));
+    m_layout_root = static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &frame, &dom_node, &context));
+    return {
+        .root = move(m_layout_root),
+        .rebuilt_subtree_roots = move(m_rebuilt_subtree_roots),
+        .layout_tree_update_escaped_rebuild_roots = m_layout_tree_update_escaped_rebuild_roots,
+    };
+}
+
+LayoutTreeBuildResult build_layout_tree(DOM::Node& dom_node)
+{
+    TreeBuilder tree_builder;
+    return tree_builder.build(dom_node);
+}
+
+void detach_top_layer_element_layout_subtree(DOM::Element& element)
+{
+    TreeBuilder::detach_top_layer_element_layout_subtree(element);
 }
 
 static RustFFI::FfiTableDisplay ffi_table_display(CSS::Display display)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -593,15 +593,6 @@ RustFFI::FfiPseudoTreeBuilderCallbacks TreeBuilder::make_ffi_pseudo_tree_builder
     };
 }
 
-RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Element& element, NonnullRefPtr<CSS::ComputedValues const> computed_values) const
-{
-    auto const* replacement_image = content_replacement_image(computed_values->computed_content());
-    if (!replacement_image)
-        return {};
-
-    return create_content_image_box(element.document(), element, move(computed_values), const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
-}
-
 static bool is_svg_resource_box(Node const& layout_node)
 {
     return is<SVGPatternBox>(layout_node) || is<SVGMaskBox>(layout_node) || is<SVGClipBox>(layout_node);
@@ -1050,16 +1041,50 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             frame.computed_values = element.computed_values();
             frame.display = frame.computed_values->display();
             return ffi_principal_display_facts(frame.display); },
-        .create_principal_element_layout = [](void* builder_pointer, void* frame_pointer, void* element_pointer, void* context_pointer) {
-            VERIFY(builder_pointer);
+        .principal_element_layout_facts = [](void* frame_pointer, void* element_pointer, void* context_pointer) -> RustFFI::FfiElementLayoutFacts {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
             VERIFY(context_pointer);
-            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            frame.layout_node = builder.create_layout_node_for_element(
-                *static_cast<DOM::Element*>(element_pointer),
-                *static_cast<Context*>(context_pointer)); },
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            auto& context = *static_cast<Context*>(context_pointer);
+            VERIFY(frame.computed_values);
+            return {
+                .has_content_replacement = content_replacement_image(frame.computed_values->computed_content()) != nullptr,
+                .context_layout_svg_mask_or_clip_path = context.layout_svg_mask_or_clip_path,
+                .context_layout_svg_pattern = context.layout_svg_pattern,
+                .is_svg_mask_element = is<SVG::SVGMaskElement>(element),
+                .is_svg_clip_path_element = is<SVG::SVGClipPathElement>(element),
+                .is_svg_pattern_element = is<SVG::SVGPatternElement>(element),
+            }; },
+        .create_principal_element_layout = [](void* builder_pointer, void* frame_pointer, void* element_pointer, RustFFI::FfiElementLayoutKind kind) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            VERIFY(frame.computed_values);
+            auto computed_values = NonnullRefPtr { *frame.computed_values };
+            switch (kind) {
+            case RustFFI::FfiElementLayoutKind::ContentReplacement: {
+                auto const* replacement_image = content_replacement_image(computed_values->computed_content());
+                VERIFY(replacement_image);
+                frame.layout_node = create_content_image_box(element.document(), element, move(computed_values), const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
+                break;
+            }
+            case RustFFI::FfiElementLayoutKind::SvgMask:
+                frame.layout_node = make_ref_counted<Layout::SVGMaskBox>(element.document(), as<SVG::SVGMaskElement>(element), move(computed_values));
+                break;
+            case RustFFI::FfiElementLayoutKind::SvgClipPath:
+                frame.layout_node = make_ref_counted<Layout::SVGClipBox>(element.document(), as<SVG::SVGClipPathElement>(element), move(computed_values));
+                break;
+            case RustFFI::FfiElementLayoutKind::SvgPattern:
+                frame.layout_node = make_ref_counted<Layout::SVGPatternBox>(element.document(), as<SVG::SVGPatternElement>(element), move(computed_values));
+                break;
+            case RustFFI::FfiElementLayoutKind::Normal:
+                frame.layout_node = element.create_layout_node(move(computed_values));
+                break;
+            } },
         .create_principal_document_layout = [](void* frame_pointer, void* document_pointer) {
             VERIFY(frame_pointer);
             VERIFY(document_pointer);
@@ -1233,35 +1258,6 @@ static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element& ele
         element.document().update_style_for_element({ element });
         element.set_needs_style_update(false);
     }
-}
-
-RefPtr<Layout::Node> TreeBuilder::create_layout_node_for_element(DOM::Element& element, Context& context) const
-{
-    auto& document = element.document();
-    NonnullRefPtr<CSS::ComputedValues const> computed_values = *element.computed_values();
-
-    if (auto content_replacement = create_content_replacement_if_needed(element, computed_values))
-        return content_replacement;
-
-    if (context.layout_svg_mask_or_clip_path) {
-        RefPtr<Layout::Node> layout_node;
-        if (is<SVG::SVGMaskElement>(element))
-            layout_node = make_ref_counted<Layout::SVGMaskBox>(document, static_cast<SVG::SVGMaskElement&>(element), move(computed_values));
-        else if (is<SVG::SVGClipPathElement>(element))
-            layout_node = make_ref_counted<Layout::SVGClipBox>(document, static_cast<SVG::SVGClipPathElement&>(element), move(computed_values));
-        else
-            VERIFY_NOT_REACHED();
-        // Only layout direct uses of SVG masks/clipPaths.
-        context.layout_svg_mask_or_clip_path = false;
-        return layout_node;
-    }
-
-    if (context.layout_svg_pattern) {
-        context.layout_svg_pattern = false;
-        return make_ref_counted<Layout::SVGPatternBox>(document, as<SVG::SVGPatternElement>(element), move(computed_values));
-    }
-
-    return element.create_layout_node(move(computed_values));
 }
 
 static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -15,6 +15,7 @@
 #include <AK/Utf16String.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibUnicode/CharacterTypes.h>
+#include <LibUnicode/Segmenter.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/Enums.h>
@@ -213,168 +214,6 @@ static CSS::AbstractImageStyleValue const* content_replacement_image(CSS::Comput
     return content.items.first().get<NonnullRefPtr<CSS::AbstractImageStyleValue const>>().ptr();
 }
 
-struct FirstLetterTarget {
-    TextNode* text_node { nullptr };
-    size_t letter_start { 0 };
-    size_t letter_end { 0 };
-};
-
-// https://drafts.csswg.org/css-pseudo-4/#first-letter-pattern
-static Optional<FirstLetterTarget> find_first_letter_in_text(TextNode& text_node)
-{
-    // NB: Matches the first-letter text pattern: (P (Zs|P)*)? (L|N|S) ((Zs|P-(Ps|Pd))* (P-(Ps|Pd))?)?
-
-    // For the preceding run: Zs excluding U+3000 IDEOGRAPHIC SPACE.
-    auto is_preceding_intervening_space = [](u32 code_point) {
-        if (code_point == 0x3000)
-            return false;
-        return Unicode::code_point_has_space_separator_general_category(code_point);
-    };
-
-    // For the trailing run: Zs excluding U+3000 IDEOGRAPHIC SPACE and word separators.
-    auto is_trailing_intervening_space = [](u32 code_point) {
-        // NB: css-text-4 defines word separators as a non-exhaustive list, but of the seven code
-        //     points it names only U+0020 SPACE and U+00A0 NO-BREAK SPACE are in the Zs category;
-        //     the rest are in Po and would never reach this check. Fixed-width spaces are explicitly
-        //     not word separators per the spec's note, so they remain valid intervening Zs here.
-        if (code_point == 0x0020 || code_point == 0x00A0 || code_point == 0x3000)
-            return false;
-        return Unicode::code_point_has_space_separator_general_category(code_point);
-    };
-
-    auto is_trailing_punctuation = [](u32 code_point) {
-        if (!Unicode::code_point_has_punctuation_general_category(code_point))
-            return false;
-
-        // NB: The css-pseudo specification excludes Ps and Pd classes (closing punctuation and dashes) from the
-        //     trailing run, whereas CSS 2.1 allowed all classes in both the preceding and trailing runs.
-        static auto const ps = Unicode::general_category_from_string("Ps"sv).value();
-        static auto const pd = Unicode::general_category_from_string("Pd"sv).value();
-        return !Unicode::code_point_has_general_category(code_point, ps)
-            && !Unicode::code_point_has_general_category(code_point, pd);
-    };
-
-    auto is_first_letter_character = [](u32 code_point) {
-        return Unicode::code_point_has_letter_general_category(code_point)
-            || Unicode::code_point_has_number_general_category(code_point)
-            || Unicode::code_point_has_symbol_general_category(code_point);
-    };
-
-    auto view = text_node.text().utf16_view();
-    auto const code_units = view.length_in_code_units();
-
-    // When white-space preserves segment breaks, a newline before any letter puts the letter on a later line, so the
-    // first formatted line is empty and ::first-letter must not match.
-    auto const white_space_collapse = text_node.parent()->computed_values().white_space_collapse();
-    auto const preserves_segment_breaks = first_is_one_of(white_space_collapse,
-        CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces);
-
-    auto advance = [&](size_t index) {
-        return index + AK::UnicodeUtils::code_unit_length_for_code_point(view.code_point_at(index));
-    };
-
-    auto grapheme_segmenter = text_node.document().grapheme_segmenter().clone();
-    grapheme_segmenter->set_segmented_text(view);
-
-    auto advance_cluster = [&](size_t index) -> size_t {
-        return grapheme_segmenter->next_boundary(index).value_or(code_units);
-    };
-
-    for (size_t match_start = 0; match_start < code_units; match_start = advance(match_start)) {
-        size_t cursor = match_start;
-        auto starting_code_point = view.code_point_at(cursor);
-
-        if (preserves_segment_breaks && (starting_code_point == '\n' || starting_code_point == '\r'))
-            return {};
-
-        // A valid match starts with either a P, or the letter itself.
-        bool const has_preceding = Unicode::code_point_has_punctuation_general_category(starting_code_point);
-        if (!has_preceding && !is_first_letter_character(starting_code_point))
-            continue;
-
-        if (has_preceding) {
-            // Preceding group: P followed by (Zs|P)*.
-            cursor = advance_cluster(cursor);
-            while (cursor < code_units) {
-                auto code_point = view.code_point_at(cursor);
-                if (!Unicode::code_point_has_punctuation_general_category(code_point)
-                    && !is_preceding_intervening_space(code_point))
-                    break;
-                cursor = advance_cluster(cursor);
-            }
-        }
-
-        // The letter (L|N|S) must follow the preceding group. If the preceding punctuation consumed the entire text
-        // node, accept it as the first-letter.
-        if (cursor >= code_units)
-            return FirstLetterTarget { &text_node, match_start, cursor };
-        if (!is_first_letter_character(view.code_point_at(cursor)))
-            continue;
-
-        auto letter_end = advance_cluster(cursor);
-
-        // Trailing group: greedy match of (Zs|P-(Ps|Pd))*.
-        while (letter_end < code_units) {
-            auto code_point = view.code_point_at(letter_end);
-            if (!is_trailing_intervening_space(code_point) && !is_trailing_punctuation(code_point))
-                break;
-            letter_end = advance_cluster(letter_end);
-        }
-
-        return FirstLetterTarget { &text_node, match_start, letter_end };
-    }
-    return {};
-}
-
-// https://drafts.csswg.org/css-pseudo-4/#first-letter-application
-static Optional<FirstLetterTarget> find_first_letter_in_block(BlockContainer& block)
-{
-    // NB: This walks a block container's inline descendants looking for the first-letter text. If the block has block
-    //     children instead of inline, recurses into each in-flow block child in turn.
-
-    auto is_marker_content = [](Node const& node) {
-        return is<ListItemMarkerBox>(node) || node.generated_for_pseudo_element() == CSS::PseudoElement::Marker;
-    };
-
-    if (block.children_are_inline()) {
-        Optional<FirstLetterTarget> result;
-        block.for_each_in_subtree([&](Node& node) {
-            if (is_marker_content(node) || node.is_out_of_flow())
-                return TraversalDecision::SkipChildrenAndContinue;
-            if (auto* text_node = as_if<TextNode>(node)) {
-                result = find_first_letter_in_text(*text_node);
-                return result.has_value() ? TraversalDecision::Break : TraversalDecision::Continue;
-            }
-            if (node.is_fragmented_inline())
-                return TraversalDecision::Continue;
-
-            return TraversalDecision::Break;
-        });
-        return result;
-    }
-
-    // We have no inline content of our own but ::first-letter can still apply to text in an in-flow block descendant,
-    // so walk into each in-flow block child in document order until one yields a letter.
-    for (auto child = block.first_child(); child; child = child->next_sibling()) {
-        if (is_marker_content(*child))
-            continue;
-        if (child->is_out_of_flow())
-            continue;
-        auto* inner_block = as_if<BlockContainer>(*child);
-        if (!inner_block)
-            break;
-        // Stop descending if this child block defines its own ::first-letter: the child will style the first letter
-        // inside it, so the ancestor's ::first-letter must not also claim the same letter.
-        if (auto* dom_element = as_if<DOM::Element>(inner_block->dom_node()); dom_element && dom_element->computed_values(CSS::PseudoElement::FirstLetter))
-            break;
-        if (auto target = find_first_letter_in_block(*inner_block); target.has_value())
-            return target;
-        if (!inner_block->is_anonymous())
-            break;
-    }
-    return {};
-}
-
 struct FirstLetterTextSlices {
     NonnullRefPtr<TextNode> first_letter_slice;
     NonnullRefPtr<TextNode> remainder_slice;
@@ -406,14 +245,15 @@ void TreeBuilder::create_first_letter_wrapper_if_needed(DOM::Element& element, B
     if (!element.computed_values(CSS::PseudoElement::FirstLetter))
         return;
 
-    auto target = find_first_letter_in_block(block_container);
-    if (!target.has_value())
+    auto callbacks = make_ffi_tree_builder_callbacks(nullptr);
+    auto target = RustFFI::rust_find_first_letter_in_block(&callbacks, &block_container);
+    if (!target.found)
         return;
 
-    auto& text_node = *target->text_node;
+    auto& text_node = as<TextNode>(*static_cast<Node*>(target.text_node));
     auto& document = element.document();
 
-    auto [first_letter_slice, remainder_slice] = create_first_letter_text_slices(document, text_node, target->letter_end);
+    auto [first_letter_slice, remainder_slice] = create_first_letter_text_slices(document, text_node, target.letter_end);
 
     auto first_letter_values = element.computed_values(CSS::PseudoElement::FirstLetter);
     VERIFY(first_letter_values);
@@ -1437,7 +1277,81 @@ static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_point
         .display_is_flow_inside = node_with_style && node_with_style->display().is_flow_inside(),
         .display_is_flex_inside = node_with_style && node_with_style->display().is_flex_inside(),
         .display_is_grid_inside = node_with_style && node_with_style->display().is_grid_inside(),
+        .is_list_item_marker_box = is<ListItemMarkerBox>(node),
+        .is_generated_for_marker = node.generated_for_pseudo_element() == CSS::PseudoElement::Marker,
+        .is_fragmented_inline = node.is_fragmented_inline(),
+        .has_first_letter_style = [&] {
+            auto* dom_element = as_if<DOM::Element>(node.dom_node());
+            return dom_element && dom_element->computed_values(CSS::PseudoElement::FirstLetter);
+        }(),
     };
+}
+
+struct FfiFirstLetterTextContext {
+    Utf16View text;
+    NonnullOwnPtr<Unicode::Segmenter> grapheme_segmenter;
+};
+
+static size_t ffi_first_letter_code_unit_length(void* context_pointer)
+{
+    VERIFY(context_pointer);
+    return static_cast<FfiFirstLetterTextContext*>(context_pointer)->text.length_in_code_units();
+}
+
+static u32 ffi_first_letter_code_point_at(void* context_pointer, size_t index)
+{
+    VERIFY(context_pointer);
+    auto& context = *static_cast<FfiFirstLetterTextContext*>(context_pointer);
+    VERIFY(index < context.text.length_in_code_units());
+    return context.text.code_point_at(index);
+}
+
+static size_t ffi_first_letter_next_grapheme_boundary(void* context_pointer, size_t index)
+{
+    VERIFY(context_pointer);
+    auto& context = *static_cast<FfiFirstLetterTextContext*>(context_pointer);
+    VERIFY(index <= context.text.length_in_code_units());
+    return context.grapheme_segmenter->next_boundary(index).value_or(context.text.length_in_code_units());
+}
+
+static RustFFI::FfiFirstLetterCodePointFacts ffi_first_letter_code_point_facts(void*, u32 code_point)
+{
+    static auto const ps = Unicode::general_category_from_string("Ps"sv).value();
+    static auto const pd = Unicode::general_category_from_string("Pd"sv).value();
+    return {
+        .is_space_separator = Unicode::code_point_has_space_separator_general_category(code_point),
+        .is_punctuation = Unicode::code_point_has_punctuation_general_category(code_point),
+        .is_letter = Unicode::code_point_has_letter_general_category(code_point),
+        .is_number = Unicode::code_point_has_number_general_category(code_point),
+        .is_symbol = Unicode::code_point_has_symbol_general_category(code_point),
+        .is_open_punctuation = Unicode::code_point_has_general_category(code_point, ps),
+        .is_dash_punctuation = Unicode::code_point_has_general_category(code_point, pd),
+    };
+}
+
+static RustFFI::FfiFirstLetterTarget ffi_find_first_letter_in_text(void*, void* node_pointer)
+{
+    VERIFY(node_pointer);
+    auto& text_node = as<TextNode>(*static_cast<Node*>(node_pointer));
+    auto text = text_node.text().utf16_view();
+    auto grapheme_segmenter = text_node.document().grapheme_segmenter().clone();
+    grapheme_segmenter->set_segmented_text(text);
+    FfiFirstLetterTextContext context { text, move(grapheme_segmenter) };
+    RustFFI::FfiFirstLetterTextCallbacks callbacks {
+        .context = &context,
+        .code_unit_length = ffi_first_letter_code_unit_length,
+        .code_point_at = ffi_first_letter_code_point_at,
+        .next_grapheme_boundary = ffi_first_letter_next_grapheme_boundary,
+        .code_point_facts = ffi_first_letter_code_point_facts,
+    };
+
+    auto const white_space_collapse = text_node.parent()->computed_values().white_space_collapse();
+    auto const preserves_segment_breaks = first_is_one_of(white_space_collapse,
+        CSS::WhiteSpaceCollapse::Preserve, CSS::WhiteSpaceCollapse::PreserveBreaks, CSS::WhiteSpaceCollapse::BreakSpaces);
+    auto target = RustFFI::rust_find_first_letter_in_text(&callbacks, preserves_segment_breaks);
+    if (target.found)
+        target.text_node = &text_node;
+    return target;
 }
 
 static void* ffi_layout_node_parent(void*, void* node_pointer)
@@ -1667,6 +1581,7 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuil
         .insert_child = ffi_insert_child,
         .set_children_are_inline = ffi_set_children_are_inline,
         .note_tree_restructuring = ffi_note_tree_restructuring,
+        .find_first_letter_in_text = ffi_find_first_letter_in_text,
     };
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -652,6 +652,59 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
             (void)static_cast<TreeBuilder*>(builder_pointer)->clear_stale_layout_and_paint_node(*static_cast<DOM::Node*>(node_pointer)); },
+        .display_contents_facts = [](void*, void* element_pointer, void* context_pointer) -> RustFFI::FfiDisplayContentsFacts {
+            VERIFY(element_pointer);
+            VERIFY(context_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            auto& context = *static_cast<Context*>(context_pointer);
+            auto* slot_element = as_if<HTML::HTMLSlotElement>(element);
+            auto shadow_root = element.shadow_root();
+            return {
+                .rendered_in_top_layer = element.rendered_in_top_layer(),
+                .context_layout_top_layer = context.layout_top_layer,
+                .content_visibility_hidden = element.computed_values()->content_visibility() == CSS::ContentVisibility::Hidden,
+                .should_layout_dom_children = slot_element ? slot_element->assigned_nodes_internal().is_empty() && element.has_children() : element.has_children(),
+                .child_needs_layout_tree_update = element.child_needs_layout_tree_update(),
+                .dom_children_parent = static_cast<DOM::ParentNode*>(&element),
+                .shadow_root = shadow_root ? static_cast<DOM::ParentNode*>(shadow_root.ptr()) : nullptr,
+                .slot_element = slot_element,
+            };
+        },
+        .set_context_layout_top_layer = [](void* context_pointer, bool layout_top_layer) {
+            VERIFY(context_pointer);
+            static_cast<Context*>(context_pointer)->layout_top_layer = layout_top_layer; },
+        .clear_synthetic_pseudo_element_layout_nodes = [](void*, void* element_pointer) {
+            VERIFY(element_pointer);
+            static_cast<DOM::Element*>(element_pointer)->clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {}); },
+        .clear_stale_inclusive_descendants = [](void* builder_pointer, void* element_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(element_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            static_cast<DOM::Element*>(element_pointer)->for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return builder.clear_stale_layout_and_paint_node(node);
+            }); },
+        .resolve_counters = [](void* element_pointer) {
+            VERIFY(element_pointer);
+            DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer) };
+            CSS::resolve_counters(element_reference); },
+        .create_pseudo_element = [](void* builder_pointer, void* element_pointer, RustFFI::FfiPseudoElement pseudo_element, RustFFI::FfiInsertionMode insertion_mode) {
+            VERIFY(builder_pointer);
+            VERIFY(element_pointer);
+            auto css_pseudo_element = [&] {
+                switch (pseudo_element) {
+                case RustFFI::FfiPseudoElement::Before:
+                    return CSS::PseudoElement::Before;
+                case RustFFI::FfiPseudoElement::After:
+                    return CSS::PseudoElement::After;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            }();
+            auto mode = insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend;
+            (void)static_cast<TreeBuilder*>(builder_pointer)->create_pseudo_element_if_needed(*static_cast<DOM::Element*>(element_pointer), css_pseudo_element, mode); },
+        .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
+            VERIFY(slot_element_pointer);
+            clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
     };
 }
 
@@ -1045,53 +1098,13 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
 void TreeBuilder::update_layout_tree_for_display_contents(DOM::Element& element, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree, bool should_create_layout_node)
 {
-    // A display:contents member builds its children through this path, so the top layer flag
-    // is consumed here the same way update_layout_tree does for members with a box.
-    Optional<TemporaryChange<bool>> layout_top_layer_cleared_for_member_descendants;
-    if (element.rendered_in_top_layer() && context.layout_top_layer)
-        layout_top_layer_cleared_for_member_descendants.emplace(context.layout_top_layer, false);
-
-    element.clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
-
-    if (should_create_layout_node) {
-        element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
-            return clear_stale_layout_and_paint_node(node);
-        });
-
-        DOM::AbstractElement element_reference { element };
-        CSS::resolve_counters(element_reference);
-    }
-
-    auto element_has_content_visibility_hidden = element.computed_values()->content_visibility() == CSS::ContentVisibility::Hidden;
-    if (!element_has_content_visibility_hidden)
-        (void)create_pseudo_element_if_needed(element, CSS::PseudoElement::Before, AppendOrPrepend::Append);
-
-    auto should_layout_dom_children = [&]() {
-        if (auto const* slot_element = as_if<HTML::HTMLSlotElement>(element))
-            return slot_element->assigned_nodes_internal().is_empty() && element.has_children();
-        return element.has_children();
-    }();
-
-    auto shadow_root = element.shadow_root();
-    if (!element_has_content_visibility_hidden && (should_create_layout_node || element.child_needs_layout_tree_update())) {
-        if (shadow_root)
-            update_layout_tree_for_shadow_root_children(*shadow_root, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
-        else if (should_layout_dom_children)
-            update_layout_tree_for_dom_children(element, context, should_create_layout_node ? MustCreateSubtree::Yes : MustCreateSubtree::No);
-    }
-
-    if (auto* slot_element = as_if<HTML::HTMLSlotElement>(element)) {
-        if (!element_has_content_visibility_hidden)
-            update_layout_tree_for_assigned_slottables(*slot_element, context, must_create_subtree);
-        else
-            clear_stale_layout_nodes_for_assigned_slottables(*slot_element);
-    }
-
-    if (!element_has_content_visibility_hidden)
-        (void)create_pseudo_element_if_needed(element, CSS::PseudoElement::After, AppendOrPrepend::Append);
-
-    element.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
-    element.set_child_needs_layout_tree_update(false);
+    auto callbacks = make_ffi_dom_tree_builder_callbacks();
+    RustFFI::rust_update_layout_tree_for_display_contents(
+        &callbacks,
+        &element,
+        &context,
+        must_create_subtree == MustCreateSubtree::Yes,
+        should_create_layout_node);
 }
 
 void TreeBuilder::update_layout_tree_for_svg_switch_children(SVG::SVGSwitchElement& switch_element, Context& context, MustCreateSubtree must_create_subtree)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/TreeBuilder.h>
+#include <LibWeb/Layout/TreeBuilderRustFFI.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/SVG/SVGSwitchElement.h>
@@ -96,18 +97,14 @@ static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithSt
 
 static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::Display display)
 {
-    // https://drafts.csswg.org/css-display-3/#outer-role
-    // Note: Outer display types do affect replaced elements.
-    if (display.is_table_inside()) {
-        if (display.is_block_outside())
-            return CSS::Display::from_short(CSS::Display::Short::Block);
-        return CSS::Display::from_short(CSS::Display::Short::Inline);
-    }
-
-    // https://drafts.csswg.org/css-display-3/#layout-specific-display
-    // When the 'display' property of a replaced element computes to one of the layout-internal values, it is handled
-    // as having a used value of 'display: inline'.
-    if (display.is_internal_table() || display.is_table_caption())
+    auto adjustment = RustFFI::rust_adjusted_table_display_for_replaced_element(
+        display.is_table_inside(),
+        display.is_block_outside(),
+        display.is_internal_table(),
+        display.is_table_caption());
+    if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Block)
+        return CSS::Display::from_short(CSS::Display::Short::Block);
+    if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Inline)
         return CSS::Display::from_short(CSS::Display::Short::Inline);
     return {};
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -110,7 +110,7 @@ void LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(DOM::Element& el
 
 static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display);
 static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
-static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&);
+static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&, bool needs_style_wrapper);
 
 static size_t ffi_assigned_node_count(void* slot_element_pointer)
 {
@@ -1009,11 +1009,22 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             frame.computed_values = document.style_computer().create_document_style();
             frame.display = frame.computed_values->display();
             frame.layout_node = make_ref_counted<Layout::Viewport>(document, frame.computed_values.release_nonnull()); },
-        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer) {
+        .principal_text_layout_facts = [](void* text_pointer) -> RustFFI::FfiTextLayoutFacts {
+            VERIFY(text_pointer);
+            auto& text = *static_cast<DOM::Text*>(text_pointer);
+            auto* style_parent = as_if<DOM::Element>(text.flat_tree_parent());
+            auto style_parent_values = style_parent ? style_parent->computed_values() : nullptr;
+            return {
+                .has_style_parent = style_parent_values != nullptr,
+                .parent_display_is_contents = style_parent_values && style_parent_values->display().is_contents(),
+                .text_is_ascii_whitespace = text.data().is_ascii_whitespace(),
+                .parent_collapses_whitespace = style_parent_values && first_is_one_of(style_parent_values->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse),
+            }; },
+        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer, bool needs_style_wrapper) {
             VERIFY(frame_pointer);
             VERIFY(text_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            frame.layout_node = create_layout_node_for_text(*static_cast<DOM::Text*>(text_pointer));
+            frame.layout_node = create_layout_node_for_text(*static_cast<DOM::Text*>(text_pointer), needs_style_wrapper);
             frame.display = CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow); },
         .reuse_principal_layout = [](void* frame_pointer, void* node_pointer) {
             VERIFY(frame_pointer);
@@ -1156,18 +1167,13 @@ static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element& ele
     }
 }
 
-static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node)
+static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node, bool needs_style_wrapper)
 {
     auto& document = text_node.document();
     RefPtr<Layout::Node> layout_node = make_ref_counted<Layout::TextNode>(document, text_node);
-    auto* style_parent = as_if<DOM::Element>(text_node.flat_tree_parent());
-    auto style_parent_values = style_parent ? style_parent->computed_values() : nullptr;
-    if (RustFFI::rust_display_contents_text_needs_style_wrapper(
-            style_parent_values != nullptr,
-            style_parent_values && style_parent_values->display().is_contents(),
-            text_node.data().is_ascii_whitespace(),
-            style_parent_values && first_is_one_of(style_parent_values->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse))) {
-        auto wrapper = make_ref_counted<Layout::InlineNode>(document, nullptr, style_parent->computed_values().release_nonnull());
+    if (needs_style_wrapper) {
+        auto& style_parent = as<DOM::Element>(*text_node.flat_tree_parent());
+        auto wrapper = make_ref_counted<Layout::InlineNode>(document, nullptr, style_parent.computed_values().release_nonnull());
         wrapper->attach_style_resources();
         wrapper->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
         wrapper->set_children_are_inline(true);

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -333,6 +333,33 @@ NonnullRefPtr<ListItemMarkerBox> TreeBuilder::create_and_attach_list_item_marker
     return list_item_marker;
 }
 
+static RustFFI::FfiPseudoElement ffi_pseudo_element(CSS::PseudoElement pseudo_element)
+{
+    switch (pseudo_element) {
+    case CSS::PseudoElement::Before:
+        return RustFFI::FfiPseudoElement::Before;
+    case CSS::PseudoElement::After:
+        return RustFFI::FfiPseudoElement::After;
+    case CSS::PseudoElement::Marker:
+        return RustFFI::FfiPseudoElement::Marker;
+    default:
+        return RustFFI::FfiPseudoElement::Other;
+    }
+}
+
+static RustFFI::FfiComputedContentType ffi_computed_content_type(CSS::ComputedContentData::Type content_type)
+{
+    switch (content_type) {
+    case CSS::ComputedContentData::Type::Normal:
+        return RustFFI::FfiComputedContentType::Normal;
+    case CSS::ComputedContentData::Type::None:
+        return RustFFI::FfiComputedContentType::None;
+    case CSS::ComputedContentData::Type::List:
+        return RustFFI::FfiComputedContentType::List;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
 {
     auto& document = element.document();
@@ -347,27 +374,29 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
 
     auto pseudo_element_display = pseudo_element_values->display();
 
-    // https://drafts.csswg.org/css-display-3/#box-generation
-    // The element and its descendants generate no boxes or text sequences.
-    if (pseudo_element_display.is_none())
-        return {};
-
     auto initial_quote_nesting_level = quote_nesting_level();
 
     // NB: Whether this pseudo-element generates a box depends only on the shape of its computed
     //     content value, so the full resolution (which reads counters that do not exist until
     //     the box is inserted) can wait until after insertion.
     auto const computed_content_type = pseudo_element_values->computed_content().type;
-
-    // ::before and ::after only exist if they have content. `content: normal` computes to `none` for them.
-    if (first_is_one_of(pseudo_element, CSS::PseudoElement::Before, CSS::PseudoElement::After)
-        && (computed_content_type == CSS::ComputedContentData::Type::Normal
-            || computed_content_type == CSS::ComputedContentData::Type::None))
-        return {};
-
-    // For ::marker with content 'none' -- do nothing.
-    if (pseudo_element == CSS::PseudoElement::Marker
-        && computed_content_type == CSS::ComputedContentData::Type::None)
+    auto const* replacement_image = content_replacement_image(pseudo_element_values->computed_content());
+    ListItemBox* originating_list_box = nullptr;
+    if (pseudo_element == CSS::PseudoElement::Marker && computed_content_type == CSS::ComputedContentData::Type::Normal)
+        originating_list_box = as_if<ListItemBox>(*element.unsafe_layout_node());
+    auto const normal_marker_has_content = originating_list_box
+        && (!originating_list_box->computed_values().list_style_type().has<Empty>() || originating_list_box->list_style_image());
+    auto const decision = RustFFI::rust_pseudo_element_decision({
+        .pseudo_element = ffi_pseudo_element(pseudo_element),
+        .content_type = ffi_computed_content_type(computed_content_type),
+        .display_is_none = pseudo_element_display.is_none(),
+        .display_is_contents = pseudo_element_display.is_contents(),
+        .display_is_list_item = pseudo_element_display.is_list_item(),
+        .has_content_replacement = replacement_image != nullptr,
+        .originating_layout_node_is_list_item = originating_list_box != nullptr,
+        .normal_marker_has_content = normal_marker_has_content,
+    });
+    if (decision == RustFFI::FfiPseudoElementDecision::None)
         return {};
 
     // For ::marker with content 'normal', create the marker pseudo-element from a ListItemMarkerBox
@@ -375,43 +404,17 @@ RefPtr<NodeWithStyle> TreeBuilder::create_pseudo_element_if_needed(DOM::Element&
     //        are rendered using the special list-item counter.
     //        See: https://github.com/LadybirdBrowser/ladybird/issues/4782
     // NB: Called during layout tree construction.
-    if (pseudo_element == CSS::PseudoElement::Marker && computed_content_type == CSS::ComputedContentData::Type::Normal)
-        if (auto* list_box = as_if<ListItemBox>(*element.unsafe_layout_node())) {
-            // https://www.w3.org/TR/css-lists-3/#content-property
-            // "::marker does not generate a box" when list-style-type is 'none' and there's no marker image. Custom
-            // ::marker content is already excluded by the outer condition checking for Type::Normal.
-            if (list_box->computed_values().list_style_type().has<Empty>() && !list_box->list_style_image()) {
-                return {};
-            }
-
-            return create_and_attach_list_item_marker(*list_box, element, NonnullRefPtr { *pseudo_element_values });
-        }
+    if (decision == RustFFI::FfiPseudoElementDecision::NormalMarker)
+        return create_and_attach_list_item_marker(*originating_list_box, element, NonnullRefPtr { *pseudo_element_values });
 
     RefPtr<NodeWithStyle> pseudo_element_node;
-
-    // https://drafts.csswg.org/css-content-3/#content-property
-    // Note: If the value of <content-list> is a single <image>, it must instead be interpreted as a
-    // <content-replacement>.
-    // Makes the element or pseudo-element a replaced element, filled with the specified <image>.
-    auto const* replacement_image = content_replacement_image(pseudo_element_values->computed_content());
-    auto is_content_replacement = replacement_image != nullptr;
-
-    // INTEROP: Blink, WebKit, and Gecko keep generated images as children of pseudo-element boxes. Preserve that
-    //          behavior for list items because our marker layout currently requires a ListItemBox.
-    if (pseudo_element_display.is_list_item())
-        is_content_replacement = false;
-
-    // https://drafts.csswg.org/css-display-3/#box-generation
-    // This value computes to 'display: none' on replaced elements.
-    // INTEROP: Blink, WebKit, and Gecko preserve image content on 'display: contents' pseudo-elements instead.
-    if (pseudo_element_display.is_contents())
-        is_content_replacement = false;
+    auto const is_content_replacement = decision == RustFFI::FfiPseudoElementDecision::ContentReplacement;
 
     if (is_content_replacement) {
         pseudo_element_node = create_content_image_box(document, nullptr, NonnullRefPtr { *pseudo_element_values }, const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
         if (auto adjusted_display = adjusted_table_display_for_replaced_element(pseudo_element_display); adjusted_display.has_value())
             pseudo_element_node->set_display(*adjusted_display);
-    } else if (pseudo_element_display.is_contents()) {
+    } else if (decision == RustFFI::FfiPseudoElementDecision::Contents) {
         pseudo_element_node = make_ref_counted<InlineNode>(document, nullptr, NonnullRefPtr { *pseudo_element_values });
         pseudo_element_node->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
     } else {

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -274,9 +274,6 @@ static FirstLetterTextSlices create_first_letter_text_slices(DOM::Document& docu
 
 void TreeBuilder::create_first_letter_wrapper_if_needed(DOM::Element& element, BlockContainer& block_container)
 {
-    if (!element.computed_values(CSS::PseudoElement::FirstLetter))
-        return;
-
     auto callbacks = make_ffi_tree_builder_callbacks(nullptr);
     auto target = RustFFI::rust_find_first_letter_in_block(&callbacks, &block_container);
     if (!target.found)
@@ -598,16 +595,6 @@ static bool is_svg_resource_box(Node const& layout_node)
     return is<SVGPatternBox>(layout_node) || is<SVGMaskBox>(layout_node) || is<SVGClipBox>(layout_node);
 }
 
-static bool layout_node_is_attached_to_dom_subtree(Node const& layout_node, DOM::Node const& subtree_root)
-{
-    for (auto* ancestor = layout_node.parent(); ancestor; ancestor = ancestor->parent()) {
-        auto* dom_node = ancestor->dom_node();
-        if (dom_node && dom_node->is_shadow_including_inclusive_descendant_of(subtree_root))
-            return true;
-    }
-    return false;
-}
-
 // The replacement box represents the same element in the same tree position, so layout state
 // saved by the previous layout pass carries over to it: the saved abspos layout inputs, and the
 // flat fragment and inline-box-piece lists held by the containing block of a node that
@@ -635,25 +622,6 @@ static void transfer_saved_layout_state_to_replacement_box(Layout::Node& old_lay
     }
 }
 
-static DOM::Element* display_contents_style_parent_for_text_node(DOM::Text& text_node)
-{
-    auto* parent = text_node.flat_tree_parent();
-    auto* parent_element = as_if<DOM::Element>(parent);
-    if (!parent_element || !parent_element->computed_values())
-        return nullptr;
-    if (!parent_element->computed_values()->display().is_contents())
-        return nullptr;
-    return parent_element;
-}
-
-static bool display_contents_text_needs_style_wrapper(DOM::Text& text_node, DOM::Element const& style_parent)
-{
-    if (!text_node.data().is_ascii_whitespace())
-        return true;
-
-    return !first_is_one_of(style_parent.computed_values()->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse);
-}
-
 TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node, DOM::Node const* cleared_subtree_root)
 {
     node.set_needs_layout_tree_update(false, DOM::SetNeedsLayoutTreeUpdateReason::None);
@@ -665,9 +633,21 @@ TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node
     // element and attached to that element's layout subtree. Skip them so they survive
     // cleanup of their DOM ancestor, unless their layout attachment is inside the
     // subtree being cleared too.
-    if (layout_node && is_svg_resource_box(*layout_node)
-        && (!cleared_subtree_root || !layout_node_is_attached_to_dom_subtree(*layout_node, *cleared_subtree_root))) {
-        return TraversalDecision::SkipChildrenAndContinue;
+    if (layout_node && is_svg_resource_box(*layout_node)) {
+        RustFFI::FfiStaleNodeCallbacks callbacks {
+            .layout_parent = [](void* layout_node_pointer) -> void* {
+                VERIFY(layout_node_pointer);
+                return static_cast<Layout::Node*>(layout_node_pointer)->parent(); },
+            .layout_dom_node = [](void* layout_node_pointer) -> void* {
+                VERIFY(layout_node_pointer);
+                return static_cast<Layout::Node*>(layout_node_pointer)->dom_node(); },
+            .dom_is_shadow_including_inclusive_descendant = [](void* node_pointer, void* root_pointer) {
+                VERIFY(node_pointer);
+                VERIFY(root_pointer);
+                return static_cast<DOM::Node*>(node_pointer)->is_shadow_including_inclusive_descendant_of(*static_cast<DOM::Node*>(root_pointer)); },
+        };
+        if (RustFFI::rust_should_preserve_svg_resource_layout_node(&callbacks, layout_node.ptr(), const_cast<DOM::Node*>(cleared_subtree_root)))
+            return TraversalDecision::SkipChildrenAndContinue;
     }
 
     if (layout_node && layout_node->parent())
@@ -684,41 +664,43 @@ TraversalDecision TreeBuilder::clear_stale_layout_and_paint_node(DOM::Node& node
 
 void TreeBuilder::detach_top_layer_element_layout_subtree(DOM::Element& element)
 {
-    // NB: Called at DOM mutation processing time, outside layout tree construction.
-    if (auto element_layout_node = RefPtr { element.unsafe_layout_node() }) {
-        // Take along any anonymous wrapper table fixup created around the box; an emptied
-        // table wrapper left behind as a viewport child asserts during layout.
-        RefPtr<Layout::Node> layout_node_to_detach = element_layout_node;
-        if (auto* top_layer_placement = element_layout_node->topmost_layout_node_of_top_layer_placement())
-            layout_node_to_detach = top_layer_placement;
-        layout_node_to_detach->prepare_subtree_for_detach_from_layout_tree();
-        if (layout_node_to_detach->parent())
-            layout_node_to_detach->remove();
-    }
-    element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
-        return clear_stale_layout_and_paint_node(node, &element);
-    });
-    if (auto* slot_element = as_if<HTML::HTMLSlotElement>(element))
-        clear_stale_layout_nodes_for_assigned_slottables(*slot_element);
-}
-
-static bool element_has_an_unrendered_flat_tree_ancestor(DOM::Element const& element)
-{
-    for (auto const* ancestor = element.flat_tree_parent(); ancestor; ancestor = ancestor->flat_tree_parent()) {
-        auto const* ancestor_element = as_if<DOM::Element>(*ancestor);
-        if (!ancestor_element)
-            continue;
-        // Null style means the style update pass skipped a display:none subtree.
-        auto ancestor_style = ancestor_element->computed_values();
-        if (!ancestor_style || ancestor_style->display().is_none())
-            return true;
-    }
-    return false;
+    RustFFI::FfiTopLayerDetachCallbacks callbacks {
+        .element_layout_node = [](void* element_pointer) -> void* {
+            VERIFY(element_pointer);
+            // NB: Called at DOM mutation processing time, outside layout tree construction.
+            return static_cast<DOM::Element*>(element_pointer)->unsafe_layout_node(); },
+        .topmost_placement_node = [](void* layout_node_pointer) -> void* {
+            VERIFY(layout_node_pointer);
+            return static_cast<Layout::Node*>(layout_node_pointer)->topmost_layout_node_of_top_layer_placement(); },
+        .prepare_subtree_for_detach = [](void* layout_node_pointer) {
+            VERIFY(layout_node_pointer);
+            static_cast<Layout::Node*>(layout_node_pointer)->prepare_subtree_for_detach_from_layout_tree(); },
+        .layout_parent = [](void* layout_node_pointer) -> void* {
+            VERIFY(layout_node_pointer);
+            return static_cast<Layout::Node*>(layout_node_pointer)->parent(); },
+        .remove_layout_node = [](void* layout_node_pointer) {
+            VERIFY(layout_node_pointer);
+            static_cast<Layout::Node*>(layout_node_pointer)->remove(); },
+        .clear_element_subtree = [](void* element_pointer) {
+            VERIFY(element_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            element.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return clear_stale_layout_and_paint_node(node, &element);
+            }); },
+        .slot_element = [](void* element_pointer) -> void* {
+            VERIFY(element_pointer);
+            return as_if<HTML::HTMLSlotElement>(*static_cast<DOM::Element*>(element_pointer)); },
+        .clear_assigned_slottables = [](void* slot_element_pointer) {
+            VERIFY(slot_element_pointer);
+            clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
+    };
+    RustFFI::rust_detach_top_layer_element_layout_subtree(&callbacks, &element);
 }
 
 struct PrincipalNodeFrame {
     RefPtr<Layout::Node> old_layout_node;
     RefPtr<Layout::Node> layout_node;
+    RefPtr<NodeWithStyle> backdrop_node;
     RefPtr<CSS::ComputedValues const> computed_values;
     CSS::Display display;
 };
@@ -862,6 +844,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
                 .layout_node_is_replaced_box_with_children = layout_node.is_replaced_box_with_children(),
                 .layout_node_is_list_item_box = layout_node.is_list_item_box(),
                 .layout_node_is_block_container = is<BlockContainer>(layout_node),
+                .has_first_letter_style = element && element->computed_values(CSS::PseudoElement::FirstLetter),
                 .is_svg_switch_element = is<SVG::SVGSwitchElement>(node),
                 .is_document = node.is_document(),
                 .has_style_containment = is<NodeWithStyle>(layout_node) && static_cast<NodeWithStyle&>(layout_node).has_style_containment(),
@@ -891,9 +874,12 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
             VERIFY(layout_node_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->wrap_in_button_layout_tree_if_needed(
-                *static_cast<DOM::Node*>(node_pointer),
-                *static_cast<Layout::Node*>(layout_node_pointer)); },
+            auto* html_element = as_if<HTML::HTMLElement>(*static_cast<DOM::Node*>(node_pointer));
+            auto callbacks = make_ffi_tree_builder_callbacks(static_cast<TreeBuilder*>(builder_pointer));
+            RustFFI::rust_wrap_button_contents_if_needed(
+                &callbacks,
+                layout_node_pointer,
+                html_element && html_element->uses_button_layout()); },
         .clear_stale_descendants = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);
@@ -933,9 +919,18 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .rendered_in_top_layer = [](void* element_pointer) {
             VERIFY(element_pointer);
             return static_cast<DOM::Element*>(element_pointer)->rendered_in_top_layer(); },
-        .has_unrendered_flat_tree_ancestor = [](void* element_pointer) {
-            VERIFY(element_pointer);
-            return element_has_an_unrendered_flat_tree_ancestor(*static_cast<DOM::Element*>(element_pointer)); },
+        .flat_tree_parent = [](void* node_pointer) -> void* {
+            VERIFY(node_pointer);
+            return static_cast<DOM::Node*>(node_pointer)->flat_tree_parent(); },
+        .flat_tree_render_facts = [](void* node_pointer) -> RustFFI::FfiFlatTreeRenderFacts {
+            VERIFY(node_pointer);
+            auto* element = as_if<DOM::Element>(*static_cast<DOM::Node*>(node_pointer));
+            auto computed_values = element ? element->computed_values() : nullptr;
+            return {
+                .is_element = element != nullptr,
+                .has_computed_style = computed_values != nullptr,
+                .display_is_none = computed_values && computed_values->display().is_none(),
+            }; },
         .clear_stale_top_layer_subtree = [](void* builder_pointer, void* element_pointer) {
             VERIFY(builder_pointer);
             VERIFY(element_pointer);
@@ -1020,6 +1015,7 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
             // NB: Called during layout tree construction.
             frame.old_layout_node = node.unsafe_layout_node();
             frame.layout_node = nullptr;
+            frame.backdrop_node = nullptr;
             frame.computed_values = nullptr; },
         .prepare_principal_element = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool should_create_layout_node) -> RustFFI::FfiPrincipalDisplayFacts {
             VERIFY(builder_pointer);
@@ -1171,15 +1167,28 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .mark_update_escaped_rebuild_roots = [](void* builder_pointer) {
             VERIFY(builder_pointer);
             static_cast<TreeBuilder*>(builder_pointer)->m_layout_tree_update_escaped_rebuild_roots = true; },
-        .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool may_replace_existing_layout_node) {
+        .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool append) -> void* {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            static_cast<TreeBuilder*>(builder_pointer)->create_backdrop_for_top_layer_element_if_needed(
+            frame.backdrop_node = builder.create_pseudo_element_if_needed(
                 *static_cast<DOM::Element*>(element_pointer),
-                frame.old_layout_node,
-                may_replace_existing_layout_node); },
+                CSS::PseudoElement::Backdrop,
+                append ? Optional<AppendOrPrepend> { AppendOrPrepend::Append } : Optional<AppendOrPrepend> {});
+            return frame.backdrop_node.ptr(); },
+        .insert_principal_backdrop_before_old = [](void* builder_pointer, void* frame_pointer, void* backdrop_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(backdrop_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            VERIFY(frame.old_layout_node);
+            VERIFY(frame.old_layout_node->parent());
+            auto& backdrop = *static_cast<Layout::Node*>(backdrop_pointer);
+            builder.note_tree_restructuring_at(*frame.old_layout_node->parent());
+            frame.old_layout_node->parent()->insert_before(backdrop, frame.old_layout_node); },
         .place_principal_layout = [](void* builder_pointer, void* frame_pointer, RustFFI::FfiPrincipalBoxPlacement placement) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
@@ -1237,13 +1246,25 @@ void TreeBuilder::clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlo
 {
     // Assigned slottables are flat tree children of a slot, not DOM descendants, so subtree
     // cleanup of the slot does not reach them.
-    for (auto const& slottable : slot_element.assigned_nodes_internal()) {
-        slottable.visit([&](DOM::Node& slottable_root) {
-            slottable_root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
-                return clear_stale_layout_and_paint_node(node, &slottable_root);
-            });
-        });
-    }
+    RustFFI::FfiAssignedCleanupCallbacks callbacks {
+        .assigned_node_count = [](void* slot_element_pointer) {
+            VERIFY(slot_element_pointer);
+            return static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal().size(); },
+        .assigned_node_at = [](void* slot_element_pointer, size_t index) -> void* {
+            VERIFY(slot_element_pointer);
+            auto assigned_nodes = static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)->assigned_nodes_internal();
+            VERIFY(index < assigned_nodes.size());
+            DOM::Node* node = nullptr;
+            assigned_nodes[index].visit([&](auto& assigned_node) { node = assigned_node.ptr(); });
+            return node; },
+        .clear_assigned_subtree = [](void* root_pointer) {
+            VERIFY(root_pointer);
+            auto& root = *static_cast<DOM::Node*>(root_pointer);
+            root.for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return clear_stale_layout_and_paint_node(node, &root);
+            }); },
+    };
+    RustFFI::rust_clear_stale_assigned_slottables(&callbacks, &slot_element);
 }
 
 // Elements inside a `display:none` subtree are skipped by `Document::update_style_recursively`,
@@ -1264,7 +1285,13 @@ static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node)
 {
     auto& document = text_node.document();
     RefPtr<Layout::Node> layout_node = make_ref_counted<Layout::TextNode>(document, text_node);
-    if (auto* style_parent = display_contents_style_parent_for_text_node(text_node); style_parent && display_contents_text_needs_style_wrapper(text_node, *style_parent)) {
+    auto* style_parent = as_if<DOM::Element>(text_node.flat_tree_parent());
+    auto style_parent_values = style_parent ? style_parent->computed_values() : nullptr;
+    if (RustFFI::rust_display_contents_text_needs_style_wrapper(
+            style_parent_values != nullptr,
+            style_parent_values && style_parent_values->display().is_contents(),
+            text_node.data().is_ascii_whitespace(),
+            style_parent_values && first_is_one_of(style_parent_values->white_space_collapse(), CSS::WhiteSpaceCollapse::Collapse))) {
         auto wrapper = make_ref_counted<Layout::InlineNode>(document, nullptr, style_parent->computed_values().release_nonnull());
         wrapper->attach_style_resources();
         wrapper->set_display(CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow));
@@ -1273,23 +1300,6 @@ static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text& text_node)
         return wrapper;
     }
     return layout_node;
-}
-
-// Each element rendered in the top layer has a ::backdrop pseudo-element, for which it is the
-// originating element. When the element's box replaces an existing one in place, the ::backdrop
-// box must be inserted before the old box so it ends up behind the element; otherwise it is
-// appended before the element's own box is.
-void TreeBuilder::create_backdrop_for_top_layer_element_if_needed(DOM::Element& element, Layout::Node* old_layout_node, bool may_replace_existing_layout_node)
-{
-    if (may_replace_existing_layout_node) {
-        if (auto backdrop_node = create_pseudo_element_if_needed(element, CSS::PseudoElement::Backdrop, {})) {
-            // The ::backdrop box is a fresh sibling of the rebuild root, outside it.
-            note_tree_restructuring_at(*old_layout_node->parent());
-            old_layout_node->parent()->insert_before(*backdrop_node, old_layout_node);
-        }
-    } else {
-        (void)create_pseudo_element_if_needed(element, CSS::PseudoElement::Backdrop, AppendOrPrepend::Append);
-    }
 }
 
 void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree)
@@ -1326,13 +1336,6 @@ static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithSt
         values.set_min_height(CSS::Size::make_px(CSSPixels(0)));
     });
     return content_box_wrapper;
-}
-
-void TreeBuilder::wrap_in_button_layout_tree_if_needed(DOM::Node& dom_node, Layout::Node& layout_node)
-{
-    auto const* html_element = as_if<HTML::HTMLElement>(dom_node);
-    auto callbacks = make_ffi_tree_builder_callbacks(this);
-    RustFFI::rust_wrap_button_contents_if_needed(&callbacks, &layout_node, html_element && html_element->uses_button_layout());
 }
 
 RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -752,32 +752,6 @@ RefPtr<NodeWithStyle> TreeBuilder::create_content_replacement_if_needed(DOM::Ele
     return create_content_image_box(element.document(), element, move(computed_values), const_cast<CSS::AbstractImageStyleValue&>(*replacement_image));
 }
 
-static bool is_ignorable_whitespace(Layout::Node const& node)
-{
-    if (auto* text_node = as_if<TextNode>(node); text_node && text_node->text_for_rendering().is_ascii_whitespace())
-        return true;
-
-    if (node.is_anonymous() && node.is_block_container() && node.children_are_inline()) {
-        bool contains_only_white_space = true;
-        node.for_each_in_inclusive_subtree([&contains_only_white_space](auto& descendant) {
-            if (auto* text_node = as_if<TextNode>(descendant)) {
-                if (!text_node->text_for_rendering().is_ascii_whitespace()) {
-                    contains_only_white_space = false;
-                    return TraversalDecision::Break;
-                }
-            } else if (descendant.is_out_of_flow() || !descendant.is_anonymous()) {
-                contains_only_white_space = false;
-                return TraversalDecision::Break;
-            }
-            return TraversalDecision::Continue;
-        });
-        if (contains_only_white_space)
-            return true;
-    }
-
-    return false;
-}
-
 static bool is_svg_resource_box(Node const& layout_node)
 {
     return is<SVGPatternBox>(layout_node) || is<SVGMaskBox>(layout_node) || is<SVGClipBox>(layout_node);
@@ -1564,428 +1538,222 @@ RefPtr<Layout::Node> TreeBuilder::build(DOM::Node& dom_node)
     return m_layout_root;
 }
 
-template<CSS::DisplayInternal internal, typename Callback>
-void TreeBuilder::for_each_in_tree_with_internal_display(NodeWithStyle& root, Callback callback)
+static RustFFI::FfiTableDisplay ffi_table_display(CSS::Display display)
 {
-    root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& box) {
-        auto const display = box.display();
-        if (display.is_internal() && display.internal() == internal)
-            callback(box);
-        return TraversalDecision::Continue;
-    });
+    if (display.is_table_inside())
+        return RustFFI::FfiTableDisplay::TableRoot;
+    if (display.is_table_row_group())
+        return RustFFI::FfiTableDisplay::TableRowGroup;
+    if (display.is_table_header_group())
+        return RustFFI::FfiTableDisplay::TableHeaderGroup;
+    if (display.is_table_footer_group())
+        return RustFFI::FfiTableDisplay::TableFooterGroup;
+    if (display.is_table_column_group())
+        return RustFFI::FfiTableDisplay::TableColumnGroup;
+    if (display.is_table_column())
+        return RustFFI::FfiTableDisplay::TableColumn;
+    if (display.is_table_row())
+        return RustFFI::FfiTableDisplay::TableRow;
+    if (display.is_table_cell())
+        return RustFFI::FfiTableDisplay::TableCell;
+    if (display.is_table_caption())
+        return RustFFI::FfiTableDisplay::TableCaption;
+    return RustFFI::FfiTableDisplay::Other;
 }
 
-template<CSS::DisplayInside inside, typename Callback>
-void TreeBuilder::for_each_in_tree_with_inside_display(NodeWithStyle& root, Callback callback)
+static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_pointer)
 {
-    root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& box) {
-        auto const display = box.display();
-        if (display.is_outside_and_inside() && display.inside() == inside)
-            callback(box);
-        return TraversalDecision::Continue;
-    });
-}
-
-// https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-void TreeBuilder::fixup_tables(NodeWithStyle& root)
-{
-    remove_irrelevant_boxes(root);
-    generate_missing_child_wrappers(root);
-    auto table_root_boxes = generate_missing_parents(root);
-    missing_cells_fixup(table_root_boxes);
-}
-
-static bool is_first_or_last_child_with_table_non_root_sibling_if_any(Node const& node)
-{
-    auto is_table_non_root_box = [](Node const& node) {
-        auto const* node_with_style = as_if<NodeWithStyle>(node);
-        if (!node_with_style)
-            return false;
-        auto const display = node_with_style->display();
-        return display.is_table_row()
-            || display.is_table_column()
-            || display.is_table_row_group()
-            || display.is_table_header_group()
-            || display.is_table_footer_group()
-            || display.is_table_column_group()
-            || display.is_table_cell()
-            || display.is_table_caption();
+    VERIFY(node_pointer);
+    auto& node = *static_cast<Node*>(node_pointer);
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    auto const* text_node = as_if<TextNode>(node);
+    return {
+        .current_display = node_with_style ? ffi_table_display(node_with_style->display()) : RustFFI::FfiTableDisplay::Other,
+        .display_before_box_type_transformation = node_with_style ? ffi_table_display(node_with_style->display_before_box_type_transformation()) : RustFFI::FfiTableDisplay::Other,
+        .is_box = is<Box>(node),
+        .has_style = node.has_style(),
+        .is_anonymous = node.is_anonymous(),
+        .is_block_container = node.is_block_container(),
+        .children_are_inline = node.children_are_inline(),
+        .is_out_of_flow = node.is_out_of_flow(),
+        .is_text = text_node != nullptr,
+        .text_is_ascii_whitespace = text_node && text_node->text_for_rendering().is_ascii_whitespace(),
+        .is_inline_outside = node_with_style && node_with_style->display().is_inline_outside(),
+        .is_table_wrapper = node.is_table_wrapper(),
+        .has_been_wrapped_in_table_wrapper = node.has_been_wrapped_in_table_wrapper(),
+        .has_replaced_element_table_display_adjustment = node_with_style && node_with_style->has_replaced_element_table_display_adjustment(),
     };
-
-    auto previous_sibling = node.previous_sibling();
-    auto next_sibling = node.next_sibling();
-    if (previous_sibling && next_sibling)
-        return false;
-
-    if (previous_sibling && !is_table_non_root_box(*previous_sibling))
-        return false;
-
-    if (next_sibling && !is_table_non_root_box(*next_sibling))
-        return false;
-
-    return true;
 }
 
-// https://drafts.csswg.org/css-tables-3/#tabular-container
-static bool is_tabular_container(Node const& node)
+static void* ffi_layout_node_parent(void*, void* node_pointer)
 {
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    if (!node_with_style)
-        return false;
-    auto const& display = node_with_style->display();
-    return display.is_table_inside()
-        || display.is_table_row()
-        || display.is_table_row_group()
-        || display.is_table_header_group()
-        || display.is_table_footer_group();
+    VERIFY(node_pointer);
+    return static_cast<Node*>(node_pointer)->parent();
 }
 
-// https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-// 1. Remove irrelevant boxes:
-void TreeBuilder::remove_irrelevant_boxes(NodeWithStyle& root)
+static void* ffi_layout_node_first_child(void*, void* node_pointer)
 {
-    // The following boxes are discarded as if they were display:none:
-
-    Vector<NonnullRefPtr<Node>> to_remove;
-
-    // 1. Children of a table-column.
-    for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableColumn>(root, [&](Box& table_column) {
-        table_column.for_each_child([&](auto& child) {
-            to_remove.append(child);
-            return IterationDecision::Continue;
-        });
-    });
-
-    // 2. Children of a table-column-group which are not a table-column.
-    for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableColumnGroup>(root, [&](Box& table_column_group) {
-        table_column_group.for_each_child([&](auto& child) {
-            auto const* child_with_style = as_if<NodeWithStyle>(child);
-            if (!child_with_style || !child_with_style->display().is_table_column())
-                to_remove.append(child);
-            return IterationDecision::Continue;
-        });
-    });
-
-    // FIXME: 3. Anonymous inline boxes which contain only white space and are between two immediate siblings each of
-    //           which is a table-non-root box.
-
-    // 4. Anonymous inline boxes which meet all of the following criteria:
-    //    - they contain only white space
-    //    - they are the first and/or last child of a tabular container
-    //    - whose immediate sibling, if any, is a table-non-root box
-    root.for_each_in_inclusive_subtree_of_type<Box>([&](auto& box) {
-        auto* parent = box.parent();
-        if (!parent
-            || !is_tabular_container(*parent)
-            || !is_first_or_last_child_with_table_non_root_sibling_if_any(box)) {
-            return TraversalDecision::Continue;
-        }
-
-        if (is_ignorable_whitespace(box)) {
-            to_remove.append(box);
-            return TraversalDecision::SkipChildrenAndContinue;
-        }
-        return TraversalDecision::Continue;
-    });
-
-    for (auto& box : to_remove)
-        box->parent()->remove_child(*box);
+    VERIFY(node_pointer);
+    return static_cast<Node*>(node_pointer)->first_child().ptr();
 }
 
-static bool is_table_track(CSS::Display display)
+static void* ffi_layout_node_next_sibling(void*, void* node_pointer)
 {
-    return display.is_table_row() || display.is_table_column();
+    VERIFY(node_pointer);
+    return static_cast<Node*>(node_pointer)->next_sibling().ptr();
 }
 
-static bool is_table_track_group(CSS::Display display)
+static void* ffi_layout_node_previous_sibling(void*, void* node_pointer)
 {
-    // Unless explicitly mentioned otherwise, mentions of table-row-groups in this spec also encompass the specialized
-    // table-header-groups and table-footer-groups.
-    return display.is_table_row_group()
-        || display.is_table_header_group()
-        || display.is_table_footer_group()
-        || display.is_table_column_group();
+    VERIFY(node_pointer);
+    return static_cast<Node*>(node_pointer)->previous_sibling().ptr();
 }
 
-static CSS::Display display_for_table_fixup(NodeWithStyle const& node)
+static Vector<NonnullRefPtr<Node>> retain_ffi_layout_nodes(void* const* node_pointers, size_t node_count)
 {
-    // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-    // For the purposes of these rules, out-of-flow elements are represented as inline elements of zero width and
-    // height. Their containing blocks are chosen accordingly.
-    //
-    // AD-HOC: Table-internal boxes can be blockified before fixup. Use the pre-transformation display for authored
-    // boxes so an out-of-flow table-header-group is still recognized as a proper table child during fixup.
-    if (node.has_replaced_element_table_display_adjustment())
-        return node.display();
-    if (!node.is_anonymous())
-        return node.display_before_box_type_transformation();
-    return node.display();
-}
-
-static bool is_proper_table_child(NodeWithStyle const& node)
-{
-    auto const display = display_for_table_fixup(node);
-    return is_table_track_group(display) || is_table_track(display) || display.is_table_caption();
-}
-
-static bool is_not_proper_table_child(Node const& node)
-{
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    if (!node_with_style)
-        return true;
-    return !is_proper_table_child(*node_with_style);
-}
-
-static bool is_not_table_row(Node const& node)
-{
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    if (!node_with_style)
-        return true;
-    return !TableGrid::is_table_row(*node_with_style);
-}
-
-static bool is_table_column(Node const& node)
-{
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    return node_with_style && node_with_style->display().is_table_column();
-}
-
-static bool is_table_cell(Node const& node)
-{
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    return node_with_style && node_with_style->display().is_table_cell();
-}
-
-static bool is_not_table_cell(Node const& node)
-{
-    if (!node.has_style())
-        return true;
-    return !is_table_cell(node);
-}
-
-static bool is_table_row_group_column_group_or_caption(Node const& node)
-{
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    if (!node_with_style)
-        return false;
-    auto const display = display_for_table_fixup(*node_with_style);
-    return is_table_track_group(display) || display.is_table_caption();
-}
-
-template<typename Matcher, typename Callback>
-static void for_each_sequence_of_consecutive_children_matching(NodeWithStyle& parent, Matcher matcher, Callback callback)
-{
-    Vector<NonnullRefPtr<Node>> sequence;
-
-    auto sequence_is_all_ignorable_whitespace = [&]() -> bool {
-        for (auto& node : sequence) {
-            if (!is_ignorable_whitespace(*node))
-                return false;
-        }
-        return true;
-    };
-
-    for (auto child = parent.first_child(); child; child = child->next_sibling()) {
-        if (matcher(*child) || (!sequence.is_empty() && is_ignorable_whitespace(*child))) {
-            sequence.append(*child);
-        } else {
-            if (!sequence.is_empty()) {
-                if (!sequence_is_all_ignorable_whitespace())
-                    callback(sequence, child);
-                sequence.clear();
-            }
-        }
+    Vector<NonnullRefPtr<Node>> nodes;
+    nodes.ensure_capacity(node_count);
+    for (size_t index = 0; index < node_count; ++index) {
+        VERIFY(node_pointers[index]);
+        nodes.unchecked_append(*static_cast<Node*>(node_pointers[index]));
     }
-    if (!sequence.is_empty() && !sequence_is_all_ignorable_whitespace())
-        callback(sequence, nullptr);
+    return nodes;
 }
 
-template<typename WrapperBoxType>
-static void wrap_in_anonymous(Vector<NonnullRefPtr<Node>>& sequence, Node* nearest_sibling, CSS::Display display)
+static void ffi_remove_layout_nodes(void*, void* const* node_pointers, size_t node_count)
 {
-    VERIFY(!sequence.is_empty());
+    auto nodes = retain_ffi_layout_nodes(node_pointers, node_count);
+    for (auto& node : nodes) {
+        VERIFY(node->parent());
+        node->parent()->remove_child(*node);
+    }
+}
+
+static void ffi_wrap_in_anonymous_table_box(void*, void* const* node_pointers, size_t node_count, void* nearest_sibling_pointer, RustFFI::FfiAnonymousTableBoxKind kind)
+{
+    VERIFY(node_count > 0);
+    auto sequence = retain_ffi_layout_nodes(node_pointers, node_count);
     auto& parent = *sequence.first()->parent();
     auto builder = CSS::ComputedValues::Builder::create_inheriting_from(parent.computed_values());
-    builder->set_display(display);
-    auto wrapper = make_ref_counted<WrapperBoxType>(parent.document(), nullptr, move(builder).build());
+    switch (kind) {
+    case RustFFI::FfiAnonymousTableBoxKind::TableRow:
+        builder->set_display(CSS::Display { CSS::DisplayInternal::TableRow });
+        break;
+    case RustFFI::FfiAnonymousTableBoxKind::TableCell:
+        builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
+        break;
+    case RustFFI::FfiAnonymousTableBoxKind::Table:
+        builder->set_display(CSS::Display::from_short(CSS::Display::Short::Table));
+        break;
+    case RustFFI::FfiAnonymousTableBoxKind::InlineTable:
+        builder->set_display(CSS::Display::from_short(CSS::Display::Short::InlineTable));
+        break;
+    }
+
+    auto wrapper = [&]() -> NonnullRefPtr<NodeWithStyle> {
+        if (kind == RustFFI::FfiAnonymousTableBoxKind::TableCell)
+            return make_ref_counted<BlockContainer>(parent.document(), nullptr, move(builder).build());
+        return make_ref_counted<Box>(parent.document(), nullptr, move(builder).build());
+    }();
     for (auto& child : sequence) {
         parent.remove_child(*child);
         wrapper->append_child(*child);
     }
     wrapper->set_children_are_inline(parent.children_are_inline());
-    if (nearest_sibling)
-        parent.insert_before(*wrapper, *nearest_sibling);
+    if (nearest_sibling_pointer)
+        parent.insert_before(*wrapper, *static_cast<Node*>(nearest_sibling_pointer));
     else
         parent.append_child(*wrapper);
 }
 
-// https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-// 2. Generate missing child wrappers:
-void TreeBuilder::generate_missing_child_wrappers(NodeWithStyle& root)
+static NonnullRefPtr<CSS::ComputedValues const> table_wrapper_computed_values(Box& table_box)
 {
-    // 1. An anonymous table-row box must be generated around each sequence of consecutive children of a table-root box
-    //    which are not proper table child boxes.
-    for_each_in_tree_with_inside_display<CSS::DisplayInside::Table>(root, [&](auto& parent) {
-        for_each_sequence_of_consecutive_children_matching(parent, is_not_proper_table_child, [&](auto sequence, auto nearest_sibling) {
-            wrap_in_anonymous<Box>(sequence, nearest_sibling, CSS::Display { CSS::DisplayInternal::TableRow });
-        });
-    });
+    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(table_box.computed_values());
+    table_box.transfer_table_box_computed_values_to_wrapper_computed_values(builder);
+    return move(builder).build();
+}
 
-    // 2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-group
-    //    box which are not table-row boxes.
-    for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableRowGroup>(root, [&](auto& parent) {
-        for_each_sequence_of_consecutive_children_matching(parent, is_not_table_row, [&](auto& sequence, auto nearest_sibling) {
-            wrap_in_anonymous<Box>(sequence, nearest_sibling, CSS::Display { CSS::DisplayInternal::TableRow });
-        });
-    });
-    // Unless explicitly mentioned otherwise, mentions of table-row-groups in this spec also encompass the specialized
-    // table-header-groups and table-footer-groups.
-    for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableHeaderGroup>(root, [&](auto& parent) {
-        for_each_sequence_of_consecutive_children_matching(parent, is_not_table_row, [&](auto& sequence, auto nearest_sibling) {
-            wrap_in_anonymous<Box>(sequence, nearest_sibling, CSS::Display { CSS::DisplayInternal::TableRow });
-        });
-    });
-    for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableFooterGroup>(root, [&](auto& parent) {
-        for_each_sequence_of_consecutive_children_matching(parent, is_not_table_row, [&](auto& sequence, auto nearest_sibling) {
-            wrap_in_anonymous<Box>(sequence, nearest_sibling, CSS::Display { CSS::DisplayInternal::TableRow });
-        });
-    });
+static void ffi_update_existing_table_wrapper(void*, void* table_root_pointer, void* wrapper_pointer)
+{
+    VERIFY(table_root_pointer);
+    VERIFY(wrapper_pointer);
+    auto& table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
+    auto& wrapper = as<TableWrapper>(*static_cast<Node*>(wrapper_pointer));
+    wrapper.set_computed_values(table_wrapper_computed_values(table_box));
+}
 
-    // 3. An anonymous table-cell box must be generated around each sequence of consecutive children of a table-row box
-    //    which are not table-cell boxes.
-    for_each_in_tree_with_internal_display<CSS::DisplayInternal::TableRow>(root, [&](auto& parent) {
-        for_each_sequence_of_consecutive_children_matching(parent, is_not_table_cell, [&](auto& sequence, auto nearest_sibling) {
-            wrap_in_anonymous<BlockContainer>(sequence, nearest_sibling, CSS::Display { CSS::DisplayInternal::TableCell });
-        });
-    });
+static void ffi_wrap_table_root(void*, void* table_root_pointer, void* nearest_sibling_pointer)
+{
+    VERIFY(table_root_pointer);
+    NonnullRefPtr table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
+    auto parent = table_box->parent();
+    VERIFY(parent);
+    auto wrapper = make_ref_counted<TableWrapper>(parent->document(), nullptr, table_wrapper_computed_values(*table_box));
+    parent->remove_child(*table_box);
+    wrapper->append_child(*table_box);
+    if (nearest_sibling_pointer)
+        parent->insert_before(*wrapper, *static_cast<Node*>(nearest_sibling_pointer));
+    else
+        parent->append_child(*wrapper);
+    table_box->set_has_been_wrapped_in_table_wrapper(true);
+}
+
+static void* ffi_create_table_grid(void*, void* table_root_pointer)
+{
+    VERIFY(table_root_pointer);
+    auto& table_box = as<Box>(*static_cast<Node*>(table_root_pointer));
+    return new TableGrid(TableGrid::calculate_row_column_grid(table_box));
+}
+
+static void ffi_destroy_table_grid(void*, void* table_grid_pointer)
+{
+    delete static_cast<TableGrid*>(table_grid_pointer);
+}
+
+static size_t ffi_table_grid_column_count(void*, void* table_grid_pointer)
+{
+    VERIFY(table_grid_pointer);
+    return static_cast<TableGrid*>(table_grid_pointer)->column_count();
+}
+
+static bool ffi_table_grid_is_occupied(void*, void* table_grid_pointer, size_t column_index, size_t row_index)
+{
+    VERIFY(table_grid_pointer);
+    return static_cast<TableGrid*>(table_grid_pointer)->occupancy_grid().contains({ column_index, row_index });
+}
+
+static void ffi_append_missing_table_cell(void*, void* row_pointer)
+{
+    VERIFY(row_pointer);
+    auto& row_box = as<Box>(*static_cast<Node*>(row_pointer));
+    auto builder = CSS::ComputedValues::Builder::create_inheriting_from(row_box.computed_values());
+    builder->set_display(CSS::Display { CSS::DisplayInternal::TableCell });
+    // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
+    builder->set_vertical_align(CSS::VerticalAlign::Middle);
+    row_box.append_child(make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
 }
 
 // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-// 3. Generate missing parents:
-Vector<NonnullRefPtr<Box>> TreeBuilder::generate_missing_parents(NodeWithStyle& root)
+void TreeBuilder::fixup_tables(NodeWithStyle& root)
 {
-    Vector<NonnullRefPtr<Box>> table_roots_to_wrap;
-    root.for_each_in_inclusive_subtree_of_type<NodeWithStyle>([&](auto& parent) {
-        // 1. An anonymous table-row box must be generated around each sequence of consecutive table-cell boxes whose
-        //    parent is not a table-row.
-        if (is_not_table_row(parent)) {
-            for_each_sequence_of_consecutive_children_matching(parent, is_table_cell, [&](auto& sequence, auto nearest_sibling) {
-                wrap_in_anonymous<Box>(sequence, nearest_sibling, CSS::Display { CSS::DisplayInternal::TableRow });
-            });
-        }
-
-        // 2. An anonymous table or inline-table box must be generated around each sequence of consecutive proper table
-        //    child boxes which are misparented.
-        {
-            // If the box’s parent is an inline, run-in, or ruby box (or any box that would perform inlinification of
-            // its children), then an inline-table box must be generated; otherwise it must be a table box.
-            // FIXME: run-in and ruby boxes
-            auto display = CSS::Display::from_short(parent.display().is_inline_outside() ? CSS::Display::Short::InlineTable : CSS::Display::Short::Table);
-
-            // A table-row is misparented if its parent is neither a table-row-group nor a table-root box.
-            if (!TableGrid::is_table_row_group(parent) && !parent.display().is_table_inside()) {
-                for_each_sequence_of_consecutive_children_matching(parent, TableGrid::is_table_row, [&](auto& sequence, auto nearest_sibling) {
-                    wrap_in_anonymous<Box>(sequence, nearest_sibling, display);
-                });
-            }
-
-            // A table-column box is misparented if its parent is neither a table-column-group box nor a table-root box.
-            if (!TableGrid::is_table_column_group(parent) && !parent.display().is_table_inside()) {
-                for_each_sequence_of_consecutive_children_matching(parent, is_table_column, [&](auto& sequence, auto nearest_sibling) {
-                    wrap_in_anonymous<Box>(sequence, nearest_sibling, display);
-                });
-            }
-
-            // A table-row-group, table-column-group, or table-caption box is misparented if its parent is not a table-root box.
-            if (!parent.display().is_table_inside()) {
-                for_each_sequence_of_consecutive_children_matching(parent, is_table_row_group_column_group_or_caption, [&](auto& sequence, auto nearest_sibling) {
-                    wrap_in_anonymous<Box>(sequence, nearest_sibling, display);
-                });
-            }
-        }
-
-        // 3. An anonymous table-wrapper box must be generated around each table-root.
-        if (auto* box = as_if<Box>(parent); box && box->display().is_table_inside()) {
-            if (box->has_been_wrapped_in_table_wrapper()) {
-                VERIFY(parent.parent());
-                VERIFY(parent.parent()->is_table_wrapper());
-                return TraversalDecision::Continue;
-            }
-
-            table_roots_to_wrap.append(*box);
-        }
-
-        return TraversalDecision::Continue;
-    });
-
-    for (auto& table_box : table_roots_to_wrap) {
-        auto nearest_sibling = table_box->next_sibling();
-        auto& parent = *table_box->parent();
-
-        auto builder = CSS::ComputedValues::Builder::create_inheriting_from(table_box->computed_values());
-        table_box->transfer_table_box_computed_values_to_wrapper_computed_values(builder);
-        auto wrapper_computed_values = move(builder).build();
-
-        if (parent.is_table_wrapper()) {
-            auto& existing_wrapper = static_cast<TableWrapper&>(parent);
-            existing_wrapper.set_computed_values(move(wrapper_computed_values));
-            continue;
-        }
-
-        auto wrapper = make_ref_counted<TableWrapper>(parent.document(), nullptr, move(wrapper_computed_values));
-
-        parent.remove_child(*table_box);
-        wrapper->append_child(*table_box);
-
-        if (nearest_sibling)
-            parent.insert_before(*wrapper, *nearest_sibling);
-        else
-            parent.append_child(*wrapper);
-
-        table_box->set_has_been_wrapped_in_table_wrapper(true);
-    }
-
-    return table_roots_to_wrap;
-}
-
-static void fixup_row(Box& row_box, TableGrid const& table_grid, size_t row_index)
-{
-    for (size_t column_index = 0; column_index < table_grid.column_count(); ++column_index) {
-        if (table_grid.occupancy_grid().contains({ column_index, row_index }))
-            continue;
-
-        auto builder = CSS::ComputedValues::Builder::create_inheriting_from(row_box.computed_values());
-        builder->set_display(Web::CSS::Display { CSS::DisplayInternal::TableCell });
-        // Ensure that the cell (with zero content height) will have the same height as the row by setting vertical-align to middle.
-        builder->set_vertical_align(CSS::VerticalAlign::Middle);
-        auto cell_box = make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build());
-        row_box.append_child(cell_box);
-    }
-}
-
-// https://drafts.csswg.org/css-tables-3/#missing-cells-fixup
-void TreeBuilder::missing_cells_fixup(Vector<NonnullRefPtr<Box>> const& table_root_boxes)
-{
-    // Once the amount of columns in a table is known, any table-row box must be modified such that it owns enough
-    // cells to fill all the columns of the table, when taking spans into account. New table-cell anonymous boxes must
-    // be appended to its rows content until this condition is met.
-    for (auto& table_box : table_root_boxes) {
-        auto table_grid = TableGrid::calculate_row_column_grid(*table_box);
-        size_t row_index = 0;
-        TableGrid::for_each_child_box_matching(*table_box, TableGrid::is_table_row_group, [&](auto& row_group_box) {
-            TableGrid::for_each_child_box_matching(row_group_box, TableGrid::is_table_row, [&](auto& row_box) {
-                fixup_row(row_box, table_grid, row_index);
-                ++row_index;
-                return IterationDecision::Continue;
-            });
-        });
-
-        TableGrid::for_each_child_box_matching(*table_box, TableGrid::is_table_row, [&](auto& row_box) {
-            fixup_row(row_box, table_grid, row_index);
-            ++row_index;
-            return IterationDecision::Continue;
-        });
-    }
+    RustFFI::FfiTreeBuilderCallbacks callbacks {
+        .context = nullptr,
+        .layout_node_facts = ffi_layout_node_facts,
+        .parent = ffi_layout_node_parent,
+        .first_child = ffi_layout_node_first_child,
+        .next_sibling = ffi_layout_node_next_sibling,
+        .previous_sibling = ffi_layout_node_previous_sibling,
+        .remove_nodes = ffi_remove_layout_nodes,
+        .wrap_in_anonymous = ffi_wrap_in_anonymous_table_box,
+        .update_existing_table_wrapper = ffi_update_existing_table_wrapper,
+        .wrap_table_root = ffi_wrap_table_root,
+        .create_table_grid = ffi_create_table_grid,
+        .destroy_table_grid = ffi_destroy_table_grid,
+        .table_grid_column_count = ffi_table_grid_column_count,
+        .table_grid_is_occupied = ffi_table_grid_is_occupied,
+        .append_missing_table_cell = ffi_append_missing_table_cell,
+    };
+    RustFFI::rust_fixup_tables(&callbacks, &root);
 }
 
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -11,7 +11,6 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/Optional.h>
-#include <AK/TemporaryChange.h>
 #include <AK/Utf16String.h>
 #include <LibGfx/DecodedImageFrame.h>
 #include <LibUnicode/CharacterTypes.h>
@@ -102,6 +101,8 @@ void TreeBuilder::set_quote_nesting_level(u32 quote_nesting_level)
 }
 
 static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder*);
+static void update_style_if_needed_for_layout_tree_bypass_path(DOM::Element&);
+static RefPtr<Layout::Node> create_layout_node_for_text(DOM::Text&);
 
 void TreeBuilder::note_tree_restructuring_at(Layout::Node const& node)
 {
@@ -606,6 +607,25 @@ static bool element_has_an_unrendered_flat_tree_ancestor(DOM::Element const& ele
     return false;
 }
 
+struct PrincipalNodeFrame {
+    RefPtr<Layout::Node> old_layout_node;
+    RefPtr<Layout::Node> layout_node;
+    RefPtr<CSS::ComputedValues const> computed_values;
+    CSS::Display display;
+};
+
+static RustFFI::FfiPrincipalDisplayFacts ffi_principal_display_facts(CSS::Display display)
+{
+    return {
+        .display_is_none = display.is_none(),
+        .display_is_contents = display.is_contents(),
+        .display_is_table_inside = display.is_table_inside(),
+        .display_is_block_outside = display.is_block_outside(),
+        .display_is_internal_table = display.is_internal_table(),
+        .display_is_table_caption = display.is_table_caption(),
+    };
+}
+
 RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callbacks()
 {
     return {
@@ -849,6 +869,209 @@ RustFFI::FfiDomTreeBuilderCallbacks TreeBuilder::make_ffi_dom_tree_builder_callb
         .set_context_layout_svg_pattern = [](void* context_pointer, bool layout_svg_pattern) {
             VERIFY(context_pointer);
             static_cast<Context*>(context_pointer)->layout_svg_pattern = layout_svg_pattern; },
+        .principal_node_entry_facts = [](void*, void* node_pointer, void* context_pointer, bool must_create_subtree) -> RustFFI::FfiPrincipalNodeEntryFacts {
+            VERIFY(node_pointer);
+            VERIFY(context_pointer);
+            auto& node = *static_cast<DOM::Node*>(node_pointer);
+            auto& context = *static_cast<Context*>(context_pointer);
+            // NB: Called during layout tree construction.
+            auto* existing_layout_node = node.unsafe_layout_node();
+            auto* element = as_if<DOM::Element>(node);
+            return {
+                .must_create_subtree = must_create_subtree,
+                .needs_layout_tree_update = node.needs_layout_tree_update(),
+                .document_needs_full_layout_tree_update = node.document().needs_full_layout_tree_update(),
+                .is_document = node.is_document(),
+                .has_layout_node = existing_layout_node != nullptr,
+                .is_element = element != nullptr,
+                .is_text = is<DOM::Text>(node),
+                .rendered_in_top_layer = element && element->rendered_in_top_layer(),
+                .context_layout_top_layer = context.layout_top_layer,
+                .layout_node_is_attached = existing_layout_node && existing_layout_node->parent(),
+                .is_svg_container = node.is_svg_container(),
+                .requires_svg_container = node.requires_svg_container(),
+                .context_has_svg_root = context.has_svg_root,
+            }; },
+        .request_top_layer_zone_rebuild = [](void* node_pointer) {
+            VERIFY(node_pointer);
+            static_cast<DOM::Node*>(node_pointer)->document().set_top_layer_needs_layout_zone_rebuild(); },
+        .push_style_ancestor = [](void* element_pointer) {
+            VERIFY(element_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            element.document().style_computer().push_ancestor(element); },
+        .pop_style_ancestor = [](void* element_pointer) {
+            VERIFY(element_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            element.document().style_computer().pop_ancestor(element); },
+        .initialize_principal_frame = [](void* frame_pointer, void* node_pointer) {
+            VERIFY(frame_pointer);
+            VERIFY(node_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            auto& node = *static_cast<DOM::Node*>(node_pointer);
+            // NB: Called during layout tree construction.
+            frame.old_layout_node = node.unsafe_layout_node();
+            frame.layout_node = nullptr;
+            frame.computed_values = nullptr; },
+        .prepare_principal_element = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool should_create_layout_node) -> RustFFI::FfiPrincipalDisplayFacts {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            auto& element = *static_cast<DOM::Element*>(element_pointer);
+            if (should_create_layout_node) {
+                // ::backdrop is a sibling of the element, not a child, so unlike other pseudo-elements, it is not
+                // automatically discarded when the element's layout is recomputed.
+                if (auto old_backdrop_node = element.pseudo_element_unsafe_layout_node(CSS::PseudoElement::Backdrop)) {
+                    builder.m_layout_tree_update_escaped_rebuild_roots = true;
+                    old_backdrop_node->remove();
+                }
+                element.clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
+                update_style_if_needed_for_layout_tree_bypass_path(element);
+            }
+            frame.computed_values = element.computed_values();
+            frame.display = frame.computed_values->display();
+            return ffi_principal_display_facts(frame.display); },
+        .create_principal_element_layout = [](void* builder_pointer, void* frame_pointer, void* element_pointer, void* context_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            VERIFY(context_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            frame.layout_node = builder.create_layout_node_for_element(
+                *static_cast<DOM::Element*>(element_pointer),
+                *static_cast<Context*>(context_pointer)); },
+        .create_principal_document_layout = [](void* frame_pointer, void* document_pointer) {
+            VERIFY(frame_pointer);
+            VERIFY(document_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            auto& document = *static_cast<DOM::Document*>(document_pointer);
+            frame.computed_values = document.style_computer().create_document_style();
+            frame.display = frame.computed_values->display();
+            frame.layout_node = make_ref_counted<Layout::Viewport>(document, frame.computed_values.release_nonnull()); },
+        .create_principal_text_layout = [](void* frame_pointer, void* text_pointer) {
+            VERIFY(frame_pointer);
+            VERIFY(text_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            frame.layout_node = create_layout_node_for_text(*static_cast<DOM::Text*>(text_pointer));
+            frame.display = CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow); },
+        .reuse_principal_layout = [](void* frame_pointer, void* node_pointer) {
+            VERIFY(frame_pointer);
+            VERIFY(node_pointer);
+            // NB: Called during layout tree construction.
+            static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node = static_cast<DOM::Node*>(node_pointer)->unsafe_layout_node(); },
+        .principal_layout_node = [](void* frame_pointer) -> void* {
+            VERIFY(frame_pointer);
+            return static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node.ptr(); },
+        .attach_principal_style_resources = [](void* frame_pointer) {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            as<NodeWithStyle>(*frame.layout_node).attach_style_resources(); },
+        .principal_layout_facts = [](void* frame_pointer) -> RustFFI::FfiPrincipalLayoutFacts {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            return {
+                .is_replaced_element = frame.layout_node->is_replaced_element(),
+                .display = ffi_principal_display_facts(frame.display),
+            }; },
+        .apply_replaced_display_adjustment = [](void* frame_pointer, RustFFI::FfiReplacedElementDisplayAdjustment adjustment) {
+            VERIFY(frame_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Block)
+                frame.display = CSS::Display::from_short(CSS::Display::Short::Block);
+            else if (adjustment == RustFFI::FfiReplacedElementDisplayAdjustment::Inline)
+                frame.display = CSS::Display::from_short(CSS::Display::Short::Inline);
+            else
+                VERIFY_NOT_REACHED();
+            as<NodeWithStyle>(*frame.layout_node).set_display(frame.display); },
+        .principal_placement_facts = [](void* builder_pointer, void* frame_pointer, void* node_pointer, void* context_pointer, bool must_create_subtree, bool should_create_layout_node) -> RustFFI::FfiPrincipalBoxPlacementFacts {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(node_pointer);
+            VERIFY(context_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            auto& node = *static_cast<DOM::Node*>(node_pointer);
+            auto& context = *static_cast<Context*>(context_pointer);
+            VERIFY(frame.layout_node);
+            auto* element = as_if<DOM::Element>(node);
+            return {
+                .must_create_subtree = must_create_subtree,
+                .should_create_layout_node = should_create_layout_node,
+                .has_old_layout_node = frame.old_layout_node != nullptr,
+                .old_layout_node_is_attached = frame.old_layout_node && frame.old_layout_node->parent(),
+                .old_and_new_layout_nodes_are_same = frame.old_layout_node == frame.layout_node,
+                .has_current_rebuild_root = builder.m_current_rebuild_root != nullptr,
+                .is_document = node.is_document(),
+                .is_element = element != nullptr,
+                .rendered_in_top_layer = element && element->rendered_in_top_layer(),
+                .context_layout_top_layer = context.layout_top_layer,
+                .layout_node_is_svg_box = frame.layout_node->is_svg_box(),
+            }; },
+        .start_principal_rebuild_root = [](void* builder_pointer, void* frame_pointer) -> void* {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            auto* prior_rebuild_root = builder.m_current_rebuild_root;
+            builder.m_current_rebuild_root = frame.layout_node.ptr();
+            builder.m_rebuilt_subtree_roots.append(frame.layout_node.ptr());
+            return prior_rebuild_root; },
+        .restore_principal_rebuild_root = [](void* builder_pointer, void* rebuild_root_pointer) {
+            VERIFY(builder_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->m_current_rebuild_root = static_cast<Layout::Node*>(rebuild_root_pointer); },
+        .mark_update_escaped_rebuild_roots = [](void* builder_pointer) {
+            VERIFY(builder_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->m_layout_tree_update_escaped_rebuild_roots = true; },
+        .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool may_replace_existing_layout_node) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            VERIFY(element_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            static_cast<TreeBuilder*>(builder_pointer)->create_backdrop_for_top_layer_element_if_needed(
+                *static_cast<DOM::Element*>(element_pointer),
+                frame.old_layout_node,
+                may_replace_existing_layout_node); },
+        .place_principal_layout = [](void* builder_pointer, void* frame_pointer, RustFFI::FfiPrincipalBoxPlacement placement) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
+            VERIFY(frame.layout_node);
+            switch (placement) {
+            case RustFFI::FfiPrincipalBoxPlacement::None:
+                break;
+            case RustFFI::FfiPrincipalBoxPlacement::DocumentRoot:
+                builder.m_layout_root = frame.layout_node;
+                break;
+            case RustFFI::FfiPrincipalBoxPlacement::ReplaceExisting:
+                VERIFY(frame.old_layout_node);
+                transfer_saved_layout_state_to_replacement_box(*frame.old_layout_node, *frame.layout_node);
+                frame.old_layout_node->prepare_subtree_for_detach_from_layout_tree();
+                frame.old_layout_node->parent()->replace_child(*frame.layout_node, *frame.old_layout_node);
+                break;
+            case RustFFI::FfiPrincipalBoxPlacement::AppendSvg:
+                builder.current_parent().append_child(*frame.layout_node);
+                break;
+            case RustFFI::FfiPrincipalBoxPlacement::NormalInsertion:
+                builder.insert_node_into_inline_or_block_ancestor(*frame.layout_node, frame.display, AppendOrPrepend::Append);
+                break;
+            } },
+        .clear_stale_inclusive_subtree = [](void* builder_pointer, void* node_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(node_pointer);
+            auto& builder = *static_cast<TreeBuilder*>(builder_pointer);
+            static_cast<DOM::Node*>(node_pointer)->for_each_shadow_including_inclusive_descendant([&](auto& node) {
+                return builder.clear_stale_layout_and_paint_node(node);
+            }); },
+        .set_context_has_svg_root = [](void* context_pointer, bool has_svg_root) {
+            VERIFY(context_pointer);
+            static_cast<Context*>(context_pointer)->has_svg_root = has_svg_root; },
     };
 }
 
@@ -972,186 +1195,13 @@ void TreeBuilder::create_backdrop_for_top_layer_element_if_needed(DOM::Element& 
 
 void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& context, MustCreateSubtree must_create_subtree)
 {
-    // NB: Called during layout tree construction.
-    auto* existing_layout_node = dom_node.unsafe_layout_node();
-    auto entry_decision = RustFFI::rust_principal_node_entry_decision({
-        .must_create_subtree = must_create_subtree == MustCreateSubtree::Yes,
-        .needs_layout_tree_update = dom_node.needs_layout_tree_update(),
-        .document_needs_full_layout_tree_update = dom_node.document().needs_full_layout_tree_update(),
-        .is_document = dom_node.is_document(),
-        .has_layout_node = existing_layout_node != nullptr,
-        .is_element = dom_node.is_element(),
-        .rendered_in_top_layer = dom_node.is_element() && static_cast<DOM::Element&>(dom_node).rendered_in_top_layer(),
-        .context_layout_top_layer = context.layout_top_layer,
-        .layout_node_is_attached = existing_layout_node && existing_layout_node->parent(),
-        .is_svg_container = dom_node.is_svg_container(),
-        .requires_svg_container = dom_node.requires_svg_container(),
-        .context_has_svg_root = context.has_svg_root,
-    });
-    if (entry_decision.top_layer != RustFFI::FfiTopLayerEntryDecision::Continue) {
-        if (entry_decision.top_layer == RustFFI::FfiTopLayerEntryDecision::SkipAndRequestZoneRebuild) {
-            // A member found here without an attached box was cleared together with a hidden
-            // ancestor subtree, and nothing is scheduled to rebuild it: request a top layer
-            // zone rebuild, which runs as another update_layout pass and re-marks every member
-            // itself. Marking the member here instead would strand dirty flags under ancestors
-            // whose walks already finished, and a later update_layout would then treat the
-            // detached member boxes as up to date.
-            dom_node.document().set_top_layer_needs_layout_zone_rebuild();
-        }
-        return;
-    }
-    bool should_create_layout_node = entry_decision.should_create_layout_node;
-    if (dom_node.is_element())
-        dom_node.document().style_computer().push_ancestor(static_cast<DOM::Element const&>(dom_node));
-
-    ScopeGuard pop_ancestor_guard = [&] {
-        if (dom_node.is_element())
-            dom_node.document().style_computer().pop_ancestor(static_cast<DOM::Element const&>(dom_node));
-    };
-
-    // NB: Called during layout tree construction.
-    RefPtr<Layout::Node> old_layout_node = dom_node.unsafe_layout_node();
-    RefPtr<Layout::Node> layout_node;
-    Optional<TemporaryChange<bool>> has_svg_root_change;
-    auto& document = dom_node.document();
-    bool should_clear_stale_layout_subtree_if_no_layout_node = true;
-
-    ScopeGuard remove_stale_layout_node_guard = [&] {
-        // If we didn't create a layout node for this DOM node,
-        // go through the shadow-including subtree and remove any old layout & paint nodes since they are now all stale.
-        if (should_clear_stale_layout_subtree_if_no_layout_node && !layout_node) {
-            dom_node.for_each_shadow_including_inclusive_descendant([&](auto& node) {
-                return clear_stale_layout_and_paint_node(node);
-            });
-        }
-    };
-
-    if (entry_decision.svg == RustFFI::FfiSvgEntryDecision::EnterSvgRoot) {
-        has_svg_root_change.emplace(context.has_svg_root, true);
-    } else if (entry_decision.svg == RustFFI::FfiSvgEntryDecision::Skip) {
-        return;
-    }
-
-    auto& style_computer = document.style_computer();
-    RefPtr<CSS::ComputedValues const> computed_values;
-    CSS::Display display;
-
-    if (!should_create_layout_node) {
-        if (is<DOM::Element>(dom_node)) {
-            auto& element = static_cast<DOM::Element&>(dom_node);
-            computed_values = element.computed_values();
-            display = computed_values->display();
-            auto box_generation = RustFFI::rust_principal_box_generation_decision(true, false, display.is_contents());
-            if (box_generation == RustFFI::FfiPrincipalBoxGenerationDecision::DisplayContents) {
-                should_clear_stale_layout_subtree_if_no_layout_node = false;
-                update_layout_tree_for_display_contents(element, context, must_create_subtree, should_create_layout_node);
-                return;
-            }
-        }
-        // NB: Called during layout tree construction.
-        layout_node = dom_node.unsafe_layout_node();
-    } else {
-        if (is<DOM::Element>(dom_node)) {
-            auto& element = static_cast<DOM::Element&>(dom_node);
-            // ::backdrop is a sibling of the element, not a child, so unlike other pseudo-elements, it's not
-            // automatically discarded when element's layout is recomputed. We must remove it manually.
-            if (auto old_backdrop_node = element.pseudo_element_unsafe_layout_node(CSS::PseudoElement::Backdrop)) {
-                // A sibling-level mutation that runs before this element's own rebuild root is
-                // established, so it always escapes the rebuilt subtrees.
-                m_layout_tree_update_escaped_rebuild_roots = true;
-                old_backdrop_node->remove();
-            }
-            element.clear_synthetic_pseudo_element_layout_nodes(Badge<TreeBuilder> {});
-            update_style_if_needed_for_layout_tree_bypass_path(element);
-            computed_values = element.computed_values();
-            display = computed_values->display();
-            auto box_generation = RustFFI::rust_principal_box_generation_decision(true, display.is_none(), display.is_contents());
-            if (box_generation == RustFFI::FfiPrincipalBoxGenerationDecision::Suppress)
-                return;
-            if (box_generation == RustFFI::FfiPrincipalBoxGenerationDecision::DisplayContents) {
-                should_clear_stale_layout_subtree_if_no_layout_node = false;
-                update_layout_tree_for_display_contents(element, context, must_create_subtree, should_create_layout_node);
-                return;
-            }
-            layout_node = create_layout_node_for_element(element, context);
-        } else if (is<DOM::Document>(dom_node)) {
-            auto document_style = style_computer.create_document_style();
-            computed_values = move(document_style);
-            display = computed_values->display();
-            layout_node = make_ref_counted<Layout::Viewport>(static_cast<DOM::Document&>(dom_node), computed_values.release_nonnull());
-        } else if (is<DOM::Text>(dom_node)) {
-            layout_node = create_layout_node_for_text(static_cast<DOM::Text&>(dom_node));
-            display = CSS::Display(CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow);
-        }
-    }
-
-    if (!layout_node)
-        return;
-
-    if (is<DOM::Element>(dom_node) || is<DOM::Document>(dom_node))
-        as<NodeWithStyle>(*layout_node).attach_style_resources();
-
-    if (layout_node->is_replaced_element()) {
-        if (auto adjusted_display = adjusted_table_display_for_replaced_element(display); adjusted_display.has_value()) {
-            display = *adjusted_display;
-            as<NodeWithStyle>(*layout_node).set_display(display);
-        }
-    }
-
-    auto* dom_element = as_if<DOM::Element>(dom_node);
-    auto placement_decision = RustFFI::rust_principal_box_placement_decision({
-        .must_create_subtree = must_create_subtree == MustCreateSubtree::Yes,
-        .should_create_layout_node = should_create_layout_node,
-        .has_old_layout_node = old_layout_node != nullptr,
-        .old_layout_node_is_attached = old_layout_node && old_layout_node->parent(),
-        .old_and_new_layout_nodes_are_same = old_layout_node == layout_node,
-        .has_current_rebuild_root = m_current_rebuild_root != nullptr,
-        .is_document = dom_node.is_document(),
-        .is_element = dom_element != nullptr,
-        .rendered_in_top_layer = dom_element && dom_element->rendered_in_top_layer(),
-        .context_layout_top_layer = context.layout_top_layer,
-        .layout_node_is_svg_box = layout_node->is_svg_box(),
-    });
-
-    Optional<TemporaryChange<Layout::Node*>> current_rebuild_root_change;
-    if (placement_decision.start_rebuild_root) {
-        current_rebuild_root_change.emplace(m_current_rebuild_root, layout_node.ptr());
-        m_rebuilt_subtree_roots.append(layout_node.ptr());
-    } else if (placement_decision.mark_update_escaped_rebuild_roots) {
-        // A fresh subtree that replaces no box in place (a ShadowRoot direct child, or a
-        // top-layer element revealed from display:none) belongs to no rebuild root, so nothing
-        // would lay its new boxes out on the partial path.
-        m_layout_tree_update_escaped_rebuild_roots = true;
-    }
-
-    if (placement_decision.create_backdrop)
-        create_backdrop_for_top_layer_element_if_needed(*dom_element, old_layout_node, placement_decision.may_replace_existing_layout_node);
-
-    // A top layer member nested inside this member must be skipped at its normal position
-    // like anywhere else in the walk, so its own turn of the pass builds its viewport box.
-    Optional<TemporaryChange<bool>> layout_top_layer_cleared_for_member_descendants;
-    if (placement_decision.clear_layout_top_layer_for_descendants)
-        layout_top_layer_cleared_for_member_descendants.emplace(context.layout_top_layer, false);
-
-    if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::DocumentRoot) {
-        m_layout_root = layout_node;
-    } else if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::ReplaceExisting) {
-        transfer_saved_layout_state_to_replacement_box(*old_layout_node, *layout_node);
-        old_layout_node->prepare_subtree_for_detach_from_layout_tree();
-        old_layout_node->parent()->replace_child(*layout_node, *old_layout_node);
-    } else if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::AppendSvg) {
-        current_parent().append_child(*layout_node);
-    } else if (placement_decision.placement == RustFFI::FfiPrincipalBoxPlacement::NormalInsertion) {
-        insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
-    }
-
+    PrincipalNodeFrame frame;
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    RustFFI::rust_update_principal_node_descendants(
+    RustFFI::rust_update_layout_tree(
         &callbacks,
+        &frame,
         &dom_node,
-        layout_node.ptr(),
         &context,
-        should_create_layout_node,
         must_create_subtree == MustCreateSubtree::Yes);
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -61,29 +61,24 @@ public:
 
     LayoutTreeBuildResult build(DOM::Node&);
 
-    enum class AppendOrPrepend {
-        Append,
-        Prepend,
-    };
-
     void note_tree_restructuring_at(Layout::Node const&);
     static void detach_top_layer_element_layout_subtree(DOM::Element&);
 
 private:
     struct PrincipalNodeFrameStorage;
+    struct PseudoElementFrameStorage;
     static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
     static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
     RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
     RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
 
-    void insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle&, Layout::Node&, CSS::Display, AppendOrPrepend);
     static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
-    RefPtr<NodeWithStyle> create_pseudo_element_if_needed(void* rust_state, DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
     static void create_first_letter_wrapper(DOM::Element&, RustFFI::FfiFirstLetterTarget);
 
     RefPtr<Layout::Node> m_layout_root;
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
+    OwnPtr<PseudoElementFrameStorage> m_pseudo_element_frames;
 
     Layout::Node* m_current_rebuild_root { nullptr };
     Vector<Layout::Node*> m_rebuilt_subtree_roots;
@@ -119,17 +114,6 @@ void LayoutTreeBuildBridge::note_tree_restructuring_at(Layout::Node const& node)
 {
     if (m_current_rebuild_root && !m_current_rebuild_root->is_inclusive_ancestor_of(node))
         m_layout_tree_update_escaped_rebuild_roots = true;
-}
-
-void LayoutTreeBuildBridge::insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle& parent, Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
-{
-    auto callbacks = make_ffi_tree_builder_callbacks(this);
-    RustFFI::rust_insert_node_into_inline_or_block_ancestor(
-        &callbacks,
-        &parent,
-        &node,
-        display.is_inline_outside(),
-        mode == AppendOrPrepend::Append ? RustFFI::FfiInsertionMode::Append : RustFFI::FfiInsertionMode::Prepend);
 }
 
 class GeneratedContentImageProvider final
@@ -324,22 +308,6 @@ NonnullRefPtr<ListItemMarkerBox> LayoutTreeBuildBridge::create_and_attach_list_i
     return list_item_marker;
 }
 
-static RustFFI::FfiPseudoElement ffi_pseudo_element(CSS::PseudoElement pseudo_element)
-{
-    switch (pseudo_element) {
-    case CSS::PseudoElement::Before:
-        return RustFFI::FfiPseudoElement::Before;
-    case CSS::PseudoElement::After:
-        return RustFFI::FfiPseudoElement::After;
-    case CSS::PseudoElement::Marker:
-        return RustFFI::FfiPseudoElement::Marker;
-    case CSS::PseudoElement::Backdrop:
-        return RustFFI::FfiPseudoElement::Backdrop;
-    default:
-        return RustFFI::FfiPseudoElement::Other;
-    }
-}
-
 static CSS::PseudoElement css_pseudo_element(RustFFI::FfiPseudoElement pseudo_element)
 {
     switch (pseudo_element) {
@@ -380,27 +348,31 @@ struct PseudoElementFrame {
     RefPtr<Layout::Node> content_item;
 };
 
-RefPtr<NodeWithStyle> LayoutTreeBuildBridge::create_pseudo_element_if_needed(void* rust_state, DOM::Element& element, CSS::PseudoElement pseudo_element, Optional<AppendOrPrepend> insertion_mode)
-{
-    PseudoElementFrame frame;
-    auto callbacks = make_ffi_pseudo_tree_builder_callbacks();
-    auto* layout_node = RustFFI::rust_create_pseudo_element(
-        &callbacks,
-        &frame,
-        rust_state,
-        &element,
-        ffi_pseudo_element(pseudo_element),
-        insertion_mode.has_value(),
-        insertion_mode.value_or(AppendOrPrepend::Append) == AppendOrPrepend::Append
-            ? RustFFI::FfiInsertionMode::Append
-            : RustFFI::FfiInsertionMode::Prepend);
-    return static_cast<NodeWithStyle*>(layout_node);
-}
+struct LayoutTreeBuildBridge::PseudoElementFrameStorage {
+    Vector<NonnullOwnPtr<PseudoElementFrame>> frames;
+    size_t active_frame_count { 0 };
+};
 
 RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tree_builder_callbacks()
 {
     return {
         .builder = this,
+        .push_frame = [](void* builder_pointer) -> void* {
+            VERIFY(builder_pointer);
+            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
+            if (!builder.m_pseudo_element_frames)
+                builder.m_pseudo_element_frames = make<PseudoElementFrameStorage>();
+            auto& storage = *builder.m_pseudo_element_frames;
+            if (storage.active_frame_count == storage.frames.size())
+                storage.frames.append(make<PseudoElementFrame>());
+            return storage.frames[storage.active_frame_count++].ptr(); },
+        .pop_frame = [](void* builder_pointer, void* frame_pointer) {
+            VERIFY(builder_pointer);
+            VERIFY(frame_pointer);
+            auto& storage = *static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_pseudo_element_frames;
+            VERIFY(storage.active_frame_count > 0);
+            VERIFY(storage.frames[storage.active_frame_count - 1].ptr() == frame_pointer);
+            --storage.active_frame_count; },
         .initialize = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo) -> RustFFI::FfiPseudoElementFacts {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
@@ -524,17 +496,6 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             frame.layout_node->set_generated_for(pseudo_element, element);
             frame.layout_node->set_initial_quote_nesting_level(initial_quote_nesting_level);
             LayoutTreeBuilderAccess::set_synthetic_pseudo_element_node(element, pseudo_element, frame.layout_node); },
-        .insert_layout_node = [](void* builder_pointer, void* frame_pointer, void* parent_pointer, RustFFI::FfiInsertionMode insertion_mode) {
-            VERIFY(builder_pointer);
-            VERIFY(frame_pointer);
-            VERIFY(parent_pointer);
-            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
-            VERIFY(frame.layout_node);
-            static_cast<LayoutTreeBuildBridge*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
-                as<NodeWithStyle>(*static_cast<Layout::Node*>(parent_pointer)),
-                *frame.layout_node,
-                frame.layout_node->display(),
-                insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend); },
         .resolve_counters = [](void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo) {
             VERIFY(element_pointer);
             DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer), css_pseudo_element(ffi_pseudo) };
@@ -575,19 +536,6 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             }
             frame.content_item->set_generated_for(css_pseudo_element(ffi_pseudo), element);
             return frame.content_item.ptr(); },
-        .insert_content_item = [](void* builder_pointer, void* content_item_pointer, void* parent_pointer) {
-            VERIFY(builder_pointer);
-            VERIFY(content_item_pointer);
-            VERIFY(parent_pointer);
-            auto& content_item = *static_cast<Layout::Node*>(content_item_pointer);
-            auto display = content_item.is_text_node()
-                ? CSS::Display::from_short(CSS::Display::Short::Inline)
-                : as<NodeWithStyle>(content_item).display();
-            static_cast<LayoutTreeBuildBridge*>(builder_pointer)->insert_node_into_inline_or_block_ancestor(
-                as<NodeWithStyle>(*static_cast<Layout::Node*>(parent_pointer)),
-                content_item,
-                display,
-                AppendOrPrepend::Append); },
     };
 }
 
@@ -701,7 +649,6 @@ void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element
 struct PrincipalNodeFrame {
     RefPtr<Layout::Node> old_layout_node;
     RefPtr<Layout::Node> layout_node;
-    RefPtr<NodeWithStyle> backdrop_node;
     RefPtr<CSS::ComputedValues const> computed_values;
     CSS::Display display;
 };
@@ -794,24 +741,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(element_pointer);
             DOM::AbstractElement element_reference { *static_cast<DOM::Element*>(element_pointer) };
             CSS::resolve_counters(element_reference); },
-        .create_pseudo_element = [](void* builder_pointer, void* rust_state, void* element_pointer, RustFFI::FfiPseudoElement pseudo_element, RustFFI::FfiInsertionMode insertion_mode) {
-            VERIFY(builder_pointer);
-            VERIFY(rust_state);
-            VERIFY(element_pointer);
-            auto css_pseudo_element = [&] {
-                switch (pseudo_element) {
-                case RustFFI::FfiPseudoElement::Before:
-                    return CSS::PseudoElement::Before;
-                case RustFFI::FfiPseudoElement::After:
-                    return CSS::PseudoElement::After;
-                case RustFFI::FfiPseudoElement::Marker:
-                    return CSS::PseudoElement::Marker;
-                default:
-                    VERIFY_NOT_REACHED();
-                }
-            }();
-            auto mode = insertion_mode == RustFFI::FfiInsertionMode::Append ? AppendOrPrepend::Append : AppendOrPrepend::Prepend;
-            (void)static_cast<LayoutTreeBuildBridge*>(builder_pointer)->create_pseudo_element_if_needed(rust_state, *static_cast<DOM::Element*>(element_pointer), css_pseudo_element, mode); },
         .clear_stale_assigned_slottables = [](void* slot_element_pointer) {
             VERIFY(slot_element_pointer);
             clear_stale_layout_nodes_for_assigned_slottables(*static_cast<HTML::HTMLSlotElement*>(slot_element_pointer)); },
@@ -968,7 +897,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             // NB: Called during layout tree construction.
             frame.old_layout_node = node.unsafe_layout_node();
             frame.layout_node = nullptr;
-            frame.backdrop_node = nullptr;
             frame.computed_values = nullptr;
             return &frame; },
         .pop_principal_frame = [](void* builder_pointer, void* frame_pointer) {
@@ -982,7 +910,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             auto& frame = *storage.frames[storage.active_frame_count - 1];
             frame.old_layout_node = nullptr;
             frame.layout_node = nullptr;
-            frame.backdrop_node = nullptr;
             frame.computed_values = nullptr;
             --storage.active_frame_count; },
         .prepare_principal_element = [](void* builder_pointer, void* frame_pointer, void* element_pointer, bool should_create_layout_node) -> RustFFI::FfiPrincipalDisplayFacts {
@@ -1128,19 +1055,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
         .mark_update_escaped_rebuild_roots = [](void* builder_pointer) {
             VERIFY(builder_pointer);
             static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_tree_update_escaped_rebuild_roots = true; },
-        .create_principal_backdrop = [](void* builder_pointer, void* frame_pointer, void* rust_state, void* element_pointer, bool append) -> void* {
-            VERIFY(builder_pointer);
-            VERIFY(frame_pointer);
-            VERIFY(rust_state);
-            VERIFY(element_pointer);
-            auto& builder = *static_cast<LayoutTreeBuildBridge*>(builder_pointer);
-            auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
-            frame.backdrop_node = builder.create_pseudo_element_if_needed(
-                rust_state,
-                *static_cast<DOM::Element*>(element_pointer),
-                CSS::PseudoElement::Backdrop,
-                append ? Optional<AppendOrPrepend> { AppendOrPrepend::Append } : Optional<AppendOrPrepend> {});
-            return frame.backdrop_node.ptr(); },
         .insert_principal_backdrop_before_old = [](void* builder_pointer, void* frame_pointer, void* backdrop_pointer) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
@@ -1175,13 +1089,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 static_cast<Layout::NodeWithStyle*>(parent_pointer)->append_child(*frame.layout_node);
                 break;
             case RustFFI::FfiPrincipalBoxPlacement::NormalInsertion:
-                VERIFY(parent_pointer);
-                builder.insert_node_into_inline_or_block_ancestor(
-                    *static_cast<Layout::NodeWithStyle*>(parent_pointer),
-                    *frame.layout_node,
-                    frame.display,
-                    AppendOrPrepend::Append);
-                break;
+                VERIFY_NOT_REACHED();
             } },
         .clear_stale_inclusive_subtree = [](void* builder_pointer, void* node_pointer) {
             VERIFY(builder_pointer);
@@ -1201,6 +1109,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(builder_pointer);
             return static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_root.ptr(); },
         .layout = make_ffi_tree_builder_callbacks(this),
+        .pseudo = make_ffi_pseudo_tree_builder_callbacks(),
     };
 }
 
@@ -1350,7 +1259,7 @@ static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_point
         .is_out_of_flow = node.is_out_of_flow(),
         .is_text = text_node != nullptr,
         .text_is_ascii_whitespace = text_node && text_node->text_for_rendering().is_ascii_whitespace(),
-        .is_inline_outside = node_with_style && node_with_style->display().is_inline_outside(),
+        .is_inline_outside = text_node || (node_with_style && node_with_style->display().is_inline_outside()),
         .is_table_wrapper = node.is_table_wrapper(),
         .has_been_wrapped_in_table_wrapper = node.has_been_wrapped_in_table_wrapper(),
         .has_replaced_element_table_display_adjustment = node_with_style && node_with_style->has_replaced_element_table_display_adjustment(),
@@ -1374,6 +1283,16 @@ static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_point
         }(),
         .has_rendered_legend = is<FieldSetBox>(node) && static_cast<FieldSetBox&>(node).rendered_legend(),
     };
+}
+
+static bool ffi_layout_node_is_inline_outside(void*, void* node_pointer)
+{
+    VERIFY(node_pointer);
+    auto& node = *static_cast<Node*>(node_pointer);
+    if (node.is_text_node())
+        return true;
+    auto const* node_with_style = as_if<NodeWithStyle>(node);
+    return node_with_style && node_with_style->display().is_inline_outside();
 }
 
 struct FfiFirstLetterTextContext {
@@ -1706,6 +1625,7 @@ static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(LayoutTr
     return {
         .context = bridge,
         .layout_node_facts = ffi_layout_node_facts,
+        .is_inline_outside = ffi_layout_node_is_inline_outside,
         .parent = ffi_layout_node_parent,
         .first_child = ffi_layout_node_first_child,
         .next_sibling = ffi_layout_node_next_sibling,

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -56,43 +56,12 @@ namespace Web::Layout {
 
 TreeBuilder::TreeBuilder() = default;
 
+static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder*);
+
 void TreeBuilder::note_tree_restructuring_at(Layout::Node const& node)
 {
     if (m_current_rebuild_root && !m_current_rebuild_root->is_inclusive_ancestor_of(node))
         m_layout_tree_update_escaped_rebuild_roots = true;
-}
-
-static bool has_inline_or_in_flow_block_children(Layout::Node const& layout_node)
-{
-    for (auto child = layout_node.first_child(); child; child = child->next_sibling()) {
-        if (child->is_inline() || child->is_in_flow())
-            return true;
-    }
-    return false;
-}
-
-static bool has_in_flow_block_children(Layout::Node const& layout_node)
-{
-    if (layout_node.children_are_inline())
-        return false;
-    for (auto child = layout_node.first_child(); child; child = child->next_sibling()) {
-        if (child->is_inline())
-            continue;
-        if (child->is_in_flow())
-            return true;
-    }
-    return false;
-}
-
-static bool is_out_of_flow_table_internal_child_of_table_root(Layout::NodeWithStyle const& parent, Layout::Node const& child)
-{
-    auto const* child_with_style = as_if<Layout::NodeWithStyle>(child);
-    return parent.display().is_table_inside()
-        && child_with_style
-        && !child.is_anonymous()
-        && child_with_style->is_out_of_flow()
-        && !child_with_style->has_replaced_element_table_display_adjustment()
-        && child_with_style->display_before_box_type_transformation().is_internal_table();
 }
 
 static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::Display display)
@@ -109,140 +78,15 @@ static Optional<CSS::Display> adjusted_table_display_for_replaced_element(CSS::D
     return {};
 }
 
-// The insertion_parent_for_*() functions maintain the invariant that the in-flow children of
-// block-level boxes must be either all block-level or all inline-level.
-
-static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& layout_parent)
-{
-    auto last_child_creating_anonymous_wrapper_if_needed = [](auto& layout_parent) -> Layout::Node& {
-        if (!layout_parent.last_child()
-            || !layout_parent.last_child()->is_anonymous()
-            || !layout_parent.last_child()->children_are_inline()
-            || layout_parent.last_child()->is_generated_for_pseudo_element()) {
-            layout_parent.append_child(layout_parent.create_anonymous_wrapper());
-        }
-        return *layout_parent.last_child();
-    };
-
-    if (is<FieldSetBox>(layout_parent))
-        return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
-
-    if (layout_parent.is_svg_foreign_object_box())
-        return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
-
-    // SVG layout ignores the inline/block distinction, and an anonymous wrapper would only hide
-    // the child from SVGFormattingContext (e.g. a shape with a foreignObject sibling).
-    if (layout_parent.is_svg_box() || layout_parent.is_svg_svg_box())
-        return layout_parent;
-
-    if (layout_parent.display().is_inline_outside() && layout_parent.display().is_flow_inside())
-        return layout_parent;
-
-    if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside())
-        return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
-
-    if (!has_in_flow_block_children(layout_parent) || layout_parent.children_are_inline())
-        return layout_parent;
-
-    // Parent has block-level children, insert into an anonymous wrapper block (and create it first if needed)
-    return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
-}
-
-static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layout_parent, Layout::Node& layout_node, TreeBuilder::AppendOrPrepend mode, TreeBuilder& tree_builder)
-{
-    // Inline is fine for in-flow block children (interrupting blocks) and for out-of-flow children;
-    // the inline formatting context emits items for both.
-    if (!layout_node.is_anonymous() && layout_parent.is_inline() && layout_parent.display().is_flow_inside())
-        return layout_parent;
-
-    // SVG layout ignores the inline/block distinction; wrapping existing inline-level siblings
-    // (e.g. shapes next to a foreignObject) would only hide them from SVGFormattingContext.
-    if (layout_parent.is_svg_box() || layout_parent.is_svg_svg_box())
-        return layout_parent;
-
-    // Make sure we're not inserting into an inline node, since those do not support block nodes.
-    auto* new_parent = &layout_parent;
-    while (is<InlineNode>(new_parent))
-        new_parent = new_parent->parent();
-
-    // If the parent block has no children, insert this block into parent.
-    if (!has_inline_or_in_flow_block_children(*new_parent))
-        return *new_parent;
-
-    // Table-internal boxes may have been blockified before insertion, but table fixup still needs to see them as
-    // direct table children instead of grouping them with neighboring table whitespace.
-    if (is_out_of_flow_table_internal_child_of_table_root(*new_parent, layout_node))
-        return *new_parent;
-
-    // If the block is out-of-flow,
-    if (layout_node.is_out_of_flow()) {
-        // And we're appending while the parent's last child is an anonymous block, join that
-        // anonymous block. Prepended boxes (e.g. an absolutely positioned ::before) belong at the
-        // very start of the parent, not at the start of its trailing inline run.
-        if (mode == TreeBuilder::AppendOrPrepend::Append
-            && !new_parent->display().is_flex_inside()
-            && !new_parent->display().is_grid_inside()
-            && !new_parent->last_child()->is_generated_for_pseudo_element()
-            && new_parent->last_child()->is_anonymous()
-            && new_parent->last_child()->children_are_inline()) {
-            return *new_parent->last_child();
-        }
-
-        // Otherwise, insert this block into parent.
-        return *new_parent;
-    }
-
-    // If the parent block has block-level children, insert this block into parent.
-    if (!new_parent->children_are_inline())
-        return *new_parent;
-
-    // Parent block has inline-level children (our siblings); wrap these siblings into an anonymous wrapper block.
-    tree_builder.note_tree_restructuring_at(*new_parent);
-    auto wrapper = new_parent->create_anonymous_wrapper();
-    wrapper->set_children_are_inline(true);
-
-    for (auto child = new_parent->first_child(); child;) {
-        auto next_child = child->next_sibling();
-        if (is_out_of_flow_table_internal_child_of_table_root(*new_parent, *child)) {
-            child = next_child;
-            continue;
-        }
-        new_parent->remove_child(*child);
-        wrapper->append_child(*child);
-        child = next_child;
-    }
-
-    new_parent->set_children_are_inline(false);
-    new_parent->append_child(wrapper);
-
-    // Then it's safe to insert this block into parent.
-    return *new_parent;
-}
-
 void TreeBuilder::insert_node_into_inline_or_block_ancestor(Layout::Node& node, CSS::Display display, AppendOrPrepend mode)
 {
-    auto& nearest_insertion_ancestor = *m_ancestor_stack.last();
-
-    auto& insertion_point = display.is_inline_outside() ? insertion_parent_for_inline_node(nearest_insertion_ancestor)
-                                                        : insertion_parent_for_block_node(nearest_insertion_ancestor, node, mode, *this);
-
-    // Insertion parents can be above the subtree being rebuilt in place: inline ancestors are
-    // skipped, and out-of-flow boxes can join a trailing anonymous sibling.
-    note_tree_restructuring_at(insertion_point);
-
-    if (mode == AppendOrPrepend::Prepend)
-        insertion_point.prepend_child(node);
-    else
-        insertion_point.append_child(node);
-
-    if (display.is_inline_outside()) {
-        // After inserting an inline-level box into a parent, mark the parent as having inline children.
-        insertion_point.set_children_are_inline(true);
-    } else if (node.is_in_flow()) {
-        // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
-        if (!as<NodeWithStyle>(insertion_point).display().is_inline_outside() || !as<NodeWithStyle>(insertion_point).display().is_flow_inside())
-            insertion_point.set_children_are_inline(false);
-    }
+    auto callbacks = make_ffi_tree_builder_callbacks(this);
+    RustFFI::rust_insert_node_into_inline_or_block_ancestor(
+        &callbacks,
+        m_ancestor_stack.last(),
+        &node,
+        display.is_inline_outside(),
+        mode == AppendOrPrepend::Append ? RustFFI::FfiInsertionMode::Append : RustFFI::FfiInsertionMode::Prepend);
 }
 
 class GeneratedContentImageProvider final
@@ -1582,6 +1426,17 @@ static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_point
         .is_table_wrapper = node.is_table_wrapper(),
         .has_been_wrapped_in_table_wrapper = node.has_been_wrapped_in_table_wrapper(),
         .has_replaced_element_table_display_adjustment = node_with_style && node_with_style->has_replaced_element_table_display_adjustment(),
+        .is_inline = node.is_inline(),
+        .is_in_flow = node.is_in_flow(),
+        .is_inline_node = is<InlineNode>(node),
+        .is_field_set_box = is<FieldSetBox>(node),
+        .is_svg_foreign_object_box = node.is_svg_foreign_object_box(),
+        .is_svg_box = node.is_svg_box(),
+        .is_svg_svg_box = node.is_svg_svg_box(),
+        .is_generated_for_pseudo_element = node.is_generated_for_pseudo_element(),
+        .display_is_flow_inside = node_with_style && node_with_style->display().is_flow_inside(),
+        .display_is_flex_inside = node_with_style && node_with_style->display().is_flex_inside(),
+        .display_is_grid_inside = node_with_style && node_with_style->display().is_grid_inside(),
     };
 }
 
@@ -1607,6 +1462,12 @@ static void* ffi_layout_node_previous_sibling(void*, void* node_pointer)
 {
     VERIFY(node_pointer);
     return static_cast<Node*>(node_pointer)->previous_sibling().ptr();
+}
+
+static void* ffi_layout_node_last_child(void*, void* node_pointer)
+{
+    VERIFY(node_pointer);
+    return static_cast<Node*>(node_pointer)->last_child().ptr();
 }
 
 static Vector<NonnullRefPtr<Node>> retain_ffi_layout_nodes(void* const* node_pointers, size_t node_count)
@@ -1733,16 +1594,65 @@ static void ffi_append_missing_table_cell(void*, void* row_pointer)
     row_box.append_child(make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
 }
 
-// https://drafts.csswg.org/css-tables-3/#fixup-algorithm
-void TreeBuilder::fixup_tables(NodeWithStyle& root)
+static void* ffi_create_and_append_anonymous_wrapper(void*, void* parent_pointer)
 {
-    RustFFI::FfiTreeBuilderCallbacks callbacks {
-        .context = nullptr,
+    VERIFY(parent_pointer);
+    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
+    auto wrapper = parent.create_anonymous_wrapper();
+    parent.append_child(*wrapper);
+    return wrapper.ptr();
+}
+
+static void ffi_wrap_children_in_anonymous(void*, void* parent_pointer, void* const* child_pointers, size_t child_count)
+{
+    VERIFY(parent_pointer);
+    auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
+    auto children = retain_ffi_layout_nodes(child_pointers, child_count);
+    auto wrapper = parent.create_anonymous_wrapper();
+    wrapper->set_children_are_inline(true);
+    for (auto& child : children) {
+        parent.remove_child(*child);
+        wrapper->append_child(*child);
+    }
+    parent.set_children_are_inline(false);
+    parent.append_child(*wrapper);
+}
+
+static void ffi_insert_child(void*, void* parent_pointer, void* child_pointer, RustFFI::FfiInsertionMode mode)
+{
+    VERIFY(parent_pointer);
+    VERIFY(child_pointer);
+    auto& parent = *static_cast<Node*>(parent_pointer);
+    NonnullRefPtr child = *static_cast<Node*>(child_pointer);
+    if (mode == RustFFI::FfiInsertionMode::Prepend)
+        parent.prepend_child(*child);
+    else
+        parent.append_child(*child);
+}
+
+static void ffi_set_children_are_inline(void*, void* node_pointer, bool children_are_inline)
+{
+    VERIFY(node_pointer);
+    static_cast<Node*>(node_pointer)->set_children_are_inline(children_are_inline);
+}
+
+static void ffi_note_tree_restructuring(void* context, void* node_pointer)
+{
+    VERIFY(context);
+    VERIFY(node_pointer);
+    static_cast<TreeBuilder*>(context)->note_tree_restructuring_at(*static_cast<Node*>(node_pointer));
+}
+
+static RustFFI::FfiTreeBuilderCallbacks make_ffi_tree_builder_callbacks(TreeBuilder* tree_builder)
+{
+    return {
+        .context = tree_builder,
         .layout_node_facts = ffi_layout_node_facts,
         .parent = ffi_layout_node_parent,
         .first_child = ffi_layout_node_first_child,
         .next_sibling = ffi_layout_node_next_sibling,
         .previous_sibling = ffi_layout_node_previous_sibling,
+        .last_child = ffi_layout_node_last_child,
         .remove_nodes = ffi_remove_layout_nodes,
         .wrap_in_anonymous = ffi_wrap_in_anonymous_table_box,
         .update_existing_table_wrapper = ffi_update_existing_table_wrapper,
@@ -1752,7 +1662,18 @@ void TreeBuilder::fixup_tables(NodeWithStyle& root)
         .table_grid_column_count = ffi_table_grid_column_count,
         .table_grid_is_occupied = ffi_table_grid_is_occupied,
         .append_missing_table_cell = ffi_append_missing_table_cell,
+        .create_and_append_anonymous_wrapper = ffi_create_and_append_anonymous_wrapper,
+        .wrap_children_in_anonymous = ffi_wrap_children_in_anonymous,
+        .insert_child = ffi_insert_child,
+        .set_children_are_inline = ffi_set_children_are_inline,
+        .note_tree_restructuring = ffi_note_tree_restructuring,
     };
+}
+
+// https://drafts.csswg.org/css-tables-3/#fixup-algorithm
+void TreeBuilder::fixup_tables(NodeWithStyle& root)
+{
+    auto callbacks = make_ffi_tree_builder_callbacks(this);
     RustFFI::rust_fixup_tables(&callbacks, &root);
 }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -6,19 +6,11 @@
 
 #pragma once
 
-#include <AK/NonnullRefPtr.h>
-#include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/Vector.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Layout {
-
-namespace RustFFI {
-
-struct FfiDomTreeBuilderCallbacks;
-struct FfiPseudoTreeBuilderCallbacks;
-
-}
 
 struct LayoutTreeBuildResult {
     RefPtr<Layout::Node> root;
@@ -29,51 +21,14 @@ struct LayoutTreeBuildResult {
 LayoutTreeBuildResult build_layout_tree(DOM::Node&);
 void detach_top_layer_element_layout_subtree(DOM::Element&);
 
-class TreeBuilder {
-public:
-    TreeBuilder() = default;
-    ~TreeBuilder();
-
-    TreeBuilder(TreeBuilder const&) = delete;
-    TreeBuilder& operator=(TreeBuilder const&) = delete;
-
-    LayoutTreeBuildResult build(DOM::Node&);
-
-    enum class AppendOrPrepend {
-        Append,
-        Prepend,
-    };
-
-    // Confinement report for the build: the roots of the subtrees that were rebuilt in place,
-    // and whether anything mutated the tree outside those subtrees. A caller that wants to
-    // re-lay out only the rebuilt subtrees must check that nothing escaped them.
-    Vector<Layout::Node*> const& rebuilt_subtree_roots() const { return m_rebuilt_subtree_roots; }
-    bool layout_tree_update_escaped_rebuild_roots() const { return m_layout_tree_update_escaped_rebuild_roots; }
-
-    void note_tree_restructuring_at(Layout::Node const&);
-
-    static void detach_top_layer_element_layout_subtree(DOM::Element&);
+class LayoutTreeBuilderAccess {
+    friend class LayoutTreeBuildBridge;
 
 private:
-    struct PrincipalNodeFrameStorage;
-    static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
-    static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
-
-    RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
-    RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
-
-    void insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle&, Layout::Node&, CSS::Display, AppendOrPrepend);
-    static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
-    RefPtr<NodeWithStyle> create_pseudo_element_if_needed(void* rust_state, DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
-    static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
-
-    RefPtr<Layout::Node> m_layout_root;
-    OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
-
-    // The root of the in-place subtree replacement currently being built, if any.
-    Layout::Node* m_current_rebuild_root { nullptr };
-    Vector<Layout::Node*> m_rebuilt_subtree_roots;
-    bool m_layout_tree_update_escaped_rebuild_roots { false };
+    static void clear_synthetic_pseudo_element_layout_nodes(DOM::Element&);
+    static void detach_layout_node(DOM::Node&);
+    static void register_svg_resource_reference(SVG::SVGElement&, DOM::Element&);
+    static void set_synthetic_pseudo_element_node(DOM::Element&, CSS::PseudoElement, Layout::NodeWithStyle*);
 };
 
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -15,6 +15,7 @@ namespace Web::Layout {
 namespace RustFFI {
 
 struct FfiDomTreeBuilderCallbacks;
+struct FfiPseudoTreeBuilderCallbacks;
 
 }
 
@@ -70,6 +71,7 @@ private:
     u32 quote_nesting_level() const;
     void set_quote_nesting_level(u32);
     RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
+    RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
 
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
     RefPtr<Layout::Node> create_layout_node_for_element(DOM::Element&, Context&) const;

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -12,6 +12,12 @@
 
 namespace Web::Layout {
 
+namespace RustFFI {
+
+struct FfiDomTreeBuilderCallbacks;
+
+}
+
 class TreeBuilder {
 public:
     TreeBuilder();
@@ -70,6 +76,7 @@ private:
     Layout::NodeWithStyle& ancestor_at(size_t) const;
     u32 quote_nesting_level() const;
     void set_quote_nesting_level(u32);
+    RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
 
     void fixup_tables(NodeWithStyle& root);
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -52,7 +52,6 @@ private:
         bool layout_svg_pattern = false;
     };
 
-    void wrap_in_button_layout_tree_if_needed(DOM::Node&, Layout::Node&);
     enum class MustCreateSubtree {
         No,
         Yes,
@@ -72,7 +71,6 @@ private:
     RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
 
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
-    void create_backdrop_for_top_layer_element_if_needed(DOM::Element&, Layout::Node* old_layout_node, bool may_replace_existing_layout_node);
     static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
     RefPtr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
     static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -52,8 +52,6 @@ private:
         bool layout_svg_pattern = false;
     };
 
-    i32 calculate_list_item_index(DOM::Node&);
-
     void wrap_in_button_layout_tree_if_needed(DOM::Node&, Layout::Node&);
     enum class MustCreateSubtree {
         No,
@@ -74,11 +72,9 @@ private:
     RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
 
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
-    RefPtr<Layout::Node> create_layout_node_for_element(DOM::Element&, Context&) const;
     void create_backdrop_for_top_layer_element_if_needed(DOM::Element&, Layout::Node* old_layout_node, bool may_replace_existing_layout_node);
     static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
     RefPtr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
-    RefPtr<NodeWithStyle> create_content_replacement_if_needed(DOM::Element&, NonnullRefPtr<CSS::ComputedValues const>) const;
     static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
 
     RefPtr<Layout::Node> m_layout_root;

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -62,17 +62,7 @@ private:
     void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(&node); }
     void pop_parent() { m_ancestor_stack.take_last(); }
 
-    template<CSS::DisplayInternal, typename Callback>
-    void for_each_in_tree_with_internal_display(NodeWithStyle& root, Callback);
-
-    template<CSS::DisplayInside, typename Callback>
-    void for_each_in_tree_with_inside_display(NodeWithStyle& root, Callback);
-
     void fixup_tables(NodeWithStyle& root);
-    void remove_irrelevant_boxes(NodeWithStyle& root);
-    void generate_missing_child_wrappers(NodeWithStyle& root);
-    Vector<NonnullRefPtr<Box>> generate_missing_parents(NodeWithStyle& root);
-    void missing_cells_fixup(Vector<NonnullRefPtr<Box>> const&);
 
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
     RefPtr<Layout::Node> create_layout_node_for_element(DOM::Element&, Context&) const;

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
 #include <LibWeb/Forward.h>
 
@@ -54,18 +55,7 @@ public:
     static void detach_top_layer_element_layout_subtree(DOM::Element&);
 
 private:
-    struct Context {
-        bool has_svg_root = false;
-        bool layout_top_layer = false;
-        bool layout_svg_mask_or_clip_path = false;
-        bool layout_svg_pattern = false;
-    };
-
-    enum class MustCreateSubtree {
-        No,
-        Yes,
-    };
-    void update_layout_tree(DOM::Node&, Context&, MustCreateSubtree);
+    struct PrincipalNodeFrameStorage;
     static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
     static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
@@ -86,6 +76,7 @@ private:
 
     RefPtr<Layout::Node> m_layout_root;
     void* m_rust_state { nullptr };
+    OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
 
     // The root of the in-place subtree replacement currently being built, if any.
     Layout::Node* m_current_rebuild_root { nullptr };

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -31,7 +31,7 @@ void detach_top_layer_element_layout_subtree(DOM::Element&);
 
 class TreeBuilder {
 public:
-    TreeBuilder();
+    TreeBuilder() = default;
     ~TreeBuilder();
 
     TreeBuilder(TreeBuilder const&) = delete;
@@ -59,23 +59,15 @@ private:
     static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
     static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
-    void push_parent(Layout::NodeWithStyle&);
-    void pop_parent();
-    Layout::NodeWithStyle& current_parent() const;
-    size_t ancestor_count() const;
-    Layout::NodeWithStyle& ancestor_at(size_t) const;
-    u32 quote_nesting_level() const;
-    void set_quote_nesting_level(u32);
     RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
     RustFFI::FfiPseudoTreeBuilderCallbacks make_ffi_pseudo_tree_builder_callbacks();
 
-    void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
+    void insert_node_into_inline_or_block_ancestor(Layout::NodeWithStyle&, Layout::Node&, CSS::Display, AppendOrPrepend);
     static NonnullRefPtr<ListItemMarkerBox> create_and_attach_list_item_marker(ListItemBox&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const> marker_style);
-    RefPtr<NodeWithStyle> create_pseudo_element_if_needed(DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
+    RefPtr<NodeWithStyle> create_pseudo_element_if_needed(void* rust_state, DOM::Element&, CSS::PseudoElement, Optional<AppendOrPrepend>);
     static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
 
     RefPtr<Layout::Node> m_layout_root;
-    void* m_rust_state { nullptr };
     OwnPtr<PrincipalNodeFrameStorage> m_principal_frames;
 
     // The root of the in-place subtree replacement currently being built, if any.

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -59,11 +59,6 @@ private:
         Yes,
     };
     void update_layout_tree(DOM::Node&, Context&, MustCreateSubtree);
-    void update_layout_tree_for_display_contents(DOM::Element&, Context&, MustCreateSubtree, bool should_create_layout_node);
-    void update_layout_tree_for_svg_switch_children(SVG::SVGSwitchElement&, Context&, MustCreateSubtree);
-    void update_layout_tree_for_shadow_root_children(DOM::ShadowRoot&, Context&, MustCreateSubtree);
-    void update_layout_tree_for_dom_children(DOM::ParentNode&, Context&, MustCreateSubtree);
-    void update_layout_tree_for_assigned_slottables(HTML::HTMLSlotElement&, Context&, MustCreateSubtree);
     static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
     static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
@@ -75,8 +70,6 @@ private:
     u32 quote_nesting_level() const;
     void set_quote_nesting_level(u32);
     RustFFI::FfiDomTreeBuilderCallbacks make_ffi_dom_tree_builder_callbacks();
-
-    void fixup_tables(NodeWithStyle& root);
 
     void insert_node_into_inline_or_block_ancestor(Layout::Node&, CSS::Display, AppendOrPrepend);
     RefPtr<Layout::Node> create_layout_node_for_element(DOM::Element&, Context&) const;

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -53,8 +53,6 @@ private:
 
     i32 calculate_list_item_index(DOM::Node&);
 
-    void update_layout_tree_before_children(DOM::Node&, Layout::Node&, Context&, bool element_has_content_visibility_hidden);
-    void update_layout_tree_after_children(DOM::Node&, Layout::Node&, Context&, bool element_has_content_visibility_hidden);
     void wrap_in_button_layout_tree_if_needed(DOM::Node&, Layout::Node&);
     enum class MustCreateSubtree {
         No,

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -15,6 +15,10 @@ namespace Web::Layout {
 class TreeBuilder {
 public:
     TreeBuilder();
+    ~TreeBuilder();
+
+    TreeBuilder(TreeBuilder const&) = delete;
+    TreeBuilder& operator=(TreeBuilder const&) = delete;
 
     RefPtr<Layout::Node> build(DOM::Node&);
 
@@ -59,8 +63,13 @@ private:
     static void clear_stale_layout_nodes_for_assigned_slottables(HTML::HTMLSlotElement&);
     static TraversalDecision clear_stale_layout_and_paint_node(DOM::Node&, DOM::Node const* cleared_subtree_root = nullptr);
 
-    void push_parent(Layout::NodeWithStyle& node) { m_ancestor_stack.append(&node); }
-    void pop_parent() { m_ancestor_stack.take_last(); }
+    void push_parent(Layout::NodeWithStyle&);
+    void pop_parent();
+    Layout::NodeWithStyle& current_parent() const;
+    size_t ancestor_count() const;
+    Layout::NodeWithStyle& ancestor_at(size_t) const;
+    u32 quote_nesting_level() const;
+    void set_quote_nesting_level(u32);
 
     void fixup_tables(NodeWithStyle& root);
 
@@ -73,14 +82,12 @@ private:
     static void create_first_letter_wrapper_if_needed(DOM::Element&, Layout::BlockContainer&);
 
     RefPtr<Layout::Node> m_layout_root;
-    Vector<Layout::NodeWithStyle*> m_ancestor_stack;
+    void* m_rust_state { nullptr };
 
     // The root of the in-place subtree replacement currently being built, if any.
     Layout::Node* m_current_rebuild_root { nullptr };
     Vector<Layout::Node*> m_rebuilt_subtree_roots;
     bool m_layout_tree_update_escaped_rebuild_roots { false };
-
-    u32 m_quote_nesting_level { 0 };
 };
 
 }

--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -19,6 +19,15 @@ struct FfiPseudoTreeBuilderCallbacks;
 
 }
 
+struct LayoutTreeBuildResult {
+    RefPtr<Layout::Node> root;
+    Vector<Layout::Node*> rebuilt_subtree_roots;
+    bool layout_tree_update_escaped_rebuild_roots { false };
+};
+
+LayoutTreeBuildResult build_layout_tree(DOM::Node&);
+void detach_top_layer_element_layout_subtree(DOM::Element&);
+
 class TreeBuilder {
 public:
     TreeBuilder();
@@ -27,7 +36,7 @@ public:
     TreeBuilder(TreeBuilder const&) = delete;
     TreeBuilder& operator=(TreeBuilder const&) = delete;
 
-    RefPtr<Layout::Node> build(DOM::Node&);
+    LayoutTreeBuildResult build(DOM::Node&);
 
     enum class AppendOrPrepend {
         Append,

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -290,7 +290,7 @@ void SVGElement::removed_from(IsSubtreeRoot is_subtree_root, Node* old_ancestor,
         document().set_needs_repaint(Badge<SVGElement> {}, InvalidateDisplayList::Yes);
 }
 
-void SVGElement::register_resource_box_referencing_element(Badge<Layout::TreeBuilder>, DOM::Element& referencing_element)
+void SVGElement::register_resource_box_referencing_element(Badge<Layout::LayoutTreeBuilderAccess>, DOM::Element& referencing_element)
 {
     m_resource_box_referencing_elements.remove_all_matching([&](auto& weak_element) {
         return !weak_element || weak_element == &referencing_element;

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -38,7 +38,7 @@ public:
     virtual bool is_presentational_hint(Utf16FlyString const&) const final override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const final override;
 
-    void register_resource_box_referencing_element(Badge<Layout::TreeBuilder>, DOM::Element&);
+    void register_resource_box_referencing_element(Badge<Layout::LayoutTreeBuilderAccess>, DOM::Element&);
 
 protected:
     SVGElement(DOM::Document&, DOM::QualifiedName);


### PR DESCRIPTION
We are incrementally moving LibWeb's style, layout, and display-list recording pipeline to Rust. This PR ports `Layout::TreeBuilder`, the stage that turns the styled DOM and flat tree into the layout tree, as the first complete layout-side step.

Rust now owns the traversal, transient builder state, incremental subtree reconstruction, principal and pseudo-element box decisions, shadow and slot traversal, top-layer and SVG handling, inline/block normalization, `::first-letter` selection, specialized wrappers, and table fixup. C++ remains responsible for accessing existing DOM and style objects, constructing concrete layout nodes, and preserving `RefPtr` ownership through narrow callbacks.

The public C++ `TreeBuilder` class is removed, and an active build enters Rust once and stays there through recursive construction, insertion, pseudo-element creation, and postprocessing. Existing behavior is preserved, with Rust unit tests covering the ported decisions and LibWeb tests covering the resulting trees and incremental updates.

This gives future Rust formatting-context ports a Rust-owned tree construction pipeline. From there we can continue moving layout state and algorithms to Rust, followed by painting and display-list recording.
