### PR TITLE
Implement external URL schemes like `mailto:`

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1542,6 +1542,29 @@ static OpenerPolicy obtain_an_opener_policy(GC::Ref<Fetch::Infrastructure::Respo
     return policy;
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#hand-off-to-external-software
+// FIXME: `resource` can also be a response: https://fetch.spec.whatwg.org/#concept-response
+static void hand_off_to_external_software(URL::URL const& resource, GC::Ref<LocalNavigable> navigable, SandboxingFlagSet sandboxing_flags, bool has_transient_activation, URL::Origin const& initiator_origin)
+{
+    // 1. If all of the following are true:
+    //    - navigable is not a top-level traversable;
+    //    - sandboxFlags has its sandboxed custom protocols navigation browsing context flag set; and
+    //    - sandboxFlags has its sandboxed top-level navigation with user activation browsing context flag set, or
+    //      hasTransientActivation is false,
+    //    then return without invoking the external software package.
+    if (!navigable->is_top_level_traversable()
+        && has_flag(sandboxing_flags, SandboxingFlagSet::SandboxedCustomProtocols)
+        && (has_flag(sandboxing_flags, SandboxingFlagSet::SandboxedTopLevelNavigationWithUserActivation) || !has_transient_activation)) {
+        return;
+    }
+
+    // 2. Perform the appropriate handoff of resource while attempting to mitigate the risk that this is an attempt to
+    //    exploit the target software. For example, user agents could prompt the user to confirm that initiatorOrigin is
+    //    to be allowed to invoke the external software in question. In particular, if hasTransientActivation is false,
+    //    then the user agent should not invoke the external software package without prior user confirmation.
+    navigable->page().client().page_did_request_external_url(resource, initiator_origin, has_transient_activation);
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#attempt-to-create-a-non-fetch-scheme-document
 static GC::Ptr<DOM::Document> attempt_to_create_a_non_fetch_scheme_document(NonFetchSchemeNavigationParams const& params)
 {
@@ -1549,25 +1572,27 @@ static GC::Ptr<DOM::Document> attempt_to_create_a_non_fetch_scheme_document(NonF
     auto const& url = params.url;
 
     // 2. Let navigable be navigationParams's navigable.
-    [[maybe_unused]] auto navigable = params.navigable;
+    auto navigable = params.navigable;
 
-    // 3. FIXME: If url is to be handled using a mechanism that does not affect navigable, e.g., because url's scheme is
+    // 3. If url is to be handled using a mechanism that does not affect navigable, e.g., because url's scheme is
     //    handled externally, then:
-    if (false) {
-        // 1. FIXME: Hand-off to external software given url, navigable, navigationParams's target snapshot sandboxing flags,
+    // AD-HOC: Checking if there is external software to hand-off to is done asynchronously, so we don't know here if it
+    //         will succeed or not. Only a few cases reject it early. We find out that a URL went unhandled in
+    //         ViewImplementation::handle_external_url(), so an equivalent of step 4 is implemented there.
+    {
+        // 1. Hand-off to external software given url, navigable, navigationParams's target snapshot sandboxing flags,
         //    navigationParams's source snapshot has transient activation, and navigationParams's initiator origin.
+        hand_off_to_external_software(url, *navigable, params.target_snapshot_sandboxing_flags, params.source_snapshot_has_transient_activation, params.initiator_origin);
 
         // 2. Return null.
         return {};
     }
 
-    // 4. FIXME: Handle url by displaying some sort of inline content, e.g., an error message because the specified scheme is
+    // 4. Handle url by displaying some sort of inline content, e.g., an error message because the specified scheme is
     //    not one of the supported protocols, or an inline prompt to allow the user to select a registered handler for
     //    the given scheme. Return the result of displaying the inline content given navigable, navigationParams's id,
     //    navigationParams's navigation timing type, and navigationParams's user involvement.
-
-    dbgln("FIXME: Don't know how to navigate to {}", url);
-    return {};
+    // AD-HOC: Not implemented here, see note on step 3 above.
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-from-a-srcdoc-resource

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1524,6 +1524,29 @@ static OpenerPolicy obtain_an_opener_policy(GC::Ref<Fetch::Infrastructure::Respo
     return policy;
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#hand-off-to-external-software
+// FIXME: `resource` can also be a response: https://fetch.spec.whatwg.org/#concept-response
+static void hand_off_to_external_software(URL::URL const& resource, GC::Ref<LocalNavigable> navigable, SandboxingFlagSet sandboxing_flags, bool has_transient_activation, URL::Origin const& initiator_origin)
+{
+    // 1. If all of the following are true:
+    //    - navigable is not a top-level traversable;
+    //    - sandboxFlags has its sandboxed custom protocols navigation browsing context flag set; and
+    //    - sandboxFlags has its sandboxed top-level navigation with user activation browsing context flag set, or
+    //      hasTransientActivation is false,
+    //    then return without invoking the external software package.
+    if (!navigable->is_top_level_traversable()
+        && has_flag(sandboxing_flags, SandboxingFlagSet::SandboxedCustomProtocols)
+        && (has_flag(sandboxing_flags, SandboxingFlagSet::SandboxedTopLevelNavigationWithUserActivation) || !has_transient_activation)) {
+        return;
+    }
+
+    // 2. Perform the appropriate handoff of resource while attempting to mitigate the risk that this is an attempt to
+    //    exploit the target software. For example, user agents could prompt the user to confirm that initiatorOrigin is
+    //    to be allowed to invoke the external software in question. In particular, if hasTransientActivation is false,
+    //    then the user agent should not invoke the external software package without prior user confirmation.
+    navigable->page().client().page_did_request_external_url(resource, initiator_origin, has_transient_activation);
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#attempt-to-create-a-non-fetch-scheme-document
 static GC::Ptr<DOM::Document> attempt_to_create_a_non_fetch_scheme_document(NonFetchSchemeNavigationParams const& params)
 {
@@ -1531,25 +1554,27 @@ static GC::Ptr<DOM::Document> attempt_to_create_a_non_fetch_scheme_document(NonF
     auto const& url = params.url;
 
     // 2. Let navigable be navigationParams's navigable.
-    [[maybe_unused]] auto navigable = params.navigable;
+    auto navigable = params.navigable;
 
-    // 3. FIXME: If url is to be handled using a mechanism that does not affect navigable, e.g., because url's scheme is
+    // 3. If url is to be handled using a mechanism that does not affect navigable, e.g., because url's scheme is
     //    handled externally, then:
-    if (false) {
-        // 1. FIXME: Hand-off to external software given url, navigable, navigationParams's target snapshot sandboxing flags,
+    // AD-HOC: Checking if there is external software to hand-off to is done asynchronously, so we don't know here if it
+    //         will succeed or not. Only a few cases reject it early. We find out that a URL went unhandled in
+    //         ViewImplementation::handle_external_url(), so an equivalent of step 4 is implemented there.
+    {
+        // 1. Hand-off to external software given url, navigable, navigationParams's target snapshot sandboxing flags,
         //    navigationParams's source snapshot has transient activation, and navigationParams's initiator origin.
+        hand_off_to_external_software(url, *navigable, params.target_snapshot_sandboxing_flags, params.source_snapshot_has_transient_activation, params.initiator_origin);
 
         // 2. Return null.
         return {};
     }
 
-    // 4. FIXME: Handle url by displaying some sort of inline content, e.g., an error message because the specified scheme is
+    // 4. Handle url by displaying some sort of inline content, e.g., an error message because the specified scheme is
     //    not one of the supported protocols, or an inline prompt to allow the user to select a registered handler for
     //    the given scheme. Return the result of displaying the inline content given navigable, navigationParams's id,
     //    navigationParams's navigation timing type, and navigationParams's user involvement.
-
-    dbgln("FIXME: Don't know how to navigate to {}", url);
-    return {};
+    // AD-HOC: Not implemented here, see note on step 3 above.
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-from-a-srcdoc-resource

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -33,6 +33,7 @@
 #include <LibRequests/CameFromCache.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
+#include <LibURL/Origin.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/AgentType.h>
 #include <LibWeb/Bindings/Navigation.h>
@@ -569,6 +570,7 @@ public:
     virtual void page_did_request_media_context_menu(CSSPixelPoint, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Page::MediaContextMenu const&) { }
     virtual void page_did_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_middle_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
+    virtual void page_did_request_external_url([[maybe_unused]] URL::URL const& url, [[maybe_unused]] URL::Origin const& initiator_origin, [[maybe_unused]] bool has_transient_activation) { }
     virtual void page_did_request_tooltip_override(CSSPixelPoint, ByteString const&) { }
     virtual void page_did_stop_tooltip_override() { }
     virtual void page_did_enter_tooltip_area(ByteString const&) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -33,6 +33,7 @@
 #include <LibRequests/CameFromCache.h>
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/RequestTimingInfo.h>
+#include <LibURL/Origin.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/AgentType.h>
 #include <LibWeb/Bindings/Navigation.h>
@@ -571,6 +572,7 @@ public:
     virtual void page_did_request_media_context_menu(CSSPixelPoint, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Page::MediaContextMenu const&) { }
     virtual void page_did_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_middle_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
+    virtual void page_did_request_external_url([[maybe_unused]] URL::URL const& url, [[maybe_unused]] URL::Origin const& initiator_origin, [[maybe_unused]] bool has_transient_activation) { }
     virtual void page_did_request_tooltip_override(CSSPixelPoint, ByteString const&) { }
     virtual void page_did_stop_tooltip_override() { }
     virtual void page_did_enter_tooltip_area(ByteString const&) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -685,7 +685,13 @@ void Application::open_urls_in_new_tabs(ReadonlySpan<URL::URL> urls) const
 
 void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab activate_tab) const
 {
-    if (auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
+    auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id);
+    if (!bookmark.has_value() || !bookmark->is_bookmark())
+        return;
+
+    if (auto view = active_web_view(); view.has_value())
+        view->open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
+    else
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
 }
 
@@ -711,12 +717,27 @@ void Application::open_bookmark_folder_in_new_tabs(String const& folder_id) cons
     Vector<URL::URL> urls;
     collect_bookmark_urls(folder->folder(), urls);
 
-    open_urls_in_new_tabs(urls);
+    Vector<URL::URL> internal_urls;
+    auto active_view = active_web_view();
+    for (auto const& url : urls) {
+        if (active_view.has_value() && !is_url_handled_internally(url))
+            active_view->open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+        else
+            internal_urls.append(url);
+    }
+
+    open_urls_in_new_tabs(internal_urls);
 }
 
 void Application::open_bookmark_in_new_window(String const& bookmark_id, IsPrivate is_private)
 {
-    if (auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
+    auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id);
+    if (!bookmark.has_value() || !bookmark->is_bookmark())
+        return;
+
+    if (auto view = active_web_view(); view.has_value())
+        view->open_url_in_new_window(bookmark->bookmark().url, is_private);
+    else
         open_url_in_new_window(bookmark->bookmark().url, is_private);
 }
 
@@ -2181,7 +2202,7 @@ void Application::create_bookmark_menu_items(Optional<MenuData> data)
             [&](BookmarkItem::Bookmark const& bookmark) {
                 auto action = Action::create(bookmark.title.value_or({}), ActionID::BookmarkItem, [this, url = bookmark.url]() {
                     if (auto view = active_web_view(); view.has_value())
-                        view->load(url);
+                        view->load_from_user_input(url);
                     else
                         open_url_in_new_tab(url, Web::HTML::ActivateTab::Yes);
                 });

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -685,7 +685,13 @@ void Application::open_urls_in_new_tabs(ReadonlySpan<URL::URL> urls) const
 
 void Application::open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab activate_tab) const
 {
-    if (auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
+    auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id);
+    if (!bookmark.has_value() || !bookmark->is_bookmark())
+        return;
+
+    if (auto view = active_web_view(); view.has_value())
+        view->open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
+    else
         open_url_in_new_tab(bookmark->bookmark().url, activate_tab);
 }
 
@@ -711,12 +717,27 @@ void Application::open_bookmark_folder_in_new_tabs(String const& folder_id) cons
     Vector<URL::URL> urls;
     collect_bookmark_urls(folder->folder(), urls);
 
-    open_urls_in_new_tabs(urls);
+    Vector<URL::URL> internal_urls;
+    auto active_view = active_web_view();
+    for (auto const& url : urls) {
+        if (active_view.has_value() && !is_url_handled_internally(url))
+            active_view->open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+        else
+            internal_urls.append(url);
+    }
+
+    open_urls_in_new_tabs(internal_urls);
 }
 
 void Application::open_bookmark_in_new_window(String const& bookmark_id, IsPrivate is_private)
 {
-    if (auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id); bookmark.has_value() && bookmark->is_bookmark())
+    auto bookmark = m_bookmark_store->find_item_by_id(bookmark_id);
+    if (!bookmark.has_value() || !bookmark->is_bookmark())
+        return;
+
+    if (auto view = active_web_view(); view.has_value())
+        view->open_url_in_new_window(bookmark->bookmark().url, is_private);
+    else
         open_url_in_new_window(bookmark->bookmark().url, is_private);
 }
 
@@ -2165,7 +2186,7 @@ void Application::create_bookmark_menu_items(Optional<MenuData> data)
             [&](BookmarkItem::Bookmark const& bookmark) {
                 auto action = Action::create(bookmark.title.value_or({}), ActionID::BookmarkItem, [this, url = bookmark.url]() {
                     if (auto view = active_web_view(); view.has_value())
-                        view->load(url);
+                        view->load_from_user_input(url);
                     else
                         open_url_in_new_tab(url, Web::HTML::ActivateTab::Yes);
                 });

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -35,6 +35,7 @@
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/BrowserProcess.h>
 #include <LibWebView/DownloadStore.h>
+#include <LibWebView/ExternalURLHandler.h>
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Options.h>
@@ -169,6 +170,8 @@ public:
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
     virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const;
     virtual void open_url_in_new_window(URL::URL const&, IsPrivate) { }
+
+    virtual void resolve_external_url_handler(URL::URL const&, ExternalURLHandlerCallback callback) const { callback(nullptr); }
 
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
     void open_bookmark_folder_in_new_tabs(String const& folder_id) const;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -34,6 +34,7 @@
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWebView/BookmarkStore.h>
 #include <LibWebView/BrowserProcess.h>
+#include <LibWebView/ExternalURLHandler.h>
 #include <LibWebView/FileDownloader.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/Options.h>
@@ -168,6 +169,8 @@ public:
     virtual void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab) const;
     virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const;
     virtual void open_url_in_new_window(URL::URL const&, IsPrivate) { }
+
+    virtual void resolve_external_url_handler(URL::URL const&, ExternalURLHandlerCallback callback) const { callback(nullptr); }
 
     void open_bookmark_in_new_tab(String const& bookmark_id, Web::HTML::ActivateTab) const;
     void open_bookmark_folder_in_new_tabs(String const& folder_id) const;

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -224,7 +224,7 @@ static Optional<AutocompleteSuggestion> search_for_query_suggestion(StringView q
 
 static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
 {
-    if (query.is_empty() || !location_looks_like_url(query))
+    if (query.is_empty() || classify_user_input(query).classification != UserInputClassification::InternalURL)
         return {};
 
     return AutocompleteSuggestion {

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -88,6 +88,9 @@ void Autocomplete::cancel_pending_query()
     m_trimmed_query = {};
     m_local_suggestions.clear();
     m_remote_suggestions.clear();
+    m_external_url.clear();
+    m_external_url_handler_query_complete = true;
+    m_external_url_has_handler = false;
 }
 
 void Autocomplete::record_engagement(OmniboxEngagement engagement)
@@ -104,7 +107,9 @@ String autocomplete_suggestion_display_text(AutocompleteSuggestion const& sugges
     if (suggestion.source == AutocompleteSuggestionSource::Search)
         return suggestion.text;
 
-    auto url = URL::create_with_url_or_path(suggestion.text.to_byte_string());
+    auto url = classify_user_input(suggestion.text).url;
+    if (!url.has_value())
+        url = URL::create_with_url_or_path(suggestion.text.to_byte_string());
     if (!url.has_value())
         return suggestion.text;
     return url_for_display(*url);
@@ -197,7 +202,7 @@ Vector<AutocompleteSuggestion> web_ui_autocomplete_suggestions(StringView input)
 
 static Optional<AutocompleteSuggestion> search_for_query_suggestion(StringView query)
 {
-    if (query.is_empty() || location_looks_like_url(query))
+    if (query.is_empty())
         return {};
 
     auto const& search_engine = Application::settings().search_engine();
@@ -222,12 +227,9 @@ static Optional<AutocompleteSuggestion> search_for_query_suggestion(StringView q
     };
 }
 
-static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
+static AutocompleteSuggestion make_literal_url_suggestion(StringView query)
 {
-    if (query.is_empty() || !location_looks_like_url(query))
-        return {};
-
-    return AutocompleteSuggestion {
+    return {
         .source = AutocompleteSuggestionSource::LiteralURL,
         .text = MUST(String::from_utf8(query)),
         .title = {},
@@ -239,6 +241,14 @@ static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
         .can_be_automatically_selected = true,
         .can_be_inline_completed = false,
     };
+}
+
+static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
+{
+    if (query.is_empty() || !location_looks_like_url(query))
+        return {};
+
+    return make_literal_url_suggestion(query);
 }
 
 static Vector<AutocompleteSuggestion> make_remote_suggestions(Vector<String> remote_suggestions)
@@ -288,12 +298,27 @@ void Autocomplete::query_autocomplete_engine(AutocompleteQueryID query_id, Strin
     m_query = move(query);
     m_local_query_complete = false;
     m_remote_query_complete = false;
+    auto classified_input = classify_user_input(m_trimmed_query);
+    m_external_url = classified_input.classification == UserInputClassification::ExternalURL
+        ? move(classified_input.url)
+        : Optional<URL::URL> {};
+    m_external_url_handler_query_complete = !m_external_url.has_value();
+    m_external_url_has_handler = false;
     m_local_suggestions.clear();
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Autocomplete query='{}' trimmed='{}'", m_query, m_trimmed_query);
 
     // Private windows may read normal-profile history but never write through this worker connection.
     Application::autocomplete_service().query(m_service_client_id, query_id, m_trimmed_query, m_max_suggestions);
+
+    if (m_external_url.has_value()) {
+        auto weak_this = make_weak_ptr();
+        Application::the().resolve_external_url_handler(*m_external_url, [weak_this, query_id](RefPtr<ExternalURLHandler> handler) mutable {
+            if (!weak_this)
+                return;
+            weak_this->external_url_handler_query_complete(query_id, move(handler));
+        });
+    }
 
     if (m_trimmed_query.is_empty()) {
         m_remote_suggestions.clear();
@@ -398,25 +423,44 @@ void Autocomplete::local_query_complete(AutocompleteQueryID query_id, Vector<Aut
     deliver_current_result();
 }
 
+void Autocomplete::external_url_handler_query_complete(AutocompleteQueryID query_id, RefPtr<ExternalURLHandler> handler)
+{
+    if (m_query_id != query_id)
+        return;
+
+    m_external_url_handler_query_complete = true;
+    m_external_url_has_handler = handler && !handler->is_ladybird();
+    deliver_current_result();
+}
+
 void Autocomplete::deliver_current_result()
 {
     if (!m_query_id.has_value())
         return;
 
-    auto web_ui_suggestions = web_ui_autocomplete_suggestions(m_trimmed_query);
-    auto verbatim_suggestion = web_ui_suggestions.is_empty() ? literal_url_suggestion(m_query) : Optional<AutocompleteSuggestion> {};
-    if (web_ui_suggestions.is_empty() && !verbatim_suggestion.has_value())
-        verbatim_suggestion = search_for_query_suggestion(m_query);
-    web_ui_suggestions.extend(m_local_suggestions);
+    auto additional_suggestions = web_ui_autocomplete_suggestions(m_trimmed_query);
+    Optional<AutocompleteSuggestion> verbatim_suggestion;
+    if (additional_suggestions.is_empty() && m_external_url_handler_query_complete) {
+        if (m_external_url_has_handler) {
+            verbatim_suggestion = make_literal_url_suggestion(m_query);
+            if (auto search_suggestion = search_for_query_suggestion(m_query); search_suggestion.has_value())
+                additional_suggestions.append(search_suggestion.release_value());
+        } else if (auto url_suggestion = literal_url_suggestion(m_query); url_suggestion.has_value()) {
+            verbatim_suggestion = url_suggestion.release_value();
+        } else {
+            verbatim_suggestion = search_for_query_suggestion(m_query);
+        }
+    }
+    additional_suggestions.extend(m_local_suggestions);
     auto merged_suggestions = mux_autocomplete_suggestions(
         m_trimmed_query,
         move(verbatim_suggestion),
-        move(web_ui_suggestions),
+        move(additional_suggestions),
         make_remote_suggestions(m_remote_suggestions),
         m_max_suggestions);
     for (auto& suggestion : merged_suggestions)
         suggestion.highlight_input = m_trimmed_query;
-    auto result_kind = m_local_query_complete && m_remote_query_complete
+    auto result_kind = m_local_query_complete && m_remote_query_complete && m_external_url_handler_query_complete
         ? AutocompleteResultKind::Final
         : AutocompleteResultKind::Intermediate;
 

--- a/Libraries/LibWebView/Autocomplete.cpp
+++ b/Libraries/LibWebView/Autocomplete.cpp
@@ -88,6 +88,9 @@ void Autocomplete::cancel_pending_query()
     m_trimmed_query = {};
     m_local_suggestions.clear();
     m_remote_suggestions.clear();
+    m_external_url.clear();
+    m_external_url_handler_query_complete = true;
+    m_external_url_has_handler = false;
 }
 
 void Autocomplete::record_engagement(OmniboxEngagement engagement)
@@ -104,7 +107,9 @@ String autocomplete_suggestion_display_text(AutocompleteSuggestion const& sugges
     if (suggestion.source == AutocompleteSuggestionSource::Search)
         return suggestion.text;
 
-    auto url = URL::create_with_url_or_path(suggestion.text.to_byte_string());
+    auto url = classify_user_input(suggestion.text).url;
+    if (!url.has_value())
+        url = URL::create_with_url_or_path(suggestion.text.to_byte_string());
     if (!url.has_value())
         return suggestion.text;
     return url_for_display(*url);
@@ -197,7 +202,7 @@ Vector<AutocompleteSuggestion> web_ui_autocomplete_suggestions(StringView input)
 
 static Optional<AutocompleteSuggestion> search_for_query_suggestion(StringView query)
 {
-    if (query.is_empty() || location_looks_like_url(query))
+    if (query.is_empty())
         return {};
 
     auto const& search_engine = Application::settings().search_engine();
@@ -222,12 +227,9 @@ static Optional<AutocompleteSuggestion> search_for_query_suggestion(StringView q
     };
 }
 
-static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
+static AutocompleteSuggestion make_literal_url_suggestion(StringView query)
 {
-    if (query.is_empty() || classify_user_input(query).classification != UserInputClassification::InternalURL)
-        return {};
-
-    return AutocompleteSuggestion {
+    return {
         .source = AutocompleteSuggestionSource::LiteralURL,
         .text = MUST(String::from_utf8(query)),
         .title = {},
@@ -239,6 +241,14 @@ static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
         .can_be_automatically_selected = true,
         .can_be_inline_completed = false,
     };
+}
+
+static Optional<AutocompleteSuggestion> literal_url_suggestion(StringView query)
+{
+    if (query.is_empty() || classify_user_input(query).classification != UserInputClassification::InternalURL)
+        return {};
+
+    return make_literal_url_suggestion(query);
 }
 
 static Vector<AutocompleteSuggestion> make_remote_suggestions(Vector<String> remote_suggestions)
@@ -288,12 +298,27 @@ void Autocomplete::query_autocomplete_engine(AutocompleteQueryID query_id, Strin
     m_query = move(query);
     m_local_query_complete = false;
     m_remote_query_complete = false;
+    auto classified_input = classify_user_input(m_trimmed_query);
+    m_external_url = classified_input.classification == UserInputClassification::ExternalURL
+        ? move(classified_input.url)
+        : Optional<URL::URL> {};
+    m_external_url_handler_query_complete = !m_external_url.has_value();
+    m_external_url_has_handler = false;
     m_local_suggestions.clear();
 
     dbgln_if(WEBVIEW_HISTORY_DEBUG, "[History] Autocomplete query='{}' trimmed='{}'", m_query, m_trimmed_query);
 
     // Private windows may read normal-profile history but never write through this worker connection.
     Application::autocomplete_service().query(m_service_client_id, query_id, m_trimmed_query, m_max_suggestions);
+
+    if (m_external_url.has_value()) {
+        auto weak_this = make_weak_ptr();
+        Application::the().resolve_external_url_handler(*m_external_url, [weak_this, query_id](RefPtr<ExternalURLHandler> handler) mutable {
+            if (!weak_this)
+                return;
+            weak_this->external_url_handler_query_complete(query_id, move(handler));
+        });
+    }
 
     if (m_trimmed_query.is_empty()) {
         m_remote_suggestions.clear();
@@ -398,25 +423,44 @@ void Autocomplete::local_query_complete(AutocompleteQueryID query_id, Vector<Aut
     deliver_current_result();
 }
 
+void Autocomplete::external_url_handler_query_complete(AutocompleteQueryID query_id, RefPtr<ExternalURLHandler> handler)
+{
+    if (m_query_id != query_id)
+        return;
+
+    m_external_url_handler_query_complete = true;
+    m_external_url_has_handler = handler && !handler->is_ladybird();
+    deliver_current_result();
+}
+
 void Autocomplete::deliver_current_result()
 {
     if (!m_query_id.has_value())
         return;
 
-    auto web_ui_suggestions = web_ui_autocomplete_suggestions(m_trimmed_query);
-    auto verbatim_suggestion = web_ui_suggestions.is_empty() ? literal_url_suggestion(m_query) : Optional<AutocompleteSuggestion> {};
-    if (web_ui_suggestions.is_empty() && !verbatim_suggestion.has_value())
-        verbatim_suggestion = search_for_query_suggestion(m_query);
-    web_ui_suggestions.extend(m_local_suggestions);
+    auto additional_suggestions = web_ui_autocomplete_suggestions(m_trimmed_query);
+    Optional<AutocompleteSuggestion> verbatim_suggestion;
+    if (additional_suggestions.is_empty() && m_external_url_handler_query_complete) {
+        if (m_external_url_has_handler) {
+            verbatim_suggestion = make_literal_url_suggestion(m_query);
+            if (auto search_suggestion = search_for_query_suggestion(m_query); search_suggestion.has_value())
+                additional_suggestions.append(search_suggestion.release_value());
+        } else if (auto url_suggestion = literal_url_suggestion(m_query); url_suggestion.has_value()) {
+            verbatim_suggestion = url_suggestion.release_value();
+        } else {
+            verbatim_suggestion = search_for_query_suggestion(m_query);
+        }
+    }
+    additional_suggestions.extend(m_local_suggestions);
     auto merged_suggestions = mux_autocomplete_suggestions(
         m_trimmed_query,
         move(verbatim_suggestion),
-        move(web_ui_suggestions),
+        move(additional_suggestions),
         make_remote_suggestions(m_remote_suggestions),
         m_max_suggestions);
     for (auto& suggestion : merged_suggestions)
         suggestion.highlight_input = m_trimmed_query;
-    auto result_kind = m_local_query_complete && m_remote_query_complete
+    auto result_kind = m_local_query_complete && m_remote_query_complete && m_external_url_handler_query_complete
         ? AutocompleteResultKind::Final
         : AutocompleteResultKind::Intermediate;
 

--- a/Libraries/LibWebView/Autocomplete.h
+++ b/Libraries/LibWebView/Autocomplete.h
@@ -14,8 +14,10 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <AK/Weakable.h>
 #include <LibCore/Forward.h>
 #include <LibRequests/Forward.h>
+#include <LibURL/URL.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/OmniboxEngagement.h>
 #include <LibWebView/PrivateBrowsing.h>
@@ -96,7 +98,7 @@ WEBVIEW_API Vector<AutocompleteSuggestion> web_ui_autocomplete_suggestions(Strin
 WEBVIEW_API bool autocomplete_urls_match(StringView left, StringView right);
 WEBVIEW_API bool autocomplete_url_can_complete(StringView query, StringView suggestion);
 
-class WEBVIEW_API Autocomplete {
+class WEBVIEW_API Autocomplete : public Weakable<Autocomplete> {
 public:
     explicit Autocomplete(IsPrivate);
     ~Autocomplete();
@@ -111,6 +113,7 @@ private:
     static ErrorOr<Vector<String>> received_autocomplete_response(AutocompleteEngine const&, Optional<ByteString const&> content_type, StringView response);
     void start_remote_query(AutocompleteQueryID, AutocompleteEngine, String query);
     void local_query_complete(AutocompleteQueryID, Vector<AutocompleteSuggestion>);
+    void external_url_handler_query_complete(AutocompleteQueryID, RefPtr<ExternalURLHandler>);
     void deliver_current_result();
     void invoke_autocomplete_query_complete(AutocompleteQueryID, Vector<AutocompleteSuggestion> suggestions, AutocompleteResultKind) const;
 
@@ -122,6 +125,9 @@ private:
     size_t m_max_suggestions { default_autocomplete_suggestion_limit };
     bool m_local_query_complete { false };
     bool m_remote_query_complete { false };
+    bool m_external_url_handler_query_complete { true };
+    bool m_external_url_has_handler { false };
+    Optional<URL::URL> m_external_url;
     Vector<AutocompleteSuggestion> m_local_suggestions;
     Vector<String> m_remote_suggestions;
     RefPtr<Core::Timer> m_remote_query_timer;

--- a/Libraries/LibWebView/AutocompleteMuxer.cpp
+++ b/Libraries/LibWebView/AutocompleteMuxer.cpp
@@ -199,6 +199,9 @@ Vector<AutocompleteSuggestion> mux_autocomplete_suggestions(
     if (limit == 0)
         return {};
 
+    auto verbatim_is_literal_url = verbatim_suggestion.has_value()
+        && verbatim_suggestion->source == AutocompleteSuggestionSource::LiteralURL;
+
     Vector<AutocompleteSuggestion> candidates;
     candidates.ensure_capacity(local_suggestions.size() + remote_suggestions.size() + (verbatim_suggestion.has_value() ? 1 : 0));
     if (verbatim_suggestion.has_value())
@@ -247,7 +250,9 @@ Vector<AutocompleteSuggestion> mux_autocomplete_suggestions(
 
     quick_sort(candidates, suggestion_is_better);
 
-    auto default_index = candidates.find_first_index_if([](auto const& suggestion) {
+    auto default_index = candidates.find_first_index_if([verbatim_is_literal_url](auto const& suggestion) {
+        if (verbatim_is_literal_url)
+            return suggestion.is_verbatim;
         return suggestion.can_be_automatically_selected;
     });
     if (default_index.has_value() && *default_index != 0) {

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     DownloadPresentation.cpp
     DownloadSegmentation.cpp
     DownloadStore.cpp
+    ExternalURLHandler.cpp
     FileDownloader.cpp
     Geolocation.cpp
     HeadlessWebView.cpp

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     DictionaryLookup.cpp
     DOMNodeProperties.cpp
     DownloadPresentation.cpp
+    ExternalURLHandler.cpp
     FileDownloader.cpp
     Geolocation.cpp
     HeadlessWebView.cpp

--- a/Libraries/LibWebView/ExternalURLHandler.cpp
+++ b/Libraries/LibWebView/ExternalURLHandler.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <LibWebView/ExternalURLHandler.h>
+
+namespace WebView {
+
+static constexpr Array denied_schemes {
+    "afp"sv,
+    "data"sv,
+    "disk"sv,
+    "disks"sv,
+    "file"sv,
+    "hcp"sv,
+    "ie.http"sv,
+    "javascript"sv,
+    "mk"sv,
+    "ms-help"sv,
+    "nntp"sv,
+    "res"sv,
+    "shell"sv,
+    "vbscript"sv,
+    "view-source"sv,
+    "vnd.ms.radio"sv,
+};
+
+bool ExternalURLRequestPolicy::is_denied_scheme(StringView scheme)
+{
+    // Block all single-letter schemes.
+    if (scheme.length() == 1)
+        return true;
+    return denied_schemes.contains_slow(scheme);
+}
+
+static constexpr auto request_allowance_lifetime = AK::Duration::from_seconds(5);
+
+ExternalURLAction ExternalURLRequestPolicy::decide(URL::URL const& url, bool has_transient_activation, MonotonicTime now)
+{
+    if (is_denied_scheme(url.scheme()))
+        return ExternalURLAction::Block;
+
+    if (!m_request_allowance.has_value())
+        return ExternalURLAction::Block;
+
+    if (now - m_request_allowance->granted_at > request_allowance_lifetime) {
+        m_request_allowance.clear();
+        return ExternalURLAction::Block;
+    }
+
+    if (m_request_allowance->source == ExternalURLRequestSource::BrowserUI
+        && m_request_allowance->expected_url != url)
+        return ExternalURLAction::Block;
+
+    // Don't prompt when the user activated a mailto: link. This matches other browsers.
+    if (url.scheme() == "mailto"sv
+        && (has_transient_activation || m_request_allowance->source == ExternalURLRequestSource::BrowserUI))
+        return ExternalURLAction::Launch;
+
+    return ExternalURLAction::Prompt;
+}
+
+Optional<ExternalURLRequestSource> ExternalURLRequestPolicy::take_request_allowance()
+{
+    if (!m_request_allowance.has_value())
+        return {};
+    return m_request_allowance.release_value().source;
+}
+
+void ExternalURLRequestPolicy::clear_page_request_allowance()
+{
+    if (m_request_allowance.has_value() && m_request_allowance->source == ExternalURLRequestSource::Page)
+        m_request_allowance.clear();
+}
+
+}

--- a/Libraries/LibWebView/ExternalURLHandler.h
+++ b/Libraries/LibWebView/ExternalURLHandler.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <AK/String.h>
+#include <AK/Time.h>
+#include <LibURL/URL.h>
+#include <LibWebView/Export.h>
+
+namespace WebView {
+
+class WEBVIEW_API ExternalURLHandler : public RefCounted<ExternalURLHandler> {
+public:
+    using LaunchCallback = Function<void(bool)>;
+
+    virtual ~ExternalURLHandler() = default;
+
+    String const& application_name() const { return m_application_name; }
+    bool is_ladybird() const { return m_is_ladybird; }
+
+    virtual void launch(URL::URL const&, LaunchCallback) const = 0;
+
+protected:
+    ExternalURLHandler(String application_name, bool is_ladybird)
+        : m_application_name(move(application_name))
+        , m_is_ladybird(is_ladybird)
+    {
+    }
+
+private:
+    String m_application_name;
+    bool m_is_ladybird { false };
+};
+
+using ExternalURLHandlerCallback = Function<void(RefPtr<ExternalURLHandler>)>;
+
+enum class ExternalURLAction : u8 {
+    Block,
+    Launch,
+    Prompt,
+};
+
+enum class ExternalURLRequestSource : u8 {
+    Page,
+    BrowserUI,
+};
+
+class WEBVIEW_API ExternalURLRequestPolicy {
+public:
+    ExternalURLAction decide(URL::URL const&, bool has_transient_activation, MonotonicTime now = MonotonicTime::now());
+    void allow_next_request(MonotonicTime now = MonotonicTime::now()) { m_request_allowance = RequestAllowance { ExternalURLRequestSource::Page, {}, now }; }
+    void allow_request_from_browser_ui(URL::URL const& url, MonotonicTime now = MonotonicTime::now()) { m_request_allowance = RequestAllowance { ExternalURLRequestSource::BrowserUI, url, now }; }
+    Optional<ExternalURLRequestSource> take_request_allowance();
+    void clear_page_request_allowance();
+
+    static bool is_denied_scheme(StringView);
+
+private:
+    struct RequestAllowance {
+        ExternalURLRequestSource source;
+        Optional<URL::URL> expected_url;
+        MonotonicTime granted_at;
+    };
+
+    Optional<RequestAllowance> m_request_allowance;
+};
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -24,6 +24,7 @@ class CompositorConnection;
 class CompositorHostBase;
 class CookieJar;
 class DownloadStore;
+class ExternalURLHandler;
 class HistoryStore;
 class HSTSStore;
 class Menu;

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -23,6 +23,7 @@ class CompositorClient;
 class CompositorConnection;
 class CompositorHostBase;
 class CookieJar;
+class ExternalURLHandler;
 class HistoryStore;
 class HSTSStore;
 class Menu;

--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -656,38 +656,42 @@ void Omnibox::activate_selected_suggestion()
 void Omnibox::commit_suggestion(size_t suggestion_index, bool should_record_engagement, bool was_explicit)
 {
     auto suggestion = m_suggestions[suggestion_index];
+    auto destination_kind = suggestion.source == AutocompleteSuggestionSource::Search
+        ? OmniboxDestinationKind::Search
+        : OmniboxDestinationKind::URL;
     if (should_record_engagement) {
         m_provider->record_engagement({
             .input = m_retained_engagement_input.value_or(m_query),
-            .destination_kind = suggestion.source == AutocompleteSuggestionSource::Search
-                ? OmniboxDestinationKind::Search
-                : OmniboxDestinationKind::URL,
+            .destination_kind = destination_kind,
             .destination = suggestion.text,
             .was_explicit = was_explicit,
         });
     }
-    commit_suggestion_text(move(suggestion.text));
+    commit_suggestion_text(move(suggestion.text), destination_kind);
 }
 
-void Omnibox::commit_suggestion_text(String text)
+void Omnibox::commit_suggestion_text(String text, OmniboxDestinationKind destination_kind)
 {
     m_provenance = TextProvenance::UserText;
     m_completion_suggestion = {};
     m_query = text;
     set_display(text, {});
     close_popup();
-    commit(move(text));
+    commit(move(text), destination_kind);
 }
 
 void Omnibox::commit_verbatim(String text)
 {
+    auto destination_kind = classify_user_input(text).classification != UserInputClassification::Search
+        ? OmniboxDestinationKind::URL
+        : OmniboxDestinationKind::Search;
     m_provider->record_engagement({
         .input = m_retained_engagement_input.value_or(text),
-        .destination_kind = location_looks_like_url(text) ? OmniboxDestinationKind::URL : OmniboxDestinationKind::Search,
+        .destination_kind = destination_kind,
         .destination = text,
         .was_explicit = false,
     });
-    commit(move(text));
+    commit(move(text), destination_kind);
 }
 
 void Omnibox::adopt_display_text_as_query()
@@ -772,8 +776,9 @@ void Omnibox::set_selection(Optional<Selection> selection)
         on_selection_change();
 }
 
-void Omnibox::commit(String text)
+void Omnibox::commit(String text, OmniboxDestinationKind destination_kind)
 {
+    m_destination_kind_for_last_commit = destination_kind;
     if (on_commit)
         on_commit(move(text));
 }

--- a/Libraries/LibWebView/Omnibox.h
+++ b/Libraries/LibWebView/Omnibox.h
@@ -92,6 +92,7 @@ public:
 
     // State for the chrome:
     String const& query() const { return m_query; }
+    OmniboxDestinationKind destination_kind_for_last_commit() const { return m_destination_kind_for_last_commit; }
     bool is_editing() const { return m_is_editing; }
     bool is_popup_visible() const { return m_popup_visible; }
     Vector<AutocompleteSuggestion> const& suggestions() const { return m_suggestions; }
@@ -145,7 +146,7 @@ private:
     void display_suggestion(size_t suggestion_index);
     void activate_selected_suggestion();
     void commit_suggestion(size_t suggestion_index, bool record_engagement, bool was_explicit);
-    void commit_suggestion_text(String);
+    void commit_suggestion_text(String, OmniboxDestinationKind);
     void commit_verbatim(String);
     void adopt_display_text_as_query();
     void apply_completion(String suggestion_text, String completion_text);
@@ -156,7 +157,7 @@ private:
     void close_popup();
     void abandon_popup_session();
     void set_selection(Optional<Selection>);
-    void commit(String text);
+    void commit(String text, OmniboxDestinationKind);
     bool selection_is_explicit() const;
     bool completion_is_suppressed() const;
 
@@ -201,6 +202,7 @@ private:
 
     u64 m_next_query_id { 0 };
     Optional<AutocompleteQueryID> m_active_query_id;
+    OmniboxDestinationKind m_destination_kind_for_last_commit { OmniboxDestinationKind::URL };
 };
 
 }

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -14,6 +14,7 @@
 #include <LibURL/PublicSuffixData.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Autocomplete.h>
+#include <LibWebView/ExternalURLHandler.h>
 #include <LibWebView/URL.h>
 
 namespace WebView {
@@ -23,65 +24,120 @@ bool is_url_handled_internally(URL::URL const& url)
     return url.scheme().is_one_of("about"sv, "blob"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv);
 }
 
-Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
+static bool has_valid_explicit_port(StringView input)
 {
-    auto search_url_or_error = [&]() -> Optional<URL::URL> {
-        if (!search_engine.has_value())
-            return {};
+    auto authority_end = input.find_any_of("/?#"sv).value_or(input.length());
+    auto authority = input.substring_view(0, authority_end);
 
-        return URL::Parser::basic_parse(search_engine->format_search_query_for_navigation(location));
-    };
+    Optional<size_t> port_separator;
+    if (authority.starts_with('[')) {
+        auto closing_bracket = authority.find(']');
+        if (!closing_bracket.has_value() || *closing_bracket + 1 >= authority.length() || authority[*closing_bracket + 1] != ':')
+            return false;
+        port_separator = *closing_bracket + 1;
+    } else {
+        port_separator = authority.find_last(':');
+        if (!port_separator.has_value())
+            return false;
+    }
 
+    auto port = authority.substring_view(*port_separator + 1);
+    if (port.is_empty())
+        return false;
+    for (auto byte : port.bytes()) {
+        if (!is_ascii_digit(byte))
+            return false;
+    }
+
+    auto url = URL::Parser::basic_parse(MUST(String::formatted("https://{}", input)));
+    return url.has_value() && url->scheme() == "https"sv;
+}
+
+ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tld)
+{
     location = location.trim_whitespace();
 
     if (FileSystem::exists(location)) {
         auto path = FileSystem::real_path(location);
         if (!path.is_error())
-            return URL::create_with_file_scheme(path.value());
-        return search_url_or_error();
+            return { UserInputClassification::InternalURL, URL::create_with_file_scheme(path.value()) };
+        return {};
     }
 
     bool https_scheme_was_guessed = false;
+    bool input_has_explicit_port = false;
 
     auto url = URL::create_with_url_or_path(location);
+    // These known schemes do not use an authority, so recognize them before
+    // testing whether the text could instead be a host and port.
+    auto has_known_external_scheme = url.has_value() && url->scheme().is_one_of("geo"sv, "mailto"sv, "sms"sv, "tel"sv);
 
-    if (!url.has_value() || url->scheme() == "localhost"sv) {
+    if (url.has_value() && is_url_handled_internally(*url)) {
+        // Continue below to apply the existing domain and public suffix checks.
+    } else if (url.has_value() && ExternalURLRequestPolicy::is_denied_scheme(url->scheme())) {
+        return {};
+    } else if (has_known_external_scheme) {
+        return { UserInputClassification::ExternalURL, move(url) };
+    } else if (has_valid_explicit_port(location)) {
         url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
         if (!url.has_value())
-            return search_url_or_error();
+            return {};
+
+        https_scheme_was_guessed = true;
+        input_has_explicit_port = true;
+    } else if (url.has_value()) {
+        return { UserInputClassification::ExternalURL, move(url) };
+    } else {
+        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
+        if (!url.has_value())
+            return {};
 
         https_scheme_was_guessed = true;
     }
 
     if (!is_url_handled_internally(*url))
-        return search_url_or_error();
+        return {};
 
     if (auto const& host = url->host(); host.has_value() && host->is_domain()) {
         auto const& domain = host->get<String>();
 
         if (domain.contains('"'))
-            return search_url_or_error();
+            return {};
 
         // https://datatracker.ietf.org/doc/html/rfc2606
         static constexpr Array RESERVED_TLDS { ".test"sv, ".example"sv, ".invalid"sv, ".localhost"sv };
         if (any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); }))
-            return url;
+            return { UserInputClassification::InternalURL, move(url) };
 
         auto public_suffix = URL::PublicSuffixData::find_matching_public_suffix(domain, URL::PublicSuffixData::IncludeStarRule::No);
         if (!public_suffix.has_value() || *public_suffix == domain) {
             if (append_tld == AppendTLD::Yes)
                 url->set_host(MUST(String::formatted("{}.com", domain)));
-            else if (https_scheme_was_guessed && domain != "localhost"sv)
-                return search_url_or_error();
+            else if (https_scheme_was_guessed && domain != "localhost"sv && !input_has_explicit_port)
+                return {};
         }
     }
 
-    return url;
+    return { UserInputClassification::InternalURL, move(url) };
+}
+
+Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
+{
+    location = location.trim_whitespace();
+
+    auto classified_input = classify_user_input(location, append_tld);
+    if (classified_input.classification == UserInputClassification::InternalURL)
+        return classified_input.url;
+
+    if (!search_engine.has_value())
+        return {};
+
+    return URL::Parser::basic_parse(search_engine->format_search_query_for_navigation(location));
 }
 
 bool location_looks_like_url(StringView location, AppendTLD append_tld)
 {
-    return sanitize_url(location, {}, append_tld).has_value();
+    return classify_user_input(location, append_tld).classification == UserInputClassification::InternalURL;
 }
 
 Optional<URL::URL> url_from_text(StringView text)
@@ -99,9 +155,9 @@ Optional<URL::URL> url_from_text(StringView text)
 bool autocomplete_urls_match(StringView left, StringView right)
 {
     auto parse_destination = [](StringView value) {
-        auto url = URL::Parser::basic_parse(value);
-        if (url.has_value() && url->scheme().is_one_of("about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv))
-            return url;
+        auto classified_input = classify_user_input(value);
+        if (classified_input.url.has_value())
+            return classified_input.url;
         return URL::Parser::basic_parse(MUST(String::formatted("https://{}", value)));
     };
 

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -14,6 +14,7 @@
 #include <LibURL/PublicSuffixData.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/Autocomplete.h>
+#include <LibWebView/ExternalURLHandler.h>
 #include <LibWebView/URL.h>
 
 namespace WebView {
@@ -23,65 +24,127 @@ bool is_url_handled_internally(URL::URL const& url)
     return url.scheme().is_one_of("about"sv, "blob"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv);
 }
 
-Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
+static bool has_valid_explicit_port(StringView input)
 {
-    auto search_url_or_error = [&]() -> Optional<URL::URL> {
-        if (!search_engine.has_value())
-            return {};
+    auto authority_end = input.find_any_of("/?#"sv).value_or(input.length());
+    auto authority = input.substring_view(0, authority_end);
 
-        return URL::Parser::basic_parse(search_engine->format_search_query_for_navigation(location));
-    };
+    Optional<size_t> port_separator;
+    if (authority.starts_with('[')) {
+        auto closing_bracket = authority.find(']');
+        if (!closing_bracket.has_value() || *closing_bracket + 1 >= authority.length() || authority[*closing_bracket + 1] != ':')
+            return false;
+        port_separator = *closing_bracket + 1;
+    } else {
+        port_separator = authority.find_last(':');
+        if (!port_separator.has_value())
+            return false;
+    }
 
+    auto port = authority.substring_view(*port_separator + 1);
+    if (port.is_empty())
+        return false;
+    for (auto byte : port.bytes()) {
+        if (!is_ascii_digit(byte))
+            return false;
+    }
+
+    auto url = URL::Parser::basic_parse(MUST(String::formatted("https://{}", input)));
+    return url.has_value() && url->scheme() == "https"sv;
+}
+
+ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tld)
+{
     location = location.trim_whitespace();
 
     if (FileSystem::exists(location)) {
         auto path = FileSystem::real_path(location);
         if (!path.is_error())
-            return URL::create_with_file_scheme(path.value());
-        return search_url_or_error();
+            return { UserInputClassification::InternalURL, URL::create_with_file_scheme(path.value()) };
+        return {};
     }
 
     bool https_scheme_was_guessed = false;
+    bool input_has_explicit_port = false;
 
     auto url = URL::create_with_url_or_path(location);
+    // These known schemes do not use an authority, so recognize them before
+    // testing whether the text could instead be a host and port.
+    auto has_known_external_scheme = url.has_value() && url->scheme().is_one_of("geo"sv, "mailto"sv, "sms"sv, "tel"sv);
 
-    if (!url.has_value() || url->scheme() == "localhost"sv) {
+    if (url.has_value() && is_url_handled_internally(*url)) {
+        // Continue below to apply the existing domain and public suffix checks.
+    } else if (url.has_value() && ExternalURLRequestPolicy::is_denied_scheme(url->scheme())) {
+        return {};
+    } else if (has_known_external_scheme) {
+        return { UserInputClassification::ExternalURL, move(url) };
+    } else if (has_valid_explicit_port(location)) {
         url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
         if (!url.has_value())
-            return search_url_or_error();
+            return {};
+
+        https_scheme_was_guessed = true;
+        input_has_explicit_port = true;
+    } else if (url.has_value()) {
+        return { UserInputClassification::ExternalURL, move(url) };
+    } else {
+        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
+        if (!url.has_value())
+            return {};
 
         https_scheme_was_guessed = true;
     }
 
     if (!is_url_handled_internally(*url))
-        return search_url_or_error();
+        return {};
 
     if (auto const& host = url->host(); host.has_value() && host->is_domain()) {
         auto const& domain = host->get<String>();
 
         if (domain.contains('"'))
-            return search_url_or_error();
+            return {};
 
         // https://datatracker.ietf.org/doc/html/rfc2606
         static constexpr Array RESERVED_TLDS { ".test"sv, ".example"sv, ".invalid"sv, ".localhost"sv };
         if (any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); }))
-            return url;
+            return { UserInputClassification::InternalURL, move(url) };
 
         auto public_suffix = URL::PublicSuffixData::find_matching_public_suffix(domain, URL::PublicSuffixData::IncludeStarRule::No);
         if (!public_suffix.has_value() || *public_suffix == domain) {
             if (append_tld == AppendTLD::Yes)
                 url->set_host(MUST(String::formatted("{}.com", domain)));
-            else if (https_scheme_was_guessed && domain != "localhost"sv)
-                return search_url_or_error();
+            else if (https_scheme_was_guessed && domain != "localhost"sv && !input_has_explicit_port)
+                return {};
         }
     }
 
-    return url;
+    return { UserInputClassification::InternalURL, move(url) };
+}
+
+Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
+{
+    location = location.trim_whitespace();
+
+    auto classified_input = classify_user_input(location, append_tld);
+    if (classified_input.classification == UserInputClassification::InternalURL)
+        return classified_input.url;
+
+    if (!search_engine.has_value())
+        return {};
+
+    return URL::Parser::basic_parse(search_engine->format_search_query_for_navigation(location));
 }
 
 bool location_looks_like_url(StringView location, AppendTLD append_tld)
 {
-    return sanitize_url(location, {}, append_tld).has_value();
+    switch (classify_user_input(location, append_tld).classification) {
+    case UserInputClassification::InternalURL:
+    case UserInputClassification::ExternalURL:
+        return true;
+    case UserInputClassification::Search:
+        return false;
+    }
+    VERIFY_NOT_REACHED();
 }
 
 Optional<URL::URL> url_from_text(StringView text)
@@ -99,9 +162,9 @@ Optional<URL::URL> url_from_text(StringView text)
 bool autocomplete_urls_match(StringView left, StringView right)
 {
     auto parse_destination = [](StringView value) {
-        auto url = URL::Parser::basic_parse(value);
-        if (url.has_value() && url->scheme().is_one_of("about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv))
-            return url;
+        auto classified_input = classify_user_input(value);
+        if (classified_input.url.has_value())
+            return classified_input.url;
         return URL::Parser::basic_parse(MUST(String::formatted("https://{}", value)));
     };
 

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -18,6 +18,11 @@
 
 namespace WebView {
 
+bool is_url_handled_internally(URL::URL const& url)
+{
+    return url.scheme().is_one_of("about"sv, "blob"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv);
+}
+
 Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
 {
     auto search_url_or_error = [&]() -> Optional<URL::URL> {
@@ -48,9 +53,7 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         https_scheme_was_guessed = true;
     }
 
-    // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.
-    static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
-    if (!any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url->scheme(); }))
+    if (!is_url_handled_internally(*url))
         return search_url_or_error();
 
     if (auto const& host = url->host(); host.has_value() && host->is_domain()) {

--- a/Libraries/LibWebView/URL.h
+++ b/Libraries/LibWebView/URL.h
@@ -21,6 +21,7 @@ enum class AppendTLD {
 };
 WEBVIEW_API Optional<URL::URL> sanitize_url(StringView, Optional<SearchEngine> const& search_engine = {}, AppendTLD = AppendTLD::No);
 WEBVIEW_API bool location_looks_like_url(StringView, AppendTLD = AppendTLD::No);
+WEBVIEW_API bool is_url_handled_internally(URL::URL const&);
 WEBVIEW_API Optional<URL::URL> url_from_text(StringView);
 WEBVIEW_API Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls);
 WEBVIEW_API String url_for_display(URL::URL const&);

--- a/Libraries/LibWebView/URL.h
+++ b/Libraries/LibWebView/URL.h
@@ -19,6 +19,19 @@ enum class AppendTLD {
     No,
     Yes,
 };
+
+enum class UserInputClassification : u8 {
+    Search,
+    InternalURL,
+    ExternalURL,
+};
+
+struct ClassifiedUserInput {
+    UserInputClassification classification { UserInputClassification::Search };
+    Optional<URL::URL> url;
+};
+
+WEBVIEW_API ClassifiedUserInput classify_user_input(StringView, AppendTLD = AppendTLD::No);
 WEBVIEW_API Optional<URL::URL> sanitize_url(StringView, Optional<SearchEngine> const& search_engine = {}, AppendTLD = AppendTLD::No);
 WEBVIEW_API bool location_looks_like_url(StringView, AppendTLD = AppendTLD::No);
 WEBVIEW_API bool is_url_handled_internally(URL::URL const&);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2964,16 +2964,16 @@ void ViewImplementation::initialize_context_menus()
     });
 
     m_open_in_new_tab_action = Action::create("Open in New Tab"sv, ActionID::OpenInNewTab, [this]() {
-        Application::the().open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
+        open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
     });
     if (m_is_private == IsPrivate::No) {
         m_open_in_new_window_action = Action::create("Open in New Window"sv, ActionID::OpenInNewWindow, [this]() {
-            Application::the().open_url_in_new_window(m_context_menu_url, IsPrivate::No);
+            open_url_in_new_window(m_context_menu_url, IsPrivate::No);
         });
     }
     if (application.supports_private_browsing_windows()) {
         m_open_in_new_private_window_action = Action::create("Open in New Private Window"sv, ActionID::OpenInNewPrivateWindow, [this]() {
-            Application::the().open_url_in_new_window(m_context_menu_url, IsPrivate::Yes);
+            open_url_in_new_window(m_context_menu_url, IsPrivate::Yes);
         });
     }
     m_download_linked_file_action = Action::create("Download Linked File"sv, ActionID::DownloadLinkedFile, [this]() {

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -296,6 +296,75 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
     client().async_load_url(page_id(), url, history_handling);
 }
 
+void ViewImplementation::load_from_user_input(URL::URL const& url)
+{
+    if (!is_url_handled_internally(url)) {
+        handle_external_url_from_user_input(url);
+        return;
+    }
+
+    load(url);
+}
+
+void ViewImplementation::load_from_user_input(StringView input)
+{
+    load_from_user_input(input, sanitize_url(input, Application::settings().search_engine()));
+}
+
+void ViewImplementation::load_from_user_input(StringView input, Optional<URL::URL> fallback_url)
+{
+    auto classified_input = classify_user_input(input);
+
+    if (classified_input.classification != UserInputClassification::ExternalURL) {
+        if (fallback_url.has_value())
+            load(*fallback_url);
+        else
+            load_navigation_error_page(input);
+        return;
+    }
+
+    VERIFY(classified_input.url.has_value());
+    auto external_url = classified_input.url.release_value();
+
+    if (fallback_url.has_value() && *fallback_url == external_url) {
+        handle_external_url_from_user_input(external_url);
+        return;
+    }
+
+    auto input_string = MUST(String::from_utf8(input));
+    auto view_id = m_view_id;
+    handle_external_url_from_user_input(external_url, [view_id, input = move(input_string), fallback_url = move(fallback_url)] {
+        auto view = ViewImplementation::find_view_by_id(view_id);
+        if (!view.has_value())
+            return;
+
+        if (fallback_url.has_value())
+            view->load(*fallback_url);
+        else
+            view->load_navigation_error_page(input);
+    });
+}
+
+void ViewImplementation::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTab activate_tab)
+{
+    if (!is_url_handled_internally(url)) {
+        handle_external_url_from_user_input(url);
+        return;
+    }
+
+    Application::the().open_url_in_new_tab(url, activate_tab);
+}
+
+void ViewImplementation::open_url_in_new_window(URL::URL const& url, IsPrivate is_private)
+{
+    if (!is_url_handled_internally(url)) {
+        handle_external_url_from_user_input(url);
+        return;
+    }
+
+    Application::the().open_url_in_new_window(url, is_private);
+}
+
 void ViewImplementation::load_html(StringView html)
 {
     set_loading_state(true);
@@ -521,8 +590,18 @@ void ViewImplementation::reset_zoom()
 
 void ViewImplementation::enqueue_input_event(Web::InputEvent event)
 {
+    auto* key_event = event.get_pointer<Web::KeyEvent>();
     auto* mouse_event = event.get_pointer<Web::MouseEvent>();
     auto* pinch_event = event.get_pointer<Web::PinchEvent>();
+
+    // User input enables a single request for an external URL.
+    if ((key_event && key_event->type == Web::KeyEvent::Type::KeyDown && !key_event->repeat
+            && first_is_one_of(key_event->key, Web::UIEvents::KeyCode::Key_Return, Web::UIEvents::KeyCode::Key_Space))
+        || (mouse_event && mouse_event->type == Web::MouseEvent::Type::MouseDown
+            && first_is_one_of(mouse_event->button, Web::UIEvents::MouseButton::Primary, Web::UIEvents::MouseButton::Middle))) {
+        m_external_url_request_policy.allow_next_request();
+    }
+
     if (mouse_event && mouse_event->type == Web::MouseEvent::Type::MouseWheel) {
         mouse_event->wheel_delta_x /= zoom_level();
         mouse_event->wheel_delta_y /= zoom_level();
@@ -586,6 +665,141 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
         [this](Web::PinchEvent const& event) {
             client().async_pinch_event(m_client_state.page_index, event);
         });
+}
+
+void ViewImplementation::handle_external_url(Badge<WebContentClient>, URL::URL url, URL::Origin initiator_origin, bool has_transient_activation)
+{
+    handle_external_url(move(url), move(initiator_origin), has_transient_activation);
+}
+
+void ViewImplementation::handle_external_url_from_user_input(URL::URL const& url, Function<void()> on_handler_unavailable)
+{
+    // Browser UI actions can submit several URLs at once, for example when opening a bookmark folder. Keep those
+    // requests ordered while a handler lookup or confirmation is in progress.
+    m_pending_external_url_requests.enqueue({ url, m_url.origin(), move(on_handler_unavailable) });
+    process_next_external_url_request();
+}
+
+void ViewImplementation::process_next_external_url_request()
+{
+    while (!m_external_url_confirmation_pending && !m_pending_external_url_requests.is_empty()) {
+        auto request = m_pending_external_url_requests.dequeue();
+        m_external_url_request_policy.allow_request_from_browser_ui(request.url);
+        handle_external_url(move(request.url), move(request.initiator_origin), false, move(request.on_handler_unavailable));
+    }
+}
+
+void ViewImplementation::complete_external_url_request()
+{
+    VERIFY(m_external_url_confirmation_pending);
+    m_external_url_confirmation_pending = false;
+
+    if (m_pending_external_url_requests.is_empty())
+        return;
+
+    auto view_id = m_view_id;
+    Core::deferred_invoke([view_id] {
+        if (auto view = ViewImplementation::find_view_by_id(view_id); view.has_value())
+            view->process_next_external_url_request();
+    });
+}
+
+void ViewImplementation::handle_external_url(URL::URL url, URL::Origin initiator_origin, bool has_transient_activation, Function<void()> on_handler_unavailable)
+{
+    if (m_external_url_confirmation_pending)
+        return;
+
+    auto action = m_external_url_request_policy.decide(url, has_transient_activation);
+    if (action == ExternalURLAction::Block)
+        return;
+
+    if (action == ExternalURLAction::Prompt && !on_request_external_url_confirmation)
+        return;
+
+    // Reserve the allowance while the handler is resolved. Browser UI allowances are specific to one navigation and
+    // are never restored.
+    auto request_source = m_external_url_request_policy.take_request_allowance();
+    if (!request_source.has_value())
+        return;
+
+    m_external_url_confirmation_pending = true;
+    auto view_id = m_view_id;
+    auto url_for_callback = url;
+    Application::the().resolve_external_url_handler(url, [view_id, url = move(url_for_callback), initiator_origin = move(initiator_origin), action, request_source = *request_source, on_handler_unavailable = move(on_handler_unavailable)](RefPtr<ExternalURLHandler> handler) mutable {
+        auto view = ViewImplementation::find_view_by_id(view_id);
+        if (!view.has_value())
+            return;
+
+        if (!handler) {
+            // This is step 4 of this algorithm:
+            // https://html.spec.whatwg.org/multipage/browsing-the-web.html#attempt-to-create-a-non-fetch-scheme-document
+            // As noted in attempt_to_create_a_non_fetch_scheme_document() in LocalNavigable.cpp, it can't happen there
+            // because resolving the external url handler is asynchronous.
+            //
+            // 4. Handle url by displaying some sort of inline content, e.g., an error message because the specified
+            //    scheme is not one of the supported protocols, or an inline prompt to allow the user to select a
+            //    registered handler for the given scheme. Return the result of displaying the inline content given
+            //    navigable, navigationParams's id, navigationParams's navigation timing type, and navigationParams's
+            //    user involvement.
+            // AD-HOC: We can't implement this directly, so show a warning dialog instead.
+            if (on_handler_unavailable) {
+                view->complete_external_url_request();
+                on_handler_unavailable();
+                return;
+            }
+
+            auto error_message = MUST(String::formatted("No application is registered to open {}", url));
+            Application::the().display_error_dialog(error_message);
+            if (auto current_view = ViewImplementation::find_view_by_id(view_id); current_view.has_value())
+                current_view->complete_external_url_request();
+            return;
+        }
+
+        if (handler->is_ladybird()) {
+            view->complete_external_url_request();
+            if (on_handler_unavailable) {
+                on_handler_unavailable();
+                return;
+            }
+
+            if (request_source == ExternalURLRequestSource::Page)
+                view->m_external_url_request_policy.allow_next_request();
+            return;
+        }
+
+        if (action == ExternalURLAction::Launch) {
+            handler->launch(url, [view_id](bool success) {
+                if (!success && ViewImplementation::find_view_by_id(view_id).has_value())
+                    Application::the().display_error_dialog("Unable to open external URL"sv);
+            });
+            if (auto current_view = ViewImplementation::find_view_by_id(view_id); current_view.has_value())
+                current_view->complete_external_url_request();
+            return;
+        }
+
+        if (!view->on_request_external_url_confirmation) {
+            if (request_source == ExternalURLRequestSource::Page)
+                view->m_external_url_request_policy.allow_next_request();
+            view->complete_external_url_request();
+            return;
+        }
+
+        auto on_complete = [view_id, url, handler](bool accepted) {
+            auto view = ViewImplementation::find_view_by_id(view_id);
+            if (!view.has_value())
+                return;
+
+            if (accepted) {
+                handler->launch(url, [view_id](bool success) {
+                    if (!success && ViewImplementation::find_view_by_id(view_id).has_value())
+                        Application::the().display_error_dialog("Unable to open external URL"sv);
+                });
+            }
+            if (auto current_view = ViewImplementation::find_view_by_id(view_id); current_view.has_value())
+                current_view->complete_external_url_request();
+        };
+        view->on_request_external_url_confirmation(url, initiator_origin, *handler, move(on_complete));
+    });
 }
 
 void ViewImplementation::did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -296,6 +296,75 @@ void ViewImplementation::load(URL::URL const& url, Web::Bindings::NavigationHist
     client().async_load_url(page_id(), url, history_handling);
 }
 
+void ViewImplementation::load_from_user_input(URL::URL const& url)
+{
+    if (!is_url_handled_internally(url)) {
+        handle_external_url_from_user_input(url);
+        return;
+    }
+
+    load(url);
+}
+
+void ViewImplementation::load_from_user_input(StringView input)
+{
+    load_from_user_input(input, sanitize_url(input, Application::settings().search_engine()));
+}
+
+void ViewImplementation::load_from_user_input(StringView input, Optional<URL::URL> fallback_url)
+{
+    auto classified_input = classify_user_input(input);
+
+    if (classified_input.classification != UserInputClassification::ExternalURL) {
+        if (fallback_url.has_value())
+            load(*fallback_url);
+        else
+            load_navigation_error_page(input);
+        return;
+    }
+
+    VERIFY(classified_input.url.has_value());
+    auto external_url = classified_input.url.release_value();
+
+    if (fallback_url.has_value() && *fallback_url == external_url) {
+        handle_external_url_from_user_input(external_url);
+        return;
+    }
+
+    auto input_string = MUST(String::from_utf8(input));
+    auto view_id = m_view_id;
+    handle_external_url_from_user_input(external_url, [view_id, input = move(input_string), fallback_url = move(fallback_url)] {
+        auto view = ViewImplementation::find_view_by_id(view_id);
+        if (!view.has_value())
+            return;
+
+        if (fallback_url.has_value())
+            view->load(*fallback_url);
+        else
+            view->load_navigation_error_page(input);
+    });
+}
+
+void ViewImplementation::open_url_in_new_tab(URL::URL const& url, Web::HTML::ActivateTab activate_tab)
+{
+    if (!is_url_handled_internally(url)) {
+        handle_external_url_from_user_input(url);
+        return;
+    }
+
+    Application::the().open_url_in_new_tab(url, activate_tab);
+}
+
+void ViewImplementation::open_url_in_new_window(URL::URL const& url, IsPrivate is_private)
+{
+    if (!is_url_handled_internally(url)) {
+        handle_external_url_from_user_input(url);
+        return;
+    }
+
+    Application::the().open_url_in_new_window(url, is_private);
+}
+
 void ViewImplementation::load_html(StringView html)
 {
     set_loading_state(true);
@@ -553,8 +622,18 @@ void ViewImplementation::reset_zoom()
 
 void ViewImplementation::enqueue_input_event(Web::InputEvent event)
 {
+    auto* key_event = event.get_pointer<Web::KeyEvent>();
     auto* mouse_event = event.get_pointer<Web::MouseEvent>();
     auto* pinch_event = event.get_pointer<Web::PinchEvent>();
+
+    // User input enables a single request for an external URL.
+    if ((key_event && key_event->type == Web::KeyEvent::Type::KeyDown && !key_event->repeat
+            && first_is_one_of(key_event->key, Web::UIEvents::KeyCode::Key_Return, Web::UIEvents::KeyCode::Key_Space))
+        || (mouse_event && mouse_event->type == Web::MouseEvent::Type::MouseDown
+            && first_is_one_of(mouse_event->button, Web::UIEvents::MouseButton::Primary, Web::UIEvents::MouseButton::Middle))) {
+        m_external_url_request_policy.allow_next_request();
+    }
+
     if (mouse_event && mouse_event->type == Web::MouseEvent::Type::MouseWheel) {
         mouse_event->wheel_delta_x /= zoom_level();
         mouse_event->wheel_delta_y /= zoom_level();
@@ -618,6 +697,152 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
         [this](Web::PinchEvent const& event) {
             client().async_pinch_event(m_client_state.page_index, event);
         });
+}
+
+void ViewImplementation::handle_external_url(Badge<WebContentClient>, URL::URL url, URL::Origin initiator_origin, bool has_transient_activation)
+{
+    handle_external_url(move(url), move(initiator_origin), has_transient_activation);
+}
+
+void ViewImplementation::handle_external_url_from_user_input(URL::URL const& url, Function<void()> on_handler_unavailable)
+{
+    // Browser UI actions can submit several URLs at once, for example when opening a bookmark folder. Keep those
+    // requests ordered while a handler lookup or confirmation is in progress.
+    m_pending_external_url_requests.enqueue({ url, m_url.origin(), move(on_handler_unavailable) });
+    process_next_external_url_request();
+}
+
+void ViewImplementation::process_next_external_url_request()
+{
+    while (!m_external_url_confirmation_pending && !m_pending_external_url_requests.is_empty()) {
+        auto request = m_pending_external_url_requests.dequeue();
+        m_external_url_request_policy.allow_request_from_browser_ui(request.url);
+        handle_external_url(move(request.url), move(request.initiator_origin), false, move(request.on_handler_unavailable));
+    }
+}
+
+void ViewImplementation::complete_external_url_request()
+{
+    VERIFY(m_external_url_confirmation_pending);
+    m_external_url_confirmation_pending = false;
+
+    if (m_pending_external_url_requests.is_empty())
+        return;
+
+    auto view_id = m_view_id;
+    Core::deferred_invoke([view_id] {
+        if (auto view = ViewImplementation::find_view_by_id(view_id); view.has_value())
+            view->process_next_external_url_request();
+    });
+}
+
+void ViewImplementation::handle_external_url(URL::URL url, URL::Origin initiator_origin, bool has_transient_activation, Function<void()> on_handler_unavailable)
+{
+    if (m_external_url_confirmation_pending)
+        return;
+
+    auto action = m_external_url_request_policy.decide(url, has_transient_activation);
+    if (action == ExternalURLAction::Block)
+        return;
+
+    auto const headless_mode = Application::browser_options().headless_mode.has_value();
+    if (!headless_mode && action == ExternalURLAction::Prompt && !on_request_external_url_confirmation)
+        return;
+
+    // Reserve the allowance while the handler is resolved. Browser UI allowances are specific to one navigation and
+    // are never restored.
+    auto request_source = m_external_url_request_policy.take_request_allowance();
+    if (!request_source.has_value())
+        return;
+
+    if (headless_mode) {
+        if (on_handler_unavailable) {
+            on_handler_unavailable();
+            return;
+        }
+
+        Application::the().display_error_dialog(MUST(String::formatted("External URL handling is unavailable in headless mode: {}", url)));
+        return;
+    }
+
+    m_external_url_confirmation_pending = true;
+    auto view_id = m_view_id;
+    auto url_for_callback = url;
+    Application::the().resolve_external_url_handler(url, [view_id, url = move(url_for_callback), initiator_origin = move(initiator_origin), action, request_source = *request_source, on_handler_unavailable = move(on_handler_unavailable)](RefPtr<ExternalURLHandler> handler) mutable {
+        auto view = ViewImplementation::find_view_by_id(view_id);
+        if (!view.has_value())
+            return;
+
+        if (!handler) {
+            // This is step 4 of this algorithm:
+            // https://html.spec.whatwg.org/multipage/browsing-the-web.html#attempt-to-create-a-non-fetch-scheme-document
+            // As noted in attempt_to_create_a_non_fetch_scheme_document() in LocalNavigable.cpp, it can't happen there
+            // because resolving the external url handler is asynchronous.
+            //
+            // 4. Handle url by displaying some sort of inline content, e.g., an error message because the specified
+            //    scheme is not one of the supported protocols, or an inline prompt to allow the user to select a
+            //    registered handler for the given scheme. Return the result of displaying the inline content given
+            //    navigable, navigationParams's id, navigationParams's navigation timing type, and navigationParams's
+            //    user involvement.
+            // AD-HOC: We can't implement this directly, so show a warning dialog instead.
+            if (on_handler_unavailable) {
+                view->complete_external_url_request();
+                on_handler_unavailable();
+                return;
+            }
+
+            auto error_message = MUST(String::formatted("No application is registered to open {}", url));
+            Application::the().display_error_dialog(error_message);
+            if (auto current_view = ViewImplementation::find_view_by_id(view_id); current_view.has_value())
+                current_view->complete_external_url_request();
+            return;
+        }
+
+        if (handler->is_ladybird()) {
+            view->complete_external_url_request();
+            if (on_handler_unavailable) {
+                on_handler_unavailable();
+                return;
+            }
+
+            if (request_source == ExternalURLRequestSource::Page)
+                view->m_external_url_request_policy.allow_next_request();
+            return;
+        }
+
+        if (action == ExternalURLAction::Launch) {
+            handler->launch(url, [view_id](bool success) {
+                if (!success && ViewImplementation::find_view_by_id(view_id).has_value())
+                    Application::the().display_error_dialog("Unable to open external URL"sv);
+            });
+            if (auto current_view = ViewImplementation::find_view_by_id(view_id); current_view.has_value())
+                current_view->complete_external_url_request();
+            return;
+        }
+
+        if (!view->on_request_external_url_confirmation) {
+            if (request_source == ExternalURLRequestSource::Page)
+                view->m_external_url_request_policy.allow_next_request();
+            view->complete_external_url_request();
+            return;
+        }
+
+        auto on_complete = [view_id, url, handler](bool accepted) {
+            auto view = ViewImplementation::find_view_by_id(view_id);
+            if (!view.has_value())
+                return;
+
+            if (accepted) {
+                handler->launch(url, [view_id](bool success) {
+                    if (!success && ViewImplementation::find_view_by_id(view_id).has_value())
+                        Application::the().display_error_dialog("Unable to open external URL"sv);
+                });
+            }
+            if (auto current_view = ViewImplementation::find_view_by_id(view_id); current_view.has_value())
+                current_view->complete_external_url_request();
+        };
+        view->on_request_external_url_confirmation(url, initiator_origin, *handler, move(on_complete));
+    });
 }
 
 void ViewImplementation::did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -2776,16 +2776,16 @@ void ViewImplementation::initialize_context_menus()
     });
 
     m_open_in_new_tab_action = Action::create("Open in New Tab"sv, ActionID::OpenInNewTab, [this]() {
-        Application::the().open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
+        open_url_in_new_tab(m_context_menu_url, Web::HTML::ActivateTab::No);
     });
     if (m_is_private == IsPrivate::No) {
         m_open_in_new_window_action = Action::create("Open in New Window"sv, ActionID::OpenInNewWindow, [this]() {
-            Application::the().open_url_in_new_window(m_context_menu_url, IsPrivate::No);
+            open_url_in_new_window(m_context_menu_url, IsPrivate::No);
         });
     }
     if (application.supports_private_browsing_windows()) {
         m_open_in_new_private_window_action = Action::create("Open in New Private Window"sv, ActionID::OpenInNewPrivateWindow, [this]() {
-            Application::the().open_url_in_new_window(m_context_menu_url, IsPrivate::Yes);
+            open_url_in_new_window(m_context_menu_url, IsPrivate::Yes);
         });
     }
     m_download_linked_file_action = Action::create("Download Linked File"sv, ActionID::DownloadLinkedFile, [this]() {

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -35,6 +35,7 @@
 #include <LibRequests/CameFromCache.h>
 #include <LibRequests/Forward.h>
 #include <LibRequests/NetworkError.h>
+#include <LibURL/Origin.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
@@ -53,6 +54,7 @@
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/DictionaryLookup.h>
+#include <LibWebView/ExternalURLHandler.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/HistoryVisitTransition.h>
 #include <LibWebView/PageInfo.h>
@@ -107,6 +109,11 @@ public:
     void set_system_visibility_state(Web::HTML::VisibilityState);
 
     void load(URL::URL const&, Web::Bindings::NavigationHistoryBehavior = Web::Bindings::NavigationHistoryBehavior::Auto);
+    void load_from_user_input(URL::URL const&);
+    void load_from_user_input(StringView);
+    void load_from_user_input(StringView, Optional<URL::URL> fallback_url);
+    void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab);
+    void open_url_in_new_window(URL::URL const&, IsPrivate);
     void set_next_history_visit_transition(HistoryVisitTransition transition) { m_history_visit_transition_for_next_load = transition; }
     void load_html(StringView);
     void load_navigation_error_page(StringView);
@@ -141,6 +148,7 @@ public:
     double maximum_frames_per_second() const { return m_maximum_frames_per_second; }
     void enqueue_input_event(Web::InputEvent);
     void did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result);
+    void handle_external_url(Badge<WebContentClient>, URL::URL, URL::Origin, bool has_transient_activation);
 
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
@@ -352,6 +360,7 @@ public:
     Function<void(Utf16String const& message)> on_request_confirm;
     Function<void(Utf16String const& message, Utf16String const& default_)> on_request_prompt;
     Function<void(Utf16String const& message)> on_request_set_prompt_text;
+    Function<void(URL::URL const&, URL::Origin const&, ExternalURLHandler const&, Function<void(bool)>)> on_request_external_url_confirmation;
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;
     Function<void(JsonObject)> on_received_dom_tree;
@@ -516,6 +525,10 @@ protected:
     void update_bookmark_action();
 
     void initialize_context_menus();
+    void handle_external_url(URL::URL, URL::Origin, bool has_transient_activation, Function<void()> on_handler_unavailable = {});
+    void handle_external_url_from_user_input(URL::URL const&, Function<void()> on_handler_unavailable = {});
+    void complete_external_url_request();
+    void process_next_external_url_request();
     void update_look_up_selected_text_action(Optional<DictionaryLookup> const& lookup, Gfx::IntPoint content_position);
     enum class PromptForPath : u8 {
         No,
@@ -603,6 +616,15 @@ protected:
     RefPtr<Action> m_media_exit_fullscreen_action;
 
     Queue<Web::InputEvent> m_pending_input_events;
+
+    struct PendingExternalURLRequest {
+        URL::URL url;
+        URL::Origin initiator_origin;
+        Function<void()> on_handler_unavailable;
+    };
+    Queue<PendingExternalURLRequest> m_pending_external_url_requests;
+    ExternalURLRequestPolicy m_external_url_request_policy;
+    bool m_external_url_confirmation_pending { false };
 
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -35,6 +35,7 @@
 #include <LibRequests/CameFromCache.h>
 #include <LibRequests/Forward.h>
 #include <LibRequests/NetworkError.h>
+#include <LibURL/Origin.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Forward.h>
@@ -53,6 +54,7 @@
 #include <LibWebView/CanonicalTraversable.h>
 #include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/DictionaryLookup.h>
+#include <LibWebView/ExternalURLHandler.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/HistoryVisitTransition.h>
 #include <LibWebView/PageInfo.h>
@@ -106,6 +108,11 @@ public:
     void set_system_visibility_state(Web::HTML::VisibilityState);
 
     void load(URL::URL const&, Web::Bindings::NavigationHistoryBehavior = Web::Bindings::NavigationHistoryBehavior::Auto);
+    void load_from_user_input(URL::URL const&);
+    void load_from_user_input(StringView);
+    void load_from_user_input(StringView, Optional<URL::URL> fallback_url);
+    void open_url_in_new_tab(URL::URL const&, Web::HTML::ActivateTab);
+    void open_url_in_new_window(URL::URL const&, IsPrivate);
     void set_next_history_visit_transition(HistoryVisitTransition transition) { m_history_visit_transition_for_next_load = transition; }
     void load_html(StringView);
     void load_navigation_error_page(StringView);
@@ -140,6 +147,7 @@ public:
     double maximum_frames_per_second() const { return m_maximum_frames_per_second; }
     void enqueue_input_event(Web::InputEvent);
     void did_finish_handling_input_event(Badge<WebContentClient>, Web::EventResult event_result);
+    void handle_external_url(Badge<WebContentClient>, URL::URL, URL::Origin, bool has_transient_activation);
 
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
     void set_preferred_contrast(Web::CSS::PreferredContrast);
@@ -348,6 +356,7 @@ public:
     Function<void(Utf16String const& message)> on_request_confirm;
     Function<void(Utf16String const& message, Utf16String const& default_)> on_request_prompt;
     Function<void(Utf16String const& message)> on_request_set_prompt_text;
+    Function<void(URL::URL const&, URL::Origin const&, ExternalURLHandler const&, Function<void(bool)>)> on_request_external_url_confirmation;
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;
     Function<void(JsonObject)> on_received_dom_tree;
@@ -506,6 +515,10 @@ protected:
     void update_bookmark_action();
 
     void initialize_context_menus();
+    void handle_external_url(URL::URL, URL::Origin, bool has_transient_activation, Function<void()> on_handler_unavailable = {});
+    void handle_external_url_from_user_input(URL::URL const&, Function<void()> on_handler_unavailable = {});
+    void complete_external_url_request();
+    void process_next_external_url_request();
     void update_look_up_selected_text_action(Optional<DictionaryLookup> const& lookup, Gfx::IntPoint content_position);
     enum class PromptForPath : u8 {
         No,
@@ -593,6 +606,15 @@ protected:
     RefPtr<Action> m_media_exit_fullscreen_action;
 
     Queue<Web::InputEvent> m_pending_input_events;
+
+    struct PendingExternalURLRequest {
+        URL::URL url;
+        URL::Origin initiator_origin;
+        Function<void()> on_handler_unavailable;
+    };
+    Queue<PendingExternalURLRequest> m_pending_external_url_requests;
+    ExternalURLRequestPolicy m_external_url_request_policy;
+    bool m_external_url_confirmation_pending { false };
 
     RefPtr<Core::Timer> m_backing_store_shrink_timer;
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -567,6 +567,9 @@ void WebContentClient::did_change_top_level_active_document(u64 page_id, Web::HT
         return;
 
     navigable->did_commit_navigation(move(replicated_state));
+
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->m_external_url_request_policy.clear_page_request_allowance();
 }
 
 void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id)
@@ -919,17 +922,26 @@ void WebContentClient::did_unhover_link(u64 page_id)
 
 void WebContentClient::did_click_link(u64 page_id, URL::URL url, ByteString target, unsigned modifiers)
 {
-    if (modifiers == Web::UIEvents::Mod_PlatformCtrl)
-        Application::the().open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
-    else if (target == "_blank"sv)
-        Application::the().open_url_in_new_tab(url, Web::HTML::ActivateTab::Yes);
-    else if (auto view = view_for_page_id(page_id); view.has_value())
+    auto open_in_background = modifiers == Web::UIEvents::Mod_PlatformCtrl;
+    auto open_in_foreground = modifiers == (Web::UIEvents::Mod_PlatformCtrl | Web::UIEvents::Mod_Shift);
+    if (open_in_background || open_in_foreground || target == "_blank"sv) {
+        if (auto view = owning_view_for_page_id(page_id); view.has_value())
+            view->open_url_in_new_tab(url, open_in_background ? Web::HTML::ActivateTab::No : Web::HTML::ActivateTab::Yes);
+    } else if (auto view = view_for_page_id(page_id); view.has_value()) {
         view->load(url);
+    }
 }
 
-void WebContentClient::did_middle_click_link(u64, URL::URL url, ByteString, unsigned)
+void WebContentClient::did_middle_click_link(u64 page_id, URL::URL url, ByteString, unsigned)
 {
-    Application::the().open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+}
+
+void WebContentClient::did_request_external_url(u64 page_id, URL::URL url, URL::Origin initiator_origin, bool has_transient_activation)
+{
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->handle_external_url({}, move(url), move(initiator_origin), has_transient_activation);
 }
 
 void WebContentClient::did_request_context_menu(u64 page_id, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target)
@@ -2072,6 +2084,15 @@ Optional<ViewImplementation&> WebContentClient::view_for_page_id(u64 page_id, So
 
     dbgln("WebContentClient::{}: Did not find a page with ID {}", location.function_name(), page_id);
     return {};
+}
+
+Optional<ViewImplementation&> WebContentClient::owning_view_for_page_id(u64 page_id)
+{
+    auto* navigable = navigable_for_page(page_id);
+    if (!navigable)
+        return {};
+
+    return ViewImplementation::find_view_for_traversable(navigable->top_level_traversable());
 }
 
 }

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -567,6 +567,9 @@ void WebContentClient::did_change_top_level_active_document(u64 page_id, Web::HT
         return;
 
     navigable->did_commit_navigation(move(replicated_state));
+
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->m_external_url_request_policy.clear_page_request_allowance();
 }
 
 void WebContentClient::did_destroy_child_frame(u64 page_id, Web::HTML::CrossProcessId frame_id)
@@ -919,17 +922,26 @@ void WebContentClient::did_unhover_link(u64 page_id)
 
 void WebContentClient::did_click_link(u64 page_id, URL::URL url, ByteString target, unsigned modifiers)
 {
-    if (modifiers == Web::UIEvents::Mod_PlatformCtrl)
-        Application::the().open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
-    else if (target == "_blank"sv)
-        Application::the().open_url_in_new_tab(url, Web::HTML::ActivateTab::Yes);
-    else if (auto view = view_for_page_id(page_id); view.has_value())
+    auto open_in_background = modifiers == Web::UIEvents::Mod_PlatformCtrl;
+    auto open_in_foreground = modifiers == (Web::UIEvents::Mod_PlatformCtrl | Web::UIEvents::Mod_Shift);
+    if (open_in_background || open_in_foreground || target == "_blank"sv) {
+        if (auto view = owning_view_for_page_id(page_id); view.has_value())
+            view->open_url_in_new_tab(url, open_in_background ? Web::HTML::ActivateTab::No : Web::HTML::ActivateTab::Yes);
+    } else if (auto view = view_for_page_id(page_id); view.has_value()) {
         view->load(url);
+    }
 }
 
-void WebContentClient::did_middle_click_link(u64, URL::URL url, ByteString, unsigned)
+void WebContentClient::did_middle_click_link(u64 page_id, URL::URL url, ByteString, unsigned)
 {
-    Application::the().open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+}
+
+void WebContentClient::did_request_external_url(u64 page_id, URL::URL url, URL::Origin initiator_origin, bool has_transient_activation)
+{
+    if (auto view = owning_view_for_page_id(page_id); view.has_value())
+        view->handle_external_url({}, move(url), move(initiator_origin), has_transient_activation);
 }
 
 void WebContentClient::did_request_context_menu(u64 page_id, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target)
@@ -2092,6 +2104,15 @@ Optional<ViewImplementation&> WebContentClient::view_for_page_id(u64 page_id, So
 
     dbgln("WebContentClient::{}: Did not find a page with ID {}", location.function_name(), page_id);
     return {};
+}
+
+Optional<ViewImplementation&> WebContentClient::owning_view_for_page_id(u64 page_id)
+{
+    auto* navigable = navigable_for_page(page_id);
+    if (!navigable)
+        return {};
+
+    return ViewImplementation::find_view_for_traversable(navigable->top_level_traversable());
 }
 
 }

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -150,6 +150,7 @@ private:
     virtual void did_unhover_link(u64 page_id) override;
     virtual void did_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
     virtual void did_middle_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
+    virtual void did_request_external_url(u64 page_id, URL::URL, URL::Origin, bool has_transient_activation) override;
     virtual void did_start_loading(u64 page_id, Optional<Utf16String>, URL::URL, Web::HTML::DocumentResource, bool, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void did_cancel_loading(u64 page_id, Optional<Utf16String>, URL::URL) override;
     virtual Messages::WebContentClient::DidStartDownloadWithoutRequestResponse did_start_download_without_request(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size) override;
@@ -285,6 +286,7 @@ private:
     virtual void close_worker_agent(u64 page_id, Web::HTML::WorkerAgentId agent_id, Web::HTML::WorkerAgentOwnerToken owner_token) override;
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
+    Optional<ViewImplementation&> owning_view_for_page_id(u64);
 
     void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id);
     bool is_renderer_owned_download(u64 page_id, u64 download_id) const;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -149,6 +149,7 @@ private:
     virtual void did_unhover_link(u64 page_id) override;
     virtual void did_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
     virtual void did_middle_click_link(u64 page_id, URL::URL, ByteString, unsigned) override;
+    virtual void did_request_external_url(u64 page_id, URL::URL, URL::Origin, bool has_transient_activation) override;
     virtual void did_start_loading(u64 page_id, Optional<Utf16String>, URL::URL, Web::HTML::DocumentResource, bool, Web::Bindings::NavigationHistoryBehavior) override;
     virtual void did_cancel_loading(u64 page_id, Optional<Utf16String>, URL::URL) override;
     virtual Messages::WebContentClient::DidStartDownloadWithoutRequestResponse did_start_download_without_request(u64 page_id, URL::URL, ByteString suggested_filename, Optional<u64> total_size) override;
@@ -284,6 +285,7 @@ private:
     virtual void close_worker_agent(u64 page_id, Web::HTML::WorkerAgentId agent_id, Web::HTML::WorkerAgentOwnerToken owner_token) override;
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
+    Optional<ViewImplementation&> owning_view_for_page_id(u64);
 
     void remember_compositor_context(Web::Compositor::CompositorContextId, Optional<u64> page_id);
     bool is_renderer_owned_download(u64 page_id, u64 download_id) const;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -594,6 +594,11 @@ void PageClient::page_did_middle_click_link(URL::URL const& url, ByteString cons
     client().async_did_middle_click_link(m_id, url, target, modifiers);
 }
 
+void PageClient::page_did_request_external_url(URL::URL const& url, URL::Origin const& initiator_origin, bool has_transient_activation)
+{
+    client().async_did_request_external_url(m_id, url, initiator_origin, has_transient_activation);
+}
+
 void PageClient::page_did_start_loading(Optional<Utf16String> const& navigation_id, URL::URL const& url, Web::HTML::DocumentResource document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     if (m_webdriver)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -590,6 +590,11 @@ void PageClient::page_did_middle_click_link(URL::URL const& url, ByteString cons
     client().async_did_middle_click_link(m_id, url, target, modifiers);
 }
 
+void PageClient::page_did_request_external_url(URL::URL const& url, URL::Origin const& initiator_origin, bool has_transient_activation)
+{
+    client().async_did_request_external_url(m_id, url, initiator_origin, has_transient_activation);
+}
+
 void PageClient::page_did_start_loading(Optional<Utf16String> const& navigation_id, URL::URL const& url, Web::HTML::DocumentResource document_resource, bool is_redirect, Web::Bindings::NavigationHistoryBehavior history_handling)
 {
     if (m_webdriver)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -199,6 +199,7 @@ private:
     virtual void page_did_unhover_link() override;
     virtual void page_did_click_link(URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_middle_click_link(URL::URL const&, ByteString const& target, unsigned modifiers) override;
+    virtual void page_did_request_external_url(URL::URL const&, URL::Origin const& initiator_origin, bool has_transient_activation) override;
     virtual void page_did_request_context_menu(Web::CSSPixelPoint, Web::ContextMenuForInputEventsTarget) override;
     virtual void page_did_request_link_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers, Optional<Gfx::Bitmap const*>) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -198,6 +198,7 @@ private:
     virtual void page_did_unhover_link() override;
     virtual void page_did_click_link(URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_middle_click_link(URL::URL const&, ByteString const& target, unsigned modifiers) override;
+    virtual void page_did_request_external_url(URL::URL const&, URL::Origin const& initiator_origin, bool has_transient_activation) override;
     virtual void page_did_request_context_menu(Web::CSSPixelPoint, Web::ContextMenuForInputEventsTarget) override;
     virtual void page_did_request_link_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_request_image_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers, Optional<Gfx::Bitmap const*>) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -10,6 +10,7 @@
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/CameFromCache.h>
 #include <LibRequests/RequestTimingInfo.h>
+#include <LibURL/Origin.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -82,6 +83,7 @@ endpoint WebContentClient
     did_unhover_link(u64 page_id) =|
     did_click_link(u64 page_id, URL::URL url, ByteString target, unsigned modifiers) =|
     did_middle_click_link(u64 page_id, URL::URL url, ByteString target, unsigned modifiers) =|
+    did_request_external_url(u64 page_id, URL::URL url, URL::Origin initiator_origin, bool has_transient_activation) =|
     did_request_context_menu(u64 page_id, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target) =|
     did_request_link_context_menu(u64 page_id, Gfx::IntPoint content_position, URL::URL url, ByteString target, unsigned modifiers) =|
     did_request_image_context_menu(u64 page_id, Gfx::IntPoint content_position, URL::URL url, ByteString target, unsigned modifiers, Optional<Gfx::ShareableBitmap> bitmap) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -10,6 +10,7 @@
 #include <LibRequests/NetworkError.h>
 #include <LibRequests/CameFromCache.h>
 #include <LibRequests/RequestTimingInfo.h>
+#include <LibURL/Origin.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -81,6 +82,7 @@ endpoint WebContentClient
     did_unhover_link(u64 page_id) =|
     did_click_link(u64 page_id, URL::URL url, ByteString target, unsigned modifiers) =|
     did_middle_click_link(u64 page_id, URL::URL url, ByteString target, unsigned modifiers) =|
+    did_request_external_url(u64 page_id, URL::URL url, URL::Origin initiator_origin, bool has_transient_activation) =|
     did_request_context_menu(u64 page_id, Gfx::IntPoint content_position, Web::ContextMenuForInputEventsTarget for_input_events_target) =|
     did_request_link_context_menu(u64 page_id, Gfx::IntPoint content_position, URL::URL url, ByteString target, unsigned modifiers) =|
     did_request_image_context_menu(u64 page_id, Gfx::IntPoint content_position, URL::URL url, ByteString target, unsigned modifiers, Optional<Gfx::ShareableBitmap> bitmap) =|

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SOURCES
     TestCookieJar.cpp
     TestDownloadSegmentation.cpp
     TestDownloadStore.cpp
+    TestExternalURLHandler.cpp
     TestHistoryStore.cpp
     TestHSTSStore.cpp
     TestOmnibox.cpp

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestAutocompleteMuxer.cpp
     TestAutocompleteRanker.cpp
     TestCookieJar.cpp
+    TestExternalURLHandler.cpp
     TestHistoryStore.cpp
     TestHSTSStore.cpp
     TestOmnibox.cpp

--- a/Tests/LibWebView/TestAutocomplete.cpp
+++ b/Tests/LibWebView/TestAutocomplete.cpp
@@ -20,6 +20,19 @@
 
 namespace {
 
+class TestExternalURLHandler final : public WebView::ExternalURLHandler {
+public:
+    TestExternalURLHandler()
+        : WebView::ExternalURLHandler("Test application"_string, false)
+    {
+    }
+
+    virtual void launch(URL::URL const&, LaunchCallback callback) const override
+    {
+        callback(true);
+    }
+};
+
 class TestApplication : public WebView::Application {
     WEB_VIEW_APPLICATION(TestApplication)
 
@@ -37,6 +50,35 @@ public:
     }
 
     virtual bool should_coordinate_browser_process() const override { return false; }
+
+    virtual void resolve_external_url_handler(URL::URL const& url, WebView::ExternalURLHandlerCallback callback) const override
+    {
+        m_pending_external_url_handler_queries.append({ url, move(callback) });
+    }
+
+    size_t pending_external_url_handler_query_count() const { return m_pending_external_url_handler_queries.size(); }
+
+    StringView pending_external_url_handler_query_scheme(size_t index) const
+    {
+        return m_pending_external_url_handler_queries[index].url.scheme();
+    }
+
+    void complete_next_external_url_handler_query(bool has_handler)
+    {
+        auto query = m_pending_external_url_handler_queries.take(0);
+        RefPtr<WebView::ExternalURLHandler> handler;
+        if (has_handler)
+            handler = adopt_ref(*new TestExternalURLHandler);
+        query.callback(move(handler));
+    }
+
+private:
+    struct PendingExternalURLHandlerQuery {
+        URL::URL url;
+        WebView::ExternalURLHandlerCallback callback;
+    };
+
+    mutable Vector<PendingExternalURLHandlerQuery> m_pending_external_url_handler_queries;
 };
 
 }
@@ -236,6 +278,135 @@ ErrorOr<int> ladybird_main(Main::Arguments arguments)
         autocomplete.query_autocomplete_engine(100, "about:set"_string);
         Core::EventLoop::current().spin_until([&]() { return about_query_completed; });
     }
+
+    auto expect_internal_url_suggestion = [&](WebView::AutocompleteQueryID query_id, StringView input) {
+        auto query_completed = false;
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.on_autocomplete_query_complete = [&](auto, auto const& suggestions, WebView::AutocompleteResultKind kind) {
+            if (kind != WebView::AutocompleteResultKind::Final)
+                return;
+            VERIFY(!suggestions.is_empty());
+            VERIFY(suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL);
+            VERIFY(suggestions.first().text == input);
+            autocomplete.cancel_pending_query();
+            query_completed = true;
+        };
+
+        auto pending_handler_queries = app->pending_external_url_handler_query_count();
+        autocomplete.query_autocomplete_engine(query_id, MUST(String::from_utf8(input)));
+        VERIFY(app->pending_external_url_handler_query_count() == pending_handler_queries);
+        Core::EventLoop::current().spin_until([&]() { return query_completed; });
+    };
+
+    expect_internal_url_suggestion(106, "localhost:8080"sv);
+    expect_internal_url_suggestion(107, "example.com:8080"sv);
+
+    auto telephone_url_query_completed = false;
+    {
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.on_autocomplete_query_complete = [&](auto, auto const& suggestions, WebView::AutocompleteResultKind kind) {
+            if (kind != WebView::AutocompleteResultKind::Final)
+                return;
+            VERIFY(!suggestions.is_empty());
+            VERIFY(suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL);
+            VERIFY(suggestions.first().text == "tel:123"sv);
+            autocomplete.cancel_pending_query();
+            telephone_url_query_completed = true;
+        };
+        autocomplete.query_autocomplete_engine(108, "tel:123"_string);
+        VERIFY(app->pending_external_url_handler_query_count() == 1);
+        VERIFY(app->pending_external_url_handler_query_scheme(0) == "tel"sv);
+        app->complete_next_external_url_handler_query(true);
+        Core::EventLoop::current().spin_until([&]() { return telephone_url_query_completed; });
+    }
+
+    auto external_url_local_query_completed = false;
+    auto external_url_query_completed = false;
+    {
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.record_engagement({
+            .input = "geo:23.4,12.4"_string,
+            .destination_kind = WebView::OmniboxDestinationKind::URL,
+            .destination = "https://ladybird.org/"_string,
+            .was_explicit = true,
+        });
+        autocomplete.on_autocomplete_query_complete = [&](auto, auto const& suggestions, WebView::AutocompleteResultKind kind) {
+            if (kind == WebView::AutocompleteResultKind::Intermediate
+                && suggestions.contains([](auto const& suggestion) {
+                       return suggestion.source == WebView::AutocompleteSuggestionSource::Adaptive
+                           && suggestion.text == "https://ladybird.org/"sv;
+                   })) {
+                VERIFY(!suggestions.contains([](auto const& suggestion) {
+                    return suggestion.source == WebView::AutocompleteSuggestionSource::LiteralURL;
+                }));
+                external_url_local_query_completed = true;
+                return;
+            }
+            if (kind != WebView::AutocompleteResultKind::Final)
+                return;
+            VERIFY(!suggestions.is_empty());
+            VERIFY(suggestions.first().source == WebView::AutocompleteSuggestionSource::LiteralURL);
+            VERIFY(suggestions.first().text == "geo:23.4,12.4"sv);
+            VERIFY(suggestions.contains([](auto const& suggestion) {
+                return suggestion.source == WebView::AutocompleteSuggestionSource::Search
+                    && suggestion.text == "geo:23.4,12.4"sv;
+            }));
+            autocomplete.cancel_pending_query();
+            external_url_query_completed = true;
+        };
+        autocomplete.query_autocomplete_engine(101, "geo:23.4,12.4"_string);
+        VERIFY(app->pending_external_url_handler_query_count() == 1);
+        VERIFY(app->pending_external_url_handler_query_scheme(0) == "geo"sv);
+        Core::EventLoop::current().spin_until([&]() { return external_url_local_query_completed; });
+        app->complete_next_external_url_handler_query(true);
+        Core::EventLoop::current().spin_until([&]() { return external_url_query_completed; });
+    }
+
+    auto unavailable_external_url_query_completed = false;
+    {
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.on_autocomplete_query_complete = [&](auto, auto const& suggestions, WebView::AutocompleteResultKind kind) {
+            if (kind != WebView::AutocompleteResultKind::Final)
+                return;
+            VERIFY(!suggestions.is_empty());
+            VERIFY(suggestions.first().source == WebView::AutocompleteSuggestionSource::Search);
+            VERIFY(suggestions.first().text == "unknown:value"sv);
+            VERIFY(!suggestions.contains([](auto const& suggestion) {
+                return suggestion.source == WebView::AutocompleteSuggestionSource::LiteralURL;
+            }));
+            autocomplete.cancel_pending_query();
+            unavailable_external_url_query_completed = true;
+        };
+        autocomplete.query_autocomplete_engine(102, "unknown:value"_string);
+        VERIFY(app->pending_external_url_handler_query_count() == 1);
+        VERIFY(app->pending_external_url_handler_query_scheme(0) == "unknown"sv);
+        app->complete_next_external_url_handler_query(false);
+        Core::EventLoop::current().spin_until([&]() { return unavailable_external_url_query_completed; });
+    }
+
+    auto replacement_query_completed = false;
+    {
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.on_autocomplete_query_complete = [&](auto query_id, auto const&, WebView::AutocompleteResultKind kind) {
+            VERIFY(query_id != 103);
+            if (query_id == 104 && kind == WebView::AutocompleteResultKind::Final) {
+                autocomplete.cancel_pending_query();
+                replacement_query_completed = true;
+            }
+        };
+        autocomplete.query_autocomplete_engine(103, "geo:23.4,12.4"_string);
+        VERIFY(app->pending_external_url_handler_query_count() == 1);
+        autocomplete.query_autocomplete_engine(104, "replacement query"_string);
+        app->complete_next_external_url_handler_query(true);
+        Core::EventLoop::current().spin_until([&]() { return replacement_query_completed; });
+    }
+
+    {
+        WebView::Autocomplete autocomplete { WebView::IsPrivate::No };
+        autocomplete.query_autocomplete_engine(105, "geo:23.4,12.4"_string);
+        VERIFY(app->pending_external_url_handler_query_count() == 1);
+    }
+    app->complete_next_external_url_handler_query(true);
 
     // A closed loopback port makes the request fail fast and deterministically, with no real network.
     // Its on_finish synchronously delivers the final result. A data: URL cannot be used because the request

--- a/Tests/LibWebView/TestAutocompleteMuxer.cpp
+++ b/Tests/LibWebView/TestAutocompleteMuxer.cpp
@@ -76,6 +76,48 @@ TEST_CASE(strong_local_navigation_can_replace_an_ambiguous_default)
     EXPECT_EQ(results[1].text, "lady"sv);
 }
 
+TEST_CASE(literal_url_remains_the_default_over_adaptive_results)
+{
+    auto results = WebView::mux_autocomplete_suggestions(
+        "mailto:hello@ladybird.org"sv,
+        suggestion(WebView::AutocompleteSuggestionSource::LiteralURL, "mailto:hello@ladybird.org"sv, 900, true, true),
+        { suggestion(WebView::AutocompleteSuggestionSource::Adaptive, "https://ladybird.org/"sv, 1400, true) },
+        {},
+        8);
+
+    EXPECT_EQ(results.size(), 2u);
+    EXPECT_EQ(results[0].text, "mailto:hello@ladybird.org"sv);
+    EXPECT(results[0].is_verbatim);
+}
+
+TEST_CASE(literal_url_and_search_remain_distinct_actions)
+{
+    auto results = WebView::mux_autocomplete_suggestions(
+        "steam://launch/1536610"sv,
+        suggestion(WebView::AutocompleteSuggestionSource::LiteralURL, "steam://launch/1536610"sv, 900, true, true),
+        {},
+        { search("steam://launch/1536610"sv, 700) },
+        8);
+
+    EXPECT_EQ(results.size(), 2u);
+    EXPECT_EQ(results[0].source, WebView::AutocompleteSuggestionSource::LiteralURL);
+    EXPECT_EQ(results[1].source, WebView::AutocompleteSuggestionSource::Search);
+}
+
+TEST_CASE(literal_external_url_is_not_replaced_by_a_guessed_https_url)
+{
+    auto results = WebView::mux_autocomplete_suggestions(
+        "steam://launch/1536610"sv,
+        suggestion(WebView::AutocompleteSuggestionSource::LiteralURL, "steam://launch/1536610"sv, 900, true, true),
+        { history("https://steam://launch/1536610"sv, 1000) },
+        {},
+        8);
+
+    EXPECT_EQ(results.size(), 2u);
+    EXPECT_EQ(results[0].source, WebView::AutocompleteSuggestionSource::LiteralURL);
+    EXPECT_EQ(results[0].text, "steam://launch/1536610"sv);
+}
+
 TEST_CASE(verbatim_action_remains_visible_when_history_fills_the_list)
 {
     Vector<WebView::AutocompleteSuggestion> history_suggestions;

--- a/Tests/LibWebView/TestExternalURLHandler.cpp
+++ b/Tests/LibWebView/TestExternalURLHandler.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibURL/Parser.h>
+#include <LibWebView/ExternalURLHandler.h>
+
+static URL::URL parse_url(StringView url)
+{
+    return URL::Parser::basic_parse(url).release_value();
+}
+
+TEST_CASE(denied_schemes)
+{
+    constexpr Array denied_schemes {
+        "afp"sv,
+        "data"sv,
+        "disk"sv,
+        "disks"sv,
+        "file"sv,
+        "hcp"sv,
+        "ie.http"sv,
+        "javascript"sv,
+        "mk"sv,
+        "ms-help"sv,
+        "nntp"sv,
+        "res"sv,
+        "shell"sv,
+        "vbscript"sv,
+        "view-source"sv,
+        "vnd.ms.radio"sv,
+    };
+
+    for (auto scheme : denied_schemes)
+        EXPECT(WebView::ExternalURLRequestPolicy::is_denied_scheme(scheme));
+
+    EXPECT(WebView::ExternalURLRequestPolicy::is_denied_scheme("c"sv));
+    EXPECT(!WebView::ExternalURLRequestPolicy::is_denied_scheme("mailto"sv));
+    EXPECT(!WebView::ExternalURLRequestPolicy::is_denied_scheme("web+test"sv));
+}
+
+TEST_CASE(mailto_with_activation_launches)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    policy.allow_next_request();
+    EXPECT_EQ(policy.decide(parse_url("mailto:foo@example.com"sv), true), WebView::ExternalURLAction::Launch);
+}
+
+TEST_CASE(mailto_without_activation_prompts)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    policy.allow_next_request();
+    EXPECT_EQ(policy.decide(parse_url("mailto:foo@example.com"sv), false), WebView::ExternalURLAction::Prompt);
+}
+
+TEST_CASE(mailto_from_browser_ui_launches)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    auto url = parse_url("mailto:foo@example.com"sv);
+    policy.allow_request_from_browser_ui(url);
+    EXPECT_EQ(policy.decide(parse_url("mailto:bar@example.com"sv), false), WebView::ExternalURLAction::Block);
+    EXPECT_EQ(policy.decide(url, false), WebView::ExternalURLAction::Launch);
+}
+
+TEST_CASE(other_schemes_always_prompt)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    policy.allow_next_request();
+    EXPECT_EQ(policy.decide(parse_url("web+test:payload"sv), true), WebView::ExternalURLAction::Prompt);
+
+    EXPECT_EQ(policy.decide(parse_url("web+test:payload"sv), false), WebView::ExternalURLAction::Prompt);
+}
+
+TEST_CASE(requests_require_an_interaction)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    auto url = parse_url("mailto:foo@example.com"sv);
+
+    EXPECT_EQ(policy.decide(url, true), WebView::ExternalURLAction::Block);
+
+    policy.allow_next_request();
+    EXPECT_EQ(policy.decide(url, true), WebView::ExternalURLAction::Launch);
+
+    EXPECT(policy.take_request_allowance().has_value());
+    EXPECT_EQ(policy.decide(url, true), WebView::ExternalURLAction::Block);
+}
+
+TEST_CASE(request_allowances_expire)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    auto url = parse_url("mailto:foo@example.com"sv);
+    auto granted_at = MonotonicTime::now();
+
+    policy.allow_next_request(granted_at);
+    EXPECT_EQ(policy.decide(url, true, granted_at + AK::Duration::from_seconds(6)), WebView::ExternalURLAction::Block);
+    EXPECT(!policy.take_request_allowance().has_value());
+}
+
+TEST_CASE(navigation_only_clears_page_allowances)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    auto url = parse_url("mailto:foo@example.com"sv);
+
+    policy.allow_next_request();
+    policy.clear_page_request_allowance();
+    EXPECT_EQ(policy.decide(url, true), WebView::ExternalURLAction::Block);
+
+    policy.allow_request_from_browser_ui(url);
+    policy.clear_page_request_allowance();
+    EXPECT_EQ(policy.decide(url, false), WebView::ExternalURLAction::Launch);
+}
+
+TEST_CASE(denied_schemes_do_not_consume_the_request_allowance)
+{
+    WebView::ExternalURLRequestPolicy policy;
+    policy.allow_next_request();
+
+    EXPECT_EQ(policy.decide(parse_url("file:///tmp/example"sv), true), WebView::ExternalURLAction::Block);
+    EXPECT_EQ(policy.decide(parse_url("mailto:foo@example.com"sv), true), WebView::ExternalURLAction::Launch);
+}

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -217,6 +217,12 @@ TEST_CASE(all_web_ui_pages_are_suggested)
     }
 }
 
+TEST_CASE(paste_and_go_treats_external_urls_as_urls)
+{
+    EXPECT_EQ(Omnibox::text_for_paste_and_go_action("mailto:hello@example.com"_string, true), "Paste and Go to mailto:hello@example.com"sv);
+    EXPECT_EQ(Omnibox::text_for_paste_and_go_action("hello world"_string, true), "Paste and Search for 'hello world'"sv);
+}
+
 TEST_CASE(web_ui_pages_are_matched_by_case_insensitive_url_prefix)
 {
     auto suggestions = WebView::web_ui_autocomplete_suggestions("ABOUT:SET"sv);

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -117,6 +117,7 @@ struct Harness {
         };
         omnibox.on_commit = [this](String text) {
             commits.append(move(text));
+            commit_destination_kinds.append(omnibox.destination_kind_for_last_commit());
         };
 
         // Mirror the popup exactly the way a real chrome does, so the tests exercise the notification
@@ -185,6 +186,7 @@ struct Harness {
     String display_text;
     Optional<size_t> selection_start;
     Vector<String> commits;
+    Vector<WebView::OmniboxDestinationKind> commit_destination_kinds;
 
     size_t popup_repaints { 0 };
     bool visible_popup { false };
@@ -628,6 +630,27 @@ TEST_CASE(verbatim_commit_records_the_unmodified_input)
     EXPECT(!harness.provider->engagements[0].was_explicit);
 }
 
+TEST_CASE(verbatim_url_candidates_use_url_or_search_resolution)
+{
+    static constexpr Array url_candidates {
+        "geo:23.4,12.4"sv,
+        "tel:123"sv,
+        "localhost:8080"sv,
+        "example.com:8080"sv,
+    };
+
+    for (auto input : url_candidates) {
+        Harness harness;
+        harness.begin_editing(input);
+
+        harness.omnibox.return_pressed();
+
+        EXPECT_EQ(harness.commits.size(), 1u);
+        EXPECT_EQ(harness.commits[0], input);
+        EXPECT_EQ(harness.commit_destination_kinds[0], WebView::OmniboxDestinationKind::URL);
+    }
+}
+
 TEST_CASE(a_user_chosen_row_wins_over_edited_text)
 {
     Harness harness;
@@ -775,6 +798,7 @@ TEST_CASE(clicking_a_suggestion_commits_it)
 
     harness.omnibox.suggestion_clicked(1);
     EXPECT_EQ(harness.commits.last(), "t"sv);
+    EXPECT_EQ(harness.commit_destination_kinds.last(), WebView::OmniboxDestinationKind::Search);
     EXPECT(!harness.omnibox.is_popup_visible());
 }
 
@@ -1112,6 +1136,7 @@ TEST_CASE(committing_may_reentrantly_end_editing)
     // The real chrome clears focus while handling a commit, which calls back into end_editing.
     harness.omnibox.on_commit = [&](String text) {
         harness.commits.append(move(text));
+        harness.commit_destination_kinds.append(harness.omnibox.destination_kind_for_last_commit());
         harness.omnibox.end_editing();
     };
 

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -117,6 +117,7 @@ struct Harness {
         };
         omnibox.on_commit = [this](String text) {
             commits.append(move(text));
+            commit_destination_kinds.append(omnibox.destination_kind_for_last_commit());
         };
 
         // Mirror the popup exactly the way a real chrome does, so the tests exercise the notification
@@ -185,6 +186,7 @@ struct Harness {
     String display_text;
     Optional<size_t> selection_start;
     Vector<String> commits;
+    Vector<WebView::OmniboxDestinationKind> commit_destination_kinds;
 
     size_t popup_repaints { 0 };
     bool visible_popup { false };
@@ -622,6 +624,27 @@ TEST_CASE(verbatim_commit_records_the_unmodified_input)
     EXPECT(!harness.provider->engagements[0].was_explicit);
 }
 
+TEST_CASE(verbatim_url_candidates_use_url_or_search_resolution)
+{
+    static constexpr Array url_candidates {
+        "geo:23.4,12.4"sv,
+        "tel:123"sv,
+        "localhost:8080"sv,
+        "example.com:8080"sv,
+    };
+
+    for (auto input : url_candidates) {
+        Harness harness;
+        harness.begin_editing(input);
+
+        harness.omnibox.return_pressed();
+
+        EXPECT_EQ(harness.commits.size(), 1u);
+        EXPECT_EQ(harness.commits[0], input);
+        EXPECT_EQ(harness.commit_destination_kinds[0], WebView::OmniboxDestinationKind::URL);
+    }
+}
+
 TEST_CASE(a_user_chosen_row_wins_over_edited_text)
 {
     Harness harness;
@@ -769,6 +792,7 @@ TEST_CASE(clicking_a_suggestion_commits_it)
 
     harness.omnibox.suggestion_clicked(1);
     EXPECT_EQ(harness.commits.last(), "t"sv);
+    EXPECT_EQ(harness.commit_destination_kinds.last(), WebView::OmniboxDestinationKind::Search);
     EXPECT(!harness.omnibox.is_popup_visible());
 }
 
@@ -1106,6 +1130,7 @@ TEST_CASE(committing_may_reentrantly_end_editing)
     // The real chrome clears focus while handling a commit, which calls back into end_editing.
     harness.omnibox.on_commit = [&](String text) {
         harness.commits.append(move(text));
+        harness.commit_destination_kinds.append(harness.omnibox.destination_kind_for_last_commit());
         harness.omnibox.end_editing();
     };
 

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -60,6 +60,15 @@ static void expect_location_does_not_look_like_url(StringView location, WebView:
     EXPECT(!WebView::location_looks_like_url(location, append_tld));
 }
 
+static void expect_user_input_classification(StringView input, WebView::UserInputClassification expected_classification, Optional<StringView> expected_url = {})
+{
+    auto classified_input = WebView::classify_user_input(input);
+    EXPECT_EQ(classified_input.classification, expected_classification);
+    EXPECT_EQ(classified_input.url.has_value(), expected_url.has_value());
+    if (expected_url.has_value())
+        EXPECT_EQ(classified_input.url->to_string(), *expected_url);
+}
+
 static void expect_context_menu_text_url(StringView text, StringView expected_url)
 {
     auto url = WebView::url_from_text(text);
@@ -225,7 +234,7 @@ TEST_CASE(location_to_search_or_url)
     expect_search_url_equals_sanitized_url("\"http://example.org\""sv);
     expect_search_url_equals_sanitized_url("example.org hello"sv);
     expect_search_url_equals_sanitized_url("http://example.org and example sites"sv);
-    expect_search_url_equals_sanitized_url("ftp://example.org"sv); // ftp:// is not in SUPPORTED_SCHEMES
+    expect_search_url_equals_sanitized_url("ftp://example.org"sv);
     expect_search_url_equals_sanitized_url("https://exa\"mple.com/what"sv);
 
     // If it can feed create_with_url_or_path -- it is a url.
@@ -257,10 +266,39 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://com.com/"sv, "com"sv, WebView::AppendTLD::Yes);
     expect_url_equals_sanitized_url("https://example.com/index.html"sv, "example/index.html"sv, WebView::AppendTLD::Yes);
 
-    expect_search_url_equals_sanitized_url("whatever:example.com"sv);     // Invalid scheme.
-    expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv); // For now, unsupported scheme.
-    // FIXME: Add support for opening mailto: scheme (below). Firefox opens mailto: locations
-    // expect_url_equals_sanitized_url("mailto:hello@example.com"sv, "mailto:hello@example.com"sv);
+    expect_search_url_equals_sanitized_url("whatever:example.com"sv);
+    expect_search_url_equals_sanitized_url("site:example.com"sv);
+    expect_url_equals_sanitized_url("https://host:8080/"sv, "host:8080"sv);
+    expect_search_url_equals_sanitized_url("steam://launch/1536610"sv);
+    expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv);
+    expect_search_url_equals_sanitized_url("geo:23.4,12.4"sv);
+    expect_search_url_equals_sanitized_url("javascript:alert(1)"sv);
+}
+
+TEST_CASE(classify_user_input)
+{
+    using enum WebView::UserInputClassification;
+
+    expect_user_input_classification("example.org"sv, InternalURL, "https://example.org/"sv);
+    expect_user_input_classification("localhost:8080"sv, InternalURL, "https://localhost:8080/"sv);
+    expect_user_input_classification("example.com:8080"sv, InternalURL, "https://example.com:8080/"sv);
+    expect_user_input_classification("host:8080/path?query#fragment"sv, InternalURL, "https://host:8080/path?query#fragment"sv);
+    expect_user_input_classification("1.2:45"sv, InternalURL, "https://1.0.0.2:45/"sv);
+    expect_user_input_classification("host:0"sv, InternalURL, "https://host:0/"sv);
+    expect_user_input_classification("host:65535"sv, InternalURL, "https://host:65535/"sv);
+
+    expect_user_input_classification("tel:123"sv, ExternalURL, "tel:123"sv);
+    expect_user_input_classification("sms:123"sv, ExternalURL, "sms:123"sv);
+    expect_user_input_classification("mailto:123"sv, ExternalURL, "mailto:123"sv);
+    expect_user_input_classification("mailto:hello@example.com"sv, ExternalURL, "mailto:hello@example.com"sv);
+    expect_user_input_classification("geo:23.4,12.4"sv, ExternalURL, "geo:23.4,12.4"sv);
+    expect_user_input_classification("steam://launch/1536610"sv, ExternalURL, "steam://launch/1536610"sv);
+    expect_user_input_classification("site:example.com"sv, ExternalURL, "site:example.com"sv);
+    expect_user_input_classification("host:65536"sv, ExternalURL, "host:65536"sv);
+
+    expect_user_input_classification("hello"sv, Search);
+    expect_user_input_classification("hello world"sv, Search);
+    expect_user_input_classification("javascript:alert(1)"sv, Search);
 }
 
 TEST_CASE(location_looks_like_url)
@@ -274,6 +312,11 @@ TEST_CASE(location_looks_like_url)
     expect_location_does_not_look_like_url("hello world"sv);
     expect_location_does_not_look_like_url("example.org hello"sv);
     expect_location_does_not_look_like_url("example.def"sv);
+    expect_location_does_not_look_like_url("site:example.com"sv);
+    expect_location_does_not_look_like_url("mailto:hello@example.com"sv);
+    expect_location_does_not_look_like_url("steam://launch/1536610"sv);
+    expect_location_does_not_look_like_url("geo:23.4,12.4"sv);
+    expect_location_does_not_look_like_url("javascript://alert"sv);
 
     expect_location_looks_like_url("example"sv, WebView::AppendTLD::Yes);
 }

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -60,6 +60,15 @@ static void expect_location_does_not_look_like_url(StringView location, WebView:
     EXPECT(!WebView::location_looks_like_url(location, append_tld));
 }
 
+static void expect_user_input_classification(StringView input, WebView::UserInputClassification expected_classification, Optional<StringView> expected_url = {})
+{
+    auto classified_input = WebView::classify_user_input(input);
+    EXPECT_EQ(classified_input.classification, expected_classification);
+    EXPECT_EQ(classified_input.url.has_value(), expected_url.has_value());
+    if (expected_url.has_value())
+        EXPECT_EQ(classified_input.url->to_string(), *expected_url);
+}
+
 static void expect_context_menu_text_url(StringView text, StringView expected_url)
 {
     auto url = WebView::url_from_text(text);
@@ -225,7 +234,7 @@ TEST_CASE(location_to_search_or_url)
     expect_search_url_equals_sanitized_url("\"http://example.org\""sv);
     expect_search_url_equals_sanitized_url("example.org hello"sv);
     expect_search_url_equals_sanitized_url("http://example.org and example sites"sv);
-    expect_search_url_equals_sanitized_url("ftp://example.org"sv); // ftp:// is not in SUPPORTED_SCHEMES
+    expect_search_url_equals_sanitized_url("ftp://example.org"sv);
     expect_search_url_equals_sanitized_url("https://exa\"mple.com/what"sv);
 
     // If it can feed create_with_url_or_path -- it is a url.
@@ -257,10 +266,39 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://com.com/"sv, "com"sv, WebView::AppendTLD::Yes);
     expect_url_equals_sanitized_url("https://example.com/index.html"sv, "example/index.html"sv, WebView::AppendTLD::Yes);
 
-    expect_search_url_equals_sanitized_url("whatever:example.com"sv);     // Invalid scheme.
-    expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv); // For now, unsupported scheme.
-    // FIXME: Add support for opening mailto: scheme (below). Firefox opens mailto: locations
-    // expect_url_equals_sanitized_url("mailto:hello@example.com"sv, "mailto:hello@example.com"sv);
+    expect_search_url_equals_sanitized_url("whatever:example.com"sv);
+    expect_search_url_equals_sanitized_url("site:example.com"sv);
+    expect_url_equals_sanitized_url("https://host:8080/"sv, "host:8080"sv);
+    expect_search_url_equals_sanitized_url("steam://launch/1536610"sv);
+    expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv);
+    expect_search_url_equals_sanitized_url("geo:23.4,12.4"sv);
+    expect_search_url_equals_sanitized_url("javascript:alert(1)"sv);
+}
+
+TEST_CASE(classify_user_input)
+{
+    using enum WebView::UserInputClassification;
+
+    expect_user_input_classification("example.org"sv, InternalURL, "https://example.org/"sv);
+    expect_user_input_classification("localhost:8080"sv, InternalURL, "https://localhost:8080/"sv);
+    expect_user_input_classification("example.com:8080"sv, InternalURL, "https://example.com:8080/"sv);
+    expect_user_input_classification("host:8080/path?query#fragment"sv, InternalURL, "https://host:8080/path?query#fragment"sv);
+    expect_user_input_classification("1.2:45"sv, InternalURL, "https://1.0.0.2:45/"sv);
+    expect_user_input_classification("host:0"sv, InternalURL, "https://host:0/"sv);
+    expect_user_input_classification("host:65535"sv, InternalURL, "https://host:65535/"sv);
+
+    expect_user_input_classification("tel:123"sv, ExternalURL, "tel:123"sv);
+    expect_user_input_classification("sms:123"sv, ExternalURL, "sms:123"sv);
+    expect_user_input_classification("mailto:123"sv, ExternalURL, "mailto:123"sv);
+    expect_user_input_classification("mailto:hello@example.com"sv, ExternalURL, "mailto:hello@example.com"sv);
+    expect_user_input_classification("geo:23.4,12.4"sv, ExternalURL, "geo:23.4,12.4"sv);
+    expect_user_input_classification("steam://launch/1536610"sv, ExternalURL, "steam://launch/1536610"sv);
+    expect_user_input_classification("site:example.com"sv, ExternalURL, "site:example.com"sv);
+    expect_user_input_classification("host:65536"sv, ExternalURL, "host:65536"sv);
+
+    expect_user_input_classification("hello"sv, Search);
+    expect_user_input_classification("hello world"sv, Search);
+    expect_user_input_classification("javascript:alert(1)"sv, Search);
 }
 
 TEST_CASE(location_looks_like_url)
@@ -269,11 +307,16 @@ TEST_CASE(location_looks_like_url)
     expect_location_looks_like_url("example.com"sv);
     expect_location_looks_like_url("localhost"sv);
     expect_location_looks_like_url("https://example.def"sv);
+    expect_location_looks_like_url("site:example.com"sv);
+    expect_location_looks_like_url("mailto:hello@example.com"sv);
+    expect_location_looks_like_url("steam://launch/1536610"sv);
+    expect_location_looks_like_url("geo:23.4,12.4"sv);
 
     expect_location_does_not_look_like_url("hello"sv);
     expect_location_does_not_look_like_url("hello world"sv);
     expect_location_does_not_look_like_url("example.org hello"sv);
     expect_location_does_not_look_like_url("example.def"sv);
+    expect_location_does_not_look_like_url("javascript://alert"sv);
 
     expect_location_looks_like_url("example"sv, WebView::AppendTLD::Yes);
 }

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -345,6 +345,7 @@ TEST_CASE(autocomplete_url_matching)
     expect_autocomplete_urls_do_not_match("https://example.com/path"sv, "https://example.com/other"sv);
     expect_autocomplete_urls_do_not_match("https://example.com"sv, "https://example.com:8443"sv);
     expect_autocomplete_urls_do_not_match("hello"sv, "https://hello.example/"sv);
+    expect_autocomplete_urls_do_not_match("steam://launch/1536610"sv, "https://steam://launch/1536610"sv);
 }
 
 TEST_CASE(autocomplete_url_completion)
@@ -367,6 +368,10 @@ TEST_CASE(autocomplete_suggestion_display_text)
     url_suggestion.source = WebView::AutocompleteSuggestionSource::History;
     url_suggestion.text = "https://www.example.com/"_string;
     EXPECT_EQ(WebView::autocomplete_suggestion_display_text(url_suggestion), "example.com"sv);
+
+    url_suggestion.source = WebView::AutocompleteSuggestionSource::LiteralURL;
+    url_suggestion.text = "steam://launch/1536610"_string;
+    EXPECT_EQ(WebView::autocomplete_suggestion_display_text(url_suggestion), "steam://launch/1536610"sv);
 
     WebView::AutocompleteSuggestion search_suggestion;
     search_suggestion.source = WebView::AutocompleteSuggestionSource::Search;

--- a/Tests/UI/Qt/CMakeLists.txt
+++ b/Tests/UI/Qt/CMakeLists.txt
@@ -9,3 +9,6 @@ endif()
 
 ladybird_test("TestNativeWindowContainerFocus.cpp" UI/Qt LIBS Qt::Core Qt::Gui Qt::Widgets)
 target_sources(TestNativeWindowContainerFocus PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/NativeWindowContainer.cpp")
+
+ladybird_test("TestStringUtils.cpp" UI/Qt NAME TestQtStringUtils LIBS LibURL Qt::Core)
+target_sources(TestQtStringUtils PRIVATE "${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp")

--- a/Tests/UI/Qt/TestStringUtils.cpp
+++ b/Tests/UI/Qt/TestStringUtils.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <LibTest/TestCase.h>
+#include <UI/Qt/StringUtils.h>
+
+#include <QUrl>
+
+TEST_CASE(qurl_conversion_preserves_percent_encoding)
+{
+    constexpr Array encoded_urls {
+        "web+test:path%20with%20spaces"sv,
+        "web+test:%E2%98%83"sv,
+        "web+test:path?value=a%26b%3Dc"sv,
+    };
+
+    for (auto encoded_url : encoded_urls) {
+        auto qurl = QUrl::fromEncoded(QByteArray { encoded_url.characters_without_null_termination(), static_cast<qsizetype>(encoded_url.length()) });
+        EXPECT_EQ(ak_url_from_qurl(qurl).to_string(), encoded_url);
+    }
+}

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -30,6 +30,8 @@ private:
     virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const override;
     virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
+    virtual void resolve_external_url_handler(URL::URL const&, WebView::ExternalURLHandlerCallback) const override;
+
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -12,6 +12,7 @@
 #include <LibWebView/URL.h>
 #include <LibWebView/ViewImplementation.h>
 #include <Utilities/Conversions.h>
+#include <Utilities/ExternalURLHandler.h>
 
 #import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
@@ -128,6 +129,11 @@ void Application::open_url_in_new_window(URL::URL const& url, WebView::IsPrivate
                        isPrivate:is_private
                      activateTab:Web::HTML::ActivateTab::Yes
                      tabLocation:TabLocation::end()];
+}
+
+void Application::resolve_external_url_handler(URL::URL const& url, WebView::ExternalURLHandlerCallback callback) const
+{
+    Ladybird::resolve_external_url_handler(url, move(callback));
 }
 
 Optional<ByteString> Application::ask_user_for_download_path(ByteString const& file) const

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(ladybird_impl STATIC
     Utilities/ApplicationIcon.mm
     Utilities/Conversions.mm
     Utilities/DictionaryLookup.mm
+    Utilities/ExternalURLHandler.mm
 )
 target_include_directories(ladybird_impl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -4,12 +4,16 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Function.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
+#include <AK/RefCounted.h>
 #include <Interface/LadybirdWebViewBridge.h>
 #include <LibURL/URL.h>
 #include <LibWakeLock/DisplaySleepInhibitor.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/URL.h>
 #include <LibWebView/Utilities.h>
 
 #import <Application/ApplicationDelegate.h>
@@ -39,6 +43,25 @@ struct HideCursor {
     {
         [NSCursor unhide];
     }
+};
+
+class ExternalURLConfirmation final : public RefCounted<ExternalURLConfirmation> {
+public:
+    explicit ExternalURLConfirmation(Function<void(bool)> on_complete)
+        : m_on_complete(move(on_complete))
+    {
+    }
+
+    void complete(bool accepted)
+    {
+        if (!m_on_complete)
+            return;
+        auto on_complete = move(m_on_complete);
+        on_complete(accepted);
+    }
+
+private:
+    Function<void(bool)> m_on_complete;
 };
 
 static Optional<u64> display_id_for_screen(NSScreen* screen)
@@ -119,6 +142,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 @property (nonatomic, strong) NSMenu* select_dropdown;
 @property (nonatomic, strong) NSTextField* status_label;
 @property (nonatomic, strong) NSAlert* dialog;
+@property (nonatomic, strong) NSAlert* external_url_confirmation_dialog;
 @property (nonatomic, strong) NSMagnificationGestureRecognizer* pinch_recognizer;
 
 // NSEvent does not provide a way to mark whether it has been handled, nor can we attach user data to the event. So
@@ -228,7 +252,7 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
 - (void)loadURL:(URL::URL const&)url
 {
-    m_web_view_bridge->load(url);
+    m_web_view_bridge->load_from_user_input(url);
 }
 
 - (WebView::ViewImplementation&)view
@@ -466,10 +490,13 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
         }
 
         if (auto urls = Ladybird::drag_event_url_list(event); !urls.is_empty()) {
-            [self loadURL:urls[0]];
+            self->m_web_view_bridge->load_from_user_input(urls[0]);
 
             for (size_t i = 1; i < urls.size(); ++i) {
-                [self.observer onCreateNewTab:urls[i] activateTab:Web::HTML::ActivateTab::No];
+                if (WebView::is_url_handled_internally(urls[i]))
+                    [self.observer onCreateNewTab:urls[i] activateTab:Web::HTML::ActivateTab::No];
+                else
+                    self->m_web_view_bridge->open_url_in_new_tab(urls[i], Web::HTML::ActivateTab::No);
             }
         }
     };
@@ -728,6 +755,41 @@ static Web::DevicePixelPoint node_picker_position_for(Ladybird::WebViewBridge co
 
         auto* input = (NSTextField*)[self.dialog accessoryView];
         [input setStringValue:ns_message];
+    };
+
+    m_web_view_bridge->on_request_external_url_confirmation = [weak_self](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil || self.dialog != nil || self.external_url_confirmation_dialog != nil) {
+            on_complete(false);
+            return;
+        }
+
+        auto initiator = initiator_origin.is_opaque() ? "This page"_string : initiator_origin.serialize();
+        auto application_name = handler.application_name().is_empty() ? "another application"sv : handler.application_name().bytes_as_string_view();
+        auto title = handler.application_name().is_empty() ? "Open external application?"_string : MUST(String::formatted("Open {}?", application_name));
+        auto message = MUST(String::formatted("{} wants to open a {} link with {}.", initiator, url.scheme(), application_name));
+        auto open_button_text = handler.application_name().is_empty() ? "Open"_string : MUST(String::formatted("Open {}", application_name));
+
+        auto completion = adopt_ref(*new ExternalURLConfirmation(AK::move(on_complete)));
+
+        self.external_url_confirmation_dialog = [[NSAlert alloc] init];
+        [[self.external_url_confirmation_dialog addButtonWithTitle:Ladybird::string_to_ns_string(open_button_text)] setTag:NSModalResponseOK];
+        [[self.external_url_confirmation_dialog addButtonWithTitle:@"Cancel"] setTag:NSModalResponseCancel];
+        [self.external_url_confirmation_dialog setMessageText:Ladybird::string_to_ns_string(title)];
+        [self.external_url_confirmation_dialog setInformativeText:Ladybird::string_to_ns_string(message)];
+
+        auto* window = [self window];
+        if (window == nil) {
+            self.external_url_confirmation_dialog = nil;
+            completion->complete(false);
+            return;
+        }
+
+        [self.external_url_confirmation_dialog beginSheetModalForWindow:window
+                                                      completionHandler:^(NSModalResponse response) {
+                                                          self.external_url_confirmation_dialog = nil;
+                                                          completion->complete(response == NSModalResponseOK);
+                                                      }];
     };
 
     m_web_view_bridge->on_request_accept_dialog = [weak_self]() {

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -714,6 +714,7 @@ static NSInteger ns_index_for_selected_suggestion(Optional<size_t> selected_sugg
 - (BOOL)locationFieldCursorIsAtEnd;
 - (void)applyOmniboxDisplay:(WebView::Omnibox::Display const&)display;
 - (void)locationFieldSelectionDidChange:(NSNotification*)notification;
+- (BOOL)navigateToLocation:(String)location destinationKind:(WebView::OmniboxDestinationKind)destination_kind;
 - (void)downloadAdded:(WebView::FileDownloader::Download const&)download;
 - (void)downloadUpdated:(WebView::FileDownloader::Download const&)download;
 - (void)downloadRemoved:(u64)download_id;
@@ -822,7 +823,7 @@ private:
             if (self == nil)
                 return;
 
-            [self navigateToLocation:move(input)];
+            [self navigateToLocation:move(input) destinationKind:self->m_omnibox->destination_kind_for_last_commit()];
         };
     }
 
@@ -1105,13 +1106,17 @@ private:
     m_omnibox->cursor_moved([self locationFieldCursorIsAtEnd]);
 }
 
-- (BOOL)navigateToLocation:(String)location
+- (BOOL)navigateToLocation:(String)location destinationKind:(WebView::OmniboxDestinationKind)destination_kind
 {
-    if (auto url = WebView::sanitize_url(location, WebView::Application::settings().search_engine()); url.has_value()) {
-        [[[self tab] web_view] view].set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
-        [self loadURL:*url];
+    auto& view = [[[self tab] web_view] view];
+    view.set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
+    if (destination_kind == WebView::OmniboxDestinationKind::Search) {
+        if (auto url = WebView::sanitize_url(location, WebView::Application::settings().search_engine()); url.has_value())
+            view.load(*url);
+        else
+            view.load_navigation_error_page(location);
     } else {
-        [[[self tab] web_view] view].load_navigation_error_page(location);
+        view.load_from_user_input(location);
     }
 
     [self focusWebView];

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -676,6 +676,7 @@ static NSInteger ns_index_for_selected_suggestion(Optional<size_t> selected_sugg
 - (BOOL)locationFieldCursorIsAtEnd;
 - (void)applyOmniboxDisplay:(WebView::Omnibox::Display const&)display;
 - (void)locationFieldSelectionDidChange:(NSNotification*)notification;
+- (BOOL)navigateToLocation:(String)location destinationKind:(WebView::OmniboxDestinationKind)destination_kind;
 - (void)downloadAdded:(WebView::FileDownloader::Download const&)download;
 - (void)downloadUpdated:(WebView::FileDownloader::Download const&)download;
 - (void)downloadRemoved:(u64)download_id;
@@ -784,7 +785,7 @@ private:
             if (self == nil)
                 return;
 
-            [self navigateToLocation:move(input)];
+            [self navigateToLocation:move(input) destinationKind:self->m_omnibox->destination_kind_for_last_commit()];
         };
     }
 
@@ -1067,13 +1068,17 @@ private:
     m_omnibox->cursor_moved([self locationFieldCursorIsAtEnd]);
 }
 
-- (BOOL)navigateToLocation:(String)location
+- (BOOL)navigateToLocation:(String)location destinationKind:(WebView::OmniboxDestinationKind)destination_kind
 {
-    if (auto url = WebView::sanitize_url(location, WebView::Application::settings().search_engine()); url.has_value()) {
-        [[[self tab] web_view] view].set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
-        [self loadURL:*url];
+    auto& view = [[[self tab] web_view] view];
+    view.set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
+    if (destination_kind == WebView::OmniboxDestinationKind::Search) {
+        if (auto url = WebView::sanitize_url(location, WebView::Application::settings().search_engine()); url.has_value())
+            view.load(*url);
+        else
+            view.load_navigation_error_page(location);
     } else {
-        [[[self tab] web_view] view].load_navigation_error_page(location);
+        view.load_from_user_input(location);
     }
 
     [self focusWebView];

--- a/UI/AppKit/Utilities/Conversions.h
+++ b/UI/AppKit/Utilities/Conversions.h
@@ -15,6 +15,7 @@
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
+#include <LibURL/URL.h>
 
 #import <Cocoa/Cocoa.h>
 
@@ -49,5 +50,7 @@ NSColor* gfx_color_to_ns_color(Gfx::Color);
 Gfx::IntPoint compute_origin_relative_to_window(NSWindow*, Gfx::IntPoint);
 
 NSImage* gfx_bitmap_to_ns_image(Gfx::Bitmap const&);
+
+NSURL* url_to_ns_url(URL::URL const&);
 
 }

--- a/UI/AppKit/Utilities/Conversions.mm
+++ b/UI/AppKit/Utilities/Conversions.mm
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
- * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2025-2026, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,7 +8,7 @@
 #include <AK/Base64.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
 
-#import <Utilities/Conversions.h>
+#import <UI/AppKit/Utilities/Conversions.h>
 
 namespace Ladybird {
 
@@ -178,6 +178,12 @@ NSImage* gfx_bitmap_to_ns_image(Gfx::Bitmap const& bitmap)
                                 length:png.value().size()];
 
     return [[NSImage alloc] initWithData:data];
+}
+
+NSURL* url_to_ns_url(URL::URL const& url)
+{
+    auto serialized_url = url.serialize();
+    return [NSURL URLWithDataRepresentation:string_to_ns_data(serialized_url.bytes_as_string_view()) relativeToURL:nil];
 }
 
 }

--- a/UI/AppKit/Utilities/ExternalURLHandler.h
+++ b/UI/AppKit/Utilities/ExternalURLHandler.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibURL/URL.h>
+#include <LibWebView/ExternalURLHandler.h>
+
+namespace Ladybird {
+
+void resolve_external_url_handler(URL::URL const&, WebView::ExternalURLHandlerCallback);
+
+}

--- a/UI/AppKit/Utilities/ExternalURLHandler.mm
+++ b/UI/AppKit/Utilities/ExternalURLHandler.mm
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/AtomicRefCounted.h>
+
+#import <Cocoa/Cocoa.h>
+#import <UI/AppKit/Utilities/Conversions.h>
+#import <UI/AppKit/Utilities/ExternalURLHandler.h>
+
+namespace Ladybird {
+
+class ExternalURLLaunchCompletion final : public AtomicRefCounted<ExternalURLLaunchCompletion> {
+public:
+    explicit ExternalURLLaunchCompletion(WebView::ExternalURLHandler::LaunchCallback callback)
+        : m_callback(move(callback))
+    {
+    }
+
+    void complete(bool success)
+    {
+        if (!m_callback)
+            return;
+        auto callback = move(m_callback);
+        callback(success);
+    }
+
+private:
+    WebView::ExternalURLHandler::LaunchCallback m_callback;
+};
+
+class AppKitExternalURLHandler final : public WebView::ExternalURLHandler {
+public:
+    AppKitExternalURLHandler(String application_name, bool is_ladybird, String application_path)
+        : WebView::ExternalURLHandler(move(application_name), is_ladybird)
+        , m_application_path(move(application_path))
+    {
+    }
+
+    virtual void launch(URL::URL const& url, LaunchCallback callback) const override
+    {
+        auto* ns_url = url_to_ns_url(url);
+        auto* application_url = [NSURL fileURLWithPath:string_to_ns_string(m_application_path)];
+        if (ns_url == nil || application_url == nil) {
+            callback(false);
+            return;
+        }
+
+        auto completion = adopt_ref(*new ExternalURLLaunchCompletion(move(callback)));
+        [[NSWorkspace sharedWorkspace] openURLs:@[ ns_url ]
+                           withApplicationAtURL:application_url
+                                  configuration:[NSWorkspaceOpenConfiguration configuration]
+                              completionHandler:^(NSRunningApplication* application, NSError* error) {
+                                  auto success = application != nil && error == nil;
+                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                      completion->complete(success);
+                                  });
+                              }];
+    }
+
+private:
+    String m_application_path;
+};
+
+void resolve_external_url_handler(URL::URL const& url, WebView::ExternalURLHandlerCallback callback)
+{
+    auto* ns_url = url_to_ns_url(url);
+    if (ns_url == nil) {
+        callback(nullptr);
+        return;
+    }
+
+    auto* application_url = [[NSWorkspace sharedWorkspace] URLForApplicationToOpenURL:ns_url];
+    if (application_url == nil) {
+        callback(nullptr);
+        return;
+    }
+
+    auto* application_name = [[NSFileManager defaultManager] displayNameAtPath:[application_url path]];
+    if (application_name == nil)
+        application_name = [[application_url lastPathComponent] stringByDeletingPathExtension];
+
+    bool is_ladybird = false;
+    if (auto* bundle_identifier = [[NSBundle bundleWithURL:application_url] bundleIdentifier]; bundle_identifier != nil) {
+        is_ladybird = [bundle_identifier caseInsensitiveCompare:@"org.ladybird.Ladybird"] == NSOrderedSame;
+    }
+
+    if (!is_ladybird) {
+        auto* handler_bundle_url = [application_url URLByResolvingSymlinksInPath];
+        auto* current_bundle_url = [[[NSBundle mainBundle] bundleURL] URLByResolvingSymlinksInPath];
+        is_ladybird = [handler_bundle_url isEqual:current_bundle_url];
+    }
+
+    auto name = application_name == nil ? "another application"_string : ns_string_to_string(application_name);
+    auto application_path = ns_string_to_string([application_url path]);
+    callback(adopt_ref(*new AppKitExternalURLHandler(move(name), is_ladybird, move(application_path))));
+}
+
+}

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #if defined(AK_OS_MACOS)
+#    include <UI/AppKit/Utilities/ExternalURLHandler.h>
 #    include <UI/Qt/MacWindow.h>
 #endif
 
