### PR TITLE
LibWeb/Painting: Prevent a heap OOB write exploit

### DIFF
--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -161,6 +161,7 @@ public:
     AccumulatedVisualContextNode const& node_at(VisualContextIndex index) const { return m_nodes[index.value()]; }
     AccumulatedVisualContextNode& node_at(VisualContextIndex index) { return m_nodes[index.value()]; }
     ReadonlySpan<AccumulatedVisualContextNode> nodes() const { return m_nodes.span(); }
+    size_t node_count() const { return m_nodes.size(); }
 
     Optional<Gfx::FloatPoint> transform_point_for_hit_test(VisualContextIndex, Gfx::FloatPoint, ScrollStateSnapshot const&, ClipBehavior = ClipBehavior::Respect) const;
     Gfx::FloatPoint inverse_transform_point(VisualContextIndex, Gfx::FloatPoint) const;

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -44,7 +44,7 @@ ErrorOr<Web::Painting::ScrollStateSnapshot> decode(Decoder& decoder)
         auto offset = TRY(decoder.decode<Gfx::FloatPoint>());
         if (index >= NumericLimits<u32>::max())
             return Error::from_string_literal("IPC decode: ScrollStateSnapshot index out of range");
-        snapshot.set_device_offset_for_index(Web::Painting::SpatialNodeIndex { static_cast<u32>(index) }, offset);
+        TRY(snapshot.m_staged_offsets.try_append({ static_cast<u32>(index), offset }));
     }
     return snapshot;
 }

--- a/Libraries/LibWeb/Painting/ScrollState.cpp
+++ b/Libraries/LibWeb/Painting/ScrollState.cpp
@@ -54,7 +54,7 @@ ErrorOr<Web::Painting::ScrollStateSnapshot> decode(Decoder& decoder)
     for (u64 i = 0; i < pair_count; ++i) {
         auto index = TRY(decoder.decode<u64>());
         auto offset = TRY(decoder.decode<Gfx::FloatPoint>());
-        snapshot.set_device_offset_for_index(Web::Painting::VisualContextIndex { index }, offset);
+        snapshot.m_staged_offsets.append({ index, offset });
     }
     return snapshot;
 }

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -8,6 +8,7 @@
 
 #include <AK/DistinctNumeric.h>
 #include <AK/NumericLimits.h>
+#include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibGfx/Point.h>
 #include <LibIPC/Forward.h>
@@ -23,6 +24,12 @@ namespace Web::Painting {
 // and the tree. Stored dense in process so display list replay and hit testing index it directly;
 // indices that are not scroll-like nodes read as zero offsets. The IPC representation is sparse
 // (index, offset) pairs.
+//
+// The dense store must never grow past the spatial node count. A compromised WebContent renderer controls the
+// indices that reach it — both as decoded wire pairs and as scroll-node indices replayed from the display list. So,
+// set_device_offset_for_index() drops any index at or past m_node_count. The compositor supplies that bound from the
+// AccumulatedVisualContextTree that owns these nodes. Until it does, the bound is unlimited — which is what the
+// trusted in-process snapshot built from live scroll nodes needs.
 class ScrollStateSnapshot {
 public:
     ReadonlySpan<Gfx::FloatPoint> device_offsets() const { return m_device_offsets; }
@@ -36,13 +43,43 @@ public:
 
     void set_device_offset_for_index(SpatialNodeIndex index, Gfx::FloatPoint offset)
     {
+        if (index.value() >= m_node_count)
+            return;
         if (index.value() >= m_device_offsets.size())
             m_device_offsets.resize(index.value() + 1);
         m_device_offsets[index.value()] = offset;
     }
 
+    // Bind the snapshot to the authoritative node count from the AccumulatedVisualContextTree that owns these nodes.
+    // Wire-decoded offsets are staged rather than densified. So, this is where a decoded index is first validated:
+    // staged pairs are applied through the bounded setter above, dropping any whose index is at or past the node count.
+    // And any offset already stored past the count is discarded. Every later mutation stays bounded by the count.
+    void set_node_count(size_t node_count)
+    {
+        m_node_count = node_count;
+        if (m_device_offsets.size() > node_count)
+            m_device_offsets.resize(node_count);
+        auto staged_offsets = move(m_staged_offsets);
+        for (auto const& staged : staged_offsets)
+            set_device_offset_for_index(SpatialNodeIndex { staged.index }, staged.offset);
+    }
+
 private:
+    template<typename T>
+    friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);
+    template<typename T>
+    friend ErrorOr<T> IPC::decode(IPC::Decoder&);
+
+    // A sparse wire pair captured by the decoder before the node count is known. Held apart from the dense store — so
+    // that a single decoded pair cannot grow the store to an arbitrary size.
+    struct StagedOffset {
+        u32 index { 0 };
+        Gfx::FloatPoint offset;
+    };
+
     Vector<Gfx::FloatPoint> m_device_offsets;
+    Vector<StagedOffset> m_staged_offsets;
+    size_t m_node_count { NumericLimits<size_t>::max() };
 };
 
 }

