### PR TITLE
LibWeb: Reject non-edge keywords when parsing a position

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2917,8 +2917,11 @@ RefPtr<PositionStyleValue const> Parser::parse_position_value(TokenStream<Compon
         auto keyword = keyword_from_string(token.token().ident());
         if (!keyword.has_value())
             return {};
+        auto edge = keyword_to_position_edge(*keyword);
+        if (!edge.has_value())
+            return {};
         transaction.commit();
-        return keyword_to_position_edge(*keyword);
+        return edge;
     };
 
     auto is_horizontal = [](PositionEdge edge, bool accept_center) -> bool {

--- a/Tests/LibWeb/Text/expected/css/position-rejects-non-edge-keywords.txt
+++ b/Tests/LibWeb/Text/expected/css/position-rejects-non-edge-keywords.txt
@@ -1,0 +1,8 @@
+circle 5px: false
+circle 5px 5px: false
+5px circle: false
+auto auto: false
+left 5px: true
+5px top: true
+center: true
+left top: true

--- a/Tests/LibWeb/Text/input/css/position-rejects-non-edge-keywords.html
+++ b/Tests/LibWeb/Text/input/css/position-rejects-non-edge-keywords.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (const value of [
+            "circle 5px",
+            "circle 5px 5px",
+            "5px circle",
+            "auto auto",
+            "left 5px",
+            "5px top",
+            "center",
+            "left top",
+        ]) {
+            println(`${value}: ${CSS.supports("object-position", value)}`);
+        }
+    });
+</script>


### PR DESCRIPTION
The position-edge parser committed its token consumption before checking that the keyword names a position edge, so any known keyword was silently swallowed and the remaining tokens could still parse as a valid position.

Found while looking into compat spec gaps.