### PR TITLE
LibWeb: Cache hit-test display list items across recordings

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7355,10 +7355,7 @@ void Document::remove_form_associated_element_with_form_attribute(HTML::FormAsso
 void Document::set_design_mode_enabled_state(bool design_mode_enabled)
 {
     m_design_mode_enabled = design_mode_enabled;
-    for_each_in_inclusive_subtree([](Node& node) {
-        node.recompute_editable_subtree_flag();
-        return TraversalDecision::Continue;
-    });
+    recompute_editable_subtree_flags_and_repaint();
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#making-entire-documents-editable:-the-designmode-idl-attribute

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2544,24 +2544,32 @@ void Document::update_scrollable_overflow(ScrollableOverflowDerivedStructureUpda
             clamp_scroll_offset(const_cast<Painting::Paintable&>(*box_paintable));
     }
 
-    if (derived_structure_updates == ScrollableOverflowDerivedStructureUpdates::HandledByAfterLayoutCommit)
-        return;
-
     bool any_overflow_changed = false;
     bool any_has_scrollable_overflow_flipped = false;
     for (auto const& [box, old_overflow_data] : old_overflow_data_by_box) {
         auto box_paintable = box->paintable_box();
         if (!box_paintable || !box_paintable->overflow_data().has_value())
             continue;
-        VERIFY(old_overflow_data.has_value());
+        // A box with no prior overflow data was just created or reset by the layout commit, so
+        // its paint cache is already clean.
+        if (!old_overflow_data.has_value())
+            continue;
         auto const& new_overflow_data = *box_paintable->overflow_data();
         bool rect_changed = old_overflow_data->scrollable_overflow_rect != new_overflow_data.scrollable_overflow_rect;
         bool has_scrollable_overflow_flipped = old_overflow_data->has_scrollable_overflow != new_overflow_data.has_scrollable_overflow;
-        any_overflow_changed |= rect_changed || has_scrollable_overflow_flipped;
+        if (!rect_changed && !has_scrollable_overflow_flipped)
+            continue;
+        // Cached paint commands and hit-test items capture scrollbar geometry and per-direction
+        // scrollability derived from the overflow rect, so they cannot be reused once it changes.
+        // This must also run for the after-layout-commit path: a subtree relayout re-measures a
+        // surviving ancestor's overflow without resetting the ancestor's paintable.
+        box_paintable->invalidate_paint_cache();
+        any_overflow_changed = true;
         any_has_scrollable_overflow_flipped |= has_scrollable_overflow_flipped;
-        if (any_has_scrollable_overflow_flipped)
-            break;
     }
+
+    if (derived_structure_updates == ScrollableOverflowDerivedStructureUpdates::HandledByAfterLayoutCommit)
+        return;
 
     // Nothing derived from scrollable overflow needs updating. In particular, this keeps transform
     // changes that ride the accumulated-visual-context value-update path free of display list

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -830,6 +830,9 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_previously_repainted_cursor_position);
     if (m_hit_test_display_list)
         m_hit_test_display_list->visit_edges(visitor);
+    // In the steady state the item cache source aliases the current list; avoid tracing it twice.
+    if (m_hit_test_display_list_used_as_item_cache_source && m_hit_test_display_list_used_as_item_cache_source != m_hit_test_display_list)
+        m_hit_test_display_list_used_as_item_cache_source->visit_edges(visitor);
     visitor.visit(m_editing_host_manager);
     visitor.visit(m_editing_history);
     visitor.visit(m_local_storage_holder);
@@ -1456,6 +1459,7 @@ void Document::tear_down_layout_tree()
     if (m_layout_root)
         m_layout_root->prepare_subtree_for_detach_from_layout_tree();
     m_hit_test_display_list = nullptr;
+    m_hit_test_display_list_used_as_item_cache_source = nullptr;
     m_layout_root = nullptr;
     m_paintable = nullptr;
     m_scrollable_overflow_contained_boxes_from_last_layout.clear();
@@ -8920,6 +8924,17 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
     context.set_paint_command_cache_mode(cache_mode);
     if (!line_box_border_overlays_replace_cacheable_content)
         context.set_paint_command_cache_source_display_list(viewport_paintable.display_list_used_as_paint_command_cache_source());
+    // An incompatible visual context tree rebuild leaves the retained list's item context indices
+    // meaningless, so it only serves as a splice source while the tree version still matches.
+    if (auto const* hit_test_item_cache_source = m_hit_test_display_list_used_as_item_cache_source.ptr();
+        hit_test_item_cache_source && hit_test_item_cache_source->visual_context_tree_version() == viewport_paintable.visual_context_tree().version()) {
+        context.set_hit_test_item_cache_source(hit_test_item_cache_source);
+        // The new recording ends up with roughly as many items as the source it splices from.
+        hit_test_display_list->ensure_item_capacity(hit_test_item_cache_source->item_count());
+    } else {
+        // Versions only move forward, so a mismatched list can never be spliced from again.
+        m_hit_test_display_list_used_as_item_cache_source = nullptr;
+    }
     viewport_paintable.refresh_scroll_state();
     viewport_paintable.initialize_async_scrolling_metadata_recording(context);
 
@@ -8966,6 +8981,8 @@ RefPtr<Painting::DisplayList> Document::record_display_list(HTML::PaintConfig co
         // Rotation can drop the last reference to the list the context's raw pointer still targets.
         context.set_paint_command_cache_source_display_list(nullptr);
         viewport_paintable.set_display_list_used_as_paint_command_cache_source(display_list, resource_storage.collect_referenced_resources(*display_list));
+        context.set_hit_test_item_cache_source(nullptr);
+        m_hit_test_display_list_used_as_item_cache_source = hit_test_display_list;
     }
 
     m_hit_test_display_list = move(hit_test_display_list);
@@ -8980,6 +8997,11 @@ void Document::set_caret_hit_test_debug_rect(Optional<CSSPixelRect> rect)
     m_caret_hit_test_debug_rect = rect;
     set_needs_repaint(InvalidateDisplayList::Yes);
     page().client().request_frame();
+}
+
+void Document::clear_hit_test_item_cache_source()
+{
+    m_hit_test_display_list_used_as_item_cache_source = nullptr;
 }
 
 Painting::HitTestDisplayList const* Document::ensure_hit_test_display_list()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1158,6 +1158,7 @@ public:
     RefPtr<Painting::DisplayList> record_display_list(HTML::PaintConfig, Painting::DisplayListResourceStorage&, Painting::PaintCommandCacheMode);
     Painting::HitTestDisplayList const* hit_test_display_list() const { return m_hit_test_display_list.ptr(); }
     Painting::HitTestDisplayList const* ensure_hit_test_display_list();