@@ -769,6 +770,8 @@ void Application::resolve_external_url_handler(URL::URL const& url, WebView::Ext
 {
 #if defined(AK_OS_LINUX)
     Ladybird::resolve_external_url_handler(url, ak_string_from_qstring(QGuiApplication::desktopFileName()), move(callback));
+#elif defined(AK_OS_MACOS)
+    Ladybird::resolve_external_url_handler(url, move(callback));
 #else
     (void)url;
     callback(nullptr);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -734,6 +734,11 @@ void Application::display_download_confirmation_dialog(StringView download_name,
 
 void Application::display_error_dialog(StringView error_message) const
 {
+    if (browser_options().headless_mode.has_value()) {
+        WebView::Application::display_error_dialog(error_message);
+        return;
+    }
+
     QMessageBox::warning(active_tab(), "Ladybird", qstring_from_ak_string(error_message));
 }
 

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #if defined(AK_OS_MACOS)
+#    include <UI/AppKit/Utilities/ExternalURLHandler.h>
 #    include <UI/Qt/MacWindow.h>
 #endif
 
@@ -780,6 +781,8 @@ void Application::resolve_external_url_handler(URL::URL const& url, WebView::Ext
 
 #if defined(AK_OS_LINUX)
     Ladybird::resolve_external_url_handler(url, ak_string_from_qstring(QGuiApplication::desktopFileName()), move(callback));
+#elif defined(AK_OS_MACOS)
+    Ladybird::resolve_external_url_handler(url, move(callback));
 #else
     (void)url;
     callback(nullptr);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -16,6 +16,10 @@
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WebContentView.h>
 
+#if defined(AK_OS_LINUX)
+#    include <UI/Qt/ExternalURLHandler.h>
+#endif
+
 #if defined(AK_OS_MACOS)
 #    include <UI/Qt/MacWindow.h>
 #endif
@@ -388,8 +392,12 @@ Core::EventLoop& Application::create_platform_event_loop()
 
     auto& event_loop = WebView::Application::create_platform_event_loop();
 
-    if (!browser_options().headless_mode.has_value())
+    if (!browser_options().headless_mode.has_value()) {
+#if defined(AK_OS_LINUX)
+        Ladybird::initialize_external_url_handler(event_loop);
+#endif
         static_cast<EventLoopImplementationQt&>(event_loop.impl()).set_main_loop();
+    }
 
     return event_loop;
 }
@@ -761,6 +769,21 @@ void Application::show_download_in_folder(WebView::FileDownloader::Download cons
     }
 
     QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(path.release_value())));
+}
+
+void Application::resolve_external_url_handler(URL::URL const& url, WebView::ExternalURLHandlerCallback callback) const
+{
+    if (browser_options().headless_mode.has_value()) {
+        WebView::Application::resolve_external_url_handler(url, move(callback));
+        return;
+    }
+
+#if defined(AK_OS_LINUX)
+    Ladybird::resolve_external_url_handler(url, ak_string_from_qstring(QGuiApplication::desktopFileName()), move(callback));
+#else
+    (void)url;
+    callback(nullptr);
+#endif
 }
 
 static QClipboard::Mode clipboard_mode(QClipboard const& clipboard, Application::ClipboardType type)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -16,6 +16,10 @@
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WebContentView.h>
 
