### PR TITLE
AK: Allocate a growing Vector with a direct kmalloc

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -853,8 +853,9 @@ public:
         new_size_in_bytes *= sizeof(StorageType);
         if (new_size_in_bytes.has_overflow())
             return Error::from_errno(ENOMEM);
-        size_t new_capacity = kmalloc_good_size(new_size_in_bytes.value()) / sizeof(StorageType);
-        auto* new_buffer = static_cast<StorageType*>(kmalloc_array(new_capacity, sizeof(StorageType)));
+        size_t allocation_size = kmalloc_good_size(new_size_in_bytes.value());
+        size_t new_capacity = allocation_size / sizeof(StorageType);
+        auto* new_buffer = static_cast<StorageType*>(kmalloc(allocation_size));
         if (new_buffer == nullptr)
             return Error::from_errno(ENOMEM);
 


### PR DESCRIPTION
The update to `try_ensure_capacity` made in 62272f0997 included computing the new byte size in a `Checked<size_t>` that returns an error on overflow before allocating, but preserved a `kmalloc_array` call that unnecessarily multiplied by the element size a second time, and re-checked the same overflow. So this commit eliminates that redundancy — by further updating `try_ensure_capacity` to take the good size just once, allocate exactly that with `kmalloc`, and derive the capacity from it.
