### PR TITLE
AK: Reject Vector capacity requests that overflow size_t

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Checked.h>
 #include <AK/Error.h>
 #include <AK/Find.h>
 #include <AK/Forward.h>
@@ -848,7 +849,11 @@ public:
     {
         if (m_capacity >= needed_capacity)
             return {};
-        size_t new_capacity = kmalloc_good_size(needed_capacity * sizeof(StorageType)) / sizeof(StorageType);
+        Checked<size_t> new_size_in_bytes = needed_capacity;
+        new_size_in_bytes *= sizeof(StorageType);
+        if (new_size_in_bytes.has_overflow())
+            return Error::from_errno(ENOMEM);
+        size_t new_capacity = kmalloc_good_size(new_size_in_bytes.value()) / sizeof(StorageType);
         auto* new_buffer = static_cast<StorageType*>(kmalloc_array(new_capacity, sizeof(StorageType)));
         if (new_buffer == nullptr)
             return Error::from_errno(ENOMEM);

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/ByteString.h>
+#include <AK/NumericLimits.h>
 #include <AK/OwnPtr.h>
 #include <AK/ReverseIterator.h>
 #include <AK/String.h>
@@ -721,4 +722,40 @@ TEST_CASE(VectorWithFastLastAccess_unsafe)
     EXPECT_EQ(v.unsafe_last(), 2);
     EXPECT_EQ(v.unsafe_take_last(), 2);
     EXPECT_EQ(v.unsafe_last(), 1);
+}
+
+TEST_CASE(try_ensure_capacity_overflow)
+{
+    Vector<u64> v;
+    auto result = v.try_ensure_capacity(NumericLimits<size_t>::max() / sizeof(u64) + 1);
+    EXPECT(result.is_error());
+    EXPECT_EQ(v.capacity(), 0u);
+    EXPECT_EQ(v.size(), 0u);
+
+    EXPECT(!v.try_append(42).is_error());
+    EXPECT_EQ(v.size(), 1u);
+    EXPECT_EQ(v[0], 42u);
+}
+
+TEST_CASE(try_resize_overflow)
+{
+    Vector<u64> v;
+    auto result = v.try_resize(NumericLimits<size_t>::max() / sizeof(u64) + 1);
+    EXPECT(result.is_error());
+    EXPECT_EQ(v.size(), 0u);
+    EXPECT_EQ(v.capacity(), 0u);
+}
+
+TEST_CASE(try_ensure_capacity_normal_growth)
+{
+    Vector<u64> v;
+    EXPECT(!v.try_ensure_capacity(1024).is_error());
+    EXPECT(v.capacity() >= 1024u);
+    EXPECT_EQ(v.size(), 0u);
+
+    v.append(1);
+    v.append(2);
+    EXPECT_EQ(v.size(), 2u);
+    EXPECT_EQ(v[0], 1u);
+    EXPECT_EQ(v[1], 2u);
 }


### PR DESCRIPTION
**Problem:** `try_ensure_capacity` multiplied `needed_capacity` by `sizeof(StorageType)` as a raw `size_t` multiply. For any `needed_capacity` larger than `SIZE_MAX` divided by the element size, the product wrapped, `kmalloc_good_size` shrank the request to the wrapped value, and the subsequent `kmalloc_array` call never saw the true product — so its own overflow check couldn’t fire. It then returned success — with `m_capacity` describing a buffer unable to hold the requested number of elements.

**Fix:** Check the multiplication with `Checked` before computing the byte count, and return `ENOMEM` on overflow. So an un-representable size is an allocation that can’t be satisfied — matching the failure mode of the corresponding failed-allocation branch. Every growth path (`resize`, `append`, `insert`, `ensure_capacity`, `grow_capacity`) funnels through that single multiply — so the whole class of overflows fails safely at the container level, regardless of the caller.

This was suggested in https://github.com/LadybirdBrowser/ladybird/issues/10847.
