### PR TITLE
LibMedia: Force a clean re-seek after an aborted decode session

### DIFF
--- a/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedAudioProducer.cpp
@@ -429,6 +429,7 @@ bool DecodedAudioProducer::ThreadData::handle_seek()
             m_current_halting_status = PipelineStatus::Pending;
             m_moved_position_pending = true;
         }
+        m_decoder_needs_keyframe_next_seek = true;
         enter_halting_state(PipelineStatus::Error, move(error));
         m_last_processed_seek_id = seek_id;
     };
@@ -521,6 +522,7 @@ void DecodedAudioProducer::ThreadData::push_data_and_decode_a_block()
 
     auto set_halting_status_and_wait_for_seek = [this](PipelineStatus status, Optional<DecoderError> error) {
         auto locker = take_lock();
+        m_decoder_needs_keyframe_next_seek = true;
         enter_halting_state(status, move(error));
 
         dbgln_if(PLAYBACK_MANAGER_DEBUG, "Decoded Audio Producer: Reached a halting pull status, waiting for a seek to start decoding again...");

--- a/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
+++ b/Libraries/LibMedia/Producers/DecodedVideoProducer.cpp
@@ -416,6 +416,7 @@ bool DecodedVideoProducer::ThreadData::handle_seek()
             m_current_halting_status = PipelineStatus::Pending;
             m_moved_position_pending = true;
         }
+        m_decoder_needs_keyframe_next_seek = true;
         enter_halting_state(PipelineStatus::Error, move(error));
         m_last_processed_seek_id = seek_id;
     };
@@ -517,6 +518,7 @@ void DecodedVideoProducer::ThreadData::push_data_and_decode_some_frames()
 
     auto set_halting_status_and_wait_for_seek = [this](PipelineStatus status, Optional<DecoderError> error) {
         auto locker = take_lock();
+        m_decoder_needs_keyframe_next_seek = true;
         enter_halting_state(status, move(error));
 
         dbgln_if(PLAYBACK_MANAGER_DEBUG, "Decoded Video Producer: Reached a halting pull status, waiting for a seek to start decoding again...");


### PR DESCRIPTION
**Problem:** Under CI, the `Screenshot/input/video-seek.html` test was failing several times a week — always in the same way: the captured page shows a blank video box even though the test received its “seeked” event.

**Cause:** A new seek aborts an in-flight decode session whose blocking read still waits on undelivered media data; in this test, the media element’s initial-buffering seek racing the script’s `currentTime = 5`. The aborted session’s error path marks its seek processed, but leaves an incoherency among: (1) the demuxer position, (2) the demuxer’s cached sample and (3) the frames already fed to the decoder. An aborted frame read can even advance the iterator past a block whose frames were never consumed. The skip-seek optimization in `MatroskaDemuxer::seek_to_most_recent_keyframe` resumes from the “current position” because the new seek then trusts that stale state, and the decoder gets a discontinuous inter frame, and rejects it as corrupted — and the seek is resolved through the Error status. `HTMLMediaElement` then fires “seeked” without any frame having reached the compositor, and the screenshot captures a never-painted box.

**Fix:** Treat an aborted or errored decode session as breaking decode continuity: set `m_decoder_needs_keyframe_next_seek` in both producers’ error funnels — exactly as auto-suspension already does when it discards the decoder. The next seek then takes the `Force` path, which re-positions the demuxer at a keyframe, resets the cached sample, and flushes the decoder — as one coherent transition. So, a seek can never resume across the remains of an interrupted session.

**Testing:** In local testing with media delivery throttled and jittered so the abort race is hit on every run, the `video-seek.html` test failed 21 of 40 runs before this change, and 0 of 100 after.
