### PR TITLE
UI: Add "Paste and Go" option to the omnibox context menu

### DIFF
--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -786,4 +786,17 @@ void Omnibox::navigate_directly_to_query(String text)
     commit_verbatim(move(text));
 }
 
+String Omnibox::text_for_paste_and_go_action(String const& clipboard_text, bool has_search_engine_enabled)
+{
+    auto display_text = clipboard_text.code_points().length() > 45
+        ? MUST(String::formatted("{}…", clipboard_text.code_points().unicode_substring_view(0, 45)))
+        : clipboard_text;
+
+    bool clipboard_holds_url = !clipboard_text.is_empty() && WebView::location_looks_like_url(clipboard_text);
+    if (clipboard_holds_url || !has_search_engine_enabled)
+        return MUST(String::formatted("Paste and Go to {}", display_text));
+
+    return MUST(String::formatted("Paste and Search for '{}'", display_text));
+}
+
 }

--- a/Libraries/LibWebView/Omnibox.cpp
+++ b/Libraries/LibWebView/Omnibox.cpp
@@ -778,4 +778,12 @@ void Omnibox::commit(String text)
         on_commit(move(text));
 }
 
+void Omnibox::navigate_directly_to_query(String text)
+{
+    m_query = text;
+    m_retained_engagement_input = {};
+    abandon_popup_session();
+    commit_verbatim(move(text));
+}
+
 }

--- a/Libraries/LibWebView/Omnibox.h
+++ b/Libraries/LibWebView/Omnibox.h
@@ -88,6 +88,8 @@ public:
     void suggestion_clicked(size_t suggestion_index);
     void navigate_directly_to_query(String text);
 
+    static String text_for_paste_and_go_action(String const& clipboard_text, bool has_search_engine_enabled);
+
     // State for the chrome:
     String const& query() const { return m_query; }
     bool is_editing() const { return m_is_editing; }

--- a/Libraries/LibWebView/Omnibox.h
+++ b/Libraries/LibWebView/Omnibox.h
@@ -86,6 +86,7 @@ public:
     bool select_next_suggestion();
     bool select_previous_suggestion();
     void suggestion_clicked(size_t suggestion_index);
+    void navigate_directly_to_query(String text);
 
     // State for the chrome:
     String const& query() const { return m_query; }

--- a/Tests/LibWebView/TestOmnibox.cpp
+++ b/Tests/LibWebView/TestOmnibox.cpp
@@ -1080,6 +1080,24 @@ TEST_CASE(accepting_a_completion_requeries_without_losing_the_learning_prefix)
     EXPECT_EQ(harness.provider->engagements[0].destination, "https://github.com/LadybirdBrowser/ladybird"sv);
 }
 