+#if defined(AK_OS_LINUX)
+#    include <UI/Qt/ExternalURLHandler.h>
+#endif
+
 #if defined(AK_OS_MACOS)
 #    include <UI/Qt/MacWindow.h>
 #endif
@@ -120,7 +124,7 @@ public:
             auto const& open_event = *static_cast<QFileOpenEvent const*>(event);
             auto const qurl = open_event.url();
             if (!qurl.isEmpty()) {
-                if (auto url = WebView::sanitize_url(ak_byte_string_from_qbytearray(qurl.toEncoded())); url.has_value())
+                if (auto url = ak_url_from_qstring(qurl.toString()); url.has_value())
                     application.on_open_file(url.release_value());
                 break;
             }
@@ -388,6 +392,10 @@ Core::EventLoop& Application::create_platform_event_loop()
     }
 
     auto& event_loop = WebView::Application::create_platform_event_loop();
+
+#if defined(AK_OS_LINUX)
+    Ladybird::initialize_external_url_handler(event_loop);
+#endif
 
     if (!browser_options().headless_mode.has_value())
         static_cast<EventLoopImplementationQt&>(event_loop.impl()).set_main_loop();
@@ -755,6 +763,16 @@ void Application::show_download_in_folder(WebView::FileDownloader::Download cons
     }
 
     QDesktopServices::openUrl(QUrl::fromLocalFile(qstring_from_ak_string(path.release_value())));