+    void clear_hit_test_item_cache_source();
     Optional<Painting::HitTestResult> hit_test(CSSPixelPoint, Painting::HitTestType);
     Optional<Painting::CaretPosition> caret_position_from_point(CSSPixelPoint);
     Optional<Painting::CaretPosition> caret_position_from_point_for_selection_start(CSSPixelPoint);
@@ -1731,6 +1732,9 @@ private:
     Vector<GC::Ref<Node>> m_style_scopes_with_pending_has_invalidations;
     CSS::SheetSetStyleCacheRegistry m_sheet_set_style_cache_registry;
     RefPtr<Painting::HitTestDisplayList> m_hit_test_display_list;
+    // The previous recording's list, retained so cached per-paintable item ranges can be spliced into
+    // the next recording. Rotated only by cache-read-write recordings; survives display list invalidation.
+    RefPtr<Painting::HitTestDisplayList> m_hit_test_display_list_used_as_item_cache_source;
     Optional<CSSPixelRect> m_caret_hit_test_debug_rect;
 
     mutable StyleInvalidationCounters m_style_invalidation_counters;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1660,7 +1660,7 @@ void Node::set_document(Document& document)
     }
 }
 
-void Node::recompute_editable_subtree_flag()
+bool Node::recompute_editable_subtree_flag()
 {
     bool new_value;
     if (is_document()) {
@@ -1676,7 +1676,18 @@ void Node::recompute_editable_subtree_flag()
     } else {
         new_value = parent() && parent()->m_in_editable_subtree;
     }
-    m_in_editable_subtree = new_value;
+    return new_value != exchange(m_in_editable_subtree, new_value);
+}
+
+void Node::recompute_editable_subtree_flags_and_repaint()
+{
+    for_each_in_inclusive_subtree([](Node& node) {
+        // Editability determines each node's empty-editable caret target in the hit-test
+        // display list, so a flip must invalidate the recorded output.
+        if (node.recompute_editable_subtree_flag())
+            node.set_needs_repaint();
+        return TraversalDecision::Continue;
+    });
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#editable

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -185,7 +185,8 @@ public:
     CSS::UserSelect user_select_used_value() const;
 
     bool in_editable_subtree() const { return m_in_editable_subtree; }
-    void recompute_editable_subtree_flag();
+    bool recompute_editable_subtree_flag();
+    void recompute_editable_subtree_flags_and_repaint();
 
     virtual bool is_dom_node() const final { return true; }
     virtual bool is_html_element() const { return false; }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -816,11 +816,18 @@ void HTMLElement::set_subtree_inertness(bool is_inert)
     };
 
     update_inertness(*this);
