### PR TITLE
LibJS: Reject an atomic access whose element straddles a resized buffer

### DIFF
--- a/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -110,7 +110,13 @@ static ThrowCompletionOr<void> revalidate_atomic_access(VM& vm, TypedArrayBase c
     VERIFY(byte_index_in_buffer >= typed_array.byte_offset());
 
     // 5. If byteIndexInBuffer ≥ taRecord.[[CachedBufferByteLength]], throw a RangeError exception.
-    if (byte_index_in_buffer >= typed_array_record.cached_buffer_byte_length.length())
+    // AD-HOC: The spec step strictly only bounds-checks the element's first byte. A length-tracking element whose start
+    //         is in bounds but end is past a buffer shrunk during argument coercion would otherwise reach the buffer
+    //         accessors and read/write out of bounds, violating their sufficient-bytes assertion. Bound-check the whole
+    //         element instead. That aligns with what V8, JSC, and SpiderMonkey already are all also functionally doing.
+    //         (The OOB access from #10759 isn’t reproducible in any of those engines.)
+    //         https://github.com/tc39/ecma262/issues/3924
+    if (byte_index_in_buffer + typed_array.element_size() > typed_array_record.cached_buffer_byte_length.length())
         return vm.throw_completion<RangeError>(ErrorType::IndexOutOfRange, byte_index_in_buffer, typed_array_record.cached_buffer_byte_length.length());
 
     // 6. Return unused.

--- a/Tests/LibJS/Runtime/builtins/Atomics/Atomics-resizable-buffer-out-of-bounds.js
+++ b/Tests/LibJS/Runtime/builtins/Atomics/Atomics-resizable-buffer-out-of-bounds.js
@@ -1,0 +1,69 @@
+// Atomics operation validate the index against the typed-array length before coercing their arguments. If an argument's
+// valueOf shrinks the backing resizable ArrayBuffer so the target element now starts in bounds but ends out of bounds,
+// the operation must throw a RangeError — rather than read or write past the (now shorter) buffer. See #10759.
+
+// A length-tracking Int32Array over a 100-byte buffer: element 24 spans bytes 96..99. Shrinking the buffer to 97 leaves
+// element 24 starting in bounds (96 < 97) but ending out of bounds (needs 99).
+function shrinkingInt32Array(newByteLength) {
+    const buffer = new ArrayBuffer(100, { maxByteLength: 100 });
+    const array = new Int32Array(buffer);
+    return {
+        array,
+        coercer: {
+            valueOf() {
+                buffer.resize(newByteLength);
+                return 1;
+            },
+        },
+    };
+}
+
+test("read-modify-write throws when the element straddles a buffer shrunk during coercion", () => {
+    ["add", "and", "or", "sub", "xor", "exchange", "store"].forEach(op => {
+        const { array, coercer } = shrinkingInt32Array(97);
+        expect(() => {
+            Atomics[op](array, 24, coercer);
+        }).toThrow(RangeError);
+    });
+});
+
+test("compareExchange throws when the element straddles a buffer shrunk during coercion", () => {
+    const { array, coercer } = shrinkingInt32Array(97);
+    expect(() => {
+        Atomics.compareExchange(array, 24, coercer, 1);
+    }).toThrow(RangeError);
+});
+
+test("load throws when the element straddles a buffer shrunk during index coercion", () => {
+    const buffer = new ArrayBuffer(100, { maxByteLength: 100 });
+    const array = new Int32Array(buffer);
+    expect(() => {
+        Atomics.load(array, {
+            valueOf() {
+                buffer.resize(97);
+                return 24;
+            },
+        });
+    }).toThrow(RangeError);
+});
+
+test("a larger element straddling a shrunk buffer also throws", () => {
+    // BigInt64Array element 11 spans bytes 88..95; shrinking to 89 leaves it straddling.
+    const buffer = new ArrayBuffer(96, { maxByteLength: 96 });
+    const array = new BigInt64Array(buffer);
+    expect(() => {
+        Atomics.and(array, 11, {
+            valueOf() {
+                buffer.resize(89);
+                return 1n;
+            },
+        });
+    }).toThrow(RangeError);
+});
+
+test("a shrink that leaves the element fully out of bounds still throws RangeError", () => {
+    const { array, coercer } = shrinkingInt32Array(50);
+    expect(() => {
+        Atomics.and(array, 24, coercer);
+    }).toThrow(RangeError);
+});


### PR DESCRIPTION
**Problem:** Atomic access could read/write OOB when an argument’s `valueOf` shrinks the backing resizable `ArrayBuffer` so that the target element ends up straddling the new, shorter buffer end.

**Cause:** An atomic access validates its index against the typed-array length before coercing its arguments, then revalidates afterward. But the revalidation only bounds-checked the element’s first byte. A length-tracking element that started in bounds but ended past a buffer shrunk during coercion slipped through to the buffer accessors.

**Fix:** Bounds-check the whole element during revalidation, rejecting when `byteIndexInBuffer + elementSize` exceeds the buffer’s byte length. That covers every op sharing the revalidation path. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10759.

The root cause here is a bug in the ES spec; see https://github.com/tc39/ecma262/issues/3924.