+}
+
+void Application::resolve_external_url_handler(URL::URL const& url, WebView::ExternalURLHandlerCallback callback) const
+{
+#if defined(AK_OS_LINUX)
+    Ladybird::resolve_external_url_handler(url, ak_string_from_qstring(QGuiApplication::desktopFileName()), move(callback));
+#else
+    (void)url;
+    callback(nullptr);
+#endif
 }
 
 static QClipboard::Mode clipboard_mode(QClipboard const& clipboard, Application::ClipboardType type)

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -120,8 +120,7 @@ public:
             auto const& open_event = *static_cast<QFileOpenEvent const*>(event);
             auto const qurl = open_event.url();
             if (!qurl.isEmpty()) {
-                if (auto url = WebView::sanitize_url(ak_byte_string_from_qbytearray(qurl.toEncoded())); url.has_value())
-                    application.on_open_file(url.release_value());
+                application.on_open_file(ak_url_from_qurl(qurl));
                 break;
             }
 

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -81,6 +81,8 @@ private:
     virtual void open_urls_in_new_tabs(ReadonlySpan<URL::URL>) const override;
     virtual void open_url_in_new_window(URL::URL const&, WebView::IsPrivate) override;
 
+    virtual void resolve_external_url_handler(URL::URL const&, WebView::ExternalURLHandlerCallback) const override;
+
     virtual Optional<ByteString> ask_user_for_download_path(ByteString const& file) const override;
     virtual void display_download_confirmation_dialog(StringView download_name, LexicalPath const& path) const override;
     virtual void display_error_dialog(StringView error_message) const override;

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -16,6 +16,7 @@
 #include <AK/TypeCasts.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HistoryStore.h>