+TEST_CASE(direct_navigation_does_not_retain_previous_engagement_input)
+{
+    Harness harness;
+    harness.begin_editing();
+
+    harness.press_key('g');
+    harness.press_key('i');
+    harness.provider->deliver({ history_row("https://github.com/LadybirdBrowser/ladybird"sv), search_row("gi"sv) });
+
+    EXPECT(harness.omnibox.accept_completion());
+
+    harness.omnibox.navigate_directly_to_query("https://example.com/"_string);
+
+    EXPECT_EQ(harness.provider->engagements.size(), 1u);
+    EXPECT_EQ(harness.provider->engagements[0].input, "https://example.com/"sv);
+    EXPECT_EQ(harness.provider->engagements[0].destination, "https://example.com/"sv);
+}
+
 TEST_CASE(committing_may_reentrantly_end_editing)
 {
     Harness harness;

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -17,6 +17,7 @@
 #import <Application/ApplicationDelegate.h>
 #import <Interface/BookmarksBar.h>
 #import <Interface/LadybirdWebView.h>
+#import <Interface/LocationSearchField.h>
 #import <Interface/Tab.h>
 #import <Interface/TabController.h>
 
@@ -538,9 +539,29 @@ void Application::on_devtools_disabled() const
 {
     if ([event type] == NSEventTypeApplicationDefined) {
         Core::ThreadEventQueue::current().process();
-    } else {
-        [super sendEvent:event];
+        return;
     }
+
+    // NSToolbarView consumes context-menu events before custom toolbar views receive them, so to have a context menu on
+    // a non-selected LocationSearchField, we have to jump through some hoops by testing if the mouse is over it and
+    // then manually showing the context menu.
+    // FIXME: Find a better way to do this.
+    if ([event type] == NSEventTypeRightMouseDown
+        || ([event type] == NSEventTypeLeftMouseDown && ([event modifierFlags] & NSEventModifierFlagControl))) {
+        auto* window = [event window];
+        auto* frame_view = [[window contentView] superview];
+        auto location = [frame_view convertPoint:[event locationInWindow] fromView:nil];
+
+        for (auto* view = [frame_view hitTest:location]; view != nil; view = [view superview]) {
+            if ([view isKindOfClass:[LocationSearchField class]]) {
+                if ([(LocationSearchField*)view handleContextMenuEvent:event])
+                    return;
+                break;
+            }
+        }
+    }
+
+    [super sendEvent:event];
 }
 
 @end

--- a/UI/AppKit/Interface/LocationSearchField.h
+++ b/UI/AppKit/Interface/LocationSearchField.h
@@ -17,8 +17,10 @@
 - (void)setShowsPageIcon:(BOOL)showsPageIcon;
 - (void)setBookmarkAction:(WebView::Action&)action;
 - (void)setZoomAction:(WebView::Action&)action;
+- (BOOL)handleContextMenuEvent:(NSEvent*)event;
 
 @property (nonatomic, copy) void (^willBeginEditing)(void);
+@property (nonatomic, copy) NSString* (^copyLinkTextProvider)(void);
 @property (nonatomic, copy) void (^pasteAndGoHandler)(NSString*);
 
 @end

--- a/UI/AppKit/Interface/LocationSearchField.h
+++ b/UI/AppKit/Interface/LocationSearchField.h
@@ -19,5 +19,6 @@
 - (void)setZoomAction:(WebView::Action&)action;
 
 @property (nonatomic, copy) void (^willBeginEditing)(void);
+@property (nonatomic, copy) void (^pasteAndGoHandler)(NSString*);
 
 @end

--- a/UI/AppKit/Interface/LocationSearchField.mm
+++ b/UI/AppKit/Interface/LocationSearchField.mm
@@ -6,6 +6,11 @@
 
 #import <Interface/LocationSearchField.h>
 #import <Interface/Menu.h>
+#import <Utilities/Conversions.h>
+
+#include <LibWebView/Application.h>
+#include <LibWebView/Omnibox.h>
+#include <LibWebView/URL.h>
 
 #if !__has_feature(objc_arc)
 #    error "This project requires ARC"
@@ -28,10 +33,11 @@ static NSImage* location_field_globe_icon()
     return image;
 }
 
-@interface LocationSearchField ()
+@interface LocationSearchField () <NSTextViewDelegate, NSMenuItemValidation>
 
 - (CGFloat)trailingBadgeInset;
 - (void)badgeLayoutDidChange;
+- (void)pasteAndGo:(NSMenuItem*)sender;
 
 @end
 
@@ -158,6 +164,76 @@ static NSImage* location_field_globe_icon()
 
     if (self.willBeginEditing)
         self.willBeginEditing();
