### PR TITLE
LibJS: Add missing typed array element store fast paths

### DIFF
--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -1947,6 +1947,36 @@ handler PutByValue(
                 dispatch_next;
             },
 
+            TYPED_ARRAY_KIND_UINT8 | TYPED_ARRAY_KIND_INT8 => {
+                guard let converted = numeric_value_to_i32(source) else try_typed_array_slow;
+                let values: Sequence<u8> = alias(
+                    caged_primitive_storage_address(elements, cached_offset, index, 1)
+                );
+                values[0] = truncate_u8(converted);
+                dispatch_next;
+            },
+
+            TYPED_ARRAY_KIND_UINT16 | TYPED_ARRAY_KIND_INT16 => {
+                guard let converted = numeric_value_to_i32(source) else try_typed_array_slow;
+                let values: Sequence<u16> = alias(
+                    caged_primitive_storage_address(elements, cached_offset, index, 2)
+                );
+                values[0] = truncate_u16(converted);
+                dispatch_next;
+            },
+
+            # Uint8Clamped is deliberately not handled here: it rounds half to even and clamps rather than truncating,
+            # so it keeps using the general path.
+
+            TYPED_ARRAY_KIND_INT32 | TYPED_ARRAY_KIND_UINT32 => {
+                guard let converted = numeric_value_to_i32(source) else try_typed_array_slow;
+                let values: Sequence<i32> = alias(
+                    caged_primitive_storage_address(elements, cached_offset, index, 4)
+                );
+                values[0] = converted;
+                dispatch_next;
+            },
+
             _ => try_typed_array_slow,
         }
     };
@@ -1999,6 +2029,15 @@ handler PutByValue(
                 caged_primitive_storage_address(elements, cached_offset, index, 4)
             );
             values[0] = source_f32;
+            dispatch_next;
+        },
+
+        TYPED_ARRAY_KIND_FLOAT64 => {
+            let source_f64 = to_f64(source_i32);
+            let values: Sequence<Value> = alias(
+                caged_primitive_storage_address(elements, cached_offset, index, 8)
+            );
+            values[0] = box_f64(source_f64);
             dispatch_next;
         },
 


### PR DESCRIPTION
Storing a number into a typed array fell back to the generic property path whenever the value's type did not match one of the combinations handled inline: integers into Float64Array had no arm at all, and non-integers into any integer-element array had none either. Since an integral double is boxed as an int32, numeric code writing to a Float64Array took the slow path for roughly every other value, depending only on whether the result happened to land on a whole number. Give both combinations inline arms, converting through ToInt32 for integer element kinds; Uint8ClampedArray keeps using the general path because it rounds half to even and clamps rather than truncating.

Pretty neutral across most js-benchmarks' tests, but gains ~25% on `container.cpp.js` and  ~10% on `gcc-loops.cpp.js`.

<details><summary>js-benchmarks results</summary>