+#include <LibWebView/URL.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
 #include <UI/Qt/ChromeLayout.h>
@@ -654,10 +655,15 @@ void BrowserWindow::initialize_tab(Tab* tab)
 
     QObject::connect(&tab->view(), &WebContentView::urls_dropped, this, [this](auto& urls) {
         VERIFY(urls.size());
-        m_current_tab->navigate(ak_url_from_qurl(urls[0]));
+        m_current_tab->view().load_from_user_input(ak_url_from_qurl(urls[0]));
 
-        for (qsizetype i = 1; i < urls.size(); ++i)
-            new_tab_from_url(ak_url_from_qurl(urls[i]), Web::HTML::ActivateTab::No, TabLocation::end());
+        for (qsizetype i = 1; i < urls.size(); ++i) {
+            auto url = ak_url_from_qurl(urls[i]);
+            if (WebView::is_url_handled_internally(url))
+                new_tab_from_url(url, Web::HTML::ActivateTab::No, TabLocation::end());
+            else
+                m_current_tab->view().open_url_in_new_tab(url, Web::HTML::ActivateTab::No);
+        }
     });
 
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -8,10 +8,16 @@ if (NOT APPLE)
     find_package(Qt6 6.9 OPTIONAL_COMPONENTS Positioning)
 endif()
 
