### PR TITLE
LibWeb: Add shared layout node storage for Rust

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -825,6 +825,7 @@ set(SOURCES
     Layout/ListItemMarkerBox.cpp
     Layout/NavigableContainerViewport.cpp
     Layout/Node.cpp
+    Layout/NodeArena.cpp
     Layout/RadioButton.cpp
     Layout/RangeInputBox.cpp
     Layout/ReplacedBox.cpp

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -188,6 +188,7 @@
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
+#include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/SVGFormattingContext.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
 #include <LibWeb/Layout/ScrollableOverflow.h>
@@ -618,6 +619,15 @@ Document::Document(JS::Realm& realm, URL::URL const& url)
 }
 
 Document::~Document() = default;
+
+Layout::NodeArena& Document::layout_node_arena()
+{
+    // Created on first layout node so documents that never build a layout tree (e.g. temporary
+    // fragment-parsing documents) skip the Rust arena round-trip entirely.
+    if (!m_layout_node_arena)
+        m_layout_node_arena = make_ref_counted<Layout::NodeArena>();
+    return *m_layout_node_arena;
+}
 
 void Document::set_temporary_document_for_fragment_parsing(Badge<HTML::HTMLParser>)
 {

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -746,6 +746,7 @@ public:
     // one at construction; a full layout pass renumbers the whole tree densely and resets the
     // counter past the dense range.
     [[nodiscard]] u32 allocate_layout_node_index() { return m_next_layout_node_index++; }
+    [[nodiscard]] Layout::NodeArena& layout_node_arena();
     void reset_layout_node_index_counter(u32 next_index)
     {
         m_next_layout_node_index = next_index;
@@ -1422,6 +1423,7 @@ private:
 
     GC::Ptr<HTML::Window> m_window;
 
+    RefPtr<Layout::NodeArena> m_layout_node_arena;
     RefPtr<Layout::Viewport> m_layout_root;
 
     GC::Ptr<Node> m_hovered_node;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -986,6 +986,7 @@ class LineBoxFragment;
 class ListItemBox;
 class ListItemMarkerBox;
 class Node;
+class NodeArena;
 class NodeWithStyle;
 class NodeWithStyleAndBoxModelMetrics;
 class RadioButton;

--- a/Libraries/LibWeb/Layout/AudioBox.h
+++ b/Libraries/LibWeb/Layout/AudioBox.h
@@ -13,8 +13,7 @@
 namespace Web::Layout {
 
 class AudioBox final : public ReplacedBox {
-    GC_CELL(AudioBox, ReplacedBox);
-    GC_DECLARE_ALLOCATOR(AudioBox);
+    LAYOUT_NODE(AudioBox, ReplacedBox);
 
 public:
     AudioBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const>);

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -44,8 +44,7 @@ struct IntrinsicSizes {
 };
 
 class WEB_API Box : public NodeWithStyleAndBoxModelMetrics {
-    GC_CELL(Box, NodeWithStyleAndBoxModelMetrics);
-    GC_DECLARE_ALLOCATOR(Box);
+    LAYOUT_NODE(Box, NodeWithStyleAndBoxModelMetrics);
 
 public:
     RefPtr<Painting::Paintable const> paintable_box() const;
@@ -87,18 +86,18 @@ public:
     // Whether an absolutely or fixed positioned descendant of this box has its containing
     // block outside this box's subtree, so the descendant's layout escapes the subtree.
     // Re-derived whenever containing block pointers are recomputed.
-    bool abspos_descendant_escapes() const { return m_abspos_descendant_escapes; }
-    void set_abspos_descendant_escapes(bool value) { m_abspos_descendant_escapes = value; }
+    bool abspos_descendant_escapes() const { return has_flag(RustFFI::NodeFlag::AbsposDescendantEscapes); }
+    void set_abspos_descendant_escapes(bool value) { set_flag(RustFFI::NodeFlag::AbsposDescendantEscapes, value); }
 
     void set_default_scroll_shift(WeakPtr<Node> anchor, bool compensates_for_horizontal_scroll, bool compensates_for_vertical_scroll)
     {
         m_default_scroll_shift_anchor = move(anchor);
-        m_compensates_for_horizontal_scroll = compensates_for_horizontal_scroll;
-        m_compensates_for_vertical_scroll = compensates_for_vertical_scroll;
+        set_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll, compensates_for_horizontal_scroll);
+        set_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll, compensates_for_vertical_scroll);
     }
     Node* default_scroll_shift_anchor() const { return m_default_scroll_shift_anchor.ptr(); }
-    bool compensates_for_horizontal_scroll() const { return m_compensates_for_horizontal_scroll; }
-    bool compensates_for_vertical_scroll() const { return m_compensates_for_vertical_scroll; }
+    bool compensates_for_horizontal_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForHorizontalScroll); }
+    bool compensates_for_vertical_scroll() const { return has_flag(RustFFI::NodeFlag::CompensatesForVerticalScroll); }
 
     IntrinsicSizes& cached_intrinsic_sizes() const
     {
@@ -119,9 +118,6 @@ private:
     OwnPtr<AbsposLayoutInputs> m_saved_abspos_layout_inputs;
 
     WeakPtr<Node> m_default_scroll_shift_anchor;
-    bool m_compensates_for_horizontal_scroll { false };
-    bool m_compensates_for_vertical_scroll { false };
-    bool m_abspos_descendant_escapes { false };
 
     OwnPtr<IntrinsicSizes> mutable m_cached_intrinsic_sizes;
 };

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -23,6 +23,7 @@
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -38,10 +39,27 @@
 
 namespace Web::Layout {
 
-Node::Node(DOM::Document& document, DOM::Node* node, AttachToDOMNode attach_to_dom_node)
-    : m_dom_node(node ? *node : document)
-    , m_anonymous(node == nullptr)
+NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document)
+    : m_arena(document.layout_node_arena())
 {
+    auto allocation = m_arena->allocate();
+    m_slot = allocation.slot;
+    m_data = allocation.data;
+    m_slot_generation = allocation.generation;
+}
+
+NodeArenaAllocation::~NodeArenaAllocation()
+{
+    m_arena->free(m_slot, m_slot_generation);
+}
+
+Node::Node(DOM::Document& document, DOM::Node* node, AttachToDOMNode attach_to_dom_node)
+    : NodeArenaAllocation(document)
+    , m_dom_node(node ? *node : document)
+{
+    set_node_kind(RustFFI::NodeKind::Node);
+    set_flag(RustFFI::NodeFlag::Anonymous, node == nullptr);
+
     if (node && attach_to_dom_node == AttachToDOMNode::Yes)
         node->set_layout_node({}, *this);
 }
@@ -50,6 +68,32 @@ Node::~Node()
 {
     if (m_paintable)
         m_paintable->detach_from_layout_node({});
+}
+
+RustFFI::NodeSlotId Node::slot_id(Node const* node)
+{
+    return node ? node->m_slot : RustFFI::NodeSlotId_INVALID;
+}
+
+void Node::synchronize_topology()
+{
+    m_data->parent = slot_id(Base::parent_ptr());
+    m_data->first_child = slot_id(Base::first_child_ptr());
+    m_data->last_child = slot_id(Base::last_child_ptr());
+    m_data->previous_sibling = slot_id(Base::previous_sibling_ptr());
+    m_data->next_sibling = slot_id(Base::next_sibling_ptr());
+}
+
+void Node::set_containing_block(Box* containing_block)
+{
+    m_containing_block = containing_block;
+    m_data->containing_block = slot_id(containing_block);
+}
+
+void Node::set_inline_containing_block(InlineNode const* containing_block)
+{
+    m_inline_containing_block_if_applicable = containing_block;
+    m_data->inline_containing_block = slot_id(containing_block);
 }
 
 static void invalidate_paint_caches(Node& node)
@@ -283,10 +327,10 @@ static Box* nearest_ancestor_capable_of_forming_a_containing_block(Node& node)
 void Node::recompute_containing_block(Badge<DOM::Document>)
 {
     // Reset the inline containing block - we'll set it below if applicable.
-    m_inline_containing_block_if_applicable = nullptr;
+    set_inline_containing_block(nullptr);
 
     if (is<TextNode>(*this)) {
-        m_containing_block = nearest_ancestor_capable_of_forming_a_containing_block(*this);
+        set_containing_block(nearest_ancestor_capable_of_forming_a_containing_block(*this));
         return;
     }
 
@@ -297,7 +341,7 @@ void Node::recompute_containing_block(Badge<DOM::Document>)
         auto* ancestor = parent();
         while (ancestor && !ancestor->establishes_an_absolute_positioning_containing_block())
             ancestor = ancestor->parent();
-        m_containing_block = static_cast<Box*>(ancestor);
+        set_containing_block(static_cast<Box*>(ancestor));
 
         // FIXME: Containing block handling for absolutely positioned elements needs architectural improvements.
         //
@@ -355,7 +399,7 @@ void Node::recompute_containing_block(Badge<DOM::Document>)
                     || computed_values.filter().has_filters() || will_change.has_property(CSS::PropertyID::Filter)
                     || computed_values.backdrop_filter().has_filters() || will_change.has_property(CSS::PropertyID::BackdropFilter);
                 if (inline_establishes_cb) {
-                    m_inline_containing_block_if_applicable = &as<InlineNode>(*layout_node);
+                    set_inline_containing_block(&as<InlineNode>(*layout_node));
                     break;
                 }
             }
@@ -382,11 +426,11 @@ void Node::recompute_containing_block(Badge<DOM::Document>)
             //   page. (They are fixed with respect to the page box only, and are not affected by being seen through a
             //   viewport; as in the case of print preview, for example.)
         }
-        m_containing_block = static_cast<Box*>(ancestor);
+        set_containing_block(static_cast<Box*>(ancestor));
         return;
     }
 
-    m_containing_block = nearest_ancestor_capable_of_forming_a_containing_block(*this);
+    set_containing_block(nearest_ancestor_capable_of_forming_a_containing_block(*this));
 }
 
 // returns containing block this node would have had if its position was static
@@ -591,10 +635,11 @@ bool NodeWithStyle::is_sticky_position() const
 NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::ComputedValues const> computed_values)
     : Node(document, node)
     , m_computed_values(move(computed_values))
-    , m_layout_index(document.allocate_layout_node_index())
 {
-    m_has_style = true;
-    m_is_body = node && node == document.body();
+    node_data().layout_index = document.allocate_layout_node_index();
+    node_data().style = m_computed_values.ptr();
+    set_flag(RustFFI::NodeFlag::HasStyle, true);
+    set_flag(RustFFI::NodeFlag::IsBody, node && node == document.body());
 }
 
 NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)
@@ -667,7 +712,7 @@ namespace Web::Layout {
 
 void NodeWithStyle::apply_style(NonnullRefPtr<CSS::ComputedValues const> computed_values)
 {
-    m_computed_values = move(computed_values);
+    set_computed_values(move(computed_values));
 
     propagate_style_to_anonymous_wrappers();
 
@@ -900,6 +945,7 @@ NonnullRefPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const
 void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const> computed_values)
 {
     m_computed_values = move(computed_values);
+    node_data().style = m_computed_values.ptr();
 }
 
 void NodeWithStyle::set_display(CSS::Display display)
@@ -1036,14 +1082,9 @@ RefPtr<Painting::Paintable> Node::create_paintable() const
     return nullptr;
 }
 