+}
+
+- (NSMenu*)textView:(NSTextView*)text_view
+               menu:(NSMenu*)menu
+           forEvent:(NSEvent*)event
+            atIndex:(NSUInteger)character_index
+{
+    if (text_view != [self currentEditor])
+        return menu;
+
+    auto existing_item_index = [menu indexOfItemWithTarget:self andAction:@selector(pasteAndGo:)];
+    if (existing_item_index >= 0)
+        [menu removeItemAtIndex:existing_item_index];
+
+    auto* pasteboard_text = [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString];
+    auto clipboard_text = pasteboard_text == nil
+        ? String {}
+        : Ladybird::ns_string_to_string(pasteboard_text);
+    auto has_search_engine_enabled = WebView::Application::settings().search_engine().has_value();
+    auto clipboard_holds_url = !clipboard_text.is_empty() && WebView::location_looks_like_url(clipboard_text);
+    auto action_will_search = !clipboard_holds_url && has_search_engine_enabled;
+
+    auto* paste_and_go_item = [[NSMenuItem alloc]
+        initWithTitle:Ladybird::string_to_ns_string(WebView::Omnibox::text_for_paste_and_go_action(clipboard_text, has_search_engine_enabled))
+               action:@selector(pasteAndGo:)
+        keyEquivalent:@""];
+    [paste_and_go_item setTarget:self];
+    [paste_and_go_item setRepresentedObject:[pasteboard_text copy]];
+    [paste_and_go_item setEnabled:[self validateMenuItem:paste_and_go_item]];
+    [paste_and_go_item setImage:action_will_search
+            ? [NSImage imageWithSystemSymbolName:@"magnifyingglass" accessibilityDescription:@"Search"]
+            : [NSImage imageNamed:NSImageNameGoRightTemplate]];
+
+    NSInteger paste_item_index = -1;
+    for (NSInteger index = 0; index < [menu numberOfItems]; ++index) {
+        if ([[menu itemAtIndex:index] action] == @selector(paste:)) {
+            paste_item_index = index;
+            break;
+        }
+    }
+
+    if (paste_item_index >= 0)
+        [menu insertItem:paste_and_go_item atIndex:paste_item_index + 1];
+    else
+        [menu addItem:paste_and_go_item];
+
+    return menu;
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem*)menu_item
+{
+    if ([menu_item action] != @selector(pasteAndGo:))
+        return YES;
+
+    id clipboard_text = [menu_item representedObject];
+    return [self isEditable]
+        && [clipboard_text isKindOfClass:[NSString class]]
+        && [(NSString*)clipboard_text length] > 0;
+}
+
+- (void)pasteAndGo:(NSMenuItem*)sender
+{
+    id clipboard_text = [sender representedObject];
+    if (![self isEditable]
+        || ![clipboard_text isKindOfClass:[NSString class]]
+        || [(NSString*)clipboard_text length] == 0)
+        return;
+
+    if (self.pasteAndGoHandler)
+        self.pasteAndGoHandler((NSString*)clipboard_text);
 }
 
 - (void)layout

--- a/UI/AppKit/Interface/LocationSearchField.mm
+++ b/UI/AppKit/Interface/LocationSearchField.mm
@@ -37,6 +37,10 @@ static NSImage* location_field_globe_icon()
 
 - (CGFloat)trailingBadgeInset;
 - (void)badgeLayoutDidChange;
+- (NSString*)copyLinkText;
+- (NSMenu*)createLocationContextMenu;
+- (NSMenuItem*)createPasteAndGoMenuItem;
+- (void)copyLink:(NSMenuItem*)sender;
 - (void)pasteAndGo:(NSMenuItem*)sender;
 
 @end
@@ -178,6 +182,54 @@ static NSImage* location_field_globe_icon()
     if (existing_item_index >= 0)
         [menu removeItemAtIndex:existing_item_index];
 
+    auto* paste_and_go_item = [self createPasteAndGoMenuItem];
+
+    NSInteger paste_item_index = -1;
+    for (NSInteger index = 0; index < [menu numberOfItems]; ++index) {
+        if ([[menu itemAtIndex:index] action] == @selector(paste:)) {
+            paste_item_index = index;
+            break;
+        }
+    }
+
+    if (paste_item_index >= 0)
+        [menu insertItem:paste_and_go_item atIndex:paste_item_index + 1];
+    else
+        [menu addItem:paste_and_go_item];
+
+    return menu;
+}
+
+- (NSMenu*)createLocationContextMenu
+{
+    auto* menu = [[NSMenu alloc] init];
+
+    auto* copy_link_item = [[NSMenuItem alloc]
+        initWithTitle:@"Copy Link"
+               action:@selector(copyLink:)
+        keyEquivalent:@""];
+    [copy_link_item setTarget:self];
+    [copy_link_item setRepresentedObject:[[self copyLinkText] copy]];
+    [copy_link_item setEnabled:[self validateMenuItem:copy_link_item]];
+    [menu addItem:copy_link_item];
+
+    [menu addItem:[self createPasteAndGoMenuItem]];
+
+    return menu;
+}
+
+- (BOOL)handleContextMenuEvent:(NSEvent*)event
+{
+    auto* editor = [self currentEditor];
+    if (editor != nil && [[self window] firstResponder] == editor)
+        return NO;
+
+    [NSMenu popUpContextMenu:[self createLocationContextMenu] withEvent:event forView:self];
+    return YES;
+}
+
+- (NSMenuItem*)createPasteAndGoMenuItem
+{
     auto* pasteboard_text = [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString];
     auto clipboard_text = pasteboard_text == nil
         ? String {}
@@ -197,31 +249,45 @@ static NSImage* location_field_globe_icon()
             ? [NSImage imageWithSystemSymbolName:@"magnifyingglass" accessibilityDescription:@"Search"]
             : [NSImage imageNamed:NSImageNameGoRightTemplate]];
 