-if (APPLE OR HAS_DIRECTX)
+if (APPLE OR (LINUX AND NOT ANDROID) OR HAS_DIRECTX)
     # The native presentation paths use platform GPU buffer handles directly instead of copying frames through CPU memory.
+    # Wayland activation also uses Qt platform APIs.
     set(QT_NO_PRIVATE_MODULE_WARNING ON)
     find_package(Qt6 6.9 REQUIRED COMPONENTS GuiPrivate)
+endif()
+
+if (LINUX AND NOT ANDROID)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0 gio-unix-2.0)
 endif()
 
 qt_add_executable(ladybird main.cpp)
@@ -43,6 +49,11 @@ if (TARGET Qt6::Positioning)
     target_sources(ladybird PRIVATE GeolocationProviderQt.cpp GeolocationProviderQt.h)
     target_link_libraries(ladybird PRIVATE Qt::Positioning)
     target_compile_definitions(ladybird PRIVATE LADYBIRD_QT_HAVE_POSITIONING=1)
+endif()
+
+if (LINUX AND NOT ANDROID)
+    target_sources(ladybird PRIVATE ExternalURLActivationToken.cpp ExternalURLHandler.cpp)
+    target_link_libraries(ladybird PRIVATE LibThreading PkgConfig::GIO Qt::GuiPrivate)
 endif()
 
 if (APPLE)

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -8,10 +8,16 @@ if (NOT APPLE)
     find_package(Qt6 6.9 REQUIRED COMPONENTS Positioning)
 endif()
 
