### PR TITLE
LibMedia: Remove the PlaybackStream underrun callback

### DIFF
--- a/Libraries/LibMedia/Audio/PlaybackStream.h
+++ b/Libraries/LibMedia/Audio/PlaybackStream.h
@@ -48,12 +48,6 @@ public:
 
     virtual ~PlaybackStream() = default;
 
-    // Sets the callback function that will be fired whenever the server consumes more data than is made available
-    // by the data request callback. It will fire when either the data request runs too long, or the data request
-    // returns no data. If all the input data has been exhausted and this event fires, that means that playback
-    // has ended.
-    virtual void set_underrun_callback(Function<void()>) = 0;
-
     // Resume playback from the suspended state, requesting new data for audio buffers as soon as possible.
     //
     // The value provided to the promise resolution will match the `total_time_played()` at the exact moment that

--- a/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.cpp
@@ -376,11 +376,6 @@ SampleSpecification PlaybackStreamAudioUnit::sample_specification() const
     return m_state->sample_specification();
 }
 
-void PlaybackStreamAudioUnit::set_underrun_callback(Function<void()>)
-{
-    // FIXME: Implement this.
-}
-
 NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> PlaybackStreamAudioUnit::resume()
 {
     auto promise = Core::ThreadedPromise<AK::Duration>::create();

--- a/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.h
+++ b/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.h
@@ -22,8 +22,6 @@ public:
 
     virtual SampleSpecification sample_specification() const override;
 
-    virtual void set_underrun_callback(Function<void()>) override;
-
     virtual NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> resume() override;
     virtual NonnullRefPtr<Core::ThreadedPromise<void>> drain_buffer_and_suspend() override;
     virtual NonnullRefPtr<Core::ThreadedPromise<void>> discard_buffer_and_suspend() override;

--- a/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
@@ -93,13 +93,6 @@ PlaybackStreamPulseAudio::~PlaybackStreamPulseAudio()
         __temporary_result.release_value();                      \
     })
 