```
Suite           Test                                    Speedup    Old (Mean ± Range)                 New (Mean ± Range)                 Max RSS (mean)
--------------  --------------------------------------  ---------  ---------------------------------  ---------------------------------  ----------------
SunSpider       3d-cube.js                              1.035      0.018 ± 0.016 … 0.022              0.018 ± 0.016 … 0.020              +0.3% (+0.0 MB)
SunSpider       3d-morph.js                             0.938      0.015 ± 0.015 … 0.015              0.016 ± 0.016 … 0.016              +0.0% (+0.0 MB)
SunSpider       3d-raytrace.js                          1.000      0.018 ± 0.017 … 0.018              0.018 ± 0.017 … 0.018              -0.0% (-0.0 MB)
SunSpider       access-binary-trees.js                  0.992      0.014 ± 0.013 … 0.014              0.014 ± 0.014 … 0.014              +0.2% (+0.0 MB)
SunSpider       access-fannkuch.js                      0.966      0.018 ± 0.018 … 0.018              0.019 ± 0.019 … 0.019              +0.1% (+0.0 MB)
SunSpider       access-nbody.js                         0.944      0.015 ± 0.015 … 0.015              0.016 ± 0.015 … 0.016              +0.1% (+0.0 MB)
SunSpider       access-nsieve.js                        0.889      0.013 ± 0.013 … 0.013              0.015 ± 0.015 … 0.015              +0.0% (+0.0 MB)
SunSpider       bitops-3bit-bits-in-byte.js             0.973      0.012 ± 0.012 … 0.012              0.012 ± 0.012 … 0.013              +0.2% (+0.0 MB)
SunSpider       bitops-bits-in-byte.js                  1.037      0.014 ± 0.014 … 0.014              0.013 ± 0.013 … 0.014              +0.1% (+0.0 MB)
SunSpider       bitops-bitwise-and.js                   1.008      0.016 ± 0.015 … 0.016              0.016 ± 0.015 … 0.016              +0.3% (+0.0 MB)
SunSpider       bitops-nsieve-bits.js                   0.959      0.014 ± 0.013 … 0.014              0.014 ± 0.014 … 0.014              +0.0% (+0.0 MB)
SunSpider       controlflow-recursive.js                0.946      0.012 ± 0.011 … 0.012              0.012 ± 0.012 … 0.012              +0.1% (+0.0 MB)
SunSpider       crypto-aes.js                           0.990      0.016 ± 0.015 … 0.016              0.016 ± 0.015 … 0.016              +0.3% (+0.1 MB)
SunSpider       crypto-md5.js                           0.965      0.012 ± 0.012 … 0.013              0.013 ± 0.012 … 0.013              +0.0% (+0.0 MB)
SunSpider       crypto-sha1.js                          1.008      0.012 ± 0.012 … 0.013              0.012 ± 0.012 … 0.012              -0.0% (-0.0 MB)
SunSpider       date-format-tofte.js                    0.982      0.030 ± 0.029 … 0.031              0.030 ± 0.030 … 0.030              +0.3% (+0.1 MB)
SunSpider       date-format-xparb.js                    0.979      0.026 ± 0.026 … 0.026              0.026 ± 0.026 … 0.026              -0.1% (-0.0 MB)
SunSpider       math-cordic.js                          0.986      0.016 ± 0.015 … 0.016              0.016 ± 0.016 … 0.016              +0.2% (+0.0 MB)
SunSpider       math-partial-sums.js                    0.971      0.013 ± 0.013 … 0.013              0.013 ± 0.013 … 0.013              +0.3% (+0.0 MB)
SunSpider       math-spectral-norm.js                   0.968      0.013 ± 0.012 … 0.013              0.013 ± 0.013 … 0.013              +0.0% (+0.0 MB)
SunSpider       regexp-dna.js                           0.986      0.148 ± 0.147 … 0.149              0.150 ± 0.148 … 0.153              +0.1% (+0.0 MB)
SunSpider       string-base64.js                        0.894      0.015 ± 0.014 … 0.015              0.016 ± 0.016 … 0.017              +0.1% (+0.0 MB)
SunSpider       string-fasta.js                         0.916      0.021 ± 0.021 … 0.022              0.023 ± 0.023 … 0.023              +0.1% (+0.0 MB)
SunSpider       string-tagcloud.js                      0.918      0.035 ± 0.034 … 0.035              0.038 ± 0.038 … 0.038              +0.0% (+0.0 MB)
SunSpider       string-unpack-code.js                   0.936      0.036 ± 0.036 … 0.037              0.039 ± 0.038 … 0.041              +0.1% (+0.0 MB)
SunSpider       string-validate-input.js                0.958      0.016 ± 0.016 … 0.016              0.017 ± 0.016 … 0.017              +0.2% (+0.0 MB)
LongSpider      3d-cube.js                              0.992      2.792 ± 2.787 … 2.795              2.813 ± 2.808 … 2.817              -0.2% (-0.1 MB)
LongSpider      3d-morph.js                             1.007      1.077 ± 1.075 … 1.081              1.070 ± 1.065 … 1.074              +0.2% (+0.0 MB)
LongSpider      3d-raytrace.js                          0.990      2.114 ± 2.110 … 2.116              2.136 ± 2.135 … 2.138              +0.2% (+0.1 MB)
LongSpider      access-binary-trees.js                  1.007      5.290 ± 5.267 … 5.322              5.254 ± 5.254 … 5.254              -6.0% (-10.3 MB)
LongSpider      access-fannkuch.js                      1.001      1.078 ± 1.076 … 1.080              1.077 ± 1.074 … 1.078              -0.2% (-0.0 MB)
LongSpider      access-nbody.js                         0.991      2.950 ± 2.939 … 2.957              2.976 ± 2.970 … 2.983              -0.0% (-0.0 MB)
LongSpider      access-nsieve.js                        0.954      0.870 ± 0.829 … 0.922              0.911 ± 0.891 … 0.926              -0.0% (-0.0 MB)
LongSpider      bitops-3bit-bits-in-byte.js             1.009      0.256 ± 0.256 … 0.257              0.254 ± 0.253 … 0.255              -0.0% (-0.0 MB)
LongSpider      bitops-bits-in-byte.js                  1.021      0.380 ± 0.373 … 0.386              0.372 ± 0.366 … 0.376              +0.0% (+0.0 MB)
LongSpider      bitops-nsieve-bits.js                   0.975      1.159 ± 1.157 … 1.160              1.189 ± 1.157 … 1.252              +0.1% (+0.0 MB)
LongSpider      controlflow-recursive.js                0.985      1.337 ± 1.333 … 1.340              1.357 ± 1.345 … 1.367              -0.1% (-0.0 MB)
LongSpider      crypto-aes.js                           1.002      3.017 ± 3.007 … 3.025              3.010 ± 3.003 … 3.024              +0.2% (+0.1 MB)
LongSpider      crypto-md5.js                           1.008      3.090 ± 3.056 … 3.124              3.066 ± 3.054 … 3.077              +0.0% (+0.0 MB)
LongSpider      crypto-sha1.js                          1.012      5.883 ± 5.875 … 5.893              5.812 ± 5.807 … 5.819              -0.0% (-0.0 MB)
LongSpider      date-format-tofte.js                    1.002      2.098 ± 2.091 … 2.107              2.093 ± 2.085 … 2.103              +1.0% (+0.3 MB)
LongSpider      date-format-xparb.js                    0.990      3.562 ± 3.544 … 3.583              3.599 ± 3.516 … 3.654              -0.1% (-0.0 MB)
LongSpider      hash-map.js                             1.008      0.722 ± 0.717 … 0.728              0.716 ± 0.716 … 0.716              -0.0% (-0.0 MB)
LongSpider      math-cordic.js                          1.020      3.267 ± 3.256 … 3.278              3.202 ± 3.170 … 3.227              +0.1% (+0.0 MB)
LongSpider      math-partial-sums.js                    1.001      0.492 ± 0.489 … 0.493              0.491 ± 0.491 … 0.491              -0.2% (-0.0 MB)
LongSpider      math-spectral-norm.js                   1.007      3.353 ± 3.342 … 3.363              3.330 ± 3.302 … 3.350              +0.0% (+0.0 MB)
LongSpider      string-base64.js                        0.984      0.806 ± 0.805 … 0.808              0.819 ± 0.814 … 0.822              -0.0% (-0.0 MB)
LongSpider      string-fasta.js                         0.991      1.114 ± 1.106 … 1.127              1.124 ± 1.122 … 1.126              -0.4% (-0.1 MB)
LongSpider      string-tagcloud.js                      0.986      0.514 ± 0.513 … 0.514              0.521 ± 0.520 … 0.521              -0.7% (-0.4 MB)
Kraken          ai-astar.js                             0.990      0.390 ± 0.389 … 0.390              0.394 ± 0.391 … 0.397              +0.1% (+0.0 MB)
Kraken          audio-beat-detection.js                 1.002      0.345 ± 0.343 … 0.345              0.344 ± 0.343 … 0.344              +0.0% (+0.0 MB)
Kraken          audio-dft.js                            1.005      0.231 ± 0.230 … 0.232              0.230 ± 0.229 … 0.230              +0.1% (+0.0 MB)
Kraken          audio-fft.js                            1.004      0.286 ± 0.285 … 0.286              0.285 ± 0.284 … 0.285              +0.0% (+0.0 MB)
Kraken          audio-oscillator.js                     1.006      0.259 ± 0.259 … 0.259              0.257 ± 0.256 … 0.258              +0.1% (+0.0 MB)
Kraken          imaging-darkroom.js                     1.004      0.423 ± 0.421 … 0.426              0.422 ± 0.421 … 0.422              +0.0% (+0.0 MB)
Kraken          imaging-desaturate.js                   1.005      0.411 ± 0.410 … 0.413              0.409 ± 0.408 … 0.410              +0.0% (+0.0 MB)
Kraken          imaging-gaussian-blur.js                1.005      1.807 ± 1.805 … 1.810              1.798 ± 1.796 … 1.802              +0.0% (+0.0 MB)
Kraken          json-parse-financial.js                 1.009      0.041 ± 0.041 … 0.042              0.041 ± 0.040 … 0.042              +0.1% (+0.0 MB)
Kraken          json-stringify-tinderbox.js             0.995      0.057 ± 0.056 … 0.057              0.057 ± 0.056 … 0.058              +0.2% (+0.1 MB)
Kraken          stanford-crypto-aes.js                  0.998      0.144 ± 0.143 … 0.145              0.144 ± 0.143 … 0.145              +0.1% (+0.0 MB)
Kraken          stanford-crypto-ccm.js                  1.000      0.109 ± 0.108 … 0.111              0.109 ± 0.109 … 0.109              -0.0% (-0.0 MB)
Kraken          stanford-crypto-pbkdf2.js               1.004      0.271 ± 0.269 … 0.273              0.270 ± 0.268 … 0.271              +0.1% (+0.0 MB)
Kraken          stanford-crypto-sha256-iterative.js     1.003      0.103 ± 0.102 … 0.103              0.102 ± 0.102 … 0.103              +0.1% (+0.0 MB)
Octane          box2d.js                                1.005      11251.333 ± 11218.000 … 11296.000  11307.333 ± 11251.000 … 11397.000  +0.6% (+0.3 MB)
Octane          code-load.js                            1.001      33628.000 ± 33500.000 … 33699.000  33673.000 ± 33574.000 … 33796.000  -0.0% (-0.7 MB)
Octane          crypto.js                               0.989      4854.667 ± 4834.000 … 4866.000     4801.667 ± 4743.000 … 4872.000     +0.2% (+0.1 MB)
Octane          deltablue.js                            1.015      2927.667 ± 2886.000 … 2955.000     2971.000 ± 2949.000 … 2982.000     +1.1% (+0.4 MB)
Octane          earley-boyer.js                         0.998      6915.000 ± 6899.000 … 6924.000     6903.000 ± 6849.000 … 6943.000     +0.3% (+0.1 MB)
Octane          gbemu.js                                1.000      23655.333 ± 23565.000 … 23812.000  23661.333 ± 23619.000 … 23705.000  +1.7% (+1.6 MB)
Octane          mandreel.js                             1.007      24761.000 ± 24679.000 … 24802.000  24927.000 ± 24679.000 … 25051.000  +0.0% (+0.1 MB)
Octane          navier-stokes.js                        1.007      5967.000 ± 5953.000 … 5977.000     6010.000 ± 6006.000 … 6012.000     +0.1% (+0.0 MB)
Octane          pdfjs.js                                1.002      12339.667 ± 12290.000 … 12382.000  12363.333 ± 12313.000 … 12406.000  -0.6% (-0.7 MB)
Octane          raytrace.js                             1.009      4698.333 ± 4675.000 … 4726.000     4739.667 ± 4694.000 … 4767.000     +0.8% (+0.3 MB)
Octane          regexp.js                               1.005      2832.667 ± 2821.000 … 2841.000     2846.000 ± 2827.000 … 2861.000     +0.3% (+0.2 MB)
Octane          richards.js                             1.019      3150.000 ± 3071.000 … 3209.000     3209.000 ± 3181.000 … 3230.000     +0.6% (+0.1 MB)
Octane          splay.js                                1.005      13776.667 ± 13638.000 … 13860.000  13843.000 ± 13679.000 … 13949.000  +0.0% (+0.1 MB)
Octane          typescript.js                           1.001      28640.000 ± 28569.000 … 28711.000  28674.333 ± 28608.000 … 28756.000  -1.1% (-2.9 MB)
Octane          zlib.js                                 0.999      9084.667 ± 9057.000 … 9104.000     9079.333 ± 9079.000 … 9080.000     +0.0% (+0.0 MB)
GarBench        array-of-objects.js                     0.996      0.449 ± 0.448 … 0.451              0.451 ± 0.450 … 0.452              +0.0% (+0.0 MB)
GarBench        closures.js                             0.998      0.714 ± 0.708 … 0.723              0.716 ± 0.710 … 0.722              +0.0% (+0.0 MB)
GarBench        cyclic-graph.js                         1.032      1.457 ± 1.455 … 1.459              1.411 ± 1.307 … 1.465              +1.0% (+2.1 MB)
GarBench        deep-linked-list.js                     1.005      0.458 ± 0.455 … 0.459              0.455 ± 0.453 … 0.459              +0.0% (+0.0 MB)
GarBench        finalization.js                         1.007      0.617 ± 0.614 … 0.620              0.613 ± 0.610 … 0.615              +0.0% (+0.0 MB)
GarBench        many-properties.js                      1.008      1.560 ± 1.553 … 1.569              1.548 ± 1.547 … 1.549              -0.0% (-0.3 MB)
GarBench        marking-stress.js                       1.002      0.728 ± 0.605 … 0.951              0.726 ± 0.610 … 0.957              +0.0% (+0.0 MB)
GarBench        mixed-sizes.js                          1.007      0.715 ± 0.714 … 0.716              0.710 ± 0.705 … 0.713              -0.0% (-0.0 MB)
GarBench        sparse-arrays.js                        1.026      1.391 ± 1.389 … 1.392              1.355 ± 1.349 … 1.365              +0.0% (+0.0 MB)
GarBench        string-heavy.js                         1.001      0.743 ± 0.741 … 0.744              0.742 ± 0.742 … 0.743              -0.0% (-0.0 MB)
GarBench        wide-tree.js                            1.005      0.715 ± 0.710 … 0.719              0.711 ± 0.704 … 0.717              +0.0% (+0.0 MB)
JetStream       bigfib.cpp.js                           0.995      2.824 ± 2.821 … 2.829              2.838 ± 2.834 … 2.846              +0.1% (+0.1 MB)
JetStream       cdjs.js                                 0.992      1.472 ± 1.467 … 1.476              1.483 ± 1.477 … 1.494              -0.1% (-0.0 MB)
JetStream       container.cpp.js                        1.245      19.519 ± 19.494 … 19.565           15.675 ± 15.629 … 15.700           +0.1% (+0.1 MB)
JetStream       dry.c.js                                1.000      6.828 ± 6.821 … 6.836              6.829 ± 6.821 … 6.835              -0.0% (-0.0 MB)
JetStream       float-mm.c.js                           1.000      11.088 ± 11.055 … 11.128           11.088 ± 11.082 … 11.099           -0.1% (-0.0 MB)
JetStream       gcc-loops.cpp.js                        1.100      44.060 ± 44.016 … 44.097           40.050 ± 39.951 … 40.155           -0.1% (-0.1 MB)
JetStream       hash-map.js                             1.009      0.723 ± 0.719 … 0.727              0.716 ± 0.714 … 0.719              -0.0% (-0.0 MB)
JetStream       n-body.c.js                             1.001      12.105 ± 11.869 … 12.234           12.090 ± 12.063 … 12.141           +0.0% (+0.0 MB)
JetStream       quicksort.c.js                          0.995      2.131 ± 2.127 … 2.137              2.142 ± 2.135 … 2.152              +0.0% (+0.0 MB)
JetStream       towers.c.js                             1.009      4.893 ± 4.885 … 4.903              4.848 ± 4.844 … 4.855              -0.0% (-0.0 MB)
JetStream3      js-tokens.js                            0.992      0.202 ± 0.200 … 0.203              0.203 ± 0.202 … 0.205              +0.3% (+0.1 MB)
JetStream3      lazy-collections.js                     1.009      0.583 ± 0.579 … 0.585              0.578 ± 0.577 … 0.579              +0.8% (+0.3 MB)
JetStream3      raytrace-private-class-fields.js        1.007      2.665 ± 2.641 … 2.688              2.646 ± 2.624 … 2.659              -0.1% (-0.0 MB)
JetStream3      raytrace-public-class-fields.js         1.014      2.014 ± 2.007 … 2.019              1.986 ± 1.976 … 1.994              -1.1% (-0.3 MB)
JetStream3      sync-file-system.js                     1.002      1.156 ± 1.138 … 1.174              1.153 ± 1.144 … 1.164              -0.5% (-0.1 MB)
JetStreamExtra  FlightPlanner.js                        0.997      0.655 ± 0.645 … 0.668              0.657 ± 0.654 … 0.660              -0.0% (-0.0 MB)
JetStreamExtra  OfflineAssembler.js                     1.002      1.013 ± 1.011 … 1.014              1.010 ± 1.007 … 1.016              -0.1% (-0.1 MB)
JetStreamExtra  UniPoker.js                             0.999      1.454 ± 1.450 … 1.460              1.455 ± 1.450 … 1.463              +0.7% (+0.2 MB)
JetStreamExtra  async-fs.js                             1.000      1.187 ± 1.185 … 1.189              1.186 ± 1.182 … 1.189              -1.0% (-0.4 MB)
JetStreamExtra  babylonjs-startup-es5.js                1.009      0.579 ± 0.577 … 0.580              0.573 ± 0.570 … 0.580              -0.0% (-0.2 MB)
JetStreamExtra  babylonjs-startup-es6.js                1.015      0.715 ± 0.712 … 0.719              0.705 ± 0.704 … 0.706              -0.0% (-0.0 MB)
JetStreamExtra  bigint-bigdenary.js                     0.996      1.220 ± 1.209 … 1.230              1.225 ± 1.219 … 1.235              +0.0% (+0.0 MB)
JetStreamExtra  bigint-noble-bls12-381.js               0.993      1.301 ± 1.294 … 1.306              1.310 ± 1.309 … 1.312              +0.1% (+0.1 MB)
JetStreamExtra  bigint-noble-ed25519.js                 1.002      1.257 ± 1.251 … 1.260              1.255 ± 1.250 … 1.262              +0.1% (+0.1 MB)
JetStreamExtra  bigint-noble-secp256k1.js               1.002      1.198 ± 1.187 … 1.211              1.196 ± 1.192 … 1.201              +0.2% (+0.2 MB)
JetStreamExtra  bigint-paillier.js                      0.987      1.391 ± 1.389 … 1.392              1.409 ± 1.405 … 1.411              +0.2% (+0.2 MB)
JetStreamExtra  doxbee-async.js                         1.001      4.021 ± 3.996 … 4.043              4.019 ± 3.983 … 4.055              -0.8% (-1.0 MB)
JetStreamExtra  doxbee-promise.js                       1.004      3.902 ± 3.886 … 3.920              3.884 ± 3.871 … 3.904              -1.0% (-2.3 MB)
JetStreamExtra  first-inspector-code-load.js            1.006      1.195 ± 1.190 … 1.200              1.188 ± 1.185 … 1.192              +0.0% (+0.0 MB)
JetStreamExtra  jsdom-d3-startup.js                     1.004      0.948 ± 0.940 … 0.954              0.944 ± 0.939 … 0.948              -0.0% (-0.1 MB)
JetStreamExtra  json-parse-inspector.js                 0.995      0.646 ± 0.645 … 0.648              0.650 ± 0.648 … 0.651              +0.0% (+0.0 MB)
JetStreamExtra  json-stringify-inspector.js             0.998      0.841 ± 0.835 … 0.846              0.842 ± 0.839 … 0.846              +0.2% (+0.5 MB)
JetStreamExtra  mobx-startup.js                         1.001      1.152 ± 1.151 … 1.153              1.151 ± 1.146 … 1.154              -0.1% (-0.0 MB)
JetStreamExtra  multi-inspector-code-load.js            1.003      1.191 ± 1.187 … 1.197              1.188 ± 1.186 … 1.189              -0.0% (-0.4 MB)
JetStreamExtra  prismjs-startup-es5.js                  0.995      1.208 ± 1.203 … 1.213              1.214 ± 1.209 … 1.218              +0.8% (+0.4 MB)
JetStreamExtra  prismjs-startup-es6.js                  0.995      1.208 ± 1.205 … 1.212              1.214 ± 1.207 … 1.225              +1.3% (+0.6 MB)
JetStreamExtra  proxy-mobx.js                           1.003      0.938 ± 0.935 … 0.940              0.935 ± 0.932 … 0.937              +0.6% (+0.2 MB)
JetStreamExtra  proxy-vue.js                            1.010      0.037 ± 0.036 … 0.038              0.037 ± 0.036 … 0.037              +0.8% (+0.2 MB)
JetStreamExtra  threejs.js                              0.997      1.271 ± 1.268 … 1.272              1.274 ± 1.273 … 1.276              +0.0% (+0.0 MB)
JetStreamExtra  typescript-lib.js                       0.988      0.448 ± 0.447 … 0.450              0.454 ± 0.452 … 0.457              +0.0% (+0.0 MB)
JetStreamExtra  validatorjs.js                          1.001      1.019 ± 1.016 … 1.023              1.019 ± 1.016 … 1.024              +0.1% (+0.0 MB)
JetStreamExtra  web-ssr.js                              1.004      1.185 ± 1.179 … 1.191              1.180 ± 1.178 … 1.183              +0.1% (+0.3 MB)
ARES-6          Air.js                                  0.988      1.221 ± 1.212 … 1.234              1.235 ± 1.224 … 1.242              -1.1% (-0.7 MB)
ARES-6          Babylon.js                              0.990      0.838 ± 0.835 … 0.844              0.846 ± 0.840 … 0.853              -0.5% (-0.2 MB)
ARES-6          Basic.js                                0.999      0.890 ± 0.884 … 0.899              0.891 ± 0.878 … 0.903              -0.1% (-0.0 MB)
ARES-6          ML.js                                   1.000      1.129 ± 1.121 … 1.135              1.128 ± 1.120 … 1.142              +0.2% (+0.1 MB)
RegExp          speedometer-jquery-regexp-1.js          0.945      0.151 ± 0.149 … 0.152              0.159 ± 0.159 … 0.160              -0.1% (-0.0 MB)
RegExp          speedometer-jquery-regexp-2.js          1.351      0.089 ± 0.088 … 0.090              0.066 ± 0.065 … 0.066              +0.1% (+0.0 MB)
MicroBench      array-destructuring-assignment-rest.js  0.994      0.235 ± 0.234 … 0.236              0.237 ± 0.236 … 0.237              +0.0% (+0.0 MB)
MicroBench      array-destructuring-assignment.js       0.995      1.638 ± 1.630 … 1.643              1.646 ± 1.635 … 1.652              +0.0% (+0.0 MB)
MicroBench      array-prototype-map.js                  1.002      0.913 ± 0.912 … 0.914              0.911 ± 0.908 … 0.914              -0.0% (-0.0 MB)
MicroBench      array-prototype-shift.js                0.969      0.014 ± 0.013 … 0.015              0.014 ± 0.014 … 0.015              +0.1% (+0.0 MB)
MicroBench      bound-call-00-args.js                   0.986      1.046 ± 1.039 … 1.052              1.061 ± 1.057 … 1.064              -0.1% (-0.0 MB)
MicroBench      bound-call-04-args.js                   0.990      1.135 ± 1.130 … 1.144              1.146 ± 1.143 … 1.150              +0.0% (+0.0 MB)
MicroBench      bound-call-16-args.js                   0.996      1.472 ± 1.442 … 1.490              1.478 ± 1.421 … 1.507              -0.1% (-0.0 MB)
MicroBench      call-00-args.js                         1.027      0.301 ± 0.296 … 0.303              0.293 ± 0.290 … 0.297              -0.0% (-0.0 MB)
MicroBench      call-01-args.js                         0.921      0.324 ± 0.320 … 0.326              0.351 ± 0.331 … 0.390              +0.0% (+0.0 MB)
MicroBench      call-02-args.js                         1.079      0.370 ± 0.332 … 0.444              0.343 ± 0.341 … 0.343              +0.0% (+0.0 MB)
MicroBench      call-03-args.js                         0.966      0.326 ± 0.324 … 0.329              0.338 ± 0.337 … 0.338              -0.1% (-0.0 MB)
MicroBench      call-04-args.js                         0.963      0.334 ± 0.333 … 0.335              0.347 ± 0.346 … 0.348              +0.0% (+0.0 MB)
MicroBench      call-16-args.js                         0.970      0.447 ± 0.438 … 0.458              0.461 ± 0.442 … 0.495              +0.0% (+0.0 MB)
MicroBench      call-32-args.js                         1.001      0.652 ± 0.648 … 0.658              0.651 ± 0.649 … 0.655              +0.0% (+0.0 MB)
MicroBench      for-in-indexed-properties.js            0.971      0.140 ± 0.139 … 0.141              0.145 ± 0.144 … 0.146              -0.0% (-0.0 MB)
MicroBench      for-in-named-properties.js              0.997      0.129 ± 0.129 … 0.130              0.130 ± 0.130 … 0.130              +0.2% (+0.0 MB)
MicroBench      for-of.js                               0.999      0.347 ± 0.345 … 0.348              0.347 ± 0.346 … 0.348              +0.0% (+0.0 MB)
MicroBench      object-keys.js                          1.008      1.135 ± 1.125 … 1.143              1.126 ± 1.106 … 1.152              -0.0% (-0.0 MB)
MicroBench      object-set-with-rope-strings.js         1.006      0.411 ± 0.409 … 0.416              0.409 ± 0.407 … 0.410              -0.1% (-0.0 MB)
MicroBench      object-spread.js                        1.012      1.246 ± 1.239 … 1.255              1.231 ± 1.224 … 1.239              +0.0% (+0.0 MB)
MicroBench      pic-add-own.js                          1.000      0.306 ± 0.305 … 0.307              0.306 ± 0.304 … 0.309              -0.5% (-0.2 MB)
MicroBench      pic-get-absent.js                       1.015      1.240 ± 1.237 … 1.242              1.221 ± 1.217 … 1.227              +0.0% (+0.0 MB)
MicroBench      pic-get-own.js                          1.000      0.332 ± 0.324 … 0.344              0.332 ± 0.328 … 0.334              +0.0% (+0.0 MB)
MicroBench      pic-get-pchain.js                       1.035      0.331 ± 0.318 … 0.358              0.320 ± 0.319 … 0.321              +0.1% (+0.0 MB)
MicroBench      pic-put-own.js                          1.010      0.328 ± 0.328 … 0.329              0.325 ± 0.322 … 0.330              -0.1% (-0.0 MB)
MicroBench      pic-put-pchain.js                       1.026      1.263 ± 1.249 … 1.272              1.231 ± 1.226 … 1.234              -0.1% (-0.0 MB)
MicroBench      proxy-call-00-args.js                   1.015      1.092 ± 1.076 … 1.113              1.076 ± 1.072 … 1.080              +0.6% (+0.1 MB)
MicroBench      proxy-call-01-args.js                   0.998      1.080 ± 1.077 … 1.082              1.082 ± 1.077 … 1.090              +0.1% (+0.0 MB)
MicroBench      proxy-call-04-args.js                   1.008      1.311 ± 1.301 … 1.331              1.300 ± 1.296 … 1.308              +0.3% (+0.1 MB)
MicroBench      proxy-call-no-trap.js                   1.007      0.469 ± 0.464 … 0.473              0.466 ± 0.464 … 0.467              +0.1% (+0.0 MB)
MicroBench      proxy-get-trap-with-bind.js             0.979      4.928 ± 4.927 … 4.929              5.033 ± 4.983 … 5.094              -0.8% (-0.4 MB)
MicroBench      proxy-get-trap.js                       0.992      0.948 ± 0.941 … 0.956              0.955 ± 0.949 … 0.961              -0.0% (-0.0 MB)
MicroBench      proxy-nested-call.js                    1.003      2.630 ± 2.621 … 2.639              2.623 ± 2.601 … 2.641              +0.2% (+0.1 MB)
MicroBench      setter-in-prototype-chain.js            0.993      1.338 ± 1.332 … 1.345              1.348 ± 1.332 … 1.376              +0.2% (+0.0 MB)
MicroBench      short-string-concat.js                  1.029      0.197 ± 0.195 … 0.200              0.191 ± 0.190 … 0.192              -0.1% (-0.0 MB)
MicroBench      strictly-equals-object.js               1.000      0.573 ± 0.571 … 0.575              0.573 ± 0.571 … 0.575              +0.2% (+0.0 MB)
AsyncBench      async-call-return.js                    1.000      0.133 ± 0.132 … 0.135              0.133 ± 0.133 … 0.134              -0.7% (-0.2 MB)
AsyncBench      async-class-method.js                   1.001      0.250 ± 0.247 … 0.252              0.249 ± 0.248 … 0.251              -1.0% (-0.3 MB)
AsyncBench      async-fan-out.js                        0.988      0.132 ± 0.130 … 0.133              0.134 ± 0.133 … 0.135              -0.1% (-0.0 MB)
AsyncBench      async-generator.js                      0.996      0.202 ± 0.202 … 0.203              0.203 ± 0.203 … 0.203              -0.7% (-0.2 MB)
AsyncBench      async-iife.js                           0.995      0.218 ± 0.218 … 0.218              0.219 ± 0.219 … 0.221              -0.6% (-0.2 MB)
AsyncBench      async-nested-calls.js                   0.999      0.320 ± 0.318 … 0.323              0.321 ± 0.319 … 0.322              -0.8% (-0.2 MB)
AsyncBench      async-pipeline.js                       0.997      0.179 ± 0.178 … 0.181              0.180 ± 0.179 … 0.182              -0.5% (-0.1 MB)
AsyncBench      async-sequential-awaits.js              0.981      0.087 ± 0.085 … 0.088              0.088 ± 0.087 … 0.090              +0.4% (+0.1 MB)
AsyncBench      async-try-catch-reject.js               1.011      0.696 ± 0.690 … 0.698              0.688 ± 0.687 … 0.692              -0.0% (-0.0 MB)
AsyncBench      await-primitive.js                      0.971      0.031 ± 0.031 … 0.032              0.032 ± 0.032 … 0.033              +0.0% (+0.0 MB)
AsyncBench      await-resolved-promise.js               0.983      0.250 ± 0.249 … 0.251              0.254 ± 0.252 … 0.255              +1.5% (+0.4 MB)
AsyncBench      await-thenable.js                       0.989      0.516 ± 0.514 … 0.517              0.522 ± 0.521 … 0.523              -0.2% (-0.1 MB)
AsyncBench      promise-all.js                          0.985      0.357 ± 0.357 … 0.358              0.363 ± 0.359 … 0.365              +1.5% (+0.4 MB)
AsyncBench      promise-allSettled.js                   1.002      0.412 ± 0.412 … 0.413              0.411 ± 0.410 … 0.413              +1.3% (+0.3 MB)
AsyncBench      promise-chain.js                        0.982      0.115 ± 0.114 … 0.115              0.117 ± 0.116 … 0.117              +0.0% (+0.0 MB)
AsyncBench      promise-new-resolve.js                  1.013      0.194 ± 0.193 … 0.194              0.191 ± 0.189 … 0.192              +1.7% (+0.5 MB)
AsyncBench      promise-race.js                         1.007      0.370 ± 0.367 … 0.376              0.368 ± 0.367 … 0.368              +0.0% (+0.0 MB)
SunSpider       Total                                   0.968      0.586                              0.605                              +0.1% (+0.5 MB)
LongSpider      Total                                   1.001      47.219                             47.194                             -0.7% (-10.6 MB)
Kraken          Total                                   1.003      4.876                              4.861                              +0.1% (+0.3 MB)
Octane          Total                                   1.003      188482.000                         189009.000                         -0.0% (-1.1 MB)
GarBench        Total                                   1.011      9.545                              9.439                              +0.0% (+1.9 MB)
JetStream       Total                                   1.081      105.642                            97.759                             +0.0% (+0.0 MB)
JetStream3      Total                                   1.008      6.618                              6.565                              -0.1% (-0.2 MB)
JetStreamExtra  Total                                   1.000      33.178                             33.173                             -0.0% (-1.6 MB)
ARES-6          Total                                   0.994      4.077                              4.100                              -0.4% (-0.8 MB)
RegExp          Total                                   1.063      0.240                              0.225                              +0.0% (+0.0 MB)
MicroBench      Total                                   0.998      30.981                             31.046                             -0.0% (-0.2 MB)
AsyncBench      Total                                   0.997      4.463                              4.474                              +0.1% (+0.4 MB)
All Suites      Total                                   1.027      298.649                            290.659                            -0.0% (-11.2 MB)
```

</details>