### PR TITLE
UI/Qt: Forward native window container key events to the host

### DIFF
--- a/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
+++ b/Tests/UI/Qt/TestNativeWindowContainerFocus.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <QApplication>
+#include <QKeyEvent>
 #include <QMouseEvent>
 #include <QWidget>
 #include <QWindow>
@@ -58,6 +59,20 @@ private:
         if (event->type() == QEvent::FocusIn || event->type() == QEvent::FocusOut)
             last_focus_event = event->type();
         return false;
+    }
+};
+
+class KeyEventRecorder final : public QObject {
+public:
+    Qt::Key last_key { Qt::Key_unknown };
+
+private:
+    virtual bool eventFilter(QObject*, QEvent* event) override
+    {
+        if (event->type() != QEvent::KeyPress)
+            return false;
+        last_key = static_cast<Qt::Key>(static_cast<QKeyEvent*>(event)->key());
+        return true;
     }
 };
 
@@ -119,7 +134,7 @@ TEST_CASE(container_focus_events_are_forwarded_to_the_host)
     TestWindow widgets;
 
     QWindow native_window;
-    Ladybird::install_native_window_container_focus_forwarding(widgets.host, native_window, widgets.container);
+    Ladybird::install_native_window_container_event_forwarding(widgets.host, native_window, widgets.container);
 
     FocusEventRecorder recorder;
     widgets.host.installEventFilter(&recorder);
@@ -148,7 +163,7 @@ TEST_CASE(native_window_mouse_press_focuses_the_container)
     TestWindow widgets;
 
     QWindow native_window;
-    Ladybird::install_native_window_container_focus_forwarding(widgets.host, native_window, widgets.container);
+    Ladybird::install_native_window_container_event_forwarding(widgets.host, native_window, widgets.container);
 
     FocusEventRecorder recorder;
     widgets.host.installEventFilter(&recorder);
@@ -172,6 +187,29 @@ TEST_CASE(native_window_mouse_press_focuses_the_container)
 
     EXPECT_EQ(QApplication::focusWidget(), &widgets.container);
     EXPECT_EQ(recorder.last_focus_event, QEvent::FocusIn);
+}
+
+TEST_CASE(container_key_events_are_forwarded_to_the_host)
+{
+    application();
+    TestWindow widgets;
+
+    QWindow native_window;
+    Ladybird::install_native_window_container_event_forwarding(widgets.host, native_window, widgets.container);
+
+    KeyEventRecorder recorder;
+    widgets.host.installEventFilter(&recorder);
+
+    Ladybird::set_native_window_container_visible(widgets.host, widgets.container, true);
+    widgets.host.setFocus();
+    QApplication::processEvents();
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.container);
+
+    QKeyEvent tab_press { QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier };
+    QApplication::sendEvent(&widgets.container, &tab_press);
+
+    EXPECT_EQ(recorder.last_key, Qt::Key_Tab);
+    EXPECT_EQ(QApplication::focusWidget(), &widgets.container);
 }
 
 TEST_CASE(visibility_changes_are_idempotent)

--- a/UI/Qt/NativeWindowContainer.cpp
+++ b/UI/Qt/NativeWindowContainer.cpp
@@ -15,9 +15,9 @@ namespace Ladybird {
 
 namespace {
 
-class FocusEventForwarder final : public QObject {
+class EventForwarder final : public QObject {
 public:
-    FocusEventForwarder(QWidget& host, QWidget& container)
+    EventForwarder(QWidget& host, QWidget& container)
         : QObject(&container)
         , m_host(host)
         , m_container(container)
@@ -34,6 +34,14 @@ private:
                 QFocusEvent forwarded_event { event->type(), static_cast<QFocusEvent*>(event)->reason() };
                 QCoreApplication::sendEvent(&m_host, &forwarded_event);
             }
+            break;
+
+        case QEvent::KeyPress:
+        case QEvent::KeyRelease:
+            // Keyboard input belongs to the host, not the container. Forwarding it from an event filter also preempts
+            // QWidget's Tab focus navigation, which would otherwise consume Tab before the host sees it.
+            if (watched == &m_container)
+                return QCoreApplication::sendEvent(&m_host, event);
             break;
 
         case QEvent::MouseButtonPress:
@@ -75,9 +83,9 @@ void set_native_window_container_visible(QWidget& host, QWidget& container, bool
     }
 }
 
-void install_native_window_container_focus_forwarding(QWidget& host, QWindow& native_window, QWidget& container)
+void install_native_window_container_event_forwarding(QWidget& host, QWindow& native_window, QWidget& container)
 {
-    auto* forwarder = new FocusEventForwarder(host, container);
+    auto* forwarder = new EventForwarder(host, container);
     native_window.installEventFilter(forwarder);
     container.installEventFilter(forwarder);
 }

--- a/UI/Qt/NativeWindowContainer.h
+++ b/UI/Qt/NativeWindowContainer.h
@@ -15,6 +15,6 @@ namespace Ladybird {
 // consistent: The container is the host's focus proxy only while it's visible.
 void set_native_window_container_visible(QWidget& host, QWidget& container, bool visible);
 
-void install_native_window_container_focus_forwarding(QWidget& host, QWindow& native_window, QWidget& container);
+void install_native_window_container_event_forwarding(QWidget& host, QWindow& native_window, QWidget& container);
 
 }

--- a/UI/Qt/WebContentViewLinux.cpp
+++ b/UI/Qt/WebContentViewLinux.cpp
@@ -951,7 +951,7 @@ void WebContentView::create_vulkan_window()
     m_vulkan_window_container->setGeometry(rect());
     m_vulkan_window_container->hide();
 
-    install_native_window_container_focus_forwarding(*this, *m_vulkan_window, *m_vulkan_window_container);
+    install_native_window_container_event_forwarding(*this, *m_vulkan_window, *m_vulkan_window_container);
 }
 
 bool WebContentView::vulkan_window_has_native_focus() const


### PR DESCRIPTION
Previously, on Wayland, tab keypresses over the web content moved focus to the location bar instead of cycling through the focusable elements of the page. A Wayland subsurface cannot take keyboard focus, so the platform delivers key events to the container widget embedding the native window rather than to the window itself. Unhandled keys propagate from the container up to the web content view, but the container consumes Tab and Shift+Tab for focus navigation before the view ever sees them.

We now forward key events from the container to the host view through the event filter already installed on the container. The filter runs before the container's own event handling, so the view now receives Tab and Shift+Tab along with every other key.