-if (APPLE OR HAS_DIRECTX)
+if (APPLE OR (LINUX AND NOT ANDROID) OR HAS_DIRECTX)
     # The native presentation paths use platform GPU buffer handles directly instead of copying frames through CPU memory.
+    # Wayland activation also uses Qt platform APIs.
     set(QT_NO_PRIVATE_MODULE_WARNING ON)
     find_package(Qt6 6.9 REQUIRED COMPONENTS GuiPrivate)
+endif()
+
+if (LINUX AND NOT ANDROID)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0 gio-unix-2.0)
 endif()
 
 qt_add_executable(ladybird main.cpp)
@@ -43,6 +49,11 @@ if (TARGET Qt6::Positioning)
     target_sources(ladybird PRIVATE GeolocationProviderQt.cpp GeolocationProviderQt.h)
     target_link_libraries(ladybird PRIVATE Qt::Positioning)
     target_compile_definitions(ladybird PRIVATE LADYBIRD_QT_HAVE_POSITIONING=1)
+endif()
+
+if (LINUX AND NOT ANDROID)
+    target_sources(ladybird PRIVATE ExternalURLActivationToken.cpp ExternalURLHandler.cpp)
+    target_link_libraries(ladybird PRIVATE LibThreading PkgConfig::GIO Qt::GuiPrivate)
 endif()
 
 if (APPLE)

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -59,7 +59,9 @@ endif()
 if (APPLE)
     target_sources(ladybird PRIVATE
         ../AppKit/Utilities/ApplicationIcon.mm
+        ../AppKit/Utilities/Conversions.mm
         ../AppKit/Utilities/DictionaryLookup.mm
+        ../AppKit/Utilities/ExternalURLHandler.mm
         MacWindow.mm
         WebContentViewMac.mm
     )

--- a/UI/Qt/ExternalURLActivationToken.cpp
+++ b/UI/Qt/ExternalURLActivationToken.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <QGuiApplication>
+#include <QMetaObject>
+#include <QTimer>
+#include <UI/Qt/ExternalURLActivationToken.h>
+#include <UI/Qt/StringUtils.h>
+#include <qpa/qplatformwindow_p.h>
+
+namespace Ladybird {
+
+class ActivationTokenRequest final : public RefCounted<ActivationTokenRequest> {
+public:
+    explicit ActivationTokenRequest(Function<void(Optional<String>)> callback)
+        : m_callback(move(callback))
+    {
+    }
+
+    void set_connection(QMetaObject::Connection connection)
+    {
+        m_connection = move(connection);
+    }
+
+    void complete(Optional<String> token)
+    {
+        if (!m_callback)
+            return;
+
+        QObject::disconnect(m_connection);
+        auto callback = move(m_callback);
+        callback(move(token));
+    }
+
+private:
+    Function<void(Optional<String>)> m_callback;
+    QMetaObject::Connection m_connection;
+};
+
+void request_external_url_activation_token(Function<void(Optional<String>)> callback)
+{
+    auto* application = as_if<QGuiApplication>(QCoreApplication::instance());
+    if (!application) {
+        callback({});
+        return;
+    }
+
+    auto* window = QGuiApplication::focusWindow();
+    auto* wayland_application = application->nativeInterface<QNativeInterface::QWaylandApplication>();
+    auto* wayland_window = window
+        ? window->nativeInterface<QNativeInterface::Private::QWaylandWindow>()
+        : nullptr;
+    if (!wayland_application || !wayland_window) {
+        callback({});
+        return;
+    }
+
+    auto request = adopt_ref(*new ActivationTokenRequest(move(callback)));
+    request->set_connection(QObject::connect(
+        wayland_window,
+        &QNativeInterface::Private::QWaylandWindow::xdgActivationTokenCreated,
+        application,
+        [request](QString const& token) {
+            request->complete(ak_string_from_qstring(token));
+        },
+        Qt::SingleShotConnection));
+
+    wayland_window->requestXdgActivationToken(wayland_application->lastInputSerial());
+
+    QTimer::singleShot(1000, application, [request] {
+        request->complete({});
+    });
+}
+
+}

--- a/UI/Qt/ExternalURLActivationToken.h
+++ b/UI/Qt/ExternalURLActivationToken.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/Optional.h>
+#include <AK/String.h>
+
+namespace Ladybird {
+
+void request_external_url_activation_token(Function<void(Optional<String>)>);
+
+}