-void PlaybackStreamPulseAudio::set_underrun_callback(Function<void()> callback)
-{
-    m_state->enqueue([&state = *m_state, callback = move(callback)]() mutable {
-        state.stream()->set_underrun_callback(move(callback));
-    });
-}
-
 NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> PlaybackStreamPulseAudio::resume()
 {
     auto promise = Core::ThreadedPromise<AK::Duration>::create();

--- a/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.h
+++ b/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.h
@@ -21,8 +21,6 @@ public:
 
     virtual SampleSpecification sample_specification() const override;
 
-    virtual void set_underrun_callback(Function<void()>) override;
-
     virtual NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> resume() override;
     virtual NonnullRefPtr<Core::ThreadedPromise<void>> drain_buffer_and_suspend() override;
     virtual NonnullRefPtr<Core::ThreadedPromise<void>> discard_buffer_and_suspend() override;

--- a/Libraries/LibMedia/Audio/PlaybackStreamWasapi.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamWasapi.cpp
@@ -100,7 +100,6 @@ struct PlaybackStreamWASAPI::AudioState : public AtomicRefCounted<PlaybackStream
     HANDLE buffer_event = 0;
 
     PlaybackStreamWASAPI::AudioDataRequestCallback data_request_callback;
-    Function<void()> underrun_callback;
 
     Sync::Mutex task_queue_mutex;
     Queue<Variant<TaskPlay, TaskDrainAndSuspend, TaskDiscardAndSuspend, TaskResumeFromUnderrun>> task_queue;
@@ -453,8 +452,6 @@ int PlaybackStreamWASAPI::AudioState::render_thread_loop(PlaybackStreamWASAPI::A
         auto output_buffer = Bytes(buffer, buffer_size).reinterpret<float>();
         auto floats_written = state.data_request_callback(output_buffer);
         if (floats_written.is_empty()) [[unlikely]] {
-            if (state.underrun_callback)
-                state.underrun_callback();
             MUST_HR(state.render_client->ReleaseBuffer(0, AUDCLNT_BUFFERFLAGS_SILENT));
             state.paused = Paused::Underrun;
             drain_buffer_and_stop(state);
@@ -467,11 +464,6 @@ int PlaybackStreamWASAPI::AudioState::render_thread_loop(PlaybackStreamWASAPI::A
     VERIFY(timeEndPeriod(1) == TIMERR_NOERROR);
 
     return 0;
-}
-
-void PlaybackStreamWASAPI::set_underrun_callback(Function<void()> underrun_callback)
-{
-    m_state->underrun_callback = move(underrun_callback);
 }
 
 NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> PlaybackStreamWASAPI::resume()

--- a/Libraries/LibMedia/Audio/PlaybackStreamWasapi.h
+++ b/Libraries/LibMedia/Audio/PlaybackStreamWasapi.h
@@ -18,9 +18,6 @@ public:
 
     virtual SampleSpecification sample_specification() const override;
 
-    // The overrun callback must be realtime safe. The buffer size might be small.
-    virtual void set_underrun_callback(Function<void()>) override;
-
     virtual NonnullRefPtr<Core::ThreadedPromise<AK::Duration>> resume() override;
     virtual NonnullRefPtr<Core::ThreadedPromise<void>> drain_buffer_and_suspend() override;
     virtual NonnullRefPtr<Core::ThreadedPromise<void>> discard_buffer_and_suspend() override;

--- a/Libraries/LibMedia/Audio/PulseAudioWrappers.cpp
+++ b/Libraries/LibMedia/Audio/PulseAudioWrappers.cpp
@@ -316,14 +316,6 @@ ErrorOr<NonnullRefPtr<PulseAudioStream>> PulseAudioContext::create_stream(Output
         },
         stream_wrapper.ptr());
 
-    pa_stream_set_underflow_callback(
-        stream, [](pa_stream*, void* user_data) {
-            auto& stream = *static_cast<PulseAudioStream*>(user_data);
-            if (stream.m_underrun_callback)
-                stream.m_underrun_callback();
-        },
-        stream_wrapper.ptr());
-
     if (auto error = pa_stream_connect_playback(stream, nullptr, &buffer_attributes, flags, nullptr, nullptr); error != 0) {
         warnln("Failed to start PulseAudio stream connection with error: {}", pulse_audio_error_to_string(static_cast<PulseAudioErrorCode>(error)));
         return Error::from_string_literal("Error while connecting the PulseAudio stream");
@@ -366,7 +358,6 @@ PulseAudioStream::~PulseAudioStream()
 {
     auto locker = m_context->main_loop_locker();
     pa_stream_set_write_callback(m_stream, nullptr, nullptr);
-    pa_stream_set_underflow_callback(m_stream, nullptr, nullptr);
     pa_stream_set_started_callback(m_stream, nullptr, nullptr);
     pa_stream_disconnect(m_stream);
     pa_stream_unref(m_stream);
@@ -380,12 +371,6 @@ PulseAudioStreamState PulseAudioStream::get_connection_state()
 bool PulseAudioStream::connection_is_good()
 {
     return PA_STREAM_IS_GOOD(pa_stream_get_state(m_stream));
-}
-
-void PulseAudioStream::set_underrun_callback(Function<void()> callback)
-{
-    auto locker = m_context->main_loop_locker();
-    m_underrun_callback = move(callback);
 }
 
 SampleSpecification PulseAudioStream::sample_specification()

--- a/Libraries/LibMedia/Audio/PulseAudioWrappers.h
+++ b/Libraries/LibMedia/Audio/PulseAudioWrappers.h
@@ -98,10 +98,6 @@ public:
     PulseAudioStreamState get_connection_state();
     bool connection_is_good();
 
-    // Sets the callback to be run when the server consumes more of the buffer than
-    // has been written yet.
-    void set_underrun_callback(Function<void()>);
-
     SampleSpecification sample_specification();
     u32 sample_rate();
     size_t sample_size();
@@ -160,8 +156,6 @@ private:
     };
 
     Atomic<CallbackState> m_callback_state { CallbackState::Parked };
-
-    Function<void()> m_underrun_callback;
 };
 
 enum class PulseAudioErrorCode {


### PR DESCRIPTION
This has been unused for a while, and only served to complicate stream implementations for no benefit.