### PR TITLE
LibWeb: Fall back to the last mousedown target for scroll key input

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -350,6 +350,7 @@ EventResult EventHandler::handle_mousedown(CSSPixelPoint visual_viewport_positio
         return EventResult::Dropped;
 
     m_mousedown_target = node;
+    m_last_mousedown_target = node;
     m_mousedown_visual_viewport_position = visual_viewport_position;
 
     auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
@@ -1307,12 +1308,23 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         if (!m_scroll_key_gesture_hold)
             m_scroll_key_gesture_hold = make<HTML::UserScrollGestureHold>(*m_navigable);
     };
-    auto scroll_container_of_focused_area_by = [&](double delta_x, double delta_y) -> bool {
-        auto focused_area = document->focused_area();
-        if (!focused_area)
+    auto scroll_target_for_key_input = [&]() -> GC::Ptr<DOM::Node> {
+        if (auto focused_area = document->focused_area())
+            return focused_area;
+        // A scroll container is typically not a focusable area, so clicking one focuses nothing. Scroll keys are
+        // still expected to scroll it afterwards, so the last mousedown target substitutes for the missing focused
+        // area. This behavior matches other engines.
+        auto last_mousedown_target = m_last_mousedown_target.ptr();
+        if (last_mousedown_target && last_mousedown_target->is_connected() && &last_mousedown_target->document() == document.ptr())
+            return last_mousedown_target;
+        return nullptr;
+    };
+    auto scroll_container_of_scroll_target_by = [&](double delta_x, double delta_y) -> bool {
+        auto scroll_target = scroll_target_for_key_input();
+        if (!scroll_target)
             return false;
         document->update_layout(DOM::UpdateLayoutReason::EventHandlerHandleKeyDown);
-        RefPtr<Painting::Paintable> containing_block = focused_area->paintable();
+        RefPtr<Painting::Paintable> containing_block = scroll_target->paintable();
         while (containing_block) {
             if (containing_block->handle_mousewheel({}, {}, 0, 0, delta_x, delta_y))
                 return true;
@@ -1322,19 +1334,19 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
     };
     auto scroll_by_for_key_input = [&](CSSPixels delta_x, CSSPixels delta_y) {
         hold_scroll_gesture_until_key_release();
-        if (scroll_container_of_focused_area_by(delta_x.to_double(), delta_y.to_double()))
+        if (scroll_container_of_scroll_target_by(delta_x.to_double(), delta_y.to_double()))
             return;
         m_navigable->scroll_viewport_by_delta({ delta_x, delta_y }, Bindings::ScrollBehavior::Auto);
     };
     auto scroll_to_the_beginning_for_key_input = [&] {
         hold_scroll_gesture_until_key_release();
-        if (scroll_container_of_focused_area_by(0, -CSSPixels::max().to_double()))
+        if (scroll_container_of_scroll_target_by(0, -CSSPixels::max().to_double()))
             return;
         m_navigable->perform_a_scroll_of_the_viewport({ 0, 0 }, Bindings::ScrollBehavior::Auto, HTML::LocalNavigable::ScrollTrigger::UserInput);
     };
     auto scroll_to_the_end_for_key_input = [&] {
         hold_scroll_gesture_until_key_release();
-        if (scroll_container_of_focused_area_by(0, CSSPixels::max().to_double()))
+        if (scroll_container_of_scroll_target_by(0, CSSPixels::max().to_double()))
             return;
         m_navigable->scroll_viewport_by_delta({ 0, CSSPixels::max() }, Bindings::ScrollBehavior::Auto);
     };

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -185,6 +185,7 @@ private:
 
     GC::Weak<DOM::Node> m_effective_legacy_mouse_pointer_position;
 
+    GC::Weak<DOM::Node> m_last_mousedown_target;
     GC::Weak<DOM::Node> m_mousedown_target;
     Optional<CSSPixelPoint> m_mousedown_visual_viewport_position;
     int m_mousedown_click_count { 0 };

--- a/Tests/LibWeb/Text/expected/keyboard-scroll-after-click-in-scroll-container.txt
+++ b/Tests/LibWeb/Text/expected/keyboard-scroll-after-click-in-scroll-container.txt
@@ -1,0 +1,5 @@
+clicking the scroll container does not focus it: PASS
+a down arrow key press scrolls the clicked scroll container: PASS
+the viewport does not scroll: PASS
+an end key press scrolls the clicked scroll container to its end: PASS
+the viewport still does not scroll: PASS

--- a/Tests/LibWeb/Text/input/keyboard-scroll-after-click-in-scroll-container.html
+++ b/Tests/LibWeb/Text/input/keyboard-scroll-after-click-in-scroll-container.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body {
+        margin: 0;
+        height: 300vh;
+    }
+    #scroller {
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+    }
+</style>
+<div id="scroller">
+    <div style="height: 1000px"></div>
+</div>
+<script>
+    promiseTest(async () => {
+        const scroller = document.getElementById("scroller");
+
+        await animationFrame();
+        await animationFrame();
+
+        const keyPressSettled = async (key) => {
+            const scrollend = new Promise(resolve => scroller.addEventListener("scrollend", resolve, { once: true }));
+            internals.sendKey(document.body, key);
+            await scrollend;
+        };
+
+        internals.click(100, 100);
+        println(`clicking the scroll container does not focus it: ${document.activeElement === document.body ? "PASS" : `FAIL (${document.activeElement.tagName})`}`);
+
+        await keyPressSettled("Down");
+        println(`a down arrow key press scrolls the clicked scroll container: ${scroller.scrollTop > 0 ? "PASS" : "FAIL"}`);
+        println(`the viewport does not scroll: ${window.scrollY === 0 ? "PASS" : `FAIL (${window.scrollY})`}`);
+
+        await keyPressSettled("End");
+        const maximumScrollTop = scroller.scrollHeight - scroller.clientHeight;
+        println(`an end key press scrolls the clicked scroll container to its end: ${scroller.scrollTop === maximumScrollTop ? "PASS" : `FAIL (${scroller.scrollTop})`}`);
+        println(`the viewport still does not scroll: ${window.scrollY === 0 ? "PASS" : `FAIL (${window.scrollY})`}`);
+    });
+</script>


### PR DESCRIPTION
Previously, scroll key input always started from the focused area, but a scroll container is typically not a focusable area, so clicking one focuses nothing and arrow, paging, and homing key presses scrolled the viewport instead of the clicked container.

We now track the target of the most recent mousedown after the press completes, and start scroll key input from it when no focused area exists. Which box scroll keys target and whether clicking a scrollable region focuses it are both left to the user agent, and this matches the behavior of other engines without making the clicked container the active element.

I came across this when trying to interact with the examples on this page: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/scroll-snap-type (scroll snapping is a separate issue to this that I'm currently working on).