### PR TITLE
LibWeb: Treat SVG paint URLs to non-paint-servers as invalid

### DIFF
--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -229,12 +229,8 @@ Optional<Gfx::Color> SVGGraphicsElement::fill_color() const
     if (!paint.has_value())
         return {};
 
-    if (paint->is_url()) {
-        if (auto referenced_element = try_resolve_url_to<SVGGraphicsElement const>(paint->as_url()))
-            return referenced_element->fill_color();
-
+    if (paint->is_url())
         return paint->fallback_color();
-    }
 
     return paint->as_color();
 }
@@ -248,12 +244,8 @@ Optional<Gfx::Color> SVGGraphicsElement::stroke_color() const
     if (!paint.has_value())
         return {};
 
-    if (paint->is_url()) {
-        if (auto referenced_element = try_resolve_url_to<SVGGraphicsElement const>(paint->as_url()))
-            return referenced_element->stroke_color();
-
+    if (paint->is_url())
         return paint->fallback_color();
-    }
 
     return paint->as_color();
 }

--- a/Tests/LibWeb/Crash/SVG/fill-and-stroke-url-reference-cycle.svg
+++ b/Tests/LibWeb/Crash/SVG/fill-and-stroke-url-reference-cycle.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+<rect id="self-fill" width="10" height="10" fill="url(#self-fill)"/>
+<rect id="self-stroke" x="20" width="10" height="10" stroke="url(#self-stroke)"/>
+<rect id="cycle-a" x="40" width="10" height="10" fill="url(#cycle-b)" stroke="url(#cycle-b)"/>
+<rect id="cycle-b" x="60" width="10" height="10" fill="url(#cycle-a)" stroke="url(#cycle-a)"/>
+</svg>

--- a/Tests/LibWeb/Ref/expected/svg-paint-url-to-non-paint-server-uses-fallback-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-paint-url-to-non-paint-server-uses-fallback-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<body>
+<svg width="400" height="140">
+    <rect x="290" y="10" width="100" height="100" fill="red"/>
+    <rect x="10" y="10" width="100" height="100" fill="green"/>
+    <rect x="150" y="10" width="100" height="100" fill="none" stroke="blue" stroke-width="8"/>
+</svg>
+</body>

--- a/Tests/LibWeb/Ref/input/svg-paint-url-to-non-paint-server-uses-fallback.html
+++ b/Tests/LibWeb/Ref/input/svg-paint-url-to-non-paint-server-uses-fallback.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<head>
+<link rel="match" href="../expected/svg-paint-url-to-non-paint-server-uses-fallback-ref.html" />
+</head>
+<body>
+<svg width="400" height="140">
+    <rect id="target" x="290" y="10" width="100" height="100" fill="red"/>
+    <rect x="10" y="10" width="100" height="100" fill="url(#target) green"/>
+    <rect x="150" y="10" width="100" height="100" fill="url(#target)" stroke="url(#target) blue" stroke-width="8"/>
+</svg>
+</body>


### PR DESCRIPTION
**Problem:** An SVG paint reference cycle — in the simplest case a rect with `fill=url(#self)` referencing itself — recursed without bound in `SVGGraphicsElement::fill_color()`, until WebContent overflowed the stack and crashed. `stroke_color()` had the same shape — reachable even at layout time through `visible_stroke_width()`.

**Cause:** `fill_color()` and `stroke_color()` resolved a `url()` paint value to any `SVGGraphicsElement`, and returned that element’s own resolved fill or stroke color. That reference chase has no basis in the spec, which requires a paint URL to reference a paint server element, and treats every other target as an invalid reference. And the chased element’s own paint can reference back. So, the walk could cycle — with no guard.

**Fix:** Drop the reference chase. References to actual paint servers are already resolved by `fill_paint_style()` and `stroke_paint_style()`. So, any URL reaching `fill_color()` or `stroke_color()` is an invalid paint server reference, for which the spec prescribes the fallback color, or no paint at all if no fallback is given. Cycles are then structurally impossible; no walk remains to need a guard, and rendering matches Gecko and Blink — which paint a shape whose fill references a non-paint-server element with the fallback color, rather than with the referenced element’s fill.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/10850
