### PR TITLE
WebDriver: Survive a WebContent crash during a navigation command

### DIFF
--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -32,12 +32,17 @@ static Web::WebDriver::Response perform_history_traversal(Session& session, Star
     connection->on_driver_execution_complete = [&](auto result) { response = move(result); };
 
     auto traversal_response = start_traversal(*connection);
-    auto immediate_response = TRY(traversal_response.take_response());
-    wait_for_navigation_completion = traversal_response.wait_for_navigation_completion();
-    if (traversal_response.will_replace_web_content_process())
+    if (!traversal_response) {
+        session.mark_current_window_as_awaiting_replacement(*connection);
+        wait_for_navigation_completion = true;
+        return JsonValue {};
+    }
+    auto immediate_response = TRY(traversal_response->take_response());
+    wait_for_navigation_completion = traversal_response->wait_for_navigation_completion();
+    if (traversal_response->will_replace_web_content_process())
         session.mark_current_window_as_awaiting_replacement(*connection);
 
-    if (!traversal_response.wait_for_driver_execution_complete())
+    if (!traversal_response->wait_for_driver_execution_complete())
         return immediate_response;
 
     Core::EventLoop::current().spin_until([&]() {
@@ -198,9 +203,11 @@ Web::WebDriver::Response Client::navigate_to(Web::WebDriver::Parameters paramete
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/url");
     auto session = TRY(Session::find_session(parameters[0]));
 
-    auto response = TRY(session->perform_async_action([&](auto& connection) {
-        auto navigate_response = connection.navigate_to(move(payload));
-        return navigate_response.response();
+    auto response = TRY(session->perform_async_action([&](auto& connection) -> Web::WebDriver::Response {
+        auto navigate_response = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::NavigateTo>(move(payload));
+        if (!navigate_response)
+            return JsonValue {};
+        return navigate_response->response();
     },
         Session::WebContentReplacement::Allow));
     TRY(session->wait_for_current_window_to_have_web_content_connection());
@@ -231,7 +238,7 @@ Web::WebDriver::Response Client::back(Web::WebDriver::Parameters parameters, Jso
     auto session = TRY(Session::find_session(parameters[0]));
 
     bool wait_for_navigation_completion = true;
-    auto response = TRY(perform_history_traversal(*session, [&](auto& connection) { return connection.back(); }, wait_for_navigation_completion));
+    auto response = TRY(perform_history_traversal(*session, [&](auto& connection) { return connection.template send_sync_but_allow_failure<Messages::WebDriverClient::Back>(); }, wait_for_navigation_completion));
     TRY(session->wait_for_current_window_to_have_web_content_connection());
     if (wait_for_navigation_completion) {
         response = TRY(session->perform_async_action([&](auto& connection) {
@@ -250,7 +257,7 @@ Web::WebDriver::Response Client::forward(Web::WebDriver::Parameters parameters, 
     auto session = TRY(Session::find_session(parameters[0]));
 
     bool wait_for_navigation_completion = true;
-    auto response = TRY(perform_history_traversal(*session, [&](auto& connection) { return connection.forward(); }, wait_for_navigation_completion));
+    auto response = TRY(perform_history_traversal(*session, [&](auto& connection) { return connection.template send_sync_but_allow_failure<Messages::WebDriverClient::Forward>(); }, wait_for_navigation_completion));
     TRY(session->wait_for_current_window_to_have_web_content_connection());
     if (wait_for_navigation_completion) {
         response = TRY(session->perform_async_action([&](auto& connection) {
@@ -268,8 +275,11 @@ Web::WebDriver::Response Client::refresh(Web::WebDriver::Parameters parameters, 
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/refresh");
     auto session = TRY(Session::find_session(parameters[0]));
 
-    auto response = TRY(session->perform_async_action([&](auto& connection) {
-        return connection.refresh();
+    auto response = TRY(session->perform_async_action([&](auto& connection) -> Web::WebDriver::Response {
+        auto refresh_response = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::Refresh>();
+        if (!refresh_response)
+            return JsonValue {};
+        return refresh_response->response();
     }));
     if (TRY(session->wait_for_current_window_to_have_web_content_connection()))
         response = TRY(session->perform_async_action([&](auto& connection) {

--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -172,9 +172,11 @@ Web::WebDriver::Response Client::navigate_to(Web::WebDriver::Parameters paramete
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/url");
     auto session = TRY(Session::find_session(parameters[0]));
 
-    auto response = TRY(session->perform_async_action([&](auto& connection) {
-        auto navigate_response = connection.navigate_to(move(payload));
-        return navigate_response.response();
+    auto response = TRY(session->perform_async_action([&](auto& connection) -> Web::WebDriver::Response {
+        auto navigate_response = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::NavigateTo>(move(payload));
+        if (!navigate_response)
+            return JsonValue {};
+        return navigate_response->response();
     },
         Session::WebContentReplacement::Allow));
     TRY(session->wait_for_current_window_to_have_web_content_connection());
@@ -205,7 +207,15 @@ Web::WebDriver::Response Client::back(Web::WebDriver::Parameters parameters, Jso
     auto session = TRY(Session::find_session(parameters[0]));
 
     auto response = TRY(session->perform_async_action(
-        [&](auto& connection) { return connection.back(); },
+        [&](auto& connection) -> Web::WebDriver::Response {
+            // A torn-down WebContent process leaves this reply unanswered. Treat the lost reply as an
+            // empty success, so only this command fails over to the replacement process instead of
+            // aborting WebDriver; the wait below then adopts the incoming process.
+            auto reply = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::Back>();
+            if (!reply)
+                return JsonValue {};
+            return reply->take_response();
+        },
         Session::WebContentReplacement::Allow));
     TRY(session->wait_for_current_window_to_have_web_content_connection());
     response = TRY(session->perform_async_action(
@@ -223,7 +233,15 @@ Web::WebDriver::Response Client::forward(Web::WebDriver::Parameters parameters, 
     auto session = TRY(Session::find_session(parameters[0]));
 
     auto response = TRY(session->perform_async_action(
-        [&](auto& connection) { return connection.forward(); },
+        [&](auto& connection) -> Web::WebDriver::Response {
+            // A torn-down WebContent process leaves this reply unanswered. Treat the lost reply as an
+            // empty success, so only this command fails over to the replacement process instead of
+            // aborting WebDriver; the wait below then adopts the incoming process.
+            auto reply = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::Forward>();
+            if (!reply)
+                return JsonValue {};
+            return reply->take_response();
+        },
         Session::WebContentReplacement::Allow));
     TRY(session->wait_for_current_window_to_have_web_content_connection());
     response = TRY(session->perform_async_action(
@@ -240,8 +258,11 @@ Web::WebDriver::Response Client::refresh(Web::WebDriver::Parameters parameters, 
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/refresh");
     auto session = TRY(Session::find_session(parameters[0]));
 
-    auto response = TRY(session->perform_async_action([&](auto& connection) {
-        return connection.refresh();
+    auto response = TRY(session->perform_async_action([&](auto& connection) -> Web::WebDriver::Response {
+        auto refresh_response = connection.template send_sync_but_allow_failure<Messages::WebDriverClient::Refresh>();
+        if (!refresh_response)
+            return JsonValue {};
+        return refresh_response->response();
     }));
     if (TRY(session->wait_for_current_window_to_have_web_content_connection()))
         response = TRY(session->perform_async_action([&](auto& connection) {

--- a/Services/WebDriver/WebContentConnection.h
+++ b/Services/WebDriver/WebContentConnection.h
@@ -24,7 +24,8 @@ public:
     Web::WebDriver::Response wait_for_navigation_completion()
     {
         auto response = send_sync_but_allow_failure<Messages::WebDriverClient::WaitForNavigationCompletion>();
-        VERIFY(response);
+        if (!response)
+            return JsonValue {};
         return response->response();
     }
 


### PR DESCRIPTION
**Problem:** `TestWebDriverSessionHistory` crash-recovery scenarios failed intermittently in CI, with the WebDriver process aborting (exit status `-4`) rather than reporting an error.

**Cause:** When a WebContent process is torn down before it replies to a sync WebDriver navigation request, the WebDriver process itself aborts. That happens when a cross-site navigation swaps the WebContent process out, or when the page crashes, before the reply reaches WebDriver. WebDriver forwarded its navigation commands to WebContent with `send_sync`, whose result is a `NonnullOwnPtr` guarded by `VERIFY(response)`. When the peer disconnected before replying, that `VERIFY` aborted the whole WebDriver process — rather than failing only the single command.

**Fix:** Send commands with `send_sync_but_allow_failure` — and treat a lost response as an empty success. A null reply can only mean the WebContent process is gone — so the recovery path already in place takes over: The window is marked as awaiting replacement, and the caller waits for and adopts the replacement process. `perform_async_action` pumps the event loop while it spins. So, the connection-closed handler runs and the spin exits rather than hanging. That mirrors `load_url_from_ui` — which already tolerated a lost reply in this same way.
