### PR TITLE
LibWeb: Share acquired AudioBuffer contents instead of copying them

### DIFF
--- a/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
@@ -1,9 +1,13 @@
 /*
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2026, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
+#include <LibGC/RootVector.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/ExternalMemory.h>
 #include <LibJS/Runtime/Realm.h>
@@ -50,15 +54,58 @@ WebIDL::ExceptionOr<GC::Ref<AudioBuffer>> AudioBuffer::construct_impl(JS::Realm&
 AudioBuffer::~AudioBuffer() = default;
 
 // https://webaudio.github.io/web-audio-api/#acquire-the-content
-NonnullRefPtr<Rendering::AudioBufferContents> AudioBuffer::acquire_contents() const
+RefPtr<Rendering::AudioBufferContents> AudioBuffer::acquire_contents()
 {
-    // AD-HOC: This operation is specified as copy-on-write; we conservatively copy the sample data every time the
-    //         content is acquired.
+    // NB: m_contents is non-null exactly while the channel arrays are detached because step 4 below has not run yet.
+    //     The snapshot then still holds the buffer's content and script has had no way to modify it, so it can be
+    //     handed out again as-is. This is what makes a sequence of acquisitions with no intervening getChannelData(),
+    //     e.g. one AudioBuffer played by many AudioBufferSourceNodes, free of allocations and copying.
+    //     https://webaudio.github.io/web-audio-api/#audio-buffer-copying
+    if (m_contents)
+        return m_contents;
+
+    // 1. If any of the AudioBuffer's ArrayBuffers are detached, return true, abort these steps, and return a
+    //    zero-length channel data buffer to the invoker.
+    if (any_of(m_channels, [](auto const& channel) { return channel->viewed_array_buffer()->is_detached(); }))
+        return nullptr;
+
+    // 2. Detach all ArrayBuffers for arrays previously returned by getChannelData() on this AudioBuffer.
+    // 3. Retain the underlying [[internal data]] from those ArrayBuffers and return references to them to the invoker.
     Vector<Vector<float>> channels;
     channels.ensure_capacity(m_channels.size());
-    for (auto const& channel : m_channels)
+    for (auto const& channel : m_channels) {
         channels.unchecked_append(copy_float32_array(*channel));
-    return make_ref_counted<Rendering::AudioBufferContents>(move(channels), m_sample_rate);
+        MUST(JS::detach_array_buffer(vm(), *channel->viewed_array_buffer()));
+    }
+    m_contents = make_ref_counted<Rendering::AudioBufferContents>(move(channels), m_sample_rate);
+
+    // 4. Attach ArrayBuffers containing copies of the data to the AudioBuffer, to be returned by the next call to
+    //    getChannelData().
+    // NB: Performed lazily by attach_acquired_channels().
+
+    return m_contents;
+}
+
+// https://webaudio.github.io/web-audio-api/#audio-buffer-copying
+WebIDL::ExceptionOr<void> AudioBuffer::attach_acquired_channels()
+{
+    // The pending final step of acquiring this buffer's content: fresh arrays holding a copy of the acquired sample
+    // data are attached the first time script reaches for the channel data again. Whoever acquired the content keeps
+    // using the snapshot, so writes through the new arrays cannot change what is already playing.
+    if (!m_contents)
+        return {};
+
+    GC::RootVector<GC::Ref<JS::Float32Array>> channels;
+    channels.ensure_capacity(m_channels.size());
+    for (auto const& samples : m_contents->channels) {
+        auto channel = TRY(JS::Float32Array::create(realm(), m_length));
+        overwrite_float32_array(channel, samples);
+        channels.unchecked_append(channel);
+    }
+
+    m_channels = move(channels);
+    m_contents = nullptr;
+    return {};
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-samplerate
@@ -91,16 +138,17 @@ WebIDL::UnsignedLong AudioBuffer::number_of_channels() const
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-getchanneldata
-WebIDL::ExceptionOr<GC::Ref<JS::Float32Array>> AudioBuffer::get_channel_data(WebIDL::UnsignedLong channel) const
+WebIDL::ExceptionOr<GC::Ref<JS::Float32Array>> AudioBuffer::get_channel_data(WebIDL::UnsignedLong channel)
 {
     if (channel >= m_channels.size())
         return WebIDL::IndexSizeError::create(realm(), "Channel index is out of range"_utf16);
 
+    TRY(attach_acquired_channels());
     return m_channels[channel];
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-copyfromchannel
-WebIDL::ExceptionOr<void> AudioBuffer::copy_from_channel(GC::Ref<JS::Float32Array> destination, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset) const
+WebIDL::ExceptionOr<void> AudioBuffer::copy_from_channel(GC::Ref<JS::Float32Array> destination, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset)
 {
     // The copyFromChannel() method copies the samples from the specified channel of the AudioBuffer to the destination array.
     //
@@ -200,7 +248,10 @@ void AudioBuffer::visit_edges(Cell::Visitor& visitor)
 
 size_t AudioBuffer::external_memory_size() const
 {
-    return JS::saturating_add_external_memory_size(Base::external_memory_size(), JS::vector_external_memory_size(m_channels));
+    auto size = JS::saturating_add_external_memory_size(Base::external_memory_size(), JS::vector_external_memory_size(m_channels));
+    if (m_contents)
+        size = JS::saturating_add_external_memory_size(size, m_contents->channels.size() * m_length * sizeof(float));
+    return size;
 }
 
 }

--- a/Libraries/LibWeb/WebAudio/AudioBuffer.h
+++ b/Libraries/LibWeb/WebAudio/AudioBuffer.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/NonnullRefPtr.h>
+#include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
@@ -32,15 +32,17 @@ public:
     WebIDL::UnsignedLong length() const;
     double duration() const;
     WebIDL::UnsignedLong number_of_channels() const;
-    WebIDL::ExceptionOr<GC::Ref<JS::Float32Array>> get_channel_data(WebIDL::UnsignedLong channel) const;
-    WebIDL::ExceptionOr<void> copy_from_channel(GC::Ref<JS::Float32Array>, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0) const;
+    WebIDL::ExceptionOr<GC::Ref<JS::Float32Array>> get_channel_data(WebIDL::UnsignedLong channel);
+    WebIDL::ExceptionOr<void> copy_from_channel(GC::Ref<JS::Float32Array>, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0);
     WebIDL::ExceptionOr<void> copy_to_channel(GC::Ref<JS::Float32Array>, WebIDL::UnsignedLong channel_number, WebIDL::UnsignedLong buffer_offset = 0);
 
     // https://webaudio.github.io/web-audio-api/#acquire-the-content
-    NonnullRefPtr<Rendering::AudioBufferContents> acquire_contents() const;
+    RefPtr<Rendering::AudioBufferContents> acquire_contents();
 
 private:
     explicit AudioBuffer(JS::Realm&, Bindings::AudioBufferOptions const&);
+
+    WebIDL::ExceptionOr<void> attach_acquired_channels();
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -52,6 +54,9 @@ private:
     // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-internal-data-slot
     // A data block holding the audio sample data.
     Vector<GC::Ref<JS::Float32Array>> m_channels; // [[internal data]] / [[number_of_channels]]
+
+    // https://webaudio.github.io/web-audio-api/#audio-buffer-copying
+    RefPtr<Rendering::AudioBufferContents> m_contents;
 
     // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-length-slot
     // The length of each channel of this AudioBuffer, which is an unsigned long.

--- a/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.cpp
+++ b/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.cpp
@@ -61,7 +61,7 @@ WebIDL::ExceptionOr<void> AudioBufferSourceNode::set_buffer(GC::Ptr<AudioBuffer>
 
     // 5. If start() has previously been called on this node, perform the operation acquire the content on buffer.
     if (source_started())
-        queue_parameters_update(m_buffer ? RefPtr<Rendering::AudioBufferContents> { m_buffer->acquire_contents() } : nullptr, true);
+        queue_parameters_update(m_buffer ? m_buffer->acquire_contents() : nullptr, true);
 
     return {};
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiobuffer-interface/acquire-the-content.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiobuffer-interface/acquire-the-content.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+2 Pass
+1 Fail
+Pass	AudioBufferSourceNode setter set with non-null buffer
+Pass	AudioBufferSourceNode buffer setter set with null
+Fail	ConvolverNode

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audiobuffer-interface/acquire-the-content.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audiobuffer-interface/acquire-the-content.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test for AudioBuffer's "acquire the content" operation</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script>
+const SAMPLERATE = 8000;
+const LENGTH = 128;
+
+var tests = {
+  "AudioBufferSourceNode setter set with non-null buffer": function(oac) {
+    var buf = oac.createBuffer(1, LENGTH, SAMPLERATE)
+    var bs = new AudioBufferSourceNode(oac);
+    var channelData = buf.getChannelData(0);
+    for (var i = 0; i < channelData.length; i++) {
+      channelData[i] = 1.0;
+    }
+    bs.buffer = buf;
+    bs.start(); // This acquires the content since buf is not null
+    for (var i = 0; i < channelData.length; i++) {
+      channelData[i] = 0.5;
+    }
+    allSamplesAtOne(buf, "reading back");
+    bs.connect(oac.destination);
+    return oac.startRendering();
+  },
+  "AudioBufferSourceNode buffer setter set with null" : (oac) => {
+    var buf = oac.createBuffer(1, LENGTH, SAMPLERATE)
+    var bs = new AudioBufferSourceNode(oac);
+    var channelData = buf.getChannelData(0);
+    for (var i = 0; i < channelData.length; i++) {
+      channelData[i] = 1.0;
+    }
+    bs.buffer = null;
+    bs.start(); // This does not acquire the content
+    bs.buffer = buf; // This does
+    for (var i = 0; i < channelData.length; i++) {
+      channelData[i] = 0.5;
+    }
+    allSamplesAtOne(buf, "reading back");
+    bs.connect(oac.destination);
+    return oac.startRendering();
+  },
+  "ConvolverNode": (oac) => {
+    var buf = oac.createBuffer(1, LENGTH, SAMPLERATE)
+    var impulse = oac.createBuffer(1, 1, SAMPLERATE)
+    var bs = new AudioBufferSourceNode(oac);
+    var convolver = new ConvolverNode(oac, {disableNormalization: true});
+
+    impulse.getChannelData(0)[0] = 1.0; // unit impulse function
+    convolver.buffer = impulse; // This does acquire the content
+    impulse.getChannelData(0)[0] = 0.5;
+
+    var channelData = buf.getChannelData(0);
+    for (var i = 0; i < channelData.length; i++) {
+      channelData[i] = 1.0;
+    }
+    bs.buffer = buf;
+    bs.start();
+
+    bs.connect(convolver).connect(oac.destination);
+    return oac.startRendering();
+  }
+};
+
+function allSamplesAtOne(audiobuffer, location) {
+  var buf = audiobuffer.getChannelData(0);
+  for (var i = 0; i < buf.length; i++) {
+    // The convolver can introduce a slight numerical error.
+    if (Math.abs(buf[i] - 1.0) > 0.0001) {
+      assert_true(false, `Invalid value at index ${i}, expected close to 1.0, found ${buf[i]} when ${location}`)
+      return Promise.reject();
+    }
+  }
+  assert_true(true, `Buffer unmodified when ${location}.`);
+  return Promise.resolve();
+}
+
+for (const test of Object.keys(tests)) {
+  promise_test(async function(t) {
+    var buf = await tests[test](new OfflineAudioContext(1, LENGTH, SAMPLERATE));
+    return allSamplesAtOne(buf, "rendering");
+  }, test);
+};
+</script>


### PR DESCRIPTION
Acquiring the content of an AudioBuffer copied its whole sample data every time, so starting an AudioBufferSourceNode cost a full copy of the buffer even when nothing had changed since the last one. The spec performs the final step of the operation lazily, at the next getChannelData() call, precisely so that consecutive acquisitions can share one snapshot. Keep that snapshot on the buffer while the channel arrays are detached and hand it out again unchanged, materialising fresh arrays only when script reaches for the channel data.