-    NSInteger paste_item_index = -1;
-    for (NSInteger index = 0; index < [menu numberOfItems]; ++index) {
-        if ([[menu itemAtIndex:index] action] == @selector(paste:)) {
-            paste_item_index = index;
-            break;
-        }
-    }
-
-    if (paste_item_index >= 0)
-        [menu insertItem:paste_and_go_item atIndex:paste_item_index + 1];
-    else
-        [menu addItem:paste_and_go_item];
-
-    return menu;
+    return paste_and_go_item;
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem*)menu_item
 {
-    if ([menu_item action] != @selector(pasteAndGo:))
-        return YES;
+    if ([menu_item action] == @selector(copyLink:)) {
+        id copy_link_text = [menu_item representedObject];
+        return [copy_link_text isKindOfClass:[NSString class]]
+            && [(NSString*)copy_link_text length] > 0;
+    }
 
-    id clipboard_text = [menu_item representedObject];
-    return [self isEditable]
-        && [clipboard_text isKindOfClass:[NSString class]]
-        && [(NSString*)clipboard_text length] > 0;
+    if ([menu_item action] == @selector(pasteAndGo:)) {
+        id clipboard_text = [menu_item representedObject];
+        return [self isEditable]
+            && [clipboard_text isKindOfClass:[NSString class]]
+            && [(NSString*)clipboard_text length] > 0;
+    }
+
+    return YES;
+}
+
+- (NSString*)copyLinkText
+{
+    if (self.copyLinkTextProvider)
+        return self.copyLinkTextProvider();
+
+    return [self stringValue];
+}
+
+- (void)copyLink:(NSMenuItem*)sender
+{
+    id copy_link_text = [sender representedObject];
+    if (![copy_link_text isKindOfClass:[NSString class]]
+        || [(NSString*)copy_link_text length] == 0)
+        return;
+
+    auto* paste_board = [NSPasteboard generalPasteboard];
+    [paste_board clearContents];
+    [paste_board setString:(NSString*)copy_link_text forType:NSPasteboardTypeString];
 }
 
 - (void)pasteAndGo:(NSMenuItem*)sender

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -1327,6 +1327,14 @@ private:
         [location_search_field setWillBeginEditing:^{
             [weak_self restoreLocationFieldForEditing];
         }];