-    for_each_in_subtree_of_type<HTMLElement>([&](auto& html_element) {
-        if (html_element.has_attribute(HTML::AttributeNames::inert))
+    for_each_in_subtree_of_type<Element>([&](auto& element) {
+        auto* html_element = as_if<HTMLElement>(element);
+        if (!html_element) {
+            // Non-HTML elements (SVG, MathML) carry no inert flag and resolve is_inert() through
+            // their nearest HTML ancestor, so their recorded hit-test output must be repainted here.
+            element.set_needs_repaint();
+            return TraversalDecision::Continue;
+        }
+        if (html_element->has_attribute(HTML::AttributeNames::inert))
             return TraversalDecision::SkipChildrenAndContinue;
         // FIXME: Exclude elements that should escape inertness.
-        update_inertness(html_element);
+        update_inertness(*html_element);
         return TraversalDecision::Continue;
     });
 }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -760,10 +760,7 @@ void HTMLElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16St
             // Having an invalid value maps to the "inherit" state.
             m_content_editable_state = ContentEditableState::Inherit;
         }
-        for_each_in_inclusive_subtree([](Node& node) {
-            node.recompute_editable_subtree_flag();
-            return TraversalDecision::Continue;
-        });
+        recompute_editable_subtree_flags_and_repaint();
     } else if (name == HTML::AttributeNames::inert) {
         // https://html.spec.whatwg.org/multipage/interaction.html#the-inert-attribute
         // The inert attribute is a boolean attribute that indicates, by its presence, that the element and all its flat tree descendants which don't otherwise escape inertness

--- a/Libraries/LibWeb/Painting/BorderRadiiData.h
+++ b/Libraries/LibWeb/Painting/BorderRadiiData.h
@@ -17,6 +17,8 @@ struct WEB_API BorderRadiusData {
     CSSPixels horizontal_radius { 0 };
     CSSPixels vertical_radius { 0 };
 
+    bool operator==(BorderRadiusData const&) const = default;
+
     Gfx::CornerRadius as_corner(DevicePixelConverter const& device_pixel_converter) const;
 
     inline operator bool() const
@@ -38,6 +40,8 @@ struct BorderRadiiData {
     BorderRadiusData top_right;
     BorderRadiusData bottom_right;
     BorderRadiusData bottom_left;
+
+    bool operator==(BorderRadiiData const&) const = default;
 
     inline bool has_any_radius() const
     {

--- a/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
@@ -59,6 +59,9 @@ public:
     Painting::DisplayList const* paint_command_cache_source_display_list() const { return m_paint_command_cache_source_display_list; }
     void set_paint_command_cache_source_display_list(Painting::DisplayList const* display_list) { m_paint_command_cache_source_display_list = display_list; }
 
+    Painting::HitTestDisplayList const* hit_test_item_cache_source() const { return m_hit_test_item_cache_source; }
+    void set_hit_test_item_cache_source(Painting::HitTestDisplayList const* hit_test_display_list) { m_hit_test_item_cache_source = hit_test_display_list; }
+
     DevicePixelRect device_viewport_rect() const { return m_device_viewport_rect; }
     void set_device_viewport_rect(DevicePixelRect const& rect) { m_device_viewport_rect = rect; }
 
@@ -95,9 +98,9 @@ public:
     DevicePixelSize enclosing_device_size(CSSPixelSize) const;
     DevicePixelSize rounded_device_size(CSSPixelSize) const;
 
-    DisplayListRecordingContext clone(Painting::DisplayListRecorder& painter) const
+    DisplayListRecordingContext clone(Painting::DisplayListRecorder& painter, Painting::HitTestDisplayList* hit_test_display_list = nullptr) const
     {
-        auto clone = DisplayListRecordingContext(painter, m_palette, m_device_pixel_converter.device_pixels_per_css_pixel(), m_chrome_metrics);
+        auto clone = DisplayListRecordingContext(painter, m_palette, m_device_pixel_converter.device_pixels_per_css_pixel(), m_chrome_metrics, hit_test_display_list);
         clone.m_device_viewport_rect = m_device_viewport_rect;
         clone.m_should_show_line_box_borders = m_should_show_line_box_borders;
         clone.m_should_paint_overlay = m_should_paint_overlay;
@@ -140,6 +143,7 @@ private:
     DevicePixelRect m_device_viewport_rect;
     Painting::PaintCommandCacheMode m_paint_command_cache_mode { Painting::PaintCommandCacheMode::ReadOnly };
     Painting::DisplayList const* m_paint_command_cache_source_display_list { nullptr };
+    Painting::HitTestDisplayList const* m_hit_test_item_cache_source { nullptr };
     bool m_should_show_line_box_borders { false };
     bool m_should_paint_overlay { true };
     bool m_draw_svg_geometry_for_clip_path { false };

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Atomic.h>
 #include <AK/QuickSort.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Node.h>
@@ -15,6 +16,8 @@
 #include <math.h>
 
 namespace Web::Painting {
+
+static Atomic<u64> s_next_id { 1 };
 
 static constexpr double spatial_index_cell_size = 128.0;
 static constexpr size_t max_bucketed_cells_per_item = 64;
@@ -174,7 +177,87 @@ void HitTestDisplayList::visit_edges(GC::Cell::Visitor& visitor)
 
 HitTestDisplayList::HitTestDisplayList(u64 visual_context_tree_version)
     : m_visual_context_tree_version(visual_context_tree_version)
+    , m_id(s_next_id.fetch_add(1, AK::MemoryOrder::memory_order_relaxed))
 {
+}
+
+Paintable::HitTestItemRange HitTestDisplayList::append_cached_items(HitTestDisplayList const& source, Paintable::HitTestItemRange source_range)
+{
+    VERIFY(&source != this);
+    VERIFY(!m_derived_structures_built);
+    VERIFY(static_cast<size_t>(source_range.start) + source_range.count <= source.m_items.size());
+
+    auto destination_start = m_items.size();
+    VERIFY(destination_start + source_range.count <= NumericLimits<u32>::max());
+    m_items.append(source.m_items.data() + source_range.start, source_range.count);
+    return { static_cast<u32>(destination_start), source_range.count };
+}
+
+bool HitTestDisplayList::items_equal_for_cache_verification(Item const& a, Item const& b)
+{
+    return a.kind == b.kind
+        && a.paintable.ptr() == b.paintable.ptr()
+        && a.chrome_widget.ptr() == b.chrome_widget.ptr()
+        && a.text_fragment == b.text_fragment
+        && a.caret_node.ptr() == b.caret_node.ptr()
+        && a.caret_offset == b.caret_offset
+        && a.rect == b.rect
+        && a.caret_rect == b.caret_rect
+        && a.caret_line_index == b.caret_line_index
+        && a.caret_line_rect == b.caret_line_rect
+        && a.block_container_margin_rect == b.block_container_margin_rect
+        && a.visual_context_index == b.visual_context_index
+        && a.border_radii == b.border_radii
+        && a.path.has_value() == b.path.has_value()
+        && a.winding_rule == b.winding_rule;
+}
+
+String HitTestDisplayList::dump_item_for_cache_verification(Item const& item)
+{
+    return MUST(String::formatted("kind={} paintable={} chrome_widget={} text_fragment={} caret_node={} caret_offset={} rect={} caret_rect={} caret_line_index={} caret_line_rect={} block_container_margin_rect={} context_index={} border_radii=[{} {} {} {} {} {} {} {}] winding_rule={} has_path={}",
+        to_underlying(item.kind),
+        static_cast<void const*>(item.paintable.ptr()),
+        static_cast<void const*>(item.chrome_widget.ptr()),
+        static_cast<void const*>(item.text_fragment),
+        static_cast<void const*>(item.caret_node.ptr()),
+        item.caret_offset,
+        item.rect,
+        item.caret_rect,
+        item.caret_line_index,
+        item.caret_line_rect,
+        item.block_container_margin_rect,
+        item.visual_context_index.value(),
+        item.border_radii.top_left.horizontal_radius,
+        item.border_radii.top_left.vertical_radius,
+        item.border_radii.top_right.horizontal_radius,
+        item.border_radii.top_right.vertical_radius,
+        item.border_radii.bottom_right.horizontal_radius,
+        item.border_radii.bottom_right.vertical_radius,
+        item.border_radii.bottom_left.horizontal_radius,
+        item.border_radii.bottom_left.vertical_radius,
+        to_underlying(item.winding_rule),
+        item.path.has_value()));
+}
+
+void HitTestDisplayList::verify_cached_items_match_fresh_recording(Paintable::HitTestItemRange spliced_range, HitTestDisplayList const& fresh_recording, Paintable const& paintable, PaintPhase phase) const
+{
+    auto matches = spliced_range.count == fresh_recording.m_items.size();
+    for (u32 i = 0; matches && i < spliced_range.count; ++i) {
+        auto const& spliced_item = m_items[spliced_range.start + i];
+        // SVG subtrees are recorded outside per-paintable captures, so path-bearing items are never spliced.
+        VERIFY(!spliced_item.path.has_value());
+        matches = items_equal_for_cache_verification(spliced_item, fresh_recording.m_items[i]);
+    }
+    if (matches)
+        return;
+
+    dbgln("Spliced hit-test display list cache mismatch for {} in paint phase {} ({} spliced items, {} fresh items)",
+        paintable.layout_node().debug_description(), to_underlying(phase), spliced_range.count, fresh_recording.m_items.size());
+    for (u32 i = 0; i < spliced_range.count; ++i)
+        dbgln("  spliced: {}", dump_item_for_cache_verification(m_items[spliced_range.start + i]));
+    for (auto const& item : fresh_recording.m_items)
+        dbgln("  fresh:   {}", dump_item_for_cache_verification(item));
+    VERIFY_NOT_REACHED();
 }
 
 CSSPixelRect HitTestDisplayList::caret_line_rect_for_item(Item const& item) const

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.h
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.h
@@ -49,6 +49,18 @@ class WEB_API HitTestDisplayList : public RefCounted<HitTestDisplayList> {
 public:
     static NonnullRefPtr<HitTestDisplayList> create(u64 visual_context_tree_version);
 
+    u64 id() const { return m_id; }
+    size_t item_count() const { return m_items.size(); }
+    void ensure_item_capacity(size_t capacity) { m_items.ensure_capacity(capacity); }
+
+    // Copies a validated range of items recorded by one (paintable, phase) from the retained previous
+    // list into this one, returning where it landed. Items are copied, never inspected: source ranges
+    // belonging to relaid-out paintables may hold dangling fragment pointers, but only ranges whose
+    // owners kept a valid cache entry (and therefore were not relaid out) are ever passed here.
+    Paintable::HitTestItemRange append_cached_items(HitTestDisplayList const& source, Paintable::HitTestItemRange);
+
+    void verify_cached_items_match_fresh_recording(Paintable::HitTestItemRange spliced_range, HitTestDisplayList const& fresh_recording, Paintable const&, PaintPhase) const;
+
     void append_box(Paintable const&, Paintable& target, CSSPixelRect, VisualContextIndex, BorderRadiiData);
     void append_svg_path(Paintable& target, Gfx::Path, Gfx::WindingRule, CSSPixelRect bounding_box, VisualContextIndex);
     void append_text_fragment(PaintableFragment const&, VisualContextIndex);
@@ -153,7 +165,11 @@ private:
     void find_topmost_caret_item_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Optional<size_t>& topmost_item_index) const;
     void find_items_in_list(Vector<size_t> const&, CSSPixelPoint local_point, ChromeMetrics const&, Vector<size_t>& hit_item_indices) const;
 
+    static bool items_equal_for_cache_verification(Item const&, Item const&);
+    static String dump_item_for_cache_verification(Item const&);
+
     u64 m_visual_context_tree_version { 0 };
+    u64 m_id { 0 };
     Vector<Item> m_items;
     mutable bool m_derived_structures_built { false };
     mutable Vector<size_t> m_caret_item_indices;

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -505,12 +505,27 @@ void Paintable::scroll_ancestor_to_offset_into_view(size_t offset)
 static bool g_paint_viewport_scrollbars = true;
 
 struct Paintable::CachedPaintData {
-    struct PhaseEntry {
+    struct PaintCommands {
         // Display list ids start at 1, so a default-constructed entry never matches a real source list.
         u64 source_display_list_id { 0 };
         DisplayListCommandRange range;
         VisualContextIndex recorded_context_index {};
         bool captured_under_empty_effective_clip { false };
+    };
+
+    struct HitTestItems {
+        // Hit-test display list ids start at 1, so a default-constructed entry never matches a real source list.
+        u64 source_hit_test_display_list_id { 0 };
+        HitTestItemRange range;
+        VisualContextIndex recorded_context_index {};
+        VisualContextIndex recorded_context_for_descendants_index {};
+    };
+
+    // Paint commands and hit-test items are stamped independently within a frame, so each setter
+    // must only ever assign its own sub-struct of the shared entry.
+    struct PhaseEntry {
+        PaintCommands paint_commands;
+        HitTestItems hit_test_items;
     };
 
     Array<PhaseEntry, paint_phase_count> phase_entries {};
@@ -987,7 +1002,7 @@ Optional<Paintable::CachedCommandRange> Paintable::valid_cached_commands(PaintPh
 {
     if (!m_cached_paint_data)
         return {};
-    auto const& entry = m_cached_paint_data->phase_entries[to_underlying(phase)];
+    auto const& entry = m_cached_paint_data->phase_entries[to_underlying(phase)].paint_commands;
     if (entry.source_display_list_id != source_display_list_id
         || entry.captured_under_empty_effective_clip != phase_has_empty_effective_clip)
         return {};
@@ -1004,11 +1019,36 @@ void Paintable::set_cached_commands(PaintPhase phase, u64 display_list_id, Displ
     if (!m_cached_paint_data)
         m_cached_paint_data = make<CachedPaintData>();
 
-    m_cached_paint_data->phase_entries[to_underlying(phase)] = {
+    m_cached_paint_data->phase_entries[to_underlying(phase)].paint_commands = {
         .source_display_list_id = display_list_id,
         .range = range,
         .recorded_context_index = recorded_context_index,
         .captured_under_empty_effective_clip = captured_under_empty_effective_clip,
+    };
+}
+
+Optional<Paintable::HitTestItemRange> Paintable::valid_cached_hit_test_items(PaintPhase phase, u64 source_hit_test_display_list_id) const
+{
+    if (!m_cached_paint_data)
+        return {};
+    auto const& entry = m_cached_paint_data->phase_entries[to_underlying(phase)].hit_test_items;
+    if (entry.source_hit_test_display_list_id != source_hit_test_display_list_id
+        || entry.recorded_context_index != accumulated_visual_context_index()
+        || entry.recorded_context_for_descendants_index != accumulated_visual_context_for_descendants_index())
+        return {};
+    return entry.range;
+}
+
+void Paintable::set_cached_hit_test_items(PaintPhase phase, u64 hit_test_display_list_id, HitTestItemRange range) const
+{
+    if (!m_cached_paint_data)
+        m_cached_paint_data = make<CachedPaintData>();
+
+    m_cached_paint_data->phase_entries[to_underlying(phase)].hit_test_items = {
+        .source_hit_test_display_list_id = hit_test_display_list_id,
+        .range = range,
+        .recorded_context_index = accumulated_visual_context_index(),
+        .recorded_context_for_descendants_index = accumulated_visual_context_for_descendants_index(),
     };
 }
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -439,6 +439,16 @@ public:
     Optional<CachedCommandRange> valid_cached_commands(PaintPhase, u64 source_display_list_id, bool phase_has_empty_effective_clip) const;
     void set_cached_commands(PaintPhase, u64 display_list_id, DisplayListCommandRange, VisualContextIndex recorded_context_index, bool captured_under_empty_effective_clip) const;
 
+    // A capture may hold hit-test items recorded under both this paintable's own context index and its
+    // descendants' context index, so spliced items are not rewritten; instead a cached range is usable
+    // only while both indices still match what they were at capture time.
+    struct HitTestItemRange {
+        u32 start { 0 };
+        u32 count { 0 };
+    };
+    Optional<HitTestItemRange> valid_cached_hit_test_items(PaintPhase, u64 source_hit_test_display_list_id) const;
+    void set_cached_hit_test_items(PaintPhase, u64 hit_test_display_list_id, HitTestItemRange) const;
+
     void set_fixed_background_visual_context(VisualContextIndex index) { m_fixed_background_visual_context = index; }
     [[nodiscard]] Optional<VisualContextIndex> fixed_background_visual_context() const { return m_fixed_background_visual_context; }
 

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NumericLimits.h>
 #include <AK/QuickSort.h>
 #include <AK/TemporaryChange.h>
 #include <LibCore/Environment.h>
@@ -18,6 +19,7 @@
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Painting/HitTestDisplayList.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
@@ -88,6 +90,14 @@ static void verify_spliced_commands_match_fresh_recording(Paintable const& paint
     VERIFY_NOT_REACHED();
 }
 
+static void verify_spliced_hit_test_items_match_fresh_recording(Paintable const& paintable, DisplayListRecordingContext& context, PaintPhase phase, Paintable::HitTestItemRange spliced_range)
+{
+    auto scratch_hit_test_display_list = HitTestDisplayList::create(context.display_list_recorder().visual_context_tree().version());
+    auto scratch_context = context.clone(context.display_list_recorder(), scratch_hit_test_display_list.ptr());
+    paintable.record_hit_test_items(scratch_context, phase);
+    context.hit_test_display_list()->verify_cached_items_match_fresh_recording(spliced_range, *scratch_hit_test_display_list, paintable, phase);
+}
+
 static void paint_node(Paintable const& paintable, DisplayListRecordingContext& context, PaintPhase phase)
 {
     TemporaryChange save_nesting_level(context.display_list_recorder().m_save_nesting_level, 0);
@@ -99,8 +109,6 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
     else
         context.display_list_recorder().set_accumulated_visual_context(paintable.accumulated_visual_context_index());
 
-    paintable.record_hit_test_items(context, phase);
-
     auto& recorder = context.display_list_recorder();
     auto const* cache_source_display_list = context.paint_command_cache_source_display_list();
     // NB: Some commands embed visual context indices in their payloads. Those
@@ -110,6 +118,32 @@ static void paint_node(Paintable const& paintable, DisplayListRecordingContext& 
         && cache_source_display_list->compatible_visual_context_tree_version() == recorder.visual_context_tree().version();
     bool const skip_cache = paintable.fixed_background_visual_context().has_value();
     bool const cache_writes_enabled = context.paint_command_cache_mode() == PaintCommandCacheMode::ReadWrite;
+
+    // Hit-test items are only ever recorded in the Background, Foreground, and Overlay phases;
+    // every record_hit_test_items() implementation early-returns for the rest.
+    bool const phase_can_record_hit_test_items = phase == PaintPhase::Background || phase == PaintPhase::Foreground || phase == PaintPhase::Overlay;
+    if (auto* hit_test_display_list = context.hit_test_display_list(); hit_test_display_list && phase_can_record_hit_test_items) {
+        auto const* item_cache_source = context.hit_test_item_cache_source();
+        auto cached_items = !skip_cache && item_cache_source
+            ? paintable.valid_cached_hit_test_items(phase, item_cache_source->id())
+            : Optional<Paintable::HitTestItemRange> {};
+        if (cached_items.has_value()) {
+            auto destination_range = hit_test_display_list->append_cached_items(*item_cache_source, *cached_items);
+            if (verify_display_list_cache_enabled()) [[unlikely]]
+                verify_spliced_hit_test_items_match_fresh_recording(paintable, context, phase, destination_range);
+            if (cache_writes_enabled)
+                paintable.set_cached_hit_test_items(phase, hit_test_display_list->id(), destination_range);
+        } else {
+            auto items_before = hit_test_display_list->item_count();
+            paintable.record_hit_test_items(context, phase);
+            if (!skip_cache && cache_writes_enabled) {
+                auto items_after = hit_test_display_list->item_count();
+                VERIFY(items_after <= NumericLimits<u32>::max());
+                paintable.set_cached_hit_test_items(phase, hit_test_display_list->id(), { static_cast<u32>(items_before), static_cast<u32>(items_after - items_before) });
+            }
+        }
+    }
+
     auto const phase_context_index = recorder.accumulated_visual_context();
     bool const phase_has_empty_effective_clip = recorder.visual_context_tree().has_empty_effective_clip(phase_context_index);
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -115,6 +115,7 @@ void ViewportPaintable::reset_for_relayout()
     clear_scroll_state();
     m_display_list_used_as_paint_command_cache_source = nullptr;
     m_paint_command_cache_source_referenced_resources = {};
+    document().clear_hit_test_item_cache_source();
     m_paintable_boxes_with_auto_content_visibility.clear();
     m_visual_context_tree.clear();
     m_visual_context_tree_needs_compositor_update = false;

--- a/Tests/LibWeb/Text/expected/hit_testing/content-editable-toggle.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/content-editable-toggle.txt
@@ -1,0 +1,5 @@
+caret before toggle: null
+caret with contenteditable: [object HTMLDivElement] @0
+caret after removal: null
+caret with designMode: [object HTMLDivElement] @0
+caret after designMode off: null

--- a/Tests/LibWeb/Text/expected/hit_testing/inert-svg-toggle.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/inert-svg-toggle.txt
@@ -1,0 +1,3 @@
+hit before inert: art
+hit with inert: body
+hit after inert removed: art

--- a/Tests/LibWeb/Text/input/hit_testing/content-editable-toggle.html
+++ b/Tests/LibWeb/Text/input/hit_testing/content-editable-toggle.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<script src="../include.js"></script>
+<div id="target"></div>
+<!-- Without the empty-editable caret target, the query resolves against this text's caret
+     line instead of the div, so the editable and non-editable answers differ. -->
+<p id="text-below">some text below the target</p>
+<script>
+    test(() => {
+        const { x, y, width, height } = target.getBoundingClientRect();
+        const cx = x + width / 2;
+        const cy = y + height / 2;
+        const caretNodeAtCenter = () => {
+            const position = document.caretPositionFromPoint(cx, cy);
+            return position ? `${position.offsetNode} @${position.offset}` : "null";
+        };
+
+        // Query once and then force a re-record, so the queries below run against
+        // steady-state recordings rather than the initial one.
+        caretNodeAtCenter();
+        document.body.style.outline = "1px solid transparent";
+
+        // NB: Results are buffered and printed at the end: println() itself mutates the DOM,
+        //     and any unrelated invalidation between a toggle and its query would rebuild the
+        //     hit-test display list and mask a missed invalidation from the toggle itself.
+        const results = [];
+        results.push(`caret before toggle: ${caretNodeAtCenter()}`);
+
+        target.setAttribute("contenteditable", "");
+        results.push(`caret with contenteditable: ${caretNodeAtCenter()}`);
+
+        target.removeAttribute("contenteditable");
+        results.push(`caret after removal: ${caretNodeAtCenter()}`);
+
+        // designMode has no attribute-change path, so recomputing the editable flags is the
+        // only invalidation these toggles get.
+        document.designMode = "on";
+        results.push(`caret with designMode: ${caretNodeAtCenter()}`);
+
+        document.designMode = "off";
+        results.push(`caret after designMode off: ${caretNodeAtCenter()}`);
+
+        for (const result of results)
+            println(result);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/hit_testing/inert-svg-toggle.html
+++ b/Tests/LibWeb/Text/input/hit_testing/inert-svg-toggle.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="container" style="width: 100px; height: 100px"><svg id="art" width="100" height="100"></svg></div>
+<script>
+    test(() => {
+        const elementAtCenter = () => {
+            const element = document.elementFromPoint(50, 50);
+            return element ? element.id || element.localName : "null";
+        };
+
+        // Query once and then force a re-record, so the queries below run against
+        // steady-state recordings rather than the initial one.
+        elementAtCenter();
+        document.body.style.outline = "1px solid transparent";
+
+        // NB: Results are buffered and printed at the end: println() itself mutates the DOM,
+        //     and any unrelated invalidation between a toggle and its query would rebuild the
+        //     hit-test display list and mask a missed invalidation from the toggle itself.
+        const results = [];
+        results.push(`hit before inert: ${elementAtCenter()}`);
+
+        container.inert = true;
+        results.push(`hit with inert: ${elementAtCenter()}`);
+
+        container.inert = false;
+        results.push(`hit after inert removed: ${elementAtCenter()}`);
+
+        for (const result of results)
+            println(result);
+    });
+</script>


### PR DESCRIPTION
Cache hit-test items with the same segment-referencing scheme used for
paint commands: each (paintable, phase) entry stores the range of items
it recorded into the previous recording's list, which the document
retains as a splice source , and on a cache hit the range is bulk-copied
into the new list. Entries live in the same per-paintable cache as paint
command ranges, so all existing invalidation applies unchanged.

Unlike paint commands, one capture can hold items recorded under both
the paintable's own context index and its descendants' index (e.g. a
self-painting inline box records piece boxes and text fragments
interleaved), so spliced items are not rewritten; instead an entry is
only valid while both recorded indices still match, and index drift is
treated as a miss. SVG subtrees are recorded outside per-paintable
captures, exactly as their painting commands are, and stay uncached.

The retained source may hold items whose ranges belong to relaid-out
paintables; those entries are invalidated together with the paintable,
so stale ranges are never spliced, and item data is copied without
being inspected.