-bool Node::is_anonymous() const
-{
-    return m_anonymous;
-}
-
 DOM::Node const* Node::dom_node() const
 {
-    if (m_anonymous)
+    if (is_anonymous())
         return nullptr;
     VERIFY(m_dom_node);
     return m_dom_node.ptr();
@@ -1051,7 +1092,7 @@ DOM::Node const* Node::dom_node() const
 
 DOM::Node* Node::dom_node()
 {
-    if (m_anonymous)
+    if (is_anonymous())
         return nullptr;
     VERIFY(m_dom_node);
     return m_dom_node.ptr();
@@ -1059,21 +1100,21 @@ DOM::Node* Node::dom_node()
 
 DOM::Element const* Node::pseudo_element_generator() const
 {
-    VERIFY(m_generated_for.has_value());
+    VERIFY(is_generated_for_pseudo_element());
     VERIFY(m_pseudo_element_generator);
     return m_pseudo_element_generator.ptr();
 }
 
 DOM::Element* Node::pseudo_element_generator()
 {
-    VERIFY(m_generated_for.has_value());
+    VERIFY(is_generated_for_pseudo_element());
     VERIFY(m_pseudo_element_generator);
     return m_pseudo_element_generator.ptr();
 }
 
 void Node::set_generated_for(CSS::PseudoElement type, DOM::Element& element)
 {
-    m_generated_for = type;
+    m_data->generated_for = encode_generated_for(type);
     m_pseudo_element_generator = element;
 }
 
@@ -1294,7 +1335,7 @@ bool NodeWithStyleAndBoxModelMetrics::is_inline_flow_interrupting_block() const
 
 void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdatePropagation propagation)
 {
-    if (m_needs_layout_update && propagation == LayoutUpdatePropagation::ThroughAncestors) {
+    if (needs_layout_update() && propagation == LayoutUpdatePropagation::ThroughAncestors) {
         // A dirty node normally implies dirty ancestors, but the walk that marked a partial
         // relayout boundary stopped there and left its ancestors clean, so a through-ancestors
         // invalidation arriving on the boundary itself must still walk and mark them.
@@ -1303,7 +1344,7 @@ void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdat
             return;
     }
 
-    if (!m_needs_layout_update) {
+    if (!needs_layout_update()) {
         if constexpr (UPDATE_LAYOUT_DEBUG) {
             // NOTE: We check some conditions here to avoid debug spam in documents that don't do layout.
             auto navigable = this->navigable();
@@ -1311,7 +1352,7 @@ void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdat
                 dbgln_if(UPDATE_LAYOUT_DEBUG, "NEED LAYOUT {}", DOM::to_string(reason));
         }
 
-        m_needs_layout_update = true;
+        set_flag(RustFFI::NodeFlag::NeedsLayoutUpdate, true);
     }
 
     if (auto* box = as_if<Box>(this))
@@ -1321,7 +1362,7 @@ void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdat
     // NOTE: if this node generated an anonymous parent, all ancestors are indiscriminately marked below.
     for_each_child_of_type<Box>([&](Box& child) {
         if (child.is_anonymous() && !is<TableWrapper>(child)) {
-            child.m_needs_layout_update = true;
+            child.set_flag(RustFFI::NodeFlag::NeedsLayoutUpdate, true);
             child.reset_cached_intrinsic_sizes();
         }
         return IterationDecision::Continue;
@@ -1333,9 +1374,9 @@ void Node::set_needs_layout_update(DOM::SetNeedsLayoutReason reason, LayoutUpdat
     }
 
     for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
-        if (ancestor->m_needs_layout_update)
+        if (ancestor->needs_layout_update())
             break;
-        ancestor->m_needs_layout_update = true;
+        ancestor->set_flag(RustFFI::NodeFlag::NeedsLayoutUpdate, true);
         if (auto* box = as_if<Box>(ancestor); box && box->is_partial_relayout_boundary()) {
             document().partial_relayout_invalidation().record_boundary(*box);
             break;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -39,6 +39,48 @@
 
 namespace Web::Layout {
 
+static RustFFI::FfiTableDisplay table_display(CSS::Display display)
+{
+    if (display.is_table_inside())
+        return RustFFI::FfiTableDisplay::TableRoot;
+    if (display.is_table_row_group())
+        return RustFFI::FfiTableDisplay::TableRowGroup;
+    if (display.is_table_header_group())
+        return RustFFI::FfiTableDisplay::TableHeaderGroup;
+    if (display.is_table_footer_group())
+        return RustFFI::FfiTableDisplay::TableFooterGroup;
+    if (display.is_table_column_group())
+        return RustFFI::FfiTableDisplay::TableColumnGroup;
+    if (display.is_table_column())
+        return RustFFI::FfiTableDisplay::TableColumn;
+    if (display.is_table_row())
+        return RustFFI::FfiTableDisplay::TableRow;
+    if (display.is_table_cell())
+        return RustFFI::FfiTableDisplay::TableCell;
+    if (display.is_table_caption())
+        return RustFFI::FfiTableDisplay::TableCaption;
+    return RustFFI::FfiTableDisplay::Other;
+}
+
+static u8 display_bits(CSS::ComputedValues const& computed_values)
+{
+    auto display = computed_values.display();
+    u8 bits = 0;
+    auto set = [&](RustFFI::NodeDisplayFlag flag, bool value) {
+        if (value)
+            bits |= static_cast<u8>(flag);
+    };
+    set(RustFFI::NodeDisplayFlag::InlineOutside, display.is_inline_outside());
+    set(RustFFI::NodeDisplayFlag::FlowInside, display.is_flow_inside());
+    set(RustFFI::NodeDisplayFlag::FlexInside, display.is_flex_inside());
+    set(RustFFI::NodeDisplayFlag::GridInside, display.is_grid_inside());
+    set(RustFFI::NodeDisplayFlag::Floating, computed_values.float_() != CSS::Float::None);
+    auto position = computed_values.position();
+    set(RustFFI::NodeDisplayFlag::AbsolutelyPositioned,
+        position == CSS::Positioning::Absolute || position == CSS::Positioning::Fixed);
+    return bits;
+}
+
 NodeArenaAllocation::NodeArenaAllocation(DOM::Document& document)
     : m_arena(document.layout_node_arena())
 {
@@ -57,8 +99,13 @@ Node::Node(DOM::Document& document, DOM::Node* node, AttachToDOMNode attach_to_d
     : NodeArenaAllocation(document)
     , m_dom_node(node ? *node : document)
 {
+    m_data->shell = this;
     set_node_kind(RustFFI::NodeKind::Node);
     set_flag(RustFFI::NodeFlag::Anonymous, node == nullptr);
+    // Some native controls use a generic box so they can host their internal shadow tree, but
+    // remain replaced elements for CSS box generation and inline layout. (ReplacedBox's
+    // constructor sets the flag for actual replaced boxes.)
+    set_flag(RustFFI::NodeFlag::IsReplacedElement, node && is<HTML::HTMLInputElement>(*node));
 
     if (node && attach_to_dom_node == AttachToDOMNode::Yes)
         node->set_layout_node({}, *this);
@@ -73,6 +120,24 @@ Node::~Node()
 RustFFI::NodeSlotId Node::slot_id(Node const* node)
 {
     return node ? node->m_slot : RustFFI::NodeSlotId_INVALID;
+}
+
+void Node::set_node_kind(RustFFI::NodeKind kind)
+{
+    m_data->kind = kind;
+#ifndef NDEBUG
+    VERIFY(RustFFI::layout_node_kind_facts_match(kind, {
+                                                           .is_box = is_box(),
+                                                           .is_block_container = is_block_container(),
+                                                           .is_text = is_text_node(),
+                                                           .is_svg_box = is_svg_box(),
+                                                       }));
+#endif
+}
+
+void* Node::arena_handle() const
+{
+    return m_arena->handle();
 }
 
 void Node::synchronize_topology()
@@ -637,9 +702,9 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRe
     , m_computed_values(move(computed_values))
 {
     node_data().layout_index = document.allocate_layout_node_index();
-    node_data().style = m_computed_values.ptr();
     set_flag(RustFFI::NodeFlag::HasStyle, true);
     set_flag(RustFFI::NodeFlag::IsBody, node && node == document.body());
+    mirror_computed_values_to_node_data();
 }
 
 NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)
@@ -848,9 +913,7 @@ bool NodeWithStyle::is_inline_table() const
 
 bool Node::is_replaced_element() const
 {
-    // Some native controls use a generic box so they can host their internal shadow tree, but
-    // remain replaced elements for CSS box generation and inline layout.
-    return is_replaced_box() || is<HTML::HTMLInputElement>(dom_node());
+    return has_flag(RustFFI::NodeFlag::IsReplacedElement);
 }
 
 bool NodeWithStyle::has_replaced_element_table_display_adjustment() const
@@ -945,7 +1008,15 @@ NonnullRefPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const
 void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const> computed_values)
 {
     m_computed_values = move(computed_values);
+    mirror_computed_values_to_node_data();
+}
+
+void NodeWithStyle::mirror_computed_values_to_node_data()
+{
     node_data().style = m_computed_values.ptr();
+    node_data().table_display = table_display(m_computed_values->display());
+    node_data().table_display_before = table_display(m_computed_values->display_before_box_type_transformation());
+    node_data().display_bits = display_bits(*m_computed_values);
 }
 
 void NodeWithStyle::set_display(CSS::Display display)
@@ -1114,6 +1185,7 @@ DOM::Element* Node::pseudo_element_generator()
 
 void Node::set_generated_for(CSS::PseudoElement type, DOM::Element& element)
 {
+    static_assert(encode_generated_for(CSS::PseudoElement::Marker) == RustFFI::GENERATED_FOR_MARKER);
     m_data->generated_for = encode_generated_for(type);
     m_pseudo_element_generator = element;
 }

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -20,11 +20,39 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Layout/TreeBuilderRustFFI.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/RefCountedTreeNode.h>
 
 namespace Web::Layout {
+
+static_assert(sizeof(RustFFI::NodeSlotId) == sizeof(u32));
+static_assert(offsetof(RustFFI::NodeSlotId, index) == 0);
+
+static_assert(sizeof(RustFFI::NodeData) == 56);
+static_assert(offsetof(RustFFI::NodeData, parent) == 0);
+static_assert(offsetof(RustFFI::NodeData, first_child) == 4);
+static_assert(offsetof(RustFFI::NodeData, last_child) == 8);
+static_assert(offsetof(RustFFI::NodeData, previous_sibling) == 12);
+static_assert(offsetof(RustFFI::NodeData, next_sibling) == 16);
+static_assert(offsetof(RustFFI::NodeData, containing_block) == 20);
+static_assert(offsetof(RustFFI::NodeData, inline_containing_block) == 24);
+static_assert(offsetof(RustFFI::NodeData, kind) == 28);
+static_assert(offsetof(RustFFI::NodeData, generated_for) == 29);
+static_assert(offsetof(RustFFI::NodeData, flags) == 32);
+static_assert(offsetof(RustFFI::NodeData, initial_quote_nesting_level) == 36);
+static_assert(offsetof(RustFFI::NodeData, layout_index) == 40);
+static_assert(offsetof(RustFFI::NodeData, style) == 48);
+
+static_assert(sizeof(RustFFI::NodeKind) == sizeof(u8));
+static_assert(sizeof(RustFFI::NodeFlag) == sizeof(u32));
+
+class NodeKindSetter;
+
+#define LAYOUT_NODE_KIND(class_) \
+private:                         \
+    NO_UNIQUE_ADDRESS NodeKindSetter m_node_kind_setter { *this, RustFFI::NodeKind::class_ }
 
 #define LAYOUT_NODE(class_, base_class)            \
 public:                                            \
@@ -32,7 +60,8 @@ public:                                            \
     virtual StringView class_name() const override \
     {                                              \
         return #class_##sv;                        \
-    }
+    }                                              \
+    LAYOUT_NODE_KIND(class_)
 
 class InlineNode;
 
@@ -52,9 +81,21 @@ enum class LayoutMode {
     IntrinsicSizing,
 };
 
+class NodeArenaAllocation {
+protected:
+    explicit NodeArenaAllocation(DOM::Document&);
+    ~NodeArenaAllocation();
+
+    NonnullRefPtr<NodeArena> m_arena;
+    RustFFI::NodeSlotId m_slot {};
+    RustFFI::NodeData* m_data { nullptr };
+    u32 m_slot_generation { 0 };
+};
+
 class WEB_API Node
     : public RefCounted<Node>
     , public Weakable<Node>
+    , private NodeArenaAllocation
     , public RefCountedTreeNode<Node> {
 
 public:
@@ -65,31 +106,36 @@ public:
     virtual ~Node();
     virtual StringView class_name() const { return "Node"sv; }
 
-    bool is_anonymous() const;
+    bool is_anonymous() const { return has_flag(RustFFI::NodeFlag::Anonymous); }
     DOM::Node const* dom_node() const;
     DOM::Node* dom_node();
 
     DOM::Element const* pseudo_element_generator() const;
     DOM::Element* pseudo_element_generator();
 
-    bool needs_layout_update() const { return m_needs_layout_update; }
+    bool needs_layout_update() const { return has_flag(RustFFI::NodeFlag::NeedsLayoutUpdate); }
 
     // Set when a style change altered geometry-determining properties of this node itself, so
     // a partial relayout must re-resolve its own size and position instead of reusing them.
-    bool needs_own_geometry_update() const { return m_needs_own_geometry_update; }
-    void set_needs_own_geometry_update() { m_needs_own_geometry_update = true; }
+    bool needs_own_geometry_update() const { return has_flag(RustFFI::NodeFlag::NeedsOwnGeometryUpdate); }
+    void set_needs_own_geometry_update() { set_flag(RustFFI::NodeFlag::NeedsOwnGeometryUpdate, true); }
     void set_needs_layout_update(DOM::SetNeedsLayoutReason, LayoutUpdatePropagation = LayoutUpdatePropagation::ThroughAncestors);
     void reset_needs_layout_update()
     {
-        m_needs_layout_update = false;
-        m_needs_own_geometry_update = false;
+        set_flag(RustFFI::NodeFlag::NeedsLayoutUpdate, false);
+        set_flag(RustFFI::NodeFlag::NeedsOwnGeometryUpdate, false);
     }
 
-    bool is_generated_for_pseudo_element() const { return m_generated_for.has_value(); }
-    Optional<CSS::PseudoElement> generated_for_pseudo_element() const { return m_generated_for; }
-    bool is_generated_for_before_pseudo_element() const { return m_generated_for == CSS::PseudoElement::Before; }
-    bool is_generated_for_after_pseudo_element() const { return m_generated_for == CSS::PseudoElement::After; }
-    bool is_generated_for_backdrop_pseudo_element() const { return m_generated_for == CSS::PseudoElement::Backdrop; }
+    bool is_generated_for_pseudo_element() const { return m_data->generated_for != 0; }
+    Optional<CSS::PseudoElement> generated_for_pseudo_element() const
+    {
+        if (!is_generated_for_pseudo_element())
+            return {};
+        return static_cast<CSS::PseudoElement>(m_data->generated_for - 1);
+    }
+    bool is_generated_for_before_pseudo_element() const { return m_data->generated_for == encode_generated_for(CSS::PseudoElement::Before); }
+    bool is_generated_for_after_pseudo_element() const { return m_data->generated_for == encode_generated_for(CSS::PseudoElement::After); }
+    bool is_generated_for_backdrop_pseudo_element() const { return m_data->generated_for == encode_generated_for(CSS::PseudoElement::Backdrop); }
     void set_generated_for(CSS::PseudoElement type, DOM::Element&);
 
     RefPtr<Painting::Paintable> paintable() { return m_paintable; }
@@ -119,7 +165,7 @@ public:
 
     String debug_description() const;
 
-    bool has_style() const { return m_has_style; }
+    bool has_style() const { return has_flag(RustFFI::NodeFlag::HasStyle); }
     bool has_style_or_parent_with_style() const;
 
     virtual bool can_have_children() const { return true; }
@@ -173,11 +219,11 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
-    bool is_flex_item() const { return m_is_flex_item; }
-    void set_flex_item(bool b) { m_is_flex_item = b; }
+    bool is_flex_item() const { return has_flag(RustFFI::NodeFlag::IsFlexItem); }
+    void set_flex_item(bool value) { set_flag(RustFFI::NodeFlag::IsFlexItem, value); }
 
-    bool is_grid_item() const { return m_is_grid_item; }
-    void set_grid_item(bool b) { m_is_grid_item = b; }
+    bool is_grid_item() const { return has_flag(RustFFI::NodeFlag::IsGridItem); }
+    void set_grid_item(bool value) { set_flag(RustFFI::NodeFlag::IsGridItem, value); }
 
     bool vertical_align_applies() const
     {
@@ -226,17 +272,17 @@ public:
     void removed_from(Node&) { }
     void children_changed() { }
 
-    bool children_are_inline() const { return m_children_are_inline; }
-    void set_children_are_inline(bool value) { m_children_are_inline = value; }
+    bool children_are_inline() const { return has_flag(RustFFI::NodeFlag::ChildrenAreInline); }
+    void set_children_are_inline(bool value) { set_flag(RustFFI::NodeFlag::ChildrenAreInline, value); }
 
-    u32 initial_quote_nesting_level() const { return m_initial_quote_nesting_level; }
-    void set_initial_quote_nesting_level(u32 value) { m_initial_quote_nesting_level = value; }
+    u32 initial_quote_nesting_level() const { return m_data->initial_quote_nesting_level; }
+    void set_initial_quote_nesting_level(u32 value) { m_data->initial_quote_nesting_level = value; }
 
     // https://drafts.csswg.org/css-ui/#propdef-user-select
     CSS::UserSelect user_select_used_value() const;
 
-    [[nodiscard]] bool has_been_wrapped_in_table_wrapper() const { return m_has_been_wrapped_in_table_wrapper; }
-    void set_has_been_wrapped_in_table_wrapper(bool value) { m_has_been_wrapped_in_table_wrapper = value; }
+    [[nodiscard]] bool has_been_wrapped_in_table_wrapper() const { return has_flag(RustFFI::NodeFlag::HasBeenWrappedInTableWrapper); }
+    void set_has_been_wrapped_in_table_wrapper(bool value) { set_flag(RustFFI::NodeFlag::HasBeenWrappedInTableWrapper, value); }
 
     enum class AttachToDOMNode {
         No,
@@ -246,8 +292,38 @@ public:
 protected:
     Node(DOM::Document&, DOM::Node*, AttachToDOMNode = AttachToDOMNode::Yes);
 
+    bool has_flag(RustFFI::NodeFlag flag) const
+    {
+        return (m_data->flags & static_cast<u32>(flag)) != 0;
+    }
+
+    void set_flag(RustFFI::NodeFlag flag, bool value)
+    {
+        if (value)
+            m_data->flags |= static_cast<u32>(flag);
+        else
+            m_data->flags &= ~static_cast<u32>(flag);
+    }
+
+    RustFFI::NodeData& node_data() { return *m_data; }
+    RustFFI::NodeData const& node_data() const { return *m_data; }
+
 private:
     friend class NodeWithStyle;
+    friend class NodeKindSetter;
+    friend class RefCountedTreeNode<Node>;
+
+    static constexpr u8 encode_generated_for(CSS::PseudoElement pseudo_element)
+    {
+        static_assert(static_cast<u8>(CSS::PseudoElement::UnknownWebKit) < 0xff);
+        return static_cast<u8>(pseudo_element) + 1;
+    }
+
+    static RustFFI::NodeSlotId slot_id(Node const*);
+    void set_containing_block(Box*);
+    void set_inline_containing_block(InlineNode const*);
+    void set_node_kind(RustFFI::NodeKind kind) { m_data->kind = kind; }
+    void synchronize_topology();
 
     // A DOM mutation can disconnect a node before the next layout-tree update. Keep the DOM node alive until this
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
@@ -264,23 +340,14 @@ private:
     InlineNode const* m_inline_containing_block_if_applicable { nullptr };
 
     GC::Weak<DOM::Element> m_pseudo_element_generator;
+};
 
-    bool m_anonymous { false };
-    bool m_has_style { false };
-    bool m_children_are_inline { false };
-
-    bool m_is_flex_item { false };
-    bool m_is_grid_item { false };
-
-    bool m_has_been_wrapped_in_table_wrapper { false };
-    bool m_is_body { false };
-
-    bool m_needs_layout_update { false };
-    bool m_needs_own_geometry_update { false };
-
-    Optional<CSS::PseudoElement> m_generated_for;
-
-    u32 m_initial_quote_nesting_level { 0 };
+class NodeKindSetter {
+public:
+    NodeKindSetter(Node& node, RustFFI::NodeKind kind)
+    {
+        node.set_node_kind(kind);
+    }
 };
 
 class WEB_API NodeWithStyle : public Node {
@@ -376,7 +443,7 @@ public:
 
     void transfer_table_box_computed_values_to_wrapper_computed_values(CSS::ComputedValues::Builder& wrapper_computed_values);
 
-    bool is_body() const { return m_is_body; }
+    bool is_body() const { return has_flag(RustFFI::NodeFlag::IsBody); }
     bool is_scroll_container() const;
 
     void set_computed_values(NonnullRefPtr<CSS::ComputedValues const>);
@@ -385,8 +452,8 @@ public:
     void set_content(CSS::ContentData const&);
     void set_overflow(CSS::Overflow overflow_x, CSS::Overflow overflow_y);
 
-    u32 layout_index() const { return m_layout_index; }
-    void set_layout_index(u32 index) { m_layout_index = index; }
+    u32 layout_index() const { return node_data().layout_index; }
+    void set_layout_index(u32 index) { node_data().layout_index = index; }
 
 protected:
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::ComputedValues const>);
@@ -402,7 +469,6 @@ private:
 
     NonnullRefPtr<CSS::ComputedValues const> m_computed_values;
     Vector<NonnullOwnPtr<ImageObserver>> m_image_observers;
-    u32 m_layout_index { 0 };
 };
 
 template<>
@@ -429,13 +495,13 @@ inline bool Node::fast_is<NodeWithStyleAndBoxModelMetrics>() const { return is_n
 
 inline bool Node::has_style_or_parent_with_style() const
 {
-    return m_has_style || (parent() != nullptr && parent()->has_style_or_parent_with_style());
+    return has_style() || (parent() != nullptr && parent()->has_style_or_parent_with_style());
 }
 
 inline Gfx::Font const& Node::first_available_font() const
 {
     VERIFY(has_style_or_parent_with_style());
-    if (m_has_style)
+    if (has_style())
         return static_cast<NodeWithStyle const*>(this)->first_available_font();
     return parent()->first_available_font();
 }

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -30,7 +30,7 @@ namespace Web::Layout {
 static_assert(sizeof(RustFFI::NodeSlotId) == sizeof(u32));
 static_assert(offsetof(RustFFI::NodeSlotId, index) == 0);
 
-static_assert(sizeof(RustFFI::NodeData) == 56);
+static_assert(sizeof(RustFFI::NodeData) == 64);
 static_assert(offsetof(RustFFI::NodeData, parent) == 0);
 static_assert(offsetof(RustFFI::NodeData, first_child) == 4);
 static_assert(offsetof(RustFFI::NodeData, last_child) == 8);
@@ -43,10 +43,16 @@ static_assert(offsetof(RustFFI::NodeData, generated_for) == 29);
 static_assert(offsetof(RustFFI::NodeData, flags) == 32);
 static_assert(offsetof(RustFFI::NodeData, initial_quote_nesting_level) == 36);
 static_assert(offsetof(RustFFI::NodeData, layout_index) == 40);
+static_assert(offsetof(RustFFI::NodeData, table_display) == 44);
+static_assert(offsetof(RustFFI::NodeData, table_display_before) == 45);
+static_assert(offsetof(RustFFI::NodeData, display_bits) == 46);
 static_assert(offsetof(RustFFI::NodeData, style) == 48);
+static_assert(offsetof(RustFFI::NodeData, shell) == 56);
 
 static_assert(sizeof(RustFFI::NodeKind) == sizeof(u8));
 static_assert(sizeof(RustFFI::NodeFlag) == sizeof(u32));
+static_assert(sizeof(RustFFI::NodeDisplayFlag) == sizeof(u8));
+static_assert(sizeof(RustFFI::FfiTableDisplay) == sizeof(u8));
 
 class NodeKindSetter;
 
@@ -105,6 +111,9 @@ public:
 
     virtual ~Node();
     virtual StringView class_name() const { return "Node"sv; }
+
+    static RustFFI::NodeSlotId slot_id(Node const*);
+    void* arena_handle() const;
 
     bool is_anonymous() const { return has_flag(RustFFI::NodeFlag::Anonymous); }
     DOM::Node const* dom_node() const;
@@ -319,10 +328,9 @@ private:
         return static_cast<u8>(pseudo_element) + 1;
     }
 
-    static RustFFI::NodeSlotId slot_id(Node const*);
     void set_containing_block(Box*);
     void set_inline_containing_block(InlineNode const*);
-    void set_node_kind(RustFFI::NodeKind kind) { m_data->kind = kind; }
+    void set_node_kind(RustFFI::NodeKind);
     void synchronize_topology();
 
     // A DOM mutation can disconnect a node before the next layout-tree update. Keep the DOM node alive until this
@@ -464,6 +472,7 @@ private:
     void reset_table_box_computed_values_used_by_wrapper_to_init_values();
     void propagate_non_inherit_values(CSS::ComputedValues::Builder&) const;
     void propagate_style_to_anonymous_wrappers();
+    void mirror_computed_values_to_node_data();
 
     void rebuild_image_observers();
 

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <LibWeb/Layout/NodeArena.h>
+
+namespace Web::Layout {
+
+NodeArena::NodeArena()
+    : m_handle(RustFFI::layout_arena_create())
+{
+    VERIFY(m_handle);
+}
+
+NodeArena::~NodeArena()
+{
+    RustFFI::layout_arena_destroy(m_handle);
+}
+
+RustFFI::NodeAllocation NodeArena::allocate()
+{
+    auto allocation = RustFFI::layout_arena_allocate(m_handle);
+    VERIFY(allocation.data);
+    return allocation;
+}
+
+void NodeArena::free(RustFFI::NodeSlotId slot, u32 generation)
+{
+    RustFFI::layout_arena_free(m_handle, slot, generation);
+}
+
+}

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/RefCounted.h>
+#include <AK/Types.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Layout/TreeBuilderRustFFI.h>
+
+namespace Web::Layout {
+
+static_assert(sizeof(RustFFI::NodeAllocation) == 24);
+static_assert(offsetof(RustFFI::NodeAllocation, slot) == 0);
+static_assert(offsetof(RustFFI::NodeAllocation, data) == 8);
+static_assert(offsetof(RustFFI::NodeAllocation, generation) == 16);
+
+class WEB_API NodeArena : public RefCounted<NodeArena> {
+    AK_MAKE_NONCOPYABLE(NodeArena);
+    AK_MAKE_NONMOVABLE(NodeArena);
+
+public:
+    NodeArena();
+    ~NodeArena();
+
+    RustFFI::NodeAllocation allocate();
+    void free(RustFFI::NodeSlotId, u32 generation);
+
+private:
+    void* m_handle { nullptr };
+};
+
+}

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -29,6 +29,7 @@ public:
 
     RustFFI::NodeAllocation allocate();
     void free(RustFFI::NodeSlotId, u32 generation);
+    void* handle() const { return m_handle; }
 
 private:
     void* m_handle { nullptr };

--- a/Libraries/LibWeb/Layout/ReplacedBox.cpp
+++ b/Libraries/LibWeb/Layout/ReplacedBox.cpp
@@ -14,6 +14,7 @@ namespace Web::Layout {
 ReplacedBox::ReplacedBox(DOM::Document& document, GC::Ptr<DOM::Element> element, NonnullRefPtr<CSS::ComputedValues const> style)
     : Box(document, element, style)
 {
+    set_flag(RustFFI::NodeFlag::IsReplacedElement, true);
 }
 
 ReplacedBox::~ReplacedBox() = default;

--- a/Libraries/LibWeb/Layout/Rust/cbindgen.toml
+++ b/Libraries/LibWeb/Layout/Rust/cbindgen.toml
@@ -20,7 +20,7 @@ parse_deps = false
 all_features = false
 
 [export]
-include = ["NodeAllocation", "NodeData", "NodeFlag", "NodeKind", "NodeSlotId"]
+include = ["FfiNodeKindFacts", "FfiTableDisplay", "NodeAllocation", "NodeData", "NodeDisplayFlag", "NodeFlag", "NodeKind", "NodeSlotId"]
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/Libraries/LibWeb/Layout/Rust/cbindgen.toml
+++ b/Libraries/LibWeb/Layout/Rust/cbindgen.toml
@@ -19,5 +19,8 @@ parse_deps = false
 [parse.expand]
 all_features = false
 
+[export]
+include = ["NodeAllocation", "NodeData", "NodeFlag", "NodeKind", "NodeSlotId"]
+
 [export.mangle]
 rename_types = "PascalCase"

--- a/Libraries/LibWeb/Layout/Rust/src/layout_node_arena.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/layout_node_arena.rs
@@ -38,7 +38,7 @@ struct SlotMetadata {
     occupied: bool,
 }
 
-struct LayoutNodeArena {
+pub(crate) struct LayoutNodeArena {
     chunks: Vec<Box<Chunk>>,
     slot_metadata: Vec<SlotMetadata>,
     free_list: Vec<u32>,
@@ -123,6 +123,20 @@ impl LayoutNodeArena {
         self.free_list.push(id.index);
     }
 
+    pub(crate) fn data(&self, id: NodeSlotId) -> *mut NodeData {
+        assert!(!id.is_invalid(), "invalid layout node arena slot ID");
+        debug_assert!(
+            self.metadata(id.index).occupied,
+            "layout node arena read an unused slot"
+        );
+        let index = id.index as usize;
+        let chunk = self
+            .chunks
+            .get(index / SLOTS_PER_CHUNK)
+            .expect("invalid layout node arena slot ID");
+        (&raw const chunk.slots[index % SLOTS_PER_CHUNK]).cast_mut()
+    }
+
     fn data_mut(&mut self, index: u32) -> &mut NodeData {
         let index = index as usize;
         let chunk = self
@@ -130,6 +144,12 @@ impl LayoutNodeArena {
             .get_mut(index / SLOTS_PER_CHUNK)
             .expect("invalid layout node arena slot ID");
         &mut chunk.slots[index % SLOTS_PER_CHUNK]
+    }
+
+    fn metadata(&self, index: u32) -> &SlotMetadata {
+        self.slot_metadata
+            .get(index as usize)
+            .expect("invalid layout node arena slot ID")
     }
 
     fn metadata_mut(&mut self, index: u32) -> &mut SlotMetadata {
@@ -199,13 +219,13 @@ mod tests {
             allocations.push(arena.allocate());
         }
 
-        assert_eq!(first_data, std::ptr::from_mut(arena.data_mut(first.slot.index)));
+        assert_eq!(first_data, arena.data(first.slot));
         // SAFETY: The first allocation is still live, and the comparison above
         // confirms that its pointer still addresses the arena slot.
         unsafe {
             (*first_data).layout_index = 42;
+            assert_eq!((*arena.data(first.slot)).layout_index, 42);
         }
-        assert_eq!(arena.data_mut(first.slot.index).layout_index, 42);
         arena.free(first.slot, first.generation);
         for allocation in allocations {
             arena.free(allocation.slot, allocation.generation);

--- a/Libraries/LibWeb/Layout/Rust/src/layout_node_arena.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/layout_node_arena.rs
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use crate::abort_on_panic;
+use crate::node_data::NodeData;
+use crate::node_data::NodeSlotId;
+use std::ffi::c_void;
+use std::thread;
+
+const SLOTS_PER_CHUNK: usize = 256;
+
+// NodeData is sized to one cache line; the aligned chunk keeps every densely-strided slot
+// line-aligned, and per-slot bookkeeping lives in a parallel array so it stays that way.
+#[repr(align(64))]
+struct Chunk {
+    slots: [NodeData; SLOTS_PER_CHUNK],
+}
+
+fn new_chunk() -> Box<Chunk> {
+    // SAFETY: Every slot is written with NodeData::default() before the chunk is exposed. The
+    // chunk is built in place on the heap because it is far too large for the stack.
+    unsafe {
+        let mut chunk = Box::<Chunk>::new_uninit();
+        let slots = &raw mut (*chunk.as_mut_ptr()).slots;
+        for offset in 0..SLOTS_PER_CHUNK {
+            (&raw mut (*slots)[offset]).write(NodeData::default());
+        }
+        chunk.assume_init()
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct SlotMetadata {
+    generation: u32,
+    occupied: bool,
+}
+
+struct LayoutNodeArena {
+    chunks: Vec<Box<Chunk>>,
+    slot_metadata: Vec<SlotMetadata>,
+    free_list: Vec<u32>,
+    next_index: u32,
+    live_count: u32,
+    owner_thread: thread::ThreadId,
+}
+
+impl LayoutNodeArena {
+    fn new() -> Self {
+        Self {
+            chunks: Vec::new(),
+            slot_metadata: Vec::new(),
+            free_list: Vec::new(),
+            next_index: 0,
+            live_count: 0,
+            owner_thread: thread::current().id(),
+        }
+    }
+
+    fn assert_owner_thread(&self) {
+        debug_assert_eq!(self.owner_thread, thread::current().id());
+    }
+
+    // Freshly created chunks are default-initialized and free() resets slots on release, so
+    // allocate() always hands out clean NodeData without writing it again.
+    fn allocate(&mut self) -> NodeAllocation {
+        self.assert_owner_thread();
+
+        let index = if let Some(index) = self.free_list.pop() {
+            index
+        } else {
+            let index = self.next_index;
+            if (index as usize).is_multiple_of(SLOTS_PER_CHUNK) {
+                self.chunks.push(new_chunk());
+            }
+            self.slot_metadata.push(SlotMetadata::default());
+            self.next_index = self
+                .next_index
+                .checked_add(1)
+                .expect("layout node arena exhausted its slot ID space");
+            index
+        };
+
+        self.live_count = self
+            .live_count
+            .checked_add(1)
+            .expect("layout node arena live count overflowed");
+
+        let metadata = self.metadata_mut(index);
+        assert!(!metadata.occupied, "layout node arena allocated a live slot");
+        metadata.generation = metadata.generation.wrapping_add(1);
+        if metadata.generation == 0 {
+            metadata.generation = 1;
+        }
+        metadata.occupied = true;
+        let generation = metadata.generation;
+
+        NodeAllocation {
+            slot: NodeSlotId { index },
+            data: self.data_mut(index),
+            generation,
+        }
+    }
+
+    fn free(&mut self, id: NodeSlotId, generation: u32) {
+        self.assert_owner_thread();
+
+        let metadata = self.metadata_mut(id.index);
+        assert!(metadata.occupied, "layout node arena freed an unused slot");
+        assert_eq!(
+            metadata.generation, generation,
+            "layout node arena freed a stale slot generation"
+        );
+        metadata.occupied = false;
+        *self.data_mut(id.index) = NodeData::default();
+
+        self.live_count = self
+            .live_count
+            .checked_sub(1)
+            .expect("layout node arena live count underflowed");
+        self.free_list.push(id.index);
+    }
+
+    fn data_mut(&mut self, index: u32) -> &mut NodeData {
+        let index = index as usize;
+        let chunk = self
+            .chunks
+            .get_mut(index / SLOTS_PER_CHUNK)
+            .expect("invalid layout node arena slot ID");
+        &mut chunk.slots[index % SLOTS_PER_CHUNK]
+    }
+
+    fn metadata_mut(&mut self, index: u32) -> &mut SlotMetadata {
+        self.slot_metadata
+            .get_mut(index as usize)
+            .expect("invalid layout node arena slot ID")
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct NodeAllocation {
+    pub slot: NodeSlotId,
+    pub data: *mut NodeData,
+    pub generation: u32,
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn layout_arena_create() -> *mut c_void {
+    abort_on_panic(|| Box::into_raw(Box::new(LayoutNodeArena::new())).cast())
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_destroy(arena: *mut c_void) {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The handle came from layout_arena_create and ownership is
+        // transferred back exactly once by the C++ RAII wrapper.
+        let arena = unsafe { Box::from_raw(arena.cast::<LayoutNodeArena>()) };
+        arena.assert_owner_thread();
+        assert_eq!(arena.live_count, 0, "layout node arena destroyed with live slots");
+    });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_allocate(arena: *mut c_void) -> NodeAllocation {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.allocate()
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_free(arena: *mut c_void, id: NodeSlotId, generation: u32) {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.free(id, generation);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Chunk, LayoutNodeArena, SLOTS_PER_CHUNK};
+
+    #[test]
+    fn node_data_addresses_remain_stable_when_chunks_are_added() {
+        let mut arena = LayoutNodeArena::new();
+        let first = arena.allocate();
+        let first_data = first.data;
+
+        let mut allocations = Vec::new();
+        for _ in 0..SLOTS_PER_CHUNK * 2 {
+            allocations.push(arena.allocate());
+        }
+
+        assert_eq!(first_data, std::ptr::from_mut(arena.data_mut(first.slot.index)));
+        // SAFETY: The first allocation is still live, and the comparison above
+        // confirms that its pointer still addresses the arena slot.
+        unsafe {
+            (*first_data).layout_index = 42;
+        }
+        assert_eq!(arena.data_mut(first.slot.index).layout_index, 42);
+        arena.free(first.slot, first.generation);
+        for allocation in allocations {
+            arena.free(allocation.slot, allocation.generation);
+        }
+    }
+
+    #[test]
+    fn node_data_slots_are_cache_line_aligned() {
+        assert_eq!(align_of::<Chunk>() % 64, 0);
+        let mut arena = LayoutNodeArena::new();
+        let allocation = arena.allocate();
+        assert_eq!(allocation.data as usize % 64, 0);
+        arena.free(allocation.slot, allocation.generation);
+    }
+
+    #[test]
+    fn freed_slots_are_reused_with_a_new_generation() {
+        let mut arena = LayoutNodeArena::new();
+        let first = arena.allocate();
+        arena.free(first.slot, first.generation);
+
+        let second = arena.allocate();
+        assert_eq!(second.slot, first.slot);
+        assert_ne!(second.generation, first.generation);
+        arena.free(second.slot, second.generation);
+    }
+}

--- a/Libraries/LibWeb/Layout/Rust/src/lib.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/lib.rs
@@ -8,6 +8,8 @@
 #[path = "../../../../RustAllocator.rs"]
 mod rust_allocator;
 
+mod layout_node_arena;
+pub mod node_data;
 mod tree_builder;
 
 use std::panic::AssertUnwindSafe;

--- a/Libraries/LibWeb/Layout/Rust/src/node_data.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/node_data.rs
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::ffi::c_void;
+
+pub const INVALID_NODE_SLOT_INDEX: u32 = u32::MAX;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct NodeSlotId {
+    pub index: u32,
+}
+
+impl NodeSlotId {
+    pub const INVALID: Self = Self {
+        index: INVALID_NODE_SLOT_INDEX,
+    };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum NodeKind {
+    Unset = 0,
+    AudioBox = 1,
+    BlockContainer = 2,
+    Box = 3,
+    BreakNode = 4,
+    CanvasBox = 5,
+    CheckBox = 6,
+    FieldSetBox = 7,
+    GeneratedTextNode = 8,
+    ImageBox = 9,
+    InlineNode = 10,
+    LegendBox = 11,
+    ListItemBox = 12,
+    ListItemMarkerBox = 13,
+    NavigableContainerViewport = 14,
+    Node = 15,
+    NodeWithStyle = 16,
+    NodeWithStyleAndBoxModelMetrics = 17,
+    RadioButton = 18,
+    RangeInputBox = 19,
+    ReplacedBox = 20,
+    SVGBox = 21,
+    SVGClipBox = 22,
+    SVGForeignObjectBox = 23,
+    SVGGeometryBox = 24,
+    SVGGraphicsBox = 25,
+    SVGImageBox = 26,
+    SVGMaskBox = 27,
+    SVGPatternBox = 28,
+    SVGSVGBox = 29,
+    SVGTextBox = 30,
+    SVGTextPathBox = 31,
+    TableWrapper = 32,
+    TextAreaBox = 33,
+    TextInputBox = 34,
+    TextNode = 35,
+    TextSliceNode = 36,
+    VideoBox = 37,
+    Viewport = 38,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum NodeFlag {
+    Anonymous = 1 << 0,
+    HasStyle = 1 << 1,
+    ChildrenAreInline = 1 << 2,
+    IsFlexItem = 1 << 3,
+    IsGridItem = 1 << 4,
+    HasBeenWrappedInTableWrapper = 1 << 5,
+    IsBody = 1 << 6,
+    NeedsLayoutUpdate = 1 << 7,
+    NeedsOwnGeometryUpdate = 1 << 8,
+    AbsposDescendantEscapes = 1 << 9,
+    CompensatesForHorizontalScroll = 1 << 10,
+    CompensatesForVerticalScroll = 1 << 11,
+}
+
+#[repr(C)]
+pub struct NodeData {
+    pub parent: NodeSlotId,
+    pub first_child: NodeSlotId,
+    pub last_child: NodeSlotId,
+    pub previous_sibling: NodeSlotId,
+    pub next_sibling: NodeSlotId,
+    pub containing_block: NodeSlotId,
+    pub inline_containing_block: NodeSlotId,
+    pub kind: NodeKind,
+    pub generated_for: u8,
+    pub flags: u32,
+    pub initial_quote_nesting_level: u32,
+    pub layout_index: u32,
+    pub style: *const c_void,
+}
+
+impl Default for NodeData {
+    fn default() -> Self {
+        Self {
+            parent: NodeSlotId::INVALID,
+            first_child: NodeSlotId::INVALID,
+            last_child: NodeSlotId::INVALID,
+            previous_sibling: NodeSlotId::INVALID,
+            next_sibling: NodeSlotId::INVALID,
+            containing_block: NodeSlotId::INVALID,
+            inline_containing_block: NodeSlotId::INVALID,
+            kind: NodeKind::Unset,
+            generated_for: 0,
+            flags: 0,
+            initial_quote_nesting_level: 0,
+            layout_index: 0,
+            style: std::ptr::null(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NodeData, NodeKind};
+
+    #[test]
+    fn node_kind_has_a_stable_default_and_byte_width() {
+        assert_eq!(std::mem::size_of::<NodeKind>(), 1);
+        assert_eq!(NodeData::default().kind, NodeKind::Unset);
+    }
+}

--- a/Libraries/LibWeb/Layout/Rust/src/node_data.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/node_data.rs
@@ -7,6 +7,7 @@
 use std::ffi::c_void;
 
 pub const INVALID_NODE_SLOT_INDEX: u32 = u32::MAX;
+pub const GENERATED_FOR_MARKER: u8 = 6;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C)]
@@ -18,6 +19,16 @@ impl NodeSlotId {
     pub const INVALID: Self = Self {
         index: INVALID_NODE_SLOT_INDEX,
     };
+
+    pub fn is_invalid(self) -> bool {
+        self == Self::INVALID
+    }
+}
+
+impl Default for NodeSlotId {
+    fn default() -> Self {
+        Self::INVALID
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -79,6 +90,35 @@ pub enum NodeFlag {
     AbsposDescendantEscapes = 1 << 9,
     CompensatesForHorizontalScroll = 1 << 10,
     CompensatesForVerticalScroll = 1 << 11,
+    IsReplacedElement = 1 << 12,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+// NB: Some variants are only constructed by C++ through the FFI.
+#[allow(dead_code)]
+pub enum FfiTableDisplay {
+    Other,
+    TableRoot,
+    TableRowGroup,
+    TableHeaderGroup,
+    TableFooterGroup,
+    TableColumnGroup,
+    TableColumn,
+    TableRow,
+    TableCell,
+    TableCaption,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum NodeDisplayFlag {
+    InlineOutside = 1 << 0,
+    FlowInside = 1 << 1,
+    FlexInside = 1 << 2,
+    GridInside = 1 << 3,
+    Floating = 1 << 4,
+    AbsolutelyPositioned = 1 << 5,
 }
 
 #[repr(C)]
@@ -95,7 +135,11 @@ pub struct NodeData {
     pub flags: u32,
     pub initial_quote_nesting_level: u32,
     pub layout_index: u32,
+    pub table_display: FfiTableDisplay,
+    pub table_display_before: FfiTableDisplay,
+    pub display_bits: u8,
     pub style: *const c_void,
+    pub shell: *mut c_void,
 }
 
 impl Default for NodeData {
@@ -113,7 +157,11 @@ impl Default for NodeData {
             flags: 0,
             initial_quote_nesting_level: 0,
             layout_index: 0,
+            table_display: FfiTableDisplay::Other,
+            table_display_before: FfiTableDisplay::Other,
+            display_bits: 0,
             style: std::ptr::null(),
+            shell: std::ptr::null_mut(),
         }
     }
 }

--- a/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
+++ b/Libraries/LibWeb/Layout/Rust/src/tree_builder.rs
@@ -5,7 +5,13 @@
  */
 
 use crate::abort_on_panic;
+use crate::layout_node_arena::LayoutNodeArena;
+use crate::node_data::{
+    FfiTableDisplay, GENERATED_FOR_MARKER, NodeData, NodeDisplayFlag, NodeFlag, NodeKind, NodeSlotId,
+};
 use std::ffi::c_void;
+
+type LayoutNode = NodeSlotId;
 
 #[derive(Default)]
 struct TreeBuilderState {
@@ -48,9 +54,10 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub clear_stale_assigned_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub principal_descendant_facts:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> FfiPrincipalDescendantFacts,
+    pub layout_node_has_first_letter_style: unsafe extern "C" fn(*mut c_void) -> bool,
     pub create_first_letter_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiFirstLetterTarget),
     pub clear_stale_descendants: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void,
+    pub ensure_replaced_children_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> NodeSlotId,
     pub top_layer_element_count: unsafe extern "C" fn(*mut c_void) -> usize,
     pub copy_top_layer_elements: unsafe extern "C" fn(*mut c_void, *mut *mut c_void, usize),
     pub rendered_in_top_layer: unsafe extern "C" fn(*mut c_void) -> bool,
@@ -76,7 +83,7 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub principal_text_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiTextLayoutFacts,
     pub create_principal_text_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub reuse_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub principal_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub attach_principal_style_resources: unsafe extern "C" fn(*mut c_void),
     pub principal_layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiPrincipalLayoutFacts,
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
@@ -89,7 +96,7 @@ pub struct FfiDomTreeBuilderCallbacks {
     pub place_principal_layout: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPrincipalBoxPlacement),
     pub clear_stale_inclusive_subtree: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub reset_style_ancestor_filter: unsafe extern "C" fn(*mut c_void),
-    pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub document_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub layout_root: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub layout: FfiTreeBuilderCallbacks,
     pub pseudo: FfiPseudoTreeBuilderCallbacks,
@@ -133,9 +140,6 @@ pub struct FfiPrincipalDescendantFacts {
     pub child_needs_layout_tree_update: bool,
     pub layout_node_can_have_children: bool,
     pub layout_node_is_replaced_box_with_children: bool,
-    pub layout_node_is_list_item_box: bool,
-    pub layout_node_is_block_container: bool,
-    pub has_first_letter_style: bool,
     pub is_svg_switch_element: bool,
     pub is_document: bool,
     pub has_style_containment: bool,
@@ -282,7 +286,6 @@ fn display_contents_text_needs_style_wrapper(
 
 #[repr(C)]
 pub struct FfiStaleNodeCallbacks {
-    pub layout_parent: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub layout_dom_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub dom_is_shadow_including_inclusive_descendant: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
 }
@@ -291,35 +294,41 @@ pub struct FfiStaleNodeCallbacks {
 ///
 /// # Safety
 ///
-/// The callback table, layout node, and optional cleared subtree root must remain valid for the duration of the call.
+/// The callback table, arena, layout node, and optional cleared subtree root must remain valid for the duration of the
+/// call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
     callbacks: *const FfiStaleNodeCallbacks,
-    layout_node: *mut c_void,
+    arena: *mut c_void,
+    layout_node: NodeSlotId,
     cleared_subtree_root: *mut c_void,
 ) -> bool {
     abort_on_panic(|| {
         assert!(!callbacks.is_null());
-        assert!(!layout_node.is_null());
+        assert!(!arena.is_null());
+        assert!(!layout_node.is_invalid());
         // SAFETY: Guaranteed by the entry point's contract.
         let callbacks = unsafe { &*callbacks };
+        let arena = arena.cast::<LayoutNodeArena>();
         if cleared_subtree_root.is_null() {
             return true;
         }
 
-        // SAFETY: The layout node remains live throughout the ancestor walk.
-        let mut ancestor = unsafe { (callbacks.layout_parent)(layout_node) };
-        while !ancestor.is_null() {
-            // SAFETY: `ancestor` is a live layout node.
-            let dom_node = unsafe { (callbacks.layout_dom_node)(ancestor) };
+        // SAFETY: The arena and layout node remain live throughout the ancestor walk.
+        let mut ancestor = unsafe { &*(*arena).data(layout_node) }.parent;
+        while !ancestor.is_invalid() {
+            // SAFETY: `ancestor` is a live layout node with a live shell.
+            let data = unsafe { &*(*arena).data(ancestor) };
+            let shell = data.shell;
+            let parent = data.parent;
+            let dom_node = unsafe { (callbacks.layout_dom_node)(shell) };
             // SAFETY: Both DOM pointers remain live throughout cleanup.
             if !dom_node.is_null()
                 && unsafe { (callbacks.dom_is_shadow_including_inclusive_descendant)(dom_node, cleared_subtree_root) }
             {
                 return false;
             }
-            // SAFETY: `ancestor` remains live throughout the walk.
-            ancestor = unsafe { (callbacks.layout_parent)(ancestor) };
+            ancestor = parent;
         }
         true
     })
@@ -327,10 +336,9 @@ pub unsafe extern "C" fn rust_should_preserve_svg_resource_layout_node(
 
 #[repr(C)]
 pub struct FfiTopLayerDetachCallbacks {
-    pub element_layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
-    pub topmost_placement_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub element_layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
+    pub topmost_placement_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub prepare_subtree_for_detach: unsafe extern "C" fn(*mut c_void),
-    pub layout_parent: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
     pub remove_layout_node: unsafe extern "C" fn(*mut c_void),
     pub clear_element_subtree: unsafe extern "C" fn(*mut c_void),
     pub slot_element: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
@@ -343,34 +351,39 @@ pub struct FfiTopLayerDetachCallbacks {
 ///
 /// # Safety
 ///
-/// The callback table and element must remain valid for the duration of the call.
+/// The callback table, arena, and element must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_detach_top_layer_element_layout_subtree(
     callbacks: *const FfiTopLayerDetachCallbacks,
+    arena: *mut c_void,
     element: *mut c_void,
 ) {
     abort_on_panic(|| {
         assert!(!callbacks.is_null());
+        assert!(!arena.is_null());
         assert!(!element.is_null());
         // SAFETY: Guaranteed by the entry point's contract.
         let callbacks = unsafe { &*callbacks };
+        let arena = arena.cast::<LayoutNodeArena>();
         // SAFETY: The element remains live throughout the call.
         let element_layout_node = unsafe { (callbacks.element_layout_node)(element) };
-        if !element_layout_node.is_null() {
+        if !element_layout_node.is_invalid() {
             // Take along any anonymous table-fixup wrapper around the box. Leaving an empty table wrapper as a
             // viewport child would violate layout invariants.
-            // SAFETY: The element layout node remains live throughout detachment.
-            let topmost = unsafe { (callbacks.topmost_placement_node)(element_layout_node) };
-            let layout_node_to_detach = if topmost.is_null() {
+            // SAFETY: The element layout node and its shell remain live throughout detachment.
+            let element_shell = unsafe { (*(*arena).data(element_layout_node)).shell };
+            let topmost = unsafe { (callbacks.topmost_placement_node)(element_shell) };
+            let layout_node_to_detach = if topmost.is_invalid() {
                 element_layout_node
             } else {
                 topmost
             };
-            // SAFETY: The chosen layout subtree remains live throughout detachment.
+            // SAFETY: The chosen layout subtree and its shell remain live throughout detachment.
+            let shell = unsafe { (*(*arena).data(layout_node_to_detach)).shell };
             unsafe {
-                (callbacks.prepare_subtree_for_detach)(layout_node_to_detach);
-                if !(callbacks.layout_parent)(layout_node_to_detach).is_null() {
-                    (callbacks.remove_layout_node)(layout_node_to_detach);
+                (callbacks.prepare_subtree_for_detach)(shell);
+                if !(*(*arena).data(layout_node_to_detach)).parent.is_invalid() {
+                    (callbacks.remove_layout_node)(shell);
                 }
             }
         }
@@ -417,7 +430,6 @@ pub struct FfiPrincipalBoxPlacementFacts {
     pub is_document: bool,
     pub is_element: bool,
     pub rendered_in_top_layer: bool,
-    pub layout_node_is_svg_box: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -442,6 +454,7 @@ struct PrincipalBoxPlacementDecision {
 
 fn principal_box_placement_decision(
     facts: FfiPrincipalBoxPlacementFacts,
+    layout_node_is_svg_box: bool,
     layout_top_layer: bool,
 ) -> PrincipalBoxPlacementDecision {
     abort_on_panic(|| {
@@ -461,7 +474,7 @@ fn principal_box_placement_decision(
             FfiPrincipalBoxPlacement::None
         } else if may_replace_existing_layout_node {
             FfiPrincipalBoxPlacement::ReplaceExisting
-        } else if facts.layout_node_is_svg_box {
+        } else if layout_node_is_svg_box {
             FfiPrincipalBoxPlacement::AppendSvg
         } else {
             FfiPrincipalBoxPlacement::NormalInsertion
@@ -517,6 +530,7 @@ fn principal_node_entry_decision(
 
 struct DomTreeBuilderHost<'a> {
     callbacks: &'a FfiDomTreeBuilderCallbacks,
+    arena: *mut LayoutNodeArena,
 }
 
 impl DomTreeBuilderHost<'_> {
@@ -533,6 +547,7 @@ impl DomTreeBuilderHost<'_> {
     fn layout(&self) -> TreeBuilderHost<'_> {
         TreeBuilderHost {
             callbacks: &self.callbacks.layout,
+            arena: self.arena,
         }
     }
 }
@@ -553,11 +568,16 @@ fn has_unrendered_flat_tree_ancestor(host: &DomTreeBuilderHost<'_>, element: *mu
     false
 }
 
-unsafe fn dom_tree_builder_host<'a>(callbacks: *const FfiDomTreeBuilderCallbacks) -> DomTreeBuilderHost<'a> {
+unsafe fn dom_tree_builder_host<'a>(
+    callbacks: *const FfiDomTreeBuilderCallbacks,
+    arena: *mut c_void,
+) -> DomTreeBuilderHost<'a> {
     assert!(!callbacks.is_null());
+    assert!(!arena.is_null());
     // SAFETY: Each exported entry point requires the callback table to remain live for the duration of its call.
     DomTreeBuilderHost {
         callbacks: unsafe { &*callbacks },
+        arena: arena.cast(),
     }
 }
 
@@ -809,9 +829,9 @@ fn ancestor_stack_contains_dom_node(
     dom_node: *mut c_void,
 ) -> bool {
     for &ancestor in &state.ancestor_stack {
-        assert!(!ancestor.is_null());
+        assert!(!ancestor.is_invalid());
         // SAFETY: `ancestor` is a live layout node.
-        if unsafe { (host.callbacks.layout_node_dom_node)(ancestor) } == dom_node {
+        if unsafe { (host.callbacks.layout_node_dom_node)(host.layout().shell(ancestor)) } == dom_node {
             return true;
         }
     }
@@ -823,7 +843,7 @@ fn update_svg_resource(
     state: &mut TreeBuilderState,
     resource: *mut c_void,
     graphics_element: *mut c_void,
-    layout_node: *mut c_void,
+    layout_node: LayoutNode,
     context: &mut TreeBuilderContext,
     prior_context_value: bool,
 ) {
@@ -848,7 +868,7 @@ fn update_svg_pattern(
     pattern: *mut c_void,
     content_element: *mut c_void,
     graphics_element: *mut c_void,
-    layout_node: *mut c_void,
+    layout_node: LayoutNode,
     context: &mut TreeBuilderContext,
 ) {
     let prior_context_value = context.layout_svg_pattern;
@@ -881,17 +901,23 @@ unsafe fn update_principal_node_descendants(
     host: &DomTreeBuilderHost<'_>,
     state: &mut TreeBuilderState,
     dom_node: *mut c_void,
-    layout_node: *mut c_void,
+    layout_node: LayoutNode,
     context: &mut TreeBuilderContext,
     should_create_layout_node: bool,
     must_create_subtree: bool,
 ) {
     abort_on_panic(|| {
         assert!(!dom_node.is_null());
-        assert!(!layout_node.is_null());
+        assert!(!layout_node.is_invalid());
+        let layout_host = host.layout();
         // SAFETY: All pointers remain live throughout the call.
-        let facts =
-            unsafe { (host.callbacks.principal_descendant_facts)(host.callbacks.builder, dom_node, layout_node) };
+        let facts = unsafe {
+            (host.callbacks.principal_descendant_facts)(
+                host.callbacks.builder,
+                dom_node,
+                layout_host.shell(layout_node),
+            )
+        };
         let prior_quote_nesting_level = state.quote_nesting_level;
 
         if should_create_layout_node {
@@ -937,11 +963,11 @@ unsafe fn update_principal_node_descendants(
                     let wrapper = unsafe {
                         (host.callbacks.ensure_replaced_children_wrapper)(
                             host.callbacks.builder,
-                            layout_node,
-                            state.current_parent(),
+                            layout_host.shell(layout_node),
+                            layout_host.shell(state.current_parent()),
                         )
                     };
-                    assert!(!wrapper.is_null());
+                    assert!(!wrapper.is_invalid());
                     state.ancestor_stack.push(wrapper);
                 }
                 // SAFETY: The callback table, shadow root, and context remain valid.
@@ -1084,7 +1110,7 @@ unsafe fn update_principal_node_descendants(
             // Add ::marker and ::after once normal and SVG resource children are complete.
             if facts.is_element && facts.layout_node_can_have_children && !facts.content_visibility_hidden {
                 state.ancestor_stack.push(layout_node);
-                if facts.layout_node_is_list_item_box {
+                if layout_host.data(layout_node).kind == NodeKind::ListItemBox {
                     create_pseudo_element(
                         host,
                         state,
@@ -1102,8 +1128,11 @@ unsafe fn update_principal_node_descendants(
                 );
                 assert!(state.ancestor_stack.pop().is_some());
 
-                if facts.layout_node_is_block_container && facts.has_first_letter_style {
-                    let target = find_first_letter_in_block(&host.layout(), layout_node);
+                // SAFETY: The layout node's shell and its associated DOM node remain live throughout the call.
+                if node_kind_is_block_container(layout_host.data(layout_node).kind)
+                    && unsafe { (host.callbacks.layout_node_has_first_letter_style)(layout_host.shell(layout_node)) }
+                {
+                    let target = find_first_letter_in_block(host, layout_node);
                     if target.found {
                         // SAFETY: `dom_node` is an Element and `target` identifies a live descendant text node.
                         unsafe {
@@ -1231,7 +1260,7 @@ fn construct_principal_layout_node(
 
     // SAFETY: The frame remains live throughout the call.
     (
-        !unsafe { (host.callbacks.principal_layout_node)(frame) }.is_null(),
+        !unsafe { (host.callbacks.principal_layout_node)(frame) }.is_invalid(),
         false,
     )
 }
@@ -1288,8 +1317,12 @@ fn update_principal_node_after_entry(
                 entry_decision.should_create_layout_node,
             )
         };
+        // SAFETY: `has_layout_node` guarantees that the frame owns a live principal layout node.
+        let layout_node = unsafe { (host.callbacks.principal_layout_node)(frame) };
+        let layout_node_is_svg_box = node_kind_is_svg_box(host.layout().data(layout_node).kind);
         let prior_layout_top_layer = context.layout_top_layer;
-        let placement = principal_box_placement_decision(placement_facts, prior_layout_top_layer);
+        let placement =
+            principal_box_placement_decision(placement_facts, layout_node_is_svg_box, prior_layout_top_layer);
 
         let mut prior_rebuild_root = std::ptr::null_mut();
         if placement.start_rebuild_root {
@@ -1311,10 +1344,14 @@ fn update_principal_node_after_entry(
             };
             let backdrop =
                 create_pseudo_element(host, update.state, dom_node, FfiPseudoElement::Backdrop, insertion_mode);
-            if placement.may_replace_existing_layout_node && !backdrop.is_null() {
+            if placement.may_replace_existing_layout_node && !backdrop.is_invalid() {
                 // SAFETY: The frame retains the attached old layout node and `backdrop` is owned by the element.
                 unsafe {
-                    (host.callbacks.insert_principal_backdrop_before_old)(host.callbacks.builder, frame, backdrop);
+                    (host.callbacks.insert_principal_backdrop_before_old)(
+                        host.callbacks.builder,
+                        frame,
+                        host.layout().shell(backdrop),
+                    );
                 }
             }
         }
@@ -1325,18 +1362,17 @@ fn update_principal_node_after_entry(
 
         // SAFETY: The builder and frame remain live, and Rust selected the placement mode.
         let current_parent = if update.state.ancestor_stack.is_empty() {
-            std::ptr::null_mut()
+            NodeSlotId::INVALID
         } else {
             update.state.current_parent()
         };
         if placement.placement == FfiPrincipalBoxPlacement::NormalInsertion {
-            let layout_node = unsafe { (host.callbacks.principal_layout_node)(frame) };
             let layout_host = host.layout();
             insert_node_into_inline_or_block_ancestor(
                 &layout_host,
                 current_parent,
                 layout_node,
-                layout_host.is_inline_outside(layout_node),
+                node_is_inline_outside(layout_host.data(layout_node)),
                 FfiInsertionMode::Append,
             );
         } else {
@@ -1344,7 +1380,7 @@ fn update_principal_node_after_entry(
                 (host.callbacks.place_principal_layout)(
                     host.callbacks.builder,
                     frame,
-                    current_parent,
+                    host.layout().shell_or_null(current_parent),
                     placement.placement,
                 );
             };
@@ -1439,16 +1475,17 @@ fn update_layout_tree(
 ///
 /// # Safety
 ///
-/// The callback table and document must remain valid for the duration of the call.
+/// The callback table, arena, and document must remain valid for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn rust_build_layout_tree(
     callbacks: *const FfiDomTreeBuilderCallbacks,
+    arena: *mut c_void,
     document: *mut c_void,
 ) -> *mut c_void {
     abort_on_panic(|| {
         assert!(!document.is_null());
         // SAFETY: Guaranteed by the entry point's contract.
-        let host = unsafe { dom_tree_builder_host(callbacks) };
+        let host = unsafe { dom_tree_builder_host(callbacks, arena) };
         let mut state = TreeBuilderState::default();
         let mut context = TreeBuilderContext::default();
         // SAFETY: All pointers remain live throughout the build.
@@ -1463,7 +1500,7 @@ pub unsafe extern "C" fn rust_build_layout_tree(
         // NB: Called during layout tree construction.
         // SAFETY: The document remains live and any attached layout root is owned by it and the builder.
         let document_layout_node = unsafe { (host.callbacks.document_layout_node)(document) };
-        if !document_layout_node.is_null() {
+        if !document_layout_node.is_invalid() {
             fixup_tables(&host.layout(), document_layout_node);
         }
 
@@ -1542,17 +1579,16 @@ pub struct FfiPseudoTreeBuilderCallbacks {
     pub initialize: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement) -> FfiPseudoElementFacts,
     pub create_layout_node:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiPseudoElement, FfiPseudoElementDecision),
-    pub layout_node: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+    pub layout_node: unsafe extern "C" fn(*mut c_void) -> NodeSlotId,
     pub attach_style_resources: unsafe extern "C" fn(*mut c_void),
     pub layout_facts: unsafe extern "C" fn(*mut c_void) -> FfiPrincipalLayoutFacts,
     pub apply_replaced_display_adjustment: unsafe extern "C" fn(*mut c_void, FfiReplacedElementDisplayAdjustment),
-    pub layout_node_is_list_item: unsafe extern "C" fn(*mut c_void) -> bool,
     pub create_nested_list_marker: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void),
     pub configure_layout_node: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32),
     pub resolve_counters: unsafe extern "C" fn(*mut c_void, FfiPseudoElement),
     pub resolve_content:
         unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, u32) -> FfiResolvedPseudoContentFacts,
-    pub create_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, usize) -> *mut c_void,
+    pub create_content_item: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiPseudoElement, usize) -> NodeSlotId,
 }
 
 fn pseudo_element_decision(facts: FfiPseudoElementFacts) -> FfiPseudoElementDecision {
@@ -1631,7 +1667,7 @@ fn create_pseudo_element(
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     insertion_mode: Option<FfiInsertionMode>,
-) -> *mut c_void {
+) -> LayoutNode {
     assert!(!element.is_null());
     let callbacks = &host.callbacks.pseudo;
     // SAFETY: The builder owns frame storage that remains live throughout the build.
@@ -1650,13 +1686,13 @@ fn create_pseudo_element_with_frame(
     element: *mut c_void,
     pseudo_element: FfiPseudoElement,
     insertion_mode: Option<FfiInsertionMode>,
-) -> *mut c_void {
+) -> LayoutNode {
     let callbacks = &host.callbacks.pseudo;
     // SAFETY: The frame and element remain live throughout initialization.
     let facts = unsafe { (callbacks.initialize)(frame, element, pseudo_element) };
     let decision = pseudo_element_decision(facts);
     if decision == FfiPseudoElementDecision::None {
-        return std::ptr::null_mut();
+        return NodeSlotId::INVALID;
     }
 
     // SAFETY: The builder, frame, and element remain live throughout construction.
@@ -1665,7 +1701,7 @@ fn create_pseudo_element_with_frame(
     }
     // SAFETY: The frame remains live throughout the call.
     let layout_node = unsafe { (callbacks.layout_node)(frame) };
-    if layout_node.is_null() || decision == FfiPseudoElementDecision::NormalMarker {
+    if layout_node.is_invalid() || decision == FfiPseudoElementDecision::NormalMarker {
         return layout_node;
     }
 
@@ -1687,8 +1723,7 @@ fn create_pseudo_element_with_frame(
     }
 
     // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker.
-    // SAFETY: The frame owns a live pseudo-element layout node.
-    if unsafe { (callbacks.layout_node_is_list_item)(frame) } {
+    if host.layout().data(layout_node).kind == NodeKind::ListItemBox {
         // SAFETY: The builder, frame, and element remain live throughout marker creation.
         unsafe { (callbacks.create_nested_list_marker)(callbacks.builder, frame, element) };
         // FIXME: Support counters on element::pseudo::marker.
@@ -1703,7 +1738,7 @@ fn create_pseudo_element_with_frame(
             &layout_host,
             state.current_parent(),
             layout_node,
-            layout_host.is_inline_outside(layout_node),
+            node_is_inline_outside(layout_host.data(layout_node)),
             insertion_mode,
         );
     }
@@ -1722,13 +1757,13 @@ fn create_pseudo_element_with_frame(
         for index in 0..resolved_content.content_item_count {
             // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
             let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
-            assert!(!content_item.is_null());
+            assert!(!content_item.is_invalid());
             let layout_host = host.layout();
             insert_node_into_inline_or_block_ancestor(
                 &layout_host,
                 state.current_parent(),
                 content_item,
-                layout_host.is_inline_outside(content_item),
+                node_is_inline_outside(layout_host.data(content_item)),
                 FfiInsertionMode::Append,
             );
         }
@@ -1762,58 +1797,6 @@ fn adjusted_table_display_for_replaced_element(
         }
         FfiReplacedElementDisplayAdjustment::None
     })
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-// NB: Some variants are only constructed by C++ through the FFI.
-#[allow(dead_code)]
-pub enum FfiTableDisplay {
-    Other,
-    TableRoot,
-    TableRowGroup,
-    TableHeaderGroup,
-    TableFooterGroup,
-    TableColumnGroup,
-    TableColumn,
-    TableRow,
-    TableCell,
-    TableCaption,
-}
-
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct FfiLayoutNodeFacts {
-    pub current_display: FfiTableDisplay,
-    pub display_before_box_type_transformation: FfiTableDisplay,
-    pub is_box: bool,
-    pub has_style: bool,
-    pub is_anonymous: bool,
-    pub is_block_container: bool,
-    pub children_are_inline: bool,
-    pub is_out_of_flow: bool,
-    pub is_text: bool,
-    pub text_is_ascii_whitespace: bool,
-    pub is_inline_outside: bool,
-    pub is_table_wrapper: bool,
-    pub has_been_wrapped_in_table_wrapper: bool,
-    pub has_replaced_element_table_display_adjustment: bool,
-    pub is_inline: bool,
-    pub is_in_flow: bool,
-    pub is_inline_node: bool,
-    pub is_field_set_box: bool,
-    pub is_svg_foreign_object_box: bool,
-    pub is_svg_box: bool,
-    pub is_svg_svg_box: bool,
-    pub is_generated_for_pseudo_element: bool,
-    pub display_is_flow_inside: bool,
-    pub display_is_flex_inside: bool,
-    pub display_is_grid_inside: bool,
-    pub is_list_item_marker_box: bool,
-    pub is_generated_for_marker: bool,
-    pub is_fragmented_inline: bool,
-    pub has_first_letter_style: bool,
-    pub has_rendered_legend: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -1878,13 +1861,6 @@ pub enum FfiInsertionMode {
 #[repr(C)]
 pub struct FfiTreeBuilderCallbacks {
     pub context: *mut c_void,
-    pub layout_node_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiLayoutNodeFacts,
-    pub is_inline_outside: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
-    pub parent: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
-    pub first_child: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
-    pub next_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
-    pub previous_sibling: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
-    pub last_child: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
     pub remove_nodes: unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize),
     pub wrap_in_anonymous:
         unsafe extern "C" fn(*mut c_void, *const *mut c_void, usize, *mut c_void, FfiAnonymousTableBoxKind),
@@ -1895,20 +1871,19 @@ pub struct FfiTreeBuilderCallbacks {
     pub table_grid_column_count: unsafe extern "C" fn(*mut c_void, *mut c_void) -> usize,
     pub table_grid_is_occupied: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, usize) -> bool,
     pub append_missing_table_cell: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub create_and_append_anonymous_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub create_and_append_anonymous_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub wrap_children_in_anonymous: unsafe extern "C" fn(*mut c_void, *mut c_void, *const *mut c_void, usize),
     pub insert_child: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiInsertionMode),
     pub set_children_are_inline: unsafe extern "C" fn(*mut c_void, *mut c_void, bool),
     pub note_tree_restructuring: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub text_is_ascii_whitespace: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub prepare_first_letter_text:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiFirstLetterTextCallbacks) -> bool,
-    pub create_button_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
-    pub rendered_legend: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
-    pub create_fieldset_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub create_button_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub rendered_legend: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
+    pub create_fieldset_content_wrapper: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub move_nodes_to_parent: unsafe extern "C" fn(*mut c_void, *mut c_void, *const *mut c_void, usize),
 }
-
-type LayoutNode = *mut c_void;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TraversalDecision {
@@ -1919,44 +1894,181 @@ enum TraversalDecision {
 
 struct TreeBuilderHost<'a> {
     callbacks: &'a FfiTreeBuilderCallbacks,
+    arena: *mut LayoutNodeArena,
+}
+
+fn node_has_flag(data: &NodeData, flag: NodeFlag) -> bool {
+    data.flags & flag as u32 != 0
+}
+
+fn node_has_display_flag(data: &NodeData, flag: NodeDisplayFlag) -> bool {
+    data.display_bits & flag as u8 != 0
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub struct FfiNodeKindFacts {
+    pub is_box: bool,
+    pub is_block_container: bool,
+    pub is_text: bool,
+    pub is_svg_box: bool,
+}
+
+// Exhaustive on purpose: adding a NodeKind variant must not compile until its facts are declared.
+fn kind_facts(kind: NodeKind) -> FfiNodeKindFacts {
+    const NON_BOX: FfiNodeKindFacts = FfiNodeKindFacts {
+        is_box: false,
+        is_block_container: false,
+        is_text: false,
+        is_svg_box: false,
+    };
+    const TEXT: FfiNodeKindFacts = FfiNodeKindFacts {
+        is_text: true,
+        ..NON_BOX
+    };
+    const BOX: FfiNodeKindFacts = FfiNodeKindFacts {
+        is_box: true,
+        ..NON_BOX
+    };
+    const BLOCK_CONTAINER: FfiNodeKindFacts = FfiNodeKindFacts {
+        is_block_container: true,
+        ..BOX
+    };
+    const SVG_BOX: FfiNodeKindFacts = FfiNodeKindFacts {
+        is_svg_box: true,
+        ..BOX
+    };
+
+    match kind {
+        NodeKind::Unset
+        | NodeKind::BreakNode
+        | NodeKind::InlineNode
+        | NodeKind::Node
+        | NodeKind::NodeWithStyle
+        | NodeKind::NodeWithStyleAndBoxModelMetrics => NON_BOX,
+        NodeKind::GeneratedTextNode | NodeKind::TextNode | NodeKind::TextSliceNode => TEXT,
+        NodeKind::AudioBox
+        | NodeKind::Box
+        | NodeKind::CanvasBox
+        | NodeKind::CheckBox
+        | NodeKind::ImageBox
+        | NodeKind::ListItemMarkerBox
+        | NodeKind::NavigableContainerViewport
+        | NodeKind::RadioButton
+        | NodeKind::ReplacedBox
+        | NodeKind::SVGSVGBox
+        | NodeKind::VideoBox => BOX,
+        NodeKind::BlockContainer
+        | NodeKind::FieldSetBox
+        | NodeKind::LegendBox
+        | NodeKind::ListItemBox
+        | NodeKind::RangeInputBox
+        | NodeKind::SVGForeignObjectBox
+        | NodeKind::TableWrapper
+        | NodeKind::TextAreaBox
+        | NodeKind::TextInputBox
+        | NodeKind::Viewport => BLOCK_CONTAINER,
+        NodeKind::SVGBox
+        | NodeKind::SVGClipBox
+        | NodeKind::SVGGeometryBox
+        | NodeKind::SVGGraphicsBox
+        | NodeKind::SVGImageBox
+        | NodeKind::SVGMaskBox
+        | NodeKind::SVGPatternBox
+        | NodeKind::SVGTextBox
+        | NodeKind::SVGTextPathBox => SVG_BOX,
+    }
+}
+
+fn node_kind_is_box(kind: NodeKind) -> bool {
+    kind_facts(kind).is_box
+}
+
+fn node_kind_is_block_container(kind: NodeKind) -> bool {
+    kind_facts(kind).is_block_container
+}
+
+fn node_kind_is_text(kind: NodeKind) -> bool {
+    kind_facts(kind).is_text
+}
+
+fn node_kind_is_svg_box(kind: NodeKind) -> bool {
+    kind_facts(kind).is_svg_box
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn layout_node_kind_facts_match(kind: NodeKind, facts: FfiNodeKindFacts) -> bool {
+    facts == kind_facts(kind)
+}
+
+fn node_is_generated_for_pseudo_element(data: &NodeData) -> bool {
+    data.generated_for != 0
+}
+
+fn node_is_inline_outside(data: &NodeData) -> bool {
+    node_kind_is_text(data.kind) || node_has_display_flag(data, NodeDisplayFlag::InlineOutside)
+}
+
+fn node_is_out_of_flow(data: &NodeData) -> bool {
+    (node_has_display_flag(data, NodeDisplayFlag::Floating) && !node_has_flag(data, NodeFlag::IsFlexItem))
+        || node_has_display_flag(data, NodeDisplayFlag::AbsolutelyPositioned)
+}
+
+fn node_has_replaced_element_table_display_adjustment(data: &NodeData) -> bool {
+    node_has_flag(data, NodeFlag::IsReplacedElement) && data.table_display_before != FfiTableDisplay::Other
+}
+
+fn node_is_fragmented_inline(data: &NodeData) -> bool {
+    data.kind == NodeKind::InlineNode
+        || (data.kind == NodeKind::ListItemBox
+            && node_has_display_flag(data, NodeDisplayFlag::InlineOutside)
+            && node_has_display_flag(data, NodeDisplayFlag::FlowInside))
 }
 
 impl TreeBuilderHost<'_> {
-    fn facts(&self, node: LayoutNode) -> FfiLayoutNodeFacts {
-        assert!(!node.is_null());
-        // SAFETY: The entry point's callback contract guarantees that every node passed to a callback is live.
-        unsafe { (self.callbacks.layout_node_facts)(self.callbacks.context, node) }
+    fn data(&self, node: LayoutNode) -> &NodeData {
+        assert!(!node.is_invalid());
+        // SAFETY: Entry points guarantee that the arena remains live, and callers only retain the reference until the
+        // next mutation callback.
+        unsafe { &*(*self.arena).data(node) }
     }
 
-    fn is_inline_outside(&self, node: LayoutNode) -> bool {
-        assert!(!node.is_null());
-        // SAFETY: The entry point's callback contract guarantees that `node` is live.
-        unsafe { (self.callbacks.is_inline_outside)(self.callbacks.context, node) }
+    fn shell(&self, node: LayoutNode) -> *mut c_void {
+        let shell = self.data(node).shell;
+        assert!(!shell.is_null());
+        shell
+    }
+
+    fn shell_or_null(&self, node: LayoutNode) -> *mut c_void {
+        if node.is_invalid() {
+            std::ptr::null_mut()
+        } else {
+            self.shell(node)
+        }
+    }
+
+    fn shells(&self, nodes: &[LayoutNode]) -> Vec<*mut c_void> {
+        nodes.iter().map(|&node| self.shell(node)).collect()
     }
 
     fn parent(&self, node: LayoutNode) -> LayoutNode {
-        // SAFETY: The entry point's callback contract guarantees that `node` is live.
-        unsafe { (self.callbacks.parent)(self.callbacks.context, node) }
+        self.data(node).parent
     }
 
     fn first_child(&self, node: LayoutNode) -> LayoutNode {
-        // SAFETY: The entry point's callback contract guarantees that `node` is live.
-        unsafe { (self.callbacks.first_child)(self.callbacks.context, node) }
+        self.data(node).first_child
     }
 
     fn next_sibling(&self, node: LayoutNode) -> LayoutNode {
-        // SAFETY: The entry point's callback contract guarantees that `node` is live.
-        unsafe { (self.callbacks.next_sibling)(self.callbacks.context, node) }
+        self.data(node).next_sibling
     }
 
     fn previous_sibling(&self, node: LayoutNode) -> LayoutNode {
-        // SAFETY: The entry point's callback contract guarantees that `node` is live.
-        unsafe { (self.callbacks.previous_sibling)(self.callbacks.context, node) }
+        self.data(node).previous_sibling
     }
 
     fn last_child(&self, node: LayoutNode) -> LayoutNode {
-        // SAFETY: The entry point's callback contract guarantees that `node` is live.
-        unsafe { (self.callbacks.last_child)(self.callbacks.context, node) }
+        self.data(node).last_child
     }
 
     fn for_each_in_inclusive_subtree(
@@ -1965,7 +2077,7 @@ impl TreeBuilderHost<'_> {
         mut callback: impl FnMut(LayoutNode) -> TraversalDecision,
     ) {
         let mut current = root;
-        while !current.is_null() {
+        while !current.is_invalid() {
             let decision = callback(current);
             if decision == TraversalDecision::Break {
                 return;
@@ -1973,7 +2085,7 @@ impl TreeBuilderHost<'_> {
 
             if decision != TraversalDecision::SkipChildrenAndContinue {
                 let first_child = self.first_child(current);
-                if !first_child.is_null() {
+                if !first_child.is_invalid() {
                     current = first_child;
                     continue;
                 }
@@ -1983,12 +2095,12 @@ impl TreeBuilderHost<'_> {
             }
 
             let next_sibling = self.next_sibling(current);
-            if !next_sibling.is_null() {
+            if !next_sibling.is_invalid() {
                 current = next_sibling;
                 continue;
             }
 
-            while current != root && self.next_sibling(current).is_null() {
+            while current != root && self.next_sibling(current).is_invalid() {
                 current = self.parent(current);
             }
             if current == root {
@@ -2000,19 +2112,21 @@ impl TreeBuilderHost<'_> {
     }
 
     fn remove_nodes(&self, nodes: &[LayoutNode]) {
+        let shells = self.shells(nodes);
         // SAFETY: All nodes remain tree-owned until the callback first retains the complete slice.
-        unsafe { (self.callbacks.remove_nodes)(self.callbacks.context, nodes.as_ptr(), nodes.len()) };
+        unsafe { (self.callbacks.remove_nodes)(self.callbacks.context, shells.as_ptr(), shells.len()) };
     }
 
     fn wrap_in_anonymous(&self, nodes: &[LayoutNode], nearest_sibling: LayoutNode, kind: FfiAnonymousTableBoxKind) {
         assert!(!nodes.is_empty());
+        let shells = self.shells(nodes);
         // SAFETY: The nodes are live siblings and `nearest_sibling` is either null or their live next sibling.
         unsafe {
             (self.callbacks.wrap_in_anonymous)(
                 self.callbacks.context,
-                nodes.as_ptr(),
-                nodes.len(),
-                nearest_sibling,
+                shells.as_ptr(),
+                shells.len(),
+                self.shell_or_null(nearest_sibling),
                 kind,
             );
         };
@@ -2021,9 +2135,9 @@ impl TreeBuilderHost<'_> {
 
 fn has_inline_or_in_flow_block_children(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     let mut child = host.first_child(node);
-    while !child.is_null() {
-        let facts = host.facts(child);
-        if facts.is_inline || facts.is_in_flow {
+    while !child.is_invalid() {
+        let data = host.data(child);
+        if node_is_inline_outside(data) || !node_is_out_of_flow(data) {
             return true;
         }
         child = host.next_sibling(child);
@@ -2032,13 +2146,13 @@ fn has_inline_or_in_flow_block_children(host: &TreeBuilderHost<'_>, node: Layout
 }
 
 fn has_in_flow_block_children(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
-    if host.facts(node).children_are_inline {
+    if node_has_flag(host.data(node), NodeFlag::ChildrenAreInline) {
         return false;
     }
     let mut child = host.first_child(node);
-    while !child.is_null() {
-        let facts = host.facts(child);
-        if !facts.is_inline && facts.is_in_flow {
+    while !child.is_invalid() {
+        let data = host.data(child);
+        if !node_is_inline_outside(data) && !node_is_out_of_flow(data) {
             return true;
         }
         child = host.next_sibling(child);
@@ -2051,30 +2165,34 @@ fn is_out_of_flow_table_internal_child_of_table_root(
     parent: LayoutNode,
     child: LayoutNode,
 ) -> bool {
-    let parent_facts = host.facts(parent);
-    let child_facts = host.facts(child);
-    parent_facts.current_display == FfiTableDisplay::TableRoot
-        && child_facts.has_style
-        && !child_facts.is_anonymous
-        && child_facts.is_out_of_flow
-        && !child_facts.has_replaced_element_table_display_adjustment
-        && is_table_non_root_box_with_display(child_facts.display_before_box_type_transformation)
+    let parent_data = host.data(parent);
+    let child_data = host.data(child);
+    parent_data.table_display == FfiTableDisplay::TableRoot
+        && node_has_flag(child_data, NodeFlag::HasStyle)
+        && !node_has_flag(child_data, NodeFlag::Anonymous)
+        && node_is_out_of_flow(child_data)
+        && !node_has_replaced_element_table_display_adjustment(child_data)
+        && is_table_non_root_box_with_display(child_data.table_display_before)
 }
 
 fn create_anonymous_wrapper(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
     // SAFETY: `parent` is a live NodeWithStyle. The callback appends and returns a live anonymous wrapper.
-    let wrapper = unsafe { (host.callbacks.create_and_append_anonymous_wrapper)(host.callbacks.context, parent) };
-    assert!(!wrapper.is_null());
+    let wrapper =
+        unsafe { (host.callbacks.create_and_append_anonymous_wrapper)(host.callbacks.context, host.shell(parent)) };
+    assert!(!wrapper.is_invalid());
     wrapper
 }
 
 fn last_child_creating_anonymous_wrapper_if_needed(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
     let last_child = host.last_child(parent);
-    if last_child.is_null() {
+    if last_child.is_invalid() {
         return create_anonymous_wrapper(host, parent);
     }
-    let facts = host.facts(last_child);
-    if !facts.is_anonymous || !facts.children_are_inline || facts.is_generated_for_pseudo_element {
+    let data = host.data(last_child);
+    if !node_has_flag(data, NodeFlag::Anonymous)
+        || !node_has_flag(data, NodeFlag::ChildrenAreInline)
+        || node_is_generated_for_pseudo_element(data)
+    {
         return create_anonymous_wrapper(host, parent);
     }
     last_child
@@ -2083,26 +2201,28 @@ fn last_child_creating_anonymous_wrapper_if_needed(host: &TreeBuilderHost<'_>, p
 // The insertion_parent_for_*() functions maintain the invariant that the in-flow children of
 // block-level boxes must be either all block-level or all inline-level.
 fn insertion_parent_for_inline_node(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
-    let facts = host.facts(parent);
-    if facts.is_field_set_box || facts.is_svg_foreign_object_box {
+    let data = host.data(parent);
+    if matches!(data.kind, NodeKind::FieldSetBox | NodeKind::SVGForeignObjectBox) {
         return last_child_creating_anonymous_wrapper_if_needed(host, parent);
     }
 
     // SVG layout ignores the inline/block distinction, and an anonymous wrapper would only hide
     // the child from SVGFormattingContext (e.g. a shape with a foreignObject sibling).
-    if facts.is_svg_box || facts.is_svg_svg_box {
+    if node_kind_is_svg_box(data.kind) || data.kind == NodeKind::SVGSVGBox {
         return parent;
     }
 
-    if facts.is_inline && facts.display_is_flow_inside {
+    if node_is_inline_outside(data) && node_has_display_flag(data, NodeDisplayFlag::FlowInside) {
         return parent;
     }
 
-    if facts.display_is_flex_inside || facts.display_is_grid_inside {
+    if node_has_display_flag(data, NodeDisplayFlag::FlexInside)
+        || node_has_display_flag(data, NodeDisplayFlag::GridInside)
+    {
         return last_child_creating_anonymous_wrapper_if_needed(host, parent);
     }
 
-    if !has_in_flow_block_children(host, parent) || facts.children_are_inline {
+    if !has_in_flow_block_children(host, parent) || node_has_flag(data, NodeFlag::ChildrenAreInline) {
         return parent;
     }
 
@@ -2116,25 +2236,28 @@ fn insertion_parent_for_block_node(
     node: LayoutNode,
     mode: FfiInsertionMode,
 ) -> LayoutNode {
-    let parent_facts = host.facts(parent);
+    let parent_data = host.data(parent);
 
     // Inline is fine for in-flow block children (interrupting blocks) and for out-of-flow children;
     // the inline formatting context emits items for both.
-    if !host.facts(node).is_anonymous && parent_facts.is_inline && parent_facts.display_is_flow_inside {
+    if !node_has_flag(host.data(node), NodeFlag::Anonymous)
+        && node_is_inline_outside(parent_data)
+        && node_has_display_flag(parent_data, NodeDisplayFlag::FlowInside)
+    {
         return parent;
     }
 
     // SVG layout ignores the inline/block distinction; wrapping existing inline-level siblings
     // (e.g. shapes next to a foreignObject) would only hide them from SVGFormattingContext.
-    if parent_facts.is_svg_box || parent_facts.is_svg_svg_box {
+    if node_kind_is_svg_box(parent_data.kind) || parent_data.kind == NodeKind::SVGSVGBox {
         return parent;
     }
 
     // Make sure we're not inserting into an inline node, since those do not support block nodes.
     let mut new_parent = parent;
-    while host.facts(new_parent).is_inline_node {
+    while host.data(new_parent).kind == NodeKind::InlineNode {
         new_parent = host.parent(new_parent);
-        assert!(!new_parent.is_null());
+        assert!(!new_parent.is_invalid());
     }
 
     // If the parent block has no children, insert this block into parent.
@@ -2148,24 +2271,24 @@ fn insertion_parent_for_block_node(
         return new_parent;
     }
 
-    let node_facts = host.facts(node);
-    let new_parent_facts = host.facts(new_parent);
+    let node_data = host.data(node);
+    let new_parent_data = host.data(new_parent);
 
     // If the block is out-of-flow,
-    if node_facts.is_out_of_flow {
+    if node_is_out_of_flow(node_data) {
         let last_child = host.last_child(new_parent);
-        assert!(!last_child.is_null());
-        let last_child_facts = host.facts(last_child);
+        assert!(!last_child.is_invalid());
+        let last_child_data = host.data(last_child);
 
         // And we're appending while the parent's last child is an anonymous block, join that
         // anonymous block. Prepended boxes (e.g. an absolutely positioned ::before) belong at the
         // very start of the parent, not at the start of its trailing inline run.
         if mode == FfiInsertionMode::Append
-            && !new_parent_facts.display_is_flex_inside
-            && !new_parent_facts.display_is_grid_inside
-            && !last_child_facts.is_generated_for_pseudo_element
-            && last_child_facts.is_anonymous
-            && last_child_facts.children_are_inline
+            && !node_has_display_flag(new_parent_data, NodeDisplayFlag::FlexInside)
+            && !node_has_display_flag(new_parent_data, NodeDisplayFlag::GridInside)
+            && !node_is_generated_for_pseudo_element(last_child_data)
+            && node_has_flag(last_child_data, NodeFlag::Anonymous)
+            && node_has_flag(last_child_data, NodeFlag::ChildrenAreInline)
         {
             return last_child;
         }
@@ -2175,18 +2298,18 @@ fn insertion_parent_for_block_node(
     }
 
     // If the parent block has block-level children, insert this block into parent.
-    if !new_parent_facts.children_are_inline {
+    if !node_has_flag(new_parent_data, NodeFlag::ChildrenAreInline) {
         return new_parent;
     }
 
     // Parent block has inline-level children (our siblings); wrap these siblings into an anonymous wrapper block.
     // SAFETY: `new_parent` is live for the duration of this call.
-    unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, new_parent) };
-    let mut children_to_wrap = Vec::new();
+    unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, host.shell(new_parent)) };
+    let mut child_shells = Vec::new();
     let mut child = host.first_child(new_parent);
-    while !child.is_null() {
+    while !child.is_invalid() {
         if !is_out_of_flow_table_internal_child_of_table_root(host, new_parent, child) {
-            children_to_wrap.push(child);
+            child_shells.push(host.shell(child));
         }
         child = host.next_sibling(child);
     }
@@ -2194,9 +2317,9 @@ fn insertion_parent_for_block_node(
     unsafe {
         (host.callbacks.wrap_children_in_anonymous)(
             host.callbacks.context,
-            new_parent,
-            children_to_wrap.as_ptr(),
-            children_to_wrap.len(),
+            host.shell(new_parent),
+            child_shells.as_ptr(),
+            child_shells.len(),
         );
     };
 
@@ -2206,13 +2329,13 @@ fn insertion_parent_for_block_node(
 
 fn insert_node_into_inline_or_block_ancestor(
     host: &TreeBuilderHost<'_>,
-    nearest_insertion_ancestor: *mut c_void,
-    node: *mut c_void,
+    nearest_insertion_ancestor: LayoutNode,
+    node: LayoutNode,
     is_inline_outside: bool,
     mode: FfiInsertionMode,
 ) {
-    assert!(!nearest_insertion_ancestor.is_null());
-    assert!(!node.is_null());
+    assert!(!nearest_insertion_ancestor.is_invalid());
+    assert!(!node.is_invalid());
 
     let insertion_point = if is_inline_outside {
         insertion_parent_for_inline_node(host, nearest_insertion_ancestor)
@@ -2223,20 +2346,31 @@ fn insert_node_into_inline_or_block_ancestor(
     // Insertion parents can be above the subtree being rebuilt in place: inline ancestors are
     // skipped, and out-of-flow boxes can join a trailing anonymous sibling.
     // SAFETY: `insertion_point` is live for the duration of this call.
-    unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, insertion_point) };
+    unsafe { (host.callbacks.note_tree_restructuring)(host.callbacks.context, host.shell(insertion_point)) };
     // SAFETY: The callback retains `node` while inserting it into the live insertion point.
-    unsafe { (host.callbacks.insert_child)(host.callbacks.context, insertion_point, node, mode) };
+    unsafe {
+        (host.callbacks.insert_child)(
+            host.callbacks.context,
+            host.shell(insertion_point),
+            host.shell(node),
+            mode,
+        );
+    };
 
     if is_inline_outside {
         // After inserting an inline-level box into a parent, mark the parent as having inline children.
         // SAFETY: `insertion_point` remains live and attached.
-        unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, true) };
-    } else if host.facts(node).is_in_flow {
-        let insertion_point_facts = host.facts(insertion_point);
+        unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, host.shell(insertion_point), true) };
+    } else if !node_is_out_of_flow(host.data(node)) {
+        let insertion_point_data = host.data(insertion_point);
         // Inline-flow parents keep their inline children flag; their IFC may contain interrupting blocks.
-        if !insertion_point_facts.is_inline || !insertion_point_facts.display_is_flow_inside {
+        if !node_is_inline_outside(insertion_point_data)
+            || !node_has_display_flag(insertion_point_data, NodeDisplayFlag::FlowInside)
+        {
             // SAFETY: `insertion_point` remains live and attached.
-            unsafe { (host.callbacks.set_children_are_inline)(host.callbacks.context, insertion_point, false) };
+            unsafe {
+                (host.callbacks.set_children_are_inline)(host.callbacks.context, host.shell(insertion_point), false);
+            };
         }
     }
 }
@@ -2364,47 +2498,49 @@ fn find_first_letter_in_layout_text(host: &TreeBuilderHost<'_>, node: LayoutNode
     let mut callbacks = std::mem::MaybeUninit::<FfiFirstLetterTextCallbacks>::uninit();
     // SAFETY: `node` is a live TextNode and the callback initializes the output table with a context that remains live
     // until the next call.
-    let preserves_segment_breaks =
-        unsafe { (host.callbacks.prepare_first_letter_text)(host.callbacks.context, node, callbacks.as_mut_ptr()) };
+    let preserves_segment_breaks = unsafe {
+        (host.callbacks.prepare_first_letter_text)(host.callbacks.context, host.shell(node), callbacks.as_mut_ptr())
+    };
     // SAFETY: The callback contract guarantees that the output table was initialized.
     let callbacks = unsafe { callbacks.assume_init() };
     let text_host = FirstLetterTextHost { callbacks: &callbacks };
     let mut target = find_first_letter_in_text(&text_host, preserves_segment_breaks);
     if target.found {
-        target.text_node = node;
+        target.text_node = host.shell(node);
     }
     target
 }
 
-fn is_marker_content(facts: FfiLayoutNodeFacts) -> bool {
-    facts.is_list_item_marker_box || facts.is_generated_for_marker
+fn is_marker_content(data: &NodeData) -> bool {
+    data.kind == NodeKind::ListItemMarkerBox || data.generated_for == GENERATED_FOR_MARKER
 }
 
 // https://drafts.csswg.org/css-pseudo-4/#first-letter-application
-fn find_first_letter_in_block(host: &TreeBuilderHost<'_>, block: LayoutNode) -> FfiFirstLetterTarget {
+fn find_first_letter_in_block(host: &DomTreeBuilderHost<'_>, block: LayoutNode) -> FfiFirstLetterTarget {
+    let layout_host = host.layout();
     // NB: This walks a block container's inline descendants looking for the first-letter text. If the block has block
     //     children instead of inline, recurses into each in-flow block child in turn.
-    if host.facts(block).children_are_inline {
+    if node_has_flag(layout_host.data(block), NodeFlag::ChildrenAreInline) {
         let mut result = FfiFirstLetterTarget::not_found();
         let mut is_root = true;
-        host.for_each_in_inclusive_subtree(block, |node| {
+        layout_host.for_each_in_inclusive_subtree(block, |node| {
             if is_root {
                 is_root = false;
                 return TraversalDecision::Continue;
             }
-            let facts = host.facts(node);
-            if is_marker_content(facts) || facts.is_out_of_flow {
+            let data = layout_host.data(node);
+            if is_marker_content(data) || node_is_out_of_flow(data) {
                 return TraversalDecision::SkipChildrenAndContinue;
             }
-            if facts.is_text {
-                result = find_first_letter_in_layout_text(host, node);
+            if node_kind_is_text(data.kind) {
+                result = find_first_letter_in_layout_text(&layout_host, node);
                 return if result.found {
                     TraversalDecision::Break
                 } else {
                     TraversalDecision::Continue
                 };
             }
-            if facts.is_fragmented_inline {
+            if node_is_fragmented_inline(data) {
                 return TraversalDecision::Continue;
             }
             TraversalDecision::Break
@@ -2414,35 +2550,37 @@ fn find_first_letter_in_block(host: &TreeBuilderHost<'_>, block: LayoutNode) -> 
 
     // We have no inline content of our own but ::first-letter can still apply to text in an in-flow block descendant,
     // so walk into each in-flow block child in document order until one yields a letter.
-    let mut child = host.first_child(block);
-    while !child.is_null() {
-        let facts = host.facts(child);
-        if is_marker_content(facts) || facts.is_out_of_flow {
-            child = host.next_sibling(child);
+    let mut child = layout_host.first_child(block);
+    while !child.is_invalid() {
+        let data = layout_host.data(child);
+        let is_anonymous = node_has_flag(data, NodeFlag::Anonymous);
+        if is_marker_content(data) || node_is_out_of_flow(data) {
+            child = layout_host.next_sibling(child);
             continue;
         }
-        if !facts.is_block_container {
+        if !node_kind_is_block_container(data.kind) {
             break;
         }
         // Stop descending if this child block defines its own ::first-letter: the child will style the first letter
         // inside it, so the ancestor's ::first-letter must not also claim the same letter.
-        if facts.has_first_letter_style {
+        // SAFETY: The child shell and its associated DOM node remain live throughout the walk.
+        if unsafe { (host.callbacks.layout_node_has_first_letter_style)(layout_host.shell(child)) } {
             break;
         }
         let target = find_first_letter_in_block(host, child);
         if target.found {
             return target;
         }
-        if !facts.is_anonymous {
+        if !is_anonymous {
             break;
         }
-        child = host.next_sibling(child);
+        child = layout_host.next_sibling(child);
     }
     FfiFirstLetterTarget::not_found()
 }
 
-fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: *mut c_void, uses_button_layout: bool) {
-    assert!(!layout_node.is_null());
+fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: LayoutNode, uses_button_layout: bool) {
+    assert!(!layout_node.is_invalid());
     if !uses_button_layout {
         return;
     }
@@ -2451,65 +2589,76 @@ fn wrap_button_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: *mut 
     // If the element is an input element, or if it is a button element and its computed value for 'display' is not
     // 'inline-grid', 'grid', 'inline-flex', or 'flex', then the element's box has a child anonymous button content
     // box with the following behaviors:
-    let facts = host.facts(layout_node);
-    if !facts.display_is_grid_inside && !facts.display_is_flex_inside {
-        let mut children = Vec::new();
+    let data = host.data(layout_node);
+    if !node_has_display_flag(data, NodeDisplayFlag::GridInside)
+        && !node_has_display_flag(data, NodeDisplayFlag::FlexInside)
+    {
+        let children_are_inline = node_has_flag(data, NodeFlag::ChildrenAreInline);
+        let mut child_shells = Vec::new();
         let mut child = host.first_child(layout_node);
-        while !child.is_null() {
-            children.push(child);
+        while !child.is_invalid() {
+            child_shells.push(host.shell(child));
             child = host.next_sibling(child);
         }
 
         // SAFETY: `layout_node` remains live and owns the returned content wrapper through its flex wrapper.
         let content_wrapper =
-            unsafe { (host.callbacks.create_button_content_wrapper)(host.callbacks.context, layout_node) };
-        assert!(!content_wrapper.is_null());
+            unsafe { (host.callbacks.create_button_content_wrapper)(host.callbacks.context, host.shell(layout_node)) };
+        assert!(!content_wrapper.is_invalid());
         // SAFETY: The parent and content wrapper remain live, and the callback retains all nodes while moving them.
         unsafe {
             (host.callbacks.set_children_are_inline)(
                 host.callbacks.context,
-                content_wrapper,
-                facts.children_are_inline,
+                host.shell(content_wrapper),
+                children_are_inline,
             );
             (host.callbacks.move_nodes_to_parent)(
                 host.callbacks.context,
-                content_wrapper,
-                children.as_ptr(),
-                children.len(),
+                host.shell(content_wrapper),
+                child_shells.as_ptr(),
+                child_shells.len(),
             );
-            (host.callbacks.set_children_are_inline)(host.callbacks.context, layout_node, false);
+            (host.callbacks.set_children_are_inline)(host.callbacks.context, host.shell(layout_node), false);
         }
     }
 }
 
-fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: *mut c_void) {
-    assert!(!layout_node.is_null());
+fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: LayoutNode) {
+    assert!(!layout_node.is_invalid());
 
     // https://html.spec.whatwg.org/multipage/rendering.html#the-fieldset-and-legend-elements
     // The anonymous fieldset content box is expected to appear after the rendered legend and is expected to contain
     // the content (including the '::before' and '::after' pseudo-elements) of the fieldset element except for the
     // rendered legend, if there is one.
-    let facts = host.facts(layout_node);
-    if facts.is_field_set_box && facts.has_rendered_legend {
-        // SAFETY: `layout_node` is a live FieldSetBox with a rendered legend.
-        let legend = unsafe { (host.callbacks.rendered_legend)(host.callbacks.context, layout_node) };
-        assert!(!legend.is_null());
+    if host.data(layout_node).kind == NodeKind::FieldSetBox {
+        // SAFETY: `layout_node` is a live FieldSetBox.
+        let legend = unsafe { (host.callbacks.rendered_legend)(host.callbacks.context, host.shell(layout_node)) };
+        if legend.is_invalid() {
+            return;
+        }
 
-        let mut children = Vec::new();
+        let mut child_shells = Vec::new();
         let mut child = host.first_child(layout_node);
-        while !child.is_null() {
+        while !child.is_invalid() {
             if child != legend {
-                children.push(child);
+                child_shells.push(host.shell(child));
             }
             child = host.next_sibling(child);
         }
 
         // SAFETY: The fieldset remains live and owns the returned wrapper.
-        let wrapper = unsafe { (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, layout_node) };
-        assert!(!wrapper.is_null());
+        let wrapper = unsafe {
+            (host.callbacks.create_fieldset_content_wrapper)(host.callbacks.context, host.shell(layout_node))
+        };
+        assert!(!wrapper.is_invalid());
         // SAFETY: The wrapper remains attached and the callback retains all nodes while moving them.
         unsafe {
-            (host.callbacks.move_nodes_to_parent)(host.callbacks.context, wrapper, children.as_ptr(), children.len());
+            (host.callbacks.move_nodes_to_parent)(
+                host.callbacks.context,
+                host.shell(wrapper),
+                child_shells.as_ptr(),
+                child_shells.len(),
+            );
         }
     }
 }
@@ -2530,22 +2679,22 @@ fn is_table_track_group(display: FfiTableDisplay) -> bool {
     )
 }
 
-fn display_for_table_fixup(facts: FfiLayoutNodeFacts) -> FfiTableDisplay {
+fn display_for_table_fixup(data: &NodeData) -> FfiTableDisplay {
     // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
     // For the purposes of these rules, out-of-flow elements are represented as inline elements of zero width and
     // height. Their containing blocks are chosen accordingly.
     //
     // AD-HOC: Table-internal boxes can be blockified before fixup. Use the pre-transformation display for authored
     // boxes so an out-of-flow table-header-group is still recognized as a proper table child during fixup.
-    if facts.has_replaced_element_table_display_adjustment || facts.is_anonymous {
-        facts.current_display
+    if node_has_replaced_element_table_display_adjustment(data) || node_has_flag(data, NodeFlag::Anonymous) {
+        data.table_display
     } else {
-        facts.display_before_box_type_transformation
+        data.table_display_before
     }
 }
 
-fn is_proper_table_child(facts: FfiLayoutNodeFacts) -> bool {
-    let display = display_for_table_fixup(facts);
+fn is_proper_table_child(data: &NodeData) -> bool {
+    let display = display_for_table_fixup(data);
     is_table_track_group(display) || is_table_track(display) || display == FfiTableDisplay::TableCaption
 }
 
@@ -2563,14 +2712,14 @@ fn is_table_non_root_box_with_display(display: FfiTableDisplay) -> bool {
     )
 }
 
-fn is_table_non_root_box(facts: FfiLayoutNodeFacts) -> bool {
-    is_table_non_root_box_with_display(facts.current_display)
+fn is_table_non_root_box(data: &NodeData) -> bool {
+    is_table_non_root_box_with_display(data.table_display)
 }
 
-fn is_tabular_container(facts: FfiLayoutNodeFacts) -> bool {
+fn is_tabular_container(data: &NodeData) -> bool {
     // https://drafts.csswg.org/css-tables-3/#tabular-container
     matches!(
-        facts.current_display,
+        data.table_display,
         FfiTableDisplay::TableRoot
             | FfiTableDisplay::TableRow
             | FfiTableDisplay::TableRowGroup
@@ -2580,21 +2729,27 @@ fn is_tabular_container(facts: FfiLayoutNodeFacts) -> bool {
 }
 
 fn is_ignorable_whitespace(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
-    let facts = host.facts(node);
-    if facts.is_text && facts.text_is_ascii_whitespace {
+    let data = host.data(node);
+    if node_kind_is_text(data.kind)
+        && unsafe { (host.callbacks.text_is_ascii_whitespace)(host.callbacks.context, host.shell(node)) }
+    {
         return true;
     }
 
-    if facts.is_anonymous && facts.is_block_container && facts.children_are_inline {
+    if node_has_flag(data, NodeFlag::Anonymous)
+        && node_kind_is_block_container(data.kind)
+        && node_has_flag(data, NodeFlag::ChildrenAreInline)
+    {
         let mut contains_only_whitespace = true;
         host.for_each_in_inclusive_subtree(node, |descendant| {
-            let descendant_facts = host.facts(descendant);
-            if descendant_facts.is_text {
-                if !descendant_facts.text_is_ascii_whitespace {
+            let descendant_data = host.data(descendant);
+            if node_kind_is_text(descendant_data.kind) {
+                if !unsafe { (host.callbacks.text_is_ascii_whitespace)(host.callbacks.context, host.shell(descendant)) }
+                {
                     contains_only_whitespace = false;
                     return TraversalDecision::Break;
                 }
-            } else if descendant_facts.is_out_of_flow || !descendant_facts.is_anonymous {
+            } else if node_is_out_of_flow(descendant_data) || !node_has_flag(descendant_data, NodeFlag::Anonymous) {
                 contains_only_whitespace = false;
                 return TraversalDecision::Break;
             }
@@ -2609,13 +2764,13 @@ fn is_ignorable_whitespace(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool
 fn is_first_or_last_child_with_table_non_root_sibling_if_any(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     let previous_sibling = host.previous_sibling(node);
     let next_sibling = host.next_sibling(node);
-    if !previous_sibling.is_null() && !next_sibling.is_null() {
+    if !previous_sibling.is_invalid() && !next_sibling.is_invalid() {
         return false;
     }
-    if !previous_sibling.is_null() && !is_table_non_root_box(host.facts(previous_sibling)) {
+    if !previous_sibling.is_invalid() && !is_table_non_root_box(host.data(previous_sibling)) {
         return false;
     }
-    if !next_sibling.is_null() && !is_table_non_root_box(host.facts(next_sibling)) {
+    if !next_sibling.is_invalid() && !is_table_non_root_box(host.data(next_sibling)) {
         return false;
     }
     true
@@ -2624,13 +2779,13 @@ fn is_first_or_last_child_with_table_non_root_sibling_if_any(host: &TreeBuilderH
 fn for_each_sequence_of_consecutive_children_matching(
     host: &TreeBuilderHost<'_>,
     parent: LayoutNode,
-    matcher: impl Fn(FfiLayoutNodeFacts) -> bool,
+    matcher: impl Fn(&NodeData) -> bool,
     mut callback: impl FnMut(&[LayoutNode], LayoutNode),
 ) {
     let mut sequence = Vec::new();
     let mut child = host.first_child(parent);
-    while !child.is_null() {
-        if matcher(host.facts(child)) || (!sequence.is_empty() && is_ignorable_whitespace(host, child)) {
+    while !child.is_invalid() {
+        if matcher(host.data(child)) || (!sequence.is_empty() && is_ignorable_whitespace(host, child)) {
             sequence.push(child);
         } else if !sequence.is_empty() {
             if !sequence.iter().all(|&node| is_ignorable_whitespace(host, node)) {
@@ -2641,7 +2796,7 @@ fn for_each_sequence_of_consecutive_children_matching(
         child = host.next_sibling(child);
     }
     if !sequence.is_empty() && !sequence.iter().all(|&node| is_ignorable_whitespace(host, node)) {
-        callback(&sequence, std::ptr::null_mut());
+        callback(&sequence, NodeSlotId::INVALID);
     }
 }
 
@@ -2651,22 +2806,22 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
     // The following boxes are discarded as if they were display:none:
     let mut to_remove = Vec::new();
     host.for_each_in_inclusive_subtree(root, |node| {
-        let facts = host.facts(node);
+        let data = host.data(node);
 
         // 1. Children of a table-column.
-        if facts.is_box && facts.current_display == FfiTableDisplay::TableColumn {
+        if node_kind_is_box(data.kind) && data.table_display == FfiTableDisplay::TableColumn {
             let mut child = host.first_child(node);
-            while !child.is_null() {
+            while !child.is_invalid() {
                 to_remove.push(child);
                 child = host.next_sibling(child);
             }
         }
 
         // 2. Children of a table-column-group which are not a table-column.
-        if facts.is_box && facts.current_display == FfiTableDisplay::TableColumnGroup {
+        if node_kind_is_box(data.kind) && data.table_display == FfiTableDisplay::TableColumnGroup {
             let mut child = host.first_child(node);
-            while !child.is_null() {
-                if host.facts(child).current_display != FfiTableDisplay::TableColumn {
+            while !child.is_invalid() {
+                if host.data(child).table_display != FfiTableDisplay::TableColumn {
                     to_remove.push(child);
                 }
                 child = host.next_sibling(child);
@@ -2681,9 +2836,9 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
         //    - they are the first and/or last child of a tabular container
         //    - whose immediate sibling, if any, is a table-non-root box
         let parent = host.parent(node);
-        if facts.is_box
-            && !parent.is_null()
-            && is_tabular_container(host.facts(parent))
+        if node_kind_is_box(data.kind)
+            && !parent.is_invalid()
+            && is_tabular_container(host.data(parent))
             && is_first_or_last_child_with_table_non_root_sibling_if_any(host, node)
             && is_ignorable_whitespace(host, node)
         {
@@ -2699,19 +2854,19 @@ fn generate_missing_child_wrappers(host: &TreeBuilderHost<'_>, root: LayoutNode)
     // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
     // 2. Generate missing child wrappers:
     host.for_each_in_inclusive_subtree(root, |parent| {
-        let facts = host.facts(parent);
-        if !facts.is_box {
+        let data = host.data(parent);
+        if !node_kind_is_box(data.kind) {
             return TraversalDecision::Continue;
         }
 
-        match facts.current_display {
+        match data.table_display {
             FfiTableDisplay::TableRoot => {
                 // 1. An anonymous table-row box must be generated around each sequence of consecutive children of a
                 //    table-root box which are not proper table child boxes.
                 for_each_sequence_of_consecutive_children_matching(
                     host,
                     parent,
-                    |child| !child.has_style || !is_proper_table_child(child),
+                    |child| !node_has_flag(child, NodeFlag::HasStyle) || !is_proper_table_child(child),
                     |sequence, nearest_sibling| {
                         host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
                     },
@@ -2723,7 +2878,9 @@ fn generate_missing_child_wrappers(host: &TreeBuilderHost<'_>, root: LayoutNode)
                 for_each_sequence_of_consecutive_children_matching(
                     host,
                     parent,
-                    |child| !child.has_style || child.current_display != FfiTableDisplay::TableRow,
+                    |child| {
+                        !node_has_flag(child, NodeFlag::HasStyle) || child.table_display != FfiTableDisplay::TableRow
+                    },
                     |sequence, nearest_sibling| {
                         host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
                     },
@@ -2735,7 +2892,9 @@ fn generate_missing_child_wrappers(host: &TreeBuilderHost<'_>, root: LayoutNode)
                 for_each_sequence_of_consecutive_children_matching(
                     host,
                     parent,
-                    |child| !child.has_style || child.current_display != FfiTableDisplay::TableCell,
+                    |child| {
+                        !node_has_flag(child, NodeFlag::HasStyle) || child.table_display != FfiTableDisplay::TableCell
+                    },
                     |sequence, nearest_sibling| {
                         host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableCell);
                     },
@@ -2752,18 +2911,27 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
     // 3. Generate missing parents:
     let mut table_roots_to_wrap = Vec::new();
     host.for_each_in_inclusive_subtree(root, |parent| {
-        let facts = host.facts(parent);
-        if !facts.has_style {
+        let (has_style, current_display, is_inline_outside, is_box, has_been_wrapped_in_table_wrapper) = {
+            let data = host.data(parent);
+            (
+                node_has_flag(data, NodeFlag::HasStyle),
+                data.table_display,
+                node_is_inline_outside(data),
+                node_kind_is_box(data.kind),
+                node_has_flag(data, NodeFlag::HasBeenWrappedInTableWrapper),
+            )
+        };
+        if !has_style {
             return TraversalDecision::Continue;
         }
 
         // 1. An anonymous table-row box must be generated around each sequence of consecutive table-cell boxes whose
         //    parent is not a table-row.
-        if facts.current_display != FfiTableDisplay::TableRow {
+        if current_display != FfiTableDisplay::TableRow {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
-                |child| child.has_style && child.current_display == FfiTableDisplay::TableCell,
+                |child| node_has_flag(child, NodeFlag::HasStyle) && child.table_display == FfiTableDisplay::TableCell,
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
                 },
@@ -2775,22 +2943,22 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         // If the box’s parent is an inline, run-in, or ruby box (or any box that would perform inlinification of its
         // children), then an inline-table box must be generated; otherwise it must be a table box.
         // FIXME: run-in and ruby boxes
-        let anonymous_table_kind = if facts.is_inline_outside {
+        let anonymous_table_kind = if is_inline_outside {
             FfiAnonymousTableBoxKind::InlineTable
         } else {
             FfiAnonymousTableBoxKind::Table
         };
 
         let is_table_row_group = matches!(
-            facts.current_display,
+            current_display,
             FfiTableDisplay::TableRowGroup | FfiTableDisplay::TableHeaderGroup | FfiTableDisplay::TableFooterGroup
         );
         // A table-row is misparented if its parent is neither a table-row-group nor a table-root box.
-        if !is_table_row_group && facts.current_display != FfiTableDisplay::TableRoot {
+        if !is_table_row_group && current_display != FfiTableDisplay::TableRoot {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
-                |child| child.has_style && child.current_display == FfiTableDisplay::TableRow,
+                |child| node_has_flag(child, NodeFlag::HasStyle) && child.table_display == FfiTableDisplay::TableRow,
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
                 },
@@ -2798,13 +2966,11 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         }
 
         // A table-column box is misparented if its parent is neither a table-column-group box nor a table-root box.
-        if facts.current_display != FfiTableDisplay::TableColumnGroup
-            && facts.current_display != FfiTableDisplay::TableRoot
-        {
+        if current_display != FfiTableDisplay::TableColumnGroup && current_display != FfiTableDisplay::TableRoot {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
-                |child| child.has_style && child.current_display == FfiTableDisplay::TableColumn,
+                |child| node_has_flag(child, NodeFlag::HasStyle) && child.table_display == FfiTableDisplay::TableColumn,
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
                 },
@@ -2813,12 +2979,12 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
 
         // A table-row-group, table-column-group, or table-caption box is misparented if its parent is not a table-root
         // box.
-        if facts.current_display != FfiTableDisplay::TableRoot {
+        if current_display != FfiTableDisplay::TableRoot {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
                 |child| {
-                    if !child.has_style {
+                    if !node_has_flag(child, NodeFlag::HasStyle) {
                         return false;
                     }
                     let display = display_for_table_fixup(child);
@@ -2831,11 +2997,11 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         }
 
         // 3. An anonymous table-wrapper box must be generated around each table-root.
-        if facts.is_box && facts.current_display == FfiTableDisplay::TableRoot {
-            if facts.has_been_wrapped_in_table_wrapper {
+        if is_box && current_display == FfiTableDisplay::TableRoot {
+            if has_been_wrapped_in_table_wrapper {
                 let parent = host.parent(parent);
-                assert!(!parent.is_null());
-                assert!(host.facts(parent).is_table_wrapper);
+                assert!(!parent.is_invalid());
+                assert_eq!(host.data(parent).kind, NodeKind::TableWrapper);
                 return TraversalDecision::Continue;
             }
             table_roots_to_wrap.push(parent);
@@ -2847,13 +3013,25 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
     for &table_root in &table_roots_to_wrap {
         let nearest_sibling = host.next_sibling(table_root);
         let parent = host.parent(table_root);
-        assert!(!parent.is_null());
-        if host.facts(parent).is_table_wrapper {
+        assert!(!parent.is_invalid());
+        if host.data(parent).kind == NodeKind::TableWrapper {
             // SAFETY: Both nodes are live and `parent` is a TableWrapper.
-            unsafe { (host.callbacks.update_existing_table_wrapper)(host.callbacks.context, table_root, parent) };
+            unsafe {
+                (host.callbacks.update_existing_table_wrapper)(
+                    host.callbacks.context,
+                    host.shell(table_root),
+                    host.shell(parent),
+                );
+            };
         } else {
             // SAFETY: `table_root` is attached and `nearest_sibling` is either null or its live next sibling.
-            unsafe { (host.callbacks.wrap_table_root)(host.callbacks.context, table_root, nearest_sibling) };
+            unsafe {
+                (host.callbacks.wrap_table_root)(
+                    host.callbacks.context,
+                    host.shell(table_root),
+                    host.shell_or_null(nearest_sibling),
+                );
+            };
         }
     }
     table_roots_to_wrap
@@ -2896,7 +3074,7 @@ fn fixup_row(host: &TreeBuilderHost<'_>, row: LayoutNode, table_grid: &TableGrid
             continue;
         }
         // SAFETY: `row` is a live table-row box.
-        unsafe { (host.callbacks.append_missing_table_cell)(host.callbacks.context, row) };
+        unsafe { (host.callbacks.append_missing_table_cell)(host.callbacks.context, host.shell(row)) };
     }
 }
 
@@ -2907,26 +3085,26 @@ fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
     // be appended to its rows content until this condition is met.
     for &table_root in table_roots {
         // SAFETY: `table_root` is a live table-root box and the callback returns a newly owned grid.
-        let grid = unsafe { (host.callbacks.create_table_grid)(host.callbacks.context, table_root) };
+        let grid = unsafe { (host.callbacks.create_table_grid)(host.callbacks.context, host.shell(table_root)) };
         assert!(!grid.is_null());
         let grid = TableGrid { host, grid };
         let mut row_index = 0;
 
         let mut child = host.first_child(table_root);
-        while !child.is_null() {
-            let child_facts = host.facts(child);
-            if child_facts.is_box
+        while !child.is_invalid() {
+            let child_data = host.data(child);
+            if node_kind_is_box(child_data.kind)
                 && matches!(
-                    child_facts.current_display,
+                    child_data.table_display,
                     FfiTableDisplay::TableRowGroup
                         | FfiTableDisplay::TableHeaderGroup
                         | FfiTableDisplay::TableFooterGroup
                 )
             {
                 let mut row = host.first_child(child);
-                while !row.is_null() {
-                    let row_facts = host.facts(row);
-                    if row_facts.is_box && row_facts.current_display == FfiTableDisplay::TableRow {
+                while !row.is_invalid() {
+                    let row_data = host.data(row);
+                    if node_kind_is_box(row_data.kind) && row_data.table_display == FfiTableDisplay::TableRow {
                         fixup_row(host, row, &grid, row_index);
                         row_index += 1;
                     }
@@ -2937,9 +3115,9 @@ fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
         }
 
         let mut child = host.first_child(table_root);
-        while !child.is_null() {
-            let child_facts = host.facts(child);
-            if child_facts.is_box && child_facts.current_display == FfiTableDisplay::TableRow {
+        while !child.is_invalid() {
+            let child_data = host.data(child);
+            if node_kind_is_box(child_data.kind) && child_data.table_display == FfiTableDisplay::TableRow {
                 fixup_row(host, child, &grid, row_index);
                 row_index += 1;
             }
@@ -2948,8 +3126,8 @@ fn missing_cells_fixup(host: &TreeBuilderHost<'_>, table_roots: &[LayoutNode]) {
     }
 }
 
-fn fixup_tables(host: &TreeBuilderHost<'_>, root: *mut c_void) {
-    assert!(!root.is_null());
+fn fixup_tables(host: &TreeBuilderHost<'_>, root: LayoutNode) {
+    assert!(!root.is_invalid());
     remove_irrelevant_boxes(host, root);
     generate_missing_child_wrappers(host, root);
     let table_roots = generate_missing_parents(host, root);
@@ -2968,6 +3146,7 @@ mod tests {
         principal_box_generation_decision, principal_box_placement_decision, principal_node_entry_decision,
         pseudo_element_decision,
     };
+    use crate::node_data::NodeSlotId;
     use std::ffi::c_void;
 
     unsafe extern "C" fn text_length(context: *mut c_void) -> usize {
@@ -3056,12 +3235,11 @@ mod tests {
     #[test]
     fn tree_builder_state_tracks_ancestors_and_quotes() {
         let mut state = super::TreeBuilderState::default();
-        let mut parent = 0_u8;
-        let parent_pointer = (&raw mut parent).cast::<c_void>();
-        state.ancestor_stack.push(parent_pointer);
+        let parent = NodeSlotId { index: 42 };
+        state.ancestor_stack.push(parent);
         assert_eq!(state.ancestor_stack.len(), 1);
-        assert_eq!(state.current_parent(), parent_pointer);
-        assert_eq!(state.ancestor_stack[0], parent_pointer);
+        assert_eq!(state.current_parent(), parent);
+        assert_eq!(state.ancestor_stack[0], parent);
 
         state.quote_nesting_level = 3;
         assert_eq!(state.quote_nesting_level, 3);
@@ -3251,9 +3429,8 @@ mod tests {
             is_document: false,
             is_element: true,
             rendered_in_top_layer: true,
-            layout_node_is_svg_box: false,
         };
-        let decision = principal_box_placement_decision(facts, true);
+        let decision = principal_box_placement_decision(facts, false, true);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::ReplaceExisting);
         assert!(decision.start_rebuild_root);
         assert!(decision.create_backdrop);
@@ -3261,8 +3438,7 @@ mod tests {
 
         facts.has_old_layout_node = false;
         facts.old_layout_node_is_attached = false;
-        facts.layout_node_is_svg_box = true;
-        let decision = principal_box_placement_decision(facts, true);
+        let decision = principal_box_placement_decision(facts, true, true);
         assert_eq!(decision.placement, FfiPrincipalBoxPlacement::AppendSvg);
         assert!(decision.mark_update_escaped_rebuild_roots);
     }

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -41,6 +41,7 @@
 #include <LibWeb/Layout/ListItemBox.h>
 #include <LibWeb/Layout/ListItemMarkerBox.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/SVGClipBox.h>
 #include <LibWeb/Layout/SVGMaskBox.h>
 #include <LibWeb/Layout/SVGPatternBox.h>
@@ -473,9 +474,9 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 frame.layout_node = DOM::Element::create_layout_node_for_display_type(document, frame.display, NonnullRefPtr { *frame.computed_values }, nullptr);
                 break;
             } },
-        .layout_node = [](void* frame_pointer) -> void* {
+        .layout_node = [](void* frame_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
-            return static_cast<PseudoElementFrame*>(frame_pointer)->layout_node.ptr(); },
+            return Node::slot_id(static_cast<PseudoElementFrame*>(frame_pointer)->layout_node.ptr()); },
         .attach_style_resources = [](void* frame_pointer) {
             VERIFY(frame_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
@@ -500,11 +501,6 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             else
                 VERIFY_NOT_REACHED();
             frame.layout_node->set_display(frame.display); },
-        .layout_node_is_list_item = [](void* frame_pointer) {
-            VERIFY(frame_pointer);
-            auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
-            VERIFY(frame.layout_node);
-            return is<ListItemBox>(*frame.layout_node); },
         .create_nested_list_marker = [](void* builder_pointer, void* frame_pointer, void* element_pointer) {
             VERIFY(builder_pointer);
             VERIFY(frame_pointer);
@@ -544,7 +540,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 .content_is_list = frame.resolved_content.type == CSS::ContentData::Type::List,
                 .content_item_count = frame.resolved_content.data.size(),
             }; },
-        .create_content_item = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo, size_t index) -> void* {
+        .create_content_item = [](void* frame_pointer, void* element_pointer, RustFFI::FfiPseudoElement ffi_pseudo, size_t index) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
             VERIFY(element_pointer);
             auto& frame = *static_cast<PseudoElementFrame*>(frame_pointer);
@@ -564,7 +560,7 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
                 frame.content_item = move(image_box);
             }
             frame.content_item->set_generated_for(css_pseudo_element(ffi_pseudo), element);
-            return frame.content_item.ptr(); },
+            return Node::slot_id(frame.content_item.ptr()); },
     };
 }
 
@@ -613,9 +609,6 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_and_paint_node(DOM::
     // subtree being cleared too.
     if (layout_node && is_svg_resource_box(*layout_node)) {
         RustFFI::FfiStaleNodeCallbacks callbacks {
-            .layout_parent = [](void* layout_node_pointer) -> void* {
-                VERIFY(layout_node_pointer);
-                return static_cast<Layout::Node*>(layout_node_pointer)->parent(); },
             .layout_dom_node = [](void* layout_node_pointer) -> void* {
                 VERIFY(layout_node_pointer);
                 return static_cast<Layout::Node*>(layout_node_pointer)->dom_node(); },
@@ -624,7 +617,8 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_and_paint_node(DOM::
                 VERIFY(root_pointer);
                 return static_cast<DOM::Node*>(node_pointer)->is_shadow_including_inclusive_descendant_of(*static_cast<DOM::Node*>(root_pointer)); },
         };
-        if (RustFFI::rust_should_preserve_svg_resource_layout_node(&callbacks, layout_node.ptr(), const_cast<DOM::Node*>(cleared_subtree_root)))
+        if (RustFFI::rust_should_preserve_svg_resource_layout_node(
+                &callbacks, layout_node->arena_handle(), Node::slot_id(layout_node.ptr()), const_cast<DOM::Node*>(cleared_subtree_root)))
             return TraversalDecision::SkipChildrenAndContinue;
     }
 
@@ -643,19 +637,16 @@ TraversalDecision LayoutTreeBuildBridge::clear_stale_layout_and_paint_node(DOM::
 void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element& element)
 {
     RustFFI::FfiTopLayerDetachCallbacks callbacks {
-        .element_layout_node = [](void* element_pointer) -> void* {
+        .element_layout_node = [](void* element_pointer) -> RustFFI::NodeSlotId {
             VERIFY(element_pointer);
             // NB: Called at DOM mutation processing time, outside layout tree construction.
-            return static_cast<DOM::Element*>(element_pointer)->unsafe_layout_node(); },
-        .topmost_placement_node = [](void* layout_node_pointer) -> void* {
+            return Node::slot_id(static_cast<DOM::Element*>(element_pointer)->unsafe_layout_node()); },
+        .topmost_placement_node = [](void* layout_node_pointer) -> RustFFI::NodeSlotId {
             VERIFY(layout_node_pointer);
-            return static_cast<Layout::Node*>(layout_node_pointer)->topmost_layout_node_of_top_layer_placement(); },
+            return Node::slot_id(static_cast<Layout::Node*>(layout_node_pointer)->topmost_layout_node_of_top_layer_placement()); },
         .prepare_subtree_for_detach = [](void* layout_node_pointer) {
             VERIFY(layout_node_pointer);
             static_cast<Layout::Node*>(layout_node_pointer)->prepare_subtree_for_detach_from_layout_tree(); },
-        .layout_parent = [](void* layout_node_pointer) -> void* {
-            VERIFY(layout_node_pointer);
-            return static_cast<Layout::Node*>(layout_node_pointer)->parent(); },
         .remove_layout_node = [](void* layout_node_pointer) {
             VERIFY(layout_node_pointer);
             static_cast<Layout::Node*>(layout_node_pointer)->remove(); },
@@ -677,7 +668,8 @@ void LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(DOM::Element
                 return clear_stale_layout_and_paint_node(node, &root);
             }); },
     };
-    RustFFI::rust_detach_top_layer_element_layout_subtree(&callbacks, &element);
+    RustFFI::rust_detach_top_layer_element_layout_subtree(
+        &callbacks, element.document().layout_node_arena().handle(), &element);
 }
 
 struct PrincipalNodeFrame {
@@ -794,9 +786,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .child_needs_layout_tree_update = node.child_needs_layout_tree_update(),
                 .layout_node_can_have_children = layout_node.can_have_children(),
                 .layout_node_is_replaced_box_with_children = layout_node.is_replaced_box_with_children(),
-                .layout_node_is_list_item_box = layout_node.is_list_item_box(),
-                .layout_node_is_block_container = is<BlockContainer>(layout_node),
-                .has_first_letter_style = element && element->computed_values(CSS::PseudoElement::FirstLetter),
                 .is_svg_switch_element = is<SVG::SVGSwitchElement>(node),
                 .is_document = node.is_document(),
                 .has_style_containment = is<NodeWithStyle>(layout_node) && static_cast<NodeWithStyle&>(layout_node).has_style_containment(),
@@ -810,6 +799,10 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .svg_fill_pattern = const_cast<SVG::SVGPatternElement*>(fill_pattern.ptr()),
                 .svg_stroke_pattern = const_cast<SVG::SVGPatternElement*>(stroke_pattern.ptr()),
             }; },
+        .layout_node_has_first_letter_style = [](void* layout_node_pointer) {
+            VERIFY(layout_node_pointer);
+            auto* element = as_if<DOM::Element>(static_cast<Node*>(layout_node_pointer)->dom_node());
+            return element && element->computed_values(CSS::PseudoElement::FirstLetter); },
         .create_first_letter_wrapper = [](void*, void* element_pointer, RustFFI::FfiFirstLetterTarget target) {
             VERIFY(element_pointer);
             create_first_letter_wrapper(*static_cast<DOM::Element*>(element_pointer), target); },
@@ -821,7 +814,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             node.for_each_shadow_including_descendant([&](auto& descendant) {
                 return builder.clear_stale_layout_and_paint_node(descendant, &node);
             }); },
-        .ensure_replaced_children_wrapper = [](void* builder_pointer, void* layout_node_pointer, void* parent_pointer) -> void* {
+        .ensure_replaced_children_wrapper = [](void* builder_pointer, void* layout_node_pointer, void* parent_pointer) -> RustFFI::NodeSlotId {
             VERIFY(builder_pointer);
             VERIFY(layout_node_pointer);
             VERIFY(parent_pointer);
@@ -830,7 +823,7 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 auto wrapper = as<NodeWithStyle>(layout_node).create_anonymous_wrapper();
                 static_cast<Layout::NodeWithStyle*>(parent_pointer)->append_child(wrapper);
             }
-            return layout_node.first_child().ptr(); },
+            return Node::slot_id(layout_node.first_child().ptr()); },
         .top_layer_element_count = [](void* document_pointer) {
             VERIFY(document_pointer);
             return static_cast<DOM::Document*>(document_pointer)->top_layer_elements().size(); },
@@ -1031,9 +1024,9 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
             VERIFY(node_pointer);
             // NB: Called during layout tree construction.
             static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node = static_cast<DOM::Node*>(node_pointer)->unsafe_layout_node(); },
-        .principal_layout_node = [](void* frame_pointer) -> void* {
+        .principal_layout_node = [](void* frame_pointer) -> RustFFI::NodeSlotId {
             VERIFY(frame_pointer);
-            return static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node.ptr(); },
+            return Node::slot_id(static_cast<PrincipalNodeFrame*>(frame_pointer)->layout_node.ptr()); },
         .attach_principal_style_resources = [](void* frame_pointer) {
             VERIFY(frame_pointer);
             auto& frame = *static_cast<PrincipalNodeFrame*>(frame_pointer);
@@ -1077,7 +1070,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 .is_document = node.is_document(),
                 .is_element = element != nullptr,
                 .rendered_in_top_layer = element && element->rendered_in_top_layer(),
-                .layout_node_is_svg_box = frame.layout_node->is_svg_box(),
             }; },
         .start_principal_rebuild_root = [](void* builder_pointer, void* frame_pointer) -> void* {
             VERIFY(builder_pointer);
@@ -1141,10 +1133,10 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
         .reset_style_ancestor_filter = [](void* document_pointer) {
             VERIFY(document_pointer);
             static_cast<DOM::Document*>(document_pointer)->style_computer().reset_ancestor_filter(); },
-        .document_layout_node = [](void* document_pointer) -> void* {
+        .document_layout_node = [](void* document_pointer) -> RustFFI::NodeSlotId {
             VERIFY(document_pointer);
             // NB: Called during layout tree construction.
-            return static_cast<DOM::Document*>(document_pointer)->unsafe_layout_node(); },
+            return Node::slot_id(static_cast<DOM::Document*>(document_pointer)->unsafe_layout_node()); },
         .layout_root = [](void* builder_pointer) -> void* {
             VERIFY(builder_pointer);
             return static_cast<LayoutTreeBuildBridge*>(builder_pointer)->m_layout_root.ptr(); },
@@ -1210,7 +1202,8 @@ static NonnullRefPtr<NodeWithStyle> create_button_content_box_wrapper(NodeWithSt
 LayoutTreeBuildResult LayoutTreeBuildBridge::build(DOM::Node& dom_node)
 {
     auto callbacks = make_ffi_dom_tree_builder_callbacks();
-    m_layout_root = static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(&callbacks, &dom_node));
+    m_layout_root = static_cast<Layout::Node*>(RustFFI::rust_build_layout_tree(
+        &callbacks, dom_node.document().layout_node_arena().handle(), &dom_node));
     return {
         .root = move(m_layout_root),
         .rebuilt_subtree_roots = move(m_rebuilt_subtree_roots),
@@ -1227,82 +1220,6 @@ LayoutTreeBuildResult build_layout_tree(DOM::Node& dom_node)
 void detach_top_layer_element_layout_subtree(DOM::Element& element)
 {
     LayoutTreeBuildBridge::detach_top_layer_element_layout_subtree(element);
-}
-
-static RustFFI::FfiTableDisplay ffi_table_display(CSS::Display display)
-{
-    if (display.is_table_inside())
-        return RustFFI::FfiTableDisplay::TableRoot;
-    if (display.is_table_row_group())
-        return RustFFI::FfiTableDisplay::TableRowGroup;
-    if (display.is_table_header_group())
-        return RustFFI::FfiTableDisplay::TableHeaderGroup;
-    if (display.is_table_footer_group())
-        return RustFFI::FfiTableDisplay::TableFooterGroup;
-    if (display.is_table_column_group())
-        return RustFFI::FfiTableDisplay::TableColumnGroup;
-    if (display.is_table_column())
-        return RustFFI::FfiTableDisplay::TableColumn;
-    if (display.is_table_row())
-        return RustFFI::FfiTableDisplay::TableRow;
-    if (display.is_table_cell())
-        return RustFFI::FfiTableDisplay::TableCell;
-    if (display.is_table_caption())
-        return RustFFI::FfiTableDisplay::TableCaption;
-    return RustFFI::FfiTableDisplay::Other;
-}
-
-static RustFFI::FfiLayoutNodeFacts ffi_layout_node_facts(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    auto& node = *static_cast<Node*>(node_pointer);
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    auto const* text_node = as_if<TextNode>(node);
-    return {
-        .current_display = node_with_style ? ffi_table_display(node_with_style->display()) : RustFFI::FfiTableDisplay::Other,
-        .display_before_box_type_transformation = node_with_style ? ffi_table_display(node_with_style->display_before_box_type_transformation()) : RustFFI::FfiTableDisplay::Other,
-        .is_box = is<Box>(node),
-        .has_style = node.has_style(),
-        .is_anonymous = node.is_anonymous(),
-        .is_block_container = node.is_block_container(),
-        .children_are_inline = node.children_are_inline(),
-        .is_out_of_flow = node.is_out_of_flow(),
-        .is_text = text_node != nullptr,
-        .text_is_ascii_whitespace = text_node && text_node->text_for_rendering().is_ascii_whitespace(),
-        .is_inline_outside = text_node || (node_with_style && node_with_style->display().is_inline_outside()),
-        .is_table_wrapper = node.is_table_wrapper(),
-        .has_been_wrapped_in_table_wrapper = node.has_been_wrapped_in_table_wrapper(),
-        .has_replaced_element_table_display_adjustment = node_with_style && node_with_style->has_replaced_element_table_display_adjustment(),
-        .is_inline = node.is_inline(),
-        .is_in_flow = node.is_in_flow(),
-        .is_inline_node = is<InlineNode>(node),
-        .is_field_set_box = is<FieldSetBox>(node),
-        .is_svg_foreign_object_box = node.is_svg_foreign_object_box(),
-        .is_svg_box = node.is_svg_box(),
-        .is_svg_svg_box = node.is_svg_svg_box(),
-        .is_generated_for_pseudo_element = node.is_generated_for_pseudo_element(),
-        .display_is_flow_inside = node_with_style && node_with_style->display().is_flow_inside(),
-        .display_is_flex_inside = node_with_style && node_with_style->display().is_flex_inside(),
-        .display_is_grid_inside = node_with_style && node_with_style->display().is_grid_inside(),
-        .is_list_item_marker_box = is<ListItemMarkerBox>(node),
-        .is_generated_for_marker = node.generated_for_pseudo_element() == CSS::PseudoElement::Marker,
-        .is_fragmented_inline = node.is_fragmented_inline(),
-        .has_first_letter_style = [&] {
-            auto* dom_element = as_if<DOM::Element>(node.dom_node());
-            return dom_element && dom_element->computed_values(CSS::PseudoElement::FirstLetter);
-        }(),
-        .has_rendered_legend = is<FieldSetBox>(node) && static_cast<FieldSetBox&>(node).rendered_legend(),
-    };
-}
-
-static bool ffi_layout_node_is_inline_outside(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    auto& node = *static_cast<Node*>(node_pointer);
-    if (node.is_text_node())
-        return true;
-    auto const* node_with_style = as_if<NodeWithStyle>(node);
-    return node_with_style && node_with_style->display().is_inline_outside();
 }
 
 static size_t ffi_first_letter_code_unit_length(void* context_pointer)
@@ -1340,36 +1257,6 @@ static RustFFI::FfiFirstLetterCodePointFacts ffi_first_letter_code_point_facts(v
         .is_open_punctuation = Unicode::code_point_has_general_category(code_point, ps),
         .is_dash_punctuation = Unicode::code_point_has_general_category(code_point, pd),
     };
-}
-
-static void* ffi_layout_node_parent(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    return static_cast<Node*>(node_pointer)->parent();
-}
-
-static void* ffi_layout_node_first_child(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    return static_cast<Node*>(node_pointer)->first_child().ptr();
-}
-
-static void* ffi_layout_node_next_sibling(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    return static_cast<Node*>(node_pointer)->next_sibling().ptr();
-}
-
-static void* ffi_layout_node_previous_sibling(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    return static_cast<Node*>(node_pointer)->previous_sibling().ptr();
-}
-
-static void* ffi_layout_node_last_child(void*, void* node_pointer)
-{
-    VERIFY(node_pointer);
-    return static_cast<Node*>(node_pointer)->last_child().ptr();
 }
 
 static Vector<NonnullRefPtr<Node>> retain_ffi_layout_nodes(void* const* node_pointers, size_t node_count)
@@ -1496,13 +1383,13 @@ static void ffi_append_missing_table_cell(void*, void* row_pointer)
     row_box.append_child(make_ref_counted<BlockContainer>(row_box.document(), nullptr, move(builder).build()));
 }
 
-static void* ffi_create_and_append_anonymous_wrapper(void*, void* parent_pointer)
+static RustFFI::NodeSlotId ffi_create_and_append_anonymous_wrapper(void*, void* parent_pointer)
 {
     VERIFY(parent_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(parent_pointer));
     auto wrapper = parent.create_anonymous_wrapper();
     parent.append_child(*wrapper);
-    return wrapper.ptr();
+    return Node::slot_id(wrapper.ptr());
 }
 
 static void ffi_wrap_children_in_anonymous(void*, void* parent_pointer, void* const* child_pointers, size_t child_count)
@@ -1545,7 +1432,7 @@ static void ffi_note_tree_restructuring(void* context, void* node_pointer)
     static_cast<LayoutTreeBuildBridge*>(context)->note_tree_restructuring_at(*static_cast<Node*>(node_pointer));
 }
 
-static void* ffi_create_button_content_wrapper(void*, void* layout_node_pointer)
+static RustFFI::NodeSlotId ffi_create_button_content_wrapper(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
     auto& parent = as<NodeWithStyle>(*static_cast<Node*>(layout_node_pointer));
@@ -1557,17 +1444,17 @@ static void* ffi_create_button_content_wrapper(void*, void* layout_node_pointer)
     auto content_box_wrapper = create_button_content_box_wrapper(parent);
     flex_wrapper->append_child(*content_box_wrapper);
     parent.append_child(*flex_wrapper);
-    return content_box_wrapper.ptr();
+    return Node::slot_id(content_box_wrapper.ptr());
 }
 
-static void* ffi_rendered_legend(void*, void* layout_node_pointer)
+static RustFFI::NodeSlotId ffi_rendered_legend(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
     auto& fieldset_box = as<FieldSetBox>(*static_cast<Node*>(layout_node_pointer));
-    return const_cast<Node*>(static_cast<Node const*>(fieldset_box.rendered_legend().ptr()));
+    return Node::slot_id(fieldset_box.rendered_legend().ptr());
 }
 
-static void* ffi_create_fieldset_content_wrapper(void*, void* layout_node_pointer)
+static RustFFI::NodeSlotId ffi_create_fieldset_content_wrapper(void*, void* layout_node_pointer)
 {
     VERIFY(layout_node_pointer);
     auto& fieldset_box = as<FieldSetBox>(*static_cast<Node*>(layout_node_pointer));
@@ -1585,7 +1472,7 @@ static void* ffi_create_fieldset_content_wrapper(void*, void* layout_node_pointe
     fieldset_box.set_overflow(CSS::InitialValues::overflow(), CSS::InitialValues::overflow());
 
     fieldset_box.append_child(*wrapper);
-    return wrapper.ptr();
+    return Node::slot_id(wrapper.ptr());
 }
 
 static void ffi_move_nodes_to_parent(void*, void* parent_pointer, void* const* node_pointers, size_t node_count)
@@ -1604,13 +1491,6 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
 {
     return {
         .context = this,
-        .layout_node_facts = ffi_layout_node_facts,
-        .is_inline_outside = ffi_layout_node_is_inline_outside,
-        .parent = ffi_layout_node_parent,
-        .first_child = ffi_layout_node_first_child,
-        .next_sibling = ffi_layout_node_next_sibling,
-        .previous_sibling = ffi_layout_node_previous_sibling,
-        .last_child = ffi_layout_node_last_child,
         .remove_nodes = ffi_remove_layout_nodes,
         .wrap_in_anonymous = ffi_wrap_in_anonymous_table_box,
         .update_existing_table_wrapper = ffi_update_existing_table_wrapper,
@@ -1625,6 +1505,9 @@ RustFFI::FfiTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_tree_builder_ca
         .insert_child = ffi_insert_child,
         .set_children_are_inline = ffi_set_children_are_inline,
         .note_tree_restructuring = ffi_note_tree_restructuring,
+        .text_is_ascii_whitespace = [](void*, void* node_pointer) {
+            VERIFY(node_pointer);
+            return as<TextNode>(*static_cast<Node*>(node_pointer)).text_for_rendering().is_ascii_whitespace(); },
         .prepare_first_letter_text = [](void* builder_pointer, void* node_pointer, RustFFI::FfiFirstLetterTextCallbacks* callbacks) {
             VERIFY(builder_pointer);
             VERIFY(node_pointer);

--- a/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Libraries/LibWeb/Layout/VideoBox.h
@@ -12,8 +12,7 @@
 namespace Web::Layout {
 
 class VideoBox final : public ReplacedBox {
-    GC_CELL(VideoBox, ReplacedBox);
-    GC_DECLARE_ALLOCATOR(VideoBox);
+    LAYOUT_NODE(VideoBox, ReplacedBox);
 
 public:
     VideoBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::ComputedValues const>);

--- a/Libraries/LibWeb/RefCountedTreeNode.h
+++ b/Libraries/LibWeb/RefCountedTreeNode.h
@@ -191,10 +191,12 @@ public:
         node->m_parent = static_cast<T&>(*this);
         m_last_child = node;
 
+        T* appended_child = node.ptr();
         if (previous_last_child)
             previous_last_child->m_next_sibling = move(node);
         else
             m_first_child = move(node);
+        synchronize_topology_around(*appended_child);
     }
 
     void prepend_child(NonnullRefPtr<T> node)
@@ -207,9 +209,11 @@ public:
             m_first_child->m_previous_sibling = node;
         node->m_next_sibling = m_first_child;
         node->m_parent = static_cast<T&>(*this);
+        T* prepended_child = node.ptr();
         m_first_child = move(node);
         if (!m_last_child)
             m_last_child = m_first_child;
+        synchronize_topology_around(*prepended_child);
     }
 
     void insert_before(NonnullRefPtr<T> node, T* child)
@@ -232,7 +236,9 @@ public:
         else
             m_first_child = node;
 
+        T* inserted_child = node.ptr();
         child->m_previous_sibling = move(node);
+        synchronize_topology_around(*inserted_child);
     }
 
     void insert_before(NonnullRefPtr<T> node, T& child)
@@ -267,6 +273,15 @@ public:
         node.m_next_sibling.clear();
         node.m_previous_sibling.clear();
         node.m_parent.clear();
+
+        if constexpr (requires { node.synchronize_topology(); }) {
+            static_cast<T&>(*this).synchronize_topology();
+            node.synchronize_topology();
+            if (previous_sibling)
+                previous_sibling->synchronize_topology();
+            if (next_sibling)
+                next_sibling->synchronize_topology();
+        }
     }
 
     void replace_child(NonnullRefPtr<T> new_child, T& old_child)
@@ -298,6 +313,10 @@ public:
         old_child_ref->m_next_sibling.clear();
         old_child_ref->m_previous_sibling.clear();
         old_child_ref->m_parent.clear();
+
+        synchronize_topology_around(*new_child);
+        if constexpr (requires { old_child.synchronize_topology(); })
+            old_child.synchronize_topology();
     }
 
     void remove()
@@ -582,6 +601,8 @@ public:
             child->m_next_sibling.clear();
             child->m_previous_sibling.clear();
             child->m_parent.clear();
+            if constexpr (requires { child->synchronize_topology(); })
+                child->synchronize_topology();
         }
         m_last_child.clear();
     }
@@ -590,6 +611,18 @@ protected:
     RefCountedTreeNode() = default;
 
 private:
+    void synchronize_topology_around(T& node)
+    {
+        if constexpr (requires { node.synchronize_topology(); }) {
+            static_cast<T&>(*this).synchronize_topology();
+            node.synchronize_topology();
+            if (auto* previous_sibling = node.previous_sibling_ptr())
+                previous_sibling->synchronize_topology();
+            if (auto* next_sibling = node.next_sibling_ptr())
+                next_sibling->synchronize_topology();
+        }
+    }
+
     WeakPtr<T> m_parent;
     RefPtr<T> m_first_child;
     WeakPtr<T> m_last_child;


### PR DESCRIPTION
Prep work before converting layout code in Rust but also removes `ffi_layout_node_facts()` which was very heavy in profiles on https://www.nyan.cat/