+        [location_search_field setCopyLinkTextProvider:^NSString* {
+            TabController* self = weak_self;
+            if (self == nil)
+                return nil;
+
+            auto const& url = [[[self tab] web_view] view].url();
+            return Ladybird::string_to_ns_string(url.serialize());
+        }];
         [location_search_field setPasteAndGoHandler:^(NSString* clipboard_text) {
             TabController* self = weak_self;
             if (self == nil)

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -1327,6 +1327,19 @@ private:
         [location_search_field setWillBeginEditing:^{
             [weak_self restoreLocationFieldForEditing];
         }];
+        [location_search_field setPasteAndGoHandler:^(NSString* clipboard_text) {
+            TabController* self = weak_self;
+            if (self == nil)
+                return;
+
+            auto query = Ladybird::ns_string_to_string(clipboard_text);
+            WebView::Omnibox::Display display {
+                .text = query,
+                .selection_start = {},
+            };
+            [self applyOmniboxDisplay:display];
+            self->m_omnibox->navigate_directly_to_query(move(query));
+        }];
 
         if (@available(macOS 26, *)) {
             [location_search_field setBordered:YES];

--- a/UI/Qt/LocationEdit.cpp
+++ b/UI/Qt/LocationEdit.cpp
@@ -17,10 +17,12 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QClipboard>
 #include <QEasingCurve>
 #include <QGraphicsDropShadowEffect>
 #include <QGuiApplication>
 #include <QKeyEvent>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPalette>
@@ -283,6 +285,50 @@ void LocationEdit::changeEvent(QEvent* event)
     if (event->type() == QEvent::PaletteChange || event->type() == QEvent::ApplicationPaletteChange || event->type() == QEvent::ThemeChange) {
         schedule_chrome_style_update();
     }
+}
+
+void LocationEdit::contextMenuEvent(QContextMenuEvent* event)
+{
+    QMenu* menu = createStandardContextMenu();
+
+    auto* paste_action = menu->findChild<QAction*>(QStringLiteral("edit-paste"), Qt::FindDirectChildrenOnly);
+
+    auto qt_clipboard_text = QGuiApplication::clipboard()->text();
+    auto clipboard_text = ak_string_from_qstring(qt_clipboard_text);
+
+    bool has_search_engine = WebView::Application::settings().search_engine().has_value();
+    auto paste_and_go_text = WebView::Omnibox::text_for_paste_and_go_action(clipboard_text, has_search_engine);
+    // Escape any &s so Qt doesn't treat them as mnemonics.
+    paste_and_go_text = MUST(paste_and_go_text.replace("&"sv, "&&"sv, ReplaceMode::All));
+
+    bool clipboard_holds_url = !has_search_engine || (!clipboard_text.is_empty() && WebView::location_looks_like_url(clipboard_text));
+    auto paste_and_go_icon = clipboard_holds_url
+        ? create_chrome_icon(ChromeIcon::Forward, palette())
+        : QIcon::fromTheme(QIcon::ThemeIcon::SystemSearch);
+
+    auto* paste_and_go_action = new QAction(paste_and_go_icon, qstring_from_ak_string(paste_and_go_text), menu);
+    paste_and_go_action->setEnabled(!isReadOnly() && !qt_clipboard_text.isEmpty());
+    connect(paste_and_go_action, &QAction::triggered, this, [this, clipboard_text, qt_clipboard_text] {
+        setText(qt_clipboard_text);
+        m_omnibox.navigate_directly_to_query(clipboard_text);
+    });
+
+    // Try to insert "Paste and Go" after the "Paste" action if we can find it.
+    bool added_paste_and_go_action = false;
+    if (paste_action) {
+        auto const& actions = menu->actions();
+        auto paste_index = actions.indexOf(paste_action);
+        if (paste_index >= 0 && paste_index + 1 < actions.size()) {
+            menu->insertAction(actions.at(paste_index + 1), paste_and_go_action);
+            added_paste_and_go_action = true;
+        }
+    }
+    // ...otherwise append it to the end.
+    if (!added_paste_and_go_action)
+        menu->addAction(paste_and_go_action);
+
+    menu->exec(event->globalPos());
+    delete menu;
 }
 
 void LocationEdit::focusInEvent(QFocusEvent* event)

--- a/UI/Qt/LocationEdit.h
+++ b/UI/Qt/LocationEdit.h
@@ -49,6 +49,7 @@ signals:
 
 private:
     virtual void changeEvent(QEvent* event) override;
+    virtual void contextMenuEvent(QContextMenuEvent* event) override;
     virtual void focusInEvent(QFocusEvent* event) override;
     virtual void focusOutEvent(QFocusEvent* event) override;
     virtual void keyPressEvent(QKeyEvent* event) override;


### PR DESCRIPTION
This is a feature I end up using surprisingly often. It acts the same as pasting and then pressing the enter key.

Also includes a bonus change for AppKit: When the omnibox isn't focused, it previously had no context menu. Safari gives this state a special simplified menu with just "Copy" and "Paste and Go" options, which seems like a good idea, so we imitate that.