--- a/Libraries/LibWeb/Painting/ScrollState.h
+++ b/Libraries/LibWeb/Painting/ScrollState.h
@@ -6,6 +6,9 @@
 
 #pragma once
 
+#include <AK/NumericLimits.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibGfx/Point.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
@@ -16,6 +19,12 @@ namespace Web::Painting {
 // Device-pixel scroll offsets keyed by the scroll node's VisualContextIndex. Stored dense in
 // process so display list replay and hit testing index it directly; indices that are not scroll
 // nodes read as zero offsets. The IPC representation is sparse (index, offset) pairs.
+//
+// The dense store must never grow past the visual-context node count. A compromised WebContent renderer controls the
+// indices that reach it — both as decoded wire pairs and as scroll-node indices replayed from the display list. So,
+// set_device_offset_for_index() drops any index at or past m_node_count. The compositor supplies that bound from the
+// AccumulatedVisualContextTree that owns these nodes. Until it does, the bound is unlimited — which is what the trusted
+// in-process snapshot built from live scroll nodes needs.
 class ScrollStateSnapshot {
 public:
     ReadonlySpan<Gfx::FloatPoint> device_offsets() const { return m_device_offsets; }
@@ -29,13 +38,43 @@ public:
 
     void set_device_offset_for_index(VisualContextIndex index, Gfx::FloatPoint offset)
     {
+        if (index.value() >= m_node_count)
+            return;
         if (index.value() >= m_device_offsets.size())
             m_device_offsets.resize(index.value() + 1);
         m_device_offsets[index.value()] = offset;
     }
 
+    // Bind the snapshot to the authoritative node count from the AccumulatedVisualContextTree that owns these nodes.
+    // Wire-decoded offsets are staged rather than densified. So, this is where a decoded index is first validated:
+    // staged pairs are applied through the bounded setter above, dropping any whose index is at or past the node count.
+    // And any offset already stored past the count is discarded. Every later mutation stays bounded by the count.
+    void set_node_count(size_t node_count)
+    {
+        m_node_count = node_count;
+        if (m_device_offsets.size() > node_count)
+            m_device_offsets.resize(node_count);
+        auto staged_offsets = move(m_staged_offsets);
+        for (auto const& staged : staged_offsets)
+            set_device_offset_for_index(VisualContextIndex { staged.index }, staged.offset);
+    }
+
 private:
+    template<typename T>
+    friend ErrorOr<void> IPC::encode(IPC::Encoder&, T const&);
+    template<typename T>
+    friend ErrorOr<T> IPC::decode(IPC::Decoder&);
+
+    // A sparse wire pair captured by the decoder before the node count is known. Held apart from the dense store — so
+    // that a single decoded pair cannot grow the store to an arbitrary size.
+    struct StagedOffset {
+        u64 index { 0 };
+        Gfx::FloatPoint offset;
+    };
+
     Vector<Gfx::FloatPoint> m_device_offsets;
+    Vector<StagedOffset> m_staged_offsets;
+    size_t m_node_count { NumericLimits<size_t>::max() };
 };
 
 // Value store for the scroll and sticky nodes of the accumulated visual context tree: the tree

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -174,6 +174,7 @@ void ContextState::install_display_list_update(
     m_visual_animation_sample_time_ns.clear();
     m_has_active_visual_animations = !m_visual_context_tree->visual_animations().is_empty();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
+    m_scroll_state_snapshot.set_node_count(m_visual_context_tree->spatial_node_count());
     update_caret_blink_timer();
     if (m_async_visual_viewport_transform.has_value() && visual_viewport_transforms_match(m_visual_context_tree->visual_viewport_transform(), *m_async_visual_viewport_transform))
         m_async_visual_viewport_transform.clear();
@@ -302,6 +303,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
 void ContextState::update_scroll_state(Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     m_scroll_state_snapshot = move(scroll_state_snapshot);
+    m_scroll_state_snapshot.set_node_count(m_visual_context_tree.has_value() ? m_visual_context_tree->spatial_node_count() : 0);
     if (!m_has_async_scrolling_state)
         return;
 

--- a/Services/Compositor/ContextState.cpp
+++ b/Services/Compositor/ContextState.cpp
@@ -151,6 +151,7 @@ void ContextState::install_display_list_update(
     m_visual_context_tree = move(visual_context_tree);
     m_visual_context_tree_for_compositing.clear();
     m_scroll_state_snapshot = move(scroll_state_snapshot);
+    m_scroll_state_snapshot.set_node_count(m_visual_context_tree->node_count());
     if (m_async_visual_viewport_transform.has_value() && visual_viewport_transforms_match(visual_viewport_transform(*m_visual_context_tree), *m_async_visual_viewport_transform))
         m_async_visual_viewport_transform.clear();
 
@@ -205,6 +206,7 @@ void ContextState::update_visual_context_tree(Web::Painting::AccumulatedVisualCo
 void ContextState::update_scroll_state(Web::Painting::ScrollStateSnapshot&& scroll_state_snapshot)
 {
     m_scroll_state_snapshot = move(scroll_state_snapshot);
+    m_scroll_state_snapshot.set_node_count(m_visual_context_tree.has_value() ? m_visual_context_tree->node_count() : 0);
     if (!m_has_async_scrolling_state)
         return;
 

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCES
     TestMicrosyntax.cpp
     TestMimeSniff.cpp
     TestNumbers.cpp
+    TestScrollState.cpp
     TestSecureContexts.cpp
     TestSessionHistoryEntry.cpp
     TestSimpleRealm.cpp
@@ -68,6 +69,7 @@ target_link_libraries(TestFetchURL PRIVATE LibURL)
 target_link_libraries(TestImageData PRIVATE LibGC LibJS)
 target_link_libraries(TestWebIDLBuffers PRIVATE LibGC LibJS)
 target_link_libraries(TestWebGLSpanWithStorage PRIVATE LibGC LibJS)
+target_link_libraries(TestScrollState PRIVATE LibGfx LibIPC)
 target_link_libraries(TestStructuredSerializeCorpus PRIVATE LibGC LibJS LibCrypto LibGfx LibIPC)
 target_link_libraries(TestStructuredSerializeDurability PRIVATE LibGC LibJS LibCrypto LibGfx LibIPC)
 target_link_libraries(TestStructuredSerializeFormat PRIVATE LibGC LibJS LibCrypto LibGfx LibIPC)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     TestNumbers.cpp
     TestPage.cpp
     TestRefCountedTreeNode.cpp
+    TestScrollState.cpp
     TestSecureContexts.cpp
     TestSessionHistoryEntry.cpp
     TestSmoothScrollAnimation.cpp
@@ -56,6 +57,7 @@ target_link_libraries(TestFetchURL PRIVATE LibURL)
 target_link_libraries(TestAccumulatedVisualContext PRIVATE LibGfx)
 target_link_libraries(TestImageData PRIVATE LibGC LibJS)
 target_link_libraries(TestPage PRIVATE LibGC LibJS)
+target_link_libraries(TestScrollState PRIVATE LibGfx LibIPC)
 target_link_libraries(TestSecureContexts PRIVATE LibURL)
 target_link_libraries(TestSessionHistoryEntry PRIVATE LibJS LibURL)
 target_link_libraries(TestSourceHighlighter PRIVATE LibURL LibWebView)

--- a/Tests/LibWeb/TestScrollState.cpp
+++ b/Tests/LibWeb/TestScrollState.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <AK/Queue.h>
+#include <LibGfx/Point.h>
+#include <LibIPC/Attachment.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibIPC/Message.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Compositor/AsyncScrollTree.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/ScrollState.h>
+#include <LibWeb/Painting/VisualContextTreeTestBuilder.h>
+
+using namespace Web::Painting;
+
+// An index far above any real node count, but still inside the range the decoder accepts. Densifying it would
+// allocate (index + 1) * sizeof(Gfx::FloatPoint), i.e. 512 MiB — the allocation the node-count bound exists to stop.
+static constexpr u32 malicious_index = 0x04000000; // 2^26
+
+struct WirePair {
+    u64 index { 0 };
+    Gfx::FloatPoint offset;
+};
+
+static ScrollStateSnapshot decode_snapshot(Vector<WirePair> const& pairs)
+{
+    IPC::MessageBuffer message_buffer;
+    IPC::Encoder encoder { message_buffer };
+    MUST(encoder.encode(static_cast<u64>(pairs.size()))); // pair_count
+    for (auto const& pair : pairs) {
+        MUST(encoder.encode(pair.index));
+        MUST(encoder.encode(pair.offset));
+    }
+
+    auto data = message_buffer.take_data();
+    FixedMemoryStream stream { data.span() };
+    Queue<IPC::Attachment> attachments;
+    IPC::Decoder decoder { stream, attachments };
+    return MUST(IPC::decode<ScrollStateSnapshot>(decoder));
+}
+
+TEST_CASE(decode_of_out_of_range_index_does_not_grow_the_dense_store)
+{
+    // #10847: a single 16-byte wire pair can claim any node index the decoder accepts. The decoder stages the pair
+    // instead of densifying — so decoding cannot abort or over-allocate. The index is validated only once the
+    // compositor supplies the node count, which drops it.
+    auto snapshot = decode_snapshot({ { malicious_index, Gfx::FloatPoint { 1, 2 } } });
+
+    snapshot.set_node_count(8);
+
+    EXPECT(snapshot.device_offsets().size() <= 8u);
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { malicious_index }), Gfx::FloatPoint {});
+}
+
+TEST_CASE(binding_to_node_count_keeps_in_range_and_drops_out_of_range)
+{
+    auto snapshot = decode_snapshot({
+        { 3, Gfx::FloatPoint { 10, 20 } },
+        { malicious_index, Gfx::FloatPoint { 30, 40 } },
+    });
+
+    snapshot.set_node_count(8);
+
+    // The in-range pair survives, the out-of-range pair is gone, and the dense store never spans more than the node count.
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { 3 }), (Gfx::FloatPoint { 10, 20 }));
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { malicious_index }), Gfx::FloatPoint {});
+    EXPECT(snapshot.device_offsets().size() <= 8u);
+}
+
+TEST_CASE(set_device_offset_ignores_index_at_or_past_node_count)
+{
+    ScrollStateSnapshot snapshot;
+    snapshot.set_node_count(4);
+
+    // A valid index is stored; an index at the bound and one far past it are both ignored, so the dense store cannot
+    // extend past the node count.
+    snapshot.set_device_offset_for_index(SpatialNodeIndex { 3 }, Gfx::FloatPoint { 5, 6 });
+    snapshot.set_device_offset_for_index(SpatialNodeIndex { 4 }, Gfx::FloatPoint { 7, 8 });
+    snapshot.set_device_offset_for_index(SpatialNodeIndex { malicious_index }, Gfx::FloatPoint { 9, 9 });
+
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { 3 }), (Gfx::FloatPoint { 5, 6 }));
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { 4 }), Gfx::FloatPoint {});
+    EXPECT(snapshot.device_offsets().size() <= 4u);
+}
+
+TEST_CASE(node_count_comes_from_the_visual_context_tree)
+{
+    VisualContextTreeTestBuilder builder;
+    builder.append_transform(VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    builder.append_transform(VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    auto tree = builder.finish();
+
+    // The builder seeds the viewport node, so two appends leave three nodes; indices 0..2 are valid.
+    EXPECT_EQ(tree.spatial_node_count(), 3u);
+
+    auto snapshot = decode_snapshot({
+        { 2, Gfx::FloatPoint { 1, 1 } },
+        { 3, Gfx::FloatPoint { 2, 2 } },
+    });
+    snapshot.set_node_count(tree.spatial_node_count());
+
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { 2 }), (Gfx::FloatPoint { 1, 1 }));
+    EXPECT_EQ(snapshot.device_offset_for_index(SpatialNodeIndex { 3 }), Gfx::FloatPoint {});
+    EXPECT(snapshot.device_offsets().size() <= tree.spatial_node_count());
+}
+
+static AccumulatedVisualContextTree make_tree_with_four_spatial_nodes()
+{
+    VisualContextTreeTestBuilder builder;
+    // The builder seeds the viewport node, so three appends leave four.
+    builder.append_transform(VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    builder.append_transform(VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    builder.append_transform(VISUAL_VIEWPORT_NODE_INDEX, Gfx::FloatMatrix4x4::identity());
+    return builder.finish();
+}
+
+static Web::Compositor::AsyncScrollNode make_scroll_node(SpatialNodeIndex scroll_node_index)
+{
+    Web::Compositor::AsyncScrollNodeID node_id {
+        .document_id = Web::UniqueNodeID { 1 },
+        .scroll_node_index = scroll_node_index,
+    };
+    return {
+        .node_id = node_id,
+        .stable_node_id = {
+            .node_id = Web::UniqueNodeID { 1 },
+            .kind = Web::Compositor::AsyncScrollNodeKind::Element,
+            .pseudo_element_type = 0,
+        },
+        .parent_node_id = {},
+        .scrollport_rect = Gfx::IntRect { 0, 0, 100, 100 },
+        .min_scroll_offset = Gfx::FloatPoint { 0, 0 },
+        .max_scroll_offset = Gfx::FloatPoint { 100, 100 },
+        .is_viewport = false,
+        .can_be_wheel_scrolled_horizontally = true,
+        .can_be_wheel_scrolled_vertically = true,
+    };
+}
+
+TEST_CASE(async_scroll_tree_ignores_out_of_range_scroll_node_index)
+{
+    // The second ingress: a crafted CompositorScrollNode command in the display list gives the scroll tree an out-of-
+    // range scroll node index — which apply_scroll_delta feeds to the same dense-store setter. The node-count bound on
+    // the snapshot drops it, instead of aborting.
+    Web::Compositor::AsyncScrollingState state;
+    auto out_of_range_index = SpatialNodeIndex { malicious_index };
+    state.scroll_nodes.append(make_scroll_node(out_of_range_index));
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(state));
+
+    auto tree = make_tree_with_four_spatial_nodes();
+    ScrollStateSnapshot snapshot;
+    snapshot.set_node_count(tree.spatial_node_count());
+    (void)scroll_tree.apply_scroll_delta(
+        Web::Compositor::AsyncScrollNodeID { .document_id = Web::UniqueNodeID { 1 }, .scroll_node_index = out_of_range_index },
+        Gfx::FloatPoint { 10, 10 },
+        tree,
+        snapshot);
+
+    EXPECT(snapshot.device_offsets().size() <= 4u);
+    EXPECT_EQ(snapshot.device_offset_for_index(out_of_range_index), Gfx::FloatPoint {});
+}
+
+TEST_CASE(async_scroll_tree_records_in_range_scroll_node_index)
+{
+    // The same path with a valid index still writes the offset, confirming the bound only rejects out-of-range indices,
+    // rather than disabling async scrolling.
+    Web::Compositor::AsyncScrollingState state;
+    auto in_range_index = SpatialNodeIndex { 2 };
+    state.scroll_nodes.append(make_scroll_node(in_range_index));
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(state));
+
+    auto tree = make_tree_with_four_spatial_nodes();
+    ScrollStateSnapshot snapshot;
+    snapshot.set_node_count(tree.spatial_node_count());
+    (void)scroll_tree.apply_scroll_delta(
+        Web::Compositor::AsyncScrollNodeID { .document_id = Web::UniqueNodeID { 1 }, .scroll_node_index = in_range_index },
+        Gfx::FloatPoint { 10, 10 },
+        tree,
+        snapshot);
+
+    EXPECT(snapshot.device_offsets().size() <= 4u);
+    EXPECT_NE(snapshot.device_offset_for_index(in_range_index), Gfx::FloatPoint {});
+}
+
+TEST_CASE(ipc_round_trip_preserves_scroll_offsets)
+{
+    ScrollStateSnapshot snapshot;
+    snapshot.set_device_offset_for_index(SpatialNodeIndex { 3 }, Gfx::FloatPoint { 10, 20 });
+
+    IPC::MessageBuffer message_buffer;
+    IPC::Encoder encoder { message_buffer };
+    MUST(encoder.encode(snapshot));
+
+    auto data = message_buffer.take_data();
+    FixedMemoryStream stream { data.span() };
+    Queue<IPC::Attachment> attachments;
+    IPC::Decoder decoder { stream, attachments };
+
+    auto decoded = MUST(IPC::decode<ScrollStateSnapshot>(decoder));
+    decoded.set_node_count(8);
+    EXPECT_EQ(decoded.device_offset_for_index(SpatialNodeIndex { 3 }), (Gfx::FloatPoint { 10, 20 }));
+    // Indices that were never set are holes that decode back to zero offsets.
+    EXPECT_EQ(decoded.device_offset_for_index(SpatialNodeIndex { 1 }), Gfx::FloatPoint {});
+}