--- a/UI/Qt/ExternalURLHandler.cpp
+++ b/UI/Qt/ExternalURLHandler.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/ByteString.h>
+#include <AK/LexicalPath.h>
+#include <AK/Optional.h>
+#include <AK/ScopeGuard.h>
+#include <AK/String.h>
+#include <LibCore/Environment.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/System.h>
+#include <LibThreading/ThreadPool.h>
+#include <UI/Qt/ExternalURLActivationToken.h>
+#include <UI/Qt/ExternalURLHandler.h>
+#include <gio/gdesktopappinfo.h>
+#include <gio/gio.h>
+
+namespace Ladybird {
+
+static constexpr auto default_ladybird_desktop_id = "org.ladybird.Ladybird.desktop"sv;
+static Core::EventLoop* s_main_thread_event_loop;
+
+struct LadybirdAppLaunchContext {
+    GAppLaunchContext parent_instance;
+    Optional<String> activation_token;
+};
+
+struct LadybirdAppLaunchContextClass {
+    GAppLaunchContextClass parent_class;
+};
+
+GType ladybird_app_launch_context_get_type();
+
+G_DEFINE_TYPE(LadybirdAppLaunchContext, ladybird_app_launch_context, G_TYPE_APP_LAUNCH_CONTEXT)
+
+static char* copy_activation_token(String const& activation_token)
+{
+    auto bytes = activation_token.bytes_as_string_view();
+    return g_strndup(bytes.characters_without_null_termination(), bytes.length());
+}
+
+static char* ladybird_app_launch_context_get_startup_notify_id(GAppLaunchContext* context, GAppInfo*, GList*)
+{
+    auto* self = reinterpret_cast<LadybirdAppLaunchContext*>(context);
+    if (!self->activation_token.has_value())
+        return nullptr;
+    return copy_activation_token(*self->activation_token);
+}
+
+static void ladybird_app_launch_context_finalize(GObject* object)
+{
+    auto* self = reinterpret_cast<LadybirdAppLaunchContext*>(object);
+    self->activation_token.~Optional<String>();
+    G_OBJECT_CLASS(ladybird_app_launch_context_parent_class)->finalize(object);
+}
+
+static void ladybird_app_launch_context_class_init(LadybirdAppLaunchContextClass* klass)
+{
+    auto* launch_context_class = G_APP_LAUNCH_CONTEXT_CLASS(klass);
+    auto* object_class = G_OBJECT_CLASS(klass);
+    launch_context_class->get_startup_notify_id = ladybird_app_launch_context_get_startup_notify_id;
+    object_class->finalize = ladybird_app_launch_context_finalize;
+}
+
+static void ladybird_app_launch_context_init(LadybirdAppLaunchContext* self)
+{
+    new (&self->activation_token) Optional<String> {};
+}
+
+static GAppLaunchContext* create_launch_context(Optional<String> const& activation_token)
+{
+    if (!activation_token.has_value() || activation_token->is_empty())
+        return nullptr;
+
+    auto* context = reinterpret_cast<LadybirdAppLaunchContext*>(g_object_new(ladybird_app_launch_context_get_type(), nullptr));
+    context->activation_token = *activation_token;
+
+    // GLib versions before 2.76 do not propagate the startup notification ID as an XDG activation token.
+    if (glib_check_version(2, 76, 0)) {
+        auto* token = copy_activation_token(*context->activation_token);
+        g_app_launch_context_setenv(G_APP_LAUNCH_CONTEXT(context), "XDG_ACTIVATION_TOKEN", token);
+        g_free(token);
+    }
+
+    return G_APP_LAUNCH_CONTEXT(context);
+}
+
+static Optional<ByteString> current_process_desktop_file()
+{
+    auto desktop_file = Core::Environment::get("GIO_LAUNCHED_DESKTOP_FILE"sv);
+    auto desktop_file_pid = Core::Environment::get("GIO_LAUNCHED_DESKTOP_FILE_PID"sv);
+    if (!desktop_file.has_value() || !desktop_file_pid.has_value())
+        return {};
+
+    auto pid = desktop_file_pid->to_number<pid_t>();
+    if (!pid.has_value() || *pid != Core::System::getpid())
+        return {};
+    return ByteString { desktop_file.value() };
+}
+
+static bool is_ladybird(GAppInfo* app_info, StringView ladybird_desktop_id, Optional<ByteString> const& ladybird_desktop_file)
+{
+    auto* application_id = g_app_info_get_id(app_info);
+    if (application_id && application_id == ladybird_desktop_id)
+        return true;
+
+    if (!ladybird_desktop_file.has_value())
+        return false;
+
+    auto* launched_app_info = g_desktop_app_info_new_from_filename(ladybird_desktop_file->characters());
+    if (!launched_app_info)
+        return false;
+    ScopeGuard release_app_info = [&] {
+        g_object_unref(launched_app_info);
+    };
+    return g_app_info_equal(app_info, G_APP_INFO(launched_app_info));
+}
+
+static bool is_dispatcher(GAppInfo* app_info)
+{
+    static constexpr Array dispatchers {
+        "exo-open"sv,
+        "gio"sv,
+        "gnome-open"sv,
+        "gvfs-open"sv,
+        "kde-open"sv,
+        "kde-open5"sv,
+        "kde-open6"sv,
+        "kioclient"sv,
+        "kioclient5"sv,
+        "kioclient6"sv,
+        "xdg-open"sv,
+    };
+
+    auto* executable = g_app_info_get_executable(app_info);
+    if (!executable)
+        return false;
+    return dispatchers.contains_slow(LexicalPath::basename(executable));
+}
+
+class GIOExternalURLHandler final : public WebView::ExternalURLHandler {
+public:
+    GIOExternalURLHandler(GAppInfo* app_info, String application_name, bool is_ladybird)
+        : WebView::ExternalURLHandler(move(application_name), is_ladybird)
+        , m_app_info(app_info)
+    {
+    }
+
+    virtual ~GIOExternalURLHandler() override
+    {
+        g_object_unref(m_app_info);
+    }
+
+    virtual void launch(URL::URL const& url, LaunchCallback callback) const override
+    {
+        NonnullRefPtr protected_this { *this };
+        request_external_url_activation_token([protected_this = move(protected_this), url, callback = move(callback)](Optional<String> activation_token) mutable {
+            callback(protected_this->launch(url, activation_token));
+        });
+    }
+
+private:
+    bool launch(URL::URL const& url, Optional<String> const& activation_token) const
+    {
+        auto serialized_url = url.serialize().to_byte_string();
+        GList uris {
+            .data = const_cast<char*>(serialized_url.characters()),
+            .next = nullptr,
+            .prev = nullptr,
+        };
+        auto* launch_context = create_launch_context(activation_token);
+        ScopeGuard release_launch_context = [&] {
+            if (launch_context)
+                g_object_unref(launch_context);
+        };
+        GError* error = nullptr;
+        if (g_app_info_launch_uris(m_app_info, &uris, launch_context, &error))
+            return true;
+
+        ScopeGuard release_error = [&] {
+            if (error)
+                g_error_free(error);
+        };
+        if (error) {
+            warnln("Unable to launch external URL with {}: {}", application_name(), error->message);
+        } else {
+            warnln("Unable to launch external URL with {}", application_name());
+        }
+        return false;
+    }
+
+    GAppInfo* m_app_info { nullptr };
+};
+
+void initialize_external_url_handler(Core::EventLoop& main_thread_event_loop)
+{
+    VERIFY(!s_main_thread_event_loop);
+    s_main_thread_event_loop = &main_thread_event_loop;
+}
+
+void resolve_external_url_handler(URL::URL const& url, String ladybird_desktop_id, WebView::ExternalURLHandlerCallback callback)
+{
+    VERIFY(s_main_thread_event_loop);
+
+    auto scheme = url.scheme().to_byte_string();
+    if (ladybird_desktop_id.is_empty())
+        ladybird_desktop_id = MUST(String::from_utf8(default_ladybird_desktop_id));
+    else if (!ladybird_desktop_id.bytes_as_string_view().ends_with(".desktop"sv))
+        ladybird_desktop_id = MUST(String::formatted("{}.desktop", ladybird_desktop_id));
+    auto ladybird_desktop_file = current_process_desktop_file();
+    Threading::ThreadPool::the().submit([scheme = move(scheme), ladybird_desktop_id = move(ladybird_desktop_id), ladybird_desktop_file = move(ladybird_desktop_file), callback = move(callback)]() mutable {
+        RefPtr<WebView::ExternalURLHandler> handler;
+        if (auto* app_info = g_app_info_get_default_for_uri_scheme(scheme.characters())) {
+            if (is_dispatcher(app_info)) {
+                g_object_unref(app_info);
+            } else {
+                auto app_is_ladybird = is_ladybird(app_info, ladybird_desktop_id, ladybird_desktop_file);
+
+                auto* application_name = g_app_info_get_display_name(app_info);
+                auto name = application_name
+                    ? String::from_utf8_with_replacement_character({ application_name, strlen(application_name) })
+                    : "another application"_string;
+
+                handler = adopt_ref(*new GIOExternalURLHandler(app_info, move(name), app_is_ladybird));
+            }
+        }
+
+        s_main_thread_event_loop->deferred_invoke([callback = move(callback), handler = move(handler)]() mutable {
+            callback(move(handler));
+        });
+    });
+}
+
+}

--- a/UI/Qt/ExternalURLHandler.h
+++ b/UI/Qt/ExternalURLHandler.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibURL/URL.h>
+#include <LibWebView/ExternalURLHandler.h>
+
+namespace Core {
+
+class EventLoop;
+
+}
+
+namespace Ladybird {
+
+void initialize_external_url_handler(Core::EventLoop&);
+void resolve_external_url_handler(URL::URL const&, String ladybird_desktop_id, WebView::ExternalURLHandlerCallback);
+
+}

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -181,6 +181,7 @@ LocationEdit::LocationEdit(QWidget* parent, WebView::IsPrivate is_private)
     };
 
     m_omnibox.on_commit = [this](String const& input) {
+        auto destination_kind = m_omnibox.destination_kind_for_last_commit();
         auto input_text = qstring_from_ak_string(input);
         if (text() != input_text)
             setText(input_text);
@@ -191,9 +192,13 @@ LocationEdit::LocationEdit(QWidget* parent, WebView::IsPrivate is_private)
         auto append_tld = ctrl_held ? WebView::AppendTLD::Yes : WebView::AppendTLD::No;
 
         auto url = WebView::sanitize_url(input, WebView::Application::settings().search_engine(), append_tld);
-        set_url(AK::move(url));
+        auto classified_input = WebView::classify_user_input(input, append_tld);
+        if (destination_kind == WebView::OmniboxDestinationKind::Search
+            || classified_input.classification != WebView::UserInputClassification::ExternalURL)
+            set_url(url);
 
-        emit returnPressed();
+        if (on_navigation)
+            on_navigation(input, AK::move(url), destination_kind);
     };
 
     connect(m_autocomplete, &Autocomplete::suggestion_clicked, this, [this](int suggestion_index) {

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <LibWebView/Omnibox.h>
 #include <LibWebView/PrivateBrowsing.h>
 #include <LibWebView/Settings.h>
@@ -43,6 +44,8 @@ public:
     bool url_is_hidden() const { return m_url_is_hidden; }
     void set_url_is_hidden(bool);
     void show_autocomplete();
+
+    Function<void(String, Optional<URL::URL>, WebView::OmniboxDestinationKind)> on_navigation;
 
 signals:
     void focus_return_requested();

--- a/UI/Qt/Menu.cpp
+++ b/UI/Qt/Menu.cpp
@@ -399,7 +399,7 @@ static QAction* create_recent_history_menu_action(QMenu& menu, WebContentView& v
     auto url = URL::Parser::basic_parse(entry.url);
     if (url.has_value()) {
         QObject::connect(action, &QAction::triggered, &view, [&view, url = url.release_value()] {
-            view.load(url);
+            view.load_from_user_input(url);
         });
     } else {
         action->setEnabled(false);

--- a/UI/Qt/StringUtils.cpp
+++ b/UI/Qt/StringUtils.cpp
@@ -63,5 +63,6 @@ Optional<URL::URL> ak_url_from_qstring(QString const& qstring)
 
 URL::URL ak_url_from_qurl(QUrl const& qurl)
 {
-    return ak_url_from_qstring(qurl.toString()).value();
+    auto encoded_url = qurl.toEncoded();
+    return URL::Parser::basic_parse(StringView(encoded_url.constData(), encoded_url.size())).value();
 }

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/DownloadPresentation.h>
+#include <LibWebView/URL.h>
 #include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/Qt/Application.h>
@@ -774,7 +775,9 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_location_edit->set_url(url);
     };
 
-    QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
+    m_location_edit->on_navigation = [this](auto input, auto fallback_url, auto destination_kind) {
+        location_edit_return_pressed(AK::move(input), AK::move(fallback_url), destination_kind);
+    };
     QObject::connect(m_location_edit, &LocationEdit::focus_return_requested, this, [this] {
         view().setFocus();
     });
@@ -849,6 +852,41 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     view().on_request_set_prompt_text = [this](auto const& message) {
         if (m_dialog && is<QInputDialog>(*m_dialog))
             static_cast<QInputDialog&>(*m_dialog).setTextValue(qstring_from_utf16_string(message));
+    };
+
+    view().on_request_external_url_confirmation = [this](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
+        if (m_dialog || m_external_url_confirmation_dialog) {
+            on_complete(false);
+            return;
+        }
+
+        auto initiator = initiator_origin.is_opaque() ? "This page"_string : initiator_origin.serialize();
+        auto application_name = handler.application_name().is_empty() ? "another application"sv : handler.application_name().bytes_as_string_view();
+        auto title = handler.application_name().is_empty() ? "Open external application?"_string : MUST(String::formatted("Open {}?", application_name));
+        auto message = MUST(String::formatted("{} wants to open a {} link with {}.", initiator, url.scheme(), application_name));
+        auto details = MUST(String::formatted("URL: '{}'", url));
+        auto open_button_text = handler.application_name().is_empty() ? "Open"_string : MUST(String::formatted("Open {}", application_name));
+
+        auto* dialog = new QMessageBox(&view());
+        m_external_url_confirmation_dialog = dialog;
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->setIcon(QMessageBox::Icon::Question);
+        dialog->setWindowTitle(qstring_from_ak_string(title));
+        dialog->setTextFormat(Qt::PlainText);
+        dialog->setText(qstring_from_ak_string(message));
+        dialog->setDetailedText(qstring_from_ak_string(details));
+        auto* open_button = dialog->addButton(qstring_from_ak_string(open_button_text), QMessageBox::ButtonRole::AcceptRole);
+        dialog->addButton(QMessageBox::StandardButton::Cancel);
+        dialog->setDefaultButton(QMessageBox::StandardButton::Cancel);
+
+        QObject::connect(dialog, &QDialog::finished, this, [this, dialog = QPointer<QMessageBox> { dialog }, open_button, on_complete = AK::move(on_complete)](auto) mutable {
+            auto accepted = dialog && dialog->clickedButton() == open_button;
+            if (m_external_url_confirmation_dialog == dialog)
+                m_external_url_confirmation_dialog = nullptr;
+            on_complete(accepted);
+        });
+
+        dialog->open();
     };
 
     view().on_request_accept_dialog = [this]() {
@@ -1169,7 +1207,7 @@ void Tab::update_hamburger_menu()
 
 void Tab::navigate(URL::URL const& url)
 {
-    view().load(url);
+    view().load_from_user_input(url);
 }
 
 void Tab::load_html(StringView html)
@@ -1177,18 +1215,25 @@ void Tab::load_html(StringView html)
     view().load_html(html);
 }
 
-void Tab::location_edit_return_pressed()
+void Tab::location_edit_return_pressed(String input, Optional<URL::URL> fallback_url, WebView::OmniboxDestinationKind destination_kind)
 {
-    auto text = m_location_edit->text();
-    if (text.isEmpty())
+    if (input.is_empty())
         return;
 
-    if (auto url = m_location_edit->url(); url.has_value()) {
-        view().set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
-        navigate(*url);
+    view().set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
+    if (destination_kind == WebView::OmniboxDestinationKind::Search) {
+        if (fallback_url.has_value())
+            view().load(*fallback_url);
+        else
+            view().load_navigation_error_page(input);
     } else {
-        view().load_navigation_error_page(ak_string_from_qstring(text));
+        view().load_from_user_input(input, AK::move(fallback_url));
     }
+
+    auto is_external_url = destination_kind == WebView::OmniboxDestinationKind::URL
+        && WebView::classify_user_input(input).classification == WebView::UserInputClassification::ExternalURL;
+    if (is_external_url)
+        m_location_edit->set_url(view().url());
 
     view().setFocus();
 }

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/DownloadPresentation.h>
+#include <LibWebView/URL.h>
 #include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/Qt/Application.h>
@@ -738,7 +739,9 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_location_edit->set_url(url);
     };
 
-    QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
+    m_location_edit->on_navigation = [this](auto input, auto fallback_url, auto destination_kind) {
+        location_edit_return_pressed(AK::move(input), AK::move(fallback_url), destination_kind);
+    };
     QObject::connect(m_location_edit, &LocationEdit::focus_return_requested, this, [this] {
         view().setFocus();
     });
@@ -813,6 +816,41 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     view().on_request_set_prompt_text = [this](auto const& message) {
         if (m_dialog && is<QInputDialog>(*m_dialog))
             static_cast<QInputDialog&>(*m_dialog).setTextValue(qstring_from_utf16_string(message));
+    };
+
+    view().on_request_external_url_confirmation = [this](auto const& url, auto const& initiator_origin, auto const& handler, auto on_complete) {
+        if (m_dialog || m_external_url_confirmation_dialog) {
+            on_complete(false);
+            return;
+        }
+
+        auto initiator = initiator_origin.is_opaque() ? "This page"_string : initiator_origin.serialize();
+        auto application_name = handler.application_name().is_empty() ? "another application"sv : handler.application_name().bytes_as_string_view();
+        auto title = handler.application_name().is_empty() ? "Open external application?"_string : MUST(String::formatted("Open {}?", application_name));
+        auto message = MUST(String::formatted("{} wants to open a {} link with {}.", initiator, url.scheme(), application_name));
+        auto details = MUST(String::formatted("URL: '{}'", url));
+        auto open_button_text = handler.application_name().is_empty() ? "Open"_string : MUST(String::formatted("Open {}", application_name));
+
+        auto* dialog = new QMessageBox(&view());
+        m_external_url_confirmation_dialog = dialog;
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+        dialog->setIcon(QMessageBox::Icon::Question);
+        dialog->setWindowTitle(qstring_from_ak_string(title));
+        dialog->setTextFormat(Qt::PlainText);
+        dialog->setText(qstring_from_ak_string(message));
+        dialog->setDetailedText(qstring_from_ak_string(details));
+        auto* open_button = dialog->addButton(qstring_from_ak_string(open_button_text), QMessageBox::ButtonRole::AcceptRole);
+        dialog->addButton(QMessageBox::StandardButton::Cancel);
+        dialog->setDefaultButton(QMessageBox::StandardButton::Cancel);
+
+        QObject::connect(dialog, &QDialog::finished, this, [this, dialog = QPointer<QMessageBox> { dialog }, open_button, on_complete = AK::move(on_complete)](auto) mutable {
+            auto accepted = dialog && dialog->clickedButton() == open_button;
+            if (m_external_url_confirmation_dialog == dialog)
+                m_external_url_confirmation_dialog = nullptr;
+            on_complete(accepted);
+        });
+
+        dialog->open();
     };
 
     view().on_request_accept_dialog = [this]() {
@@ -1133,7 +1171,7 @@ void Tab::update_hamburger_menu()
 
 void Tab::navigate(URL::URL const& url)
 {
-    view().load(url);
+    view().load_from_user_input(url);
 }
 
 void Tab::load_html(StringView html)
@@ -1141,18 +1179,25 @@ void Tab::load_html(StringView html)
     view().load_html(html);
 }
 
-void Tab::location_edit_return_pressed()
+void Tab::location_edit_return_pressed(String input, Optional<URL::URL> fallback_url, WebView::OmniboxDestinationKind destination_kind)
 {
-    auto text = m_location_edit->text();
-    if (text.isEmpty())
+    if (input.is_empty())
         return;
 
-    if (auto url = m_location_edit->url(); url.has_value()) {
-        view().set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
-        navigate(*url);
+    view().set_next_history_visit_transition(WebView::HistoryVisitTransition::Omnibox);
+    if (destination_kind == WebView::OmniboxDestinationKind::Search) {
+        if (fallback_url.has_value())
+            view().load(*fallback_url);
+        else
+            view().load_navigation_error_page(input);
     } else {
-        view().load_navigation_error_page(ak_string_from_qstring(text));
+        view().load_from_user_input(input, AK::move(fallback_url));
     }
+
+    auto is_external_url = destination_kind == WebView::OmniboxDestinationKind::URL
+        && WebView::classify_user_input(input).classification == WebView::UserInputClassification::ExternalURL;
+    if (is_external_url)
+        m_location_edit->set_url(view().url());
 
     view().setFocus();
 }

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -27,6 +27,7 @@
 #include <QWidget>
 
 class QTimer;
+class QMessageBox;
 namespace Ladybird {
 
 class BrowserWindow;
@@ -103,7 +104,6 @@ public:
 
 public slots:
     void focus_location_editor();
-    void location_edit_return_pressed();
 
 signals:
     void title_changed(int id, QString const&);
@@ -111,6 +111,7 @@ signals:
     void audio_play_state_changed(int id, Web::HTML::AudioPlayState);
 
 private:
+    void location_edit_return_pressed(String, Optional<URL::URL>, WebView::OmniboxDestinationKind);
     virtual void resizeEvent(QResizeEvent*) override;
     virtual bool event(QEvent*) override;
 
@@ -187,6 +188,7 @@ private:
     QString m_downloads_button_tooltip;
 
     QPointer<QDialog> m_dialog;
+    QPointer<QMessageBox> m_external_url_confirmation_dialog;
 
     bool m_already_requested_close { false };
 };


### PR DESCRIPTION
[Screencast_20260724_105916.webm](https://github.com/user-attachments/assets/53248037-3649-4d22-8f01-df4de7dce589)

(AppKit is also implemented, and looks similar, but AppKit-y.)

A lot of the behaviour isn't defined by the spec, so this is a combination of how other browsers behave:
- Single-character schemes are treated as invalid. (Presumably because that matches Windows drive letters.)
- We have a set of other ignored schemes that could be dangerous.
- Attempts to recursively launch Ladybird are detected and blocked (or at least, we try to).
- User-activated `mailto:` links are opened without prompting.
- Any other links prompt the user to confirm they want to launch the application.
- External-link opening is limited so that only one can be activated for each user interaction with the page.

If no application is found, we show an error dialog. This is slightly off from what the spec wants, but we can't follow that directly because our lookup/launch is asynchronous.

On Linux, this adds a dependency on GIO for looking up and launching the system's preferred handler for the URL scheme.

This PR doesn't implement any kind of "open and don't ask me again" functionality, it just prompts every time. We'll probably want that eventually though.

Closes #5735.