### PR TITLE
LibJS: Some fixes for test262

### DIFF
--- a/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1366,7 +1366,8 @@ static ThrowCompletionOr<Utf16String> transform_case(VM& vm, Utf16String const& 
     auto match = Intl::lookup_matching_locale_by_prefix({ { requested_locale } });
 
     // 6. If match is not undefined, let locale be match.[[locale]]; else let locale be "und".
-    auto locale = match.has_value() ? match->locale.utf16_view() : u"und"sv;
+    // NB: LibUnicode reads locale views as bytes, so keep the fallback in ASCII storage.
+    auto locale = match.has_value() ? match->locale.utf16_view() : Utf16View { "und"sv };
 
     // 7. Let codePoints be StringToCodePoints(S).
 

--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -487,6 +487,11 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::every)
 template<typename T>
 inline void fast_typed_array_fill(TypedArrayBase& typed_array, u32 begin, u32 end, T value)
 {
+    // NB: The range is empty when it was clamped from both sides, e.g. fill(v, -1, -3).
+    //     The byte count below is unsigned, so an inverted range must not reach it.
+    if (begin >= end)
+        return;
+
     Checked<size_t> computed_begin = begin;
     computed_begin *= sizeof(T);
     computed_begin += typed_array.byte_offset();
@@ -1735,6 +1740,12 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
 
         // e. Set count to max(final - k, 0).
         count = max(final - k, 0);
+
+        // NB: The source shrank away while its bounds were being coerced, so there is
+        //     nothing left to copy. The remaining steps are all no-ops for an empty
+        //     range, but the source byte index is now past the end of its buffer.
+        if (count == 0)
+            return array;
 
         // f. Let srcType be TypedArrayElementType(O).
         // g. Let targetType be TypedArrayElementType(A).

--- a/Tests/LibJS/Runtime/builtins/String/String.prototype.toLocaleLowerCase.js
+++ b/Tests/LibJS/Runtime/builtins/String/String.prototype.toLocaleLowerCase.js
@@ -26,6 +26,8 @@ test("special case folding", () => {
     expect("\u1FC7".toLocaleLowerCase()).toBe("\u1FC7");
     expect("\u1FF7".toLocaleLowerCase()).toBe("\u1FF7");
 
+    expect("\u0130".toLocaleLowerCase("und")).toBe("\u0069\u0307");
+
     expect("I".toLocaleLowerCase()).toBe("i");
     expect("I".toLocaleLowerCase("az")).toBe("\u0131");
     expect("I".toLocaleLowerCase("tr")).toBe("\u0131");

--- a/Tests/LibJS/Runtime/builtins/String/String.prototype.toLocaleUpperCase.js
+++ b/Tests/LibJS/Runtime/builtins/String/String.prototype.toLocaleUpperCase.js
@@ -28,6 +28,8 @@ test("special case folding", () => {
     expect("\u1FC7".toLocaleUpperCase()).toBe("\u0397\u0342\u0399");
     expect("\u1FF7".toLocaleUpperCase()).toBe("\u03A9\u0342\u0399");
 
+    expect("i\u0307".toLocaleUpperCase("und")).toBe("I\u0307");
+
     expect("i".toLocaleUpperCase()).toBe("I");
     expect("i".toLocaleUpperCase("lt")).toBe("I");
 

--- a/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.fill.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.fill.js
@@ -76,3 +76,13 @@ test("basic functionality", () => {
         expect(typedArray[2]).toBe(0n);
     });
 });
+
+test("negative start after negative end", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T(5);
+
+        expect(typedArray.fill(8, -1, -3)).toBe(typedArray);
+
+        for (let i = 0; i < 5; ++i) expect(typedArray[i]).toBe(0);
+    });
+});

--- a/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.slice.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.slice.js
@@ -66,3 +66,23 @@ test("basic functionality", () => {
         expect(second_slice).toHaveLength(0);
     });
 });
+
+test("source buffer resized to zero while coercing bounds", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const byteLength = 4 * T.BYTES_PER_ELEMENT;
+        const arrayBuffer = new ArrayBuffer(byteLength, { maxByteLength: byteLength });
+        const typedArray = new T(arrayBuffer);
+        typedArray.fill(1);
+
+        const start = {
+            valueOf() {
+                arrayBuffer.resize(0);
+                return 1;
+            },
+        };
+
+        const slice = typedArray.slice(start);
+        expect(slice).toHaveLength(3);
+        for (let i = 0; i < 3; ++i) expect(slice[i]).toBe(0);
+    });
+});


### PR DESCRIPTION
See individual commits for details.

```
    test/built-ins/TypedArray/prototype/fill/fill-values-custom-start-and-end.js 💥 -> ✅
    test/built-ins/TypedArray/prototype/slice/resize-count-bytes-to-zero.js      💥 -> ✅
    test/intl402/String/prototype/toLocaleLowerCase/capital_I_with_dot.js        💥 -> ✅
    test/intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js 💥 -> ✅
    test/staging/sm/TypedArray/fill.js                                           💥 -> ✅
```