### PR TITLE
LibWeb: Allow non-alternate style sheets to be disabled

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -7872,7 +7872,7 @@ void Document::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&
 {
     if (m_style_sheets) {
         for (auto& style_sheet : m_style_sheets->sheets()) {
-            if (!(style_sheet->is_alternate() && style_sheet->disabled()))
+            if (!style_sheet->disabled())
                 callback(*style_sheet);
         }
     }

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -917,6 +917,12 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                 nullptr,
                 nullptr);
 
+            // NB: Removing the disabled attribute explicitly enables the style sheet, regardless of which style sheet
+            //     set is currently preferred. Creating the sheet may have disabled it based on its title, so restore
+            //     the state requested by the link element.
+            if (m_explicitly_enabled)
+                m_loaded_style_sheet->set_disabled(false);
+
             // 2. Fire an event named load at el.
             dispatch_event(*DOM::Event::create(realm(), HTML::EventNames::load));
         }

--- a/Tests/LibWeb/Text/expected/css/disabled-style-sheet.txt
+++ b/Tests/LibWeb/Text/expected/css/disabled-style-sheet.txt
@@ -1,0 +1,3 @@
+Before disabling style sheet: rgb(255, 255, 0)
+After disabling style sheet: rgba(0, 0, 0, 0)
+After explicitly enabling linked style sheet: rgb(0, 0, 255)

--- a/Tests/LibWeb/Text/input/css/disabled-style-sheet.html
+++ b/Tests/LibWeb/Text/input/css/disabled-style-sheet.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style title="preferred">
+    body { background: yellow; }
+</style>
+<link id="linked-style-sheet" rel="stylesheet" title="linked" disabled href="data:text/css,body { background: blue; }">
+<script>
+    asyncTest(done => {
+        println(`Before disabling style sheet: ${getComputedStyle(document.body).backgroundColor}`);
+        document.styleSheets[0].disabled = true;
+        println(`After disabling style sheet: ${getComputedStyle(document.body).backgroundColor}`);
+
+        const link = document.querySelector("#linked-style-sheet");
+        link.onload = () => {
+            println(`After explicitly enabling linked style sheet: ${getComputedStyle(document.body).backgroundColor}`);
+            done();
+        };
+        link.disabled = false;
+    });
+</script>


### PR DESCRIPTION
m_explicitly_enabled previously only cleared the sheet's alternate flag, and didn't remove the disabled state. We previously masked this by only paying attention to the disabled state of alternate style sheets, but the correct fix is to clear that disabled state.

Fixes the dark-mode toggle on https://adarkroom.doublespeakgames.com/ which could be turned on, but not turned off.