--- a/Tests/LibWeb/TestScrollState.cpp
+++ b/Tests/LibWeb/TestScrollState.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <AK/Queue.h>
+#include <LibGfx/Point.h>
+#include <LibIPC/Attachment.h>
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibIPC/Message.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Compositor/AsyncScrollTree.h>
+#include <LibWeb/Compositor/AsyncScrollingState.h>
+#include <LibWeb/Painting/AccumulatedVisualContext.h>
+#include <LibWeb/Painting/ScrollState.h>
+
+using namespace Web::Painting;
+
+// An index far above any real node count that overflows (index + 1) * sizeof(Gfx::FloatPoint) in size_t.
+static constexpr u64 malicious_index = 0x2000000000000000ULL; // 2^61
+
+struct WirePair {
+    u64 index { 0 };
+    Gfx::FloatPoint offset;
+};
+
+static ScrollStateSnapshot decode_snapshot(Vector<WirePair> const& pairs)
+{
+    IPC::MessageBuffer message_buffer;
+    IPC::Encoder encoder { message_buffer };
+    MUST(encoder.encode(static_cast<u64>(pairs.size()))); // pair_count
+    for (auto const& pair : pairs) {
+        MUST(encoder.encode(pair.index));
+        MUST(encoder.encode(pair.offset));
+    }
+
+    auto data = message_buffer.take_data();
+    FixedMemoryStream stream { data.span() };
+    Queue<IPC::Attachment> attachments;
+    IPC::Decoder decoder { stream, attachments };
+    return MUST(IPC::decode<ScrollStateSnapshot>(decoder));
+}
+
+TEST_CASE(decode_of_out_of_range_index_does_not_grow_the_dense_store)
+{
+    // #10847: a single 16-byte wire pair can claim an arbitrary 64-bit node index. The decoder stages the pair instead
+    // of densifying — so decoding cannot abort or over-allocate. The index is validated only once the compositor
+    // supplies the node count, which drops it.
+    auto snapshot = decode_snapshot({ { malicious_index, Gfx::FloatPoint { 1, 2 } } });
+
+    snapshot.set_node_count(8);
+
+    EXPECT(snapshot.device_offsets().size() <= 8u);
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { malicious_index }), Gfx::FloatPoint {});
+}
+
+TEST_CASE(binding_to_node_count_keeps_in_range_and_drops_out_of_range)
+{
+    auto snapshot = decode_snapshot({
+        { 3, Gfx::FloatPoint { 10, 20 } },
+        { malicious_index, Gfx::FloatPoint { 30, 40 } },
+    });
+
+    snapshot.set_node_count(8);
+
+    // The in-range pair survives, the out-of-range pair is gone, and the dense store never spans more than the node count.
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { 3 }), (Gfx::FloatPoint { 10, 20 }));
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { malicious_index }), Gfx::FloatPoint {});
+    EXPECT(snapshot.device_offsets().size() <= 8u);
+}
+
+TEST_CASE(set_device_offset_ignores_index_at_or_past_node_count)
+{
+    ScrollStateSnapshot snapshot;
+    snapshot.set_node_count(4);
+
+    // A valid index is stored; an index at the bound and one far past it are both ignored, so the dense store cannot
+    // extend past the node count.
+    snapshot.set_device_offset_for_index(VisualContextIndex { 3 }, Gfx::FloatPoint { 5, 6 });
+    snapshot.set_device_offset_for_index(VisualContextIndex { 4 }, Gfx::FloatPoint { 7, 8 });
+    snapshot.set_device_offset_for_index(VisualContextIndex { malicious_index }, Gfx::FloatPoint { 9, 9 });
+
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { 3 }), (Gfx::FloatPoint { 5, 6 }));
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { 4 }), Gfx::FloatPoint {});
+    EXPECT(snapshot.device_offsets().size() <= 4u);
+}
+
+TEST_CASE(node_count_comes_from_the_visual_context_tree)
+{
+    auto tree = AccumulatedVisualContextTree::create();
+    tree.append(EffectsData {}, VISUAL_VIEWPORT_NODE_INDEX);
+    tree.append(EffectsData {}, VISUAL_VIEWPORT_NODE_INDEX);
+
+    // create() seeds the viewport node, so two appends leave three nodes; indices 0..2 are valid.
+    EXPECT_EQ(tree.node_count(), 3u);
+
+    auto snapshot = decode_snapshot({
+        { 2, Gfx::FloatPoint { 1, 1 } },
+        { 3, Gfx::FloatPoint { 2, 2 } },
+    });
+    snapshot.set_node_count(tree.node_count());
+
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { 2 }), (Gfx::FloatPoint { 1, 1 }));
+    EXPECT_EQ(snapshot.device_offset_for_index(VisualContextIndex { 3 }), Gfx::FloatPoint {});
+    EXPECT(snapshot.device_offsets().size() <= tree.node_count());
+}
+
+static Web::Compositor::AsyncScrollNode make_scroll_node(VisualContextIndex scroll_node_index)
+{
+    Web::Compositor::AsyncScrollNodeID node_id {
+        .document_id = Web::UniqueNodeID { 1 },
+        .scroll_node_index = scroll_node_index,
+    };
+    return {
+        .node_id = node_id,
+        .stable_node_id = {
+            .node_id = Web::UniqueNodeID { 1 },
+            .kind = Web::Compositor::AsyncScrollNodeKind::Element,
+            .pseudo_element_type = 0,
+        },
+        .parent_node_id = {},
+        .scrollport_rect = Gfx::IntRect { 0, 0, 100, 100 },
+        .max_scroll_offset = Gfx::FloatPoint { 100, 100 },
+        .is_viewport = false,
+        .can_be_wheel_scrolled_horizontally = true,
+        .can_be_wheel_scrolled_vertically = true,
+    };
+}
+
+TEST_CASE(async_scroll_tree_ignores_out_of_range_scroll_node_index)
+{
+    // The second ingress: a crafted CompositorScrollNode command in the display list gives the scroll tree an out-of-
+    // range scroll node index — which apply_scroll_delta feeds to the same dense-store setter. The node-count bound on
+    // the snapshot drops it, instead of aborting.
+    Web::Compositor::AsyncScrollingState state;
+    auto out_of_range_index = VisualContextIndex { malicious_index };
+    state.scroll_nodes.append(make_scroll_node(out_of_range_index));
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(state));
+
+    ScrollStateSnapshot snapshot;
+    snapshot.set_node_count(4);
+    (void)scroll_tree.apply_scroll_delta(
+        Web::Compositor::AsyncScrollNodeID { .document_id = Web::UniqueNodeID { 1 }, .scroll_node_index = out_of_range_index },
+        Gfx::FloatPoint { 10, 10 },
+        snapshot);
+
+    EXPECT(snapshot.device_offsets().size() <= 4u);
+    EXPECT_EQ(snapshot.device_offset_for_index(out_of_range_index), Gfx::FloatPoint {});
+}
+
+TEST_CASE(async_scroll_tree_records_in_range_scroll_node_index)
+{
+    // The same path with a valid index still writes the offset, confirming the bound only rejects out-of-range indices,
+    // rather than disabling async scrolling.
+    Web::Compositor::AsyncScrollingState state;
+    auto in_range_index = VisualContextIndex { 2 };
+    state.scroll_nodes.append(make_scroll_node(in_range_index));
+
+    Web::Compositor::AsyncScrollTree scroll_tree;
+    scroll_tree.set_state(move(state));
+
+    ScrollStateSnapshot snapshot;
+    snapshot.set_node_count(4);
+    (void)scroll_tree.apply_scroll_delta(
+        Web::Compositor::AsyncScrollNodeID { .document_id = Web::UniqueNodeID { 1 }, .scroll_node_index = in_range_index },
+        Gfx::FloatPoint { 10, 10 },
+        snapshot);
+
+    EXPECT(snapshot.device_offsets().size() <= 4u);
+    EXPECT_NE(snapshot.device_offset_for_index(in_range_index), Gfx::FloatPoint {});
+}
+
+TEST_CASE(ipc_round_trip_preserves_scroll_offsets)
+{
+    ScrollStateSnapshot snapshot;
+    snapshot.set_device_offset_for_index(VisualContextIndex { 3 }, Gfx::FloatPoint { 10, 20 });
+
+    IPC::MessageBuffer message_buffer;
+    IPC::Encoder encoder { message_buffer };
+    MUST(encoder.encode(snapshot));
+
+    auto data = message_buffer.take_data();
+    FixedMemoryStream stream { data.span() };
+    Queue<IPC::Attachment> attachments;
+    IPC::Decoder decoder { stream, attachments };
+
+    auto decoded = MUST(IPC::decode<ScrollStateSnapshot>(decoder));
+    decoded.set_node_count(8);
+    EXPECT_EQ(decoded.device_offset_for_index(VisualContextIndex { 3 }), (Gfx::FloatPoint { 10, 20 }));
+    // Indices that were never set are holes that decode back to zero offsets.
+    EXPECT_EQ(decoded.device_offset_for_index(VisualContextIndex { 1 }), Gfx::FloatPoint {});
+}


### PR DESCRIPTION
**Problem:** `IPC::decode<ScrollStateSnapshot>` could be caused by a compromised WebContent renderer to read attacker-controlled index/offset wire pairs: One 16-byte pair can demand an arbitrary dense allocation, and even an index small enough to allocate lets a single pair force a 512 MiB dense store. Also, `decode<DisplayList>` did no per-command validation on the `scroll_node_index` received from `CompositorScrollNode` commands in the `DisplayList`.

**Cause:** `set_device_offset_for_index` grows a dense vector keyed by an untrusted `VisualContextIndex` with no bound against the actual visual-context node count. The snapshot decode densified the store eagerly — before the compositor could validate anything.

**Fix:** `set_device_offset_for_index` now drops any index at or past a node-count bound carried by the snapshot. The decoder stages the sparse wire pairs instead of densifying them — so a decode can neither abort nor over-allocate. The compositor then binds the snapshot to the tree node count in `install_display_list_update` (the tree from the same message) and `update_scroll_state` (the stored tree) — applying the staged pairs, and dropping every out-of-range index. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10847.
