### PR TITLE
LibJS: Make the Flap AOT compiler faster and more robust

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -60,3 +60,29 @@ jobs:
             --all-targets -- -D clippy::all
           cargo test --manifest-path Libraries/LibJS/BytecodeDef/Cargo.toml \
             --all-targets
+
+      - name: Generate and assemble the Flap interpreter
+        run: |
+          cargo build --release --manifest-path Libraries/LibJS/Flap/Cargo.toml
+          mkdir -p "${RUNNER_TEMP}/flap-smoke"
+          for arch in x86_64 aarch64; do
+            Libraries/LibJS/Flap/target/release/flapc \
+              --arch "${arch}" \
+              --object-format elf \
+              --constants Libraries/LibJS/Flap/tests/interpreter-layout.conf \
+              --bytecode-def Libraries/LibJS/Bytecode/Bytecode.def \
+              --input Libraries/LibJS/Interpreter/interpreter.flap \
+              --output "${RUNNER_TEMP}/flap-smoke/${arch}.S"
+            clang --target="${arch}-unknown-linux-gnu" \
+              -c "${RUNNER_TEMP}/flap-smoke/${arch}.S" \
+              -o "${RUNNER_TEMP}/flap-smoke/${arch}.o"
+            Libraries/LibJS/Flap/target/release/flapc \
+              --arch "${arch}" \
+              --object-format elf \
+              --constants Libraries/LibJS/Flap/tests/interpreter-layout.conf \
+              --bytecode-def Libraries/LibJS/Bytecode/Bytecode.def \
+              --input Libraries/LibJS/Interpreter/interpreter.flap \
+              --output "${RUNNER_TEMP}/flap-smoke/${arch}-repeat.S"
+            cmp "${RUNNER_TEMP}/flap-smoke/${arch}.S" \
+              "${RUNNER_TEMP}/flap-smoke/${arch}-repeat.S"
+          done

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -24,3 +24,39 @@ jobs:
 
       - name: Lint
         run: "${GITHUB_WORKSPACE}/Meta/lint-ci.sh"
+
+  flap:
+    permissions:
+      contents: read
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: github.repository == 'LadybirdBrowser/ladybird'
+    container:
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set Up Environment
+        uses: ./.github/actions/setup
+        with:
+          os: 'Linux'
+          arch: 'x86_64'
+          type: 'lint'
+
+      - name: Check Flap
+        run: |
+          cargo fmt --manifest-path Libraries/LibJS/Flap/Cargo.toml -- --check
+          cargo clippy --manifest-path Libraries/LibJS/Flap/Cargo.toml \
+            --all-targets -- -D clippy::all
+          cargo test --manifest-path Libraries/LibJS/Flap/Cargo.toml \
+            --all-targets
+
+      - name: Check BytecodeDef
+        run: |
+          cargo fmt --manifest-path Libraries/LibJS/BytecodeDef/Cargo.toml -- --check
+          cargo clippy --manifest-path Libraries/LibJS/BytecodeDef/Cargo.toml \
+            --all-targets -- -D clippy::all
+          cargo test --manifest-path Libraries/LibJS/BytecodeDef/Cargo.toml \
+            --all-targets

--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -11,6 +11,8 @@
 //! of truth for instruction field offsets and sizes.
 
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub struct Field {
@@ -48,110 +50,247 @@ impl From<(&'static str, usize, usize, &'static str)> for FieldType {
 /// On 64-bit: alignof(void*) = 8.
 pub const STRUCT_ALIGN: usize = 8;
 
-pub fn parse_bytecode_def(content: &str) -> Vec<OpDef> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub source_name: String,
+    pub line: usize,
+    pub column: usize,
+    pub message: String,
+}
+
+impl ParseError {
+    fn new(source_name: &str, line: usize, column: usize, message: impl Into<String>) -> Self {
+        Self {
+            source_name: source_name.to_string(),
+            line,
+            column,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{}:{}:{}: error: {}",
+            self.source_name, self.line, self.column, self.message
+        )
+    }
+}
+
+impl Error for ParseError {}
+
+fn is_identifier(name: &str) -> bool {
+    let mut characters = name.chars();
+    characters
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+        && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+}
+
+pub fn parse_bytecode_def(source_name: &str, content: &str) -> Result<Vec<OpDef>, ParseError> {
     let mut ops = Vec::new();
     let mut current: Option<OpDef> = None;
-    let mut in_op = false;
+    let mut op_names = HashMap::new();
+    let mut field_names = HashMap::new();
+    let mut op_start = None;
 
-    for raw_line in content.lines() {
+    for (line_index, raw_line) in content.lines().enumerate() {
+        let line = line_index + 1;
         let stripped = raw_line.trim();
+        let column = raw_line.len() - raw_line.trim_start().len() + 1;
         if stripped.is_empty() || stripped.starts_with("//") || stripped.starts_with('#') {
             continue;
         }
 
         if stripped.starts_with("op ") {
-            assert!(!in_op, "Nested op blocks");
-            in_op = true;
-            let rest = stripped.strip_prefix("op ").unwrap().trim();
-            let name = if let Some(idx) = rest.find('<') {
-                rest[..idx].trim().to_string()
+            if current.is_some() {
+                return Err(ParseError::new(source_name, line, column, "nested op block"));
+            }
+            let declaration = stripped.strip_prefix("op ").unwrap().trim();
+            let (name, parent) = if let Some((name, parent)) = declaration.split_once('<') {
+                (name.trim(), Some(parent.trim()))
             } else {
-                rest.to_string()
+                (declaration, None)
             };
+            if name.is_empty() {
+                return Err(ParseError::new(source_name, line, column, "missing op name"));
+            }
+            if !is_identifier(name) {
+                return Err(ParseError::new(
+                    source_name,
+                    line,
+                    column,
+                    format!("invalid op name '{name}'"),
+                ));
+            }
+            if parent.is_some_and(str::is_empty) {
+                return Err(ParseError::new(source_name, line, column, "missing parent op name"));
+            }
+            if parent.is_some_and(|parent| !is_identifier(parent)) {
+                return Err(ParseError::new(
+                    source_name,
+                    line,
+                    column,
+                    format!("invalid parent op name '{}'", parent.unwrap()),
+                ));
+            }
+            if let Some(previous_line) = op_names.insert(name.to_string(), line) {
+                return Err(ParseError::new(
+                    source_name,
+                    line,
+                    column,
+                    format!("duplicate op '{name}' previously defined on line {previous_line}"),
+                ));
+            }
             current = Some(OpDef {
-                name,
+                name: name.to_string(),
                 fields: Vec::new(),
                 is_terminator: false,
             });
+            field_names.clear();
+            op_start = Some((line, column));
             continue;
         }
 
         if stripped == "endop" {
-            assert!(in_op && current.is_some(), "endop without op");
-            ops.push(current.take().unwrap());
-            in_op = false;
+            let Some(op) = current.take() else {
+                return Err(ParseError::new(source_name, line, column, "endop without op"));
+            };
+            validate_op_layout(&op).map_err(|message| ParseError::new(source_name, line, column, message))?;
+            ops.push(op);
+            op_start = None;
             continue;
         }
 
-        if !in_op {
-            continue;
-        }
+        let Some(op) = current.as_mut() else {
+            return Err(ParseError::new(
+                source_name,
+                line,
+                column,
+                format!("unexpected top-level line '{stripped}'"),
+            ));
+        };
 
         if stripped.starts_with('@') {
-            if stripped == "@terminator" {
-                current.as_mut().unwrap().is_terminator = true;
+            match stripped {
+                "@terminator" => op.is_terminator = true,
+                "@nothrow" => {}
+                _ => {
+                    return Err(ParseError::new(
+                        source_name,
+                        line,
+                        column,
+                        format!("unknown annotation '{stripped}'"),
+                    ));
+                }
             }
             continue;
         }
 
-        let (lhs, rhs) = stripped.split_once(':').expect("Malformed field line");
-        let field_name = lhs.trim().to_string();
-        let mut field_type = rhs.trim().to_string();
+        let Some((lhs, rhs)) = stripped.split_once(':') else {
+            return Err(ParseError::new(source_name, line, column, "malformed field line"));
+        };
+        let field_name = lhs.trim();
+        if field_name.is_empty() {
+            return Err(ParseError::new(source_name, line, column, "missing field name"));
+        }
+        if !is_identifier(field_name) {
+            return Err(ParseError::new(
+                source_name,
+                line,
+                column,
+                format!("invalid field name '{field_name}'"),
+            ));
+        }
+        if let Some(previous_line) = field_names.insert(field_name.to_string(), line) {
+            return Err(ParseError::new(
+                source_name,
+                line,
+                column,
+                format!("duplicate field '{field_name}' previously defined on line {previous_line}"),
+            ));
+        }
+        let mut field_type = rhs.trim();
         let is_array = field_type.ends_with("[]");
         if is_array {
-            field_type = field_type[..field_type.len() - 2].trim().to_string();
+            field_type = field_type[..field_type.len() - 2].trim();
         }
-        current.as_mut().unwrap().fields.push(Field {
-            name: field_name,
-            ty: field_type,
+        if try_field_type_info(field_type).is_none() {
+            let type_column = raw_line.find(':').unwrap() + 2 + rhs.len() - rhs.trim_start().len();
+            return Err(ParseError::new(
+                source_name,
+                line,
+                type_column,
+                format!("unknown field type '{field_type}'"),
+            ));
+        }
+        op.fields.push(Field {
+            name: field_name.to_string(),
+            ty: field_type.to_string(),
             is_array,
         });
     }
-    assert!(!in_op, "Unclosed op block");
+    if let Some(op) = current {
+        let (line, column) = op_start.unwrap();
+        return Err(ParseError::new(
+            source_name,
+            line,
+            column,
+            format!("unclosed op block '{}'", op.name),
+        ));
+    }
 
     // Remove the base "Instruction" definition (not an actual opcode).
     ops.retain(|op| op.name != "Instruction");
-    ops
+    Ok(ops)
+}
+
+fn try_field_type_info(ty: &str) -> Option<FieldType> {
+    Some(
+        match ty {
+            "bool" => ("bool", 1, 1, "bool"),
+            "u32" => ("u32", 4, 4, "u32"),
+            "u64" => ("u64", 8, 8, "u64"),
+            "Operand" => ("Operand", 4, 4, "operand"),
+            "Optional<Operand>" => ("Option<Operand>", 4, 4, "optional_operand"),
+            "Label" => ("Label", 4, 4, "label"),
+            "Optional<Label>" => ("Option<Label>", 4, 8, "optional_label"),
+            "IdentifierTableIndex" => ("IdentifierTableIndex", 4, 4, "u32_newtype"),
+            "Optional<IdentifierTableIndex>" => ("Option<IdentifierTableIndex>", 4, 4, "optional_u32_newtype"),
+            "PropertyKeyTableIndex" => ("PropertyKeyTableIndex", 4, 4, "u32_newtype"),
+            "StringTableIndex" => ("StringTableIndex", 4, 4, "u32_newtype"),
+            "Optional<StringTableIndex>" => ("Option<StringTableIndex>", 4, 4, "optional_u32_newtype"),
+            "RegexTableIndex" => ("RegexTableIndex", 4, 4, "u32_newtype"),
+            "EnvironmentCoordinate" => ("EnvironmentCoordinate", 4, 8, "env_coord"),
+            "Builtin" => ("u8", 1, 1, "u8"),
+            "Completion::Type" => ("u32", 4, 4, "u32"),
+            "IteratorHint" => ("u32", 4, 4, "u32"),
+            "EnvironmentMode" => ("u32", 4, 4, "u32"),
+            "PutKind" => ("u32", 4, 4, "u32"),
+            "ArgumentsKind" => ("u32", 4, 4, "u32"),
+            "FunctionNamePrefix" => ("u32", 4, 4, "u32"),
+            "Value" => ("u64", 8, 8, "u64"),
+            "PropertyLookupCacheIndex"
+            | "GlobalVariableCacheIndex"
+            | "EnvironmentCoordinateCacheIndex"
+            | "TemplateObjectCacheIndex"
+            | "ObjectShapeCacheIndex"
+            | "ObjectPropertyIteratorCacheIndex" => ("u32", 4, 4, "u32"),
+            _ => return None,
+        }
+        .into(),
+    )
 }
 
 pub fn field_type_info(ty: &str) -> FieldType {
-    match ty {
-        "bool" => ("bool", 1, 1, "bool"),
-        "u32" => ("u32", 4, 4, "u32"),
-        "u64" => ("u64", 8, 8, "u64"),
-        "Operand" => ("Operand", 4, 4, "operand"),
-        "Optional<Operand>" => ("Option<Operand>", 4, 4, "optional_operand"),
-        "Label" => ("Label", 4, 4, "label"),
-        "Optional<Label>" => ("Option<Label>", 4, 8, "optional_label"),
-        "IdentifierTableIndex" => ("IdentifierTableIndex", 4, 4, "u32_newtype"),
-        "Optional<IdentifierTableIndex>" => ("Option<IdentifierTableIndex>", 4, 4, "optional_u32_newtype"),
-        "PropertyKeyTableIndex" => ("PropertyKeyTableIndex", 4, 4, "u32_newtype"),
-        "StringTableIndex" => ("StringTableIndex", 4, 4, "u32_newtype"),
-        "Optional<StringTableIndex>" => ("Option<StringTableIndex>", 4, 4, "optional_u32_newtype"),
-        "RegexTableIndex" => ("RegexTableIndex", 4, 4, "u32_newtype"),
-        "EnvironmentCoordinate" => ("EnvironmentCoordinate", 4, 8, "env_coord"),
-        "Builtin" => ("u8", 1, 1, "u8"),
-        "Completion::Type" => ("u32", 4, 4, "u32"),
-        "IteratorHint" => ("u32", 4, 4, "u32"),
-        "EnvironmentMode" => ("u32", 4, 4, "u32"),
-        "PutKind" => ("u32", 4, 4, "u32"),
-        "ArgumentsKind" => ("u32", 4, 4, "u32"),
-        "FunctionNamePrefix" => ("u32", 4, 4, "u32"),
-        "Value" => ("u64", 8, 8, "u64"),
-        "PropertyLookupCacheIndex"
-        | "GlobalVariableCacheIndex"
-        | "EnvironmentCoordinateCacheIndex"
-        | "TemplateObjectCacheIndex"
-        | "ObjectShapeCacheIndex"
-        | "ObjectPropertyIteratorCacheIndex" => ("u32", 4, 4, "u32"),
-        _ => unreachable!("Unknown field type: {ty}"),
-    }
-    .into()
+    try_field_type_info(ty).unwrap_or_else(|| panic!("Unknown field type: {ty}"))
 }
 
 pub fn round_up(value: usize, align: usize) -> usize {
     assert!(align.is_power_of_two());
-    (value + align - 1) & !(align - 1)
+    value.checked_add(align - 1).expect("layout size overflow") & !(align - 1)
 }
 
 /// Returns the user-visible fields (excludes m_type, m_strict, m_length).
@@ -180,6 +319,35 @@ pub fn find_m_length_offset(fields: &[Field]) -> usize {
         offset += info.size;
     }
     panic!("m_length field not found");
+}
+
+fn validate_op_layout(op: &OpDef) -> Result<(), String> {
+    let mut offset = 2usize;
+    for field in &op.fields {
+        if field.is_array || field.name == "m_type" || field.name == "m_strict" {
+            continue;
+        }
+        let info = try_field_type_info(&field.ty).expect("field types are checked while parsing");
+        offset = offset
+            .checked_add(info.align - 1)
+            .map(|offset| offset & !(info.align - 1))
+            .and_then(|offset| offset.checked_add(info.size))
+            .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?;
+    }
+    if op.fields.iter().any(|field| field.is_array) {
+        if !op
+            .fields
+            .iter()
+            .any(|field| field.name == "m_length" && field.ty == "u32" && !field.is_array)
+        {
+            return Err(format!("array op '{}' requires a u32 m_length field", op.name));
+        }
+    } else {
+        offset
+            .checked_add(STRUCT_ALIGN - 1)
+            .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?;
+    }
+    Ok(())
 }
 
 /// Computed layout info for a single opcode.
@@ -234,4 +402,93 @@ pub fn compute_layouts(ops: &[OpDef]) -> HashMap<String, OpLayout> {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_operations_fields_and_annotations() {
+        let ops = parse_bytecode_def(
+            "Bytecode.def",
+            r#"
+op Instruction
+    m_type: bool
+    m_strict: bool
+endop
+
+op Call < Instruction
+    @terminator
+    @nothrow
+    m_length: u32
+    m_argument_count: u32
+    m_arguments: Operand[]
+endop
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].name, "Call");
+        assert!(ops[0].is_terminator);
+        assert_eq!(ops[0].fields.len(), 3);
+        assert!(ops[0].fields[2].is_array);
+    }
+
+    #[test]
+    fn parses_current_bytecode_definition() {
+        let ops = parse_bytecode_def(
+            "Libraries/LibJS/Bytecode/Bytecode.def",
+            include_str!("../../Bytecode/Bytecode.def"),
+        )
+        .unwrap();
+
+        assert!(ops.len() > 100);
+    }
+
+    #[test]
+    fn reports_structured_parse_errors() {
+        let error = parse_bytecode_def("broken.def", "op Add\n    m_value: Mystery\nendop\n").unwrap_err();
+
+        assert_eq!(error.source_name, "broken.def");
+        assert_eq!(error.line, 2);
+        assert_eq!(error.column, 14);
+        assert_eq!(error.message, "unknown field type 'Mystery'");
+        assert_eq!(
+            error.to_string(),
+            "broken.def:2:14: error: unknown field type 'Mystery'"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_definitions() {
+        for (source, message) in [
+            ("unexpected\n", "unexpected top-level line"),
+            ("endop\n", "endop without op"),
+            ("op Outer\nop Inner\n", "nested op block"),
+            ("op Open\n", "unclosed op block"),
+            ("op Bad\n    @mystery\nendop\n", "unknown annotation"),
+            ("op Bad\n    malformed\nendop\n", "malformed field line"),
+            ("op 42\nendop\n", "invalid op name"),
+            ("op Bad < Parent < Other\nendop\n", "invalid parent op name"),
+            ("op Bad\n    42: u32\nendop\n", "invalid field name"),
+            ("op First\nendop\nop First\nendop\n", "duplicate op 'First'"),
+            (
+                "op Fields\n    value: u32\n    value: u64\nendop\n",
+                "duplicate field 'value'",
+            ),
+            (
+                "op Array\n    m_values: Value[]\nendop\n",
+                "requires a u32 m_length field",
+            ),
+        ] {
+            let error = parse_bytecode_def("broken.def", source).unwrap_err();
+            assert!(
+                error.message.contains(message),
+                "expected '{message}', got '{}'",
+                error.message
+            );
+        }
+    }
 }

--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -22,10 +22,22 @@ pub struct Field {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct OpDef {
     pub name: String,
+    pub parent: String,
     pub fields: Vec<Field>,
     pub is_terminator: bool,
+    pub layout: OpLayout,
+    pub array: Option<ArrayLayout>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArrayLayout {
+    pub field_index: usize,
+    pub count_field_index: usize,
+    pub offset: usize,
+    pub element_size: usize,
 }
 
 pub struct FieldType {
@@ -146,8 +158,11 @@ pub fn parse_bytecode_def(source_name: &str, content: &str) -> Result<Vec<OpDef>
             }
             current = Some(OpDef {
                 name: name.to_string(),
+                parent: parent.unwrap_or_default().to_string(),
                 fields: Vec::new(),
                 is_terminator: false,
+                layout: OpLayout::default(),
+                array: None,
             });
             field_names.clear();
             op_start = Some((line, column));
@@ -155,10 +170,10 @@ pub fn parse_bytecode_def(source_name: &str, content: &str) -> Result<Vec<OpDef>
         }
 
         if stripped == "endop" {
-            let Some(op) = current.take() else {
+            let Some(mut op) = current.take() else {
                 return Err(ParseError::new(source_name, line, column, "endop without op"));
             };
-            validate_op_layout(&op).map_err(|message| ParseError::new(source_name, line, column, message))?;
+            validate_op(&mut op).map_err(|message| ParseError::new(source_name, line, column, message))?;
             ops.push(op);
             op_start = None;
             continue;
@@ -301,28 +316,45 @@ pub fn user_fields(op: &OpDef) -> Vec<&Field> {
         .collect()
 }
 
-/// Compute the byte offset of the m_length field within the C++ struct.
-pub fn find_m_length_offset(fields: &[Field]) -> usize {
-    let mut offset: usize = 2; // after m_type + m_strict
-    for f in fields {
-        if f.is_array {
-            continue;
-        }
-        if f.name == "m_type" || f.name == "m_strict" {
-            continue;
-        }
-        let info = field_type_info(&f.ty);
-        offset = round_up(offset, info.align);
-        if f.name == "m_length" {
-            return offset;
-        }
-        offset += info.size;
-    }
-    panic!("m_length field not found");
+fn count_field_index(op: &OpDef, array_field: &Field) -> Option<usize> {
+    let plural = format!("{}_count", array_field.name);
+    let singular = array_field.name.strip_suffix('s').map(|name| format!("{name}_count"));
+    op.fields.iter().position(|field| {
+        !field.is_array
+            && field.ty == "u32"
+            && (field.name == plural || singular.as_ref().is_some_and(|name| field.name == *name))
+    })
 }
 
-fn validate_op_layout(op: &OpDef) -> Result<(), String> {
+fn validate_op(op: &mut OpDef) -> Result<(), String> {
+    if op.name == "Instruction" {
+        if !op.parent.is_empty() {
+            return Err("base op 'Instruction' cannot have a parent".to_string());
+        }
+    } else if op.parent != "Instruction" {
+        return Err(format!("op '{}' must derive directly from Instruction", op.name));
+    }
+
     let mut offset = 2usize;
+    let mut field_offsets = HashMap::new();
+    let array_indices = op
+        .fields
+        .iter()
+        .enumerate()
+        .filter_map(|(index, field)| field.is_array.then_some(index))
+        .collect::<Vec<_>>();
+    if array_indices.len() > 1 {
+        return Err(format!("op '{}' has more than one flexible array field", op.name));
+    }
+    if let Some(array_index) = array_indices.first()
+        && *array_index + 1 != op.fields.len()
+    {
+        return Err(format!(
+            "flexible array field '{}' in op '{}' must be last",
+            op.fields[*array_index].name, op.name
+        ));
+    }
+
     for field in &op.fields {
         if field.is_array || field.name == "m_type" || field.name == "m_strict" {
             continue;
@@ -331,77 +363,83 @@ fn validate_op_layout(op: &OpDef) -> Result<(), String> {
         offset = offset
             .checked_add(info.align - 1)
             .map(|offset| offset & !(info.align - 1))
-            .and_then(|offset| offset.checked_add(info.size))
+            .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?;
+        field_offsets.insert(field.name.clone(), offset);
+        offset = offset
+            .checked_add(info.size)
             .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?;
     }
-    if op.fields.iter().any(|field| field.is_array) {
-        if !op
+
+    let array = if let Some(array_index) = array_indices.first().copied() {
+        let length_field = op
             .fields
             .iter()
-            .any(|field| field.name == "m_length" && field.ty == "u32" && !field.is_array)
-        {
+            .position(|field| field.name == "m_length" && field.ty == "u32" && !field.is_array);
+        if length_field.is_none() {
             return Err(format!("array op '{}' requires a u32 m_length field", op.name));
         }
-    } else {
-        offset
-            .checked_add(STRUCT_ALIGN - 1)
+        let count_field_index = count_field_index(op, &op.fields[array_index]).ok_or_else(|| {
+            format!(
+                "array field '{}' in op '{}' requires a matching u32 count field",
+                op.fields[array_index].name, op.name
+            )
+        })?;
+        let info = try_field_type_info(&op.fields[array_index].ty).expect("field types are checked while parsing");
+        let array_offset = offset
+            .checked_add(info.align - 1)
+            .map(|offset| offset & !(info.align - 1))
             .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?;
-    }
+        field_offsets.insert(op.fields[array_index].name.clone(), array_offset);
+        Some(ArrayLayout {
+            field_index: array_index,
+            count_field_index,
+            offset: array_offset,
+            element_size: info.size,
+        })
+    } else {
+        None
+    };
+    let size = if array.is_some() {
+        None
+    } else {
+        Some(
+            offset
+                .checked_add(STRUCT_ALIGN - 1)
+                .map(|offset| offset & !(STRUCT_ALIGN - 1))
+                .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?,
+        )
+    };
+    let minimum_size = offset
+        .checked_add(STRUCT_ALIGN - 1)
+        .map(|offset| offset & !(STRUCT_ALIGN - 1))
+        .ok_or_else(|| format!("layout of op '{}' overflows usize", op.name))?;
+    let m_length_offset = field_offsets.get("m_length").copied();
+    op.layout = OpLayout {
+        field_offsets,
+        size,
+        minimum_size,
+        m_length_offset,
+    };
+    op.array = array;
     Ok(())
 }
 
 /// Computed layout info for a single opcode.
-#[derive(Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct OpLayout {
     /// Byte offset of each field within the C++ struct (keyed by field name, e.g. "m_dst").
     pub field_offsets: HashMap<String, usize>,
     /// Total encoded size (for fixed-size instructions), or None for variable-length.
     pub size: Option<usize>,
+    /// Minimum encoded size, including the fixed header and tail padding.
+    pub minimum_size: usize,
+    /// Byte offset of m_length for variable-length instructions.
+    pub m_length_offset: Option<usize>,
 }
 
 /// Compute field offsets and total sizes for all opcodes.
 pub fn compute_layouts(ops: &[OpDef]) -> HashMap<String, OpLayout> {
-    let mut result = HashMap::new();
-
-    for op in ops {
-        let has_array = op.fields.iter().any(|f| f.is_array);
-        let mut field_offsets = HashMap::new();
-        let mut offset: usize = 2; // after m_type + m_strict header
-
-        // First pass: fixed (non-array) fields
-        for f in &op.fields {
-            if f.is_array || f.name == "m_type" || f.name == "m_strict" {
-                continue;
-            }
-            let info = field_type_info(&f.ty);
-            offset = round_up(offset, info.align);
-            field_offsets.insert(f.name.clone(), offset);
-            offset += info.size;
-        }
-
-        // Flexible array members start after the fixed fields with only the
-        // element's alignment. This can be before the struct's final tail
-        // padding on targets like MSVC.
-        if has_array {
-            for f in &op.fields {
-                if !f.is_array {
-                    continue;
-                }
-                let info = field_type_info(&f.ty);
-                field_offsets.insert(f.name.clone(), round_up(offset, info.align));
-            }
-        }
-
-        let size = if has_array {
-            None
-        } else {
-            Some(round_up(offset, STRUCT_ALIGN))
-        };
-
-        result.insert(op.name.clone(), OpLayout { field_offsets, size });
-    }
-
-    result
+    ops.iter().map(|op| (op.name.clone(), op.layout.clone())).collect()
 }
 
 #[cfg(test)]
@@ -473,15 +511,27 @@ endop
             ("op 42\nendop\n", "invalid op name"),
             ("op Bad < Parent < Other\nendop\n", "invalid parent op name"),
             ("op Bad\n    42: u32\nendop\n", "invalid field name"),
-            ("op First\nendop\nop First\nendop\n", "duplicate op 'First'"),
             (
-                "op Fields\n    value: u32\n    value: u64\nendop\n",
+                "op First < Instruction\nendop\nop First < Instruction\nendop\n",
+                "duplicate op 'First'",
+            ),
+            (
+                "op Fields < Instruction\n    value: u32\n    value: u64\nendop\n",
                 "duplicate field 'value'",
             ),
             (
-                "op Array\n    m_values: Value[]\nendop\n",
+                "op Array < Instruction\n    m_values: Value[]\nendop\n",
                 "requires a u32 m_length field",
             ),
+            (
+                "op Array < Instruction\n    m_length: u32\n    m_values: Value[]\nendop\n",
+                "requires a matching u32 count field",
+            ),
+            (
+                "op Array < Instruction\n    m_length: u32\n    m_value_count: u32\n    m_values: Value[]\n    m_tail: u32\nendop\n",
+                "must be last",
+            ),
+            ("op Derived < Mystery\nendop\n", "must derive directly from Instruction"),
         ] {
             let error = parse_bytecode_def("broken.def", source).unwrap_err();
             assert!(

--- a/Libraries/LibJS/BytecodeDef/src/lib.rs
+++ b/Libraries/LibJS/BytecodeDef/src/lib.rs
@@ -500,6 +500,19 @@ endop
     }
 
     #[test]
+    fn parses_single_byte_mutations_without_panicking() {
+        let seed = b"op Add < Instruction\n    m_value: Value\n    m_length: u32\nendop\n";
+        for index in 0..seed.len() {
+            for replacement in [b' ', b'\n', b'<', b':', b'[', b']', b'0', b'a'] {
+                let mut mutated = seed.to_vec();
+                mutated[index] = replacement;
+                let source = std::str::from_utf8(&mutated).unwrap();
+                let _ = parse_bytecode_def("mutated.def", source);
+            }
+        }
+    }
+
+    #[test]
     fn rejects_malformed_definitions() {
         for (source, message) in [
             ("unexpected\n", "unexpected top-level line"),

--- a/Libraries/LibJS/Flap/Cargo.lock
+++ b/Libraries/LibJS/Flap/Cargo.lock
@@ -11,4 +11,11 @@ name = "flapc"
 version = "0.1.0"
 dependencies = [
  "bytecode_def",
+ "smallvec",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"

--- a/Libraries/LibJS/Flap/Cargo.toml
+++ b/Libraries/LibJS/Flap/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 bytecode_def = { path = "../BytecodeDef" }
+smallvec = "=1.15.1"
 
 [[bench]]
 name = "compiler"

--- a/Libraries/LibJS/Flap/Cargo.toml
+++ b/Libraries/LibJS/Flap/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 
 [dependencies]
 bytecode_def = { path = "../BytecodeDef" }
+
+[[bench]]
+name = "compiler"
+harness = false

--- a/Libraries/LibJS/Flap/benches/compiler.rs
+++ b/Libraries/LibJS/Flap/benches/compiler.rs
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use flapc::{
+    Architecture, CompilationMetrics, CompilationUnit, CompileOptions, Compiler, ObjectFormat, SourceInput, Target,
+};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        unsafe { System.realloc(pointer, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const INTERPRETER: &str = include_str!("../../Interpreter/interpreter.flap");
+const LAYOUT: &str = include_str!("../tests/interpreter-layout.conf");
+const BYTECODE_DEF: &str = include_str!("../../Bytecode/Bytecode.def");
+
+fn compiler() -> Compiler {
+    Compiler::new(CompileOptions {
+        target: Target {
+            architecture: Architecture::X86_64,
+            object_format: ObjectFormat::Elf,
+        },
+        has_jscvt: false,
+        enable_assertions: false,
+    })
+}
+
+fn compilation_unit() -> CompilationUnit<'static> {
+    CompilationUnit {
+        source: SourceInput {
+            name: "interpreter.flap",
+            contents: INTERPRETER,
+        },
+        constants: Some(SourceInput {
+            name: "interpreter-layout.conf",
+            contents: LAYOUT,
+        }),
+        bytecode_def: Some(SourceInput {
+            name: "Bytecode.def",
+            contents: BYTECODE_DEF,
+        }),
+    }
+}
+
+#[derive(Default)]
+struct Totals {
+    elapsed: Duration,
+    metrics: Option<CompilationMetrics>,
+    allocations: u64,
+    allocated_bytes: u64,
+}
+
+fn main() {
+    let iterations = std::env::args()
+        .skip_while(|argument| argument != "--iterations")
+        .nth(1)
+        .map(|argument| {
+            argument
+                .parse::<u32>()
+                .expect("--iterations requires a positive integer")
+        })
+        .unwrap_or(20);
+    assert!(iterations != 0, "--iterations must not be zero");
+
+    let compiler = compiler();
+    compiler
+        .compile(compilation_unit())
+        .expect("interpreter warmup compilation should succeed");
+
+    let mut totals = Totals::default();
+    for _ in 0..iterations {
+        let allocations_before = ALLOCATIONS.load(Ordering::Relaxed);
+        let bytes_before = ALLOCATED_BYTES.load(Ordering::Relaxed);
+        let started_at = Instant::now();
+        let (assembly, metrics) = compiler
+            .compile_with_metrics(compilation_unit())
+            .expect("interpreter compilation should succeed");
+        totals.elapsed += started_at.elapsed();
+        totals.metrics = Some(add_metrics(totals.metrics, metrics));
+        totals.allocations += ALLOCATIONS.load(Ordering::Relaxed) - allocations_before;
+        totals.allocated_bytes += ALLOCATED_BYTES.load(Ordering::Relaxed) - bytes_before;
+        black_box(assembly);
+    }
+
+    let metrics = totals.metrics.unwrap();
+    println!("Flap AOT interpreter benchmark ({iterations} iterations)");
+    println!(
+        "total={:.3} ms allocations={} allocated={:.2} MiB",
+        milliseconds(totals.elapsed) / f64::from(iterations),
+        totals.allocations / u64::from(iterations),
+        totals.allocated_bytes as f64 / f64::from(iterations) / (1024.0 * 1024.0)
+    );
+    println!(
+        "prepare={:.3} lower={:.3} select={:.3} allocate={:.3} finalize={:.3} emit={:.3} ms",
+        milliseconds(metrics.prepare) / f64::from(iterations),
+        milliseconds(metrics.lower) / f64::from(iterations),
+        milliseconds(metrics.select) / f64::from(iterations),
+        milliseconds(metrics.allocate) / f64::from(iterations),
+        milliseconds(metrics.finalize) / f64::from(iterations),
+        milliseconds(metrics.emit) / f64::from(iterations),
+    );
+    println!(
+        "handlers={} SSA={}/{}/{} LowIR={} target={}/{} machine={}",
+        metrics.handlers / iterations as usize,
+        metrics.ssa_blocks / iterations as usize,
+        metrics.ssa_instructions / iterations as usize,
+        metrics.ssa_values / iterations as usize,
+        metrics.low_ir_instructions / iterations as usize,
+        metrics.target_instructions / iterations as usize,
+        metrics.virtual_registers / iterations as usize,
+        metrics.machine_instructions / iterations as usize,
+    );
+}
+
+fn add_metrics(total: Option<CompilationMetrics>, metrics: CompilationMetrics) -> CompilationMetrics {
+    let Some(total) = total else {
+        return metrics;
+    };
+    CompilationMetrics {
+        prepare: total.prepare + metrics.prepare,
+        lower: total.lower + metrics.lower,
+        select: total.select + metrics.select,
+        allocate: total.allocate + metrics.allocate,
+        finalize: total.finalize + metrics.finalize,
+        emit: total.emit + metrics.emit,
+        handlers: total.handlers + metrics.handlers,
+        ssa_blocks: total.ssa_blocks + metrics.ssa_blocks,
+        ssa_instructions: total.ssa_instructions + metrics.ssa_instructions,
+        ssa_values: total.ssa_values + metrics.ssa_values,
+        low_ir_instructions: total.low_ir_instructions + metrics.low_ir_instructions,
+        target_instructions: total.target_instructions + metrics.target_instructions,
+        virtual_registers: total.virtual_registers + metrics.virtual_registers,
+        machine_instructions: total.machine_instructions + metrics.machine_instructions,
+    }
+}
+
+fn milliseconds(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}

--- a/Libraries/LibJS/Flap/src/bytecode.rs
+++ b/Libraries/LibJS/Flap/src/bytecode.rs
@@ -6,7 +6,8 @@
 
 //! Prepared bytecode metadata used by reusable handler lowering.
 
-use bytecode_def::OpLayout;
+use crate::types::Type;
+use bytecode_def::OpDef;
 
 /// The identity of a handler parameter that names a bytecode field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -36,20 +37,49 @@ pub(crate) struct HandlerLayout {
 }
 
 impl HandlerLayout {
-    pub(crate) fn new(parameter_names: &[String], layout: Option<&OpLayout>) -> Self {
-        Self {
-            size: layout.and_then(|layout| layout.size),
-            fields: parameter_names
-                .iter()
-                .map(|name| {
-                    let name = bytecode_field_name(name);
-                    FieldLayout {
-                        offset: layout.and_then(|layout| layout.field_offsets.get(&name)).copied(),
-                        name,
-                    }
-                })
-                .collect(),
+    pub(crate) fn new(
+        handler_name: &str,
+        parameter_names: &[String],
+        parameter_types: &[Type],
+        op: Option<&OpDef>,
+    ) -> Result<Self, String> {
+        if parameter_names.len() != parameter_types.len() {
+            return Err(format!(
+                "handler '{handler_name}' has {} parameter names but {} parameter types",
+                parameter_names.len(),
+                parameter_types.len()
+            ));
         }
+        let layout = op.map(|op| &op.layout);
+        let fields = parameter_names
+            .iter()
+            .zip(parameter_types)
+            .map(|(name, parameter_type)| {
+                let name = bytecode_field_name(name);
+                if let Some(op) = op {
+                    let field = op
+                        .fields
+                        .iter()
+                        .find(|field| field.name == name)
+                        .ok_or_else(|| format!("handler parameter '{name}' does not name a bytecode field"))?;
+                    if !bytecode_field_type_matches(field, parameter_type) {
+                        return Err(format!(
+                            "handler parameter '{name}' has type {parameter_type}, but bytecode field '{}.{name}' has type {}",
+                            op.name,
+                            bytecode_field_type_name(field),
+                        ));
+                    }
+                }
+                Ok(FieldLayout {
+                    offset: layout.and_then(|layout| layout.field_offsets.get(&name)).copied(),
+                    name,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            size: layout.and_then(|layout| layout.size),
+            fields,
+        })
     }
 
     pub(crate) fn field_name(&self, field: BytecodeFieldId) -> &str {
@@ -66,6 +96,37 @@ fn bytecode_field_name(name: &str) -> String {
         .map_or_else(|| format!("m_{name}"), |_| name.to_string())
 }
 
+fn bytecode_field_type_name(field: &bytecode_def::Field) -> String {
+    if field.is_array {
+        format!("{}[]", field.ty)
+    } else {
+        field.ty.clone()
+    }
+}
+
+fn bytecode_field_type_matches(field: &bytecode_def::Field, parameter_type: &Type) -> bool {
+    if field.is_array {
+        return field.ty == "Operand" && *parameter_type == Type::Sequence(Box::new(Type::U32));
+    }
+    match field.ty.as_str() {
+        "bool" => *parameter_type == Type::Bool || *parameter_type == Type::U8,
+        "u32" | "Completion::Type" | "IteratorHint" | "EnvironmentMode" | "ArgumentsKind" | "FunctionNamePrefix" => {
+            *parameter_type == Type::U32
+        }
+        "u64" => *parameter_type == Type::U64,
+        "Operand" => *parameter_type == Type::Operand,
+        "Label" | "Optional<Label>" => *parameter_type == Type::BytecodeOffset,
+        "EnvironmentCoordinate" => *parameter_type == Type::EnvironmentCoordinate,
+        "EnvironmentCoordinateCacheIndex" => *parameter_type == Type::EnvironmentCoordinateCacheIndex,
+        "GlobalVariableCacheIndex" => *parameter_type == Type::GlobalVariableCacheIndex,
+        "PropertyLookupCacheIndex" | "Optional<IdentifierTableIndex>" | "PropertyKeyTableIndex" => {
+            *parameter_type == Type::PropertyLookupCacheIndex
+        }
+        "PutKind" => *parameter_type == Type::U8 || *parameter_type == Type::U32,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -73,16 +134,41 @@ mod tests {
 
     #[test]
     fn aligns_layout_offsets_with_handler_parameters() {
-        let layout = OpLayout {
-            field_offsets: HashMap::from([("m_lhs".to_string(), 4), ("m_rhs".to_string(), 8)]),
-            size: Some(12),
-            ..OpLayout::default()
-        };
-        let prepared = HandlerLayout::new(&["lhs".to_string(), "m_rhs".to_string()], Some(&layout));
+        let mut op = bytecode_def::parse_bytecode_def(
+            "TestBytecode.def",
+            "op Add < Instruction\n    m_lhs: Operand\n    m_rhs: Operand\nendop\n",
+        )
+        .unwrap()
+        .remove(0);
+        op.layout.field_offsets = HashMap::from([("m_lhs".to_string(), 4), ("m_rhs".to_string(), 8)]);
+        op.layout.size = Some(12);
+        let prepared = HandlerLayout::new(
+            "Add",
+            &["lhs".to_string(), "m_rhs".to_string()],
+            &[Type::Operand, Type::Operand],
+            Some(&op),
+        )
+        .unwrap();
 
         assert_eq!(prepared.size, Some(12));
         assert_eq!(prepared.field_offset(BytecodeFieldId::new(0)), Some(4));
         assert_eq!(prepared.field_offset(BytecodeFieldId::new(1)), Some(8));
         assert_eq!(prepared.field_name(BytecodeFieldId::new(1)), "m_rhs");
+    }
+    #[test]
+    fn rejects_mismatched_handler_parameter_metadata_before_field_types() {
+        let op =
+            bytecode_def::parse_bytecode_def("TestBytecode.def", "op Put < Instruction\n    m_kind: PutKind\nendop\n")
+                .unwrap()
+                .remove(0);
+        let error = HandlerLayout::new(
+            "Put",
+            &["kind".to_string(), "extra".to_string()],
+            &[Type::U32],
+            Some(&op),
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "handler 'Put' has 2 parameter names but 1 parameter types");
     }
 }

--- a/Libraries/LibJS/Flap/src/bytecode.rs
+++ b/Libraries/LibJS/Flap/src/bytecode.rs
@@ -14,10 +14,7 @@ pub(crate) struct BytecodeFieldId(u32);
 
 impl BytecodeFieldId {
     pub(crate) fn new(index: usize) -> Self {
-        Self(
-            u32::try_from(index)
-                .expect("Flap handler parameter count fits in u32"),
-        )
+        Self(u32::try_from(index).expect("Flap handler parameter count fits in u32"))
     }
 
     pub(crate) fn index(self) -> usize {
@@ -39,10 +36,7 @@ pub(crate) struct HandlerLayout {
 }
 
 impl HandlerLayout {
-    pub(crate) fn new(
-        parameter_names: &[String],
-        layout: Option<&OpLayout>,
-    ) -> Self {
+    pub(crate) fn new(parameter_names: &[String], layout: Option<&OpLayout>) -> Self {
         Self {
             size: layout.and_then(|layout| layout.size),
             fields: parameter_names
@@ -50,9 +44,7 @@ impl HandlerLayout {
                 .map(|name| {
                     let name = bytecode_field_name(name);
                     FieldLayout {
-                        offset: layout
-                            .and_then(|layout| layout.field_offsets.get(&name))
-                            .copied(),
+                        offset: layout.and_then(|layout| layout.field_offsets.get(&name)).copied(),
                         name,
                     }
                 })
@@ -64,10 +56,7 @@ impl HandlerLayout {
         &self.fields[field.index()].name
     }
 
-    pub(crate) fn field_offset(
-        &self,
-        field: BytecodeFieldId,
-    ) -> Option<usize> {
+    pub(crate) fn field_offset(&self, field: BytecodeFieldId) -> Option<usize> {
         self.fields[field.index()].offset
     }
 }
@@ -85,29 +74,14 @@ mod tests {
     #[test]
     fn aligns_layout_offsets_with_handler_parameters() {
         let layout = OpLayout {
-            field_offsets: HashMap::from([
-                ("m_lhs".to_string(), 4),
-                ("m_rhs".to_string(), 8),
-            ]),
+            field_offsets: HashMap::from([("m_lhs".to_string(), 4), ("m_rhs".to_string(), 8)]),
             size: Some(12),
         };
-        let prepared = HandlerLayout::new(
-            &["lhs".to_string(), "m_rhs".to_string()],
-            Some(&layout),
-        );
+        let prepared = HandlerLayout::new(&["lhs".to_string(), "m_rhs".to_string()], Some(&layout));
 
         assert_eq!(prepared.size, Some(12));
-        assert_eq!(
-            prepared.field_offset(BytecodeFieldId::new(0)),
-            Some(4)
-        );
-        assert_eq!(
-            prepared.field_offset(BytecodeFieldId::new(1)),
-            Some(8)
-        );
-        assert_eq!(
-            prepared.field_name(BytecodeFieldId::new(1)),
-            "m_rhs"
-        );
+        assert_eq!(prepared.field_offset(BytecodeFieldId::new(0)), Some(4));
+        assert_eq!(prepared.field_offset(BytecodeFieldId::new(1)), Some(8));
+        assert_eq!(prepared.field_name(BytecodeFieldId::new(1)), "m_rhs");
     }
 }

--- a/Libraries/LibJS/Flap/src/bytecode.rs
+++ b/Libraries/LibJS/Flap/src/bytecode.rs
@@ -76,6 +76,7 @@ mod tests {
         let layout = OpLayout {
             field_offsets: HashMap::from([("m_lhs".to_string(), 4), ("m_rhs".to_string(), 8)]),
             size: Some(12),
+            ..OpLayout::default()
         };
         let prepared = HandlerLayout::new(&["lhs".to_string(), "m_rhs".to_string()], Some(&layout));
 

--- a/Libraries/LibJS/Flap/src/bytecode.rs
+++ b/Libraries/LibJS/Flap/src/bytecode.rs
@@ -119,10 +119,8 @@ fn bytecode_field_type_matches(field: &bytecode_def::Field, parameter_type: &Typ
         "EnvironmentCoordinate" => *parameter_type == Type::EnvironmentCoordinate,
         "EnvironmentCoordinateCacheIndex" => *parameter_type == Type::EnvironmentCoordinateCacheIndex,
         "GlobalVariableCacheIndex" => *parameter_type == Type::GlobalVariableCacheIndex,
-        "PropertyLookupCacheIndex" | "Optional<IdentifierTableIndex>" | "PropertyKeyTableIndex" => {
-            *parameter_type == Type::PropertyLookupCacheIndex
-        }
-        "PutKind" => *parameter_type == Type::U8 || *parameter_type == Type::U32,
+        "PropertyLookupCacheIndex" => *parameter_type == Type::PropertyLookupCacheIndex,
+        "PutKind" => *parameter_type == Type::U8,
         _ => false,
     }
 }
@@ -155,6 +153,45 @@ mod tests {
         assert_eq!(prepared.field_offset(BytecodeFieldId::new(1)), Some(8));
         assert_eq!(prepared.field_name(BytecodeFieldId::new(1)), "m_rhs");
     }
+
+    #[test]
+    fn rejects_unrelated_index_types_as_property_lookup_cache_indices() {
+        let op = bytecode_def::parse_bytecode_def(
+            "TestBytecode.def",
+            "op Get < Instruction\n    m_cache: PropertyKeyTableIndex\nendop\n",
+        )
+        .unwrap()
+        .remove(0);
+        let error = HandlerLayout::new(
+            "Get",
+            &["cache".to_string()],
+            &[Type::PropertyLookupCacheIndex],
+            Some(&op),
+        )
+        .unwrap_err();
+
+        assert!(
+            error.contains(
+                "handler parameter 'm_cache' has type PropertyLookupCacheIndex, but bytecode field 'Get.m_cache' has type PropertyKeyTableIndex"
+            ),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rejects_wide_put_kind_handler_parameters() {
+        let op =
+            bytecode_def::parse_bytecode_def("TestBytecode.def", "op Put < Instruction\n    m_kind: PutKind\nendop\n")
+                .unwrap()
+                .remove(0);
+        let error = HandlerLayout::new("Put", &["kind".to_string()], &[Type::U32], Some(&op)).unwrap_err();
+
+        assert!(
+            error.contains("handler parameter 'm_kind' has type u32, but bytecode field 'Put.m_kind' has type PutKind"),
+            "{error}"
+        );
+    }
+
     #[test]
     fn rejects_mismatched_handler_parameter_metadata_before_field_types() {
         let op =

--- a/Libraries/LibJS/Flap/src/frontend/ast.rs
+++ b/Libraries/LibJS/Flap/src/frontend/ast.rs
@@ -7,8 +7,8 @@
 //! Flap abstract syntax tree.
 
 use super::diagnostic::SourceSpan;
-use crate::types::{BlockTemperature, Type};
 pub(crate) use crate::types::ParameterMode;
+use crate::types::{BlockTemperature, Type};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Parameter {
@@ -98,7 +98,10 @@ pub(crate) enum BinaryOperator {
 pub(crate) enum ExpressionKind {
     Name(String),
     Integer(i64),
-    Call { callee: String, arguments: Vec<Expression> },
+    Call {
+        callee: String,
+        arguments: Vec<Expression>,
+    },
     Unary {
         operator: UnaryOperator,
         operand: Box<Expression>,
@@ -147,14 +150,8 @@ pub(crate) enum Pattern {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ElseContinuation {
     Label(String),
-    Invocation {
-        target: String,
-        arguments: Vec<Expression>,
-    },
-    Block {
-        temperature: BlockTemperature,
-        body: Block,
-    },
+    Invocation { target: String, arguments: Vec<Expression> },
+    Block { temperature: BlockTemperature, body: Block },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/Libraries/LibJS/Flap/src/frontend/diagnostic.rs
+++ b/Libraries/LibJS/Flap/src/frontend/diagnostic.rs
@@ -9,16 +9,16 @@
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct SourceLocation {
-    pub(crate) offset: usize,
-    pub(crate) line: usize,
-    pub(crate) column: usize,
+pub struct SourceLocation {
+    pub offset: usize,
+    pub line: usize,
+    pub column: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SourceSpan {
-    pub(crate) start: SourceLocation,
-    pub(crate) end: SourceLocation,
+    pub start: SourceLocation,
+    pub end: SourceLocation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/Libraries/LibJS/Flap/src/frontend/layout.rs
+++ b/Libraries/LibJS/Flap/src/frontend/layout.rs
@@ -7,7 +7,7 @@
 //! Validated database for generated LibJS data-layout descriptions.
 
 use crate::types::Type;
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct LayoutConstantId(u32);
@@ -110,7 +110,7 @@ pub(crate) struct LayoutConstants {
 impl LayoutConstants {
     fn new() -> Self {
         Self {
-            by_name: HashMap::new(),
+            by_name: HashMap::default(),
             known: [None; KnownLayoutConstant::COUNT],
         }
     }
@@ -223,7 +223,7 @@ impl LayoutDatabase {
             fields: Vec::new(),
             constants: LayoutConstants::new(),
         };
-        let mut field_names = HashSet::new();
+        let mut field_names = HashSet::default();
         let mut unresolved_fields = Vec::new();
 
         for (index, source_line) in source.lines().enumerate() {

--- a/Libraries/LibJS/Flap/src/frontend/layout.rs
+++ b/Libraries/LibJS/Flap/src/frontend/layout.rs
@@ -6,8 +6,8 @@
 
 //! Validated database for generated LibJS data-layout descriptions.
 
-use crate::types::Type;
 use crate::hash::{HashMap, HashSet};
+use crate::types::Type;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct LayoutConstantId(u32);
@@ -91,9 +91,7 @@ impl LayoutConstant {
     }
 
     pub(crate) fn known(self) -> Option<KnownLayoutConstant> {
-        KnownLayoutConstant::ALL
-            .get(self.id.0 as usize)
-            .copied()
+        KnownLayoutConstant::ALL.get(self.id.0 as usize).copied()
     }
 
     pub(crate) fn is(self, known: KnownLayoutConstant) -> bool {
@@ -136,11 +134,7 @@ impl LayoutConstants {
         } else {
             LayoutConstantCategory::Other
         };
-        let constant = LayoutConstant {
-            id,
-            value,
-            category,
-        };
+        let constant = LayoutConstant { id, value, category };
         self.by_name.insert(name.to_string(), constant);
         if let Some(known) = known {
             self.known[known as usize] = Some(constant);
@@ -152,17 +146,12 @@ impl LayoutConstants {
         self.by_name.get(name).copied()
     }
 
-    pub(crate) fn known(
-        &self,
-        constant: KnownLayoutConstant,
-    ) -> Option<LayoutConstant> {
+    pub(crate) fn known(&self, constant: KnownLayoutConstant) -> Option<LayoutConstant> {
         self.known[constant as usize]
     }
 
     #[cfg(test)]
-    pub(crate) fn from_values(
-        values: impl IntoIterator<Item = (String, i64)>,
-    ) -> Self {
+    pub(crate) fn from_values(values: impl IntoIterator<Item = (String, i64)>) -> Self {
         let mut constants = Self::new();
         for (name, value) in values {
             constants.insert(&name, value).unwrap();
@@ -346,11 +335,7 @@ impl LayoutDatabase {
                     owner: field.owner,
                     name: field.name,
                     ty: field.ty,
-                    offset: resolve_layout_value(
-                        field.line,
-                        &field.offset,
-                        &database.constants,
-                    )?,
+                    offset: resolve_layout_value(field.line, &field.offset, &database.constants)?,
                     nonnull: field.nonnull,
                     embedded: field.embedded,
                     pair: field.pair,
@@ -358,24 +343,12 @@ impl LayoutDatabase {
                     pinned_offset: field
                         .pinned_offset
                         .as_deref()
-                        .map(|value| {
-                            resolve_layout_value(
-                                field.line,
-                                value,
-                                &database.constants,
-                            )
-                        })
+                        .map(|value| resolve_layout_value(field.line, value, &database.constants))
                         .transpose()?,
                     stride: field
                         .stride
                         .as_deref()
-                        .map(|value| {
-                            resolve_layout_value(
-                                field.line,
-                                value,
-                                &database.constants,
-                            )
-                        })
+                        .map(|value| resolve_layout_value(field.line, value, &database.constants))
                         .transpose()?,
                 })
             })
@@ -397,23 +370,14 @@ impl LayoutDatabase {
     }
 }
 
-fn resolve_layout_value(
-    line: usize,
-    value: &str,
-    constants: &LayoutConstants,
-) -> Result<LayoutValue, LayoutError> {
+fn resolve_layout_value(line: usize, value: &str, constants: &LayoutConstants) -> Result<LayoutValue, LayoutError> {
     if let Ok(value) = parse_integer(value) {
         return Ok(LayoutValue::Immediate(value));
     }
     constants
         .get(value)
         .map(LayoutValue::Constant)
-        .ok_or_else(|| {
-            LayoutError::new(
-                line,
-                format!("field references undefined layout value '{value}'"),
-            )
-        })
+        .ok_or_else(|| LayoutError::new(line, format!("field references undefined layout value '{value}'")))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -473,10 +437,7 @@ mod tests {
         let database =
             LayoutDatabase::parse("const OBJECT_SHAPE = 16\nfield Object.shape Shape OBJECT_SHAPE nonnull\n").unwrap();
 
-        assert_eq!(
-            database.constants().get("OBJECT_SHAPE").unwrap().value(),
-            16
-        );
+        assert_eq!(database.constants().get("OBJECT_SHAPE").unwrap().value(), 16);
         assert_eq!(database.fields()[0].owner, Type::Object);
         assert_eq!(database.fields()[0].ty, Type::Shape);
         assert!(database.fields()[0].nonnull);
@@ -495,18 +456,13 @@ mod tests {
             database.fields()[0].pinned_offset,
             Some(LayoutValue::Constant(constant)) if constant.value() == 8
         ));
-        assert_eq!(
-            database.fields()[1].stride,
-            Some(LayoutValue::Immediate(8))
-        );
+        assert_eq!(database.fields()[1].stride, Some(LayoutValue::Immediate(8)));
     }
 
     #[test]
     fn resolves_forward_layout_value_references() {
-        let database = LayoutDatabase::parse(
-            "field Object.shape Shape OBJECT_SHAPE nonnull\nconst OBJECT_SHAPE = 16\n",
-        )
-        .unwrap();
+        let database =
+            LayoutDatabase::parse("field Object.shape Shape OBJECT_SHAPE nonnull\nconst OBJECT_SHAPE = 16\n").unwrap();
 
         assert!(matches!(
             database.fields()[0].offset,

--- a/Libraries/LibJS/Flap/src/frontend/parser.rs
+++ b/Libraries/LibJS/Flap/src/frontend/parser.rs
@@ -1987,6 +1987,19 @@ handler Sub(lhs: i32, rhs: i32) {
     }
 
     #[test]
+    fn parses_single_byte_mutations_without_panicking() {
+        let seed = b"handler Add(lhs: i32, rhs: i32) { let value = lhs + rhs; assert_nonzero(value); dispatch_next; }";
+        for index in 0..seed.len() {
+            for replacement in [b' ', b'\n', b'{', b'}', b'(', b')', b';', b'0', b'a'] {
+                let mut mutated = seed.to_vec();
+                mutated[index] = replacement;
+                let source = std::str::from_utf8(&mutated).unwrap();
+                let _ = parse("mutated.flap", source);
+            }
+        }
+    }
+
+    #[test]
     fn binds_bitwise_arithmetic_before_comparisons() {
         let handler = parse_handler(
             "handler Check(flags: i32) { guard flags & 2 != 0 else slow; let slow = || { dispatch_next; }; }",

--- a/Libraries/LibJS/Flap/src/frontend/parser.rs
+++ b/Libraries/LibJS/Flap/src/frontend/parser.rs
@@ -448,9 +448,10 @@ impl<'a> Parser<'a> {
         }
         self.consume(TokenKind::RightParen, "')'")?;
         if let Some(index) = parameters.iter().position(|parameter| parameter.is_else)
-            && index + 1 != parameters.len() {
-                return self.error("an else parameter must be last");
-            }
+            && index + 1 != parameters.len()
+        {
+            return self.error("an else parameter must be last");
+        }
         Ok(parameters)
     }
 
@@ -510,12 +511,7 @@ impl<'a> Parser<'a> {
         }
         let constructor = match name.as_str() {
             "Label" => return Ok(Type::label()),
-            "Value"
-            | "ptr"
-            | "Sequence"
-            | "Field"
-            | "BinaryOperation"
-            | "CheckedBinaryOperation" => name,
+            "Value" | "ptr" | "Sequence" | "Field" | "BinaryOperation" | "CheckedBinaryOperation" => name,
             _ => return Err(Diagnostic::new(self.filename, span, format!("unknown type '{name}'"))),
         };
         self.consume(TokenKind::LeftAngle, "'<'")?;
@@ -586,7 +582,10 @@ impl<'a> Parser<'a> {
             self.consume_keyword("else")?;
             let failure = self.parse_else_continuation()?;
             let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
-            return Ok(Statement::new(StatementKind::Guard { condition, failure }, SourceSpan { start, end }));
+            return Ok(Statement::new(
+                StatementKind::Guard { condition, failure },
+                SourceSpan { start, end },
+            ));
         }
         if self.at_keyword("goto") {
             self.advance();
@@ -597,7 +596,10 @@ impl<'a> Parser<'a> {
                 Vec::new()
             };
             let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
-            return Ok(Statement::new(StatementKind::ContinuationJump { target, arguments }, SourceSpan { start, end }));
+            return Ok(Statement::new(
+                StatementKind::ContinuationJump { target, arguments },
+                SourceSpan { start, end },
+            ));
         }
         if self.at_keyword("let") {
             self.advance();
@@ -745,7 +747,11 @@ impl<'a> Parser<'a> {
             let body = self.parse_block()?;
             let end = body.span.end;
             return Ok(Statement::new(
-                StatementKind::While { condition, body, post_tested: false },
+                StatementKind::While {
+                    condition,
+                    body,
+                    post_tested: false,
+                },
                 SourceSpan { start, end },
             ));
         }
@@ -756,12 +762,19 @@ impl<'a> Parser<'a> {
             let condition = self.parse_expression()?;
             let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
             return Ok(Statement::new(
-                StatementKind::While { condition, body, post_tested: true },
+                StatementKind::While {
+                    condition,
+                    body,
+                    post_tested: true,
+                },
                 SourceSpan { start, end },
             ));
         }
         if matches!(&self.current().kind, TokenKind::Identifier(_))
-            && self.tokens.get(self.index + 1).is_some_and(|token| token.kind == TokenKind::LeftBracket)
+            && self
+                .tokens
+                .get(self.index + 1)
+                .is_some_and(|token| token.kind == TokenKind::LeftBracket)
         {
             let base = self.parse_primary_expression()?;
             self.consume(TokenKind::LeftBracket, "'['")?;
@@ -770,7 +783,10 @@ impl<'a> Parser<'a> {
             self.consume(TokenKind::Equals, "'='")?;
             let value = self.parse_expression()?;
             let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
-            return Ok(Statement::new(StatementKind::IndexAssign { base, index, value }, SourceSpan { start, end }));
+            return Ok(Statement::new(
+                StatementKind::IndexAssign { base, index, value },
+                SourceSpan { start, end },
+            ));
         }
 
         if matches!(&self.current().kind, TokenKind::Identifier(_))
@@ -783,7 +799,10 @@ impl<'a> Parser<'a> {
             self.advance();
             let initializer = self.parse_expression()?;
             let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
-            return Ok(Statement::new(StatementKind::Assign { name, initializer }, SourceSpan { start, end }));
+            return Ok(Statement::new(
+                StatementKind::Assign { name, initializer },
+                SourceSpan { start, end },
+            ));
         }
 
         let expression = self.parse_expression()?;
@@ -804,7 +823,10 @@ impl<'a> Parser<'a> {
             ));
         }
         let end = self.consume(TokenKind::Semicolon, "';'")?.span.end;
-        Ok(Statement::new(StatementKind::Expression(expression), SourceSpan { start, end }))
+        Ok(Statement::new(
+            StatementKind::Expression(expression),
+            SourceSpan { start, end },
+        ))
     }
 
     fn parse_tuple_pattern(&mut self) -> Result<Pattern, Diagnostic> {
@@ -1057,9 +1079,7 @@ impl<'a> Parser<'a> {
                         return self.error("scalar match arms must use the same body style");
                     }
                     style = Some(current_style);
-                    if current_style == ScalarMatchArmStyle::Target
-                        && temperature != BlockTemperature::Default
-                    {
+                    if current_style == ScalarMatchArmStyle::Target && temperature != BlockTemperature::Default {
                         return self.error("a target match arm cannot have a block layout annotation");
                     }
                     let body = if current_style == ScalarMatchArmStyle::Block {
@@ -1080,24 +1100,19 @@ impl<'a> Parser<'a> {
                 }
                 self.advance();
                 self.consume(TokenKind::FatArrow, "'=>'")?;
-                let fallback = if style == Some(ScalarMatchArmStyle::Target)
-                    && self.current().kind == TokenKind::LeftBrace
-                {
-                    self.parse_block()?
-                } else {
-                    let (target, span) = self.consume_identifier("fallback label or closure")?;
-                    Self::jump_block(target, span)
-                };
+                let fallback =
+                    if style == Some(ScalarMatchArmStyle::Target) && self.current().kind == TokenKind::LeftBrace {
+                        self.parse_block()?
+                    } else {
+                        let (target, span) = self.consume_identifier("fallback label or closure")?;
+                        Self::jump_block(target, span)
+                    };
                 if self.current().kind == TokenKind::Comma {
                     self.advance();
                 }
                 let end = self.consume(TokenKind::RightBrace, "'}'")?.span.end;
                 return Ok(Statement::new(
-                    StatementKind::ScalarMatch {
-                        value,
-                        arms,
-                        fallback,
-                    },
+                    StatementKind::ScalarMatch { value, arms, fallback },
                     SourceSpan { start, end },
                 ));
             }
@@ -1229,10 +1244,7 @@ impl<'a> Parser<'a> {
         self.parse_binary_expression(0)
     }
 
-    fn parse_binary_expression(
-        &mut self,
-        minimum_precedence: u8,
-    ) -> Result<Expression, Diagnostic> {
+    fn parse_binary_expression(&mut self, minimum_precedence: u8) -> Result<Expression, Diagnostic> {
         let mut expression = self.parse_unary_expression()?;
         while let Some(precedence) = self.infix_precedence()
             && precedence >= minimum_precedence
@@ -1280,30 +1292,14 @@ impl<'a> Parser<'a> {
         Some(match self.current().kind {
             TokenKind::DoubleAmpersand => 1,
             TokenKind::DoubleEquals => 2,
-            TokenKind::Bang
-                if matches!(
-                    self.peek(1).kind,
-                    TokenKind::Equals | TokenKind::DoubleEquals
-                ) =>
-            {
-                2
-            }
-            TokenKind::Identifier(_)
-                if self.at_keyword("has")
-                    || self.at_keyword("lacks")
-                    || self.at_keyword("is") =>
-            {
+            TokenKind::Bang if matches!(self.peek(1).kind, TokenKind::Equals | TokenKind::DoubleEquals) => 2,
+            TokenKind::Identifier(_) if self.at_keyword("has") || self.at_keyword("lacks") || self.at_keyword("is") => {
                 2
             }
             TokenKind::Pipe => 3,
             TokenKind::Caret => 4,
             TokenKind::Ampersand => 5,
-            TokenKind::LeftAngle | TokenKind::RightAngle
-                if self.peek(1).kind
-                    == self.current().kind =>
-            {
-                7
-            }
+            TokenKind::LeftAngle | TokenKind::RightAngle if self.peek(1).kind == self.current().kind => 7,
             TokenKind::LeftAngle | TokenKind::RightAngle => 6,
             TokenKind::Plus | TokenKind::Minus => 8,
             TokenKind::Star | TokenKind::Slash | TokenKind::Percent => 9,
@@ -1311,10 +1307,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn consume_infix_operator(
-        &mut self,
-        precedence: u8,
-    ) -> Result<InfixOperator, Diagnostic> {
+    fn consume_infix_operator(&mut self, precedence: u8) -> Result<InfixOperator, Diagnostic> {
         let binary = |operator| Ok(InfixOperator::Binary(operator));
         if self.at_keyword("has") || self.at_keyword("lacks") {
             let set = self.at_keyword("has");
@@ -1327,17 +1320,15 @@ impl<'a> Parser<'a> {
             if negated {
                 self.advance();
             }
-            if self.at_keyword("Value")
-                && self.peek(1).kind == TokenKind::LeftAngle
-            {
+            if self.at_keyword("Value") && self.peek(1).kind == TokenKind::LeftAngle {
                 self.advance();
                 self.consume(TokenKind::LeftAngle, "'<'")?;
-                let (type_name, _) =
-                    self.consume_identifier("Value representation type")?;
+                let (type_name, _) = self.consume_identifier("Value representation type")?;
                 self.consume(TokenKind::RightAngle, "'>'")?;
-                return Ok(InfixOperator::ValueTypeTest(
-                    UnaryOperator::ValueTypeTest { type_name, negated },
-                ));
+                return Ok(InfixOperator::ValueTypeTest(UnaryOperator::ValueTypeTest {
+                    type_name,
+                    negated,
+                }));
             }
             return binary(BinaryOperator::Identity { negated });
         }
@@ -1362,23 +1353,15 @@ impl<'a> Parser<'a> {
                 }
                 match (token, or_equal) {
                     (TokenKind::LeftAngle, false) => BinaryOperator::LessThan,
-                    (TokenKind::RightAngle, false) => {
-                        BinaryOperator::GreaterThan
-                    }
-                    (TokenKind::LeftAngle, true) => {
-                        BinaryOperator::LessThanOrEqual
-                    }
-                    (TokenKind::RightAngle, true) => {
-                        BinaryOperator::GreaterThanOrEqual
-                    }
+                    (TokenKind::RightAngle, false) => BinaryOperator::GreaterThan,
+                    (TokenKind::LeftAngle, true) => BinaryOperator::LessThanOrEqual,
+                    (TokenKind::RightAngle, true) => BinaryOperator::GreaterThanOrEqual,
                     _ => unreachable!(),
                 }
             }
             (7, TokenKind::LeftAngle | TokenKind::RightAngle) => {
                 self.advance();
-                if token == TokenKind::RightAngle
-                    && self.current().kind == TokenKind::RightAngle
-                {
+                if token == TokenKind::RightAngle && self.current().kind == TokenKind::RightAngle {
                     self.advance();
                     BinaryOperator::UnsignedRightShift
                 } else if token == TokenKind::LeftAngle {
@@ -1706,7 +1689,11 @@ handler Mod(lhs: Value, rhs: Value) {
         let declaration = parse_inline_function(
             "inline fn scalars(a: i8, b: i16, c: i32, d: i64, e: u8, f: u16, g: u32, h: u64, i: f32, j: f64) {}",
         );
-        let types: Vec<_> = declaration.parameters.iter().map(|parameter| parameter.ty.clone()).collect();
+        let types: Vec<_> = declaration
+            .parameters
+            .iter()
+            .map(|parameter| parameter.ty.clone())
+            .collect();
 
         assert_eq!(
             types,
@@ -1841,9 +1828,8 @@ inline fn convert(value: Value, else failure: Label) -> i32 {
 
     #[test]
     fn parses_two_armed_if_statements() {
-        let handler = parse_handler(
-            "handler Choose(value: u32) { if value == 0 { dispatch_next; } else { dispatch_next; } }",
-        );
+        let handler =
+            parse_handler("handler Choose(value: u32) { if value == 0 { dispatch_next; } else { dispatch_next; } }");
 
         assert!(matches!(
             &handler.body.statements[0].kind,
@@ -1858,9 +1844,8 @@ inline fn convert(value: Value, else failure: Label) -> i32 {
 
     #[test]
     fn parses_value_if_as_an_inline_function_tail_expression() {
-        let declaration = parse_inline_function(
-            "inline fn max(lhs: u32, rhs: u32) -> u32 { if lhs >= rhs { lhs } else { rhs } }",
-        );
+        let declaration =
+            parse_inline_function("inline fn max(lhs: u32, rhs: u32) -> u32 { if lhs >= rhs { lhs } else { rhs } }");
 
         assert!(matches!(
             declaration.body.statements.as_slice(),
@@ -1937,9 +1922,7 @@ inline fn convert(value: Value, else failure: Label) -> i32 {
 
     #[test]
     fn parses_typed_bytecode_fields() {
-        let declaration = parse_handler(
-            "handler Call(argument_count: Field<u32>) { dispatch_next; }",
-        );
+        let declaration = parse_handler("handler Call(argument_count: Field<u32>) { dispatch_next; }");
 
         assert_eq!(declaration.parameters[0].ty, Type::Field(Box::new(Type::U32)));
     }
@@ -1955,9 +1938,7 @@ inline fn convert(value: Value, else failure: Label) -> i32 {
 
     #[test]
     fn parses_readable_integer_literals() {
-        let tokens = Lexer::new("integers.flap", "0xffff_ffff 4_294_967_295")
-            .lex()
-            .unwrap();
+        let tokens = Lexer::new("integers.flap", "0xffff_ffff 4_294_967_295").lex().unwrap();
 
         assert_eq!(tokens[0].kind, TokenKind::Integer(0xffff_ffff));
         assert_eq!(tokens[1].kind, TokenKind::Integer(0xffff_ffff));

--- a/Libraries/LibJS/Flap/src/hash.rs
+++ b/Libraries/LibJS/Flap/src/hash.rs
@@ -6,11 +6,13 @@
 
 //! Hash tables for the compiler's own bookkeeping.
 //!
-//! Nearly every key here is a small dense index, or a value carrying an
-//! identity hash it computed once. The standard library's hasher is built to
-//! resist keys chosen by an attacker, which none of these tables ever see, and
-//! hashing shows up across the whole compiler when compiling a program: the
-//! tables are rebuilt from nothing on every compile.
+//! Most keys here are small dense indices or values carrying an identity hash
+//! computed once. Some front-end tables also contain identifiers copied from
+//! source. Using a deterministic hasher for those is safe only under the
+//! crate-level contract that Flap compiles trusted generated input; it is not
+//! collision resistant and must not silently cross an untrusted-source
+//! boundary. Hashing shows up across the whole compiler, and these tables are
+//! rebuilt from nothing on every compile.
 
 use std::hash::{BuildHasherDefault, Hasher};
 

--- a/Libraries/LibJS/Flap/src/hash.rs
+++ b/Libraries/LibJS/Flap/src/hash.rs
@@ -36,7 +36,9 @@ impl Hasher for Hash {
     fn write(&mut self, bytes: &[u8]) {
         let mut chunks = bytes.chunks_exact(8);
         for chunk in &mut chunks {
-            self.add(u64::from_le_bytes(chunk.try_into().expect("a chunk of eight bytes is eight bytes")));
+            self.add(u64::from_le_bytes(
+                chunk.try_into().expect("a chunk of eight bytes is eight bytes"),
+            ));
         }
         let mut remainder = [0; 8];
         remainder[..chunks.remainder().len()].copy_from_slice(chunks.remainder());

--- a/Libraries/LibJS/Flap/src/hash.rs
+++ b/Libraries/LibJS/Flap/src/hash.rs
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Hash tables for the compiler's own bookkeeping.
+//!
+//! Nearly every key here is a small dense index, or a value carrying an
+//! identity hash it computed once. The standard library's hasher is built to
+//! resist keys chosen by an attacker, which none of these tables ever see, and
+//! hashing shows up across the whole compiler when compiling a program: the
+//! tables are rebuilt from nothing on every compile.
+
+use std::hash::{BuildHasherDefault, Hasher};
+
+pub(crate) type HashMap<K, V> = std::collections::HashMap<K, V, BuildHasherDefault<Hash>>;
+pub(crate) type HashSet<T> = std::collections::HashSet<T, BuildHasherDefault<Hash>>;
+
+/// A multiply-rotate hash, in the style of the one rustc uses for its own
+/// interned indices.
+#[derive(Default)]
+pub(crate) struct Hash {
+    state: u64,
+}
+
+impl Hash {
+    const MULTIPLIER: u64 = 0x517c_c1b7_2722_0a95;
+
+    fn add(&mut self, word: u64) {
+        self.state = (self.state.rotate_left(5) ^ word).wrapping_mul(Self::MULTIPLIER);
+    }
+}
+
+impl Hasher for Hash {
+    fn write(&mut self, bytes: &[u8]) {
+        let mut chunks = bytes.chunks_exact(8);
+        for chunk in &mut chunks {
+            self.add(u64::from_le_bytes(chunk.try_into().expect("a chunk of eight bytes is eight bytes")));
+        }
+        let mut remainder = [0; 8];
+        remainder[..chunks.remainder().len()].copy_from_slice(chunks.remainder());
+        self.add(u64::from_le_bytes(remainder));
+    }
+
+    fn write_u8(&mut self, value: u8) {
+        self.add(u64::from(value));
+    }
+
+    fn write_u16(&mut self, value: u16) {
+        self.add(u64::from(value));
+    }
+
+    fn write_u32(&mut self, value: u32) {
+        self.add(u64::from(value));
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.add(value);
+    }
+
+    fn write_usize(&mut self, value: usize) {
+        self.add(value as u64);
+    }
+
+    fn finish(&self) -> u64 {
+        self.state
+    }
+}

--- a/Libraries/LibJS/Flap/src/hir/capture.rs
+++ b/Libraries/LibJS/Flap/src/hir/capture.rs
@@ -6,9 +6,7 @@
 
 //! Lexical capture analysis for nested HIR regions.
 
-use super::{
-    Statement, VariableId, statement_uses_and_defs,
-};
+use super::{Statement, VariableId, statement_uses_and_defs};
 use crate::hash::HashSet;
 
 pub(super) fn collect_captures(statements: &[Statement], outer_variable_count: usize) -> Vec<VariableId> {

--- a/Libraries/LibJS/Flap/src/hir/capture.rs
+++ b/Libraries/LibJS/Flap/src/hir/capture.rs
@@ -9,10 +9,10 @@
 use super::{
     Statement, VariableId, statement_uses_and_defs,
 };
-use std::collections::HashSet;
+use crate::hash::HashSet;
 
 pub(super) fn collect_captures(statements: &[Statement], outer_variable_count: usize) -> Vec<VariableId> {
-    let mut captures = HashSet::new();
+    let mut captures = HashSet::default();
     for statement in statements {
         let (uses, definitions) = statement_uses_and_defs(statement);
         captures.extend(
@@ -30,8 +30,8 @@ pub(super) fn collect_captures(statements: &[Statement], outer_variable_count: u
 }
 
 pub(super) fn collect_input_captures(statements: &[Statement], outer_variable_count: usize) -> Vec<VariableId> {
-    let mut captures = HashSet::new();
-    let mut definitions = HashSet::new();
+    let mut captures = HashSet::default();
+    let mut definitions = HashSet::default();
     for statement in statements {
         let (uses, defs) = statement_uses_and_defs(statement);
         captures.extend(

--- a/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
+++ b/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
@@ -14,7 +14,8 @@ use super::{
 use crate::frontend::ast::ParameterMode;
 use crate::frontend::diagnostic::Diagnostic;
 use crate::types::Type;
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
+use crate::hash::HashSet;
 
 fn successors(index: usize, statements: &[Statement]) -> Vec<usize> {
     let next = (index + 1 < statements.len()).then_some(index + 1);

--- a/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
+++ b/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
@@ -11,29 +11,15 @@ use crate::frontend::ast::ParameterMode;
 use crate::frontend::diagnostic::Diagnostic;
 use crate::hash::HashSet;
 use crate::types::Type;
-use std::collections::VecDeque;
 
-fn successors(index: usize, statements: &[Statement]) -> Vec<usize> {
-    let next = (index + 1 < statements.len()).then_some(index + 1);
-    match &statements[index].kind {
-        StatementKindIr::Call(_, call) if call.terminal => Vec::new(),
-        StatementKindIr::ScalarMatch { .. } => Vec::new(),
-        StatementKindIr::ValueMatch { destination: None, .. } => Vec::new(),
-        _ => next.into_iter().collect(),
-    }
-}
-
-fn definitions_on_edge(statement: &Statement, successor: usize, next: Option<usize>) -> Vec<VariableId> {
-    match &statement.kind {
-        StatementKindIr::ValueRefinement { binding, tag, .. } => {
-            let mut definitions = vec![*tag];
-            if Some(successor) == next {
-                definitions.push(*binding);
-            }
-            definitions
-        }
-        _ => statement_uses_and_defs(statement).1,
-    }
+fn statement_continues(statement: &Statement) -> bool {
+    !matches!(
+        &statement.kind,
+        StatementKindIr::Call(_, call) if call.terminal
+    ) && !matches!(
+        &statement.kind,
+        StatementKindIr::ScalarMatch { .. } | StatementKindIr::ValueMatch { destination: None, .. }
+    )
 }
 
 pub(super) fn check_definite_initialization(
@@ -68,61 +54,17 @@ fn check_definite_initialization_with_entry(
     check_outputs: bool,
 ) -> Result<(), Diagnostic> {
     if statements.is_empty() {
-        if check_outputs
-            && let Some(id) = outputs
-                .iter()
-                .find(|id| variables[**id].parameter_mode == Some(ParameterMode::Out))
-        {
-            return Err(Diagnostic::new(
-                filename,
-                variables[*id].span,
-                format!(
-                    "Out<{}> parameter '{}' is not initialized on this returning path",
-                    variables[*id].ty, variables[*id].name
-                ),
-            ));
-        }
+        check_initialized_outputs(filename, variables, outputs, &entry, check_outputs, None)?;
         return Ok(());
     }
-    let all: HashSet<VariableId> = (0..variables.len()).collect();
-    let mut inputs = vec![all; statements.len()];
-    inputs[0] = entry;
-    let mut reachable = vec![false; statements.len()];
-    reachable[0] = true;
-    let mut queue: VecDeque<usize> = (0..statements.len()).collect();
-    while let Some(index) = queue.pop_front() {
-        if !reachable[index] {
-            continue;
-        }
-        for successor in successors(index, statements) {
-            let mut output = inputs[index].clone();
-            output.extend(definitions_on_edge(
-                &statements[index],
-                successor,
-                (index + 1 < statements.len()).then_some(index + 1),
-            ));
-            let new_input = if reachable[successor] {
-                inputs[successor].intersection(&output).copied().collect()
-            } else {
-                output.clone()
-            };
-            if !reachable[successor] || new_input != inputs[successor] {
-                reachable[successor] = true;
-                inputs[successor] = new_input;
-                queue.push_back(successor);
-            }
-        }
-    }
 
-    for (index, statement) in statements.iter().enumerate() {
-        if !reachable[index] {
-            continue;
-        }
-        let check_nested = |statements: &[Statement], entry| {
-            check_definite_initialization_with_entry(filename, variables, statements, entry, &[], false)
-        };
-        let (uses, _) = statement_uses_and_defs(statement);
-        if let Some(id) = uses.into_iter().find(|id| !inputs[index].contains(id)) {
+    let mut initialized = entry;
+    let check_nested = |statements: &[Statement], entry| {
+        check_definite_initialization_with_entry(filename, variables, statements, entry, &[], false)
+    };
+    for statement in statements {
+        let (uses, definitions) = statement_uses_and_defs(statement);
+        if let Some(id) = uses.into_iter().find(|id| !initialized.contains(id)) {
             return Err(Diagnostic::new(
                 filename,
                 statement.span,
@@ -142,14 +84,14 @@ fn check_definite_initialization_with_entry(
                 .collect::<Vec<_>>();
             nested_arms.push((&fallback.body, tag.iter().copied().collect()));
             for (arm, bindings) in nested_arms {
-                let entry = inputs[index].iter().copied().chain(bindings).collect();
+                let entry = initialized.iter().copied().chain(bindings).collect();
                 check_nested(arm, entry)?;
             }
         }
         if let StatementKindIr::Call(_, call) = &statement.kind
             && let Some(failure) = &call.failure
         {
-            check_nested(&failure.body, inputs[index].clone())?;
+            check_nested(&failure.body, initialized.clone())?;
         }
         if let StatementKindIr::If {
             destination,
@@ -164,7 +106,7 @@ fn check_definite_initialization_with_entry(
             } else {
                 condition_uses_and_defs(condition).1
             };
-            let entry = inputs[index].iter().copied().chain(definitions).collect::<HashSet<_>>();
+            let entry = initialized.iter().copied().chain(definitions).collect::<HashSet<_>>();
             check_nested(then_body, entry.clone())?;
             if let Some(else_body) = else_body {
                 check_nested(else_body, entry)?;
@@ -177,12 +119,12 @@ fn check_definite_initialization_with_entry(
             ..
         } = &statement.kind
         {
-            check_nested(condition_setup, inputs[index].clone())?;
+            check_nested(condition_setup, initialized.clone())?;
             let setup_definitions = condition_setup
                 .iter()
                 .flat_map(|statement| statement_uses_and_defs(statement).1);
             let (_, condition_definitions) = condition_uses_and_defs(condition);
-            let entry = inputs[index]
+            let entry = initialized
                 .iter()
                 .copied()
                 .chain(setup_definitions)
@@ -190,32 +132,47 @@ fn check_definite_initialization_with_entry(
                 .collect();
             check_nested(loop_body, entry)?;
         }
-    }
-
-    if check_outputs {
-        for (index, statement) in statements.iter().enumerate() {
-            if !reachable[index] || !successors(index, statements).is_empty() {
-                continue;
-            }
-            let is_terminal = matches!(&statement.kind, StatementKindIr::Call(_, call) if call.terminal);
-            if is_terminal {
-                continue;
-            }
-            let (_, defs) = statement_uses_and_defs(statement);
-            let initialized: HashSet<_> = inputs[index].iter().copied().chain(defs).collect();
-            for id in outputs {
-                if variables[*id].parameter_mode == Some(ParameterMode::Out) && !initialized.contains(id) {
-                    return Err(Diagnostic::new(
-                        filename,
-                        statement.span,
-                        format!(
-                            "Out<{}> parameter '{}' is not initialized on this returning path",
-                            variables[*id].ty, variables[*id].name
-                        ),
-                    ));
-                }
-            }
+        initialized.extend(definitions);
+        if !statement_continues(statement) {
+            check_initialized_outputs(filename, variables, outputs, &initialized, false, Some(statement))?;
+            return Ok(());
         }
     }
+
+    check_initialized_outputs(
+        filename,
+        variables,
+        outputs,
+        &initialized,
+        check_outputs,
+        statements.last(),
+    )?;
     Ok(())
+}
+
+fn check_initialized_outputs(
+    filename: &str,
+    variables: &[Variable],
+    outputs: &[VariableId],
+    initialized: &HashSet<VariableId>,
+    check_outputs: bool,
+    exit: Option<&Statement>,
+) -> Result<(), Diagnostic> {
+    if !check_outputs {
+        return Ok(());
+    }
+    let Some(id) = outputs
+        .iter()
+        .find(|id| variables[**id].parameter_mode == Some(ParameterMode::Out) && !initialized.contains(id))
+    else {
+        return Ok(());
+    };
+    Err(Diagnostic::new(
+        filename,
+        exit.map_or(variables[*id].span, |statement| statement.span),
+        format!(
+            "Out<{}> parameter '{}' is not initialized on this returning path",
+            variables[*id].ty, variables[*id].name
+        ),
+    ))
 }

--- a/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
+++ b/Libraries/LibJS/Flap/src/hir/definite_initialization.rs
@@ -6,34 +6,24 @@
 
 //! Definite-initialization analysis for typed HIR.
 
-use super::{
-    Body, Statement, StatementKindIr, Variable,
-    VariableId,
-    condition_uses_and_defs, statement_uses_and_defs,
-};
+use super::{Body, Statement, StatementKindIr, Variable, VariableId, condition_uses_and_defs, statement_uses_and_defs};
 use crate::frontend::ast::ParameterMode;
 use crate::frontend::diagnostic::Diagnostic;
+use crate::hash::HashSet;
 use crate::types::Type;
 use std::collections::VecDeque;
-use crate::hash::HashSet;
 
 fn successors(index: usize, statements: &[Statement]) -> Vec<usize> {
     let next = (index + 1 < statements.len()).then_some(index + 1);
     match &statements[index].kind {
         StatementKindIr::Call(_, call) if call.terminal => Vec::new(),
         StatementKindIr::ScalarMatch { .. } => Vec::new(),
-        StatementKindIr::ValueMatch {
-            destination: None, ..
-        } => Vec::new(),
+        StatementKindIr::ValueMatch { destination: None, .. } => Vec::new(),
         _ => next.into_iter().collect(),
     }
 }
 
-fn definitions_on_edge(
-    statement: &Statement,
-    successor: usize,
-    next: Option<usize>,
-) -> Vec<VariableId> {
+fn definitions_on_edge(statement: &Statement, successor: usize, next: Option<usize>) -> Vec<VariableId> {
     match &statement.kind {
         StatementKindIr::ValueRefinement { binding, tag, .. } => {
             let mut definitions = vec![*tag];
@@ -56,8 +46,7 @@ pub(super) fn check_definite_initialization(
         .iter()
         .copied()
         .filter(|id| {
-            body.variables[*id].parameter_mode != Some(ParameterMode::Out)
-                || body.variables[*id].ty == Type::Operand
+            body.variables[*id].parameter_mode != Some(ParameterMode::Out) || body.variables[*id].ty == Type::Operand
         })
         .collect();
     check_definite_initialization_with_entry(
@@ -83,16 +72,16 @@ fn check_definite_initialization_with_entry(
             && let Some(id) = outputs
                 .iter()
                 .find(|id| variables[**id].parameter_mode == Some(ParameterMode::Out))
-            {
-                return Err(Diagnostic::new(
-                    filename,
-                    variables[*id].span,
-                    format!(
-                        "Out<{}> parameter '{}' is not initialized on this returning path",
-                        variables[*id].ty, variables[*id].name
-                    ),
-                ));
-            }
+        {
+            return Err(Diagnostic::new(
+                filename,
+                variables[*id].span,
+                format!(
+                    "Out<{}> parameter '{}' is not initialized on this returning path",
+                    variables[*id].ty, variables[*id].name
+                ),
+            ));
+        }
         return Ok(());
     }
     let all: HashSet<VariableId> = (0..variables.len()).collect();
@@ -130,14 +119,7 @@ fn check_definite_initialization_with_entry(
             continue;
         }
         let check_nested = |statements: &[Statement], entry| {
-            check_definite_initialization_with_entry(
-                filename,
-                variables,
-                statements,
-                entry,
-                &[],
-                false,
-            )
+            check_definite_initialization_with_entry(filename, variables, statements, entry, &[], false)
         };
         let (uses, _) = statement_uses_and_defs(statement);
         if let Some(id) = uses.into_iter().find(|id| !inputs[index].contains(id)) {
@@ -148,20 +130,13 @@ fn check_definite_initialization_with_entry(
             ));
         }
         if let StatementKindIr::ValueMatch {
-            tag,
-            arms,
-            fallback,
-            ..
+            tag, arms, fallback, ..
         } = &statement.kind
         {
             let mut nested_arms = arms
                 .iter()
                 .map(|arm| {
-                    let bindings = tag
-                        .iter()
-                        .chain(arm.binding.iter())
-                        .copied()
-                        .collect::<Vec<_>>();
+                    let bindings = tag.iter().chain(arm.binding.iter()).copied().collect::<Vec<_>>();
                     (&arm.body, bindings)
                 })
                 .collect::<Vec<_>>();
@@ -189,11 +164,7 @@ fn check_definite_initialization_with_entry(
             } else {
                 condition_uses_and_defs(condition).1
             };
-            let entry = inputs[index]
-                .iter()
-                .copied()
-                .chain(definitions)
-                .collect::<HashSet<_>>();
+            let entry = inputs[index].iter().copied().chain(definitions).collect::<HashSet<_>>();
             check_nested(then_body, entry.clone())?;
             if let Some(else_body) = else_body {
                 check_nested(else_body, entry)?;

--- a/Libraries/LibJS/Flap/src/hir/definitions.rs
+++ b/Libraries/LibJS/Flap/src/hir/definitions.rs
@@ -14,7 +14,7 @@ use crate::intrinsic::{
     ComparisonRelation, FieldAccess, Intrinsic, OperationValue, ValueOperation,
 };
 use crate::types::{BlockTemperature, InterpreterRegister, RegisterReference, Type};
-use std::collections::HashSet;
+use crate::hash::HashSet;
 use std::fmt;
 
 pub(crate) type VariableId = usize;

--- a/Libraries/LibJS/Flap/src/hir/definitions.rs
+++ b/Libraries/LibJS/Flap/src/hir/definitions.rs
@@ -365,6 +365,7 @@ pub(crate) struct Body {
 pub(crate) struct InlineFunction {
     pub(crate) id: InlineFunctionId,
     pub(crate) name: String,
+    pub(crate) span: SourceSpan,
     pub(crate) parameters: Vec<VariableId>,
     pub(crate) return_type: Option<Type>,
     pub(crate) body: Body,

--- a/Libraries/LibJS/Flap/src/hir/definitions.rs
+++ b/Libraries/LibJS/Flap/src/hir/definitions.rs
@@ -9,12 +9,10 @@
 use crate::frontend::ast::ParameterMode;
 use crate::frontend::diagnostic::SourceSpan;
 use crate::frontend::layout::LayoutValue;
-use crate::identity::{ExternalSymbol, InlineFunctionId};
-use crate::intrinsic::{
-    ComparisonRelation, FieldAccess, Intrinsic, OperationValue, ValueOperation,
-};
-use crate::types::{BlockTemperature, InterpreterRegister, RegisterReference, Type};
 use crate::hash::HashSet;
+use crate::identity::{ExternalSymbol, InlineFunctionId};
+use crate::intrinsic::{ComparisonRelation, FieldAccess, Intrinsic, OperationValue, ValueOperation};
+use crate::types::{BlockTemperature, InterpreterRegister, RegisterReference, Type};
 use std::fmt;
 
 pub(crate) type VariableId = usize;
@@ -149,13 +147,11 @@ impl Call {
         match self.target {
             CallTarget::Intrinsic(Intrinsic::Bytecode(_)) => true,
             CallTarget::Intrinsic(Intrinsic::LowLevel(
-                crate::intrinsic::LowLevelOperation::LoadLabel
-                    | crate::intrinsic::LowLevelOperation::LoadVm,
+                crate::intrinsic::LowLevelOperation::LoadLabel | crate::intrinsic::LowLevelOperation::LoadVm,
             )) => true,
             CallTarget::Intrinsic(Intrinsic::Memory(operation)) => !operation.writes(),
             CallTarget::Intrinsic(Intrinsic::Operand(
-                crate::intrinsic::OperandOperation::Load(_)
-                    | crate::intrinsic::OperandOperation::LoadPair,
+                crate::intrinsic::OperandOperation::Load(_) | crate::intrinsic::OperandOperation::LoadPair,
             )) => true,
             CallTarget::FieldAccess(access) => !access.kind.writes(),
             _ => false,
@@ -299,10 +295,7 @@ pub(crate) enum StatementKindIr {
 }
 
 impl StatementKindIr {
-    pub(crate) fn call(
-        destinations: impl IntoIterator<Item = VariableId>,
-        call: Call,
-    ) -> Self {
+    pub(crate) fn call(destinations: impl IntoIterator<Item = VariableId>, call: Call) -> Self {
         Self::Call(destinations.into_iter().collect(), call)
     }
 }
@@ -315,7 +308,9 @@ macro_rules! visit_nested_bodies {
                     ($visit)(&failure.body);
                 }
             }
-            Self::If { then_body, else_body, .. } => {
+            Self::If {
+                then_body, else_body, ..
+            } => {
                 ($visit)(then_body);
                 if let Some(else_body) = else_body {
                     ($visit)(else_body);
@@ -337,9 +332,7 @@ macro_rules! visit_nested_bodies {
                 ($visit)(body);
             }
             Self::While {
-                condition_setup,
-                body,
-                ..
+                condition_setup, body, ..
             } => {
                 ($visit)(condition_setup);
                 ($visit)(body);
@@ -350,10 +343,7 @@ macro_rules! visit_nested_bodies {
 }
 
 impl StatementKindIr {
-    pub(crate) fn for_each_nested_body(
-        &self,
-        mut visit: impl FnMut(&[Statement]),
-    ) {
+    pub(crate) fn for_each_nested_body(&self, mut visit: impl FnMut(&[Statement])) {
         visit_nested_bodies!(self, visit);
     }
 }

--- a/Libraries/LibJS/Flap/src/hir/intrinsic.rs
+++ b/Libraries/LibJS/Flap/src/hir/intrinsic.rs
@@ -8,8 +8,8 @@
 
 use crate::frontend::ast::ParameterMode;
 use crate::intrinsic::{
-    BranchOperation, CheckedIntegerOperation, FloatingPointOperation, IntegerSignedness,
-    Intrinsic, IntrinsicCallSignature, IntrinsicResultType, IntrinsicValueType,
+    BranchOperation, CheckedIntegerOperation, FloatingPointOperation, IntegerSignedness, Intrinsic,
+    IntrinsicCallSignature, IntrinsicResultType, IntrinsicValueType,
 };
 use crate::types::Type;
 
@@ -78,20 +78,18 @@ pub(super) fn operation_signature(ty: &Type) -> Option<Signature> {
 pub(super) fn resolve_operation(name: &str, ty: &Type) -> Option<Intrinsic> {
     let intrinsic = Intrinsic::from_name(name)?;
     match (ty, intrinsic) {
-        (Type::BinaryOperation(inner), Intrinsic::IntegerBinary(_))
-            if **inner == Type::I32 => Some(intrinsic),
+        (Type::BinaryOperation(inner), Intrinsic::IntegerBinary(_)) if **inner == Type::I32 => Some(intrinsic),
         (
             Type::CheckedBinaryOperation(inner),
             Intrinsic::CheckedInteger(
-                CheckedIntegerOperation::Add
-                | CheckedIntegerOperation::Subtract
-                | CheckedIntegerOperation::Multiply,
+                CheckedIntegerOperation::Add | CheckedIntegerOperation::Subtract | CheckedIntegerOperation::Multiply,
             ),
         ) if **inner == Type::I32 => Some(intrinsic),
-        (
-            Type::BinaryOperation(inner),
-            Intrinsic::FloatingPoint(FloatingPointOperation::Binary(_)),
-        ) if **inner == Type::F64 => Some(intrinsic),
+        (Type::BinaryOperation(inner), Intrinsic::FloatingPoint(FloatingPointOperation::Binary(_)))
+            if **inner == Type::F64 =>
+        {
+            Some(intrinsic)
+        }
         (
             Type::IntegerCondition,
             Intrinsic::Branch(BranchOperation::Ordered {
@@ -99,9 +97,7 @@ pub(super) fn resolve_operation(name: &str, ty: &Type) -> Option<Intrinsic> {
                 ..
             }),
         )
-        | (Type::FloatCondition, Intrinsic::Branch(BranchOperation::Float(_))) => {
-            Some(intrinsic)
-        }
+        | (Type::FloatCondition, Intrinsic::Branch(BranchOperation::Float(_))) => Some(intrinsic),
         _ => None,
     }
 }
@@ -159,9 +155,7 @@ pub(super) fn resolve_intrinsic(name: &str, argument_count: usize) -> Option<Res
     let intrinsic = Intrinsic::from_name(name)?;
     Some(ResolvedIntrinsic {
         intrinsic,
-        signature: semantic_signature(
-            intrinsic.call_signature(argument_count)?,
-        ),
+        signature: semantic_signature(intrinsic.call_signature(argument_count)?),
     })
 }
 

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -15,19 +15,23 @@ pub(crate) use definitions::*;
 
 use crate::frontend::ast;
 use crate::frontend::ast::{BinaryOperator, ExpressionKind, ParameterMode, StatementKind, UnaryOperator};
-use crate::types::{BlockTemperature, InterpreterRegister, Type};
 use crate::frontend::diagnostic::{Diagnostic, SourceSpan};
 use crate::frontend::layout;
+use crate::hash::{HashMap, HashSet};
 use crate::identity::{ExternalSymbol, InlineFunctionId};
-use crate::intrinsic::{AddressOperation, AggregateOperation, BinaryOperation, BytecodeOperation, CallOperation, ComparisonRelation, ControlOperation, FieldAccess, FieldAccessKind, FieldPair, FieldWidth, FloatBinaryOperation, FloatingPointOperation, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, LowLevelOperation, MemoryOperation, OperandLoad, OperandOperation, OperationValue, ShiftOperation, ValueOperation};
+use crate::intrinsic::{
+    AddressOperation, AggregateOperation, BinaryOperation, BytecodeOperation, CallOperation, ComparisonRelation,
+    ControlOperation, FieldAccess, FieldAccessKind, FieldPair, FieldWidth, FloatBinaryOperation,
+    FloatingPointOperation, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, LowLevelOperation,
+    MemoryOperation, OperandLoad, OperandOperation, OperationValue, ShiftOperation, ValueOperation,
+};
+use crate::types::{BlockTemperature, InterpreterRegister, Type};
 use capture::{collect_captures, collect_input_captures};
 use definite_initialization::check_definite_initialization;
 use intrinsic::{
-    Signature, intrinsic_is_terminal,
-    resolve_intrinsic,
-    operation_signature, resolve_operation, signature, signatures_match,
+    Signature, intrinsic_is_terminal, operation_signature, resolve_intrinsic, resolve_operation, signature,
+    signatures_match,
 };
-use crate::hash::{HashMap, HashSet};
 
 #[derive(Clone)]
 struct Symbol {
@@ -162,7 +166,10 @@ impl<'a> Checker<'a> {
                 let mut continuation_parameters = Vec::with_capacity(parameters.len());
                 for parameter in parameters {
                     if !names.insert(parameter.name.clone()) {
-                        return self.error(parameter.span, format!("duplicate continuation parameter '{}'", parameter.name));
+                        return self.error(
+                            parameter.span,
+                            format!("duplicate continuation parameter '{}'", parameter.name),
+                        );
                     }
                     continuation_parameters.push(ContinuationParameter {
                         name: parameter.name.clone(),
@@ -177,7 +184,10 @@ impl<'a> Checker<'a> {
                             lowered_name: format!(".{}_s{scope_id}", name.trim_start_matches('.')),
                             temperature: *temperature,
                             ty: Type::Continuation(
-                                continuation_parameters.iter().map(|parameter| parameter.ty.clone()).collect(),
+                                continuation_parameters
+                                    .iter()
+                                    .map(|parameter| parameter.ty.clone())
+                                    .collect(),
                             ),
                             parameters: continuation_parameters,
                         },
@@ -227,8 +237,8 @@ impl<'a> Checker<'a> {
             ast::ElseContinuation::Label(label) => {
                 let target = self.check_value(
                     &ast::Expression {
-                    kind: ExpressionKind::Name(label.clone()),
-                    span,
+                        kind: ExpressionKind::Name(label.clone()),
+                        span,
                     },
                     &Type::label(),
                 )?;
@@ -240,14 +250,17 @@ impl<'a> Checker<'a> {
                     temperature: BlockTemperature::Default,
                     captures: Vec::new(),
                     body: vec![Statement::new(
-                        StatementKindIr::call([], Call::with_control_flow(
-                            CallTarget::Intrinsic(Intrinsic::Control(ControlOperation::JumpLabel)),
-                            vec![target],
-                            vec![ParameterMode::In],
-                            None,
-                            true,
-                            branch_target,
-                        )),
+                        StatementKindIr::call(
+                            [],
+                            Call::with_control_flow(
+                                CallTarget::Intrinsic(Intrinsic::Control(ControlOperation::JumpLabel)),
+                                vec![target],
+                                vec![ParameterMode::In],
+                                None,
+                                true,
+                                branch_target,
+                            ),
+                        ),
                         span,
                     )],
                 })
@@ -282,10 +295,12 @@ impl<'a> Checker<'a> {
         name: &str,
         span: SourceSpan,
     ) -> Value {
-        if let [Statement {
-            kind: StatementKindIr::Call(destinations, call),
-            ..
-        }] = continuation.body.as_slice()
+        if let [
+            Statement {
+                kind: StatementKindIr::Call(destinations, call),
+                ..
+            },
+        ] = continuation.body.as_slice()
             && destinations.is_empty()
             && call.terminal
             && call.intrinsic() == Some(Intrinsic::Control(ControlOperation::JumpLabel))
@@ -316,9 +331,7 @@ impl<'a> Checker<'a> {
             .iter()
             .zip(element_types)
             .map(|(pattern, ty)| match pattern {
-                ast::Pattern::Binding { name, ty: None } => {
-                    self.declare(name, ty, None, span)
-                }
+                ast::Pattern::Binding { name, ty: None } => self.declare(name, ty, None, span),
                 ast::Pattern::Wildcard => Ok(self.declare_hidden("discard", ty, span)),
                 _ => self.error(span, "invalid tuple binding pattern"),
             })
@@ -380,10 +393,7 @@ impl<'a> Checker<'a> {
             return self.check_label(label, span);
         }
         let continuation = self.check_else_continuation(continuation, span)?;
-        let ValueKind::Label(label) = self
-            .materialize_else_continuation(continuation, "guard", span)
-            .kind
-        else {
+        let ValueKind::Label(label) = self.materialize_else_continuation(continuation, "guard", span).kind else {
             unreachable!()
         };
         Ok(label)
@@ -404,11 +414,7 @@ impl<'a> Checker<'a> {
         } else {
             None
         };
-        let active_value_tag = if let (
-            Some(tag),
-            ValueKind::Variable(value),
-        ) = (tag, &value.kind)
-        {
+        let active_value_tag = if let (Some(tag), ValueKind::Variable(value)) = (tag, &value.kind) {
             self.active_value_tags.push((*value, tag));
             true
         } else {
@@ -448,10 +454,7 @@ impl<'a> Checker<'a> {
                     Diagnostic::new(
                         self.filename,
                         statement.span,
-                        format!(
-                            "Value<{}> match arm does not produce a value",
-                            arm.representation
-                        ),
+                        format!("Value<{}> match arm does not produce a value", arm.representation),
                     )
                 })?;
                 if let Some(expected) = &result_type
@@ -459,25 +462,16 @@ impl<'a> Checker<'a> {
                 {
                     return self.error(
                         statement.span,
-                        format!(
-                            "value-producing match arms produce {expected} and {arm_type}"
-                        ),
+                        format!("value-producing match arms produce {expected} and {arm_type}"),
                     );
                 }
                 result_type = Some(arm_type);
                 (binding, body, Some(value))
             } else {
-                let (binding, body) = self.check_bound_block(
-                    arm.binding.as_deref(),
-                    binding_type,
-                    &arm.body,
-                    statement.span,
-                )?;
+                let (binding, body) =
+                    self.check_bound_block(arm.binding.as_deref(), binding_type, &arm.body, statement.span)?;
                 if !body.last().is_some_and(statement_is_terminal) {
-                    return self.error(
-                        statement.span,
-                        "every match arm must terminate control flow",
-                    );
+                    return self.error(statement.span, "every match arm must terminate control flow");
                 }
                 (binding, body, None)
             };
@@ -495,10 +489,7 @@ impl<'a> Checker<'a> {
             return self.error(statement.span, "Value match requires an i32 arm");
         }
         if name.is_some() && !kinds.contains(&ValueMatchArmKind::Double) {
-            return self.error(
-                statement.span,
-                "value-producing Value match requires an f64 arm",
-            );
+            return self.error(statement.span, "value-producing Value match requires an f64 arm");
         }
         let fallback = self.check_value_match_fallback(fallback)?;
         if !fallback.body.last().is_some_and(statement_is_terminal) {
@@ -512,20 +503,12 @@ impl<'a> Checker<'a> {
             );
         }
         let destination = if let Some(name) = name {
-            let result_type = result_type.ok_or_else(|| {
-                Diagnostic::new(
-                    self.filename,
-                    statement.span,
-                    "value-producing match has no arms",
-                )
-            })?;
+            let result_type = result_type
+                .ok_or_else(|| Diagnostic::new(self.filename, statement.span, "value-producing match has no arms"))?;
             let destination = self.declare(name, result_type, None, statement.span)?;
             for (arm, value) in &mut checked_arms {
                 arm.body.push(Statement::new(
-                    StatementKindIr::call(
-                        [destination],
-                        value.take().expect("value-producing arm has a value"),
-                    ),
+                    StatementKindIr::call([destination], value.take().expect("value-producing arm has a value")),
                     statement.span,
                 ));
             }
@@ -536,10 +519,7 @@ impl<'a> Checker<'a> {
         if active_value_tag {
             self.active_value_tags.pop();
         }
-        let arms = checked_arms
-            .into_iter()
-            .map(|(arm, _)| arm)
-            .collect::<Vec<_>>();
+        let arms = checked_arms.into_iter().map(|(arm, _)| arm).collect::<Vec<_>>();
         let mut captures = if destination.is_some() {
             arms.iter()
                 .flat_map(|arm| collect_captures(&arm.body, outer_variable_count))
@@ -599,81 +579,93 @@ impl<'a> Checker<'a> {
             ));
             return Ok(());
         };
-        let (destination, then_body, else_body) = if let Some(name) = name {
-            let (mut then_body, then_value) = self.check_value_block(then_body, ty.as_ref())?;
-            let (mut else_body, else_value) = self.check_value_block(else_body, ty.as_ref())?;
-            let then_type = then_value.return_type.clone().ok_or_else(|| {
-                Diagnostic::new(self.filename, statement.span, "then arm does not produce a value")
-            })?;
-            let else_type = else_value.return_type.clone().ok_or_else(|| {
-                Diagnostic::new(self.filename, statement.span, "else arm does not produce a value")
-            })?;
-            if then_type != else_type {
-                return self.error(
-                    statement.span,
-                    format!("value-producing if arms produce {then_type} and {else_type}"),
-                );
-            }
-            if let Some(expected) = ty
-                && *expected != then_type
-            {
-                return self.error(
-                    statement.span,
-                    format!("value-producing if produces {then_type}, not {expected}"),
-                );
-            }
-            let destination = self.declare(name, then_type, None, statement.span)?;
-            then_body.push(Statement::new(StatementKindIr::call([destination], then_value), statement.span));
-            else_body.push(Statement::new(StatementKindIr::call([destination], else_value), statement.span));
-            (Some(destination), then_body, else_body)
-        } else {
-            let active_value_tag = match &condition {
-                Condition::ValueTag {
-                    value: Value { kind: ValueKind::Variable(value), .. },
-                    tag,
-                    ..
-                } => {
-                    self.active_value_tags.push((*value, *tag));
-                    true
+        let (destination, then_body, else_body) =
+            if let Some(name) = name {
+                let (mut then_body, then_value) = self.check_value_block(then_body, ty.as_ref())?;
+                let (mut else_body, else_value) = self.check_value_block(else_body, ty.as_ref())?;
+                let then_type = then_value.return_type.clone().ok_or_else(|| {
+                    Diagnostic::new(self.filename, statement.span, "then arm does not produce a value")
+                })?;
+                let else_type = else_value.return_type.clone().ok_or_else(|| {
+                    Diagnostic::new(self.filename, statement.span, "else arm does not produce a value")
+                })?;
+                if then_type != else_type {
+                    return self.error(
+                        statement.span,
+                        format!("value-producing if arms produce {then_type} and {else_type}"),
+                    );
                 }
-                _ => false,
+                if let Some(expected) = ty
+                    && *expected != then_type
+                {
+                    return self.error(
+                        statement.span,
+                        format!("value-producing if produces {then_type}, not {expected}"),
+                    );
+                }
+                let destination = self.declare(name, then_type, None, statement.span)?;
+                then_body.push(Statement::new(
+                    StatementKindIr::call([destination], then_value),
+                    statement.span,
+                ));
+                else_body.push(Statement::new(
+                    StatementKindIr::call([destination], else_value),
+                    statement.span,
+                ));
+                (Some(destination), then_body, else_body)
+            } else {
+                let active_value_tag = match &condition {
+                    Condition::ValueTag {
+                        value:
+                            Value {
+                                kind: ValueKind::Variable(value),
+                                ..
+                            },
+                        tag,
+                        ..
+                    } => {
+                        self.active_value_tags.push((*value, *tag));
+                        true
+                    }
+                    _ => false,
+                };
+                let then_body = self.check_scoped_block(then_body)?;
+                let else_body = self.check_scoped_block(else_body)?;
+                if active_value_tag {
+                    self.active_value_tags.pop();
+                }
+                (None, then_body, else_body)
             };
-            let then_body = self.check_scoped_block(then_body)?;
-            let else_body = self.check_scoped_block(else_body)?;
-            if active_value_tag {
-                self.active_value_tags.pop();
-            }
-            (None, then_body, else_body)
-        };
         let mut captures = collect_captures(&then_body, outer_variable_count);
         captures.extend(collect_captures(&else_body, outer_variable_count));
         captures.sort_unstable();
         captures.dedup();
         if destination.is_none()
             && let Condition::ValueTag {
-            value,
-            tag,
-            source_tag,
-            mask: Some(_),
-            ..
-        } = &mut condition
+                value,
+                tag,
+                source_tag,
+                mask: Some(_),
+                ..
+            } = &mut condition
             && source_tag.is_none()
             && captures.contains(tag)
         {
             let raw_tag = *tag;
             let compared_tag = self.declare_hidden("if_else_compared_tag", Type::ValueTag, statement.span);
             self.statements.push(Statement::new(
-                StatementKindIr::call([], Call::new(
-                    CallTarget::Intrinsic(Intrinsic::Value(ValueOperation::ExtractTag {
-                        rematerialized: false,
-                    })),
-                    vec![
-                        Value::new(ValueKind::Variable(raw_tag), Type::ValueTag, statement.span),
-                        value.clone(),
-                    ],
-                    vec![ParameterMode::Out, ParameterMode::In],
-                    None,
-                )),
+                StatementKindIr::call(
+                    [],
+                    Call::new(
+                        CallTarget::Intrinsic(Intrinsic::Value(ValueOperation::ExtractTag { rematerialized: false })),
+                        vec![
+                            Value::new(ValueKind::Variable(raw_tag), Type::ValueTag, statement.span),
+                            value.clone(),
+                        ],
+                        vec![ParameterMode::Out, ParameterMode::In],
+                        None,
+                    ),
+                ),
                 statement.span,
             ));
             *tag = compared_tag;
@@ -702,16 +694,14 @@ impl<'a> Checker<'a> {
         value: &ast::Expression,
         failure: &ast::ElseContinuation,
     ) -> Result<(), Diagnostic> {
-        let Some(ast::Pattern::Binding { name: binding, ty: None }) = binding.as_deref() else {
+        let Some(ast::Pattern::Binding {
+            name: binding,
+            ty: None,
+        }) = binding.as_deref()
+        else {
             return self.error(statement.span, "Value refinement requires an untyped binding");
         };
-        let (
-            binding_type,
-            expected_tag,
-            payload_operation,
-            hidden_tag_name,
-            reuse_active_tag,
-        ) = match representation {
+        let (binding_type, expected_tag, payload_operation, hidden_tag_name, reuse_active_tag) = match representation {
             "i32" => (
                 Type::I32,
                 Some("INT32_TAG"),
@@ -719,13 +709,7 @@ impl<'a> Checker<'a> {
                 "int32_tag",
                 false,
             ),
-            "f64" => (
-                Type::F64,
-                None,
-                ValueOperation::ValueToFloat64,
-                "double_tag",
-                false,
-            ),
+            "f64" => (Type::F64, None, ValueOperation::ValueToFloat64, "double_tag", false),
             "Object" => (
                 Type::Object,
                 Some("OBJECT_TAG"),
@@ -746,10 +730,7 @@ impl<'a> Checker<'a> {
             if binding_symbol.ty != binding_type {
                 return self.error(
                     statement.span,
-                    format!(
-                        "Value refinement requires {binding_type}, found {}",
-                        binding_symbol.ty
-                    ),
+                    format!("Value refinement requires {binding_type}, found {}", binding_symbol.ty),
                 );
             }
             self.ensure_writable(&binding_symbol, statement.span)?;
@@ -759,9 +740,7 @@ impl<'a> Checker<'a> {
         };
         let value = self.check_materialized_value(value, &Type::Value)?;
         let failure = self.check_guard_continuation(failure, statement.span)?;
-        let tag = if reuse_active_tag
-            && let Some(tag) = self.lookup("tag").filter(|tag| tag.ty == Type::ValueTag)
-        {
+        let tag = if reuse_active_tag && let Some(tag) = self.lookup("tag").filter(|tag| tag.ty == Type::ValueTag) {
             tag.id
         } else {
             self.declare_hidden(hidden_tag_name, Type::ValueTag, statement.span)
@@ -788,7 +767,8 @@ impl<'a> Checker<'a> {
     ) -> Result<(), Diagnostic> {
         if name.contains('.') {
             let call = self.check_field_store(name, initializer, statement.span)?;
-            self.statements.push(Statement::new(StatementKindIr::call([], call), statement.span));
+            self.statements
+                .push(Statement::new(StatementKindIr::call([], call), statement.span));
             return Ok(());
         }
         let Some(symbol) = self.lookup(name).cloned() else {
@@ -797,16 +777,21 @@ impl<'a> Checker<'a> {
             };
             let call = self.check_initializer_with_expected(initializer, Some(&machine_type))?;
             let Some(return_type) = &call.return_type else {
-                return self.error(initializer.span, format!("'{}' does not return a value", call.display_name()));
+                return self.error(
+                    initializer.span,
+                    format!("'{}' does not return a value", call.display_name()),
+                );
             };
             let intrinsic = match call.target {
                 CallTarget::Intrinsic(intrinsic @ Intrinsic::LowLevel(LowLevelOperation::Move))
                 | CallTarget::Intrinsic(intrinsic @ Intrinsic::Address(AddressOperation::EmbeddedField)) => intrinsic,
                 CallTarget::FieldAccess(field_access) => Intrinsic::Memory(field_access.kind.memory_operation()),
-                _ => return self.error(
-                    initializer.span,
-                    "machine register assignment currently requires a binding or field projection",
-                ),
+                _ => {
+                    return self.error(
+                        initializer.span,
+                        "machine register assignment currently requires a binding or field projection",
+                    );
+                }
             };
             if return_type != &machine_type {
                 return self.error(
@@ -828,7 +813,10 @@ impl<'a> Checker<'a> {
         self.ensure_writable(&symbol, statement.span)?;
         let call = self.check_initializer_with_expected(initializer, Some(&symbol.ty))?;
         let Some(return_type) = &call.return_type else {
-            return self.error(initializer.span, format!("'{}' does not return a value", call.display_name()));
+            return self.error(
+                initializer.span,
+                format!("'{}' does not return a value", call.display_name()),
+            );
         };
         if *return_type != symbol.ty {
             return self.error(
@@ -836,10 +824,8 @@ impl<'a> Checker<'a> {
                 format!("cannot assign {return_type} to '{name}' of type {}", symbol.ty),
             );
         }
-        self.statements.push(Statement::new(
-            StatementKindIr::call([symbol.id], call),
-            statement.span,
-        ));
+        self.statements
+            .push(Statement::new(StatementKindIr::call([symbol.id], call), statement.span));
         Ok(())
     }
 
@@ -880,7 +866,10 @@ impl<'a> Checker<'a> {
         }
         let body = self.check_scoped_block(fallback)?;
         if !body.last().is_some_and(statement_is_terminal) {
-            return self.error(statement.span, "a scalar match fallback block must terminate control flow");
+            return self.error(
+                statement.span,
+                "a scalar match fallback block must terminate control flow",
+            );
         }
         captures.extend(collect_input_captures(&body, outer_variable_count));
         normalize_variables(&mut captures);
@@ -953,8 +942,7 @@ impl<'a> Checker<'a> {
         failure: &ast::ElseContinuation,
     ) -> Result<(), Diagnostic> {
         let failure = self.check_else_continuation(failure, statement.span)?;
-        let failure =
-            self.materialize_else_continuation(failure, callee, statement.span);
+        let failure = self.materialize_else_continuation(failure, callee, statement.span);
         let call = self.check_call(callee, arguments, Some(failure), statement.span)?;
         let Some(Type::Tuple(element_types)) = call.return_type.clone() else {
             return self.error(statement.span, format!("'{callee}' does not return a tuple"));
@@ -969,9 +957,11 @@ impl<'a> Checker<'a> {
                 ),
             );
         }
-        let destinations =
-            self.declare_tuple_destinations(patterns, element_types, statement.span)?;
-        self.statements.push(Statement::new(StatementKindIr::call(destinations, call), statement.span));
+        let destinations = self.declare_tuple_destinations(patterns, element_types, statement.span)?;
+        self.statements.push(Statement::new(
+            StatementKindIr::call(destinations, call),
+            statement.span,
+        ));
         Ok(())
     }
 
@@ -986,12 +976,13 @@ impl<'a> Checker<'a> {
     ) -> Result<(), Diagnostic> {
         let outer_variable_count = self.variables.len();
         let failure = self.check_else_continuation(failure, statement.span)?;
-        let structured_failure = resolve_intrinsic(callee, arguments.len())
-            .is_some_and(|resolved| matches!(
+        let structured_failure = resolve_intrinsic(callee, arguments.len()).is_some_and(|resolved| {
+            matches!(
                 resolved.intrinsic,
                 Intrinsic::CheckedInteger(operation)
                     if operation.unchecked().is_some()
-            ));
+            )
+        });
         let (mut call, failure) = if structured_failure {
             let target = Value::new(
                 ValueKind::Label(format!(".fallible_{callee}_{}", self.statements.len())),
@@ -1003,12 +994,8 @@ impl<'a> Checker<'a> {
                 Some(failure),
             )
         } else {
-            let target =
-                self.materialize_else_continuation(failure, callee, statement.span);
-            (
-                self.check_call(callee, arguments, Some(target), statement.span)?,
-                None,
-            )
+            let target = self.materialize_else_continuation(failure, callee, statement.span);
+            (self.check_call(callee, arguments, Some(target), statement.span)?, None)
         };
         let Some(return_type) = call.return_type.clone() else {
             return self.error(statement.span, format!("'{callee}' does not return a value"));
@@ -1023,10 +1010,7 @@ impl<'a> Checker<'a> {
         let destination = self.declare(name, destination_type, None, statement.span)?;
         if let Some(failure) = failure {
             call.failure = Some(CallFailure {
-                captures: collect_captures(
-                    &failure.body,
-                    outer_variable_count,
-                ),
+                captures: collect_captures(&failure.body, outer_variable_count),
                 body: failure.body,
             });
         }
@@ -1047,7 +1031,10 @@ impl<'a> Checker<'a> {
         if let Some(initializer) = initializer {
             let call = self.check_initializer_with_expected(initializer, ty.as_ref())?;
             let Some(return_type) = call.return_type.clone() else {
-                return self.error(initializer.span, format!("'{}' does not return a value", call.display_name()));
+                return self.error(
+                    initializer.span,
+                    format!("'{}' does not return a value", call.display_name()),
+                );
             };
             if matches!(return_type, Type::Tuple(_)) {
                 return self.error(initializer.span, "a tuple return value must be destructured");
@@ -1061,13 +1048,9 @@ impl<'a> Checker<'a> {
                     ),
                 );
             }
-            let id = self.declare(
-                name,
-                ty.clone().unwrap_or(return_type),
-                None,
-                statement.span,
-            )?;
-            self.statements.push(Statement::new(StatementKindIr::call([id], call), statement.span));
+            let id = self.declare(name, ty.clone().unwrap_or(return_type), None, statement.span)?;
+            self.statements
+                .push(Statement::new(StatementKindIr::call([id], call), statement.span));
         } else {
             self.declare(
                 name,
@@ -1103,9 +1086,11 @@ impl<'a> Checker<'a> {
                 ),
             );
         }
-        let destinations =
-            self.declare_tuple_destinations(patterns, element_types, statement.span)?;
-        self.statements.push(Statement::new(StatementKindIr::call(destinations, call), statement.span));
+        let destinations = self.declare_tuple_destinations(patterns, element_types, statement.span)?;
+        self.statements.push(Statement::new(
+            StatementKindIr::call(destinations, call),
+            statement.span,
+        ));
         Ok(())
     }
 
@@ -1143,26 +1128,34 @@ impl<'a> Checker<'a> {
                 let (base, element_type) = self.check_index_base(base)?;
                 let index = self.check_sequence_index(index)?;
                 let value = self.check_materialized_value(value, &element_type)?;
-                let (_, store_operation, scale) = sequence_access(&element_type)
-                    .ok_or_else(|| Diagnostic::new(self.filename, value.span, format!("cannot store sequence element of type {element_type}")))?;
+                let (_, store_operation, scale) = sequence_access(&element_type).ok_or_else(|| {
+                    Diagnostic::new(
+                        self.filename,
+                        value.span,
+                        format!("cannot store sequence element of type {element_type}"),
+                    )
+                })?;
                 self.statements.push(Statement::new(
-                    StatementKindIr::call([], Call::new(
-                        CallTarget::Intrinsic(Intrinsic::Memory(store_operation)),
-                        vec![
-                            Value::new(
-                                ValueKind::Memory(vec![
-                                    base,
-                                    index,
-                                    Value::new(ValueKind::Integer(scale), Type::U8, statement.span),
-                                ]),
-                                Type::Memory,
-                                statement.span,
-                            ),
-                            value,
-                        ],
-                        vec![ParameterMode::In, ParameterMode::In],
-                        None,
-                    )),
+                    StatementKindIr::call(
+                        [],
+                        Call::new(
+                            CallTarget::Intrinsic(Intrinsic::Memory(store_operation)),
+                            vec![
+                                Value::new(
+                                    ValueKind::Memory(vec![
+                                        base,
+                                        index,
+                                        Value::new(ValueKind::Integer(scale), Type::U8, statement.span),
+                                    ]),
+                                    Type::Memory,
+                                    statement.span,
+                                ),
+                                value,
+                            ],
+                            vec![ParameterMode::In, ParameterMode::In],
+                            None,
+                        ),
+                    ),
                     statement.span,
                 ));
             }
@@ -1176,7 +1169,8 @@ impl<'a> Checker<'a> {
                 if call.return_type.is_some() {
                     return self.error(expression.span, format!("return value of '{callee}' is ignored"));
                 }
-                self.statements.push(Statement::new(StatementKindIr::call([], call), statement.span));
+                self.statements
+                    .push(Statement::new(StatementKindIr::call([], call), statement.span));
             }
             StatementKind::FallibleCall {
                 callee,
@@ -1184,22 +1178,25 @@ impl<'a> Checker<'a> {
                 failure,
             } => {
                 let failure = self.check_else_continuation(failure, statement.span)?;
-                let failure =
-                    self.materialize_else_continuation(failure, callee, statement.span);
+                let failure = self.materialize_else_continuation(failure, callee, statement.span);
                 let call = self.check_call(callee, arguments, Some(failure), statement.span)?;
                 if call.return_type.is_some() {
                     return self.error(statement.span, format!("return value of '{callee}' is ignored"));
                 }
-                self.statements.push(Statement::new(StatementKindIr::call([], call), statement.span));
+                self.statements
+                    .push(Statement::new(StatementKindIr::call([], call), statement.span));
             }
             StatementKind::GuardLet {
-                pattern: ast::Pattern::ValueRepresentation { representation, binding },
+                pattern:
+                    ast::Pattern::ValueRepresentation {
+                        representation,
+                        binding,
+                    },
                 initializer: value,
                 failure,
-            } if matches!(
-                representation.as_str(),
-                "i32" | "f64" | "Object" | "PrimitiveString"
-            ) => self.check_value_refinement_statement(statement, representation, binding, value, failure)?,
+            } if matches!(representation.as_str(), "i32" | "f64" | "Object" | "PrimitiveString") => {
+                self.check_value_refinement_statement(statement, representation, binding, value, failure)?
+            }
             StatementKind::GuardLet { .. } => return self.error(statement.span, "invalid fallible binding pattern"),
             StatementKind::ValueMatch {
                 name,
@@ -1207,15 +1204,14 @@ impl<'a> Checker<'a> {
                 arms,
                 fallback,
             } => self.check_value_match_statement(statement, name, value, arms, fallback)?,
-            StatementKind::ScalarMatch { value, arms, fallback } => self.check_scalar_match_statement(statement, value, arms, fallback)?,
+            StatementKind::ScalarMatch { value, arms, fallback } => {
+                self.check_scalar_match_statement(statement, value, arms, fallback)?
+            }
             StatementKind::Guard { condition, failure } => {
                 let condition = self.check_condition(condition)?;
                 let failure = self.check_guard_continuation(failure, statement.span)?;
                 self.statements.push(Statement::new(
-                    StatementKindIr::Guard {
-                        condition,
-                        failure,
-                    },
+                    StatementKindIr::Guard { condition, failure },
                     statement.span,
                 ));
             }
@@ -1245,7 +1241,11 @@ impl<'a> Checker<'a> {
                 then_body,
                 else_body,
             } => self.check_if_statement(statement, name, ty, condition, temperature, then_body, else_body)?,
-            StatementKind::While { condition, body, post_tested } => {
+            StatementKind::While {
+                condition,
+                body,
+                post_tested,
+            } => {
                 let outer_variable_count = self.variables.len();
                 let condition_start = self.statements.len();
                 let condition = self.check_condition(condition)?;
@@ -1295,14 +1295,13 @@ impl<'a> Checker<'a> {
                 Intrinsic::Call(CallOperation::Interpreter | CallOperation::RawNative)
             ) && resolved.signature.return_type.is_some()
         });
-        let indirect_condition = self.lookup(callee).is_some_and(|symbol| {
-            matches!(symbol.ty, Type::IntegerCondition | Type::FloatCondition)
-        });
+        let indirect_condition = self
+            .lookup(callee)
+            .is_some_and(|symbol| matches!(symbol.ty, Type::IntegerCondition | Type::FloatCondition));
         let bytecode_load = (|| {
             if arguments.len() != 1
                 || !resolved_intrinsic.as_ref().is_some_and(|resolved| {
-                    resolved.intrinsic
-                        == Intrinsic::Operand(OperandOperation::Load(OperandLoad::Field))
+                    resolved.intrinsic == Intrinsic::Operand(OperandOperation::Load(OperandLoad::Field))
                 })
             {
                 return None;
@@ -1333,14 +1332,14 @@ impl<'a> Checker<'a> {
             let resolved = resolved_intrinsic
                 .take()
                 .expect("returning builtins are resolved intrinsics");
-            (
-                CallTarget::Intrinsic(resolved.intrinsic),
-                resolved.signature,
-            )
+            (CallTarget::Intrinsic(resolved.intrinsic), resolved.signature)
         } else if let Some((parameter_type, return_type, width)) = &bytecode_load {
             (
                 CallTarget::Intrinsic(Intrinsic::Bytecode(BytecodeOperation::Load(*width))),
-                signature(&[(ParameterMode::In, parameter_type.clone())], Some(return_type.clone())),
+                signature(
+                    &[(ParameterMode::In, parameter_type.clone())],
+                    Some(return_type.clone()),
+                ),
             )
         } else if let Some(signature) = self.signatures.get(callee).cloned() {
             (
@@ -1388,23 +1387,22 @@ impl<'a> Checker<'a> {
         }
 
         let mut values = Vec::new();
-        for (argument, (mode, expected_type)) in arguments
-            .iter()
-            .zip(&signature.parameters[..explicit_parameter_count])
+        for (argument, (mode, expected_type)) in arguments.iter().zip(&signature.parameters[..explicit_parameter_count])
         {
             if *expected_type == Type::Operand
                 && let ExpressionKind::Name(name) = &argument.kind
-                    && let Some(symbol) = self.lookup(name) {
-                        match (mode, symbol.parameter_mode) {
-                            (ParameterMode::In, Some(ParameterMode::Out)) => {
-                                return self.error(argument.span, "cannot read through an out Operand parameter");
-                            }
-                            (ParameterMode::InOut, Some(ParameterMode::Out)) => {
-                                return self.error(argument.span, "cannot read through an out Operand parameter");
-                            }
-                            _ => {}
-                        }
+                && let Some(symbol) = self.lookup(name)
+            {
+                match (mode, symbol.parameter_mode) {
+                    (ParameterMode::In, Some(ParameterMode::Out)) => {
+                        return self.error(argument.span, "cannot read through an out Operand parameter");
                     }
+                    (ParameterMode::InOut, Some(ParameterMode::Out)) => {
+                        return self.error(argument.span, "cannot read through an out Operand parameter");
+                    }
+                    _ => {}
+                }
+            }
             let value = if *expected_type == Type::AnyGpr {
                 self.check_materialized_gpr_value(argument)?
             } else if *mode == ParameterMode::In
@@ -1425,13 +1423,13 @@ impl<'a> Checker<'a> {
                         .as_ref()
                         .map(ToString::to_string)
                         .unwrap_or_else(|| "no value".to_string());
-                    return self.error(
-                        argument.span,
-                        format!("expected {expected_type}, found {found}"),
-                    );
+                    return self.error(argument.span, format!("expected {expected_type}, found {found}"));
                 }
                 let destination = self.declare_hidden("argument", expected_type.clone(), argument.span);
-                self.statements.push(Statement::new(StatementKindIr::call([destination], call), argument.span));
+                self.statements.push(Statement::new(
+                    StatementKindIr::call([destination], call),
+                    argument.span,
+                ));
                 Value::new(ValueKind::Variable(destination), expected_type.clone(), argument.span)
             } else {
                 self.check_value(argument, expected_type)?
@@ -1458,11 +1456,10 @@ impl<'a> Checker<'a> {
             values.push(failure);
         }
 
-        let terminal = signature.terminal
-            || matches!(target, CallTarget::Intrinsic(intrinsic) if intrinsic.is_terminal());
-        let branch_target = failure_target.or_else(|| {
-            branch_target(&target, &values, &self.variables, indirect_condition)
-        });
+        let terminal =
+            signature.terminal || matches!(target, CallTarget::Intrinsic(intrinsic) if intrinsic.is_terminal());
+        let branch_target =
+            failure_target.or_else(|| branch_target(&target, &values, &self.variables, indirect_condition));
         Ok(Call::with_control_flow(
             target,
             values,
@@ -1495,11 +1492,7 @@ impl<'a> Checker<'a> {
             ));
         }
         let width = field_width(&field.ty, false)
-            .ok_or_else(|| Diagnostic::new(
-                self.filename,
-                span,
-                format!("cannot load field of type {}", field.ty),
-            ))?;
+            .ok_or_else(|| Diagnostic::new(self.filename, span, format!("cannot load field of type {}", field.ty)))?;
         Ok(Call::new(
             CallTarget::FieldAccess(FieldAccess {
                 kind: FieldAccessKind::Load {
@@ -1516,34 +1509,25 @@ impl<'a> Checker<'a> {
 
     fn field_memory(&self, base: Value, field: &LayoutField, span: SourceSpan) -> Value {
         let (base, offset) = match (&base.kind, &field.pinned_base, &field.pinned_offset) {
-            (ValueKind::MachineRegister(_), Some(pinned_base), Some(pinned_offset)) => {
-                (
-                    Value::new(
-                        ValueKind::MachineRegister(pinned_base.clone().into()),
-                        machine_register_type(pinned_base)
-                            .expect("generated pinned field base must name a machine register"),
-                        span,
-                    ),
-                    *pinned_offset,
-                )
-            }
+            (ValueKind::MachineRegister(_), Some(pinned_base), Some(pinned_offset)) => (
+                Value::new(
+                    ValueKind::MachineRegister(pinned_base.clone().into()),
+                    machine_register_type(pinned_base)
+                        .expect("generated pinned field base must name a machine register"),
+                    span,
+                ),
+                *pinned_offset,
+            ),
             _ => (base, field.offset),
         };
         Value::new(
-            ValueKind::Memory(vec![
-                base,
-                Value::new(ValueKind::LayoutValue(offset), Type::U64, span),
-            ]),
+            ValueKind::Memory(vec![base, Value::new(ValueKind::LayoutValue(offset), Type::U64, span)]),
             Type::Memory,
             span,
         )
     }
 
-    fn check_field_projection_base(
-        &mut self,
-        name: &str,
-        span: SourceSpan,
-    ) -> Result<(Value, String), Diagnostic> {
+    fn check_field_projection_base(&mut self, name: &str, span: SourceSpan) -> Result<(Value, String), Diagnostic> {
         let mut components = name.split('.');
         let base_name = components.next().unwrap();
         let base = if let Some(base) = self.lookup(base_name).cloned() {
@@ -1562,10 +1546,8 @@ impl<'a> Checker<'a> {
             let call = self.check_field_load(base, intermediate_field, span)?;
             let ty = call.return_type.clone().unwrap();
             let destination = self.declare_hidden("field_base", ty.clone(), span);
-            self.statements.push(Statement::new(
-                StatementKindIr::call([destination], call),
-                span,
-            ));
+            self.statements
+                .push(Statement::new(StatementKindIr::call([destination], call), span));
             base = Value::new(ValueKind::Variable(destination), ty, span);
         }
         Ok((base, (*field_name).to_string()))
@@ -1586,12 +1568,21 @@ impl<'a> Checker<'a> {
             .layouts
             .get(&(base.ty.clone(), field_name.clone()))
             .cloned()
-            .ok_or_else(|| Diagnostic::new(self.filename, span, format!("type {} has no field '{field_name}'", base.ty)))?;
+            .ok_or_else(|| {
+                Diagnostic::new(
+                    self.filename,
+                    span,
+                    format!("type {} has no field '{field_name}'", base.ty),
+                )
+            })?;
         if field.embedded {
             return self.error(span, format!("cannot assign embedded field '{}.{field_name}'", base.ty));
         }
         if field.nonnull && matches!(&initializer.kind, ExpressionKind::Name(name) if name == "null") {
-            return self.error(initializer.span, format!("cannot assign null to non-null field '{}.{field_name}'", base.ty));
+            return self.error(
+                initializer.span,
+                format!("cannot assign null to non-null field '{}.{field_name}'", base.ty),
+            );
         }
         if matches!(
             &initializer.kind,
@@ -1601,7 +1592,10 @@ impl<'a> Checker<'a> {
             if field.ty != Type::ScriptOrModule {
                 return self.error(
                     initializer.span,
-                    format!("cannot zero-initialize field '{}.{field_name}' of type {}", base.ty, field.ty),
+                    format!(
+                        "cannot zero-initialize field '{}.{field_name}' of type {}",
+                        base.ty, field.ty
+                    ),
                 );
             }
             return Ok(Call::new(
@@ -1620,7 +1614,10 @@ impl<'a> Checker<'a> {
         }
         if field.ty == Type::ScriptOrModule {
             let ExpressionKind::Name(source_name) = &initializer.kind else {
-                return self.error(initializer.span, "a ScriptOrModule field can only be copied from another ScriptOrModule field");
+                return self.error(
+                    initializer.span,
+                    "a ScriptOrModule field can only be copied from another ScriptOrModule field",
+                );
             };
             let (source_base, source_field_name) = self.check_field_projection_base(source_name, initializer.span)?;
             let source_field = self
@@ -1635,16 +1632,21 @@ impl<'a> Checker<'a> {
                     )
                 })?;
             if source_field.ty != Type::ScriptOrModule {
-                return self.error(initializer.span, format!("expected ScriptOrModule, got {}", source_field.ty));
+                return self.error(
+                    initializer.span,
+                    format!("expected ScriptOrModule, got {}", source_field.ty),
+                );
             }
-            let memory = |base, offset: layout::LayoutValue, value_span| Value::new(
-                ValueKind::Memory(vec![
-                    base,
-                    Value::new(ValueKind::LayoutValue(offset), Type::U64, value_span),
-                ]),
-                Type::Memory,
-                value_span,
-            );
+            let memory = |base, offset: layout::LayoutValue, value_span| {
+                Value::new(
+                    ValueKind::Memory(vec![
+                        base,
+                        Value::new(ValueKind::LayoutValue(offset), Type::U64, value_span),
+                    ]),
+                    Type::Memory,
+                    value_span,
+                )
+            };
             return Ok(Call::new(
                 CallTarget::Intrinsic(Intrinsic::Aggregate(AggregateOperation::Copy16)),
                 vec![
@@ -1658,20 +1660,13 @@ impl<'a> Checker<'a> {
         let memory = self.field_memory(base, &field, span);
         let value = self.check_materialized_value(initializer, &field.ty)?;
         let width = field_width(&field.ty, true)
-            .ok_or_else(|| Diagnostic::new(
-                self.filename,
-                span,
-                format!("cannot store field of type {}", field.ty),
-            ))?;
+            .ok_or_else(|| Diagnostic::new(self.filename, span, format!("cannot store field of type {}", field.ty)))?;
         Ok(Call::new(
             CallTarget::FieldAccess(FieldAccess {
                 kind: FieldAccessKind::Store(width),
                 pair: field.pair,
             }),
-            vec![
-                memory,
-                value,
-            ],
+            vec![memory, value],
             vec![ParameterMode::In, ParameterMode::In],
             None,
         ))
@@ -1733,21 +1728,32 @@ impl<'a> Checker<'a> {
                     };
                     return Ok(Call::new(
                         CallTarget::Intrinsic(Intrinsic::LowLevel(LowLevelOperation::Move)),
-                        vec![Value::new(ValueKind::MachineRegister(name.clone().into()), ty.clone(), expression.span)],
+                        vec![Value::new(
+                            ValueKind::MachineRegister(name.clone().into()),
+                            ty.clone(),
+                            expression.span,
+                        )],
                         vec![ParameterMode::In],
                         Some(ty),
                     ));
                 };
                 Ok(Call::new(
                     CallTarget::Intrinsic(Intrinsic::LowLevel(LowLevelOperation::Move)),
-                    vec![Value::new(ValueKind::Variable(symbol.id), symbol.ty.clone(), expression.span)],
+                    vec![Value::new(
+                        ValueKind::Variable(symbol.id),
+                        symbol.ty.clone(),
+                        expression.span,
+                    )],
                     vec![ParameterMode::In],
                     Some(symbol.ty),
                 ))
             }
             ExpressionKind::Integer(_) => {
                 let Some(expected) = expected else {
-                    return self.error(expression.span, "an integer literal initializer requires an explicit type");
+                    return self.error(
+                        expression.span,
+                        "an integer literal initializer requires an explicit type",
+                    );
                 };
                 let value = self.check_value(expression, expected)?;
                 Ok(Call::new(
@@ -1760,8 +1766,13 @@ impl<'a> Checker<'a> {
             ExpressionKind::Index { base, index } => {
                 let (base, element_type) = self.check_index_base(base)?;
                 let index = self.check_sequence_index(index)?;
-                let (load_operation, _, scale) = sequence_access(&element_type)
-                    .ok_or_else(|| Diagnostic::new(self.filename, expression.span, format!("cannot load sequence element of type {element_type}")))?;
+                let (load_operation, _, scale) = sequence_access(&element_type).ok_or_else(|| {
+                    Diagnostic::new(
+                        self.filename,
+                        expression.span,
+                        format!("cannot load sequence element of type {element_type}"),
+                    )
+                })?;
                 Ok(Call::new(
                     CallTarget::Intrinsic(Intrinsic::Memory(load_operation)),
                     vec![Value::new(
@@ -1815,7 +1826,10 @@ impl<'a> Checker<'a> {
             ExpressionKind::Binary { operator, lhs, rhs } => {
                 self.check_binary_initializer(*operator, lhs, rhs, expected, expression.span)
             }
-            _ => self.error(expression.span, "a binding initializer must be a call or arithmetic expression"),
+            _ => self.error(
+                expression.span,
+                "a binding initializer must be a call or arithmetic expression",
+            ),
         }
     }
 
@@ -1861,11 +1875,7 @@ impl<'a> Checker<'a> {
             })?;
             return Ok(Call::new(
                 CallTarget::Intrinsic(Intrinsic::Address(AddressOperation::SequenceElement)),
-                vec![
-                    base,
-                    index,
-                    Value::new(ValueKind::LayoutValue(*scale), Type::U64, span),
-                ],
+                vec![base, index, Value::new(ValueKind::LayoutValue(*scale), Type::U64, span)],
                 vec![ParameterMode::In, ParameterMode::In, ParameterMode::In],
                 Some(element_type),
             ));
@@ -1908,16 +1918,14 @@ impl<'a> Checker<'a> {
     ) -> Result<Call, Diagnostic> {
         if let Some(operation) = integer_binary_operation(operator) {
             let integer_operation = IntegerBinaryOperation::Binary(operation);
-            let integer_type = self
-                .infer_integer_arithmetic_type(expected, lhs)
-                .or_else(|| {
-                    matches!(
-                        operation,
-                        BinaryOperation::And | BinaryOperation::Or | BinaryOperation::Xor
-                    )
-                    .then(|| self.infer_value_tag_bitwise_type(expected, lhs))
-                    .flatten()
-                });
+            let integer_type = self.infer_integer_arithmetic_type(expected, lhs).or_else(|| {
+                matches!(
+                    operation,
+                    BinaryOperation::And | BinaryOperation::Or | BinaryOperation::Xor
+                )
+                .then(|| self.infer_value_tag_bitwise_type(expected, lhs))
+                .flatten()
+            });
             if let Some(integer_type) = integer_type {
                 return self.check_integer_arithmetic(lhs, rhs, &integer_type, integer_operation);
             }
@@ -1945,7 +1953,10 @@ impl<'a> Checker<'a> {
                 } else {
                     "arithmetic"
                 };
-                return self.error(lhs.span, format!("f64 {operation} requires a binding as its left operand"));
+                return self.error(
+                    lhs.span,
+                    format!("f64 {operation} requires a binding as its left operand"),
+                );
             }
             return Ok(Call::new(
                 CallTarget::Intrinsic(Intrinsic::FloatingPoint(FloatingPointOperation::Binary(operation))),
@@ -1957,7 +1968,10 @@ impl<'a> Checker<'a> {
         if operator == BinaryOperator::Modulo {
             return Ok(Call::new(
                 CallTarget::InlineFunction(self.inline_function_id("modulo", span)?),
-                vec![self.check_value(lhs, &Type::Value)?, self.check_value(rhs, &Type::Value)?],
+                vec![
+                    self.check_value(lhs, &Type::Value)?,
+                    self.check_value(rhs, &Type::Value)?,
+                ],
                 vec![ParameterMode::In, ParameterMode::In],
                 Some(Type::Value),
             ));
@@ -2008,13 +2022,14 @@ impl<'a> Checker<'a> {
                 _ => unreachable!(),
             };
             return Ok(Call::new(
-                CallTarget::Intrinsic(Intrinsic::IntegerComparison(
-                    IntegerComparisonOperation::Relational {
-                        relation,
-                        domain: crate::intrinsic::ComparisonDomain::Value,
-                    },
-                )),
-                vec![self.check_value(lhs, &Type::Value)?, self.check_value(rhs, &Type::Value)?],
+                CallTarget::Intrinsic(Intrinsic::IntegerComparison(IntegerComparisonOperation::Relational {
+                    relation,
+                    domain: crate::intrinsic::ComparisonDomain::Value,
+                })),
+                vec![
+                    self.check_value(lhs, &Type::Value)?,
+                    self.check_value(rhs, &Type::Value)?,
+                ],
                 vec![ParameterMode::In, ParameterMode::In],
                 Some(Type::Value),
             ));
@@ -2042,11 +2057,7 @@ impl<'a> Checker<'a> {
         ))
     }
 
-    fn infer_integer_arithmetic_type(
-        &self,
-        expected: Option<&Type>,
-        lhs: &ast::Expression,
-    ) -> Option<Type> {
+    fn infer_integer_arithmetic_type(&self, expected: Option<&Type>, lhs: &ast::Expression) -> Option<Type> {
         if let Some(expected) = expected.filter(|ty| is_integer_arithmetic_type(ty)) {
             return Some(expected.clone());
         }
@@ -2061,11 +2072,7 @@ impl<'a> Checker<'a> {
         }
     }
 
-    fn infer_value_tag_bitwise_type(
-        &self,
-        expected: Option<&Type>,
-        lhs: &ast::Expression,
-    ) -> Option<Type> {
+    fn infer_value_tag_bitwise_type(&self, expected: Option<&Type>, lhs: &ast::Expression) -> Option<Type> {
         if expected == Some(&Type::ValueTag) {
             return Some(Type::ValueTag);
         }
@@ -2091,7 +2098,10 @@ impl<'a> Checker<'a> {
                     Diagnostic::new(self.filename, expression.span, "indexed base does not produce a value")
                 })?;
                 let destination = self.declare_hidden("indexed_base", ty.clone(), expression.span);
-                self.statements.push(Statement::new(StatementKindIr::call([destination], call), expression.span));
+                self.statements.push(Statement::new(
+                    StatementKindIr::call([destination], call),
+                    expression.span,
+                ));
                 Value::new(ValueKind::Variable(destination), ty, expression.span)
             }
             ExpressionKind::Name(name) => {
@@ -2100,8 +2110,8 @@ impl<'a> Checker<'a> {
                     .map(|symbol| symbol.ty.clone())
                     .or_else(|| machine_register_type(name))
                     .ok_or_else(|| {
-                    Diagnostic::new(self.filename, expression.span, format!("unknown binding '{name}'"))
-                })?;
+                        Diagnostic::new(self.filename, expression.span, format!("unknown binding '{name}'"))
+                    })?;
                 self.check_value(expression, &ty)?
             }
             _ => return self.error(expression.span, "indexed base must be a binding or field projection"),
@@ -2124,7 +2134,10 @@ impl<'a> Checker<'a> {
             _ => Type::U32,
         };
         if !matches!(expected, Type::U32 | Type::U64) {
-            return self.error(expression.span, format!("sequence index must be u32 or u64, found {expected}"));
+            return self.error(
+                expression.span,
+                format!("sequence index must be u32 or u64, found {expected}"),
+            );
         }
         self.check_materialized_value(expression, &expected)
     }
@@ -2243,33 +2256,48 @@ impl<'a> Checker<'a> {
             return Ok(Condition::LogicalNot(Box::new(self.check_condition(operand)?)));
         }
         let scalar_equality = match &expression.kind {
-            ExpressionKind::Binary { operator: BinaryOperator::LooseEqual, lhs, rhs } => {
-                Some((true, lhs, rhs))
-            }
-            ExpressionKind::Binary { operator: BinaryOperator::LooseNotEqual, lhs, rhs } => {
-                Some((false, lhs, rhs))
-            }
+            ExpressionKind::Binary {
+                operator: BinaryOperator::LooseEqual,
+                lhs,
+                rhs,
+            } => Some((true, lhs, rhs)),
+            ExpressionKind::Binary {
+                operator: BinaryOperator::LooseNotEqual,
+                lhs,
+                rhs,
+            } => Some((false, lhs, rhs)),
             _ => None,
         };
         if let Some((equal, lhs, rhs)) = scalar_equality {
             if let Some(condition) = self.check_scalar_equality(lhs, rhs, equal)? {
                 return Ok(condition);
             }
-            return self.error(expression.span, "Value equality requires an explicit equality operation");
+            return self.error(
+                expression.span,
+                "Value equality requires an explicit equality operation",
+            );
         }
         let scalar_relational = match &expression.kind {
-            ExpressionKind::Binary { operator: BinaryOperator::LessThan, lhs, rhs } => {
-                Some((ComparisonRelation::Less, lhs, rhs))
-            }
-            ExpressionKind::Binary { operator: BinaryOperator::GreaterThan, lhs, rhs } => {
-                Some((ComparisonRelation::Greater, lhs, rhs))
-            }
-            ExpressionKind::Binary { operator: BinaryOperator::LessThanOrEqual, lhs, rhs } => {
-                Some((ComparisonRelation::LessOrEqual, lhs, rhs))
-            }
-            ExpressionKind::Binary { operator: BinaryOperator::GreaterThanOrEqual, lhs, rhs } => {
-                Some((ComparisonRelation::GreaterOrEqual, lhs, rhs))
-            }
+            ExpressionKind::Binary {
+                operator: BinaryOperator::LessThan,
+                lhs,
+                rhs,
+            } => Some((ComparisonRelation::Less, lhs, rhs)),
+            ExpressionKind::Binary {
+                operator: BinaryOperator::GreaterThan,
+                lhs,
+                rhs,
+            } => Some((ComparisonRelation::Greater, lhs, rhs)),
+            ExpressionKind::Binary {
+                operator: BinaryOperator::LessThanOrEqual,
+                lhs,
+                rhs,
+            } => Some((ComparisonRelation::LessOrEqual, lhs, rhs)),
+            ExpressionKind::Binary {
+                operator: BinaryOperator::GreaterThanOrEqual,
+                lhs,
+                rhs,
+            } => Some((ComparisonRelation::GreaterOrEqual, lhs, rhs)),
             _ => None,
         };
         if let Some((relation, lhs, rhs)) = scalar_relational {
@@ -2303,9 +2331,7 @@ impl<'a> Checker<'a> {
             ast::Pattern::Binding { .. }
             | ast::Pattern::Tuple(_)
             | ast::Pattern::Wildcard
-            | ast::Pattern::ValueRepresentation { .. } => {
-                self.error(span, "pattern is not valid in a scalar match")
-            }
+            | ast::Pattern::ValueRepresentation { .. } => self.error(span, "pattern is not valid in a scalar match"),
         }
     }
 
@@ -2324,7 +2350,12 @@ impl<'a> Checker<'a> {
             _ => return Ok(None),
         };
         let rhs = self.check_materialized_value(rhs, &lhs_type)?;
-        Ok(Some(Condition::ScalarRelational { lhs, rhs, relation, signed }))
+        Ok(Some(Condition::ScalarRelational {
+            lhs,
+            rhs,
+            relation,
+            signed,
+        }))
     }
 
     fn check_scalar_equality(
@@ -2358,7 +2389,11 @@ impl<'a> Checker<'a> {
                     return Ok(None);
                 };
                 return Ok(Some((
-                    Value::new(ValueKind::MachineRegister(name.clone().into()), ty.clone(), expression.span),
+                    Value::new(
+                        ValueKind::MachineRegister(name.clone().into()),
+                        ty.clone(),
+                        expression.span,
+                    ),
                     ty,
                 )));
             };
@@ -2377,18 +2412,17 @@ impl<'a> Checker<'a> {
             return self.error(expression.span, "left operand does not produce a value");
         };
         let destination = self.declare_hidden("condition", ty.clone(), expression.span);
-        self.statements.push(Statement::new(StatementKindIr::call([destination], call), expression.span));
+        self.statements.push(Statement::new(
+            StatementKindIr::call([destination], call),
+            expression.span,
+        ));
         Ok(Some((
             Value::new(ValueKind::Variable(destination), ty.clone(), expression.span),
             ty,
         )))
     }
 
-    fn check_materialized_value(
-        &mut self,
-        expression: &ast::Expression,
-        expected: &Type,
-    ) -> Result<Value, Diagnostic> {
+    fn check_materialized_value(&mut self, expression: &ast::Expression, expected: &Type) -> Result<Value, Diagnostic> {
         if let ExpressionKind::Call { callee, arguments } = &expression.kind
             && callee == "alias"
         {
@@ -2414,8 +2448,15 @@ impl<'a> Checker<'a> {
                 return self.error(expression.span, format!("expected {expected}, found {found}"));
             }
             let destination = self.declare_hidden("expression", expected.clone(), expression.span);
-            self.statements.push(Statement::new(StatementKindIr::call([destination], call), expression.span));
-            return Ok(Value::new(ValueKind::Variable(destination), expected.clone(), expression.span));
+            self.statements.push(Statement::new(
+                StatementKindIr::call([destination], call),
+                expression.span,
+            ));
+            return Ok(Value::new(
+                ValueKind::Variable(destination),
+                expected.clone(),
+                expression.span,
+            ));
         }
         self.check_value(expression, expected)
     }
@@ -2435,17 +2476,15 @@ impl<'a> Checker<'a> {
                     .transpose()?,
                 ExpressionKind::Name(_) => {
                     let call = self.check_initializer(source)?;
-                    call.return_type
-                        .as_ref()
-                        .is_some_and(is_pointer_like)
-                        .then_some(call)
+                    call.return_type.as_ref().is_some_and(is_pointer_like).then_some(call)
                 }
                 _ => None,
             };
             if let Some(call) = pointer_call {
                 let source_type = call.return_type.clone().unwrap();
                 let destination = self.declare_hidden("alias_source", source_type.clone(), source.span);
-                self.statements.push(Statement::new(StatementKindIr::call([destination], call), source.span));
+                self.statements
+                    .push(Statement::new(StatementKindIr::call([destination], call), source.span));
                 Value::new(ValueKind::Variable(destination), source_type, source.span)
             } else {
                 self.check_materialized_gpr_value(source)?
@@ -2482,7 +2521,10 @@ impl<'a> Checker<'a> {
             return self.error(expression.span, format!("'{callee}' does not return f64"));
         }
         let destination = self.declare_hidden("expression", Type::F64, expression.span);
-        self.statements.push(Statement::new(StatementKindIr::call([destination], call), expression.span));
+        self.statements.push(Statement::new(
+            StatementKindIr::call([destination], call),
+            expression.span,
+        ));
         Ok(Value::new(ValueKind::Variable(destination), Type::F64, expression.span))
     }
 
@@ -2523,7 +2565,11 @@ impl<'a> Checker<'a> {
                             format!("expected {expected}, found {} for '{name}'", symbol.ty),
                         );
                     }
-                    return Ok(Value::new(ValueKind::Variable(symbol.id), symbol.ty.clone(), expression.span));
+                    return Ok(Value::new(
+                        ValueKind::Variable(symbol.id),
+                        symbol.ty.clone(),
+                        expression.span,
+                    ));
                 }
                 if let Some(ty) = machine_register_type(name) {
                     if &ty != expected {
@@ -2549,20 +2595,16 @@ impl<'a> Checker<'a> {
                 }
                 if *expected == Type::SlowPath
                     && (name.starts_with("asm_slow_path_")
-                        || name
-                            .chars()
-                            .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'))
+                        || name.chars().all(|character| {
+                            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+                        }))
                 {
                     return Ok(Value::new(
-                        ValueKind::SlowPath(
-                            ExternalSymbol::new(
-                                if name.starts_with("asm_slow_path_") {
-                                    name.clone()
-                                } else {
-                                    format!("asm_slow_path_{name}")
-                                },
-                            ),
-                        ),
+                        ValueKind::SlowPath(ExternalSymbol::new(if name.starts_with("asm_slow_path_") {
+                            name.clone()
+                        } else {
+                            format!("asm_slow_path_{name}")
+                        })),
                         Type::SlowPath,
                         expression.span,
                     ));
@@ -2574,12 +2616,11 @@ impl<'a> Checker<'a> {
                         expression.span,
                     ));
                 }
-                let matches_inline_operation = operation_signature(expected)
-                    .is_some_and(|signature| {
-                        self.signatures
-                            .get(name)
-                            .is_some_and(|candidate| signatures_match(candidate, &signature))
-                    });
+                let matches_inline_operation = operation_signature(expected).is_some_and(|signature| {
+                    self.signatures
+                        .get(name)
+                        .is_some_and(|candidate| signatures_match(candidate, &signature))
+                });
                 if let Some(intrinsic) = resolve_operation(name, expected) {
                     return Ok(Value::new(
                         ValueKind::Operation(OperationValue::Intrinsic(intrinsic)),
@@ -2604,9 +2645,11 @@ impl<'a> Checker<'a> {
                 }
                 self.error(expression.span, format!("unknown name '{name}'"))
             }
-            ExpressionKind::Integer(value) if is_integer_representation(expected) => {
-                Ok(Value::new(ValueKind::Integer(*value), expected.clone(), expression.span))
-            }
+            ExpressionKind::Integer(value) if is_integer_representation(expected) => Ok(Value::new(
+                ValueKind::Integer(*value),
+                expected.clone(),
+                expression.span,
+            )),
             ExpressionKind::Integer(_) => {
                 self.error(expression.span, format!("expected {expected}, found integer literal"))
             }
@@ -2615,9 +2658,7 @@ impl<'a> Checker<'a> {
             | ExpressionKind::Binary { .. }
             | ExpressionKind::Index { .. }
             | ExpressionKind::Tuple(_)
-            | ExpressionKind::Memory(_) => {
-                self.error(expression.span, "nested expressions are not supported here")
-            }
+            | ExpressionKind::Memory(_) => self.error(expression.span, "nested expressions are not supported here"),
         }
     }
 
@@ -2625,7 +2666,11 @@ impl<'a> Checker<'a> {
         if let ExpressionKind::Name(name) = &expression.kind {
             if let Some(symbol) = self.lookup(name) {
                 if matches!(symbol.ty, Type::Field(_)) {
-                    return Ok(Value::new(ValueKind::Variable(symbol.id), symbol.ty.clone(), expression.span));
+                    return Ok(Value::new(
+                        ValueKind::Variable(symbol.id),
+                        symbol.ty.clone(),
+                        expression.span,
+                    ));
                 }
                 if !is_gpr_type(&symbol.ty) {
                     return self.error(
@@ -2678,39 +2723,48 @@ impl<'a> Checker<'a> {
             );
         }
         let destination = self.declare_hidden("expression", return_type.clone(), expression.span);
-        self.statements.push(Statement::new(StatementKindIr::call([destination], call), expression.span));
-        Ok(Value::new(ValueKind::Variable(destination), return_type, expression.span))
+        self.statements.push(Statement::new(
+            StatementKindIr::call([destination], call),
+            expression.span,
+        ));
+        Ok(Value::new(
+            ValueKind::Variable(destination),
+            return_type,
+            expression.span,
+        ))
     }
 
     fn check_memory_component(&self, expression: &ast::Expression) -> Result<Value, Diagnostic> {
         if let ExpressionKind::Name(name) = &expression.kind
             && let Some(symbol) = self.lookup(name)
-                && matches!(
-                    symbol.ty,
-                    Type::Field(_) | Type::Operand
-                ) {
-                    return Ok(Value::new(ValueKind::Variable(symbol.id), symbol.ty.clone(), expression.span));
-                }
+            && matches!(symbol.ty, Type::Field(_) | Type::Operand)
+        {
+            return Ok(Value::new(
+                ValueKind::Variable(symbol.id),
+                symbol.ty.clone(),
+                expression.span,
+            ));
+        }
         self.check_gpr_value(expression)
     }
 
     fn resolve_continuation_symbol(&self, name: &str) -> Option<&ContinuationSymbol> {
-        self.continuation_scopes
-            .iter()
-            .rev()
-            .find_map(|scope| scope.get(name))
+        self.continuation_scopes.iter().rev().find_map(|scope| scope.get(name))
     }
 
     fn push_jump(&mut self, target: &str, span: SourceSpan) {
         self.statements.push(Statement::new(
-            StatementKindIr::call([], Call::with_control_flow(
-                CallTarget::Intrinsic(Intrinsic::Control(ControlOperation::JumpLabel)),
-                vec![Value::new(ValueKind::Label(target.to_string()), Type::label(), span)],
-                vec![ParameterMode::In],
-                None,
-                true,
-                Some(target.to_string()),
-            )),
+            StatementKindIr::call(
+                [],
+                Call::with_control_flow(
+                    CallTarget::Intrinsic(Intrinsic::Control(ControlOperation::JumpLabel)),
+                    vec![Value::new(ValueKind::Label(target.to_string()), Type::label(), span)],
+                    vec![ParameterMode::In],
+                    None,
+                    true,
+                    Some(target.to_string()),
+                ),
+            ),
             span,
         ));
     }
@@ -2741,7 +2795,10 @@ impl<'a> Checker<'a> {
         for (argument, parameter) in arguments.iter().zip(parameters) {
             let call = self.check_initializer_with_expected(argument, Some(&parameter.ty))?;
             let Some(return_type) = &call.return_type else {
-                return self.error(argument.span, format!("'{}' does not return a value", call.display_name()));
+                return self.error(
+                    argument.span,
+                    format!("'{}' does not return a value", call.display_name()),
+                );
             };
             if *return_type != parameter.ty {
                 return self.error(argument.span, format!("expected {}, found {return_type}", parameter.ty));
@@ -2942,20 +2999,17 @@ fn branch_target(
         || matches!(
             target,
             CallTarget::Intrinsic(
-                Intrinsic::Branch(_)
-                    | Intrinsic::CheckedInteger(_)
-                    | Intrinsic::Control(ControlOperation::JumpLabel)
+                Intrinsic::Branch(_) | Intrinsic::CheckedInteger(_) | Intrinsic::Control(ControlOperation::JumpLabel)
             )
         ))
-        && let Some(value) = values.last() {
-            return match &value.kind {
-                ValueKind::Label(label) => Some(label.clone()),
-                ValueKind::Variable(variable) if value.ty == Type::label() => {
-                    Some(variables[*variable].name.clone())
-                }
-                _ => None,
-            };
-        }
+        && let Some(value) = values.last()
+    {
+        return match &value.kind {
+            ValueKind::Label(label) => Some(label.clone()),
+            ValueKind::Variable(variable) if value.ty == Type::label() => Some(variables[*variable].name.clone()),
+            _ => None,
+        };
+    }
     None
 }
 
@@ -2968,10 +3022,7 @@ fn ast_block_is_terminal(block: &ast::Block, signatures: &HashMap<String, Signat
 
 fn ast_statement_is_terminal(statement: &ast::Statement, signatures: &HashMap<String, Signature>) -> bool {
     let call_is_terminal = |callee: &str| {
-        intrinsic_is_terminal(callee)
-            || signatures
-                .get(callee)
-                .is_some_and(|signature| signature.terminal)
+        intrinsic_is_terminal(callee) || signatures.get(callee).is_some_and(|signature| signature.terminal)
     };
     match &statement.kind {
         ast::StatementKind::Expression(ast::Expression {
@@ -3320,9 +3371,10 @@ pub(crate) fn check_with_layouts(
             pair
         });
         if let Some(stride) = field.stride
-            && let Some(previous) = aggregate_strides.insert(owner.clone(), stride) {
-                assert_eq!(previous, stride, "conflicting generated strides for {}", field.owner);
-            }
+            && let Some(previous) = aggregate_strides.insert(owner.clone(), stride)
+        {
+            assert_eq!(previous, stride, "conflicting generated strides for {}", field.owner);
+        }
         layouts.insert(
             (owner, field.name.clone()),
             LayoutField {
@@ -3398,7 +3450,10 @@ pub(crate) fn check_with_layouts(
                             for (index, value) in return_values.iter().enumerate() {
                                 let name = format!("__return_value_{index}");
                                 ast_body.statements.push(ast::Statement {
-                                    kind: ast::StatementKind::Assign { name, initializer: value.clone() },
+                                    kind: ast::StatementKind::Assign {
+                                        name,
+                                        initializer: value.clone(),
+                                    },
                                     span: declaration.span,
                                 });
                             }
@@ -3438,18 +3493,17 @@ pub(crate) fn check_with_layouts(
                         }
                     }
                 }
-                let (parameters, body) =
-                    check_body(
-                        filename,
-                        &signatures,
-                        &inline_function_ids,
-                        &ast_parameters,
-                        &ast_body,
-                        true,
-                        false,
-                        &layouts,
-                        &aggregate_strides,
-                    )?;
+                let (parameters, body) = check_body(
+                    filename,
+                    &signatures,
+                    &inline_function_ids,
+                    &ast_parameters,
+                    &ast_body,
+                    true,
+                    false,
+                    &layouts,
+                    &aggregate_strides,
+                )?;
                 inline_functions.push(InlineFunction {
                     id: inline_function_ids[&declaration.name],
                     name: declaration.name.clone(),
@@ -3466,18 +3520,17 @@ pub(crate) fn check_with_layouts(
                         format!("duplicate declaration '{}'", declaration.name),
                     ));
                 }
-                let (parameters, body) =
-                    check_body(
-                        filename,
-                        &signatures,
-                        &inline_function_ids,
-                        &declaration.parameters,
-                        &declaration.body,
-                        false,
-                        true,
-                        &layouts,
-                        &aggregate_strides,
-                    )?;
+                let (parameters, body) = check_body(
+                    filename,
+                    &signatures,
+                    &inline_function_ids,
+                    &declaration.parameters,
+                    &declaration.body,
+                    false,
+                    true,
+                    &layouts,
+                    &aggregate_strides,
+                )?;
                 handlers.push(Handler {
                     name: declaration.name.clone(),
                     parameters,
@@ -3487,12 +3540,18 @@ pub(crate) fn check_with_layouts(
             }
         }
     }
-    Ok(Program { inline_functions, handlers })
+    Ok(Program {
+        inline_functions,
+        handlers,
+    })
 }
 
 fn statement_uses_and_defs(statement: &Statement) -> (Vec<VariableId>, Vec<VariableId>) {
     let call_uses_and_defs = |call: &Call| {
-        if call.intrinsic() == Some(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Xor)))
+        if call.intrinsic()
+            == Some(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                BinaryOperation::Xor,
+            )))
             && call.arguments.len() == 2
             && call.arguments[0].kind == call.arguments[1].kind
             && let ValueKind::Variable(id) = call.arguments[0].kind
@@ -3506,9 +3565,10 @@ fn statement_uses_and_defs(statement: &Statement) -> (Vec<VariableId>, Vec<Varia
                 uses.extend(value_variable_ids(value));
             }
             if matches!(mode, ParameterMode::Out | ParameterMode::InOut)
-                && let ValueKind::Variable(id) = value.kind {
-                    defs.push(id);
-                }
+                && let ValueKind::Variable(id) = value.kind
+            {
+                defs.push(id);
+            }
         }
         (uses, defs)
     };
@@ -3519,12 +3579,10 @@ fn statement_uses_and_defs(statement: &Statement) -> (Vec<VariableId>, Vec<Varia
             defs.extend(destinations.iter().copied());
             (uses, defs)
         }
-        StatementKindIr::MachineAssign { arguments, .. } => {
-            (direct_value_variables(arguments), Vec::new())
-        }
-        StatementKindIr::ValueRefinement { binding, value, tag, .. } => {
-            (direct_value_variables([value]), vec![*tag, *binding])
-        }
+        StatementKindIr::MachineAssign { arguments, .. } => (direct_value_variables(arguments), Vec::new()),
+        StatementKindIr::ValueRefinement {
+            binding, value, tag, ..
+        } => (direct_value_variables([value]), vec![*tag, *binding]),
         StatementKindIr::ValueMatch {
             destination,
             value,
@@ -3536,7 +3594,9 @@ fn statement_uses_and_defs(statement: &Statement) -> (Vec<VariableId>, Vec<Varia
             normalize_variables(&mut uses);
             (uses, destination.iter().copied().collect())
         }
-        StatementKindIr::ScalarMatch { value, captures, arms, .. } => {
+        StatementKindIr::ScalarMatch {
+            value, captures, arms, ..
+        } => {
             let mut uses = captures.clone();
             uses.extend(direct_value_variables([value]));
             for arm in arms {
@@ -3555,9 +3615,12 @@ fn statement_uses_and_defs(statement: &Statement) -> (Vec<VariableId>, Vec<Varia
         } => {
             let (mut uses, mut definitions) = condition_uses_and_defs(condition);
             if else_body.is_some() {
-                uses.extend(captures.iter().copied().filter(|capture| {
-                    destination.is_some() || !definitions.contains(capture)
-                }));
+                uses.extend(
+                    captures
+                        .iter()
+                        .copied()
+                        .filter(|capture| destination.is_some() || !definitions.contains(capture)),
+                );
                 definitions.extend(destination);
             } else if !terminal {
                 // Conditional definitions are also uses at the join because the
@@ -3633,28 +3696,19 @@ fn value_variable_ids(value: &Value) -> Vec<VariableId> {
 pub(crate) fn condition_uses_and_defs(condition: &Condition) -> (Vec<VariableId>, Vec<VariableId>) {
     match condition {
         Condition::LogicalNot(condition) => condition_uses_and_defs(condition),
-        Condition::ScalarEquality { lhs, rhs, .. } => (
-            direct_value_variables([lhs, rhs]),
-            Vec::new(),
-        ),
-        Condition::ScalarRelational { lhs, rhs, .. } => (
-            direct_value_variables([lhs, rhs]),
-            Vec::new(),
-        ),
-        Condition::BitTest { value, mask, .. } => (
-            direct_value_variables([value, mask]),
-            Vec::new(),
-        ),
-        Condition::ValueTag { value, tag, source_tag, .. } => {
+        Condition::ScalarEquality { lhs, rhs, .. } => (direct_value_variables([lhs, rhs]), Vec::new()),
+        Condition::ScalarRelational { lhs, rhs, .. } => (direct_value_variables([lhs, rhs]), Vec::new()),
+        Condition::BitTest { value, mask, .. } => (direct_value_variables([value, mask]), Vec::new()),
+        Condition::ValueTag {
+            value, tag, source_tag, ..
+        } => {
             let mut uses = direct_value_variables([value]);
             if let Some(source_tag) = source_tag {
                 uses.push(*source_tag);
             }
             (uses, vec![*tag])
         }
-        Condition::ValueBits { value, expected, .. } => {
-            (direct_value_variables([value]), vec![*expected])
-        }
+        Condition::ValueBits { value, expected, .. } => (direct_value_variables([value]), vec![*expected]),
     }
 }
 
@@ -3667,9 +3721,7 @@ pub(super) fn statement_is_terminal(statement: &Statement) -> bool {
             then_body,
             else_body: Some(else_body),
             ..
-        } => {
-            block_is_terminal(then_body) && block_is_terminal(else_body)
-        }
+        } => block_is_terminal(then_body) && block_is_terminal(else_body),
         _ => false,
     }
 }
@@ -3677,12 +3729,7 @@ pub(super) fn statement_is_terminal(statement: &Statement) -> bool {
 pub(super) fn block_is_terminal(body: &[Statement]) -> bool {
     body.iter()
         .rev()
-        .find(|statement| {
-            !matches!(
-                statement.kind,
-                StatementKindIr::Continuation { .. }
-            )
-        })
+        .find(|statement| !matches!(statement.kind, StatementKindIr::Continuation { .. }))
         .is_some_and(statement_is_terminal)
 }
 
@@ -3764,10 +3811,7 @@ handler Read(src: in Operand) {
         let StatementKindIr::Call(_, call) = &program.handlers[0].body.statements[1].kind else {
             panic!("expected inline function call")
         };
-        assert_eq!(
-            call.target,
-            CallTarget::InlineFunction(program.inline_functions[0].id)
-        );
+        assert_eq!(call.target, CallTarget::InlineFunction(program.inline_functions[0].id));
     }
 
     #[test]
@@ -3839,9 +3883,7 @@ handler Invoke() {
                 if id == add.id
         ));
 
-        let StatementKindIr::Call(_, call) =
-            &program.handlers[0].body.statements[0].kind
-        else {
+        let StatementKindIr::Call(_, call) = &program.handlers[0].body.statements[0].kind else {
             panic!("expected interpreter call")
         };
         assert!(matches!(
@@ -3921,16 +3963,17 @@ handler Add(lhs: i32, rhs: i32) {
         )
         .unwrap();
 
-        let StatementKindIr::Call(destinations, call) =
-            &program.handlers[0].body.statements[1].kind
-        else {
+        let StatementKindIr::Call(destinations, call) = &program.handlers[0].body.statements[1].kind else {
             panic!("expected checked add")
         };
         let failure = call.failure.as_ref().expect("expected structured failure");
         assert_eq!(program.handlers[0].body.variables[destinations[0]].ty, Type::I32);
-        assert_eq!(call.intrinsic(), Some(Intrinsic::CheckedInteger(
-            crate::intrinsic::CheckedIntegerOperation::Add,
-        )));
+        assert_eq!(
+            call.intrinsic(),
+            Some(Intrinsic::CheckedInteger(
+                crate::intrinsic::CheckedIntegerOperation::Add,
+            ))
+        );
         assert_eq!(failure.captures, &[0, 2]);
     }
 
@@ -3974,7 +4017,10 @@ handler Check(value: i32) {
 "#,
         )
         .unwrap_err();
-        assert_eq!(unexpected_else.message, "'identity' does not accept an else continuation");
+        assert_eq!(
+            unexpected_else.message,
+            "'identity' does not accept an else continuation"
+        );
     }
 
     rejects!(
@@ -4053,7 +4099,11 @@ inline fn bad(frame: in ExecutionContext) {
         .unwrap();
         let error = check_with_layouts("test.flap", &ast, layouts.fields()).unwrap_err();
 
-        assert!(error.message.contains("cannot write through an in ExecutionContext parameter"));
+        assert!(
+            error
+                .message
+                .contains("cannot write through an in ExecutionContext parameter")
+        );
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -3035,191 +3035,12 @@ fn ast_statement_is_terminal(statement: &ast::Statement, signatures: &HashMap<St
     }
 }
 
-fn collect_inline_calls_from_expression(
-    expression: &ast::Expression,
-    inline_function_indices: &HashMap<String, usize>,
-    callees: &mut Vec<usize>,
-) {
-    match &expression.kind {
-        ExpressionKind::Call { callee, arguments } => {
-            if let Some(callee) = inline_function_indices.get(callee)
-                && !callees.contains(callee)
-            {
-                callees.push(*callee);
-            }
-            for argument in arguments {
-                collect_inline_calls_from_expression(argument, inline_function_indices, callees);
-            }
-        }
-        ExpressionKind::Unary { operand, .. } => {
-            collect_inline_calls_from_expression(operand, inline_function_indices, callees);
-        }
-        ExpressionKind::Binary { lhs, rhs, .. } => {
-            collect_inline_calls_from_expression(lhs, inline_function_indices, callees);
-            collect_inline_calls_from_expression(rhs, inline_function_indices, callees);
-        }
-        ExpressionKind::Index { base, index } => {
-            collect_inline_calls_from_expression(base, inline_function_indices, callees);
-            collect_inline_calls_from_expression(index, inline_function_indices, callees);
-        }
-        ExpressionKind::Memory(components) | ExpressionKind::Tuple(components) => {
-            for component in components {
-                collect_inline_calls_from_expression(component, inline_function_indices, callees);
-            }
-        }
-        ExpressionKind::Name(_) | ExpressionKind::Integer(_) => {}
-    }
-}
-
-fn collect_inline_calls_from_pattern(
-    pattern: &ast::Pattern,
-    inline_function_indices: &HashMap<String, usize>,
-    callees: &mut Vec<usize>,
-) {
-    match pattern {
-        ast::Pattern::Tuple(patterns) | ast::Pattern::Alternatives(patterns) => {
-            for pattern in patterns {
-                collect_inline_calls_from_pattern(pattern, inline_function_indices, callees);
-            }
-        }
-        ast::Pattern::Expression(expression) => {
-            collect_inline_calls_from_expression(expression, inline_function_indices, callees);
-        }
-        ast::Pattern::ValueRepresentation {
-            binding: Some(binding), ..
-        } => collect_inline_calls_from_pattern(binding, inline_function_indices, callees),
-        ast::Pattern::Binding { .. }
-        | ast::Pattern::Wildcard
-        | ast::Pattern::ValueRepresentation { binding: None, .. } => {}
-    }
-}
-
-fn collect_inline_calls_from_else_continuation(
-    continuation: &ast::ElseContinuation,
-    inline_function_indices: &HashMap<String, usize>,
-    callees: &mut Vec<usize>,
-) {
-    match continuation {
-        ast::ElseContinuation::Invocation { arguments, .. } => {
-            for argument in arguments {
-                collect_inline_calls_from_expression(argument, inline_function_indices, callees);
-            }
-        }
-        ast::ElseContinuation::Block { body, .. } => {
-            collect_inline_calls_from_block(body, inline_function_indices, callees);
-        }
-        ast::ElseContinuation::Label(_) => {}
-    }
-}
-
-fn collect_inline_calls_from_block(
-    block: &ast::Block,
-    inline_function_indices: &HashMap<String, usize>,
-    callees: &mut Vec<usize>,
-) {
-    for statement in &block.statements {
-        match &statement.kind {
-            ast::StatementKind::Let { pattern, initializer } => {
-                collect_inline_calls_from_pattern(pattern, inline_function_indices, callees);
-                if let Some(initializer) = initializer {
-                    collect_inline_calls_from_expression(initializer, inline_function_indices, callees);
-                }
-            }
-            ast::StatementKind::GuardLet {
-                pattern,
-                initializer,
-                failure,
-            } => {
-                collect_inline_calls_from_pattern(pattern, inline_function_indices, callees);
-                collect_inline_calls_from_expression(initializer, inline_function_indices, callees);
-                collect_inline_calls_from_else_continuation(failure, inline_function_indices, callees);
-            }
-            ast::StatementKind::FallibleCall {
-                callee,
-                arguments,
-                failure,
-            } => {
-                if let Some(callee) = inline_function_indices.get(callee)
-                    && !callees.contains(callee)
-                {
-                    callees.push(*callee);
-                }
-                for argument in arguments {
-                    collect_inline_calls_from_expression(argument, inline_function_indices, callees);
-                }
-                collect_inline_calls_from_else_continuation(failure, inline_function_indices, callees);
-            }
-            ast::StatementKind::Assign { initializer, .. } => {
-                collect_inline_calls_from_expression(initializer, inline_function_indices, callees);
-            }
-            ast::StatementKind::IndexAssign { base, index, value } => {
-                collect_inline_calls_from_expression(base, inline_function_indices, callees);
-                collect_inline_calls_from_expression(index, inline_function_indices, callees);
-                collect_inline_calls_from_expression(value, inline_function_indices, callees);
-            }
-            ast::StatementKind::Expression(expression) => {
-                collect_inline_calls_from_expression(expression, inline_function_indices, callees);
-            }
-            ast::StatementKind::ValueMatch {
-                value, arms, fallback, ..
-            } => {
-                collect_inline_calls_from_expression(value, inline_function_indices, callees);
-                for arm in arms {
-                    collect_inline_calls_from_block(&arm.body, inline_function_indices, callees);
-                }
-                collect_inline_calls_from_block(&fallback.body, inline_function_indices, callees);
-            }
-            ast::StatementKind::ScalarMatch { value, arms, fallback } => {
-                collect_inline_calls_from_expression(value, inline_function_indices, callees);
-                for arm in arms {
-                    collect_inline_calls_from_pattern(&arm.pattern, inline_function_indices, callees);
-                    collect_inline_calls_from_block(&arm.body, inline_function_indices, callees);
-                }
-                collect_inline_calls_from_block(fallback, inline_function_indices, callees);
-            }
-            ast::StatementKind::Guard { condition, failure } => {
-                collect_inline_calls_from_expression(condition, inline_function_indices, callees);
-                collect_inline_calls_from_else_continuation(failure, inline_function_indices, callees);
-            }
-            ast::StatementKind::Continuation { body, .. } => {
-                collect_inline_calls_from_block(body, inline_function_indices, callees);
-            }
-            ast::StatementKind::ContinuationJump { arguments, .. } => {
-                for argument in arguments {
-                    collect_inline_calls_from_expression(argument, inline_function_indices, callees);
-                }
-            }
-            ast::StatementKind::If {
-                condition,
-                then_body,
-                else_body,
-                ..
-            } => {
-                collect_inline_calls_from_expression(condition, inline_function_indices, callees);
-                collect_inline_calls_from_block(then_body, inline_function_indices, callees);
-                if let Some(else_body) = else_body {
-                    collect_inline_calls_from_block(else_body, inline_function_indices, callees);
-                }
-            }
-            ast::StatementKind::While { condition, body, .. } => {
-                collect_inline_calls_from_expression(condition, inline_function_indices, callees);
-                collect_inline_calls_from_block(body, inline_function_indices, callees);
-            }
-        }
-    }
-    if let Some(value) = &block.value {
-        collect_inline_calls_from_expression(value, inline_function_indices, callees);
-    }
-}
-
 fn collect_signatures(filename: &str, program: &ast::Program) -> Result<HashMap<String, Signature>, Diagnostic> {
     let mut signatures = HashMap::default();
-    let mut inline_functions = Vec::new();
     for declaration in &program.declarations {
         let ast::Declaration::InlineFunction(declaration) = declaration else {
             continue;
         };
-        inline_functions.push(declaration);
         let signature = Signature {
             parameters: declaration
                 .parameters
@@ -3239,59 +3060,192 @@ fn collect_signatures(filename: &str, program: &ast::Program) -> Result<HashMap<
         }
     }
 
-    let inline_function_indices = inline_functions
-        .iter()
-        .enumerate()
-        .map(|(index, function)| (function.name.clone(), index))
-        .collect::<HashMap<_, _>>();
-    let callees = inline_functions
-        .iter()
-        .map(|function| {
-            let mut callees = Vec::new();
-            collect_inline_calls_from_block(&function.body, &inline_function_indices, &mut callees);
-            callees
-        })
-        .collect::<Vec<_>>();
-    let mut incoming_edge_counts = vec![0usize; inline_functions.len()];
-    for function_callees in &callees {
-        for callee in function_callees {
-            incoming_edge_counts[*callee] += 1;
-        }
-    }
-    let mut ready = incoming_edge_counts
-        .iter()
-        .enumerate()
-        .filter_map(|(index, count)| (*count == 0).then_some(index))
-        .collect::<Vec<_>>();
-    let mut topological_order = Vec::with_capacity(inline_functions.len());
-    while let Some(function) = ready.pop() {
-        topological_order.push(function);
-        for callee in &callees[function] {
-            incoming_edge_counts[*callee] -= 1;
-            if incoming_edge_counts[*callee] == 0 {
-                ready.push(*callee);
+    loop {
+        let mut newly_terminal = Vec::new();
+        for declaration in &program.declarations {
+            let ast::Declaration::InlineFunction(function) = declaration else {
+                continue;
+            };
+            if !signatures[&function.name].terminal && ast_block_is_terminal(&function.body, &signatures) {
+                newly_terminal.push(function.name.clone());
             }
         }
-    }
-    if topological_order.len() != inline_functions.len() {
-        let function = incoming_edge_counts.iter().position(|count| *count != 0).unwrap();
-        return Err(Diagnostic::new(
-            filename,
-            inline_functions[function].span,
-            format!(
-                "recursive inline function cycle involving '{}'",
-                inline_functions[function].name
-            ),
-        ));
-    }
-
-    for function in topological_order.into_iter().rev() {
-        let function = inline_functions[function];
-        if ast_block_is_terminal(&function.body, &signatures) {
-            signatures.get_mut(&function.name).unwrap().terminal = true;
+        if newly_terminal.is_empty() {
+            break;
+        }
+        for name in newly_terminal {
+            signatures.get_mut(&name).unwrap().terminal = true;
         }
     }
     Ok(signatures)
+}
+
+#[derive(Default)]
+struct InlineCallSummary {
+    callees: HashSet<usize>,
+    invoked_parameters: HashSet<usize>,
+}
+
+#[derive(Clone, Copy)]
+enum InlineOperationArgument {
+    Function(InlineFunctionId),
+    Parameter(VariableId),
+}
+
+struct InlineCallSite {
+    callee: usize,
+    operation_arguments: Vec<Option<InlineOperationArgument>>,
+}
+
+fn collect_inline_call_facts(
+    statements: &[Statement],
+    parameter_indices: &HashMap<VariableId, usize>,
+    summary: &mut InlineCallSummary,
+    call_sites: &mut Vec<InlineCallSite>,
+) {
+    for statement in statements {
+        if let StatementKindIr::Call(_, call) = &statement.kind {
+            match call.target {
+                CallTarget::InlineFunction(callee) => {
+                    summary.callees.insert(callee.index());
+                    call_sites.push(InlineCallSite {
+                        callee: callee.index(),
+                        operation_arguments: call
+                            .arguments
+                            .iter()
+                            .map(|argument| match argument.kind {
+                                ValueKind::Operation(OperationValue::InlineFunction(function)) => {
+                                    Some(InlineOperationArgument::Function(function))
+                                }
+                                ValueKind::Variable(variable) if parameter_indices.contains_key(&variable) => {
+                                    Some(InlineOperationArgument::Parameter(variable))
+                                }
+                                _ => None,
+                            })
+                            .collect(),
+                    });
+                }
+                CallTarget::OperationParameter(parameter) => {
+                    if let Some(index) = parameter_indices.get(&parameter) {
+                        summary.invoked_parameters.insert(*index);
+                    }
+                }
+                _ => {}
+            }
+        }
+        statement
+            .kind
+            .for_each_nested_body(|body| collect_inline_call_facts(body, parameter_indices, summary, call_sites));
+    }
+}
+
+fn find_inline_cycle(
+    function: usize,
+    graph: &[Vec<usize>],
+    states: &mut [u8],
+    stack: &mut Vec<usize>,
+) -> Option<Vec<usize>> {
+    states[function] = 1;
+    stack.push(function);
+    for &callee in &graph[function] {
+        if states[callee] == 0 {
+            if let Some(cycle) = find_inline_cycle(callee, graph, states, stack) {
+                return Some(cycle);
+            }
+        } else if states[callee] == 1 {
+            let start = stack.iter().position(|candidate| *candidate == callee).unwrap();
+            let mut cycle = stack[start..].to_vec();
+            cycle.push(callee);
+            return Some(cycle);
+        }
+    }
+    stack.pop();
+    states[function] = 2;
+    None
+}
+
+fn validate_inline_call_graph(filename: &str, inline_functions: &[InlineFunction]) -> Result<(), Diagnostic> {
+    let parameter_indices = inline_functions
+        .iter()
+        .map(|function| {
+            function
+                .parameters
+                .iter()
+                .enumerate()
+                .map(|(index, parameter)| (*parameter, index))
+                .collect::<HashMap<_, _>>()
+        })
+        .collect::<Vec<_>>();
+    let mut summaries = (0..inline_functions.len())
+        .map(|_| InlineCallSummary::default())
+        .collect::<Vec<_>>();
+    let mut call_sites = (0..inline_functions.len()).map(|_| Vec::new()).collect::<Vec<_>>();
+    for (function, inline_function) in inline_functions.iter().enumerate() {
+        collect_inline_call_facts(
+            &inline_function.body.statements,
+            &parameter_indices[function],
+            &mut summaries[function],
+            &mut call_sites[function],
+        );
+    }
+
+    let mut invoked_parameters = Vec::new();
+    loop {
+        let mut changed = false;
+        for (function, function_calls) in call_sites.iter().enumerate() {
+            for call in function_calls {
+                invoked_parameters.clear();
+                invoked_parameters.extend(summaries[call.callee].invoked_parameters.iter().copied());
+                for &parameter in &invoked_parameters {
+                    let Some(Some(argument)) = call.operation_arguments.get(parameter) else {
+                        continue;
+                    };
+                    match argument {
+                        InlineOperationArgument::Function(callee) => {
+                            changed |= summaries[function].callees.insert(callee.index());
+                        }
+                        InlineOperationArgument::Parameter(variable) => {
+                            if let Some(parameter) = parameter_indices[function].get(variable) {
+                                changed |= summaries[function].invoked_parameters.insert(*parameter);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    let graph = summaries
+        .into_iter()
+        .map(|summary| summary.callees.into_iter().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let mut states = vec![0; inline_functions.len()];
+    for function in 0..inline_functions.len() {
+        if states[function] != 0 {
+            continue;
+        }
+        let Some(cycle) = find_inline_cycle(function, &graph, &mut states, &mut Vec::new()) else {
+            continue;
+        };
+        let names = cycle
+            .iter()
+            .map(|function| inline_functions[*function].name.as_str())
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        let member = cycle[0];
+        return Err(Diagnostic::new(
+            filename,
+            inline_functions[member].span,
+            format!(
+                "recursive inline function cycle involving '{}': {names}",
+                inline_functions[member].name
+            ),
+        ));
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3502,6 +3456,7 @@ pub(crate) fn check_with_layouts(
                 inline_functions.push(InlineFunction {
                     id: inline_function_ids[&declaration.name],
                     name: declaration.name.clone(),
+                    span: declaration.span,
                     parameters,
                     return_type: declaration.return_type.clone(),
                     body,
@@ -3535,6 +3490,7 @@ pub(crate) fn check_with_layouts(
             }
         }
     }
+    validate_inline_call_graph(filename, &inline_functions)?;
     Ok(Program {
         inline_functions,
         handlers,
@@ -4364,6 +4320,27 @@ inline fn second(value: i32) -> i32 {
 }
 "#,
         "recursive inline function cycle involving"
+    );
+
+    rejects!(
+        rejects_recursion_through_an_operation_parameter,
+        r#"
+inline fn apply(lhs: inout i32, rhs: i32, operation: BinaryOperation<i32>) {
+    operation(lhs, rhs);
+}
+
+inline fn recurse(lhs: inout i32, rhs: i32) {
+    apply(lhs, rhs, recurse);
+}
+
+handler Loop(lhs: i32, rhs: i32) {
+    let value = lhs;
+    recurse(value, rhs);
+    assert_nonzero(value);
+    dispatch_next;
+}
+"#,
+        "recursive inline function cycle involving 'recurse': recurse -> recurse"
     );
 
     #[test]

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -74,6 +74,7 @@ struct Checker<'a> {
     aggregate_strides: &'a HashMap<Type, layout::LayoutValue>,
     bytecode_fields: HashSet<VariableId>,
     known_null_pointers: HashSet<VariableId>,
+    known_integer_literals: HashSet<VariableId>,
     active_value_tags: Vec<(VariableId, VariableId)>,
 }
 
@@ -109,6 +110,7 @@ impl<'a> Checker<'a> {
             aggregate_strides,
             bytecode_fields: HashSet::default(),
             known_null_pointers: HashSet::default(),
+            known_integer_literals: HashSet::default(),
             active_value_tags: Vec::new(),
         }
     }
@@ -829,6 +831,7 @@ impl<'a> Checker<'a> {
             );
         }
         self.update_known_null_pointer(symbol.id, initializer, &symbol.ty);
+        self.update_known_integer_literal(symbol.id, initializer, &symbol.ty);
         self.statements
             .push(Statement::new(StatementKindIr::call([symbol.id], call), statement.span));
         Ok(())
@@ -1056,6 +1059,7 @@ impl<'a> Checker<'a> {
             let declared_type = ty.clone().unwrap_or(return_type);
             let id = self.declare(name, declared_type.clone(), None, statement.span)?;
             self.update_known_null_pointer(id, initializer, &declared_type);
+            self.update_known_integer_literal(id, initializer, &declared_type);
             self.statements
                 .push(Statement::new(StatementKindIr::call([id], call), statement.span));
         } else {
@@ -1689,6 +1693,35 @@ impl<'a> Checker<'a> {
         }
         self.lookup(name)
             .is_some_and(|symbol| symbol.ty == *ty && self.known_null_pointers.contains(&symbol.id))
+    }
+
+    fn update_known_integer_literal(&mut self, variable: VariableId, initializer: &ast::Expression, ty: &Type) {
+        if self.initializer_is_known_integer_literal(initializer, ty) {
+            self.known_integer_literals.insert(variable);
+        } else {
+            self.known_integer_literals.remove(&variable);
+        }
+    }
+
+    fn initializer_is_known_integer_literal(&self, initializer: &ast::Expression, ty: &Type) -> bool {
+        if !is_integer_arithmetic_type(ty) {
+            return false;
+        }
+        match &initializer.kind {
+            ExpressionKind::Integer(_) => true,
+            ExpressionKind::Name(name) => self
+                .lookup(name)
+                .is_some_and(|symbol| symbol.ty == *ty && self.known_integer_literals.contains(&symbol.id)),
+            _ => false,
+        }
+    }
+
+    fn value_is_known_integer_literal(&self, value: &Value) -> bool {
+        match value.kind {
+            ValueKind::Integer(_) | ValueKind::Constant(_) => true,
+            ValueKind::Variable(variable) => self.known_integer_literals.contains(&variable),
+            _ => false,
+        }
     }
 
     fn check_initializer(&mut self, expression: &ast::Expression) -> Result<Call, Diagnostic> {
@@ -2536,6 +2569,9 @@ impl<'a> Checker<'a> {
         );
         let raw_alias = (source.ty == Type::U64 || is_pointer_like(&source.ty))
             && (*expected == Type::U64 || is_pointer_like(expected));
+        if raw_alias && is_pointer_like(expected) && self.value_is_known_integer_literal(&source) {
+            return self.error(span, format!("cannot alias integer literal as {expected}"));
+        }
         if !explicit_type_change && !raw_alias {
             return self.error(span, format!("cannot alias {} as {expected}", source.ty));
         }
@@ -4208,6 +4244,12 @@ handler Box(dst: out Operand, value: bool) {
         rejects_implicit_numeric_promotion,
         "handler Bad(value: u8) { let widened: u64 = value; dispatch_next; }",
         "cannot initialize 'widened' of type u64 with u8"
+    );
+
+    rejects!(
+        rejects_aliasing_integer_literals_to_pointer_types,
+        "handler Bad() { let raw: u64 = 1; let object: Object = alias(raw); dispatch_next; }",
+        "cannot alias integer literal as Object"
     );
 
     accepts!(

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -27,7 +27,7 @@ use intrinsic::{
     resolve_intrinsic,
     operation_signature, resolve_operation, signature, signatures_match,
 };
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 #[derive(Clone)]
 struct Symbol {
@@ -96,13 +96,13 @@ impl<'a> Checker<'a> {
             signatures,
             inline_function_ids,
             variables: Vec::new(),
-            scopes: vec![HashMap::new()],
+            scopes: vec![HashMap::default()],
             continuation_scopes: Vec::new(),
             next_continuation_scope: 0,
             statements: Vec::new(),
             layouts,
             aggregate_strides,
-            bytecode_fields: HashSet::new(),
+            bytecode_fields: HashSet::default(),
             active_value_tags: Vec::new(),
         }
     }
@@ -149,7 +149,7 @@ impl<'a> Checker<'a> {
     fn collect_continuations(&mut self, block: &ast::Block) -> Result<HashMap<String, ContinuationSymbol>, Diagnostic> {
         let scope_id = self.next_continuation_scope;
         self.next_continuation_scope += 1;
-        let mut continuations = HashMap::new();
+        let mut continuations = HashMap::default();
         for statement in &block.statements {
             if let StatementKind::Continuation {
                 name,
@@ -158,7 +158,7 @@ impl<'a> Checker<'a> {
                 ..
             } = &statement.kind
             {
-                let mut names = HashSet::new();
+                let mut names = HashSet::default();
                 let mut continuation_parameters = Vec::with_capacity(parameters.len());
                 for parameter in parameters {
                     if !names.insert(parameter.name.clone()) {
@@ -193,7 +193,7 @@ impl<'a> Checker<'a> {
 
     fn check_block(&mut self, block: &ast::Block, create_scope: bool) -> Result<(), Diagnostic> {
         if create_scope {
-            self.scopes.push(HashMap::new());
+            self.scopes.push(HashMap::default());
         }
         let continuations = self.collect_continuations(block)?;
         self.continuation_scopes.push(continuations);
@@ -208,7 +208,7 @@ impl<'a> Checker<'a> {
     }
 
     fn check_scoped_block(&mut self, block: &ast::Block) -> Result<Vec<Statement>, Diagnostic> {
-        self.scopes.push(HashMap::new());
+        self.scopes.push(HashMap::default());
         let start = self.statements.len();
         let result = self.check_block(block, false);
         let statements = self.statements.split_off(start);
@@ -342,7 +342,7 @@ impl<'a> Checker<'a> {
         block: &ast::Block,
         span: SourceSpan,
     ) -> Result<(Option<VariableId>, Vec<Statement>), Diagnostic> {
-        self.scopes.push(HashMap::new());
+        self.scopes.push(HashMap::default());
         let binding = binding
             .map(|binding| self.declare(binding, ty, None, span))
             .transpose()?;
@@ -362,7 +362,7 @@ impl<'a> Checker<'a> {
         expected: Option<&Type>,
         span: SourceSpan,
     ) -> Result<(Option<VariableId>, Vec<Statement>, Call), Diagnostic> {
-        self.scopes.push(HashMap::new());
+        self.scopes.push(HashMap::default());
         let binding = binding
             .map(|binding| self.declare(binding, binding_type, None, span))
             .transpose()?;
@@ -2138,7 +2138,7 @@ impl<'a> Checker<'a> {
             .value
             .as_ref()
             .expect("the parser requires a tail expression for value-producing blocks");
-        self.scopes.push(HashMap::new());
+        self.scopes.push(HashMap::default());
         let start = self.statements.len();
         self.check_block(block, false)?;
         let mut value = self.check_initializer_with_expected(value, expected)?;
@@ -2990,7 +2990,7 @@ fn ast_statement_is_terminal(statement: &ast::Statement, signatures: &HashMap<St
 }
 
 fn collect_signatures(filename: &str, program: &ast::Program) -> Result<HashMap<String, Signature>, Diagnostic> {
-    let mut signatures = HashMap::new();
+    let mut signatures = HashMap::default();
     for declaration in &program.declarations {
         let ast::Declaration::InlineFunction(declaration) = declaration else {
             continue;
@@ -3074,7 +3074,7 @@ fn check_body(
         bytecode_fields: if parameters_are_bytecode_fields {
             parameter_ids.iter().copied().collect()
         } else {
-            HashSet::new()
+            HashSet::default()
         },
     };
     check_definite_initialization(filename, &body, &parameter_ids, check_outputs)?;
@@ -3090,9 +3090,9 @@ pub(crate) fn check_with_layouts(
     program: &ast::Program,
     layout_fields: &[layout::Field],
 ) -> Result<Program, Diagnostic> {
-    let mut layouts = HashMap::new();
-    let mut aggregate_strides = HashMap::new();
-    let mut pairs = HashMap::new();
+    let mut layouts = HashMap::default();
+    let mut aggregate_strides = HashMap::default();
+    let mut pairs = HashMap::default();
     let mut next_pair_id = 0u32;
     for field in layout_fields {
         let owner = field.owner.clone();
@@ -3139,7 +3139,7 @@ pub(crate) fn check_with_layouts(
         .collect::<HashMap<_, _>>();
     let mut inline_functions = Vec::new();
     let mut handlers = Vec::new();
-    let mut declaration_names = HashSet::new();
+    let mut declaration_names = HashSet::default();
     for declaration in &program.declarations {
         match declaration {
             ast::Declaration::InlineFunction(declaration) => {

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -63,15 +63,15 @@ struct TypedElseContinuation {
 
 struct Checker<'a> {
     filename: &'a str,
-    signatures: HashMap<String, Signature>,
-    inline_function_ids: HashMap<String, InlineFunctionId>,
+    signatures: &'a HashMap<String, Signature>,
+    inline_function_ids: &'a HashMap<String, InlineFunctionId>,
     variables: Vec<Variable>,
     scopes: Vec<HashMap<String, Symbol>>,
     continuation_scopes: Vec<HashMap<String, ContinuationSymbol>>,
     next_continuation_scope: u64,
     statements: Vec<Statement>,
-    layouts: HashMap<(Type, String), LayoutField>,
-    aggregate_strides: HashMap<Type, layout::LayoutValue>,
+    layouts: &'a HashMap<(Type, String), LayoutField>,
+    aggregate_strides: &'a HashMap<Type, layout::LayoutValue>,
     bytecode_fields: HashSet<VariableId>,
     active_value_tags: Vec<(VariableId, VariableId)>,
 }
@@ -90,10 +90,10 @@ struct LayoutField {
 impl<'a> Checker<'a> {
     fn new(
         filename: &'a str,
-        signatures: HashMap<String, Signature>,
-        inline_function_ids: HashMap<String, InlineFunctionId>,
-        layouts: HashMap<(Type, String), LayoutField>,
-        aggregate_strides: HashMap<Type, layout::LayoutValue>,
+        signatures: &'a HashMap<String, Signature>,
+        inline_function_ids: &'a HashMap<String, InlineFunctionId>,
+        layouts: &'a HashMap<(Type, String), LayoutField>,
+        aggregate_strides: &'a HashMap<Type, layout::LayoutValue>,
     ) -> Self {
         Self {
             filename,
@@ -3260,13 +3260,7 @@ fn check_body(
     layouts: &HashMap<(Type, String), LayoutField>,
     aggregate_strides: &HashMap<Type, layout::LayoutValue>,
 ) -> Result<(Vec<VariableId>, Body), Diagnostic> {
-    let mut checker = Checker::new(
-        filename,
-        signatures.clone(),
-        inline_function_ids.clone(),
-        layouts.clone(),
-        aggregate_strides.clone(),
-    );
+    let mut checker = Checker::new(filename, signatures, inline_function_ids, layouts, aggregate_strides);
     let mut parameter_ids = Vec::new();
     for parameter in parameters {
         parameter_ids.push(checker.declare(

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -546,16 +546,18 @@ impl<'a> Checker<'a> {
         Ok(())
     }
 
-    fn check_if_statement(
-        &mut self,
-        statement: &ast::Statement,
-        name: &Option<String>,
-        ty: &Option<Type>,
-        condition: &ast::Expression,
-        temperature: &BlockTemperature,
-        then_body: &ast::Block,
-        else_body: &Option<ast::Block>,
-    ) -> Result<(), Diagnostic> {
+    fn check_if_statement(&mut self, statement: &ast::Statement) -> Result<(), Diagnostic> {
+        let ast::StatementKind::If {
+            name,
+            ty,
+            condition,
+            temperature,
+            then_body,
+            else_body,
+        } = &statement.kind
+        else {
+            unreachable!()
+        };
         let mut condition = self.check_condition(condition)?;
         let outer_variable_count = self.variables.len();
         let Some(else_body) = else_body else {
@@ -1233,14 +1235,7 @@ impl<'a> Checker<'a> {
                 let (_, _, body) = self.check_continuation_invocation(target, arguments, statement.span)?;
                 self.statements.extend(body);
             }
-            StatementKind::If {
-                name,
-                ty,
-                condition,
-                temperature,
-                then_body,
-                else_body,
-            } => self.check_if_statement(statement, name, ty, condition, temperature, then_body, else_body)?,
+            StatementKind::If { .. } => self.check_if_statement(statement)?,
             StatementKind::While {
                 condition,
                 body,

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -61,6 +61,12 @@ struct TypedElseContinuation {
     body: Vec<Statement>,
 }
 
+#[derive(Clone)]
+struct TypeFacts {
+    known_null_pointers: HashSet<VariableId>,
+    known_integer_literals: HashSet<VariableId>,
+}
+
 struct Checker<'a> {
     filename: &'a str,
     signatures: &'a HashMap<String, Signature>,
@@ -128,6 +134,18 @@ impl<'a> Checker<'a> {
 
     fn lookup(&self, name: &str) -> Option<&Symbol> {
         self.scopes.iter().rev().find_map(|scope| scope.get(name))
+    }
+
+    fn type_facts(&self) -> TypeFacts {
+        TypeFacts {
+            known_null_pointers: self.known_null_pointers.clone(),
+            known_integer_literals: self.known_integer_literals.clone(),
+        }
+    }
+
+    fn restore_type_facts(&mut self, facts: TypeFacts) {
+        self.known_null_pointers = facts.known_null_pointers;
+        self.known_integer_literals = facts.known_integer_literals;
     }
 
     fn declare(
@@ -222,11 +240,13 @@ impl<'a> Checker<'a> {
     }
 
     fn check_scoped_block(&mut self, block: &ast::Block) -> Result<Vec<Statement>, Diagnostic> {
+        let facts = self.type_facts();
         self.scopes.push(HashMap::default());
         let start = self.statements.len();
         let result = self.check_block(block, false);
         let statements = self.statements.split_off(start);
         self.scopes.pop();
+        self.restore_type_facts(facts);
         result?;
         Ok(statements)
     }
@@ -359,6 +379,7 @@ impl<'a> Checker<'a> {
         block: &ast::Block,
         span: SourceSpan,
     ) -> Result<(Option<VariableId>, Vec<Statement>), Diagnostic> {
+        let facts = self.type_facts();
         self.scopes.push(HashMap::default());
         let binding = binding
             .map(|binding| self.declare(binding, ty, None, span))
@@ -367,6 +388,7 @@ impl<'a> Checker<'a> {
         let result = self.check_block(block, false);
         let statements = self.statements.split_off(start);
         self.scopes.pop();
+        self.restore_type_facts(facts);
         result?;
         Ok((binding, statements))
     }
@@ -379,12 +401,14 @@ impl<'a> Checker<'a> {
         expected: Option<&Type>,
         span: SourceSpan,
     ) -> Result<(Option<VariableId>, Vec<Statement>, Call), Diagnostic> {
+        let facts = self.type_facts();
         self.scopes.push(HashMap::default());
         let binding = binding
             .map(|binding| self.declare(binding, binding_type, None, span))
             .transpose()?;
         let result = self.check_value_block(block, expected);
         self.scopes.pop();
+        self.restore_type_facts(facts);
         result.map(|(statements, value)| (binding, statements, value))
     }
 
@@ -2214,19 +2238,23 @@ impl<'a> Checker<'a> {
             .value
             .as_ref()
             .expect("the parser requires a tail expression for value-producing blocks");
+        let facts = self.type_facts();
         self.scopes.push(HashMap::default());
         let start = self.statements.len();
-        self.check_block(block, false)?;
-        let mut value = self.check_initializer_with_expected(value, expected)?;
-        if value.intrinsic() == Some(Intrinsic::LowLevel(LowLevelOperation::Move))
-            && value.return_type == Some(Type::BytecodeOffset)
-            && matches!(value.arguments[0].kind, ValueKind::Variable(source) if self.bytecode_fields.contains(&source))
-        {
-            value.target = CallTarget::Intrinsic(Intrinsic::LowLevel(LowLevelOperation::LoadLabel));
-        }
+        let result = self.check_block(block, false).and_then(|()| {
+            let mut value = self.check_initializer_with_expected(value, expected)?;
+            if value.intrinsic() == Some(Intrinsic::LowLevel(LowLevelOperation::Move))
+                && value.return_type == Some(Type::BytecodeOffset)
+                && matches!(value.arguments[0].kind, ValueKind::Variable(source) if self.bytecode_fields.contains(&source))
+            {
+                value.target = CallTarget::Intrinsic(Intrinsic::LowLevel(LowLevelOperation::LoadLabel));
+            }
+            Ok(value)
+        });
         let statements = self.statements.split_off(start);
         self.scopes.pop();
-        Ok((statements, value))
+        self.restore_type_facts(facts);
+        Ok((statements, result?))
     }
 
     fn check_condition(&mut self, expression: &ast::Expression) -> Result<Condition, Diagnostic> {
@@ -4173,6 +4201,60 @@ handler StoreNull(address: u64) {
     }
 
     #[test]
+    fn rejects_null_binding_store_after_conditional_assignment() {
+        let layouts =
+            crate::frontend::layout::LayoutDatabase::parse("const SHAPE = 0\nfield Object.shape Shape SHAPE nonnull\n")
+                .unwrap();
+        let ast = parser::parse(
+            "test.flap",
+            r#"
+handler StoreNull(address: u64, flag: u32) {
+    let object: Object = alias(address);
+    let shape: Shape = null;
+    if load(flag) == 0 {
+        shape = object.shape;
+    } else {
+    }
+    object.shape = shape;
+    dispatch_next;
+}
+"#,
+        )
+        .unwrap();
+        let error = check_with_layouts("test.flap", &ast, layouts.fields()).unwrap_err();
+
+        assert!(
+            error
+                .message
+                .contains("cannot assign null to non-null field 'Object.shape'"),
+            "{}",
+            error.message
+        );
+    }
+
+    #[test]
+    fn accepts_reassigned_null_binding_store_to_nonnull_field() {
+        let layouts =
+            crate::frontend::layout::LayoutDatabase::parse("const SHAPE = 0\nfield Object.shape Shape SHAPE nonnull\n")
+                .unwrap();
+        let ast = parser::parse(
+            "test.flap",
+            r#"
+handler StoreShape(address: u64) {
+    let object: Object = alias(address);
+    let shape: Shape = null;
+    shape = object.shape;
+    object.shape = shape;
+    dispatch_next;
+}
+"#,
+        )
+        .unwrap();
+
+        check_with_layouts("test.flap", &ast, layouts.fields()).unwrap();
+    }
+
+    #[test]
     fn does_not_apply_pointer_nonzero_checks_to_byte_fields() {
         let layouts = crate::frontend::layout::LayoutDatabase::parse(
             "const FLAG = 0\nfield ExecutionContext.flag bool FLAG nonnull\n",
@@ -4250,6 +4332,35 @@ handler Box(dst: out Operand, value: bool) {
         rejects_aliasing_integer_literals_to_pointer_types,
         "handler Bad() { let raw: u64 = 1; let object: Object = alias(raw); dispatch_next; }",
         "cannot alias integer literal as Object"
+    );
+
+    rejects!(
+        rejects_aliasing_conditionally_assigned_integer_literals_to_pointer_types,
+        r#"
+handler Bad(address: u64, flag: u32) {
+    let raw: u64 = 1;
+    if load(flag) == 0 {
+        raw = address;
+    } else {
+    }
+    let object: Object = alias(raw);
+    dispatch_next;
+}
+"#,
+        "cannot alias integer literal as Object"
+    );
+
+    accepts!(
+        accepts_aliasing_reassigned_integer_variables_to_pointer_types,
+        r#"
+handler Good(address: u64) {
+    let raw: u64 = 1;
+    raw = address;
+    let object: Object = alias(raw);
+    assert_nonzero(object);
+    dispatch_next;
+}
+"#
     );
 
     accepts!(

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -4235,6 +4235,22 @@ inline fn terminal(value: out Value, slow: SlowPath) {
     );
 
     accepts!(
+        permits_uninitialized_output_on_terminal_match_paths,
+        r#"
+inline fn terminal(value: out Value, input: Value, slow: SlowPath) {
+    match input {
+        Value<i32>(integer) => {
+            call_slow_path(slow);
+        },
+        _ => {
+            call_slow_path(slow);
+        },
+    }
+}
+"#
+    );
+
+    accepts!(
         treats_goto_handler_as_terminal_in_continuations,
         r#"
 handler Jump(target: BytecodeOffset) {

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -2989,12 +2989,191 @@ fn ast_statement_is_terminal(statement: &ast::Statement, signatures: &HashMap<St
     }
 }
 
+fn collect_inline_calls_from_expression(
+    expression: &ast::Expression,
+    inline_function_indices: &HashMap<String, usize>,
+    callees: &mut Vec<usize>,
+) {
+    match &expression.kind {
+        ExpressionKind::Call { callee, arguments } => {
+            if let Some(callee) = inline_function_indices.get(callee)
+                && !callees.contains(callee)
+            {
+                callees.push(*callee);
+            }
+            for argument in arguments {
+                collect_inline_calls_from_expression(argument, inline_function_indices, callees);
+            }
+        }
+        ExpressionKind::Unary { operand, .. } => {
+            collect_inline_calls_from_expression(operand, inline_function_indices, callees);
+        }
+        ExpressionKind::Binary { lhs, rhs, .. } => {
+            collect_inline_calls_from_expression(lhs, inline_function_indices, callees);
+            collect_inline_calls_from_expression(rhs, inline_function_indices, callees);
+        }
+        ExpressionKind::Index { base, index } => {
+            collect_inline_calls_from_expression(base, inline_function_indices, callees);
+            collect_inline_calls_from_expression(index, inline_function_indices, callees);
+        }
+        ExpressionKind::Memory(components) | ExpressionKind::Tuple(components) => {
+            for component in components {
+                collect_inline_calls_from_expression(component, inline_function_indices, callees);
+            }
+        }
+        ExpressionKind::Name(_) | ExpressionKind::Integer(_) => {}
+    }
+}
+
+fn collect_inline_calls_from_pattern(
+    pattern: &ast::Pattern,
+    inline_function_indices: &HashMap<String, usize>,
+    callees: &mut Vec<usize>,
+) {
+    match pattern {
+        ast::Pattern::Tuple(patterns) | ast::Pattern::Alternatives(patterns) => {
+            for pattern in patterns {
+                collect_inline_calls_from_pattern(pattern, inline_function_indices, callees);
+            }
+        }
+        ast::Pattern::Expression(expression) => {
+            collect_inline_calls_from_expression(expression, inline_function_indices, callees);
+        }
+        ast::Pattern::ValueRepresentation {
+            binding: Some(binding), ..
+        } => collect_inline_calls_from_pattern(binding, inline_function_indices, callees),
+        ast::Pattern::Binding { .. }
+        | ast::Pattern::Wildcard
+        | ast::Pattern::ValueRepresentation { binding: None, .. } => {}
+    }
+}
+
+fn collect_inline_calls_from_else_continuation(
+    continuation: &ast::ElseContinuation,
+    inline_function_indices: &HashMap<String, usize>,
+    callees: &mut Vec<usize>,
+) {
+    match continuation {
+        ast::ElseContinuation::Invocation { arguments, .. } => {
+            for argument in arguments {
+                collect_inline_calls_from_expression(argument, inline_function_indices, callees);
+            }
+        }
+        ast::ElseContinuation::Block { body, .. } => {
+            collect_inline_calls_from_block(body, inline_function_indices, callees);
+        }
+        ast::ElseContinuation::Label(_) => {}
+    }
+}
+
+fn collect_inline_calls_from_block(
+    block: &ast::Block,
+    inline_function_indices: &HashMap<String, usize>,
+    callees: &mut Vec<usize>,
+) {
+    for statement in &block.statements {
+        match &statement.kind {
+            ast::StatementKind::Let { pattern, initializer } => {
+                collect_inline_calls_from_pattern(pattern, inline_function_indices, callees);
+                if let Some(initializer) = initializer {
+                    collect_inline_calls_from_expression(initializer, inline_function_indices, callees);
+                }
+            }
+            ast::StatementKind::GuardLet {
+                pattern,
+                initializer,
+                failure,
+            } => {
+                collect_inline_calls_from_pattern(pattern, inline_function_indices, callees);
+                collect_inline_calls_from_expression(initializer, inline_function_indices, callees);
+                collect_inline_calls_from_else_continuation(failure, inline_function_indices, callees);
+            }
+            ast::StatementKind::FallibleCall {
+                callee,
+                arguments,
+                failure,
+            } => {
+                if let Some(callee) = inline_function_indices.get(callee)
+                    && !callees.contains(callee)
+                {
+                    callees.push(*callee);
+                }
+                for argument in arguments {
+                    collect_inline_calls_from_expression(argument, inline_function_indices, callees);
+                }
+                collect_inline_calls_from_else_continuation(failure, inline_function_indices, callees);
+            }
+            ast::StatementKind::Assign { initializer, .. } => {
+                collect_inline_calls_from_expression(initializer, inline_function_indices, callees);
+            }
+            ast::StatementKind::IndexAssign { base, index, value } => {
+                collect_inline_calls_from_expression(base, inline_function_indices, callees);
+                collect_inline_calls_from_expression(index, inline_function_indices, callees);
+                collect_inline_calls_from_expression(value, inline_function_indices, callees);
+            }
+            ast::StatementKind::Expression(expression) => {
+                collect_inline_calls_from_expression(expression, inline_function_indices, callees);
+            }
+            ast::StatementKind::ValueMatch {
+                value, arms, fallback, ..
+            } => {
+                collect_inline_calls_from_expression(value, inline_function_indices, callees);
+                for arm in arms {
+                    collect_inline_calls_from_block(&arm.body, inline_function_indices, callees);
+                }
+                collect_inline_calls_from_block(&fallback.body, inline_function_indices, callees);
+            }
+            ast::StatementKind::ScalarMatch { value, arms, fallback } => {
+                collect_inline_calls_from_expression(value, inline_function_indices, callees);
+                for arm in arms {
+                    collect_inline_calls_from_pattern(&arm.pattern, inline_function_indices, callees);
+                    collect_inline_calls_from_block(&arm.body, inline_function_indices, callees);
+                }
+                collect_inline_calls_from_block(fallback, inline_function_indices, callees);
+            }
+            ast::StatementKind::Guard { condition, failure } => {
+                collect_inline_calls_from_expression(condition, inline_function_indices, callees);
+                collect_inline_calls_from_else_continuation(failure, inline_function_indices, callees);
+            }
+            ast::StatementKind::Continuation { body, .. } => {
+                collect_inline_calls_from_block(body, inline_function_indices, callees);
+            }
+            ast::StatementKind::ContinuationJump { arguments, .. } => {
+                for argument in arguments {
+                    collect_inline_calls_from_expression(argument, inline_function_indices, callees);
+                }
+            }
+            ast::StatementKind::If {
+                condition,
+                then_body,
+                else_body,
+                ..
+            } => {
+                collect_inline_calls_from_expression(condition, inline_function_indices, callees);
+                collect_inline_calls_from_block(then_body, inline_function_indices, callees);
+                if let Some(else_body) = else_body {
+                    collect_inline_calls_from_block(else_body, inline_function_indices, callees);
+                }
+            }
+            ast::StatementKind::While { condition, body, .. } => {
+                collect_inline_calls_from_expression(condition, inline_function_indices, callees);
+                collect_inline_calls_from_block(body, inline_function_indices, callees);
+            }
+        }
+    }
+    if let Some(value) = &block.value {
+        collect_inline_calls_from_expression(value, inline_function_indices, callees);
+    }
+}
+
 fn collect_signatures(filename: &str, program: &ast::Program) -> Result<HashMap<String, Signature>, Diagnostic> {
     let mut signatures = HashMap::default();
+    let mut inline_functions = Vec::new();
     for declaration in &program.declarations {
         let ast::Declaration::InlineFunction(declaration) = declaration else {
             continue;
         };
+        inline_functions.push(declaration);
         let signature = Signature {
             parameters: declaration
                 .parameters
@@ -3013,24 +3192,57 @@ fn collect_signatures(filename: &str, program: &ast::Program) -> Result<HashMap<
             ));
         }
     }
-    loop {
-        let newly_terminal: Vec<_> = program
-            .declarations
-            .iter()
-            .filter_map(|declaration| {
-                let ast::Declaration::InlineFunction(declaration) = declaration else {
-                    return None;
-                };
-                (!signatures[&declaration.name].terminal
-                    && ast_block_is_terminal(&declaration.body, &signatures))
-                .then_some(declaration.name.clone())
-            })
-            .collect();
-        if newly_terminal.is_empty() {
-            break;
+
+    let inline_function_indices = inline_functions
+        .iter()
+        .enumerate()
+        .map(|(index, function)| (function.name.clone(), index))
+        .collect::<HashMap<_, _>>();
+    let callees = inline_functions
+        .iter()
+        .map(|function| {
+            let mut callees = Vec::new();
+            collect_inline_calls_from_block(&function.body, &inline_function_indices, &mut callees);
+            callees
+        })
+        .collect::<Vec<_>>();
+    let mut incoming_edge_counts = vec![0usize; inline_functions.len()];
+    for function_callees in &callees {
+        for callee in function_callees {
+            incoming_edge_counts[*callee] += 1;
         }
-        for name in newly_terminal {
-            signatures.get_mut(&name).unwrap().terminal = true;
+    }
+    let mut ready = incoming_edge_counts
+        .iter()
+        .enumerate()
+        .filter_map(|(index, count)| (*count == 0).then_some(index))
+        .collect::<Vec<_>>();
+    let mut topological_order = Vec::with_capacity(inline_functions.len());
+    while let Some(function) = ready.pop() {
+        topological_order.push(function);
+        for callee in &callees[function] {
+            incoming_edge_counts[*callee] -= 1;
+            if incoming_edge_counts[*callee] == 0 {
+                ready.push(*callee);
+            }
+        }
+    }
+    if topological_order.len() != inline_functions.len() {
+        let function = incoming_edge_counts.iter().position(|count| *count != 0).unwrap();
+        return Err(Diagnostic::new(
+            filename,
+            inline_functions[function].span,
+            format!(
+                "recursive inline function cycle involving '{}'",
+                inline_functions[function].name
+            ),
+        ));
+    }
+
+    for function in topological_order.into_iter().rev() {
+        let function = inline_functions[function];
+        if ast_block_is_terminal(&function.body, &signatures) {
+            signatures.get_mut(&function.name).unwrap().terminal = true;
         }
     }
     Ok(signatures)
@@ -4083,6 +4295,30 @@ handler Jump(target: Label) {
     goto finish;
 }
 "#
+    );
+
+    rejects!(
+        rejects_directly_recursive_inline_functions,
+        r#"
+inline fn recurse(value: i32) -> i32 {
+    recurse(value)
+}
+"#,
+        "recursive inline function cycle involving 'recurse'"
+    );
+
+    rejects!(
+        rejects_mutually_recursive_inline_functions,
+        r#"
+inline fn first(value: i32) -> i32 {
+    second(value)
+}
+
+inline fn second(value: i32) -> i32 {
+    first(value)
+}
+"#,
+        "recursive inline function cycle involving"
     );
 
     #[test]

--- a/Libraries/LibJS/Flap/src/hir/mod.rs
+++ b/Libraries/LibJS/Flap/src/hir/mod.rs
@@ -73,6 +73,7 @@ struct Checker<'a> {
     layouts: &'a HashMap<(Type, String), LayoutField>,
     aggregate_strides: &'a HashMap<Type, layout::LayoutValue>,
     bytecode_fields: HashSet<VariableId>,
+    known_null_pointers: HashSet<VariableId>,
     active_value_tags: Vec<(VariableId, VariableId)>,
 }
 
@@ -107,6 +108,7 @@ impl<'a> Checker<'a> {
             layouts,
             aggregate_strides,
             bytecode_fields: HashSet::default(),
+            known_null_pointers: HashSet::default(),
             active_value_tags: Vec::new(),
         }
     }
@@ -826,6 +828,7 @@ impl<'a> Checker<'a> {
                 format!("cannot assign {return_type} to '{name}' of type {}", symbol.ty),
             );
         }
+        self.update_known_null_pointer(symbol.id, initializer, &symbol.ty);
         self.statements
             .push(Statement::new(StatementKindIr::call([symbol.id], call), statement.span));
         Ok(())
@@ -1050,7 +1053,9 @@ impl<'a> Checker<'a> {
                     ),
                 );
             }
-            let id = self.declare(name, ty.clone().unwrap_or(return_type), None, statement.span)?;
+            let declared_type = ty.clone().unwrap_or(return_type);
+            let id = self.declare(name, declared_type.clone(), None, statement.span)?;
+            self.update_known_null_pointer(id, initializer, &declared_type);
             self.statements
                 .push(Statement::new(StatementKindIr::call([id], call), statement.span));
         } else {
@@ -1573,7 +1578,7 @@ impl<'a> Checker<'a> {
         if field.embedded {
             return self.error(span, format!("cannot assign embedded field '{}.{field_name}'", base.ty));
         }
-        if field.nonnull && matches!(&initializer.kind, ExpressionKind::Name(name) if name == "null") {
+        if field.nonnull && self.initializer_is_known_null_pointer(initializer, &field.ty) {
             return self.error(
                 initializer.span,
                 format!("cannot assign null to non-null field '{}.{field_name}'", base.ty),
@@ -1667,6 +1672,25 @@ impl<'a> Checker<'a> {
         ))
     }
 
+    fn update_known_null_pointer(&mut self, variable: VariableId, initializer: &ast::Expression, ty: &Type) {
+        if self.initializer_is_known_null_pointer(initializer, ty) {
+            self.known_null_pointers.insert(variable);
+        } else {
+            self.known_null_pointers.remove(&variable);
+        }
+    }
+
+    fn initializer_is_known_null_pointer(&self, initializer: &ast::Expression, ty: &Type) -> bool {
+        let ExpressionKind::Name(name) = &initializer.kind else {
+            return false;
+        };
+        if name == "null" {
+            return is_pointer_like(ty);
+        }
+        self.lookup(name)
+            .is_some_and(|symbol| symbol.ty == *ty && self.known_null_pointers.contains(&symbol.id))
+    }
+
     fn check_initializer(&mut self, expression: &ast::Expression) -> Result<Call, Diagnostic> {
         self.check_initializer_with_expected(expression, None)
     }
@@ -1706,6 +1730,17 @@ impl<'a> Checker<'a> {
                             vec![Value::new(constant_value_kind(constant), Type::Value, expression.span)],
                             vec![ParameterMode::In],
                             Some(Type::Value),
+                        ));
+                    }
+                    if name == "null"
+                        && let Some(expected) = expected
+                        && is_pointer_like(expected)
+                    {
+                        return Ok(Call::new(
+                            CallTarget::Intrinsic(Intrinsic::LowLevel(LowLevelOperation::Move)),
+                            vec![Value::new(ValueKind::Integer(0), expected.clone(), expression.span)],
+                            vec![ParameterMode::In],
+                            Some(expected.clone()),
                         ));
                     }
                     if let Some(expected) = expected
@@ -4071,6 +4106,34 @@ handler Initialize(address: u64) {
         .unwrap();
 
         check_with_layouts("test.flap", &ast, layouts.fields()).unwrap();
+    }
+
+    #[test]
+    fn rejects_definitely_null_binding_store_to_nonnull_field() {
+        let layouts =
+            crate::frontend::layout::LayoutDatabase::parse("const SHAPE = 0\nfield Object.shape Shape SHAPE nonnull\n")
+                .unwrap();
+        let ast = parser::parse(
+            "test.flap",
+            r#"
+handler StoreNull(address: u64) {
+    let object: Object = alias(address);
+    let shape: Shape = null;
+    object.shape = shape;
+    dispatch_next;
+}
+"#,
+        )
+        .unwrap();
+        let error = check_with_layouts("test.flap", &ast, layouts.fields()).unwrap_err();
+
+        assert!(
+            error
+                .message
+                .contains("cannot assign null to non-null field 'Object.shape'"),
+            "{}",
+            error.message
+        );
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/intrinsic.rs
+++ b/Libraries/LibJS/Flap/src/intrinsic.rs
@@ -164,10 +164,7 @@ impl IntrinsicEffects {
     };
 
     pub(crate) fn can_be_eliminated(self) -> bool {
-        !self.memory.writes()
-            && !self.machine_state.writes()
-            && !self.may_call
-            && !self.may_trap
+        !self.memory.writes() && !self.machine_state.writes() && !self.may_call && !self.may_trap
     }
 }
 
@@ -224,7 +221,10 @@ impl FieldAccessKind {
 
     pub(crate) fn memory_operation(self) -> MemoryOperation {
         match self {
-            Self::Load { width: FieldWidth::U64, nonzero: true } => MemoryOperation::Load64NonZero,
+            Self::Load {
+                width: FieldWidth::U64,
+                nonzero: true,
+            } => MemoryOperation::Load64NonZero,
             Self::Load { width, .. } => MemoryOperation::Load {
                 width: width.into(),
                 signed: false,
@@ -235,8 +235,13 @@ impl FieldAccessKind {
 
     pub(crate) fn paired_operation(self) -> Option<MemoryOperation> {
         match self {
-            Self::Load { width: FieldWidth::U64, .. } => Some(MemoryOperation::LoadPair(PairWidth::DoubleWord)),
-            Self::Load { width: FieldWidth::U32, nonzero: false } => Some(MemoryOperation::LoadPair(PairWidth::Word)),
+            Self::Load {
+                width: FieldWidth::U64, ..
+            } => Some(MemoryOperation::LoadPair(PairWidth::DoubleWord)),
+            Self::Load {
+                width: FieldWidth::U32,
+                nonzero: false,
+            } => Some(MemoryOperation::LoadPair(PairWidth::Word)),
             Self::Store(FieldWidth::U64) => Some(MemoryOperation::StorePair(PairWidth::DoubleWord)),
             Self::Store(FieldWidth::U32) => Some(MemoryOperation::StorePair(PairWidth::Word)),
             _ => None,
@@ -480,16 +485,42 @@ impl BranchOperation {
             ComparisonRelation::GreaterOrEqual => ComparisonRelation::Less,
         };
         Some(match self {
-            Self::Equality { width, condition } => Self::Equality { width, condition: condition.inverted() },
-            Self::Ordered { width, relation, signedness } => Self::Ordered { width, relation: ordered(relation), signedness },
-            Self::Zero { width, condition } => Self::Zero { width, condition: condition.inverted() },
-            Self::Sign { width, condition } => Self::Sign { width, condition: condition.inverted() },
-            Self::Bits { width, condition } => Self::Bits { width, condition: condition.inverted() },
+            Self::Equality { width, condition } => Self::Equality {
+                width,
+                condition: condition.inverted(),
+            },
+            Self::Ordered {
+                width,
+                relation,
+                signedness,
+            } => Self::Ordered {
+                width,
+                relation: ordered(relation),
+                signedness,
+            },
+            Self::Zero { width, condition } => Self::Zero {
+                width,
+                condition: condition.inverted(),
+            },
+            Self::Sign { width, condition } => Self::Sign {
+                width,
+                condition: condition.inverted(),
+            },
+            Self::Bits { width, condition } => Self::Bits {
+                width,
+                condition: condition.inverted(),
+            },
             Self::Bit(condition) => Self::Bit(condition.inverted()),
             Self::Tag(condition) => Self::Tag(condition.inverted()),
             Self::Singleton(condition) => Self::Singleton(condition.inverted()),
-            Self::Memory { width, condition } => Self::Memory { width, condition: condition.inverted() },
-            Self::ValueBitsNegative => Self::Sign { width: IntegerWidth::U64, condition: SignCondition::NotNegative },
+            Self::Memory { width, condition } => Self::Memory {
+                width,
+                condition: condition.inverted(),
+            },
+            Self::ValueBitsNegative => Self::Sign {
+                width: IntegerWidth::U64,
+                condition: SignCondition::NotNegative,
+            },
             Self::Float(_) | Self::AnyEqual => return None,
         })
     }
@@ -531,8 +562,7 @@ impl ValueOperation {
     pub(crate) fn is_rematerialized(self) -> bool {
         matches!(
             self,
-            Self::UnboxInt32 { rematerialized: true }
-                | Self::ExtractTag { rematerialized: true }
+            Self::UnboxInt32 { rematerialized: true } | Self::ExtractTag { rematerialized: true }
         )
     }
 }
@@ -750,9 +780,7 @@ impl OperandOperation {
     pub(crate) fn reads_machine_state(self) -> bool {
         matches!(
             self,
-            Self::Load(OperandLoad::Field) | Self::LoadPair
-                | Self::Store(OperandStore::Field)
-                | Self::Copy
+            Self::Load(OperandLoad::Field) | Self::LoadPair | Self::Store(OperandStore::Field) | Self::Copy
         )
     }
 }
@@ -805,8 +833,7 @@ impl ControlOperation {
     pub(crate) fn writes_machine_state(self) -> bool {
         matches!(
             self,
-            Self::DispatchNext | Self::DispatchVariable | Self::GotoHandler
-                | Self::Exit | Self::JumpBytecode
+            Self::DispatchNext | Self::DispatchVariable | Self::GotoHandler | Self::Exit | Self::JumpBytecode
         )
     }
 
@@ -817,10 +844,7 @@ impl ControlOperation {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum MemoryOperation {
-    Load {
-        width: MemoryWidth,
-        signed: bool,
-    },
+    Load { width: MemoryWidth, signed: bool },
     Load64NonZero,
     Store(MemoryWidth),
     LoadPair(PairWidth),
@@ -869,15 +893,17 @@ impl MemoryOperation {
         match self {
             Self::Load { width, .. } | Self::Store(width) => width,
             Self::Load64NonZero => MemoryWidth::DoubleWord,
-            Self::LoadPair(PairWidth::Word)
-            | Self::StorePair(PairWidth::Word) => MemoryWidth::Word,
-            Self::LoadPair(PairWidth::DoubleWord)
-            | Self::StorePair(PairWidth::DoubleWord) => MemoryWidth::DoubleWord,
+            Self::LoadPair(PairWidth::Word) | Self::StorePair(PairWidth::Word) => MemoryWidth::Word,
+            Self::LoadPair(PairWidth::DoubleWord) | Self::StorePair(PairWidth::DoubleWord) => MemoryWidth::DoubleWord,
         }
     }
 
     pub(crate) fn address_count(self) -> usize {
-        if matches!(self, Self::LoadPair(_) | Self::StorePair(_)) { 2 } else { 1 }
+        if matches!(self, Self::LoadPair(_) | Self::StorePair(_)) {
+            2
+        } else {
+            1
+        }
     }
 
     pub(crate) fn writes(self) -> bool {
@@ -1015,10 +1041,7 @@ impl Intrinsic {
             },
             Self::Bytecode(operation) => IntrinsicEffects {
                 memory: ModRef::Read,
-                machine_state: if matches!(
-                    operation,
-                    BytecodeOperation::Load(FieldWidth::U8 | FieldWidth::U32)
-                ) {
+                machine_state: if matches!(operation, BytecodeOperation::Load(FieldWidth::U8 | FieldWidth::U32)) {
                     ModRef::Read
                 } else {
                     ModRef::None
@@ -1056,9 +1079,9 @@ impl Intrinsic {
             },
             Self::LowLevel(
                 LowLevelOperation::LoadLabel
-                    | LowLevelOperation::LoadEffectiveAddress
-                    | LowLevelOperation::Add
-                    | LowLevelOperation::Subtract,
+                | LowLevelOperation::LoadEffectiveAddress
+                | LowLevelOperation::Add
+                | LowLevelOperation::Subtract,
             )
             | Self::Branch(_) => IntrinsicEffects::UNKNOWN,
             Self::Address(_)
@@ -1103,9 +1126,7 @@ mod tests {
             ModRef::Write
         );
         assert_eq!(
-            Intrinsic::LowLevel(LowLevelOperation::LoadVm)
-                .effects()
-                .machine_state,
+            Intrinsic::LowLevel(LowLevelOperation::LoadVm).effects().machine_state,
             ModRef::Read
         );
         assert!(Intrinsic::Assertion(AssertionOperation::NonZero).effects().may_trap);
@@ -1153,12 +1174,7 @@ mod tests {
 
         assert!(Intrinsic::from_name("to_f64").unwrap().call_signature(1).is_some());
         assert!(Intrinsic::from_name("to_f64").unwrap().call_signature(2).is_none());
-        assert!(
-            Intrinsic::from_name("call_interp")
-                .unwrap()
-                .call_signature(1)
-                .is_some()
-        );
+        assert!(Intrinsic::from_name("call_interp").unwrap().call_signature(1).is_some());
         assert!(Intrinsic::from_name("call_interp_result").is_none());
         assert!(Intrinsic::from_name("xor_integer").is_none());
     }

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -78,12 +78,18 @@ pub struct OptimizationReportOptions {
     pub dump_changed_ir: bool,
 }
 
+/// One named in-memory compiler input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SourceInput<'a> {
+    pub name: &'a str,
+    pub contents: &'a str,
+}
+
 /// In-memory source inputs for one Flap compilation.
 pub struct CompilationUnit<'a> {
-    pub source_name: &'a str,
-    pub source: &'a str,
-    pub constants: Option<&'a str>,
-    pub bytecode_def: Option<&'a str>,
+    pub source: SourceInput<'a>,
+    pub constants: Option<SourceInput<'a>>,
+    pub bytecode_def: Option<SourceInput<'a>>,
 }
 
 #[derive(Clone)]
@@ -166,26 +172,50 @@ impl CompileError {
         }
     }
 
-    fn from_layout_error(error: LayoutError) -> Self {
-        let location = SourceLocation {
-            offset: 0,
-            line: error.line,
-            column: 1,
+    fn from_layout_error(source: SourceInput<'_>, error: LayoutError) -> Self {
+        let location = (error.line != 0).then(|| {
+            let offset = source
+                .contents
+                .split_inclusive('\n')
+                .take(error.line.saturating_sub(1))
+                .map(str::len)
+                .sum::<usize>();
+            let line = source.contents[offset..].lines().next().unwrap_or_default();
+            let indentation = line.len() - line.trim_start().len();
+            SourceLocation {
+                offset: offset + indentation,
+                line: error.line,
+                column: indentation + 1,
+            }
+        });
+        let message = if let Some(location) = location {
+            format!(
+                "{}:{}:{}: error: {}",
+                source.name, location.line, location.column, error.message
+            )
+        } else {
+            format!("{}: error: {}", source.name, error.message)
         };
         Self {
             stage: CompileStage::Layout,
             handler: None,
-            span: Some(SourceSpan {
+            span: location.map(|location| SourceSpan {
                 start: location,
                 end: location,
             }),
-            message: error.to_string(),
+            message,
         }
     }
 
-    fn from_bytecode_def_error(error: bytecode_def::ParseError) -> Self {
+    fn from_bytecode_def_error(source: SourceInput<'_>, error: bytecode_def::ParseError) -> Self {
+        let line_offset = source
+            .contents
+            .split_inclusive('\n')
+            .take(error.line.saturating_sub(1))
+            .map(str::len)
+            .sum::<usize>();
         let location = SourceLocation {
-            offset: 0,
+            offset: line_offset + error.column.saturating_sub(1),
             line: error.line,
             column: error.column,
         };
@@ -252,16 +282,17 @@ impl Compiler {
     ) -> Result<(PreparedProgram, Option<OptimizationReport>), CompileError> {
         let layouts = unit
             .constants
-            .map(LayoutDatabase::parse)
-            .transpose()
-            .map_err(CompileError::from_layout_error)?;
+            .map(|source| {
+                LayoutDatabase::parse(source.contents).map_err(|error| CompileError::from_layout_error(source, error))
+            })
+            .transpose()?;
 
-        let ast = frontend::parser::parse(unit.source_name, unit.source)
+        let ast = frontend::parser::parse(unit.source.name, unit.source.contents)
             .map_err(|diagnostic| CompileError::from_diagnostic(CompileStage::Parse, diagnostic))?;
         let typed_program = if let Some(layouts) = &layouts {
-            hir::check_with_layouts(unit.source_name, &ast, layouts.fields())
+            hir::check_with_layouts(unit.source.name, &ast, layouts.fields())
         } else {
-            hir::check(unit.source_name, &ast)
+            hir::check(unit.source.name, &ast)
         }
         .map_err(|diagnostic| CompileError::from_diagnostic(CompileStage::Semantic, diagnostic))?;
 
@@ -323,8 +354,8 @@ impl Compiler {
             .map(|handler| (handler.name(), handler.id))
             .collect::<HashMap<_, _>>();
         let (op_layouts, dispatch_handlers) = if let Some(bytecode_def) = unit.bytecode_def {
-            let ops = bytecode_def::parse_bytecode_def("Bytecode.def", bytecode_def)
-                .map_err(CompileError::from_bytecode_def_error)?;
+            let ops = bytecode_def::parse_bytecode_def(bytecode_def.name, bytecode_def.contents)
+                .map_err(|error| CompileError::from_bytecode_def_error(bytecode_def, error))?;
             // The interpreter dispatches on a single opcode byte, so a table beyond 256 entries
             // would have unreachable handlers.
             if ops.len() > DISPATCH_TABLE_SIZE {
@@ -488,10 +519,18 @@ const CANON_NAN_BITS = 0x7FF8000000000000
 
     fn unit(bytecode_def: &'static str) -> CompilationUnit<'static> {
         CompilationUnit {
-            source_name: "test.flap",
-            source: "handler Nop() { dispatch_next; }",
-            constants: Some(REQUIRED_LAYOUT),
-            bytecode_def: Some(bytecode_def),
+            source: SourceInput {
+                name: "test.flap",
+                contents: "handler Nop() { dispatch_next; }",
+            },
+            constants: Some(SourceInput {
+                name: "layout.conf",
+                contents: REQUIRED_LAYOUT,
+            }),
+            bytecode_def: Some(SourceInput {
+                name: "TestBytecode.def",
+                contents: bytecode_def,
+            }),
         }
     }
 
@@ -584,8 +623,10 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         let compiler = compiler(Architecture::X86_64);
         let parse_error = compiler
             .prepare(CompilationUnit {
-                source_name: "bad.flap",
-                source: "handler Broken(",
+                source: SourceInput {
+                    name: "bad.flap",
+                    contents: "handler Broken(",
+                },
                 constants: None,
                 bytecode_def: None,
             })
@@ -597,9 +638,14 @@ const CANON_NAN_BITS = 0x7FF8000000000000
 
         let layout_error = compiler
             .prepare(CompilationUnit {
-                source_name: "test.flap",
-                source: "handler Nop() { dispatch_next; }",
-                constants: Some("field Object.shape Shape MISSING nullable\n"),
+                source: SourceInput {
+                    name: "test.flap",
+                    contents: "handler Nop() { dispatch_next; }",
+                },
+                constants: Some(SourceInput {
+                    name: "broken-layout.conf",
+                    contents: "field Object.shape Shape MISSING nullable\n",
+                }),
                 bytecode_def: None,
             })
             .err()
@@ -607,32 +653,44 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         assert_eq!(layout_error.stage, CompileStage::Layout);
         assert_eq!(layout_error.span.unwrap().start.line, 1);
         assert!(layout_error.message.contains("undefined layout value"));
+        assert!(layout_error.message.contains("broken-layout.conf:1:1"));
 
         let bytecode_error = compiler
             .prepare(CompilationUnit {
-                source_name: "test.flap",
-                source: "handler Nop() { dispatch_next; }",
+                source: SourceInput {
+                    name: "test.flap",
+                    contents: "handler Nop() { dispatch_next; }",
+                },
                 constants: None,
-                bytecode_def: Some("op Nop\n    malformed\nendop\n"),
+                bytecode_def: Some(SourceInput {
+                    name: "BrokenBytecode.def",
+                    contents: "op Nop\n    malformed\nendop\n",
+                }),
             })
             .err()
             .expect("invalid bytecode definition should fail");
         assert_eq!(bytecode_error.stage, CompileStage::Parse);
         let span = bytecode_error.span.unwrap();
+        assert_eq!(span.start.offset, 11);
         assert_eq!(span.start.line, 2);
         assert_eq!(span.start.column, 5);
         assert!(
             bytecode_error
                 .message
-                .contains("Bytecode.def:2:5: error: malformed field line")
+                .contains("BrokenBytecode.def:2:5: error: malformed field line")
         );
 
         let emission_error = compiler
             .compile(CompilationUnit {
-                source_name: "test.flap",
-                source: "handler Nop() { dispatch_next; }",
+                source: SourceInput {
+                    name: "test.flap",
+                    contents: "handler Nop() { dispatch_next; }",
+                },
                 constants: None,
-                bytecode_def: Some("op Nop < Instruction\nendop\n"),
+                bytecode_def: Some(SourceInput {
+                    name: "TestBytecode.def",
+                    contents: "op Nop < Instruction\nendop\n",
+                }),
             })
             .expect_err("missing runtime metadata should fail");
         assert_eq!(emission_error.stage, CompileStage::Emission);

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -40,6 +40,7 @@ use frontend::layout::{LayoutConstants, LayoutDatabase, LayoutError};
 use identity::HandlerId;
 use std::error::Error;
 use std::fmt;
+use std::time::{Duration, Instant};
 use target::emitter::DISPATCH_TABLE_SIZE;
 use types::BlockTemperature;
 
@@ -100,6 +101,31 @@ pub struct CompilationUnit<'a> {
     pub source: SourceInput<'a>,
     pub constants: Option<SourceInput<'a>>,
     pub bytecode_def: Option<SourceInput<'a>>,
+}
+
+/// Timing and IR size measurements collected by an instrumented compilation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompilationMetrics {
+    pub prepare: Duration,
+    pub lower: Duration,
+    pub select: Duration,
+    pub allocate: Duration,
+    pub finalize: Duration,
+    pub emit: Duration,
+    pub handlers: usize,
+    pub ssa_blocks: usize,
+    pub ssa_instructions: usize,
+    pub ssa_values: usize,
+    pub low_ir_instructions: usize,
+    pub target_instructions: usize,
+    pub virtual_registers: usize,
+    pub machine_instructions: usize,
+}
+
+impl CompilationMetrics {
+    pub fn elapsed(&self) -> Duration {
+        self.prepare + self.lower + self.select + self.allocate + self.finalize + self.emit
+    }
 }
 
 #[derive(Clone)]
@@ -268,6 +294,91 @@ impl Compiler {
     pub fn compile(&self, unit: CompilationUnit<'_>) -> Result<Assembly, CompileError> {
         let prepared = self.prepare(unit)?;
         self.compile_prepared(&prepared)
+    }
+
+    /// Compile while collecting stage timings and IR size measurements.
+    ///
+    /// The regular compilation entry points do not collect these metrics and
+    /// therefore do not pay for timers or IR traversal.
+    pub fn compile_with_metrics(
+        &self,
+        unit: CompilationUnit<'_>,
+    ) -> Result<(Assembly, CompilationMetrics), CompileError> {
+        let started_at = Instant::now();
+        let prepared = self.prepare(unit)?;
+        let prepare = started_at.elapsed();
+        let handlers = prepared.handlers.len();
+        let ssa_blocks = prepared
+            .handlers
+            .iter()
+            .map(|handler| handler.function.blocks.len())
+            .sum();
+        let ssa_instructions = prepared
+            .handlers
+            .iter()
+            .map(|handler| handler.function.instructions.len())
+            .sum();
+        let ssa_values = prepared
+            .handlers
+            .iter()
+            .map(|handler| handler.function.values.len())
+            .sum();
+
+        let started_at = Instant::now();
+        let program = self.lower(&prepared)?;
+        let lower = started_at.elapsed();
+        let low_ir_instructions = program.handlers.iter().map(|handler| handler.instructions.len()).sum();
+
+        let started_at = Instant::now();
+        let selected = self.select(program)?;
+        let select = started_at.elapsed();
+        let target_instructions = selected
+            .functions
+            .iter()
+            .map(|function| function.instructions.len())
+            .sum();
+        let virtual_registers = selected
+            .functions
+            .iter()
+            .map(|function| function.virtual_registers.len())
+            .sum();
+
+        let started_at = Instant::now();
+        let allocated = self.allocate(selected)?;
+        let allocate = started_at.elapsed();
+
+        let started_at = Instant::now();
+        let machine = self.finalize(allocated)?;
+        let finalize = started_at.elapsed();
+        let machine_instructions = machine
+            .functions
+            .iter()
+            .map(|function| function.hot_instructions.len() + function.cold_instructions.len())
+            .sum();
+
+        let started_at = Instant::now();
+        let assembly = self.emit_program(&machine)?;
+        let emit = started_at.elapsed();
+
+        Ok((
+            assembly,
+            CompilationMetrics {
+                prepare,
+                lower,
+                select,
+                allocate,
+                finalize,
+                emit,
+                handlers,
+                ssa_blocks,
+                ssa_instructions,
+                ssa_values,
+                low_ir_instructions,
+                target_instructions,
+                virtual_registers,
+                machine_instructions,
+            },
+        ))
     }
 
     /// Parse, type-check, inline, and optimize all reusable handler templates.
@@ -554,6 +665,26 @@ const CANON_NAN_BITS = 0x7FF8000000000000
             assert!(assembly.as_str().contains("js_interpreter"));
             assert!(assembly.as_str().contains("handler_Nop"));
         }
+    }
+
+    #[test]
+    fn reports_compilation_metrics() {
+        let compiler = compiler(Architecture::X86_64);
+        let (assembly, metrics) = compiler
+            .compile_with_metrics(unit("op Nop < Instruction\nendop\n"))
+            .expect("instrumented compilation should succeed");
+
+        assert!(assembly.as_str().contains("handler_Nop"));
+        assert_eq!(metrics.handlers, 1);
+        assert!(metrics.ssa_blocks != 0);
+        assert!(metrics.ssa_instructions != 0);
+        assert!(metrics.low_ir_instructions != 0);
+        assert!(metrics.target_instructions != 0);
+        assert!(metrics.machine_instructions != 0);
+        assert_eq!(
+            metrics.elapsed(),
+            metrics.prepare + metrics.lower + metrics.select + metrics.allocate + metrics.finalize + metrics.emit
+        );
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -13,8 +13,8 @@
 //! system and command-line adapter.
 
 pub(crate) mod bytecode;
-pub(crate) mod hash;
 pub(crate) mod frontend;
+pub(crate) mod hash;
 pub(crate) mod hir;
 pub(crate) mod identity;
 pub(crate) mod intrinsic;
@@ -23,11 +23,11 @@ pub(crate) mod ssa;
 pub(crate) mod target;
 pub(crate) mod types;
 
+use crate::hash::HashMap;
 use bytecode::HandlerLayout as BytecodeHandlerLayout;
 use frontend::diagnostic::{Diagnostic, SourceLocation};
 use frontend::layout::{LayoutConstants, LayoutDatabase, LayoutError};
 use identity::HandlerId;
-use crate::hash::HashMap;
 use std::error::Error;
 use std::fmt;
 use target::emitter::DISPATCH_TABLE_SIZE;
@@ -36,9 +36,7 @@ use types::BlockTemperature;
 pub use frontend::diagnostic::SourceSpan;
 pub use low_ir::Program as LowProgram;
 pub use ssa::report::OptimizationReport;
-pub use target::ir::{
-    AllocatedProgram, MachineProgram, Program as TargetProgram,
-};
+pub use target::ir::{AllocatedProgram, MachineProgram, Program as TargetProgram};
 
 /// A machine architecture supported by Flap's textual assembly backends.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -121,7 +119,6 @@ impl Assembly {
     pub fn as_str(&self) -> &str {
         &self.text
     }
-
 }
 
 /// A diagnostic produced by one of the compiler stages.
@@ -148,11 +145,7 @@ pub struct CompileError {
 }
 
 impl CompileError {
-    pub(crate) fn new(
-        stage: CompileStage,
-        handler: Option<&str>,
-        message: impl Into<String>,
-    ) -> Self {
+    pub(crate) fn new(stage: CompileStage, handler: Option<&str>, message: impl Into<String>) -> Self {
         Self {
             stage,
             handler: handler.map(str::to_string),
@@ -252,9 +245,7 @@ impl Compiler {
         }
         .map_err(|diagnostic| CompileError::from_diagnostic(CompileStage::Semantic, diagnostic))?;
 
-        let constants = layouts
-            .map(LayoutDatabase::into_constants)
-            .unwrap_or_default();
+        let constants = layouts.map(LayoutDatabase::into_constants).unwrap_or_default();
 
         let ssa_inline_functions = typed_program
             .inline_functions
@@ -304,10 +295,7 @@ impl Compiler {
         };
 
         for handler in &mut handlers {
-            ssa::optimize::resolve_layout_constants(
-                &mut handler.function,
-                &constants,
-            )?;
+            ssa::optimize::resolve_layout_constants(&mut handler.function, &constants)?;
         }
 
         let handler_ids = handlers
@@ -342,9 +330,7 @@ impl Compiler {
             .map(|handler| {
                 BytecodeHandlerLayout::new(
                     &handler.function.parameter_names,
-                    op_layouts
-                        .as_ref()
-                        .and_then(|layouts| layouts.get(handler.name())),
+                    op_layouts.as_ref().and_then(|layouts| layouts.get(handler.name())),
                 )
             })
             .collect();
@@ -365,8 +351,7 @@ impl Compiler {
     /// Lower every prepared handler template to target-independent LowIR.
     pub fn lower(&self, prepared: &PreparedProgram) -> Result<LowProgram, CompileError> {
         let mut program = LowProgram::new();
-        program.runtime =
-            low_ir::RuntimeConstants::from_layout(&prepared.constants);
+        program.runtime = low_ir::RuntimeConstants::from_layout(&prepared.constants);
         program.dispatch_handlers = prepared.bytecode.dispatch_handlers.clone();
 
         for template in &prepared.handlers {
@@ -378,8 +363,7 @@ impl Compiler {
             )?;
             low_ir::lowering::materialize_bytecode_layout(
                 &mut handler,
-                &prepared.bytecode.handler_layouts
-                    [template.id.index()],
+                &prepared.bytecode.handler_layouts[template.id.index()],
             )?;
             program.handlers.push(handler);
         }
@@ -393,10 +377,7 @@ impl Compiler {
     }
 
     /// Assign physical registers to a selected target program.
-    pub fn allocate(
-        &self,
-        program: TargetProgram,
-    ) -> Result<AllocatedProgram, CompileError> {
+    pub fn allocate(&self, program: TargetProgram) -> Result<AllocatedProgram, CompileError> {
         if program.architecture != self.architecture() {
             return Err(CompileError::new(
                 CompileStage::Allocation,
@@ -497,8 +478,8 @@ const CANON_NAN_BITS = 0x7FF8000000000000
     fn compiles_from_in_memory_sources_for_each_target() {
         for architecture in [Architecture::X86_64, Architecture::Aarch64] {
             let assembly = compiler(architecture)
-            .compile(unit("op Nop\nendop\n"))
-            .expect("in-memory compilation should succeed");
+                .compile(unit("op Nop\nendop\n"))
+                .expect("in-memory compilation should succeed");
 
             assert!(assembly.as_str().contains("js_interpreter"));
             assert!(assembly.as_str().contains("handler_Nop"));
@@ -509,7 +490,9 @@ const CANON_NAN_BITS = 0x7FF8000000000000
     fn exposes_reusable_compiler_stages() {
         let compiler = compiler(Architecture::X86_64);
 
-        let prepared = compiler.prepare(unit("op Nop\nendop\n")).expect("preparation should succeed");
+        let prepared = compiler
+            .prepare(unit("op Nop\nendop\n"))
+            .expect("preparation should succeed");
         let program = compiler.lower(&prepared).expect("machine lowering should succeed");
         let selected = compiler.select(program).expect("selection should succeed");
         assert_eq!(selected.architecture(), Architecture::X86_64);
@@ -517,23 +500,23 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         let machine = compiler.finalize(allocated).expect("finalization should succeed");
         assert_eq!(machine.architecture(), Architecture::X86_64);
         let staged = compiler.emit_program(&machine).expect("emission should succeed");
-        assert_eq!(staged, compiler.emit_program(&machine).expect("re-emission should succeed"));
-        let one_shot = compiler.compile(unit("op Nop\nendop\n")).expect("one-shot compilation should succeed");
+        assert_eq!(
+            staged,
+            compiler.emit_program(&machine).expect("re-emission should succeed")
+        );
+        let one_shot = compiler
+            .compile(unit("op Nop\nendop\n"))
+            .expect("one-shot compilation should succeed");
         assert_eq!(staged, one_shot);
     }
 
     #[test]
     fn resolves_bytecode_dispatch_to_handler_identities() {
         let compiler = compiler(Architecture::X86_64);
-        let prepared = compiler
-            .prepare(unit("op Nop\nendop\nop Missing\nendop\n"))
-            .unwrap();
+        let prepared = compiler.prepare(unit("op Nop\nendop\nop Missing\nendop\n")).unwrap();
         let handler_id = prepared.handlers[0].id;
 
-        assert_eq!(
-            prepared.bytecode.dispatch_handlers,
-            [Some(handler_id), None]
-        );
+        assert_eq!(prepared.bytecode.dispatch_handlers, [Some(handler_id), None]);
         let lowered = compiler.lower(&prepared).unwrap();
         assert_eq!(lowered.handlers[0].id, handler_id);
         assert_eq!(lowered.dispatch_handlers, [Some(handler_id), None]);

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -25,7 +25,7 @@ pub(crate) mod types;
 
 use crate::hash::HashMap;
 use bytecode::HandlerLayout as BytecodeHandlerLayout;
-use frontend::diagnostic::{Diagnostic, SourceLocation};
+use frontend::diagnostic::Diagnostic;
 use frontend::layout::{LayoutConstants, LayoutDatabase, LayoutError};
 use identity::HandlerId;
 use std::error::Error;
@@ -33,9 +33,12 @@ use std::fmt;
 use target::emitter::DISPATCH_TABLE_SIZE;
 use types::BlockTemperature;
 
-pub use frontend::diagnostic::SourceSpan;
+pub use frontend::diagnostic::{SourceLocation, SourceSpan};
 pub use low_ir::Program as LowProgram;
-pub use ssa::report::OptimizationReport;
+pub use ssa::report::{
+    FixedPointOptimizationReport, FunctionOptimizationReport, OptimizationRecord, OptimizationRemark,
+    OptimizationRemarkKind, OptimizationReport, PassRunReport,
+};
 pub use target::ir::{AllocatedProgram, MachineProgram, Program as TargetProgram};
 
 /// A machine architecture supported by Flap's textual assembly backends.
@@ -558,6 +561,19 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         assert_eq!(report.pipeline, "aot-prepare");
         assert_eq!(report.functions.len(), 1);
         assert_eq!(report.functions[0].function, "Nop");
+        assert!(report.functions[0].records.iter().any(|record| {
+            matches!(
+                record,
+                OptimizationRecord::Pass(pass) if pass.name == "sparse-conditional-constant-propagation"
+            )
+        }));
+        assert!(report.functions[0].records.iter().any(|record| {
+            matches!(
+                record,
+                OptimizationRecord::FixedPoint(fixed_point)
+                    if fixed_point.name == "block-parameter-cleanup" && fixed_point.converged
+            )
+        }));
         let report = report.to_string();
         assert!(report.contains("pass sparse-conditional-constant-propagation"));
         assert!(report.contains("fixed-point block-parameter-cleanup: iterations=1/2 converged"));

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -179,6 +179,23 @@ impl CompileError {
             message: error.to_string(),
         }
     }
+
+    fn from_bytecode_def_error(error: bytecode_def::ParseError) -> Self {
+        let location = SourceLocation {
+            offset: 0,
+            line: error.line,
+            column: error.column,
+        };
+        Self {
+            stage: CompileStage::Parse,
+            handler: None,
+            span: Some(SourceSpan {
+                start: location,
+                end: location,
+            }),
+            message: error.to_string(),
+        }
+    }
 }
 
 impl fmt::Display for CompileError {
@@ -303,7 +320,8 @@ impl Compiler {
             .map(|handler| (handler.name(), handler.id))
             .collect::<HashMap<_, _>>();
         let (op_layouts, dispatch_handlers) = if let Some(bytecode_def) = unit.bytecode_def {
-            let ops = bytecode_def::parse_bytecode_def(bytecode_def);
+            let ops = bytecode_def::parse_bytecode_def("Bytecode.def", bytecode_def)
+                .map_err(CompileError::from_bytecode_def_error)?;
             // The interpreter dispatches on a single opcode byte, so a table beyond 256 entries
             // would have unreachable handlers.
             if ops.len() > DISPATCH_TABLE_SIZE {
@@ -571,6 +589,25 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         assert_eq!(layout_error.stage, CompileStage::Layout);
         assert_eq!(layout_error.span.unwrap().start.line, 1);
         assert!(layout_error.message.contains("undefined layout value"));
+
+        let bytecode_error = compiler
+            .prepare(CompilationUnit {
+                source_name: "test.flap",
+                source: "handler Nop() { dispatch_next; }",
+                constants: None,
+                bytecode_def: Some("op Nop\n    malformed\nendop\n"),
+            })
+            .err()
+            .expect("invalid bytecode definition should fail");
+        assert_eq!(bytecode_error.stage, CompileStage::Parse);
+        let span = bytecode_error.span.unwrap();
+        assert_eq!(span.start.line, 2);
+        assert_eq!(span.start.column, 5);
+        assert!(
+            bytecode_error
+                .message
+                .contains("Bytecode.def:2:5: error: malformed field line")
+        );
 
         let emission_error = compiler
             .compile(CompilationUnit {

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -11,6 +11,16 @@
 //! allocation, and target-specific assembly emission. The compiler operates
 //! entirely on in-memory inputs and outputs; the `flapc` binary is only a file
 //! system and command-line adapter.
+//!
+//! # Security and resource contract
+//!
+//! Flap is an internal compiler for trusted, generated build inputs. Its parser
+//! and optimization pipeline do not impose general-purpose nesting, value,
+//! block, or diagnostic budgets, and its internal string tables use a
+//! deterministic non-cryptographic hasher. Do not expose this API directly to
+//! attacker-controlled source. A service accepting untrusted Flap programs
+//! must enforce input and resource limits before compilation and replace or
+//! isolate the deterministic source-key tables.
 
 pub(crate) mod bytecode;
 pub(crate) mod frontend;

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -496,7 +496,7 @@ const CANON_NAN_BITS = 0x7FF8000000000000
     fn compiles_from_in_memory_sources_for_each_target() {
         for architecture in [Architecture::X86_64, Architecture::Aarch64] {
             let assembly = compiler(architecture)
-                .compile(unit("op Nop\nendop\n"))
+                .compile(unit("op Nop < Instruction\nendop\n"))
                 .expect("in-memory compilation should succeed");
 
             assert!(assembly.as_str().contains("js_interpreter"));
@@ -509,7 +509,7 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         let compiler = compiler(Architecture::X86_64);
 
         let prepared = compiler
-            .prepare(unit("op Nop\nendop\n"))
+            .prepare(unit("op Nop < Instruction\nendop\n"))
             .expect("preparation should succeed");
         let program = compiler.lower(&prepared).expect("machine lowering should succeed");
         let selected = compiler.select(program).expect("selection should succeed");
@@ -523,7 +523,7 @@ const CANON_NAN_BITS = 0x7FF8000000000000
             compiler.emit_program(&machine).expect("re-emission should succeed")
         );
         let one_shot = compiler
-            .compile(unit("op Nop\nendop\n"))
+            .compile(unit("op Nop < Instruction\nendop\n"))
             .expect("one-shot compilation should succeed");
         assert_eq!(staged, one_shot);
     }
@@ -531,7 +531,9 @@ const CANON_NAN_BITS = 0x7FF8000000000000
     #[test]
     fn resolves_bytecode_dispatch_to_handler_identities() {
         let compiler = compiler(Architecture::X86_64);
-        let prepared = compiler.prepare(unit("op Nop\nendop\nop Missing\nendop\n")).unwrap();
+        let prepared = compiler
+            .prepare(unit("op Nop < Instruction\nendop\nop Missing < Instruction\nendop\n"))
+            .unwrap();
         let handler_id = prepared.handlers[0].id;
 
         assert_eq!(prepared.bytecode.dispatch_handlers, [Some(handler_id), None]);
@@ -545,7 +547,7 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         let compiler = compiler(Architecture::X86_64);
         let (_, report) = compiler
             .prepare_with_optimization_report(
-                unit("op Nop\nendop\n"),
+                unit("op Nop < Instruction\nendop\n"),
                 OptimizationReportOptions {
                     include_remarks: true,
                     dump_changed_ir: true,
@@ -614,7 +616,7 @@ const CANON_NAN_BITS = 0x7FF8000000000000
                 source_name: "test.flap",
                 source: "handler Nop() { dispatch_next; }",
                 constants: None,
-                bytecode_def: Some("op Nop\nendop\n"),
+                bytecode_def: Some("op Nop < Instruction\nendop\n"),
             })
             .expect_err("missing runtime metadata should fail");
         assert_eq!(emission_error.stage, CompileStage::Emission);

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -474,7 +474,7 @@ impl Compiler {
             .iter()
             .map(|handler| (handler.name(), handler.id))
             .collect::<HashMap<_, _>>();
-        let (op_layouts, dispatch_handlers) = if let Some(bytecode_def) = unit.bytecode_def {
+        let (ops, dispatch_handlers) = if let Some(bytecode_def) = unit.bytecode_def {
             let ops = bytecode_def::parse_bytecode_def(bytecode_def.name, bytecode_def.contents)
                 .map_err(|error| CompileError::from_bytecode_def_error(bytecode_def, error))?;
             // The interpreter dispatches on a single opcode byte, so a table beyond 256 entries
@@ -489,24 +489,30 @@ impl Compiler {
                     ),
                 ));
             }
-            (
-                Some(bytecode_def::compute_layouts(&ops)),
-                ops.iter()
-                    .map(|op| handler_ids.get(op.name.as_str()).copied())
-                    .collect(),
-            )
+            let dispatch_handlers = ops
+                .iter()
+                .map(|op| handler_ids.get(op.name.as_str()).copied())
+                .collect();
+            (Some(ops), dispatch_handlers)
         } else {
             (None, Vec::new())
         };
+        let ops_by_name = ops
+            .as_ref()
+            .map(|ops| ops.iter().map(|op| (op.name.as_str(), op)).collect::<HashMap<_, _>>())
+            .unwrap_or_default();
         let handler_layouts = handlers
             .iter()
             .map(|handler| {
                 BytecodeHandlerLayout::new(
+                    handler.name(),
                     &handler.function.parameter_names,
-                    op_layouts.as_ref().and_then(|layouts| layouts.get(handler.name())),
+                    &handler.function.parameter_types,
+                    ops_by_name.get(handler.name()).copied(),
                 )
+                .map_err(|message| CompileError::new(CompileStage::Semantic, Some(handler.name()), message))
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok((
             PreparedProgram {
@@ -723,6 +729,30 @@ const CANON_NAN_BITS = 0x7FF8000000000000
         let lowered = compiler.lower(&prepared).unwrap();
         assert_eq!(lowered.handlers[0].id, handler_id);
         assert_eq!(lowered.dispatch_handlers, [Some(handler_id), None]);
+    }
+
+    #[test]
+    fn rejects_handler_parameter_type_mismatches_against_bytecode_fields() {
+        let compiler = compiler(Architecture::X86_64);
+        let error = compiler
+            .prepare(CompilationUnit {
+                source: SourceInput {
+                    name: "test.flap",
+                    contents: "handler Test(lhs: u64) { let value = load(lhs); dispatch_variable(value); }",
+                },
+                constants: None,
+                bytecode_def: Some(SourceInput {
+                    name: "TestBytecode.def",
+                    contents: "op Test < Instruction\n    m_lhs: Operand\nendop\n",
+                }),
+            })
+            .err()
+            .expect("handler parameter type mismatch should fail");
+
+        assert_eq!(error.stage, CompileStage::Semantic);
+        assert_eq!(error.handler.as_deref(), Some("Test"));
+        assert!(error.message.contains("handler parameter 'm_lhs' has type u64"));
+        assert!(error.message.contains("bytecode field 'Test.m_lhs' has type Operand"));
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/lib.rs
+++ b/Libraries/LibJS/Flap/src/lib.rs
@@ -13,6 +13,7 @@
 //! system and command-line adapter.
 
 pub(crate) mod bytecode;
+pub(crate) mod hash;
 pub(crate) mod frontend;
 pub(crate) mod hir;
 pub(crate) mod identity;
@@ -26,7 +27,7 @@ use bytecode::HandlerLayout as BytecodeHandlerLayout;
 use frontend::diagnostic::{Diagnostic, SourceLocation};
 use frontend::layout::{LayoutConstants, LayoutDatabase, LayoutError};
 use identity::HandlerId;
-use std::collections::HashMap;
+use crate::hash::HashMap;
 use std::error::Error;
 use std::fmt;
 use target::emitter::DISPATCH_TABLE_SIZE;

--- a/Libraries/LibJS/Flap/src/low_ir/analysis.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/analysis.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Shared machine-instruction use and definition classification.
+
+use super::{ControlFlowOpcode, Instruction, Operand, VirtualRegister, visit_virtual_registers};
+use crate::Architecture;
+use crate::target::description::OperandKind;
+
+#[derive(Debug, Default)]
+pub(crate) struct VirtualRegisterAccess {
+    pub(crate) reads: Vec<VirtualRegister>,
+    pub(crate) definitions: Vec<VirtualRegister>,
+}
+
+impl VirtualRegisterAccess {
+    fn read(&mut self, register: &VirtualRegister) {
+        if !self.reads.contains(register) {
+            self.reads.push(register.clone());
+        }
+    }
+
+    fn define(&mut self, register: &VirtualRegister) {
+        if !self.definitions.contains(register) {
+            self.definitions.push(register.clone());
+        }
+    }
+}
+
+pub(crate) fn virtual_register_access(
+    instruction: &Instruction<Operand, impl ControlFlowOpcode>,
+    architecture: Option<Architecture>,
+) -> VirtualRegisterAccess {
+    let mut access = VirtualRegisterAccess::default();
+    let description = instruction.opcode.description();
+    let zeroes_register = description.zeroes_if_inputs_alias
+        && instruction.operands.len() >= 2
+        && instruction.operands[0] == instruction.operands[1];
+
+    for (position, operand) in instruction.operands.iter().enumerate() {
+        if position < 2 && zeroes_register {
+            if position == 0
+                && let Operand::VirtualRegister(register) = operand
+            {
+                access.define(register);
+            }
+            continue;
+        }
+        let kind = architecture.map_or_else(
+            || description.operand_kind(position, instruction.operands.len()),
+            |architecture| description.selected_operand_kind(position, instruction.operands.len(), architecture),
+        );
+        let Some(kind) = kind else {
+            continue;
+        };
+        let reads = matches!(
+            kind,
+            OperandKind::GprIn
+                | OperandKind::GprInOut
+                | OperandKind::FprIn
+                | OperandKind::FprInOut
+                | OperandKind::RegisterIn
+                | OperandKind::GprInOrImm
+                | OperandKind::GprInOrMemory
+                | OperandKind::Memory
+        );
+        let defines = matches!(
+            kind,
+            OperandKind::GprOut
+                | OperandKind::GprInOut
+                | OperandKind::GprScratch
+                | OperandKind::FprOut
+                | OperandKind::FprInOut
+                | OperandKind::FprScratch
+                | OperandKind::RegisterOut
+        );
+        if reads {
+            visit_virtual_registers(operand, &mut |register| access.read(register));
+        }
+        if defines && let Operand::VirtualRegister(register) = operand {
+            access.define(register);
+        }
+    }
+    access
+}

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -46,6 +46,8 @@ struct LinearizationPlan<O, C> {
     referenced_labels: HashSet<Label>,
 }
 
+type InstructionList<O, C> = Vec<Instruction<O, C>>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct ControlFlowGraph<O = Operand, C = Operation> {
     blocks: Vec<BasicBlock<O, C>>,
@@ -359,8 +361,8 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         loop {
             let mut removed_any = false;
             let mut previous: Option<usize> = None;
-            for index in 0..self.blocks.len() {
-                if removed[index] {
+            for (index, is_removed) in removed.iter_mut().enumerate() {
+                if *is_removed {
                     continue;
                 }
                 let removable = (|| {
@@ -386,7 +388,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                     previous = Some(index);
                     continue;
                 }
-                removed[index] = true;
+                *is_removed = true;
                 removed_any = true;
                 for label in block_label_references(std::slice::from_ref(&self.blocks[index])) {
                     if let Some(count) = references.get_mut(label) {
@@ -436,7 +438,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
     pub(crate) fn linearize_hot_and_cold(
         mut self,
         layout: &BlockLayout,
-    ) -> (Vec<Instruction<O, C>>, Vec<Instruction<O, C>>) {
+    ) -> (InstructionList<O, C>, InstructionList<O, C>) {
         let referenced_anywhere = self.explicitly_referenced_labels();
         let hot = self.plan_linearization(&layout.hot, &referenced_anywhere);
         let cold = self.plan_linearization(&layout.cold, &referenced_anywhere);
@@ -713,11 +715,9 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 .collect::<Vec<_>>()
         };
 
-        for block_index in 0..self.blocks.len() {
-            let (branch_targets, terminal) = edges[block_index].clone();
-
-            let has_fallthrough = !terminal && block_index + 1 < self.blocks.len();
-            let block = &mut self.blocks[block_index];
+        let block_count = self.blocks.len();
+        for (block_index, (block, (branch_targets, terminal))) in self.blocks.iter_mut().zip(edges).enumerate() {
+            let has_fallthrough = !terminal && block_index + 1 < block_count;
             block.successors.clear();
             block.successors.extend(branch_targets.into_iter().map(|target| Edge {
                 target,

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use super::{
-    ControlFlowOpcode, ControlFlowOperand, Instruction, Label, Operand,
-};
-use crate::target::description::{ControlOperation, Operation};
+use super::{ControlFlowOpcode, ControlFlowOperand, Instruction, Label, Operand};
 #[cfg(test)]
 use crate::target::description::{CallKind, EqualityCondition, IntegerWidth, PairWidth, ZeroCondition};
+use crate::target::description::{ControlOperation, Operation};
 use crate::hash::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -40,9 +38,23 @@ pub(crate) struct BlockLayout {
     pub(crate) cold: Vec<BlockId>,
 }
 
+/// What laying a set of blocks out in a given order does to them.
+struct LinearizationPlan<O, C> {
+    inverted_branches: HashMap<BlockId, (usize, Instruction<O, C>)>,
+    skipped_blocks: HashSet<BlockId>,
+    omitted_jumps: HashSet<BlockId>,
+    referenced_labels: HashSet<Label>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ControlFlowGraph<O = Operand, C = Operation> {
     blocks: Vec<BasicBlock<O, C>>,
+}
+
+impl<O, C> Default for ControlFlowGraph<O, C> {
+    fn default() -> Self {
+        Self { blocks: Vec::new() }
+    }
 }
 
 #[cfg(test)]
@@ -70,7 +82,8 @@ fn block_label_references<O: ControlFlowOperand, C: ControlFlowOpcode>(
 ///
 /// Register allocation runs before any graph edit and only needs to know where
 /// control can go next. Building a whole control-flow graph to answer that
-/// copies every instruction into a block and then copies them all back out.
+/// copies every instruction into a block and then copies them all back out,
+/// which on a large function is the largest single cost of allocating it.
 pub(crate) fn instruction_successors<O: ControlFlowOperand, C: ControlFlowOpcode>(
     instructions: &[&Instruction<O, C>],
 ) -> Vec<Vec<usize>> {
@@ -119,10 +132,11 @@ pub(crate) fn instruction_successors<O: ControlFlowOperand, C: ControlFlowOpcode
 }
 
 impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
-    pub(crate) fn from_instructions(
-        instructions: Vec<Instruction<O, C>>,
-    ) -> Result<Self, String> {
+    pub(crate) fn from_instructions(instructions: Vec<Instruction<O, C>>) -> Result<Self, String> {
         let cold_labels = collect_cold_labels(&instructions)?;
+        // Dropping the cold annotations in place, rather than collecting the
+        // rest into a second vector, saves moving every instruction of the
+        // function an extra time.
         let mut instructions = instructions;
         instructions.retain(|instruction| instruction.opcode.operation() != Operation::Cold);
         if instructions.is_empty() {
@@ -329,12 +343,18 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         // How many times each label is branched to, rather than the set of
         // labels that are. Removing a block drops exactly the references its
         // own instructions made, so the tally is adjusted instead of being
-        // rebuilt after each block removal.
+        // rebuilt, which on a large program means not cloning every label
+        // in the function once per block removed.
         let mut references: HashMap<Label, usize> = HashMap::default();
         for label in block_label_references(&self.blocks) {
             *references.entry(label.clone()).or_default() += 1;
         }
 
+        // Sweeping forward removes the same blocks in the same order as
+        // restarting the search after each removal would, and a removal can
+        // only ever make another block removable, so repeating until a sweep
+        // finds nothing reaches the same fixpoint without rescanning the
+        // function once per block removed.
         let mut removed = vec![false; self.blocks.len()];
         loop {
             let mut removed_any = false;
@@ -408,10 +428,35 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         self.rebuild_successors();
     }
 
-    pub(crate) fn linearize_omitting_jumps_to_next_block(
+    /// Lay the graph out hot part first, taking ownership of its instructions.
+    ///
+    /// Finalization is the last thing to read the graph, so the instructions
+    /// are moved out rather than copied. Both parts are planned before either
+    /// is emitted, since planning reads blocks the other part will take.
+    pub(crate) fn linearize_hot_and_cold(
+        mut self,
+        layout: &BlockLayout,
+    ) -> (Vec<Instruction<O, C>>, Vec<Instruction<O, C>>) {
+        let referenced_anywhere = self.explicitly_referenced_labels();
+        let hot = self.plan_linearization(&layout.hot, &referenced_anywhere);
+        let cold = self.plan_linearization(&layout.cold, &referenced_anywhere);
+        let hot = self.take_linearized(&layout.hot, &hot);
+        let cold = self.take_linearized(&layout.cold, &cold);
+        (hot, cold)
+    }
+
+    /// Every label some instruction branches to, wherever it sits.
+    fn explicitly_referenced_labels(&self) -> HashSet<Label> {
+        block_label_references(&self.blocks).cloned().collect()
+    }
+
+    /// Work out which blocks are skipped, which jumps are omitted and which
+    /// branches are inverted when these blocks are laid out in this order.
+    fn plan_linearization(
         &self,
         blocks: &[BlockId],
-    ) -> Vec<Instruction<O, C>> {
+        explicitly_referenced_labels: &HashSet<Label>,
+    ) -> LinearizationPlan<O, C> {
         let inverted_branches = blocks
             .iter()
             .enumerate()
@@ -438,15 +483,6 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 Some((block_id, (2, branch)))
             })
             .collect::<HashMap<_, _>>();
-        let explicitly_referenced_labels = self
-            .blocks
-            .iter()
-            .flat_map(|block| &block.instructions)
-            .filter(|instruction| instruction.opcode.operation() != Operation::Label)
-            .flat_map(|instruction| &instruction.operands)
-            .filter_map(ControlFlowOperand::label)
-            .cloned()
-            .collect::<HashSet<_>>();
         let mut inverted_branches = inverted_branches;
         let mut skipped_blocks = HashSet::default();
         for blocks in blocks.windows(3) {
@@ -477,8 +513,10 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             let jump = match fallthrough.instructions.as_slice() {
                 [jump] => jump,
                 [label, jump]
-                    if defined_label(label)
-                        .is_some_and(|label| !explicitly_referenced_labels.contains(label)) => jump,
+                    if defined_label(label).is_some_and(|label| !explicitly_referenced_labels.contains(label)) =>
+                {
+                    jump
+                }
                 _ => continue,
             };
             let Some(jump_target) = (jump.opcode.operation() == Operation::Control(ControlOperation::JumpLabel))
@@ -498,19 +536,25 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             .enumerate()
             .filter_map(|(index, &block_id)| {
                 let block = &self.blocks[block_id.0];
-                blocks.get(index + 1).is_some_and(|&next_block_id| {
-                    let Some(last) = block.instructions.last() else {
-                        return false;
-                    };
-                    let Some(target) = (last.opcode.operation() == Operation::Control(ControlOperation::JumpLabel)).then(|| sole_label_operand(last)).flatten() else {
-                        return false;
-                    };
-                    self.blocks[next_block_id.0]
-                        .instructions
-                        .first()
-                        .and_then(defined_label)
-                        .is_some_and(|label| label == target)
-                }).then_some(block_id)
+                blocks
+                    .get(index + 1)
+                    .is_some_and(|&next_block_id| {
+                        let Some(last) = block.instructions.last() else {
+                            return false;
+                        };
+                        let Some(target) = (last.opcode.operation() == Operation::Control(ControlOperation::JumpLabel))
+                            .then(|| sole_label_operand(last))
+                            .flatten()
+                        else {
+                            return false;
+                        };
+                        self.blocks[next_block_id.0]
+                            .instructions
+                            .first()
+                            .and_then(defined_label)
+                            .is_some_and(|label| label == target)
+                    })
+                    .then_some(block_id)
             })
             .filter(|block| !inverted_branches.contains_key(block))
             .filter(|block| !skipped_blocks.contains(block))
@@ -536,34 +580,63 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 }
             }
             if let Some((_, branch)) = inverted_branches.get(&block_id) {
-                referenced_labels.extend(
-                    branch
-                        .operands
-                        .iter()
-                        .filter_map(ControlFlowOperand::label)
-                        .cloned(),
-                );
+                referenced_labels.extend(branch.operands.iter().filter_map(ControlFlowOperand::label).cloned());
             }
         }
+        LinearizationPlan {
+            inverted_branches,
+            skipped_blocks,
+            omitted_jumps,
+            referenced_labels,
+        }
+    }
+
+    /// How many instructions of a block survive its plan.
+    fn planned_length(&self, block: BlockId, plan: &LinearizationPlan<O, C>) -> usize {
+        self.blocks[block.0].instructions.len()
+            - usize::from(plan.omitted_jumps.contains(&block))
+            - plan.inverted_branches.get(&block).map_or(0, |(removed, _)| *removed)
+    }
+
+    /// Emit the planned instructions, moving them out of the graph.
+    fn take_linearized(&mut self, blocks: &[BlockId], plan: &LinearizationPlan<O, C>) -> Vec<Instruction<O, C>> {
         let mut instructions = Vec::new();
         for &block_id in blocks {
-            if skipped_blocks.contains(&block_id) {
+            if plan.skipped_blocks.contains(&block_id) {
+                continue;
+            }
+            let end = self.planned_length(block_id, plan);
+            let mut block = std::mem::take(&mut self.blocks[block_id.0].instructions);
+            block.truncate(end);
+            instructions.extend(block.into_iter().filter(|instruction| {
+                defined_label(instruction).is_none_or(|label| plan.referenced_labels.contains(label))
+            }));
+            if let Some((_, branch)) = plan.inverted_branches.get(&block_id) {
+                instructions.push(branch.clone());
+            }
+        }
+        instructions
+    }
+
+    pub(crate) fn linearize_omitting_jumps_to_next_block(&self, blocks: &[BlockId]) -> Vec<Instruction<O, C>> {
+        let plan = self.plan_linearization(blocks, &self.explicitly_referenced_labels());
+        let mut instructions = Vec::new();
+        for &block_id in blocks {
+            if plan.skipped_blocks.contains(&block_id) {
                 continue;
             }
             let block = &self.blocks[block_id.0];
-            let end = block.instructions.len()
-                - usize::from(omitted_jumps.contains(&block_id))
-                - inverted_branches.get(&block_id).map_or(0, |(removed, _)| *removed);
+            let end = self.planned_length(block_id, &plan);
             instructions.extend(
                 block.instructions[..end]
                     .iter()
                     .filter(|instruction| {
                         defined_label(instruction)
-                            .is_none_or(|label| referenced_labels.contains(label))
+                            .is_none_or(|label| plan.referenced_labels.contains(label))
                     })
                     .cloned(),
             );
-            if let Some((_, branch)) = inverted_branches.get(&block_id) {
+            if let Some((_, branch)) = plan.inverted_branches.get(&block_id) {
                 instructions.push(branch.clone());
             }
         }
@@ -661,18 +734,14 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
     }
 }
 
-fn defined_label<O: ControlFlowOperand, C: ControlFlowOpcode>(
-    instruction: &Instruction<O, C>,
-) -> Option<&Label> {
+fn defined_label<O: ControlFlowOperand, C: ControlFlowOpcode>(instruction: &Instruction<O, C>) -> Option<&Label> {
     if instruction.opcode.operation() != Operation::Label {
         return None;
     }
     sole_label_operand(instruction)
 }
 
-fn sole_label_operand<O: ControlFlowOperand, C>(
-    instruction: &Instruction<O, C>,
-) -> Option<&Label> {
+fn sole_label_operand<O: ControlFlowOperand, C>(instruction: &Instruction<O, C>) -> Option<&Label> {
     let [operand] = instruction.operands.as_slice() else {
         return None;
     };
@@ -693,15 +762,10 @@ fn collect_cold_labels<O: ControlFlowOperand, C: ControlFlowOpcode>(
         .collect()
 }
 
-fn instruction_ends_block<O: ControlFlowOperand, C: ControlFlowOpcode>(
-    instruction: &Instruction<O, C>,
-) -> bool {
+fn instruction_ends_block<O: ControlFlowOperand, C: ControlFlowOpcode>(instruction: &Instruction<O, C>) -> bool {
     instruction.opcode.description().terminal
         || (instruction.opcode.operation() != Operation::Label
-            && instruction
-                .operands
-                .iter()
-                .any(|operand| operand.label().is_some()))
+            && instruction.operands.iter().any(|operand| operand.label().is_some()))
 }
 
 #[cfg(test)]
@@ -744,8 +808,7 @@ mod tests {
 
     #[test]
     fn supports_operand_specific_control_flow_graphs() {
-        let graph: ControlFlowGraph<TestOperand> =
-            ControlFlowGraph::from_instructions(vec![Instruction {
+        let graph: ControlFlowGraph<TestOperand> = ControlFlowGraph::from_instructions(vec![Instruction {
             opcode: Operation::Label,
             operands: vec![TestOperand::Label(".entry".into())],
         }])
@@ -757,7 +820,10 @@ mod tests {
     #[test]
     fn builds_basic_blocks_and_successor_edges() {
         let graph = ControlFlowGraph::from_instructions(vec![
-            instruction(Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero), vec![Operand::VirtualRegister("value".into()), label(".zero")]),
+            instruction(
+                Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero),
+                vec![Operand::VirtualRegister("value".into()), label(".zero")],
+            ),
             instruction(Operation::Control(ControlOperation::DispatchNext), vec![]),
             instruction(Operation::Label, vec![label(".zero")]),
             instruction(Operation::Control(ControlOperation::JumpLabel), vec![label(".done")]),
@@ -800,15 +866,19 @@ mod tests {
     #[test]
     fn outlines_cold_blocks_without_changing_block_contents() {
         let graph = ControlFlowGraph::from_instructions(vec![
-            instruction(Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero), vec![Operand::VirtualRegister("value".into()), label(".slow")]),
+            instruction(
+                Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero),
+                vec![Operand::VirtualRegister("value".into()), label(".slow")],
+            ),
             instruction(Operation::Control(ControlOperation::DispatchNext), vec![]),
             instruction(Operation::Cold, vec![label(".slow")]),
             instruction(Operation::Label, vec![label(".slow")]),
-            instruction(Operation::Call(CallKind::SlowPath), vec![
-                Operand::Relocation(crate::low_ir::Relocation::function_call(
+            instruction(
+                Operation::Call(CallKind::SlowPath),
+                vec![Operand::Relocation(crate::low_ir::Relocation::function_call(
                     crate::identity::ExternalSymbol::new("slow_path"),
-                )),
-            ]),
+                ))],
+            ),
         ])
         .unwrap();
         let layout = graph.layout_hot_and_cold().unwrap();
@@ -839,17 +909,25 @@ mod tests {
     #[test]
     fn inverts_branches_whose_taken_target_follows_a_jump_block() {
         let graph = ControlFlowGraph::from_instructions(vec![
-            instruction(Operation::branch_memory(PairWidth::Word, EqualityCondition::Equal), vec![Operand::VirtualRegister("value".into()), Operand::Immediate(1), label(".success")]),
+            instruction(
+                Operation::branch_memory(PairWidth::Word, EqualityCondition::Equal),
+                vec![
+                    Operand::VirtualRegister("value".into()),
+                    Operand::Immediate(1),
+                    label(".success"),
+                ],
+            ),
             instruction(Operation::Control(ControlOperation::JumpLabel), vec![label(".slow")]),
             instruction(Operation::Label, vec![label(".success")]),
             instruction(Operation::Control(ControlOperation::DispatchNext), vec![]),
             instruction(Operation::Cold, vec![label(".slow")]),
             instruction(Operation::Label, vec![label(".slow")]),
-            instruction(Operation::Call(CallKind::SlowPath), vec![
-                Operand::Relocation(crate::low_ir::Relocation::function_call(
+            instruction(
+                Operation::Call(CallKind::SlowPath),
+                vec![Operand::Relocation(crate::low_ir::Relocation::function_call(
                     crate::identity::ExternalSymbol::new("slow_path"),
-                )),
-            ]),
+                ))],
+            ),
         ])
         .unwrap();
         let layout = graph.layout_hot_and_cold().unwrap();
@@ -874,12 +952,16 @@ mod tests {
             instruction(Operation::Control(ControlOperation::DispatchNext), vec![]),
             instruction(Operation::Cold, vec![label(".slow")]),
             instruction(Operation::Label, vec![label(".slow")]),
-            instruction(Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero), vec![Operand::VirtualRegister("value".into()), label(".done")]),
-            instruction(Operation::Call(CallKind::SlowPath), vec![
-                Operand::Relocation(crate::low_ir::Relocation::function_call(
+            instruction(
+                Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero),
+                vec![Operand::VirtualRegister("value".into()), label(".done")],
+            ),
+            instruction(
+                Operation::Call(CallKind::SlowPath),
+                vec![Operand::Relocation(crate::low_ir::Relocation::function_call(
                     crate::identity::ExternalSymbol::new("slow_path"),
-                )),
-            ]),
+                ))],
+            ),
             instruction(Operation::Label, vec![label(".done")]),
             instruction(Operation::Control(ControlOperation::Exit), vec![]),
         ])
@@ -893,7 +975,10 @@ mod tests {
     #[test]
     fn rejects_cold_fallthrough() {
         let graph = ControlFlowGraph::from_instructions(vec![
-            instruction(Operation::Move(IntegerWidth::U64), vec![Operand::VirtualRegister("value".into()), Operand::Immediate(1)]),
+            instruction(
+                Operation::Move(IntegerWidth::U64),
+                vec![Operand::VirtualRegister("value".into()), Operand::Immediate(1)],
+            ),
             instruction(Operation::Cold, vec![label(".slow")]),
             instruction(Operation::Label, vec![label(".slow")]),
             instruction(Operation::Control(ControlOperation::Exit), vec![]),
@@ -914,10 +999,7 @@ mod tests {
             instruction(Operation::Label, vec![label(".slow")]),
             instruction(
                 Operation::Move(IntegerWidth::U64),
-                vec![
-                    Operand::VirtualRegister("value".into()),
-                    Operand::Immediate(1),
-                ],
+                vec![Operand::VirtualRegister("value".into()), Operand::Immediate(1)],
             ),
         ])
         .unwrap();
@@ -949,7 +1031,10 @@ mod tests {
     #[test]
     fn removes_unreferenced_jump_blocks_after_threading() {
         let mut graph = ControlFlowGraph::from_instructions(vec![
-            instruction(Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero), vec![Operand::VirtualRegister("value".into()), label(".edge")]),
+            instruction(
+                Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero),
+                vec![Operand::VirtualRegister("value".into()), label(".edge")],
+            ),
             instruction(Operation::Control(ControlOperation::JumpLabel), vec![label(".done")]),
             instruction(Operation::Cold, vec![label(".edge")]),
             instruction(Operation::Label, vec![label(".edge")]),

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -50,6 +50,21 @@ pub(crate) struct LinearControlFlow<O, C> {
     pub(crate) successors: Vec<Vec<usize>>,
 }
 
+/// Every label these blocks branch to, once per branch that names it.
+///
+/// A label instruction names the label it defines rather than one it refers
+/// to, so those are left out.
+fn block_label_references<O: ControlFlowOperand, C: ControlFlowOpcode>(
+    blocks: &[BasicBlock<O, C>],
+) -> impl Iterator<Item = &Label> {
+    blocks
+        .iter()
+        .flat_map(|block| &block.instructions)
+        .filter(|instruction| instruction.opcode.operation() != Operation::Label)
+        .flat_map(|instruction| &instruction.operands)
+        .filter_map(ControlFlowOperand::label)
+}
+
 impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
     pub(crate) fn from_instructions(
         instructions: Vec<Instruction<O, C>>,
@@ -206,16 +221,16 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
     }
 
     pub(crate) fn remove_unreferenced_jump_blocks(&mut self) {
+        // How many times each label is branched to, rather than the set of
+        // labels that are. Removing a block drops exactly the references its
+        // own instructions made, so the tally is adjusted instead of being
+        // rebuilt after each block removal.
+        let mut references: HashMap<Label, usize> = HashMap::new();
+        for label in block_label_references(&self.blocks) {
+            *references.entry(label.clone()).or_default() += 1;
+        }
+
         loop {
-            let referenced_labels = self
-                .blocks
-                .iter()
-                .flat_map(|block| &block.instructions)
-                .filter(|instruction| instruction.opcode.operation() != Operation::Label)
-                .flat_map(|instruction| &instruction.operands)
-                .filter_map(ControlFlowOperand::label)
-                .cloned()
-                .collect::<HashSet<_>>();
             let removable_block = self.blocks.iter().enumerate().find_map(|(index, block)| {
                 let [label, jump] = block.instructions.as_slice() else {
                     return None;
@@ -226,12 +241,20 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                     .instructions
                     .last()
                     .is_some_and(|instruction| instruction.opcode.description().terminal);
-                (jump.opcode.operation() == Operation::Control(ControlOperation::JumpLabel) && previous_is_terminal && !referenced_labels.contains(label)).then_some(index)
+                (jump.opcode.operation() == Operation::Control(ControlOperation::JumpLabel)
+                    && previous_is_terminal
+                    && references.get(label).copied().unwrap_or_default() == 0)
+                    .then_some(index)
             });
             let Some(index) = removable_block else {
                 break;
             };
-            self.blocks.remove(index);
+            let removed = self.blocks.remove(index);
+            for label in block_label_references(std::slice::from_ref(&removed)) {
+                if let Some(count) = references.get_mut(label) {
+                    *count -= 1;
+                }
+            }
         }
         self.rebuild_successors();
     }

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -89,16 +89,10 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         }
 
         let block_starts: Vec<_> = block_starts.into_iter().collect();
-        let mut blocks = Vec::with_capacity(block_starts.len());
         let mut instruction_to_block = vec![BlockId(0); instructions.len()];
         for (block_index, &start) in block_starts.iter().enumerate() {
             let end = block_starts.get(block_index + 1).copied().unwrap_or(instructions.len());
             instruction_to_block[start..end].fill(BlockId(block_index));
-            blocks.push(BasicBlock {
-                instructions: instructions[start..end].to_vec(),
-                successors: Vec::new(),
-                is_cold: false,
-            });
         }
 
         let labels = instructions
@@ -108,6 +102,20 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 defined_label(instruction).map(|label| (label.clone(), instruction_to_block[index]))
             })
             .collect::<HashMap<_, _>>();
+
+        // Split the listing back to front so each block takes ownership of its
+        // own instructions. Copying them into the blocks instead would clone an
+        // operand vector per instruction, and a large function has thousands.
+        let mut instructions = instructions;
+        let mut blocks = Vec::with_capacity(block_starts.len());
+        for &start in block_starts.iter().rev() {
+            blocks.push(BasicBlock {
+                instructions: instructions.split_off(start),
+                successors: Vec::new(),
+                is_cold: false,
+            });
+        }
+        blocks.reverse();
 
         for label in cold_labels {
             let block_id = labels

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -464,6 +464,31 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         (hot, cold)
     }
 
+    /// Count instructions after applying the same plan used by final
+    /// linearization, without cloning or consuming the graph.
+    pub(crate) fn linearized_instruction_count(&self) -> Result<usize, String> {
+        let layout = self.layout_hot_and_cold()?;
+        let referenced_anywhere = self.explicitly_referenced_labels();
+        let mut count = 0;
+        for blocks in [&layout.hot, &layout.cold] {
+            let plan = self.plan_linearization(blocks, &referenced_anywhere);
+            for block in blocks {
+                if plan.skipped_blocks.contains(block) {
+                    continue;
+                }
+                let end = self.planned_length(*block, &plan);
+                count += self.blocks[block.0].instructions[..end]
+                    .iter()
+                    .filter(|instruction| {
+                        defined_label(instruction).is_none_or(|label| plan.referenced_labels.contains(label))
+                    })
+                    .count();
+                count += usize::from(plan.inverted_branches.contains_key(block));
+            }
+        }
+        Ok(count)
+    }
+
     /// Every label some instruction branches to, wherever it sits.
     fn explicitly_referenced_labels(&self) -> HashSet<Label> {
         block_label_references(&self.blocks).cloned().collect()
@@ -637,6 +662,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         instructions
     }
 
+    #[cfg(test)]
     pub(crate) fn linearize_omitting_jumps_to_next_block(&self, blocks: &[BlockId]) -> Vec<Instruction<O, C>> {
         let plan = self.plan_linearization(blocks, &self.explicitly_referenced_labels());
         let mut instructions = Vec::new();

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -133,6 +133,23 @@ pub(crate) fn instruction_successors<O: ControlFlowOperand, C: ControlFlowOpcode
     successors
 }
 
+/// The basic-block index containing each instruction in a flat listing.
+pub(crate) fn instruction_blocks<O: ControlFlowOperand, C: ControlFlowOpcode>(
+    instructions: &[&Instruction<O, C>],
+) -> Vec<usize> {
+    let mut blocks = Vec::with_capacity(instructions.len());
+    let mut block = 0;
+    for (index, instruction) in instructions.iter().enumerate() {
+        if index > 0
+            && (instruction.opcode.operation() == Operation::Label || instruction_ends_block(instructions[index - 1]))
+        {
+            block += 1;
+        }
+        blocks.push(block);
+    }
+    blocks
+}
+
 impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
     pub(crate) fn from_instructions(instructions: Vec<Instruction<O, C>>) -> Result<Self, String> {
         let cold_labels = collect_cold_labels(&instructions)?;

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -10,7 +10,8 @@ use super::{
 use crate::target::description::{ControlOperation, Operation};
 #[cfg(test)]
 use crate::target::description::{CallKind, EqualityCondition, IntegerWidth, PairWidth, ZeroCondition};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
+use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct BlockId(usize);
@@ -264,7 +265,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         let resolved = redirects
             .keys()
             .filter_map(|start| {
-                let mut visited = HashSet::new();
+                let mut visited = HashSet::default();
                 let mut target = start;
                 while visited.insert(target) {
                     let Some(redirect) = redirects.get(target) else {
@@ -299,7 +300,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         // labels that are. Removing a block drops exactly the references its
         // own instructions made, so the tally is adjusted instead of being
         // rebuilt after each block removal.
-        let mut references: HashMap<Label, usize> = HashMap::new();
+        let mut references: HashMap<Label, usize> = HashMap::default();
         for label in block_label_references(&self.blocks) {
             *references.entry(label.clone()).or_default() += 1;
         }
@@ -418,7 +419,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             .cloned()
             .collect::<HashSet<_>>();
         let mut inverted_branches = inverted_branches;
-        let mut skipped_blocks = HashSet::new();
+        let mut skipped_blocks = HashSet::default();
         for blocks in blocks.windows(3) {
             let [source_id, fallthrough_id, target_id] = blocks else {
                 unreachable!();
@@ -485,7 +486,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             .filter(|block| !inverted_branches.contains_key(block))
             .filter(|block| !skipped_blocks.contains(block))
             .collect::<HashSet<_>>();
-        let mut referenced_labels = HashSet::new();
+        let mut referenced_labels = HashSet::default();
         for (block_index, block) in self.blocks.iter().enumerate() {
             let block_id = BlockId(block_index);
             if skipped_blocks.contains(&block_id) {

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -206,6 +206,23 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             })
             .collect::<HashMap<_, _>>();
 
+        // Follow each chain of jump-only blocks once, here, rather than once
+        // per branch that names its head.
+        let resolved = redirects
+            .keys()
+            .filter_map(|start| {
+                let mut visited = HashSet::new();
+                let mut target = start;
+                while visited.insert(target) {
+                    let Some(redirect) = redirects.get(target) else {
+                        break;
+                    };
+                    target = redirect;
+                }
+                (target != start).then(|| (start.clone(), target.clone()))
+            })
+            .collect::<HashMap<_, _>>();
+
         for block in &mut self.blocks {
             for instruction in &mut block.instructions {
                 if instruction.opcode.operation() == Operation::Label {
@@ -215,11 +232,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                     let Some(target) = operand.label_mut() else {
                         continue;
                     };
-                    let mut visited = HashSet::new();
-                    while visited.insert(target.clone()) {
-                        let Some(redirect) = redirects.get(target) else {
-                            break;
-                        };
+                    if let Some(redirect) = resolved.get(target) {
                         *target = redirect.clone();
                     }
                 }
@@ -238,32 +251,54 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             *references.entry(label.clone()).or_default() += 1;
         }
 
+        let mut removed = vec![false; self.blocks.len()];
         loop {
-            let removable_block = self.blocks.iter().enumerate().find_map(|(index, block)| {
-                let [label, jump] = block.instructions.as_slice() else {
-                    return None;
-                };
-                let label = defined_label(label)?;
-                let previous = index.checked_sub(1).and_then(|index| self.blocks.get(index))?;
-                let previous_is_terminal = previous
-                    .instructions
-                    .last()
-                    .is_some_and(|instruction| instruction.opcode.description().terminal);
-                (jump.opcode.operation() == Operation::Control(ControlOperation::JumpLabel)
-                    && previous_is_terminal
-                    && references.get(label).copied().unwrap_or_default() == 0)
-                    .then_some(index)
-            });
-            let Some(index) = removable_block else {
-                break;
-            };
-            let removed = self.blocks.remove(index);
-            for label in block_label_references(std::slice::from_ref(&removed)) {
-                if let Some(count) = references.get_mut(label) {
-                    *count -= 1;
+            let mut removed_any = false;
+            let mut previous: Option<usize> = None;
+            for index in 0..self.blocks.len() {
+                if removed[index] {
+                    continue;
+                }
+                let removable = (|| {
+                    let block = &self.blocks[index];
+                    let [label, jump] = block.instructions.as_slice() else {
+                        return false;
+                    };
+                    let Some(label) = defined_label(label) else {
+                        return false;
+                    };
+                    let Some(previous) = previous else {
+                        return false;
+                    };
+                    let previous_is_terminal = self.blocks[previous]
+                        .instructions
+                        .last()
+                        .is_some_and(|instruction| instruction.opcode.description().terminal);
+                    jump.opcode.operation() == Operation::Control(ControlOperation::JumpLabel)
+                        && previous_is_terminal
+                        && references.get(label).copied().unwrap_or_default() == 0
+                })();
+                if !removable {
+                    previous = Some(index);
+                    continue;
+                }
+                removed[index] = true;
+                removed_any = true;
+                for label in block_label_references(std::slice::from_ref(&self.blocks[index])) {
+                    if let Some(count) = references.get_mut(label) {
+                        *count -= 1;
+                    }
                 }
             }
+            if !removed_any {
+                break;
+            }
         }
+        let mut index = 0;
+        self.blocks.retain(|_| {
+            index += 1;
+            !removed[index - 1]
+        });
         self.rebuild_successors();
     }
 
@@ -272,10 +307,10 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             return;
         }
 
-        let mut reachable = HashSet::new();
+        let mut reachable = vec![false; self.blocks.len()];
         let mut pending = vec![BlockId(0)];
         while let Some(block) = pending.pop() {
-            if !reachable.insert(block) {
+            if std::mem::replace(&mut reachable[block.0], true) {
                 continue;
             }
             pending.extend(self.blocks[block.0].successors.iter().map(|edge| edge.target));
@@ -283,7 +318,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
 
         let mut index = 0usize;
         self.blocks.retain(|_| {
-            let keep = reachable.contains(&BlockId(index));
+            let keep = reachable[index];
             index += 1;
             keep
         });
@@ -479,38 +514,46 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
     }
 
     fn rebuild_successors(&mut self) {
-        let labels = self
-            .blocks
-            .iter()
-            .enumerate()
-            .filter_map(|(index, block)| {
-                block
-                    .instructions
-                    .first()
-                    .and_then(defined_label)
-                    .map(|label| (label.clone(), BlockId(index)))
-            })
-            .collect::<HashMap<_, _>>();
-
-        for block_index in 0..self.blocks.len() {
-            let (branch_targets, terminal) = {
-                let last_instruction = self.blocks[block_index]
-                    .instructions
-                    .last()
-                    .expect("basic block must contain an instruction");
-                let branch_targets = if last_instruction.opcode.operation() == Operation::Label {
-                    Vec::new()
-                } else {
-                    last_instruction
+        // Successors are recomputed after every graph edit, so the label index
+        // borrows the labels rather than cloning each one. A large function
+        // has a label per block, and the strings are not small.
+        let edges = {
+            let labels = self
+                .blocks
+                .iter()
+                .enumerate()
+                .filter_map(|(index, block)| {
+                    block
+                        .instructions
+                        .first()
+                        .and_then(defined_label)
+                        .map(|label| (label, BlockId(index)))
+                })
+                .collect::<HashMap<_, _>>();
+            self.blocks
+                .iter()
+                .map(|block| {
+                    let last_instruction = block
+                        .instructions
+                        .last()
+                        .expect("basic block must contain an instruction");
+                    let terminal = last_instruction.opcode.description().terminal;
+                    if last_instruction.opcode.operation() == Operation::Label {
+                        return (Vec::new(), terminal);
+                    }
+                    let targets = last_instruction
                         .operands
                         .iter()
                         .filter_map(ControlFlowOperand::label)
                         .filter_map(|label| labels.get(label).copied())
-                        .collect()
-                };
-                let terminal = last_instruction.opcode.description().terminal;
-                (branch_targets, terminal)
-            };
+                        .collect();
+                    (targets, terminal)
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for block_index in 0..self.blocks.len() {
+            let (branch_targets, terminal) = edges[block_index].clone();
 
             let has_fallthrough = !terminal && block_index + 1 < self.blocks.len();
             let block = &mut self.blocks[block_index];

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -123,10 +123,8 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         instructions: Vec<Instruction<O, C>>,
     ) -> Result<Self, String> {
         let cold_labels = collect_cold_labels(&instructions)?;
-        let instructions: Vec<_> = instructions
-            .into_iter()
-            .filter(|instruction| instruction.opcode.operation() != Operation::Cold)
-            .collect();
+        let mut instructions = instructions;
+        instructions.retain(|instruction| instruction.opcode.operation() != Operation::Cold);
         if instructions.is_empty() {
             return Ok(Self { blocks: Vec::new() });
         }
@@ -166,7 +164,6 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         // Split the listing back to front so each block takes ownership of its
         // own instructions. Copying them into the blocks instead would clone an
         // operand vector per instruction, and a large function has thousands.
-        let mut instructions = instructions;
         let mut blocks = Vec::with_capacity(block_starts.len());
         for &start in block_starts.iter().rev() {
             blocks.push(BasicBlock {

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -5,10 +5,10 @@
  */
 
 use super::{ControlFlowOpcode, ControlFlowOperand, Instruction, Label, Operand};
+use crate::hash::{HashMap, HashSet};
 #[cfg(test)]
 use crate::target::description::{CallKind, EqualityCondition, IntegerWidth, PairWidth, ZeroCondition};
 use crate::target::description::{ControlOperation, Operation};
-use crate::hash::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct BlockId(usize);
@@ -631,8 +631,7 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 block.instructions[..end]
                     .iter()
                     .filter(|instruction| {
-                        defined_label(instruction)
-                            .is_none_or(|label| plan.referenced_labels.contains(label))
+                        defined_label(instruction).is_none_or(|label| plan.referenced_labels.contains(label))
                     })
                     .cloned(),
             );

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -11,7 +11,6 @@ use crate::target::description::{ControlOperation, Operation};
 #[cfg(test)]
 use crate::target::description::{CallKind, EqualityCondition, IntegerWidth, PairWidth, ZeroCondition};
 use crate::hash::{HashMap, HashSet};
-use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct BlockId(usize);
@@ -132,17 +131,24 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             return Ok(Self { blocks: Vec::new() });
         }
 
-        let mut block_starts = BTreeSet::from([0]);
+        // Marking the starts in a bitmap and then collecting them keeps this
+        // out of an ordered set, which allocates a node per block.
+        let mut starts_block = vec![false; instructions.len()];
+        starts_block[0] = true;
         for (index, instruction) in instructions.iter().enumerate() {
             if instruction.opcode.operation() == Operation::Label {
-                block_starts.insert(index);
+                starts_block[index] = true;
             }
             if instruction_ends_block(instruction) && index + 1 < instructions.len() {
-                block_starts.insert(index + 1);
+                starts_block[index + 1] = true;
             }
         }
 
-        let block_starts: Vec<_> = block_starts.into_iter().collect();
+        let block_starts = starts_block
+            .iter()
+            .enumerate()
+            .filter_map(|(index, starts)| starts.then_some(index))
+            .collect::<Vec<_>>();
         let mut instruction_to_block = vec![BlockId(0); instructions.len()];
         for (block_index, &start) in block_starts.iter().enumerate() {
             let end = block_starts.get(block_index + 1).copied().unwrap_or(instructions.len());

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -248,7 +248,33 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         Some(instruction)
     }
 
+    /// Tidy the graph after an edit: thread branches through jump-only blocks,
+    /// drop jump blocks nothing reaches, and drop blocks control cannot reach.
+    ///
+    /// Only the last of those reads the successor lists, so they are rebuilt
+    /// once before it rather than after each step.
+    pub(crate) fn simplify(&mut self) {
+        self.thread_jumps();
+        self.drop_unreferenced_jump_blocks();
+        self.rebuild_successors();
+        self.remove_unreachable_blocks();
+    }
+
+    #[cfg(test)]
     pub(crate) fn thread_unconditional_jumps(&mut self) {
+        self.thread_jumps();
+        self.rebuild_successors();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn remove_unreferenced_jump_blocks(&mut self) {
+        self.drop_unreferenced_jump_blocks();
+        self.rebuild_successors();
+    }
+
+    /// Thread branches through jump-only blocks. Leaves the successor lists
+    /// stale; `simplify` rebuilds them once for all of its steps.
+    fn thread_jumps(&mut self) {
         let redirects = self
             .blocks
             .iter()
@@ -292,10 +318,11 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
                 }
             }
         }
-        self.rebuild_successors();
     }
 
-    pub(crate) fn remove_unreferenced_jump_blocks(&mut self) {
+    /// Drop jump-only blocks nothing branches to. Leaves the successor lists
+    /// stale; `simplify` rebuilds them once for all of its steps.
+    fn drop_unreferenced_jump_blocks(&mut self) {
         // How many times each label is branched to, rather than the set of
         // labels that are. Removing a block drops exactly the references its
         // own instructions made, so the tally is adjusted instead of being
@@ -353,7 +380,6 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
             index += 1;
             !removed[index - 1]
         });
-        self.rebuild_successors();
     }
 
     pub(crate) fn remove_unreachable_blocks(&mut self) {

--- a/Libraries/LibJS/Flap/src/low_ir/cfg.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/cfg.rs
@@ -45,6 +45,7 @@ pub(crate) struct ControlFlowGraph<O = Operand, C = Operation> {
     blocks: Vec<BasicBlock<O, C>>,
 }
 
+#[cfg(test)]
 pub(crate) struct LinearControlFlow<O, C> {
     pub(crate) instructions: Vec<Instruction<O, C>>,
     pub(crate) successors: Vec<Vec<usize>>,
@@ -63,6 +64,58 @@ fn block_label_references<O: ControlFlowOperand, C: ControlFlowOpcode>(
         .filter(|instruction| instruction.opcode.operation() != Operation::Label)
         .flat_map(|instruction| &instruction.operands)
         .filter_map(ControlFlowOperand::label)
+}
+
+/// What can follow each instruction of a flat listing.
+///
+/// Register allocation runs before any graph edit and only needs to know where
+/// control can go next. Building a whole control-flow graph to answer that
+/// copies every instruction into a block and then copies them all back out.
+pub(crate) fn instruction_successors<O: ControlFlowOperand, C: ControlFlowOpcode>(
+    instructions: &[&Instruction<O, C>],
+) -> Vec<Vec<usize>> {
+    let count = instructions.len();
+    let mut starts_block = vec![false; count];
+    if count == 0 {
+        return Vec::new();
+    }
+    starts_block[0] = true;
+    for (index, instruction) in instructions.iter().enumerate() {
+        if instruction.opcode.operation() == Operation::Label {
+            starts_block[index] = true;
+        }
+        if instruction_ends_block(instruction) && index + 1 < count {
+            starts_block[index + 1] = true;
+        }
+    }
+
+    let labels = instructions
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| starts_block[*index])
+        .filter_map(|(index, instruction)| defined_label(instruction).map(|label| (label, index)))
+        .collect::<HashMap<_, _>>();
+
+    let mut successors = vec![Vec::new(); count];
+    for (index, instruction) in instructions.iter().enumerate() {
+        if index + 1 < count && !starts_block[index + 1] {
+            successors[index].push(index + 1);
+            continue;
+        }
+        if instruction.opcode.operation() != Operation::Label {
+            successors[index].extend(
+                instruction
+                    .operands
+                    .iter()
+                    .filter_map(ControlFlowOperand::label)
+                    .filter_map(|label| labels.get(label).copied()),
+            );
+        }
+        if !instruction.opcode.description().terminal && index + 1 < count {
+            successors[index].push(index + 1);
+        }
+    }
+    successors
 }
 
 impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
@@ -487,6 +540,12 @@ impl<O: ControlFlowOperand, C: ControlFlowOpcode> ControlFlowGraph<O, C> {
         instructions
     }
 
+    /// Every instruction of the graph, in block order.
+    pub(crate) fn instructions(&self) -> impl Iterator<Item = &Instruction<O, C>> {
+        self.blocks.iter().flat_map(|block| &block.instructions)
+    }
+
+    #[cfg(test)]
     pub(crate) fn linearize_for_analysis(&self) -> LinearControlFlow<O, C> {
         let mut block_starts = Vec::with_capacity(self.blocks.len());
         let mut instruction_count = 0;

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -1506,17 +1506,13 @@ fn lowered_single_use_load(
         .chain(&branch.folded_inputs)
         .copied()
         .collect::<HashSet<_>>();
-    let adjacent = function.blocks.iter().any(|block| {
-        let first = block.instructions.iter().position(|id| *id == load_instruction);
-        let last = block.instructions.iter().position(|id| *id == branch.instruction);
-        first.zip(last).is_some_and(|(first, last)| {
-            first < last
-                && block.instructions[first + 1..last]
-                    .iter()
-                    .all(|id| omitted.contains(id))
-        })
-    });
-    if !adjacent {
+    let (load_block, first) = function.position(load_instruction)?;
+    let (branch_block, last) = function.position(branch.instruction)?;
+    if load_block != branch_block || first >= last {
+        return None;
+    }
+    let between = &function.blocks[load_block as usize].instructions[first as usize + 1..last as usize];
+    if !between.iter().all(|id| omitted.contains(id)) {
         return None;
     }
     let mut lowered = Vec::new();
@@ -1637,6 +1633,7 @@ pub(crate) struct FunctionUses<'a> {
     user_offsets: Vec<u32>,
     users: Vec<ValueUser>,
     registers: Vec<Option<VirtualRegister>>,
+    positions: Vec<Option<(u32, u32)>>,
 }
 
 /// One place a value is read.
@@ -1650,6 +1647,15 @@ impl<'a> FunctionUses<'a> {
     fn new(function: &'a Function) -> Self {
         let mut counts = vec![0u32; function.values.len()];
         let mut terminator_inputs = Vec::new();
+        // Where each instruction sits. Selection asks whether two instructions
+        // are adjacent in a block, and searching the whole function for them is
+        // quadratic on a stitched program.
+        let mut positions = vec![None; function.instructions.len()];
+        for (block_index, block) in function.blocks.iter().enumerate() {
+            for (position, instruction) in block.instructions.iter().enumerate() {
+                positions[instruction.0] = Some((block_index as u32, position as u32));
+            }
+        }
         for instruction in &function.instructions {
             for input in &instruction.inputs {
                 counts[input.0] += 1;
@@ -1720,7 +1726,13 @@ impl<'a> FunctionUses<'a> {
             user_offsets,
             users,
             registers,
+            positions,
         }
+    }
+
+    /// The block an instruction belongs to and where it sits in it.
+    fn position(&self, instruction: InstructionId) -> Option<(u32, u32)> {
+        self.positions[instruction.0]
     }
 
     /// The virtual register an SSA value is named by, if it lives in one.

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -236,8 +236,13 @@ fn lower_handler_internal(
     let preferred_order = schedule_blocks(function);
     let alternate_order = schedule_blocks_with_successor_order(function, false);
     let profile_order = schedule_blocks_by_profile(function);
-    let mut candidate_orders = vec![preferred_order.clone(), alternate_order, profile_order];
-    candidate_orders.dedup();
+    let mut candidate_orders = vec![preferred_order.clone()];
+    if alternate_order != preferred_order {
+        candidate_orders.push(alternate_order);
+    }
+    if !candidate_orders.contains(&profile_order) {
+        candidate_orders.push(profile_order);
+    }
     let lowered = lower_blocks(function, &folded_instructions, constants, preferred_order.clone())?;
     let mut selected = None;
     for order in candidate_orders {
@@ -253,7 +258,11 @@ fn lower_handler_internal(
         }
     }
     let selected_order = selected.expect("there is always a preferred block order").2;
-    let mut instructions = reorder_lowered_blocks(&lowered, &preferred_order, &selected_order)?;
+    let mut instructions = if selected_order == preferred_order {
+        lowered
+    } else {
+        reorder_lowered_blocks(&lowered, &preferred_order, &selected_order)?
+    };
     // Preserve the semantic exec_ctx value for targets that derive it from a
     // different pinned base. The dedicated instruction also exposes any
     // scratch register needed for that derivation to register allocation.

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -555,8 +555,8 @@ fn schedule_blocks_with_successor_order(function: &Function, reverse_successors:
         }
     }
     reverse_postorder.reverse();
-    for index in 0..function.blocks.len() {
-        if !std::mem::replace(&mut visited[index], true) {
+    for (index, was_visited) in visited.iter_mut().enumerate() {
+        if !std::mem::replace(was_visited, true) {
             reverse_postorder.push(BlockId(index));
         }
     }

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -35,7 +35,7 @@ pub(crate) fn lower_handler_with_constants(
     constants: &LayoutConstants,
     id: crate::identity::HandlerId,
 ) -> Result<Handler, CompileError> {
-    let function = &FunctionUses::new(function);
+    let function = &FunctionUses::new(function, id);
     let mut handler = lower_handler_internal(function, is_cold, constants, id)
         .map_err(|message| CompileError::new(CompileStage::LowIr, Some(&function.name), message))?;
     materialize_layout_constants(&mut handler);
@@ -1591,7 +1591,7 @@ enum ValueUser {
 }
 
 impl<'a> FunctionUses<'a> {
-    fn new(function: &'a Function) -> Self {
+    fn new(function: &'a Function, handler: crate::identity::HandlerId) -> Self {
         let mut counts = vec![0u32; function.values.len()];
         let mut terminator_inputs = Vec::new();
         // Where each instruction sits. Selection asks whether two instructions
@@ -1645,15 +1645,12 @@ impl<'a> FunctionUses<'a> {
                 filled[input.0] += 1;
             }
         }
-        // Every operand naming an SSA value names it by the same virtual
-        // register, and lowering emits an operand per use, so the register is
-        // built once per value rather than formatted, allocated and hashed once
-        // per use.
+        let mut register_index = 0u32;
         let registers = function
             .values
             .iter()
             .enumerate()
-            .map(|(index, value)| {
+            .map(|(value_index, value)| {
                 if !matches!(
                     value.definition,
                     ValueDefinition::InstructionResult { .. }
@@ -1663,10 +1660,13 @@ impl<'a> FunctionUses<'a> {
                     return None;
                 }
                 let class = value.ty.register_class()?;
-                Some(VirtualRegister::with_class(format!("ssa_{index}"), class))
+                let register = VirtualRegister::ssa(handler, register_index, value_index, class);
+                register_index = register_index
+                    .checked_add(1)
+                    .expect("one handler cannot contain more than u32::MAX virtual registers");
+                Some(register)
             })
             .collect();
-
         Self {
             function,
             counts,

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -6,19 +6,28 @@
 
 //! Lower target-independent SSA into LowIR.
 
-use crate::types::{InterpreterRegister, RegisterClass, Type};
-use crate::bytecode::{
-    BytecodeFieldId, HandlerLayout as BytecodeHandlerLayout,
+use super::{
+    AddressDisplacement, AddressRegister, AddressScale, Handler, Instruction, Label, MemoryAddress, Operand,
+    Relocation, VirtualRegister, emit_instructions as emit, intern_virtual_registers,
 };
-use crate::frontend::layout::{
-    KnownLayoutConstant, LayoutConstantCategory, LayoutConstants,
-};
-use crate::intrinsic::{AddressOperation, AggregateOperation, AssertionOperation, BranchOperation, BytecodeOperation, CallOperation, CheckedIntegerOperation, ClassificationOperation, ComparisonDomain, ComparisonRelation, ControlOperation, FloatConversion, FloatingPointOperation, IntegerBinaryOperation, IntegerComparisonOperation, IntegerSignedness, Intrinsic, LowLevelOperation, MemoryOperation, OperandLoad, OperandOperation, OperandStore, ValueOperation};
-use crate::ssa::{BlockId, BlockLayout, Constant, Edge, Function, InstructionId, Operation, Terminator, ValueDefinition, ValueId};
-use crate::target::description::{BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, Operation as MachineOperation, OrderedCondition, OverflowOperation, PairWidth, SignCondition, TestCondition, ZeroCondition};
-use crate::{CompileError, CompileStage};
-use super::{AddressDisplacement, AddressRegister, AddressScale, Handler, Instruction, Label, MemoryAddress, Operand, Relocation, VirtualRegister, emit_instructions as emit, intern_virtual_registers};
+use crate::bytecode::{BytecodeFieldId, HandlerLayout as BytecodeHandlerLayout};
+use crate::frontend::layout::{KnownLayoutConstant, LayoutConstantCategory, LayoutConstants};
 use crate::hash::{HashMap, HashSet};
+use crate::intrinsic::{
+    AddressOperation, AggregateOperation, AssertionOperation, BranchOperation, BytecodeOperation, CallOperation,
+    CheckedIntegerOperation, ClassificationOperation, ComparisonDomain, ComparisonRelation, ControlOperation,
+    FloatConversion, FloatingPointOperation, IntegerBinaryOperation, IntegerComparisonOperation, IntegerSignedness,
+    Intrinsic, LowLevelOperation, MemoryOperation, OperandLoad, OperandOperation, OperandStore, ValueOperation,
+};
+use crate::ssa::{
+    BlockId, BlockLayout, Constant, Edge, Function, InstructionId, Operation, Terminator, ValueDefinition, ValueId,
+};
+use crate::target::description::{
+    BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, Operation as MachineOperation, OrderedCondition,
+    OverflowOperation, PairWidth, SignCondition, TestCondition, ZeroCondition,
+};
+use crate::types::{InterpreterRegister, RegisterClass, Type};
+use crate::{CompileError, CompileStage};
 
 pub(crate) fn lower_handler_with_constants(
     function: &Function,
@@ -27,10 +36,8 @@ pub(crate) fn lower_handler_with_constants(
     id: crate::identity::HandlerId,
 ) -> Result<Handler, CompileError> {
     let function = &FunctionUses::new(function);
-    let mut handler =
-        lower_handler_internal(function, is_cold, constants, id).map_err(|message| {
-        CompileError::new(CompileStage::LowIr, Some(&function.name), message)
-    })?;
+    let mut handler = lower_handler_internal(function, is_cold, constants, id)
+        .map_err(|message| CompileError::new(CompileStage::LowIr, Some(&function.name), message))?;
     materialize_layout_constants(&mut handler);
     Ok(handler)
 }
@@ -74,10 +81,7 @@ fn materialize_bytecode_field(
                 CompileError::new(
                     CompileStage::LowIr,
                     Some(handler),
-                    format!(
-                        "unknown bytecode field '{}'",
-                        layout.field_name(field)
-                    ),
+                    format!("unknown bytecode field '{}'", layout.field_name(field)),
                 )
             })?
             .try_into()
@@ -98,12 +102,8 @@ fn materialize_bytecode_field(
             *operand = Operand::Immediate(resolve(*field)?);
         }
         Operand::Address(address) => {
-            if let Some(AddressDisplacement::BytecodeField(field)) =
-                &address.displacement
-            {
-                address.displacement = Some(
-                    AddressDisplacement::Immediate(resolve(*field)?),
-                );
+            if let Some(AddressDisplacement::BytecodeField(field)) = &address.displacement {
+                address.displacement = Some(AddressDisplacement::Immediate(resolve(*field)?));
             }
         }
         _ => {}
@@ -111,9 +111,7 @@ fn materialize_bytecode_field(
     Ok(())
 }
 
-pub(crate) fn materialize_layout_constants(
-    handler: &mut Handler,
-) {
+pub(crate) fn materialize_layout_constants(handler: &mut Handler) {
     for instruction in &mut handler.instructions {
         for operand in &mut instruction.operands {
             resolve_layout_constant(operand);
@@ -132,15 +130,10 @@ fn resolve_layout_constant(operand: &mut Operand) {
         }
         Operand::Address(address) => {
             if let Some(AddressScale::LayoutConstant(constant)) = address.scale {
-                address.scale =
-                    Some(AddressScale::Immediate(constant.value()));
+                address.scale = Some(AddressScale::Immediate(constant.value()));
             }
-            if let Some(AddressDisplacement::LayoutConstant(constant)) =
-                &address.displacement
-            {
-                address.displacement = Some(AddressDisplacement::Immediate(
-                    constant.value(),
-                ));
+            if let Some(AddressDisplacement::LayoutConstant(constant)) = &address.displacement {
+                address.displacement = Some(AddressDisplacement::Immediate(constant.value()));
             }
         }
         _ => {}
@@ -185,7 +178,10 @@ fn lower_handler_internal(
             folded_instructions.insert(instruction);
         }
         if matches!(instruction.operation, Operation::Intrinsic(Intrinsic::IntegerBinary(operation)) if operation.supports_narrow_result())
-            && instruction.results.first().is_some_and(|result| integer_result_can_stay_narrow(function, *result))
+            && instruction
+                .results
+                .first()
+                .is_some_and(|result| integer_result_can_stay_narrow(function, *result))
         {
             for input in &instruction.inputs {
                 if let Some((instructions, _)) = folded_32bit_operation_source(function, *input) {
@@ -203,18 +199,20 @@ fn lower_handler_internal(
         }
     }
     for block in &function.blocks {
-        let Some(Terminator::CheckedOperation {
-            operation,
-            inputs,
-            ..
-        }) = &block.terminator
-        else {
+        let Some(Terminator::CheckedOperation { operation, inputs, .. }) = &block.terminator else {
             continue;
         };
-        if matches!(operation, Operation::Intrinsic(Intrinsic::CheckedInteger(CheckedIntegerOperation::Add | CheckedIntegerOperation::Subtract | CheckedIntegerOperation::Multiply))) {
-            folded_instructions.extend(inputs.iter().filter_map(|input| {
-                folded_checked_i32_source(function, *input).map(|(instruction, _)| instruction)
-            }));
+        if matches!(
+            operation,
+            Operation::Intrinsic(Intrinsic::CheckedInteger(
+                CheckedIntegerOperation::Add | CheckedIntegerOperation::Subtract | CheckedIntegerOperation::Multiply
+            ))
+        ) {
+            folded_instructions.extend(
+                inputs.iter().filter_map(|input| {
+                    folded_checked_i32_source(function, *input).map(|(instruction, _)| instruction)
+                }),
+            );
         } else if let Operation::Intrinsic(Intrinsic::Branch(operation)) = operation
             && typed_narrow_signed_branch_operation(function, *operation, inputs).is_some()
         {
@@ -225,27 +223,23 @@ fn lower_handler_internal(
             }
         }
     }
-    folded_instructions.extend(function.instructions.iter().enumerate().filter_map(|(index, instruction)| {
-        (instruction.operation == Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse)))
-            .then_some(InstructionId(index))
-    }));
+    folded_instructions.extend(
+        function
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(index, instruction)| {
+                (instruction.operation == Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse)))
+                    .then_some(InstructionId(index))
+            }),
+    );
     let preferred_order = schedule_blocks(function);
     let alternate_order = schedule_blocks_with_successor_order(function, false);
     let profile_order = schedule_blocks_by_profile(function);
     let preferred_profile_score = profile_layout_score(function, &preferred_order);
     let alternate_profile_score = profile_layout_score(function, &alternate_order);
-    let preferred = lower_blocks(
-        function,
-        &folded_instructions,
-        constants,
-        preferred_order,
-    )?;
-    let alternate = lower_blocks(
-        function,
-        &folded_instructions,
-        constants,
-        alternate_order,
-    )?;
+    let preferred = lower_blocks(function, &folded_instructions, constants, preferred_order)?;
+    let alternate = lower_blocks(function, &folded_instructions, constants, alternate_order)?;
     let preferred_cost = control_flow_cost(&preferred)?;
     let alternate_cost = control_flow_cost(&alternate)?;
     let (selected_profile_score, mut selected) = if alternate_profile_score > preferred_profile_score
@@ -257,12 +251,7 @@ fn lower_handler_internal(
     };
     let profile_score = profile_layout_score(function, &profile_order);
     if profile_score > selected_profile_score {
-        selected = lower_blocks(
-            function,
-            &folded_instructions,
-            constants,
-            profile_order,
-        )?;
+        selected = lower_blocks(function, &folded_instructions, constants, profile_order)?;
     }
     let mut instructions = selected;
     // Preserve the semantic exec_ctx value for targets that derive it from a
@@ -270,13 +259,10 @@ fn lower_handler_internal(
     // scratch register needed for that derivation to register allocation.
     for instruction in &mut instructions {
         let stores_execution_context = match instruction.operands.get(1) {
-            Some(Operand::InterpreterRegister(register)) => {
-                *register == InterpreterRegister::ExecutionContext
-            }
+            Some(Operand::InterpreterRegister(register)) => *register == InterpreterRegister::ExecutionContext,
             _ => false,
         };
-        if instruction.opcode.operation()
-            == MachineOperation::store(MemoryWidth::DoubleWord)
+        if instruction.opcode.operation() == MachineOperation::store(MemoryWidth::DoubleWord)
             && stores_execution_context
         {
             instruction.opcode = MachineOperation::StoreExecutionContext;
@@ -301,9 +287,7 @@ fn profile_layout_score(function: &Function, blocks: &[BlockId]) -> usize {
             function.blocks[pair[0].0]
                 .terminator
                 .as_ref()
-                .is_some_and(|terminator| {
-                    terminator.successors().any(|successor| successor.block == pair[1])
-                })
+                .is_some_and(|terminator| terminator.successors().any(|successor| successor.block == pair[1]))
         })
         .count()
 }
@@ -344,11 +328,7 @@ fn lower_blocks(
         function.blocks[index]
             .terminator
             .as_ref()
-            .is_some_and(|terminator| {
-                terminator
-                    .successors()
-                    .any(|edge| edge.block == function.entry)
-            })
+            .is_some_and(|terminator| terminator.successors().any(|edge| edge.block == function.entry))
             || function
                 .guard_exits(BlockId(index))
                 .any(|(_, failure)| failure == function.entry)
@@ -381,10 +361,7 @@ fn lower_blocks(
                     )
                 })
                 .map(|offset| instruction_index + 1 + offset);
-            if let Some(failure) = function.instructions[instruction_id.0]
-                .operation
-                .guard_failure()
-            {
+            if let Some(failure) = function.instructions[instruction_id.0].operation.guard_failure() {
                 let name = format!("guard_{}", instruction_id.0);
                 let continue_label = Label::new(format!(".ssa_{name}_pass"));
                 emit_conditional_branch(
@@ -402,12 +379,7 @@ fn lower_blocks(
                 continue;
             }
             if let Some(next_index) = next_instruction
-                && lower_field_access_pair(
-                    function,
-                    instruction_id,
-                    instructions[next_index],
-                    &mut body,
-                )?
+                && lower_field_access_pair(function, instruction_id, instructions[next_index], &mut body)?
             {
                 instruction_index = next_index + 1;
                 continue;
@@ -426,12 +398,7 @@ fn lower_blocks(
             .ok_or_else(|| format!("block {block_id:?} has no terminator"))?
         {
             Terminator::Jump(edge) => {
-                lower_edge_copies(
-                    function,
-                    edge,
-                    &mut body,
-                    &mut edge_temporary,
-                )?;
+                lower_edge_copies(function, edge, &mut body, &mut edge_temporary)?;
                 emit!(body; MachineOperation::Control(ControlOperation::JumpLabel) => [Operand::Label(block_label(edge.block))];);
             }
             Terminator::Branch {
@@ -449,29 +416,14 @@ fn lower_blocks(
                     &then_label,
                     &mut body,
                 )?;
-                lower_edge_copies(
-                    function,
-                    else_edge,
-                    &mut body,
-                    &mut edge_temporary,
-                )?;
+                lower_edge_copies(function, else_edge, &mut body, &mut edge_temporary)?;
                 emit!(body; MachineOperation::Control(ControlOperation::JumpLabel) => [Operand::Label(block_label(else_edge.block))];);
                 emit!(body; MachineOperation::Label => [Operand::Label(then_label)];);
-                lower_edge_copies(
-                    function,
-                    then_edge,
-                    &mut body,
-                    &mut edge_temporary,
-                )?;
+                lower_edge_copies(function, then_edge, &mut body, &mut edge_temporary)?;
                 emit!(body; MachineOperation::Control(ControlOperation::JumpLabel) => [Operand::Label(block_label(then_edge.block))];);
             }
             Terminator::Switch { value, cases, default } => {
-                let preferred_tail_after = preferred_switch_tail_after(
-                    &block_order,
-                    position,
-                    cases,
-                    default,
-                );
+                let preferred_tail_after = preferred_switch_tail_after(&block_order, position, cases, default);
                 if let Some((target, tail)) = lower_switch(
                     function,
                     block_id,
@@ -531,9 +483,11 @@ fn lower_blocks(
                     Some(label.clone())
                 })
                 .collect::<Vec<_>>();
-            body.extend(internal_labels.into_iter().map(|label| {
-                machine_instruction(MachineOperation::Cold, vec![Operand::Label(label)])
-            }));
+            body.extend(
+                internal_labels
+                    .into_iter()
+                    .map(|label| machine_instruction(MachineOperation::Cold, vec![Operand::Label(label)])),
+            );
         }
     }
     if !deferred_switch_tails.is_empty() {
@@ -719,16 +673,13 @@ fn lower_switch(
         && let Some(preferred_tail_after) = preferred_tail_after
     {
         let tail_label = Label::new(format!(".ssa_switch_{}_after_preferred", block.0));
-        if emit_inverted_switch_group_test(
-            function,
-            &value,
-            &cases[..group_length],
-            &tail_label,
-            output,
-        )? {
+        if emit_inverted_switch_group_test(function, &value, &cases[..group_length], &tail_label, output)? {
             lower_edge_copies(function, preferred_edge, output, temporary_index)?;
             emit!(output; MachineOperation::Control(ControlOperation::JumpLabel) => [Operand::Label(block_label(preferred_edge.block))];);
-            let mut tail = vec![machine_instruction(MachineOperation::Label, vec![Operand::Label(tail_label)])];
+            let mut tail = vec![machine_instruction(
+                MachineOperation::Label,
+                vec![Operand::Label(tail_label)],
+            )];
             lower_switch_cases(
                 function,
                 block,
@@ -742,16 +693,7 @@ fn lower_switch(
             return Ok(Some((preferred_tail_after, tail)));
         }
     }
-    lower_switch_cases(
-        function,
-        block,
-        &value,
-        cases,
-        0,
-        default,
-        output,
-        temporary_index,
-    )?;
+    lower_switch_cases(function, block, &value, cases, 0, default, output, temporary_index)?;
     Ok(None)
 }
 
@@ -810,9 +752,7 @@ fn emit_inverted_switch_group_test(
         .collect::<Option<Vec<_>>>();
     let Some(values) = values.filter(|values| {
         values.last().unwrap().checked_add(1).is_some()
-            && values
-                .windows(2)
-                .all(|pair| pair[0].checked_add(1) == Some(pair[1]))
+            && values.windows(2).all(|pair| pair[0].checked_add(1) == Some(pair[1]))
     }) else {
         return Ok(false);
     };
@@ -852,9 +792,7 @@ fn lower_switch_cases(
             .filter(|values| {
                 values.len() > 1
                     && values.last().unwrap().checked_add(1).is_some()
-                    && values
-                        .windows(2)
-                        .all(|pair| pair[0].checked_add(1) == Some(pair[1]))
+                    && values.windows(2).all(|pair| pair[0].checked_add(1) == Some(pair[1]))
             });
         if let Some(values) = consecutive_integers {
             let start = values[0];
@@ -937,7 +875,10 @@ fn lower_checked_operation(
         }
     } else if let Operation::Intrinsic(Intrinsic::FloatingPoint(operation)) = operation {
         if !operation.is_fallible() {
-            return Err(format!("non-fallible floating-point operation '{}' used as a checked operation", operation.name()));
+            return Err(format!(
+                "non-fallible floating-point operation '{}' used as a checked operation",
+                operation.name()
+            ));
         }
         let operands = results
             .iter()
@@ -969,7 +910,9 @@ fn lower_checked_operation(
                 emit!(output; MachineOperation::Overflow(OverflowOperation::MultiplyCopy) => [result, value_operand(function, lhs)?, value_operand(function, rhs_value)?, Operand::Label(failure_label.clone())];);
             } else {
                 emit!(output; MachineOperation::Move(IntegerWidth::U64) => [result.clone(), value_operand(function, lhs)?];);
-                if checked_operation == OverflowOperation::AddWithOverflow && integer_constant(function, *rhs) == Some(1) {
+                if checked_operation == OverflowOperation::AddWithOverflow
+                    && integer_constant(function, *rhs) == Some(1)
+                {
                     emit!(output; MachineOperation::Overflow(OverflowOperation::Increment) => [result, Operand::Label(failure_label.clone())];);
                 } else if checked_operation == OverflowOperation::SubtractWithOverflow
                     && integer_constant(function, *rhs) == Some(1)
@@ -1001,7 +944,10 @@ fn lower_checked_operation(
     } else {
         let (operation_name, machine_operation) = match operation {
             Operation::Parameter(parameter) => {
-                return Err(format!("unresolved operation parameter {} reached LowIR lowering", parameter.0));
+                return Err(format!(
+                    "unresolved operation parameter {} reached LowIR lowering",
+                    parameter.0
+                ));
             }
             Operation::Intrinsic(Intrinsic::LowLevel(operation)) => {
                 (operation.name(), Some(low_level_machine_operation(*operation)))
@@ -1021,8 +967,7 @@ fn lower_checked_operation(
             .chain([Operand::Label(failure_label.clone())])
             .collect();
         output.push(machine_instruction(
-            machine_operation
-                .ok_or_else(|| format!("checked operation '{operation_name}' has no LowIR operation"))?,
+            machine_operation.ok_or_else(|| format!("checked operation '{operation_name}' has no LowIR operation"))?,
             operands,
         ));
     }
@@ -1051,11 +996,7 @@ struct SelectedBranch {
 }
 
 impl SelectedBranch {
-    fn new(
-        instruction: InstructionId,
-        operation: MachineOperation,
-        inputs: Vec<SelectedBranchInput>,
-    ) -> Self {
+    fn new(instruction: InstructionId, operation: MachineOperation, inputs: Vec<SelectedBranchInput>) -> Self {
         Self {
             instruction,
             operation,
@@ -1101,7 +1042,10 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
         Operation::Intrinsic(Intrinsic::Classification(classification)) => (None, Some(*classification)),
         _ => return None,
     };
-    if matches!(comparison, Some(IntegerComparisonOperation::Equal | IntegerComparisonOperation::NotEqual)) {
+    if matches!(
+        comparison,
+        Some(IntegerComparisonOperation::Equal | IntegerComparisonOperation::NotEqual)
+    ) {
         let [lhs, rhs] = operation.inputs.as_slice() else {
             return None;
         };
@@ -1141,11 +1085,16 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
         let [lhs, rhs] = operation.inputs.as_slice() else {
             return None;
         };
-        if function.values[lhs.0].ty == Type::U32 && is_i32_max(function, *rhs)
-        {
+        if function.values[lhs.0].ty == Type::U32 && is_i32_max(function, *rhs) {
             return Some(SelectedBranch::new(
                 instruction,
-                if matches!(comparison, Some(IntegerComparisonOperation::Relational { relation: ComparisonRelation::LessOrEqual, .. })) {
+                if matches!(
+                    comparison,
+                    Some(IntegerComparisonOperation::Relational {
+                        relation: ComparisonRelation::LessOrEqual,
+                        ..
+                    })
+                ) {
                     MachineOperation::branch_bit(TestCondition::Clear)
                 } else {
                     MachineOperation::branch_bit(TestCondition::Set)
@@ -1170,14 +1119,28 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
                 .unwrap_or((*lhs, Vec::new()));
             let mut branch = SelectedBranch::new(
                 instruction,
-                if matches!(comparison, Some(IntegerComparisonOperation::Relational { relation: ComparisonRelation::Less, .. })) {
+                if matches!(
+                    comparison,
+                    Some(IntegerComparisonOperation::Relational {
+                        relation: ComparisonRelation::Less,
+                        ..
+                    })
+                ) {
                     MachineOperation::branch_sign(
-                        if function.values[lhs.0].ty == Type::I32 { IntegerWidth::U32 } else { IntegerWidth::U64 },
+                        if function.values[lhs.0].ty == Type::I32 {
+                            IntegerWidth::U32
+                        } else {
+                            IntegerWidth::U64
+                        },
                         SignCondition::Negative,
                     )
                 } else {
                     MachineOperation::branch_sign(
-                        if function.values[lhs.0].ty == Type::I32 { IntegerWidth::U32 } else { IntegerWidth::U64 },
+                        if function.values[lhs.0].ty == Type::I32 {
+                            IntegerWidth::U32
+                        } else {
+                            IntegerWidth::U64
+                        },
                         SignCondition::NotNegative,
                     )
                 },
@@ -1242,14 +1205,30 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
         .all(|input| function.values[input.0].ty == Type::ValueTag);
     let comparison = comparison?;
     let branch_operation = match comparison {
-        IntegerComparisonOperation::Equal if compares_value_tags => MachineOperation::branch_equality(IntegerWidth::U16, EqualityCondition::Equal),
-        IntegerComparisonOperation::NotEqual if compares_value_tags => MachineOperation::branch_equality(IntegerWidth::U16, EqualityCondition::NotEqual),
-        IntegerComparisonOperation::Equal if compares_u32 => MachineOperation::branch_equality(IntegerWidth::U32, EqualityCondition::Equal),
-        IntegerComparisonOperation::NotEqual if compares_u32 => MachineOperation::branch_equality(IntegerWidth::U32, EqualityCondition::NotEqual),
-        IntegerComparisonOperation::Equal => MachineOperation::branch_equality(IntegerWidth::U64, EqualityCondition::Equal),
-        IntegerComparisonOperation::NotEqual => MachineOperation::branch_equality(IntegerWidth::U64, EqualityCondition::NotEqual),
+        IntegerComparisonOperation::Equal if compares_value_tags => {
+            MachineOperation::branch_equality(IntegerWidth::U16, EqualityCondition::Equal)
+        }
+        IntegerComparisonOperation::NotEqual if compares_value_tags => {
+            MachineOperation::branch_equality(IntegerWidth::U16, EqualityCondition::NotEqual)
+        }
+        IntegerComparisonOperation::Equal if compares_u32 => {
+            MachineOperation::branch_equality(IntegerWidth::U32, EqualityCondition::Equal)
+        }
+        IntegerComparisonOperation::NotEqual if compares_u32 => {
+            MachineOperation::branch_equality(IntegerWidth::U32, EqualityCondition::NotEqual)
+        }
+        IntegerComparisonOperation::Equal => {
+            MachineOperation::branch_equality(IntegerWidth::U64, EqualityCondition::Equal)
+        }
+        IntegerComparisonOperation::NotEqual => {
+            MachineOperation::branch_equality(IntegerWidth::U64, EqualityCondition::NotEqual)
+        }
         IntegerComparisonOperation::Relational { relation, domain } => MachineOperation::branch_ordered(
-            if compares_i32 { IntegerWidth::U32 } else { IntegerWidth::U64 },
+            if compares_i32 {
+                IntegerWidth::U32
+            } else {
+                IntegerWidth::U64
+            },
             relation,
             match domain {
                 ComparisonDomain::SignedInteger => IntegerSignedness::Signed,
@@ -1257,8 +1236,12 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
                 ComparisonDomain::Value => return None,
             },
         ),
-        IntegerComparisonOperation::BitsSet => MachineOperation::branch_bits(MemoryWidth::DoubleWord, TestCondition::Set),
-        IntegerComparisonOperation::BitsClear => MachineOperation::branch_bits(MemoryWidth::DoubleWord, TestCondition::Clear),
+        IntegerComparisonOperation::BitsSet => {
+            MachineOperation::branch_bits(MemoryWidth::DoubleWord, TestCondition::Set)
+        }
+        IntegerComparisonOperation::BitsClear => {
+            MachineOperation::branch_bits(MemoryWidth::DoubleWord, TestCondition::Clear)
+        }
     };
     let direct_tag_source = operation
         .inputs
@@ -1275,10 +1258,14 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
         .map(|input| {
             if matches!(
                 branch_operation,
-                MachineOperation::Branch(BranchOperation::Equality { width: IntegerWidth::U32, .. })
-                    | MachineOperation::Branch(BranchOperation::Ordered { width: IntegerWidth::U32, .. })
-            )
-                && let Some((instructions, source)) = folded_32bit_operation_source(function, input)
+                MachineOperation::Branch(BranchOperation::Equality {
+                    width: IntegerWidth::U32,
+                    ..
+                }) | MachineOperation::Branch(BranchOperation::Ordered {
+                    width: IntegerWidth::U32,
+                    ..
+                })
+            ) && let Some((instructions, source)) = folded_32bit_operation_source(function, input)
             {
                 folded_inputs.extend(instructions);
                 source
@@ -1328,9 +1315,7 @@ fn fold_load_into_branch(function: &FunctionUses<'_>, branch: &mut SelectedBranc
                     width: IntegerWidth::U64,
                     condition,
                 }),
-            )
-                if byte_immediate.is_some() =>
-            (
+            ) if byte_immediate.is_some() => (
                 MachineOperation::branch_equality(IntegerWidth::U8, condition),
                 other.unwrap(),
             ),
@@ -1340,9 +1325,7 @@ fn fold_load_into_branch(function: &FunctionUses<'_>, branch: &mut SelectedBranc
                     width: MemoryWidth::DoubleWord,
                     condition,
                 }),
-            )
-                if byte_immediate.is_some() =>
-            (
+            ) if byte_immediate.is_some() => (
                 MachineOperation::branch_bits(MemoryWidth::Byte, condition),
                 other.unwrap(),
             ),
@@ -1361,20 +1344,26 @@ fn fold_load_into_branch(function: &FunctionUses<'_>, branch: &mut SelectedBranc
             ),
             (
                 width @ (MemoryWidth::Word | MemoryWidth::DoubleWord),
-                MachineOperation::Branch(BranchOperation::Equality { width: branch_width, condition }),
-            ) if other.as_ref().is_some_and(|other| {
-                branch_register_is_compatible(function, other, width, branch_width)
-            }) => (
-                MachineOperation::branch_memory(
-                    match width {
-                        MemoryWidth::Word => PairWidth::Word,
-                        MemoryWidth::DoubleWord => PairWidth::DoubleWord,
-                        _ => unreachable!(),
-                    },
+                MachineOperation::Branch(BranchOperation::Equality {
+                    width: branch_width,
                     condition,
-                ),
-                other.unwrap(),
-            ),
+                }),
+            ) if other
+                .as_ref()
+                .is_some_and(|other| branch_register_is_compatible(function, other, width, branch_width)) =>
+            {
+                (
+                    MachineOperation::branch_memory(
+                        match width {
+                            MemoryWidth::Word => PairWidth::Word,
+                            MemoryWidth::DoubleWord => PairWidth::DoubleWord,
+                            _ => unreachable!(),
+                        },
+                        condition,
+                    ),
+                    other.unwrap(),
+                )
+            }
             _ => continue,
         };
         branch.operation = operation;
@@ -1395,8 +1384,7 @@ fn branch_register_is_compatible(
     };
     if !matches!(
         (load_width, branch_width),
-        (MemoryWidth::Word, IntegerWidth::U32 | IntegerWidth::U64)
-            | (MemoryWidth::DoubleWord, IntegerWidth::U64)
+        (MemoryWidth::Word, IntegerWidth::U32 | IntegerWidth::U64) | (MemoryWidth::DoubleWord, IntegerWidth::U64)
     ) {
         return false;
     }
@@ -1424,9 +1412,7 @@ fn lowered_single_use_load(
     let mut instructions = Vec::new();
     loop {
         let (instruction, source) = single_use_instruction(function, value)?;
-        if source.operation
-            != Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse))
-        {
+        if source.operation != Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse)) {
             instructions.push(instruction);
             break;
         }
@@ -1462,19 +1448,13 @@ fn lowered_single_use_load(
     let [load] = lowered.as_slice() else {
         return None;
     };
-    let MachineOperation::Memory(MemoryOperation::Load {
-        width,
-        signed: false,
-    }) = load.opcode.operation()
-    else {
+    let MachineOperation::Memory(MemoryOperation::Load { width, signed: false }) = load.opcode.operation() else {
         return None;
     };
     let [destination, address] = load.operands.as_slice() else {
         return None;
     };
-    if destination != &value_operand(function, value).ok()?
-        || !matches!(address, Operand::Address(_))
-    {
+    if destination != &value_operand(function, value).ok()? || !matches!(address, Operand::Address(_)) {
         return None;
     }
     Some(LoweredLoad {
@@ -1499,7 +1479,8 @@ fn branch_input_integer(function: &Function, input: &SelectedBranchInput) -> Opt
 
 fn direct_tag_source(function: &FunctionUses<'_>, tag: ValueId) -> Option<DirectTagSource> {
     let (extract_instruction, extract) = single_use_instruction(function, tag)?;
-    if extract.operation != Operation::Intrinsic(Intrinsic::Value(ValueOperation::ExtractTag { rematerialized: false })) {
+    if extract.operation != Operation::Intrinsic(Intrinsic::Value(ValueOperation::ExtractTag { rematerialized: false }))
+    {
         return None;
     }
     let [value] = extract.inputs.as_slice() else {
@@ -1512,10 +1493,7 @@ fn direct_tag_source(function: &FunctionUses<'_>, tag: ValueId) -> Option<Direct
     })
 }
 
-fn selected_int32_pair(
-    function: &FunctionUses<'_>,
-    condition: ValueId,
-) -> Option<(InstructionId, ValueId, ValueId)> {
+fn selected_int32_pair(function: &FunctionUses<'_>, condition: ValueId) -> Option<(InstructionId, ValueId, ValueId)> {
     let (instruction, operation) = single_use_instruction(function, condition)?;
     if operation.operation != Operation::Intrinsic(Intrinsic::Classification(ClassificationOperation::Int32Pair)) {
         return None;
@@ -1547,13 +1525,8 @@ fn single_use_instruction<'a>(
     defining_instruction(function, value)
 }
 
-fn defining_instruction(
-    function: &Function,
-    value: ValueId,
-) -> Option<(InstructionId, &super::ir::Instruction)> {
-    let ValueDefinition::InstructionResult { instruction, .. } =
-        function.values[value.0].definition
-    else {
+fn defining_instruction(function: &Function, value: ValueId) -> Option<(InstructionId, &super::ir::Instruction)> {
+    let ValueDefinition::InstructionResult { instruction, .. } = function.values[value.0].definition else {
         return None;
     };
     Some((instruction, &function.instructions[instruction.0]))
@@ -1694,7 +1667,10 @@ fn value_use_count(function: &FunctionUses<'_>, value: ValueId) -> usize {
 }
 
 fn is_integer_zero(function: &Function, value: ValueId) -> bool {
-    matches!(function.values[value.0].definition, ValueDefinition::Constant(Constant::Integer(0)))
+    matches!(
+        function.values[value.0].definition,
+        ValueDefinition::Constant(Constant::Integer(0))
+    )
 }
 
 fn is_i32_max(function: &Function, value: ValueId) -> bool {
@@ -1706,9 +1682,7 @@ fn is_i32_max(function: &Function, value: ValueId) -> bool {
 
 fn direct_tag_constant(function: &Function, value: ValueId) -> Option<Operand> {
     match &function.values[value.0].definition {
-        ValueDefinition::Constant(Constant::Layout(constant))
-            if constant.category() == LayoutConstantCategory::Tag =>
-        {
+        ValueDefinition::Constant(Constant::Layout(constant)) if constant.category() == LayoutConstantCategory::Tag => {
             Some(Operand::LayoutConstant(*constant))
         }
         ValueDefinition::Constant(Constant::Integer(tag)) if u16::try_from(*tag).is_ok() => {
@@ -1741,9 +1715,7 @@ fn singleton_value_branch(function: &FunctionUses<'_>, branch: &SelectedBranch) 
         if value_use_count(function, singleton) != 1 {
             return None;
         }
-        let ValueDefinition::Constant(Constant::Layout(singleton)) =
-            &function.values[singleton.0].definition
-        else {
+        let ValueDefinition::Constant(Constant::Layout(singleton)) = &function.values[singleton.0].definition else {
             return None;
         };
         if ![
@@ -1933,10 +1905,7 @@ fn lower_field_access_pair(
 
 /// The SSA results of an instruction, whose count semantic analysis has
 /// already checked against the operation's signature.
-fn require_results<'a, T, const COUNT: usize>(
-    results: &'a [T],
-    what: &str,
-) -> Result<&'a [T; COUNT], String> {
+fn require_results<'a, T, const COUNT: usize>(results: &'a [T], what: &str) -> Result<&'a [T; COUNT], String> {
     results
         .try_into()
         .map_err(|_| format!("'{what}' requires {COUNT} SSA result(s)"))
@@ -1944,10 +1913,7 @@ fn require_results<'a, T, const COUNT: usize>(
 
 /// The SSA inputs of an instruction, whose count semantic analysis has
 /// already checked against the operation's signature.
-fn require_inputs<'a, T, const COUNT: usize>(
-    inputs: &'a [T],
-    what: &str,
-) -> Result<&'a [T; COUNT], String> {
+fn require_inputs<'a, T, const COUNT: usize>(inputs: &'a [T], what: &str) -> Result<&'a [T; COUNT], String> {
     inputs
         .try_into()
         .map_err(|_| format!("'{what}' requires {COUNT} SSA input(s)"))
@@ -1979,24 +1945,16 @@ fn lower_instruction(
             emit!(output; MachineOperation::ExtractTag => [destination.clone(), value.clone()];);
         }
         Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Copy)) => {
-            let [Operand::BytecodeField(destination), Operand::BytecodeField(source)] = inputs.as_slice()
-            else {
+            let [Operand::BytecodeField(destination), Operand::BytecodeField(source)] = inputs.as_slice() else {
                 return Err("'copy_operand' requires two bytecode fields".to_string());
             };
-            let destination_index_register = VirtualRegister::new(format!(
-                "ssa_move_operand_{}_destination_index",
-                instruction_id.0
-            ));
-            let source_index_register = VirtualRegister::new(format!(
-                "ssa_move_operand_{}_source_index",
-                instruction_id.0
-            ));
+            let destination_index_register =
+                VirtualRegister::new(format!("ssa_move_operand_{}_destination_index", instruction_id.0));
+            let source_index_register =
+                VirtualRegister::new(format!("ssa_move_operand_{}_source_index", instruction_id.0));
             let destination_index = Operand::VirtualRegister(destination_index_register.clone());
             let source_index = Operand::VirtualRegister(source_index_register.clone());
-            let value = Operand::VirtualRegister(format!(
-                "ssa_move_operand_{}_value",
-                instruction_id.0
-            ).into());
+            let value = Operand::VirtualRegister(format!("ssa_move_operand_{}_value", instruction_id.0).into());
             emit!(output; MachineOperation::load_pair(PairWidth::Word) => [destination_index.clone(), source_index.clone(), bytecode_field_memory(destination), bytecode_field_memory(source)];);
             emit!(output;
                 MachineOperation::load(MemoryWidth::DoubleWord, false) => [value.clone(), Operand::Address(MemoryAddress {
@@ -2031,7 +1989,9 @@ fn lower_instruction(
             };
             emit!(output; MachineOperation::load(MemoryWidth::Word, false) => [destination.clone(), bytecode_field_memory(field)];);
         }
-        Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Load(OperandLoad::Index | OperandLoad::RematerializedIndex))) => {
+        Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Load(
+            OperandLoad::Index | OperandLoad::RematerializedIndex,
+        ))) => {
             let [destination] = require_results(&results, "load_indexed_operand")?;
             let [index] = require_inputs(&inputs, "load_indexed_operand")?;
             emit!(output; MachineOperation::load(MemoryWidth::DoubleWord, false) => [destination.clone(), indexed_value_memory(index)?];);
@@ -2047,10 +2007,7 @@ fn lower_instruction(
         Operation::Intrinsic(Intrinsic::Value(ValueOperation::ValueToFloat64)) => {
             let [destination] = require_results(&results, "unbox_f64")?;
             let [source] = require_inputs(&inputs, "unbox_f64")?;
-            if matches!(
-                source,
-                Operand::Immediate(_) | Operand::LayoutConstant(_)
-            ) {
+            if matches!(source, Operand::Immediate(_) | Operand::LayoutConstant(_)) {
                 let temporary = Operand::VirtualRegister(format!("ssa_fp_bits_{}", instruction_id.0).into());
                 emit!(output; MachineOperation::Move(IntegerWidth::U64) => [temporary.clone(), source.clone()];);
                 emit!(output; MachineOperation::FloatMove => [destination.clone(), temporary];);
@@ -2061,22 +2018,13 @@ fn lower_instruction(
         Operation::Intrinsic(Intrinsic::Value(ValueOperation::BoxNumber)) => {
             let [destination] = require_results(&results, "box_number")?;
             let [source] = require_inputs(&inputs, "box_number")?;
-            let integer = Operand::VirtualRegister(format!(
-                "ssa_box_number_{}_integer",
-                instruction_id.0
-            ).into());
+            let integer = Operand::VirtualRegister(format!("ssa_box_number_{}_integer", instruction_id.0).into());
             let check_negative_zero = Operand::Label(Label::new(format!(
                 ".ssa_box_number_{}_check_negative_zero",
                 instruction_id.0
             )));
-            let not_integer = Operand::Label(Label::new(format!(
-                ".ssa_box_number_{}_not_integer",
-                instruction_id.0
-            )));
-            let done = Operand::Label(Label::new(format!(
-                ".ssa_box_number_{}_done",
-                instruction_id.0
-            )));
+            let not_integer = Operand::Label(Label::new(format!(".ssa_box_number_{}_not_integer", instruction_id.0)));
+            let done = Operand::Label(Label::new(format!(".ssa_box_number_{}_done", instruction_id.0)));
             emit!(output; MachineOperation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)) => [integer.clone(), source.clone(), not_integer.clone()];);
             emit!(output; MachineOperation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero) => [integer.clone(), check_negative_zero.clone()];);
             emit!(output; MachineOperation::BoxInt32 { clean: false } => [destination.clone(), integer.clone()];);
@@ -2091,7 +2039,9 @@ fn lower_instruction(
             emit!(output; MachineOperation::Control(ControlOperation::JumpLabel) => [done.clone()];);
             emit!(output; MachineOperation::Label => [done];);
         }
-        Operation::Intrinsic(Intrinsic::LowLevel(operation @ (LowLevelOperation::ClearBit | LowLevelOperation::ToggleBit))) => {
+        Operation::Intrinsic(Intrinsic::LowLevel(
+            operation @ (LowLevelOperation::ClearBit | LowLevelOperation::ToggleBit),
+        )) => {
             let [destination] = require_results(&results, operation.name())?;
             let [source, bit] = require_inputs(&inputs, operation.name())?;
             emit!(output; MachineOperation::Move(IntegerWidth::U64) => [destination.clone(), source.clone()];);
@@ -2123,12 +2073,13 @@ fn lower_instruction(
         Operation::Intrinsic(Intrinsic::Value(operation @ (ValueOperation::ToInt32 | ValueOperation::ToUint32))) => {
             let [destination] = require_results(&results, operation.name())?;
             let folded_boolean = folded_i32_bool_source(function, instruction);
-            let source = if let Some((_, source)) = folded_boolean.or_else(|| folded_u32_unbox_source(function, instruction)) {
-                value_operand(function, source)?
-            } else {
-                let [source] = require_inputs(&inputs, operation.name())?;
-                source.clone()
-            };
+            let source =
+                if let Some((_, source)) = folded_boolean.or_else(|| folded_u32_unbox_source(function, instruction)) {
+                    value_operand(function, source)?
+                } else {
+                    let [source] = require_inputs(&inputs, operation.name())?;
+                    source.clone()
+                };
             let representation_only = folded_boolean.is_none()
                 && matches!(
                     (operation, &function.values[instruction.inputs[0].0].ty),
@@ -2208,7 +2159,10 @@ fn lower_instruction(
             }
         }
         Operation::Intrinsic(Intrinsic::IntegerComparison(operation)) => {
-            return Err(format!("comparison '{}' was not folded into control flow", operation.name()));
+            return Err(format!(
+                "comparison '{}' was not folded into control flow",
+                operation.name()
+            ));
         }
         Operation::Intrinsic(Intrinsic::FloatingPoint(FloatingPointOperation::Binary(operation))) => {
             let name = FloatingPointOperation::Binary(*operation).name();
@@ -2298,9 +2252,7 @@ fn lower_instruction(
         }
         Operation::Intrinsic(Intrinsic::Call(operation)) => {
             let expected_inputs = match operation {
-                CallOperation::SlowPath
-                | CallOperation::Interpreter
-                | CallOperation::RawNative => 1,
+                CallOperation::SlowPath | CallOperation::Interpreter | CallOperation::RawNative => 1,
                 CallOperation::Helper => 2,
             };
             if inputs.len() != expected_inputs || results.len() != operation.result_count() {
@@ -2312,7 +2264,10 @@ fn lower_instruction(
             ));
         }
         Operation::Intrinsic(Intrinsic::Branch(operation)) => {
-            return Err(format!("branch operation '{}' reached instruction lowering", operation.name()));
+            return Err(format!(
+                "branch operation '{}' reached instruction lowering",
+                operation.name()
+            ));
         }
         Operation::Intrinsic(Intrinsic::Assertion(operation)) => {
             output.push(machine_instruction(MachineOperation::Assertion(*operation), inputs));
@@ -2332,16 +2287,25 @@ fn lower_instruction(
             ));
         }
         Operation::Intrinsic(Intrinsic::CheckedInteger(operation)) => {
-            return Err(format!("checked operation '{}' reached instruction lowering", operation.name()));
+            return Err(format!(
+                "checked operation '{}' reached instruction lowering",
+                operation.name()
+            ));
         }
         Operation::Intrinsic(Intrinsic::Classification(operation)) => {
-            return Err(format!("classification operation '{}' reached instruction lowering", operation.name()));
+            return Err(format!(
+                "classification operation '{}' reached instruction lowering",
+                operation.name()
+            ));
         }
         Operation::Intrinsic(Intrinsic::Control(operation)) => {
             output.push(machine_instruction(MachineOperation::Control(*operation), inputs));
         }
         Operation::Parameter(parameter) => {
-            return Err(format!("unresolved operation parameter {} reached LowIR lowering", parameter.0));
+            return Err(format!(
+                "unresolved operation parameter {} reached LowIR lowering",
+                parameter.0
+            ));
         }
         Operation::InlineCall(id) => {
             return Err(format!("unexpanded inline call #{} reached LowIR lowering", id.index()));
@@ -2351,9 +2315,11 @@ fn lower_instruction(
             let operation = match intrinsic {
                 Intrinsic::Address(AddressOperation::EmbeddedField) => MachineOperation::LoadEffectiveAddress,
                 Intrinsic::LowLevel(LowLevelOperation::Move)
-                    if destination == Operand::InterpreterRegister(crate::types::InterpreterRegister::ProgramCounter) => {
-                        MachineOperation::Move(IntegerWidth::U32)
-                    }
+                    if destination
+                        == Operand::InterpreterRegister(crate::types::InterpreterRegister::ProgramCounter) =>
+                {
+                    MachineOperation::Move(IntegerWidth::U32)
+                }
                 Intrinsic::LowLevel(LowLevelOperation::Move) => MachineOperation::Move(IntegerWidth::U64),
                 Intrinsic::Memory(operation) => {
                     lower_memory_operation(*operation, &[destination], &inputs, output)?;
@@ -2363,9 +2329,7 @@ fn lower_instruction(
             };
             output.push(Instruction {
                 opcode: operation,
-                operands: std::iter::once(destination)
-                    .chain(inputs)
-                    .collect(),
+                operands: std::iter::once(destination).chain(inputs).collect(),
             });
         }
         Operation::BlockReference(_) => {}
@@ -2385,7 +2349,12 @@ fn folded_bitwise_not_source(
         function,
         instruction,
         Operation::Intrinsic(Intrinsic::LowLevel(LowLevelOperation::BitwiseNotInt32)),
-        |operation| matches!(operation, Operation::Intrinsic(Intrinsic::Value(ValueOperation::UnboxInt32 { .. }))),
+        |operation| {
+            matches!(
+                operation,
+                Operation::Intrinsic(Intrinsic::Value(ValueOperation::UnboxInt32 { .. }))
+            )
+        },
     )
 }
 
@@ -2403,16 +2372,11 @@ fn folded_checked_i32_source(function: &FunctionUses<'_>, value: ValueId) -> Opt
     Some((instruction, *source))
 }
 
-fn folded_32bit_operation_source(
-    function: &FunctionUses<'_>,
-    value: ValueId,
-) -> Option<(Vec<InstructionId>, ValueId)> {
+fn folded_32bit_operation_source(function: &FunctionUses<'_>, value: ValueId) -> Option<(Vec<InstructionId>, ValueId)> {
     let mut instructions = Vec::new();
     let mut source = value;
     loop {
-        if value_use_count(function, source) != 1
-            && !integer_result_can_stay_narrow(function, source)
-        {
+        if value_use_count(function, source) != 1 && !integer_result_can_stay_narrow(function, source) {
             break;
         }
         let Some((instruction, conversion)) = defining_instruction(function, source) else {
@@ -2420,7 +2384,9 @@ fn folded_32bit_operation_source(
         };
         if !matches!(
             conversion.operation,
-            Operation::Intrinsic(Intrinsic::Value(ValueOperation::UnboxInt32 { rematerialized: false } | ValueOperation::ToUint32))
+            Operation::Intrinsic(Intrinsic::Value(
+                ValueOperation::UnboxInt32 { rematerialized: false } | ValueOperation::ToUint32
+            ))
         ) {
             break;
         }
@@ -2434,9 +2400,14 @@ fn folded_32bit_operation_source(
 }
 
 fn folded_shift_count(function: &FunctionUses<'_>, value: ValueId) -> Option<(Vec<InstructionId>, ValueId)> {
-    let (mut instructions, value) = folded_32bit_operation_source(function, value).unwrap_or_else(|| (Vec::new(), value));
+    let (mut instructions, value) =
+        folded_32bit_operation_source(function, value).unwrap_or_else(|| (Vec::new(), value));
     let (instruction, mask) = single_use_instruction(function, value)?;
-    if mask.operation != Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::And))) {
+    if mask.operation
+        != Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+            BinaryOperation::And,
+        )))
+    {
         return None;
     }
     let [lhs, rhs] = mask.inputs.as_slice() else {
@@ -2464,7 +2435,12 @@ fn folded_u32_unbox_source(
         function,
         instruction,
         Operation::Intrinsic(Intrinsic::Value(ValueOperation::ToUint32)),
-        |operation| matches!(operation, Operation::Intrinsic(Intrinsic::Value(ValueOperation::UnboxInt32 { .. }))),
+        |operation| {
+            matches!(
+                operation,
+                Operation::Intrinsic(Intrinsic::Value(ValueOperation::UnboxInt32 { .. }))
+            )
+        },
     )
 }
 
@@ -2493,9 +2469,7 @@ fn folded_unary_source(
         return None;
     };
     let (unbox_instruction, source) = defining_instruction(function, *input)?;
-    if !source_matches(&source.operation)
-        || value_use_count(function, *input) != 1
-    {
+    if !source_matches(&source.operation) || value_use_count(function, *input) != 1 {
         return None;
     }
     let [boxed] = source.inputs.as_slice() else {
@@ -2514,24 +2488,28 @@ fn value_operand(function: &FunctionUses<'_>, value: ValueId) -> Result<Operand,
         Operand::VirtualRegister(VirtualRegister::with_class(name, class))
     };
     Ok(match &function.values[value.0].definition {
-        ValueDefinition::FunctionParameter(index) => {
-            Operand::BytecodeField(BytecodeFieldId::new(*index))
+        ValueDefinition::FunctionParameter(index) => Operand::BytecodeField(BytecodeFieldId::new(*index)),
+        ValueDefinition::InstructionResult { instruction, .. }
+            if function.instructions[instruction.0].operation == Operation::Address =>
+        {
+            memory_operand(function, &function.instructions[instruction.0].inputs)?
         }
         ValueDefinition::InstructionResult { instruction, .. }
-            if function.instructions[instruction.0].operation == Operation::Address => {
-                memory_operand(function, &function.instructions[instruction.0].inputs)?
+            if matches!(
+                function.instructions[instruction.0].operation,
+                Operation::BlockReference(_)
+            ) =>
+        {
+            let Operation::BlockReference(target) = function.instructions[instruction.0].operation else {
+                unreachable!()
+            };
+            if !function.instructions[instruction.0].inputs.is_empty() {
+                return Err("capturing block references cannot be used as machine labels".to_string());
             }
-        ValueDefinition::InstructionResult { instruction, .. }
-            if matches!(function.instructions[instruction.0].operation, Operation::BlockReference(_)) => {
-                let Operation::BlockReference(target) = function.instructions[instruction.0].operation else {
-                    unreachable!()
-                };
-                if !function.instructions[instruction.0].inputs.is_empty() {
-                    return Err("capturing block references cannot be used as machine labels".to_string());
-                }
-                Operand::Label(block_label(target))
-            }
-        ValueDefinition::InstructionResult { .. } | ValueDefinition::BlockParameter { .. }
+            Operand::Label(block_label(target))
+        }
+        ValueDefinition::InstructionResult { .. }
+        | ValueDefinition::BlockParameter { .. }
         | ValueDefinition::TerminatorResult { .. } => Operand::VirtualRegister(
             function
                 .register(value)
@@ -2539,9 +2517,7 @@ fn value_operand(function: &FunctionUses<'_>, value: ValueId) -> Result<Operand,
                 .clone(),
         ),
         ValueDefinition::Constant(Constant::Integer(value)) => Operand::Immediate(*value),
-        ValueDefinition::Constant(Constant::Layout(constant)) => {
-            Operand::LayoutConstant(*constant)
-        }
+        ValueDefinition::Constant(Constant::Layout(constant)) => Operand::LayoutConstant(*constant),
         ValueDefinition::Constant(Constant::KnownLayout(known)) => {
             return Err(format!(
                 "unresolved known layout constant {} reached LowIR lowering",
@@ -2549,14 +2525,10 @@ fn value_operand(function: &FunctionUses<'_>, value: ValueId) -> Result<Operand,
             ));
         }
         ValueDefinition::Constant(Constant::LayoutValue(value)) => {
-            return Err(format!(
-                "unresolved layout value {value:?} reached LowIR lowering"
-            ));
+            return Err(format!("unresolved layout value {value:?} reached LowIR lowering"));
         }
         ValueDefinition::Constant(Constant::Symbol(name)) => {
-            return Err(format!(
-                "unresolved layout constant '{name}' reached LowIR lowering"
-            ));
+            return Err(format!("unresolved layout constant '{name}' reached LowIR lowering"));
         }
         ValueDefinition::Constant(Constant::SlowPath(name))
         | ValueDefinition::Constant(Constant::FunctionSymbol(name)) => {
@@ -2580,8 +2552,7 @@ fn value_operand(function: &FunctionUses<'_>, value: ValueId) -> Result<Operand,
 }
 
 fn offset_memory(base: &Operand, offset: i64) -> Result<Operand, String> {
-    let base = address_register(base)
-        .ok_or_else(|| "indexed memory requires a register base".to_string())?;
+    let base = address_register(base).ok_or_else(|| "indexed memory requires a register base".to_string())?;
     Ok(Operand::Address(MemoryAddress {
         base,
         index: None,
@@ -2616,14 +2587,17 @@ fn resolve_reuse_value(function: &Function, mut value: ValueId) -> ValueId {
 
 fn memory_operand(function: &FunctionUses<'_>, components: &[ValueId]) -> Result<Operand, String> {
     if !(1..=3).contains(&components.len()) {
-        return Err(format!("memory address requires one to three components, got {}", components.len()));
+        return Err(format!(
+            "memory address requires one to three components, got {}",
+            components.len()
+        ));
     }
     let mut operands = components
         .iter()
         .map(|component| value_operand(function, *component))
         .collect::<Result<Vec<_>, _>>()?;
-    let base = address_register(&operands.remove(0))
-        .ok_or_else(|| "memory address base must be a register".to_string())?;
+    let base =
+        address_register(&operands.remove(0)).ok_or_else(|| "memory address base must be a register".to_string())?;
     let mut address = MemoryAddress {
         base,
         index: None,
@@ -2639,16 +2613,16 @@ fn memory_operand(function: &FunctionUses<'_>, components: &[ValueId]) -> Result
             address.displacement = Some(AddressDisplacement::Immediate(*offset));
         }
         [Operand::LayoutConstant(offset)] => {
-            address.displacement =
-                Some(AddressDisplacement::LayoutConstant(*offset));
+            address.displacement = Some(AddressDisplacement::LayoutConstant(*offset));
         }
         [Operand::BytecodeField(offset)] => {
-            address.displacement =
-                Some(AddressDisplacement::BytecodeField(*offset));
+            address.displacement = Some(AddressDisplacement::BytecodeField(*offset));
         }
         [Operand::Immediate(index), Operand::Immediate(scale)] => {
             address.displacement = Some(AddressDisplacement::Immediate(
-                index.checked_mul(*scale).ok_or_else(|| "constant sequence offset overflow".to_string())?,
+                index
+                    .checked_mul(*scale)
+                    .ok_or_else(|| "constant sequence offset overflow".to_string())?,
             ));
         }
         [index, scale] if address_register(index).is_some() => {
@@ -2660,9 +2634,7 @@ fn memory_operand(function: &FunctionUses<'_>, components: &[ValueId]) -> Result
                     address.scale = Some(AddressScale::LayoutConstant(*scale));
                 }
                 Operand::BytecodeField(displacement) => {
-                    address.displacement = Some(
-                        AddressDisplacement::BytecodeField(*displacement),
-                    );
+                    address.displacement = Some(AddressDisplacement::BytecodeField(*displacement));
                 }
                 other => return Err(format!("invalid memory address scale {other:?}")),
             }
@@ -2705,13 +2677,15 @@ fn typed_narrow_signed_branch_operation(
     ))
 }
 
-fn branch_uses_narrow_inputs(
-    function: &Function,
-    operation: BranchOperation,
-    inputs: &[ValueId],
-) -> bool {
+fn branch_uses_narrow_inputs(function: &Function, operation: BranchOperation, inputs: &[ValueId]) -> bool {
     are_i32_pair(function, inputs)
-        && matches!(operation, BranchOperation::Ordered { signedness: IntegerSignedness::Signed, .. })
+        && matches!(
+            operation,
+            BranchOperation::Ordered {
+                signedness: IntegerSignedness::Signed,
+                ..
+            }
+        )
 }
 
 fn typed_signed_comparison_uses_narrow_inputs(
@@ -2720,7 +2694,13 @@ fn typed_signed_comparison_uses_narrow_inputs(
     inputs: &[ValueId],
 ) -> bool {
     are_i32_pair(function, inputs)
-        && matches!(operation, IntegerComparisonOperation::Relational { domain: ComparisonDomain::SignedInteger, .. })
+        && matches!(
+            operation,
+            IntegerComparisonOperation::Relational {
+                domain: ComparisonDomain::SignedInteger,
+                ..
+            }
+        )
 }
 
 fn checked_i32_operation_uses_narrow_inputs(
@@ -2728,15 +2708,11 @@ fn checked_i32_operation_uses_narrow_inputs(
     operation: CheckedIntegerOperation,
     inputs: &[ValueId],
 ) -> bool {
-    are_i32_pair(function, inputs)
-        && operation != CheckedIntegerOperation::Negate
+    are_i32_pair(function, inputs) && operation != CheckedIntegerOperation::Negate
 }
 
 fn are_i32_pair(function: &Function, inputs: &[ValueId]) -> bool {
-    inputs.len() == 2
-        && inputs
-            .iter()
-            .all(|input| function.values[input.0].ty == Type::I32)
+    inputs.len() == 2 && inputs.iter().all(|input| function.values[input.0].ty == Type::I32)
 }
 
 /// Clear the top half of a 32-bit result computed at full width.
@@ -2766,11 +2742,7 @@ fn integer_result_can_stay_narrow(function: &FunctionUses<'_>, result: ValueId) 
     }
 }
 
-fn i32_consumers_stay_narrow(
-    function: &FunctionUses<'_>,
-    value: ValueId,
-    visiting: &mut HashSet<ValueId>,
-) -> bool {
+fn i32_consumers_stay_narrow(function: &FunctionUses<'_>, value: ValueId, visiting: &mut HashSet<ValueId>) -> bool {
     if !visiting.insert(value) {
         return false;
     }
@@ -2812,18 +2784,21 @@ fn i32_consumers_stay_narrow(
         found_use = true;
         match &instruction.operation {
             Operation::InlineCall(_) => return false,
-            Operation::Intrinsic(Intrinsic::Value(ValueOperation::BoxInt32 { clean: true } | ValueOperation::ToUint32)) => continue,
+            Operation::Intrinsic(Intrinsic::Value(
+                ValueOperation::BoxInt32 { clean: true } | ValueOperation::ToUint32,
+            )) => continue,
             Operation::Intrinsic(Intrinsic::IntegerBinary(operation)) if operation.supports_narrow_result() => {}
             Operation::Intrinsic(Intrinsic::IntegerComparison(operation))
-                if typed_signed_comparison_uses_narrow_inputs(function, *operation, &instruction.inputs) => continue,
+                if typed_signed_comparison_uses_narrow_inputs(function, *operation, &instruction.inputs) =>
+            {
+                continue;
+            }
             _ => return false,
         }
         if !instruction.results.iter().all(|result| {
-                matches!(function.values[result.0].ty, Type::I32 | Type::U32)
-                    && (function.values[result.0].ty == Type::U32
-                        || i32_consumers_stay_narrow(function, *result, visiting))
-            })
-        {
+            matches!(function.values[result.0].ty, Type::I32 | Type::U32)
+                && (function.values[result.0].ty == Type::U32 || i32_consumers_stay_narrow(function, *result, visiting))
+        }) {
             return false;
         }
     }
@@ -2837,8 +2812,10 @@ fn materialize_symbolic_logical_rhs(
     rhs: &Operand,
     output: &mut Vec<Instruction>,
 ) -> Result<Operand, String> {
-    if !matches!(operation, IntegerBinaryOperation::Binary(BinaryOperation::Or) | IntegerBinaryOperation::Binary(BinaryOperation::Xor))
-        || !matches!(rhs, Operand::LayoutConstant(_))
+    if !matches!(
+        operation,
+        IntegerBinaryOperation::Binary(BinaryOperation::Or) | IntegerBinaryOperation::Binary(BinaryOperation::Xor)
+    ) || !matches!(rhs, Operand::LayoutConstant(_))
     {
         return Ok(rhs.clone());
     }
@@ -2996,8 +2973,7 @@ fn materialize_symbolic_branch_rhs(
                 width: IntegerWidth::U32,
                 ..
             })
-        )
-            && is_direct_u32_constant(rhs))
+        ) && is_direct_u32_constant(rhs))
     {
         return;
     }
@@ -3043,16 +3019,10 @@ fn value_machine_operation(operation: ValueOperation) -> Option<MachineOperation
         | ValueOperation::TruncateUint16
         | ValueOperation::ReinterpretUint64AsValue => MachineOperation::Move(IntegerWidth::U64),
         ValueOperation::BoxInt32 { clean } => MachineOperation::BoxInt32 { clean },
-        ValueOperation::BoxFloat64 | ValueOperation::ValueToFloat64 => {
-            MachineOperation::FloatMove
-        }
-        ValueOperation::UnboxInt32 { .. } | ValueOperation::UnboxBoolean => {
-            MachineOperation::UnboxInt32
-        }
+        ValueOperation::BoxFloat64 | ValueOperation::ValueToFloat64 => MachineOperation::FloatMove,
+        ValueOperation::UnboxInt32 { .. } | ValueOperation::UnboxBoolean => MachineOperation::UnboxInt32,
         ValueOperation::ExtractTag { .. } => MachineOperation::ExtractTag,
-        ValueOperation::ToInt32 | ValueOperation::ToUint32 => {
-            MachineOperation::Move(IntegerWidth::U32)
-        }
+        ValueOperation::ToInt32 | ValueOperation::ToUint32 => MachineOperation::Move(IntegerWidth::U32),
         ValueOperation::UnboxObject => MachineOperation::UnboxObject,
         ValueOperation::BoxNumber | ValueOperation::LogicalNot => return None,
     })
@@ -3110,24 +3080,16 @@ fn indexed_value_memory(index: &Operand) -> Result<Operand, String> {
 }
 
 fn operand_load_index(instruction: InstructionId, result_index: usize) -> Operand {
-    Operand::VirtualRegister(format!(
-        "ssa_operand_load_{}_{}_index",
-        instruction.0, result_index
-    ).into())
+    Operand::VirtualRegister(format!("ssa_operand_load_{}_{}_index", instruction.0, result_index).into())
 }
 
 fn is_fpr(ty: &Type) -> bool {
     ty.register_class() == Some(RegisterClass::FloatingPoint)
 }
 
-fn layout_operand(
-    constants: &LayoutConstants,
-    known: KnownLayoutConstant,
-) -> Result<Operand, String> {
+fn layout_operand(constants: &LayoutConstants, known: KnownLayoutConstant) -> Result<Operand, String> {
     constants
         .known(known)
         .map(Operand::LayoutConstant)
-        .ok_or_else(|| {
-            format!("unknown constant '{}'", known.name())
-        })
+        .ok_or_else(|| format!("unknown constant '{}'", known.name()))
 }

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -1857,7 +1857,19 @@ fn copy_instruction(destination: Operand, source: Operand, ty: &Type) -> Instruc
 }
 
 fn block_label(block: BlockId) -> Label {
-    Label::new(format!(".ssa_block_{}", block.0))
+    // Block labels are function-local and depend only on the block index, even
+    // though this cache outlives each function lowered on the thread.
+    thread_local! {
+        static LABELS: std::cell::RefCell<Vec<Label>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+    LABELS.with(|labels| {
+        let mut labels = labels.borrow_mut();
+        while labels.len() <= block.0 {
+            let next = labels.len();
+            labels.push(Label::new(format!(".ssa_block_{next}")));
+        }
+        labels[block.0].clone()
+    })
 }
 
 fn lower_memory_operation(

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -153,24 +153,16 @@ fn lower_handler_internal(
     constants: &LayoutConstants,
     id: crate::identity::HandlerId,
 ) -> Result<Handler, String> {
-    let mut folded_instructions = function
-        .blocks
-        .iter()
-        .filter_map(|block| {
-            let Some(Terminator::Branch { condition, .. }) = &block.terminator else {
-                return None;
-            };
-            selected_branch(function, *condition)
-                .map(|branch| branch.instruction)
-                .or_else(|| selected_int32_pair(function, *condition).map(|(instruction, _, _)| instruction))
-        })
-        .collect::<HashSet<_>>();
+    let mut folded_instructions = FoldedInstructions::new(function.instructions.len());
     for block in &function.blocks {
         let Some(Terminator::Branch { condition, .. }) = &block.terminator else {
             continue;
         };
         if let Some(branch) = selected_branch(function, *condition) {
+            folded_instructions.insert(branch.instruction);
             folded_instructions.extend(branch.folded_inputs);
+        } else if let Some((instruction, _, _)) = selected_int32_pair(function, *condition) {
+            folded_instructions.insert(instruction);
         }
     }
     for instruction in &function.instructions {
@@ -307,9 +299,32 @@ fn profile_layout_score(function: &Function, blocks: &[BlockId]) -> usize {
         .count()
 }
 
+/// The instructions a later one has absorbed, so lowering must not emit them.
+struct FoldedInstructions(Vec<bool>);
+
+impl FoldedInstructions {
+    fn new(instructions: usize) -> Self {
+        Self(vec![false; instructions])
+    }
+
+    fn insert(&mut self, instruction: InstructionId) {
+        self.0[instruction.0] = true;
+    }
+
+    fn extend(&mut self, instructions: impl IntoIterator<Item = InstructionId>) {
+        for instruction in instructions {
+            self.insert(instruction);
+        }
+    }
+
+    fn contains(&self, instruction: InstructionId) -> bool {
+        self.0[instruction.0]
+    }
+}
+
 fn lower_blocks(
     function: &FunctionUses<'_>,
-    folded_instructions: &HashSet<InstructionId>,
+    folded_instructions: &FoldedInstructions,
     constants: &LayoutConstants,
     block_order: Vec<BlockId>,
 ) -> Result<Vec<Instruction>, String> {
@@ -330,7 +345,7 @@ fn lower_blocks(
             .instructions
             .iter()
             .copied()
-            .filter(|instruction| !folded_instructions.contains(instruction))
+            .filter(|instruction| !folded_instructions.contains(*instruction))
             .collect::<Vec<_>>();
         let mut instruction_index = 0;
         while instruction_index < instructions.len() {
@@ -618,42 +633,43 @@ fn schedule_blocks(function: &Function) -> Vec<BlockId> {
 }
 
 fn schedule_blocks_with_successor_order(function: &Function, reverse_successors: bool) -> Vec<BlockId> {
-    fn visit(
-        function: &Function,
-        block: BlockId,
-        reverse_successors: bool,
-        visited: &mut HashSet<BlockId>,
-        postorder: &mut Vec<BlockId>,
-    ) {
-        if !visited.insert(block) {
-            return;
+    // Walk the graph with an explicit stack to handle deeply nested control
+    // flow without consuming the call stack.
+    let mut visited = vec![false; function.blocks.len()];
+    let mut reverse_postorder = Vec::with_capacity(function.blocks.len());
+    let mut stack = vec![(function.entry, 0usize)];
+    visited[function.entry.0] = true;
+    while let Some((block, next)) = stack.last_mut() {
+        let block = *block;
+        let successors = function.blocks[block.0]
+            .terminator
+            .as_ref()
+            .map_or(0, Terminator::successor_count);
+        if *next == successors {
+            reverse_postorder.push(block);
+            stack.pop();
+            continue;
         }
-        if let Some(terminator) = &function.blocks[block.0].terminator {
-            let mut successors = terminator.successors().collect::<Vec<_>>();
-            if reverse_successors {
-                successors.reverse();
-            }
-            for successor in successors {
-                visit(function, successor.block, reverse_successors, visited, postorder);
-            }
+        let index = if reverse_successors {
+            successors - 1 - *next
+        } else {
+            *next
+        };
+        *next += 1;
+        let successor = function.blocks[block.0]
+            .terminator
+            .as_ref()
+            .expect("a block with successors has a terminator")
+            .successor(index)
+            .block;
+        if !std::mem::replace(&mut visited[successor.0], true) {
+            stack.push((successor, 0));
         }
-        postorder.push(block);
     }
-
-    let mut visited = HashSet::default();
-    let mut reverse_postorder = Vec::new();
-    visit(
-        function,
-        function.entry,
-        reverse_successors,
-        &mut visited,
-        &mut reverse_postorder,
-    );
     reverse_postorder.reverse();
     for index in 0..function.blocks.len() {
-        let block = BlockId(index);
-        if visited.insert(block) {
-            reverse_postorder.push(block);
+        if !std::mem::replace(&mut visited[index], true) {
+            reverse_postorder.push(BlockId(index));
         }
     }
     let mut scheduled = reverse_postorder

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -1623,25 +1623,73 @@ fn defining_instruction(
 pub(crate) struct FunctionUses<'a> {
     function: &'a Function,
     counts: Vec<u32>,
+    user_offsets: Vec<u32>,
+    users: Vec<ValueUser>,
+}
+
+/// One place a value is read.
+#[derive(Clone, Copy)]
+enum ValueUser {
+    Instruction(InstructionId),
+    Terminator(BlockId),
 }
 
 impl<'a> FunctionUses<'a> {
     fn new(function: &'a Function) -> Self {
         let mut counts = vec![0u32; function.values.len()];
-        let inputs = function
-            .instructions
-            .iter()
-            .flat_map(|instruction| instruction.inputs.iter().copied())
-            .chain(
-                function
-                    .blocks
-                    .iter()
-                    .flat_map(|block| block.terminator.as_ref().into_iter().flat_map(Terminator::inputs)),
-            );
-        for input in inputs {
-            counts[input.0] += 1;
+        let mut terminator_inputs = Vec::new();
+        for instruction in &function.instructions {
+            for input in &instruction.inputs {
+                counts[input.0] += 1;
+            }
         }
-        Self { function, counts }
+        for block in &function.blocks {
+            let Some(terminator) = block.terminator.as_ref() else {
+                continue;
+            };
+            for input in terminator.inputs() {
+                counts[input.0] += 1;
+            }
+        }
+        // The users of each value live in one flat array, indexed by a per-value
+        // offset. Asking who reads a value is the question the narrowing
+        // analysis asks about nearly every result it lowers.
+        let mut user_offsets = Vec::with_capacity(counts.len() + 1);
+        let mut total = 0;
+        for count in &counts {
+            user_offsets.push(total);
+            total += count;
+        }
+        user_offsets.push(total);
+        let mut filled = user_offsets.clone();
+        let mut users = vec![ValueUser::Instruction(InstructionId(0)); total as usize];
+        for (index, instruction) in function.instructions.iter().enumerate() {
+            for input in &instruction.inputs {
+                users[filled[input.0] as usize] = ValueUser::Instruction(InstructionId(index));
+                filled[input.0] += 1;
+            }
+        }
+        for (index, block) in function.blocks.iter().enumerate() {
+            let Some(terminator) = block.terminator.as_ref() else {
+                continue;
+            };
+            terminator_inputs.clear();
+            terminator_inputs.extend(terminator.inputs());
+            for input in &terminator_inputs {
+                users[filled[input.0] as usize] = ValueUser::Terminator(BlockId(index));
+                filled[input.0] += 1;
+            }
+        }
+        Self {
+            function,
+            counts,
+            user_offsets,
+            users,
+        }
+    }
+
+    fn users_of(&self, value: ValueId) -> &[ValueUser] {
+        &self.users[self.user_offsets[value.0] as usize..self.user_offsets[value.0 + 1] as usize]
     }
 }
 
@@ -2702,7 +2750,7 @@ fn narrow_wide_result_to_i32(
     emit!(output; MachineOperation::Move(IntegerWidth::U32) => [destination.clone(), destination.clone()];);
 }
 
-fn integer_result_can_stay_narrow(function: &Function, result: ValueId) -> bool {
+fn integer_result_can_stay_narrow(function: &FunctionUses<'_>, result: ValueId) -> bool {
     match function.values[result.0].ty {
         Type::U32 => true,
         Type::I32 => i32_consumers_stay_narrow(function, result, &mut HashSet::new()),
@@ -2711,47 +2759,48 @@ fn integer_result_can_stay_narrow(function: &Function, result: ValueId) -> bool 
 }
 
 fn i32_consumers_stay_narrow(
-    function: &Function,
+    function: &FunctionUses<'_>,
     value: ValueId,
     visiting: &mut HashSet<ValueId>,
 ) -> bool {
     if !visiting.insert(value) {
         return false;
     }
-    for block in &function.blocks {
-        let terminator = block.terminator.as_ref().unwrap();
-        if !terminator.inputs().contains(&value) {
-            continue;
-        }
-        let Terminator::CheckedOperation {
-            operation,
-            inputs,
-            success,
-            failure,
-            ..
-        } = terminator
-        else {
-            return false;
-        };
-        let uses_narrow_inputs = match operation {
-            Operation::Intrinsic(Intrinsic::Branch(operation)) => branch_uses_narrow_inputs(function, *operation, inputs),
-            Operation::Intrinsic(Intrinsic::CheckedInteger(operation)) => checked_i32_operation_uses_narrow_inputs(function, *operation, inputs),
-            _ => false,
-        };
-        if !inputs.contains(&value)
-            || success.arguments.contains(&value)
-            || failure.arguments.contains(&value)
-            || !uses_narrow_inputs
-        {
-            return false;
-        }
-    }
-
     let mut found_use = false;
-    for instruction in &function.instructions {
-        if !instruction.inputs.contains(&value) {
-            continue;
-        }
+    for user in function.users_of(value) {
+        let instruction = match user {
+            ValueUser::Terminator(block) => {
+                let terminator = function.blocks[block.0].terminator.as_ref().unwrap();
+                let Terminator::CheckedOperation {
+                    operation,
+                    inputs,
+                    success,
+                    failure,
+                    ..
+                } = terminator
+                else {
+                    return false;
+                };
+                let uses_narrow_inputs = match operation {
+                    Operation::Intrinsic(Intrinsic::Branch(operation)) => {
+                        branch_uses_narrow_inputs(function, *operation, inputs)
+                    }
+                    Operation::Intrinsic(Intrinsic::CheckedInteger(operation)) => {
+                        checked_i32_operation_uses_narrow_inputs(function, *operation, inputs)
+                    }
+                    _ => false,
+                };
+                if !inputs.contains(&value)
+                    || success.arguments.contains(&value)
+                    || failure.arguments.contains(&value)
+                    || !uses_narrow_inputs
+                {
+                    return false;
+                }
+                continue;
+            }
+            ValueUser::Instruction(instruction) => &function.instructions[instruction.0],
+        };
         found_use = true;
         match &instruction.operation {
             Operation::InlineCall(_) => return false,

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -1649,7 +1649,7 @@ impl<'a> FunctionUses<'a> {
         let mut terminator_inputs = Vec::new();
         // Where each instruction sits. Selection asks whether two instructions
         // are adjacent in a block, and searching the whole function for them is
-        // quadratic on a stitched program.
+        // quadratic on a large program.
         let mut positions = vec![None; function.instructions.len()];
         for (block_index, block) in function.blocks.iter().enumerate() {
             for (position, instruction) in block.instructions.iter().enumerate() {

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -8,7 +8,7 @@
 
 use super::{
     AddressDisplacement, AddressRegister, AddressScale, Handler, Instruction, Label, MemoryAddress, Operand,
-    Relocation, VirtualRegister, emit_instructions as emit, intern_virtual_registers,
+    Relocation, VirtualRegister, emit_instructions as emit,
 };
 use crate::bytecode::{BytecodeFieldId, HandlerLayout as BytecodeHandlerLayout};
 use crate::frontend::layout::{KnownLayoutConstant, LayoutConstantCategory, LayoutConstants};
@@ -269,7 +269,6 @@ fn lower_handler_internal(
             instruction.operands.pop();
         }
     }
-    intern_virtual_registers(id, &mut instructions);
     Ok(Handler {
         id,
         name: function.name.clone(),

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -166,6 +166,15 @@ fn lower_handler_internal(
         }
     }
     for instruction in &function.instructions {
+        if instruction.operation.guard_failure().is_some() {
+            let condition = instruction.inputs[0];
+            if let Some(branch) = selected_branch(function, condition) {
+                folded_instructions.insert(branch.instruction);
+                folded_instructions.extend(branch.folded_inputs);
+            } else if let Some((instruction, _, _)) = selected_int32_pair(function, condition) {
+                folded_instructions.insert(instruction);
+            }
+        }
         if let Some((instruction, _)) = folded_bitwise_not_source(function, instruction) {
             folded_instructions.insert(instruction);
         }
@@ -331,9 +340,22 @@ fn lower_blocks(
     let mut body = Vec::new();
     let mut edge_temporary = 0usize;
     let mut deferred_switch_tails = HashMap::<BlockId, Vec<Instruction>>::default();
+    let entry_is_branch_target = (0..function.blocks.len()).any(|index| {
+        function.blocks[index]
+            .terminator
+            .as_ref()
+            .is_some_and(|terminator| {
+                terminator
+                    .successors()
+                    .any(|edge| edge.block == function.entry)
+            })
+            || function
+                .guard_exits(BlockId(index))
+                .any(|(_, failure)| failure == function.entry)
+    });
     for (position, &block_id) in block_order.iter().enumerate() {
         let block = &function.blocks[block_id.0];
-        if block_id != function.entry {
+        if block_id != function.entry || entry_is_branch_target {
             let label = block_label(block_id);
             if block.layout == BlockLayout::Cold {
                 emit!(body; MachineOperation::Cold => [Operand::Label(label.clone())];);
@@ -359,6 +381,26 @@ fn lower_blocks(
                     )
                 })
                 .map(|offset| instruction_index + 1 + offset);
+            if let Some(failure) = function.instructions[instruction_id.0]
+                .operation
+                .guard_failure()
+            {
+                let name = format!("guard_{}", instruction_id.0);
+                let continue_label = Label::new(format!(".ssa_{name}_pass"));
+                emit_conditional_branch(
+                    function,
+                    constants,
+                    &name,
+                    block_body_start,
+                    function.instructions[instruction_id.0].inputs[0],
+                    &continue_label,
+                    &mut body,
+                )?;
+                emit!(body; MachineOperation::Control(ControlOperation::JumpLabel) => [Operand::Label(block_label(failure))];);
+                emit!(body; MachineOperation::Label => [Operand::Label(continue_label)];);
+                instruction_index += 1;
+                continue;
+            }
             if let Some(next_index) = next_instruction
                 && lower_field_access_pair(
                     function,
@@ -398,121 +440,15 @@ fn lower_blocks(
                 else_edge,
             } => {
                 let then_label = Label::new(format!(".ssa_edge_{}_then", block_id.0));
-                let branch = selected_branch(function, *condition);
-                if let Some((_, lhs, rhs)) = selected_int32_pair(function, *condition) {
-                    let failure_label = Label::new(format!(".ssa_edge_{}_else", block_id.0));
-                    emit!(body;
-                        MachineOperation::branch_tag(EqualityCondition::NotEqual) => [value_operand(function, lhs)?, layout_operand(
-                                constants,
-                                KnownLayoutConstant::Int32Tag,
-                            )?, Operand::Label(failure_label.clone())];
-                    );
-                    emit!(body;
-                        MachineOperation::branch_tag(EqualityCondition::Equal) => [value_operand(function, rhs)?, layout_operand(
-                                constants,
-                                KnownLayoutConstant::Int32Tag,
-                            )?, Operand::Label(then_label.clone())];
-                    );
-                    emit!(body; MachineOperation::Label => [Operand::Label(failure_label)];);
-                } else if let Some(branch) = branch {
-                    let direct_tag_branch = branch.direct_tag_source.as_ref().and_then(|source| {
-                        if !branch.early_branches.is_empty() || branch.and_mask.is_some() {
-                            return None;
-                        }
-                        let [SelectedBranchInput::Value(lhs), SelectedBranchInput::Value(rhs)] =
-                            branch.inputs.as_slice()
-                        else {
-                            return None;
-                        };
-                        if !matches!(
-                            branch.operation,
-                            MachineOperation::Branch(BranchOperation::Equality {
-                                width: IntegerWidth::U64 | IntegerWidth::U16,
-                                ..
-                            })
-                        ) {
-                            return None;
-                        }
-                        if *lhs == source.tag {
-                            direct_tag_constant(function, *rhs).map(|tag| (source.value, tag))
-                        } else if *rhs == source.tag {
-                            direct_tag_constant(function, *lhs).map(|tag| (source.value, tag))
-                        } else {
-                            None
-                        }
-                    }).or_else(|| singleton_value_branch(function, &branch));
-                    if let Some(source) = branch.direct_tag_source.as_ref()
-                        && direct_tag_branch.is_none()
-                    {
-                        let tag = value_operand(function, source.tag)?;
-                        emit!(body; MachineOperation::ExtractTag => [tag, value_operand(function, source.value)?];);
-                    }
-                    for early_branch in &branch.early_branches {
-                        let mut operands = early_branch
-                            .inputs
-                            .iter()
-                            .map(|input| branch_input_operand(function, constants, input))
-                            .collect::<Result<Vec<_>, _>>()?;
-                        materialize_symbolic_branch_rhs(
-                            early_branch.operation,
-                            block_id,
-                            block_body_start,
-                            &mut operands,
-                            &mut body,
-                        );
-                        operands.push(Operand::Label(then_label.clone()));
-                        body.push(machine_instruction(early_branch.operation, operands));
-                    }
-                    if let Some((value, expected_tag)) = direct_tag_branch {
-                        let singleton = matches!(
-                            &expected_tag,
-                            Operand::LayoutConstant(constant)
-                                if constant.category()
-                                    == LayoutConstantCategory::Value
-                        );
-                        emit!(body;
-                            match (
-                                singleton,
-                                matches!(
-                                    branch.operation,
-                                    MachineOperation::Branch(BranchOperation::Equality {
-                                        condition: EqualityCondition::Equal,
-                                        ..
-                                    })
-                                ),
-                            ) {
-                                (true, true) => MachineOperation::branch_singleton(EqualityCondition::Equal),
-                                (true, false) => MachineOperation::branch_singleton(EqualityCondition::NotEqual),
-                                (false, true) => MachineOperation::branch_tag(EqualityCondition::Equal),
-                                (false, false) => MachineOperation::branch_tag(EqualityCondition::NotEqual),
-                            } => [value_operand(function, value)?, expected_tag, Operand::Label(then_label.clone())];
-                        );
-                    } else {
-                        let mut operands = branch
-                            .inputs
-                            .iter()
-                            .map(|input| branch_input_operand(function, constants, input))
-                            .collect::<Result<Vec<_>, _>>()?;
-                        if let Some((source, destination, mask)) = branch.and_mask {
-                            if source != destination {
-                                let destination = value_operand(function, destination)?;
-                                emit!(body; MachineOperation::Move(IntegerWidth::U64) => [destination, value_operand(function, source)?];);
-                            }
-                            emit!(body; MachineOperation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::And), width: IntegerWidth::U16 } => [value_operand(function, destination)?, layout_operand(constants, mask)?];);
-                        }
-                        materialize_symbolic_branch_rhs(
-                            branch.operation,
-                            block_id,
-                            block_body_start,
-                            &mut operands,
-                            &mut body,
-                        );
-                        operands.push(Operand::Label(then_label.clone()));
-                        body.push(machine_instruction(branch.operation, operands));
-                    }
-                } else {
-                    emit!(body; MachineOperation::branch_zero(IntegerWidth::U64, ZeroCondition::NonZero) => [value_operand(function, *condition)?, Operand::Label(then_label.clone())];);
-                }
+                emit_conditional_branch(
+                    function,
+                    constants,
+                    &format!("{}", block_id.0),
+                    block_body_start,
+                    *condition,
+                    &then_label,
+                    &mut body,
+                )?;
                 lower_edge_copies(
                     function,
                     else_edge,
@@ -2434,6 +2370,9 @@ fn lower_instruction(
         }
         Operation::BlockReference(_) => {}
         Operation::Address => {}
+        // A guard needs the block's label naming and its emitted position, so
+        // block lowering handles it rather than this per-instruction pass.
+        Operation::Guard { .. } => return Err("a guard is lowered with its block".to_string()),
     }
     Ok(())
 }
@@ -2911,9 +2850,133 @@ fn materialize_symbolic_logical_rhs(
     Ok(temporary)
 }
 
+/// Emit the machine branch that goes to `then_label` when `condition` holds.
+///
+/// A branch terminator and a guard differ only in where control goes when the
+/// condition fails, so both select their machine instruction here. `name` makes
+/// the labels and temporaries this emits unique within the handler.
+fn emit_conditional_branch(
+    function: &FunctionUses<'_>,
+    constants: &LayoutConstants,
+    name: &str,
+    block_body_start: usize,
+    condition: ValueId,
+    then_label: &Label,
+    body: &mut Vec<Instruction>,
+) -> Result<(), String> {
+    let branch = selected_branch(function, condition);
+    if let Some((_, lhs, rhs)) = selected_int32_pair(function, condition) {
+        let failure_label = Label::new(format!(".ssa_edge_{name}_else"));
+        emit!(body;
+            MachineOperation::branch_tag(EqualityCondition::NotEqual) => [value_operand(function, lhs)?, layout_operand(
+                    constants,
+                    KnownLayoutConstant::Int32Tag,
+                )?, Operand::Label(failure_label.clone())];
+        );
+        emit!(body;
+            MachineOperation::branch_tag(EqualityCondition::Equal) => [value_operand(function, rhs)?, layout_operand(
+                    constants,
+                    KnownLayoutConstant::Int32Tag,
+                )?, Operand::Label(then_label.clone())];
+        );
+        emit!(body; MachineOperation::Label => [Operand::Label(failure_label)];);
+    } else if let Some(branch) = branch {
+        let direct_tag_branch = branch
+            .direct_tag_source
+            .as_ref()
+            .and_then(|source| {
+                if !branch.early_branches.is_empty() || branch.and_mask.is_some() {
+                    return None;
+                }
+                let [SelectedBranchInput::Value(lhs), SelectedBranchInput::Value(rhs)] = branch.inputs.as_slice()
+                else {
+                    return None;
+                };
+                if !matches!(
+                    branch.operation,
+                    MachineOperation::Branch(BranchOperation::Equality {
+                        width: IntegerWidth::U64 | IntegerWidth::U16,
+                        ..
+                    })
+                ) {
+                    return None;
+                }
+                if *lhs == source.tag {
+                    direct_tag_constant(function, *rhs).map(|tag| (source.value, tag))
+                } else if *rhs == source.tag {
+                    direct_tag_constant(function, *lhs).map(|tag| (source.value, tag))
+                } else {
+                    None
+                }
+            })
+            .or_else(|| singleton_value_branch(function, &branch));
+        if let Some(source) = branch.direct_tag_source.as_ref()
+            && direct_tag_branch.is_none()
+        {
+            let tag = value_operand(function, source.tag)?;
+            emit!(body; MachineOperation::ExtractTag => [tag, value_operand(function, source.value)?];);
+        }
+        for early_branch in &branch.early_branches {
+            let mut operands = early_branch
+                .inputs
+                .iter()
+                .map(|input| branch_input_operand(function, constants, input))
+                .collect::<Result<Vec<_>, _>>()?;
+            materialize_symbolic_branch_rhs(early_branch.operation, name, block_body_start, &mut operands, body);
+            operands.push(Operand::Label(then_label.clone()));
+            body.push(machine_instruction(early_branch.operation, operands));
+        }
+        if let Some((value, expected_tag)) = direct_tag_branch {
+            let singleton = matches!(
+                &expected_tag,
+                Operand::LayoutConstant(constant)
+                    if constant.category()
+                        == LayoutConstantCategory::Value
+            );
+            emit!(body;
+                match (
+                    singleton,
+                    matches!(
+                        branch.operation,
+                        MachineOperation::Branch(BranchOperation::Equality {
+                            condition: EqualityCondition::Equal,
+                            ..
+                        })
+                    ),
+                ) {
+                    (true, true) => MachineOperation::branch_singleton(EqualityCondition::Equal),
+                    (true, false) => MachineOperation::branch_singleton(EqualityCondition::NotEqual),
+                    (false, true) => MachineOperation::branch_tag(EqualityCondition::Equal),
+                    (false, false) => MachineOperation::branch_tag(EqualityCondition::NotEqual),
+                } => [value_operand(function, value)?, expected_tag, Operand::Label(then_label.clone())];
+            );
+        } else {
+            let mut operands = branch
+                .inputs
+                .iter()
+                .map(|input| branch_input_operand(function, constants, input))
+                .collect::<Result<Vec<_>, _>>()?;
+            if let Some((source, destination, mask)) = branch.and_mask {
+                if source != destination {
+                    let destination = value_operand(function, destination)?;
+                    emit!(body; MachineOperation::Move(IntegerWidth::U64) => [destination, value_operand(function, source)?];);
+                }
+                emit!(body; MachineOperation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::And), width: IntegerWidth::U16 } => [value_operand(function, destination)?, layout_operand(constants, mask)?];);
+            }
+            materialize_symbolic_branch_rhs(branch.operation, name, block_body_start, &mut operands, body);
+            operands.push(Operand::Label(then_label.clone()));
+            body.push(machine_instruction(branch.operation, operands));
+        }
+    } else {
+        emit!(body; MachineOperation::branch_zero(IntegerWidth::U64, ZeroCondition::NonZero) => [value_operand(function, condition)?, Operand::Label(then_label.clone())];);
+    }
+
+    Ok(())
+}
+
 fn materialize_symbolic_branch_rhs(
     operation: MachineOperation,
-    block: BlockId,
+    name: &str,
     block_body_start: usize,
     operands: &mut [Operand],
     output: &mut Vec<Instruction>,
@@ -2950,7 +3013,7 @@ fn materialize_symbolic_branch_rhs(
         *rhs = register;
         return;
     }
-    let temporary = Operand::VirtualRegister(format!("ssa_branch_{}_rhs", block.0).into());
+    let temporary = Operand::VirtualRegister(format!("ssa_branch_{name}_rhs").into());
     emit!(output; MachineOperation::Move(IntegerWidth::U64) => [temporary.clone(), rhs.clone()];);
     *rhs = temporary;
 }

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -26,6 +26,7 @@ pub(crate) fn lower_handler_with_constants(
     constants: &LayoutConstants,
     id: crate::identity::HandlerId,
 ) -> Result<Handler, CompileError> {
+    let function = &FunctionUses::new(function);
     let mut handler =
         lower_handler_internal(function, is_cold, constants, id).map_err(|message| {
         CompileError::new(CompileStage::LowIr, Some(&function.name), message)
@@ -147,7 +148,7 @@ fn resolve_layout_constant(operand: &mut Operand) {
 }
 
 fn lower_handler_internal(
-    function: &Function,
+    function: &FunctionUses<'_>,
     is_cold: bool,
     constants: &LayoutConstants,
     id: crate::identity::HandlerId,
@@ -310,7 +311,7 @@ fn profile_layout_score(function: &Function, blocks: &[BlockId]) -> usize {
 }
 
 fn lower_blocks(
-    function: &Function,
+    function: &FunctionUses<'_>,
     folded_instructions: &HashSet<InstructionId>,
     constants: &LayoutConstants,
     block_order: Vec<BlockId>,
@@ -953,7 +954,7 @@ fn lower_switch_cases(
 
 #[allow(clippy::too_many_arguments)]
 fn lower_checked_operation(
-    function: &Function,
+    function: &FunctionUses<'_>,
     block: BlockId,
     operation: &Operation,
     inputs: &[ValueId],
@@ -1140,13 +1141,13 @@ enum SelectedBranchInput {
     Layout(KnownLayoutConstant),
 }
 
-fn selected_branch(function: &Function, condition: ValueId) -> Option<SelectedBranch> {
+fn selected_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<SelectedBranch> {
     let mut branch = select_branch(function, condition)?;
     fold_load_into_branch(function, &mut branch);
     Some(branch)
 }
 
-fn select_branch(function: &Function, condition: ValueId) -> Option<SelectedBranch> {
+fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<SelectedBranch> {
     let (instruction, operation) = single_use_instruction(function, condition)?;
     let (comparison, classification) = match &operation.operation {
         Operation::Intrinsic(Intrinsic::IntegerComparison(comparison)) => (Some(*comparison), None),
@@ -1359,7 +1360,7 @@ fn branch_input_operand(
     }
 }
 
-fn fold_load_into_branch(function: &Function, branch: &mut SelectedBranch) {
+fn fold_load_into_branch(function: &FunctionUses<'_>, branch: &mut SelectedBranch) {
     for load_index in 0..branch.inputs.len().min(2) {
         let SelectedBranchInput::Value(value) = branch.inputs[load_index] else {
             continue;
@@ -1468,7 +1469,7 @@ struct LoweredLoad {
 }
 
 fn lowered_single_use_load(
-    function: &Function,
+    function: &FunctionUses<'_>,
     value: ValueId,
     branch: &SelectedBranch,
 ) -> Option<LoweredLoad> {
@@ -1553,7 +1554,7 @@ fn branch_input_integer(function: &Function, input: &SelectedBranchInput) -> Opt
     }
 }
 
-fn direct_tag_source(function: &Function, tag: ValueId) -> Option<DirectTagSource> {
+fn direct_tag_source(function: &FunctionUses<'_>, tag: ValueId) -> Option<DirectTagSource> {
     let (extract_instruction, extract) = single_use_instruction(function, tag)?;
     if extract.operation != Operation::Intrinsic(Intrinsic::Value(ValueOperation::ExtractTag { rematerialized: false })) {
         return None;
@@ -1569,7 +1570,7 @@ fn direct_tag_source(function: &Function, tag: ValueId) -> Option<DirectTagSourc
 }
 
 fn selected_int32_pair(
-    function: &Function,
+    function: &FunctionUses<'_>,
     condition: ValueId,
 ) -> Option<(InstructionId, ValueId, ValueId)> {
     let (instruction, operation) = single_use_instruction(function, condition)?;
@@ -1582,7 +1583,7 @@ fn selected_int32_pair(
     Some((instruction, *lhs, *rhs))
 }
 
-fn single_use_reused_source(function: &Function, value: ValueId) -> Option<(InstructionId, ValueId)> {
+fn single_use_reused_source(function: &FunctionUses<'_>, value: ValueId) -> Option<(InstructionId, ValueId)> {
     let (instruction, reuse) = single_use_instruction(function, value)?;
     if reuse.operation != Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse)) {
         return None;
@@ -1593,10 +1594,10 @@ fn single_use_reused_source(function: &Function, value: ValueId) -> Option<(Inst
     Some((instruction, *source))
 }
 
-fn single_use_instruction(
-    function: &Function,
+fn single_use_instruction<'a>(
+    function: &'a FunctionUses<'a>,
     value: ValueId,
-) -> Option<(InstructionId, &super::ir::Instruction)> {
+) -> Option<(InstructionId, &'a super::ir::Instruction)> {
     if value_use_count(function, value) != 1 {
         return None;
     }
@@ -1615,19 +1616,45 @@ fn defining_instruction(
     Some((instruction, &function.instructions[instruction.0]))
 }
 
-fn value_use_count(function: &Function, value: ValueId) -> usize {
-    function
-        .instructions
-        .iter()
-        .flat_map(|instruction| &instruction.inputs)
-        .filter(|input| **input == value)
-        .count()
-        + function
-            .blocks
+/// A function together with how many times each of its values is used.
+///
+/// Lowering asks that question constantly, and answering it by scanning the
+/// whole function each time makes compilation quadratic in the function size.
+pub(crate) struct FunctionUses<'a> {
+    function: &'a Function,
+    counts: Vec<u32>,
+}
+
+impl<'a> FunctionUses<'a> {
+    fn new(function: &'a Function) -> Self {
+        let mut counts = vec![0u32; function.values.len()];
+        let inputs = function
+            .instructions
             .iter()
-            .flat_map(|block| block.terminator.as_ref().into_iter().flat_map(Terminator::inputs))
-            .filter(|input| *input == value)
-            .count()
+            .flat_map(|instruction| instruction.inputs.iter().copied())
+            .chain(
+                function
+                    .blocks
+                    .iter()
+                    .flat_map(|block| block.terminator.as_ref().into_iter().flat_map(Terminator::inputs)),
+            );
+        for input in inputs {
+            counts[input.0] += 1;
+        }
+        Self { function, counts }
+    }
+}
+
+impl std::ops::Deref for FunctionUses<'_> {
+    type Target = Function;
+
+    fn deref(&self) -> &Function {
+        self.function
+    }
+}
+
+fn value_use_count(function: &FunctionUses<'_>, value: ValueId) -> usize {
+    function.counts[value.0] as usize
 }
 
 fn is_integer_zero(function: &Function, value: ValueId) -> bool {
@@ -1655,7 +1682,7 @@ fn direct_tag_constant(function: &Function, value: ValueId) -> Option<Operand> {
     }
 }
 
-fn singleton_value_branch(function: &Function, branch: &SelectedBranch) -> Option<(ValueId, Operand)> {
+fn singleton_value_branch(function: &FunctionUses<'_>, branch: &SelectedBranch) -> Option<(ValueId, Operand)> {
     if !branch.early_branches.is_empty()
         || branch.and_mask.is_some()
         || !matches!(
@@ -1879,7 +1906,7 @@ fn require_inputs<'a, T, const COUNT: usize>(
 }
 
 fn lower_instruction(
-    function: &Function,
+    function: &FunctionUses<'_>,
     instruction_id: InstructionId,
     instruction: &super::ir::Instruction,
     output: &mut Vec<Instruction>,
@@ -2298,7 +2325,7 @@ fn lower_instruction(
 }
 
 fn folded_bitwise_not_source(
-    function: &Function,
+    function: &FunctionUses<'_>,
     instruction: &super::ir::Instruction,
 ) -> Option<(InstructionId, ValueId)> {
     folded_unary_source(
@@ -2309,7 +2336,7 @@ fn folded_bitwise_not_source(
     )
 }
 
-fn folded_checked_i32_source(function: &Function, value: ValueId) -> Option<(InstructionId, ValueId)> {
+fn folded_checked_i32_source(function: &FunctionUses<'_>, value: ValueId) -> Option<(InstructionId, ValueId)> {
     if value_use_count(function, value) != 1 && !integer_result_can_stay_narrow(function, value) {
         return None;
     }
@@ -2324,7 +2351,7 @@ fn folded_checked_i32_source(function: &Function, value: ValueId) -> Option<(Ins
 }
 
 fn folded_32bit_operation_source(
-    function: &Function,
+    function: &FunctionUses<'_>,
     value: ValueId,
 ) -> Option<(Vec<InstructionId>, ValueId)> {
     let mut instructions = Vec::new();
@@ -2353,7 +2380,7 @@ fn folded_32bit_operation_source(
     (!instructions.is_empty()).then_some((instructions, source))
 }
 
-fn folded_shift_count(function: &Function, value: ValueId) -> Option<(Vec<InstructionId>, ValueId)> {
+fn folded_shift_count(function: &FunctionUses<'_>, value: ValueId) -> Option<(Vec<InstructionId>, ValueId)> {
     let (mut instructions, value) = folded_32bit_operation_source(function, value).unwrap_or_else(|| (Vec::new(), value));
     let (instruction, mask) = single_use_instruction(function, value)?;
     if mask.operation != Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::And))) {
@@ -2377,7 +2404,7 @@ fn folded_shift_count(function: &Function, value: ValueId) -> Option<(Vec<Instru
 }
 
 fn folded_u32_unbox_source(
-    function: &Function,
+    function: &FunctionUses<'_>,
     instruction: &super::ir::Instruction,
 ) -> Option<(InstructionId, ValueId)> {
     folded_unary_source(
@@ -2389,7 +2416,7 @@ fn folded_u32_unbox_source(
 }
 
 fn folded_i32_bool_source(
-    function: &Function,
+    function: &FunctionUses<'_>,
     instruction: &super::ir::Instruction,
 ) -> Option<(InstructionId, ValueId)> {
     folded_unary_source(
@@ -2401,7 +2428,7 @@ fn folded_i32_bool_source(
 }
 
 fn folded_unary_source(
-    function: &Function,
+    function: &FunctionUses<'_>,
     instruction: &super::ir::Instruction,
     operation: Operation,
     source_matches: impl FnOnce(&Operation) -> bool,

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -620,9 +620,7 @@ fn control_flow_cost(instructions: &[Instruction]) -> Result<usize, String> {
     super::optimize::invert_branches_over_jumps(&mut instructions);
     super::optimize::remove_unreferenced_labels(&mut instructions);
     let mut graph = super::cfg::ControlFlowGraph::from_instructions(instructions)?;
-    graph.thread_unconditional_jumps();
-    graph.remove_unreferenced_jump_blocks();
-    graph.remove_unreachable_blocks();
+    graph.simplify();
     let layout = graph.layout_hot_and_cold()?;
     Ok(graph.linearize_omitting_jumps_to_next_block(&layout.hot).len()
         + graph.linearize_omitting_jumps_to_next_block(&layout.cold).len())

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -28,6 +28,7 @@ use crate::target::description::{
 };
 use crate::types::{InterpreterRegister, RegisterClass, Type};
 use crate::{CompileError, CompileStage};
+use std::ops::Range;
 
 pub(crate) fn lower_handler_with_constants(
     function: &Function,
@@ -244,9 +245,10 @@ fn lower_handler_internal(
         candidate_orders.push(profile_order);
     }
     let lowered = lower_blocks(function, &folded_instructions, constants, preferred_order.clone())?;
+    let lowered_blocks = LoweredBlockFragments::new(&lowered, &preferred_order)?;
     let mut selected = None;
     for order in candidate_orders {
-        let instructions = reorder_lowered_blocks(&lowered, &preferred_order, &order)?;
+        let instructions = lowered_blocks.layout_instructions(&lowered, &order);
         let mut graph = super::cfg::ControlFlowGraph::from_instructions(instructions)?;
         graph.simplify();
         let cost = graph.linearized_instruction_count()?;
@@ -261,7 +263,7 @@ fn lower_handler_internal(
     let mut instructions = if selected_order == preferred_order {
         lowered
     } else {
-        reorder_lowered_blocks(&lowered, &preferred_order, &selected_order)?
+        lowered_blocks.reorder(&lowered, &selected_order)
     };
     // Preserve the semantic exec_ctx value for targets that derive it from a
     // different pinned base. The dedicated instruction also exposes any
@@ -511,56 +513,112 @@ fn lower_blocks(
     Ok(body)
 }
 
-fn reorder_lowered_blocks(
-    instructions: &[Instruction],
-    original_order: &[BlockId],
-    new_order: &[BlockId],
-) -> Result<Vec<Instruction>, String> {
-    let labels = original_order
-        .iter()
-        .map(|block| (block_label(*block), *block))
-        .collect::<HashMap<_, _>>();
-    let mut starts = Vec::with_capacity(original_order.len());
-    for (index, instruction) in instructions.iter().enumerate() {
-        if instruction.opcode.operation() != MachineOperation::Label {
-            continue;
+struct LoweredBlockFragments {
+    ranges: Vec<Range<usize>>,
+}
+
+impl LoweredBlockFragments {
+    fn new(instructions: &[Instruction], original_order: &[BlockId]) -> Result<Self, String> {
+        let labels = original_order
+            .iter()
+            .map(|block| (block_label(*block), *block))
+            .collect::<HashMap<_, _>>();
+        let mut starts = Vec::with_capacity(original_order.len());
+        for (index, instruction) in instructions.iter().enumerate() {
+            if instruction.opcode.operation() != MachineOperation::Label {
+                continue;
+            }
+            let [Operand::Label(label)] = instruction.operands.as_slice() else {
+                continue;
+            };
+            let Some(block) = labels.get(label).copied() else {
+                continue;
+            };
+            let start = if index > 0
+                && instructions[index - 1].opcode.operation() == MachineOperation::Cold
+                && instructions[index - 1].operands == instruction.operands
+            {
+                index - 1
+            } else {
+                index
+            };
+            starts.push((block, start));
         }
-        let [Operand::Label(label)] = instruction.operands.as_slice() else {
-            continue;
-        };
-        let Some(block) = labels.get(label).copied() else {
-            continue;
-        };
-        let start = if index > 0
-            && instructions[index - 1].opcode.operation() == MachineOperation::Cold
-            && instructions[index - 1].operands == instruction.operands
-        {
-            index - 1
-        } else {
-            index
-        };
-        starts.push((block, start));
-    }
-    if starts.first().is_none_or(|(_, start)| *start != 0) {
-        starts.insert(0, (original_order[0], 0));
-    }
-    let ranges = starts
-        .iter()
-        .enumerate()
-        .map(|(position, (block, start))| {
+        if starts.first().is_none_or(|(_, start)| *start != 0) {
+            starts.insert(0, (original_order[0], 0));
+        }
+        let mut ranges = vec![0..0; original_order.len()];
+        let mut found = vec![false; original_order.len()];
+        for (position, (block, start)) in starts.iter().enumerate() {
             let end = starts.get(position + 1).map_or(instructions.len(), |(_, start)| *start);
-            (*block, (*start, end))
-        })
-        .collect::<HashMap<_, _>>();
-    if ranges.len() != original_order.len() {
-        return Err("lowered block fragments do not cover the scheduled SSA blocks".to_string());
+            if block.0 >= ranges.len() || std::mem::replace(&mut found[block.0], true) {
+                return Err("lowered block fragments do not cover the scheduled SSA blocks".to_string());
+            }
+            ranges[block.0] = *start..end;
+        }
+        if found.contains(&false) {
+            return Err("lowered block fragments do not cover the scheduled SSA blocks".to_string());
+        }
+        Ok(Self { ranges })
     }
-    let mut reordered = Vec::with_capacity(instructions.len());
-    for block in new_order {
-        let (start, end) = ranges[block];
-        reordered.extend_from_slice(&instructions[start..end]);
+
+    fn reorder(&self, instructions: &[Instruction], new_order: &[BlockId]) -> Vec<Instruction> {
+        let mut reordered = Vec::with_capacity(instructions.len());
+        for block in new_order {
+            reordered.extend_from_slice(&instructions[self.ranges[block.0].clone()]);
+        }
+        reordered
     }
-    Ok(reordered)
+
+    fn layout_instructions(
+        &self,
+        instructions: &[Instruction],
+        new_order: &[BlockId],
+    ) -> Vec<Instruction<LayoutOperand>> {
+        let mut reordered = Vec::with_capacity(instructions.len());
+        for block in new_order {
+            reordered.extend(instructions[self.ranges[block.0].clone()].iter().map(|instruction| {
+                Instruction {
+                    opcode: instruction.opcode,
+                    operands: instruction
+                        .operands
+                        .iter()
+                        .map(|operand| match operand {
+                            Operand::Label(label) => LayoutOperand::Label(label.clone()),
+                            _ => LayoutOperand::Other,
+                        })
+                        .collect(),
+                }
+            }));
+        }
+        reordered
+    }
+}
+
+#[derive(Clone, Debug)]
+enum LayoutOperand {
+    Label(Label),
+    Other,
+}
+
+impl super::ControlFlowOperand for LayoutOperand {
+    fn label(&self) -> Option<&Label> {
+        match self {
+            Self::Label(label) => Some(label),
+            Self::Other => None,
+        }
+    }
+
+    fn label_mut(&mut self) -> Option<&mut Label> {
+        match self {
+            Self::Label(label) => Some(label),
+            Self::Other => None,
+        }
+    }
+
+    fn from_label(label: Label) -> Self {
+        Self::Label(label)
+    }
 }
 
 fn schedule_blocks(function: &Function) -> Vec<BlockId> {
@@ -2560,7 +2618,7 @@ fn value_operand(function: &FunctionUses<'_>, value: ValueId) -> Result<Operand,
         | ValueDefinition::TerminatorResult { .. } => Operand::VirtualRegister(
             function
                 .register(value)
-                .expect("materialized SSA values have a register class")
+                .ok_or_else(|| format!("SSA value {value:?} has no register class"))?
                 .clone(),
         ),
         ValueDefinition::Constant(Constant::Integer(value)) => Operand::Immediate(*value),
@@ -2824,6 +2882,7 @@ fn i32_consumers_stay_narrow(function: &FunctionUses<'_>, value: ValueId, visiti
                 {
                     return false;
                 }
+                found_use = true;
                 continue;
             }
             ValueUser::Instruction(instruction) => &function.instructions[instruction.0],
@@ -3146,6 +3205,49 @@ mod tests {
     use super::*;
 
     #[test]
+    fn rejects_materialized_values_without_a_register_class() {
+        let mut function = Function::new("invalid", Vec::new(), Vec::new());
+        let value = function.append_instruction(
+            function.entry,
+            Intrinsic::LowLevel(LowLevelOperation::Negate),
+            Vec::new(),
+            vec![Type::Tuple(Vec::new())],
+        )[0];
+        let function = FunctionUses::new(&function, crate::identity::HandlerId::new(0));
+
+        assert_eq!(
+            value_operand(&function, value).unwrap_err(),
+            format!("SSA value {value:?} has no register class")
+        );
+    }
+
+    #[test]
+    fn keeps_i32_values_narrow_when_only_a_checked_terminator_uses_them() {
+        let mut function = Function::new("narrow", vec![Type::I32, Type::I32], Vec::new());
+        let value = function.append_instruction(
+            function.entry,
+            Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add)),
+            vec![function.parameter(0), function.parameter(1)],
+            vec![Type::I32],
+        )[0];
+        let success = function.create_named_block("success", BlockLayout::Hot, vec![Type::I32]);
+        let failure = function.create_empty_block("failure", BlockLayout::Cold);
+        function.set_checked_operation(
+            function.entry,
+            Intrinsic::CheckedInteger(CheckedIntegerOperation::Add),
+            vec![value, function.parameter(1)],
+            vec![Type::I32],
+            crate::ssa::Effects::PURE,
+            success,
+            Vec::new(),
+            Edge::new(failure),
+        );
+        let function = FunctionUses::new(&function, crate::identity::HandlerId::new(0));
+
+        assert!(integer_result_can_stay_narrow(&function, value));
+    }
+
+    #[test]
     fn reorders_lowered_block_fragments_without_splitting_internal_labels() {
         let first = BlockId(0);
         let second = BlockId(1);
@@ -3154,7 +3256,8 @@ mod tests {
             machine_instruction(MachineOperation::Label, vec![Operand::Label(block_label(second))]),
             machine_instruction(MachineOperation::Label, vec![Operand::Label(Label::new(".internal"))]),
         ];
-        let reordered = reorder_lowered_blocks(&instructions, &[first, second], &[second, first]).unwrap();
+        let fragments = LoweredBlockFragments::new(&instructions, &[first, second]).unwrap();
+        let reordered = fragments.reorder(&instructions, &[second, first]);
 
         assert_eq!(reordered[0].operands, [Operand::Label(block_label(second))]);
         assert_eq!(reordered[1].operands, [Operand::Label(Label::new(".internal"))]);

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -770,7 +770,7 @@ fn schedule_blocks_by_profile(function: &Function) -> Vec<BlockId> {
 
 #[allow(clippy::too_many_arguments)]
 fn lower_switch(
-    function: &Function,
+    function: &FunctionUses<'_>,
     block: BlockId,
     next_block: Option<BlockId>,
     preferred_tail_after: Option<BlockId>,
@@ -859,7 +859,7 @@ fn first_preferred_switch_group<'a>(
 }
 
 fn emit_inverted_switch_group_test(
-    function: &Function,
+    function: &FunctionUses<'_>,
     value: &Operand,
     cases: &[(ValueId, Edge)],
     failure: &Label,
@@ -893,7 +893,7 @@ fn emit_inverted_switch_group_test(
 
 #[allow(clippy::too_many_arguments)]
 fn lower_switch_cases(
-    function: &Function,
+    function: &FunctionUses<'_>,
     block: BlockId,
     value: &Operand,
     cases: &[(ValueId, Edge)],
@@ -1361,7 +1361,7 @@ fn select_branch(function: &FunctionUses<'_>, condition: ValueId) -> Option<Sele
 }
 
 fn branch_input_operand(
-    function: &Function,
+    function: &FunctionUses<'_>,
     constants: &LayoutConstants,
     input: &SelectedBranchInput,
 ) -> Result<Operand, String> {
@@ -1451,7 +1451,7 @@ fn fold_load_into_branch(function: &FunctionUses<'_>, branch: &mut SelectedBranc
 }
 
 fn branch_register_is_compatible(
-    function: &Function,
+    function: &FunctionUses<'_>,
     input: &SelectedBranchInput,
     load_width: MemoryWidth,
     branch_width: IntegerWidth,
@@ -1638,6 +1638,7 @@ pub(crate) struct FunctionUses<'a> {
     counts: Vec<u32>,
     user_offsets: Vec<u32>,
     users: Vec<ValueUser>,
+    registers: Vec<Option<VirtualRegister>>,
 }
 
 /// One place a value is read.
@@ -1693,12 +1694,40 @@ impl<'a> FunctionUses<'a> {
                 filled[input.0] += 1;
             }
         }
+        // Every operand naming an SSA value names it by the same virtual
+        // register, and lowering emits an operand per use, so the register is
+        // built once per value rather than formatted, allocated and hashed once
+        // per use.
+        let registers = function
+            .values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                if !matches!(
+                    value.definition,
+                    ValueDefinition::InstructionResult { .. }
+                        | ValueDefinition::BlockParameter { .. }
+                        | ValueDefinition::TerminatorResult { .. }
+                ) {
+                    return None;
+                }
+                let class = value.ty.register_class()?;
+                Some(VirtualRegister::with_class(format!("ssa_{index}"), class))
+            })
+            .collect();
+
         Self {
             function,
             counts,
             user_offsets,
             users,
+            registers,
         }
+    }
+
+    /// The virtual register an SSA value is named by, if it lives in one.
+    fn register(&self, value: ValueId) -> Option<&VirtualRegister> {
+        self.registers[value.0].as_ref()
     }
 
     fn users_of(&self, value: ValueId) -> &[ValueUser] {
@@ -1793,7 +1822,7 @@ fn integer_constant(function: &Function, value: ValueId) -> Option<i64> {
 }
 
 fn lower_edge_copies(
-    function: &Function,
+    function: &FunctionUses<'_>,
     edge: &Edge,
     output: &mut Vec<Instruction>,
     temporary_index: &mut usize,
@@ -1894,7 +1923,7 @@ fn lower_memory_operation(
 }
 
 fn lower_field_access_pair(
-    function: &Function,
+    function: &FunctionUses<'_>,
     first_id: InstructionId,
     second_id: InstructionId,
     output: &mut Vec<Instruction>,
@@ -2526,7 +2555,7 @@ fn folded_unary_source(
     Some((unbox_instruction, *boxed))
 }
 
-fn value_operand(function: &Function, value: ValueId) -> Result<Operand, String> {
+fn value_operand(function: &FunctionUses<'_>, value: ValueId) -> Result<Operand, String> {
     let value = resolve_reuse_value(function, value);
     let virtual_register = |name| {
         let class = function.values[value.0]
@@ -2554,7 +2583,12 @@ fn value_operand(function: &Function, value: ValueId) -> Result<Operand, String>
                 Operand::Label(block_label(target))
             }
         ValueDefinition::InstructionResult { .. } | ValueDefinition::BlockParameter { .. }
-        | ValueDefinition::TerminatorResult { .. } => virtual_register(format!("ssa_{}", value.0)),
+        | ValueDefinition::TerminatorResult { .. } => Operand::VirtualRegister(
+            function
+                .register(value)
+                .expect("materialized SSA values have a register class")
+                .clone(),
+        ),
         ValueDefinition::Constant(Constant::Integer(value)) => Operand::Immediate(*value),
         ValueDefinition::Constant(Constant::Layout(constant)) => {
             Operand::LayoutConstant(*constant)
@@ -2631,7 +2665,7 @@ fn resolve_reuse_value(function: &Function, mut value: ValueId) -> ValueId {
     }
 }
 
-fn memory_operand(function: &Function, components: &[ValueId]) -> Result<Operand, String> {
+fn memory_operand(function: &FunctionUses<'_>, components: &[ValueId]) -> Result<Operand, String> {
     if !(1..=3).contains(&components.len()) {
         return Err(format!("memory address requires one to three components, got {}", components.len()));
     }

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -301,10 +301,7 @@ fn profile_layout_score(function: &Function, blocks: &[BlockId]) -> usize {
                 .terminator
                 .as_ref()
                 .is_some_and(|terminator| {
-                    terminator
-                        .successors()
-                        .iter()
-                        .any(|successor| successor.block == pair[1])
+                    terminator.successors().any(|successor| successor.block == pair[1])
                 })
         })
         .count()
@@ -632,7 +629,7 @@ fn schedule_blocks_with_successor_order(function: &Function, reverse_successors:
             return;
         }
         if let Some(terminator) = &function.blocks[block.0].terminator {
-            let mut successors = terminator.successors();
+            let mut successors = terminator.successors().collect::<Vec<_>>();
             if reverse_successors {
                 successors.reverse();
             }

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -2151,10 +2151,12 @@ fn lower_instruction(
                 emit!(output; narrow_integer_operation(machine_operation) => [destination.clone(), lhs, rhs];);
             } else if *operation == IntegerBinaryOperation::Binary(BinaryOperation::Multiply) {
                 emit!(output; machine_operation => [destination.clone(), lhs.clone(), rhs.clone()];);
+                narrow_wide_result_to_i32(function, instruction.results[0], destination, output);
             } else {
                 emit!(output; MachineOperation::Move(IntegerWidth::U64) => [destination.clone(), lhs.clone()];);
                 let rhs = materialize_symbolic_logical_rhs(*operation, destination, rhs, output)?;
                 emit!(output; machine_operation => [destination.clone(), rhs];);
+                narrow_wide_result_to_i32(function, instruction.results[0], destination, output);
             }
         }
         Operation::Intrinsic(Intrinsic::IntegerComparison(operation)) => {
@@ -2679,6 +2681,25 @@ fn are_i32_pair(function: &Function, inputs: &[ValueId]) -> bool {
         && inputs
             .iter()
             .all(|input| function.values[input.0].ty == Type::I32)
+}
+
+/// Clear the top half of a 32-bit result computed at full width.
+///
+/// Addition, subtraction and multiplication cannot produce a narrow result
+/// directly, because the overflow check they usually carry needs the wide one,
+/// so they are emitted at full width and the checked form truncates afterwards.
+/// An unchecked one has no such check to truncate for it, and everything that
+/// consumes an `i32` is entitled to assume the top half is clear.
+fn narrow_wide_result_to_i32(
+    function: &Function,
+    result: ValueId,
+    destination: &Operand,
+    output: &mut Vec<Instruction>,
+) {
+    if function.values[result.0].ty != Type::I32 {
+        return;
+    }
+    emit!(output; MachineOperation::Move(IntegerWidth::U32) => [destination.clone(), destination.clone()];);
 }
 
 fn integer_result_can_stay_narrow(function: &Function, result: ValueId) -> bool {

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -18,7 +18,7 @@ use crate::ssa::{BlockId, BlockLayout, Constant, Edge, Function, InstructionId, 
 use crate::target::description::{BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, Operation as MachineOperation, OrderedCondition, OverflowOperation, PairWidth, SignCondition, TestCondition, ZeroCondition};
 use crate::{CompileError, CompileStage};
 use super::{AddressDisplacement, AddressRegister, AddressScale, Handler, Instruction, Label, MemoryAddress, Operand, Relocation, VirtualRegister, emit_instructions as emit, intern_virtual_registers};
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 pub(crate) fn lower_handler_with_constants(
     function: &Function,
@@ -315,7 +315,7 @@ fn lower_blocks(
 ) -> Result<Vec<Instruction>, String> {
     let mut body = Vec::new();
     let mut edge_temporary = 0usize;
-    let mut deferred_switch_tails = HashMap::<BlockId, Vec<Instruction>>::new();
+    let mut deferred_switch_tails = HashMap::<BlockId, Vec<Instruction>>::default();
     for (position, &block_id) in block_order.iter().enumerate() {
         let block = &function.blocks[block_id.0];
         if block_id != function.entry {
@@ -640,7 +640,7 @@ fn schedule_blocks_with_successor_order(function: &Function, reverse_successors:
         postorder.push(block);
     }
 
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::default();
     let mut reverse_postorder = Vec::new();
     visit(
         function,
@@ -2750,7 +2750,7 @@ fn narrow_wide_result_to_i32(
 fn integer_result_can_stay_narrow(function: &FunctionUses<'_>, result: ValueId) -> bool {
     match function.values[result.0].ty {
         Type::U32 => true,
-        Type::I32 => i32_consumers_stay_narrow(function, result, &mut HashSet::new()),
+        Type::I32 => i32_consumers_stay_narrow(function, result, &mut HashSet::default()),
         _ => false,
     }
 }

--- a/Libraries/LibJS/Flap/src/low_ir/lowering.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/lowering.rs
@@ -236,24 +236,24 @@ fn lower_handler_internal(
     let preferred_order = schedule_blocks(function);
     let alternate_order = schedule_blocks_with_successor_order(function, false);
     let profile_order = schedule_blocks_by_profile(function);
-    let preferred_profile_score = profile_layout_score(function, &preferred_order);
-    let alternate_profile_score = profile_layout_score(function, &alternate_order);
-    let preferred = lower_blocks(function, &folded_instructions, constants, preferred_order)?;
-    let alternate = lower_blocks(function, &folded_instructions, constants, alternate_order)?;
-    let preferred_cost = control_flow_cost(&preferred)?;
-    let alternate_cost = control_flow_cost(&alternate)?;
-    let (selected_profile_score, mut selected) = if alternate_profile_score > preferred_profile_score
-        || alternate_profile_score == preferred_profile_score && alternate_cost < preferred_cost
-    {
-        (alternate_profile_score, alternate)
-    } else {
-        (preferred_profile_score, preferred)
-    };
-    let profile_score = profile_layout_score(function, &profile_order);
-    if profile_score > selected_profile_score {
-        selected = lower_blocks(function, &folded_instructions, constants, profile_order)?;
+    let mut candidate_orders = vec![preferred_order.clone(), alternate_order, profile_order];
+    candidate_orders.dedup();
+    let lowered = lower_blocks(function, &folded_instructions, constants, preferred_order.clone())?;
+    let mut selected = None;
+    for order in candidate_orders {
+        let instructions = reorder_lowered_blocks(&lowered, &preferred_order, &order)?;
+        let mut graph = super::cfg::ControlFlowGraph::from_instructions(instructions)?;
+        graph.simplify();
+        let cost = graph.linearized_instruction_count()?;
+        let profile_score = profile_layout_score(function, &order);
+        if selected.as_ref().is_none_or(|(selected_profile, selected_cost, _)| {
+            profile_score > *selected_profile || profile_score == *selected_profile && cost < *selected_cost
+        }) {
+            selected = Some((profile_score, cost, order));
+        }
     }
-    let mut instructions = selected;
+    let selected_order = selected.expect("there is always a preferred block order").2;
+    let mut instructions = reorder_lowered_blocks(&lowered, &preferred_order, &selected_order)?;
     // Preserve the semantic exec_ctx value for targets that derive it from a
     // different pinned base. The dedicated instruction also exposes any
     // scratch register needed for that derivation to register allocation.
@@ -502,17 +502,56 @@ fn lower_blocks(
     Ok(body)
 }
 
-fn control_flow_cost(instructions: &[Instruction]) -> Result<usize, String> {
-    let mut instructions = instructions.to_vec();
-    super::optimize::invert_branches_over_jumps(&mut instructions);
-    super::optimize::remove_unreferenced_labels(&mut instructions);
-    super::optimize::invert_branches_over_jumps(&mut instructions);
-    super::optimize::remove_unreferenced_labels(&mut instructions);
-    let mut graph = super::cfg::ControlFlowGraph::from_instructions(instructions)?;
-    graph.simplify();
-    let layout = graph.layout_hot_and_cold()?;
-    Ok(graph.linearize_omitting_jumps_to_next_block(&layout.hot).len()
-        + graph.linearize_omitting_jumps_to_next_block(&layout.cold).len())
+fn reorder_lowered_blocks(
+    instructions: &[Instruction],
+    original_order: &[BlockId],
+    new_order: &[BlockId],
+) -> Result<Vec<Instruction>, String> {
+    let labels = original_order
+        .iter()
+        .map(|block| (block_label(*block), *block))
+        .collect::<HashMap<_, _>>();
+    let mut starts = Vec::with_capacity(original_order.len());
+    for (index, instruction) in instructions.iter().enumerate() {
+        if instruction.opcode.operation() != MachineOperation::Label {
+            continue;
+        }
+        let [Operand::Label(label)] = instruction.operands.as_slice() else {
+            continue;
+        };
+        let Some(block) = labels.get(label).copied() else {
+            continue;
+        };
+        let start = if index > 0
+            && instructions[index - 1].opcode.operation() == MachineOperation::Cold
+            && instructions[index - 1].operands == instruction.operands
+        {
+            index - 1
+        } else {
+            index
+        };
+        starts.push((block, start));
+    }
+    if starts.first().is_none_or(|(_, start)| *start != 0) {
+        starts.insert(0, (original_order[0], 0));
+    }
+    let ranges = starts
+        .iter()
+        .enumerate()
+        .map(|(position, (block, start))| {
+            let end = starts.get(position + 1).map_or(instructions.len(), |(_, start)| *start);
+            (*block, (*start, end))
+        })
+        .collect::<HashMap<_, _>>();
+    if ranges.len() != original_order.len() {
+        return Err("lowered block fragments do not cover the scheduled SSA blocks".to_string());
+    }
+    let mut reordered = Vec::with_capacity(instructions.len());
+    for block in new_order {
+        let (start, end) = ranges[block];
+        reordered.extend_from_slice(&instructions[start..end]);
+    }
+    Ok(reordered)
 }
 
 fn schedule_blocks(function: &Function) -> Vec<BlockId> {
@@ -3091,4 +3130,28 @@ fn layout_operand(constants: &LayoutConstants, known: KnownLayoutConstant) -> Re
         .known(known)
         .map(Operand::LayoutConstant)
         .ok_or_else(|| format!("unknown constant '{}'", known.name()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reorders_lowered_block_fragments_without_splitting_internal_labels() {
+        let first = BlockId(0);
+        let second = BlockId(1);
+        let instructions = vec![
+            machine_instruction(MachineOperation::Move(IntegerWidth::U64), vec![]),
+            machine_instruction(MachineOperation::Label, vec![Operand::Label(block_label(second))]),
+            machine_instruction(MachineOperation::Label, vec![Operand::Label(Label::new(".internal"))]),
+        ];
+        let reordered = reorder_lowered_blocks(&instructions, &[first, second], &[second, first]).unwrap();
+
+        assert_eq!(reordered[0].operands, [Operand::Label(block_label(second))]);
+        assert_eq!(reordered[1].operands, [Operand::Label(Label::new(".internal"))]);
+        assert_eq!(
+            reordered[2].opcode.operation(),
+            MachineOperation::Move(IntegerWidth::U64)
+        );
+    }
 }

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -292,15 +292,6 @@ pub(crate) enum Operand {
 }
 
 impl Operand {
-    pub(crate) fn references(&self, register: &VirtualRegister) -> bool {
-        match self {
-            Self::VirtualRegister(candidate) => candidate == register,
-            Self::Address(address) => std::iter::once(&address.base)
-                .chain(&address.index)
-                .any(|candidate| matches!(candidate, AddressRegister::Virtual(candidate) if candidate == register)),
-            _ => false,
-        }
-    }
 }
 
 pub(crate) trait ControlFlowOperand: Clone {

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -87,6 +87,16 @@ impl VirtualRegister {
         }
     }
 
+    pub(crate) fn ssa(function: HandlerId, index: u32, value: usize, class: RegisterClass) -> Self {
+        Self {
+            id: Some(VirtualRegisterId { function, index }),
+            name: format!("ssa_{value}").into(),
+            class,
+            origin: VirtualRegisterOrigin::Ssa,
+            identity_hash: 0,
+        }
+    }
+
     pub(crate) fn class(&self) -> RegisterClass {
         self.class
     }
@@ -452,16 +462,11 @@ pub(crate) fn visit_virtual_registers_mut(operand: &mut Operand, visit: &mut imp
 }
 
 pub(crate) fn intern_virtual_registers(function: HandlerId, instructions: &mut [Instruction]) -> Vec<VirtualRegister> {
-    // Number the registers in the order they first appear. The numbering only
-    // has to be deterministic, and ordering by name means comparing strings
-    // while sorting every register of a large function, which is among the
-    // most expensive things the whole pipeline does.
     let mut ids = HashMap::default();
     let mut interned_registers = Vec::new();
     for instruction in instructions.iter() {
         for operand in &instruction.operands {
             visit_virtual_registers(operand, &mut |register| {
-                assert!(register.id.is_none(), "virtual registers may only be interned once");
                 if !ids.contains_key(register) {
                     let id = VirtualRegisterId {
                         function,
@@ -589,5 +594,26 @@ mod tests {
         assert_ne!(value.id(), index.id());
         assert!(value.id().is_some());
         assert_eq!(registers, [value.clone(), index.clone()]);
+    }
+
+    #[test]
+    fn compacts_preassigned_virtual_register_ids() {
+        let handler = HandlerId::new(3);
+        let first = VirtualRegister::ssa(handler, 0, 0, RegisterClass::GeneralPurpose);
+        let last = VirtualRegister::ssa(handler, 2, 9, RegisterClass::GeneralPurpose);
+        let mut instructions = vec![Instruction {
+            opcode: MachineOperation::Move(IntegerWidth::U64),
+            operands: vec![Operand::VirtualRegister(first), Operand::VirtualRegister(last)],
+        }];
+
+        let registers = intern_virtual_registers(handler, &mut instructions);
+
+        assert_eq!(registers.len(), 2);
+        assert_eq!(registers[0].id().unwrap().index(), 0);
+        assert_eq!(registers[1].id().unwrap().index(), 1);
+        let Operand::VirtualRegister(last) = &instructions[0].operands[1] else {
+            unreachable!()
+        };
+        assert_eq!(last.id().unwrap().index(), 1);
     }
 }

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -475,7 +475,7 @@ pub(crate) fn intern_virtual_registers(
 
     // Number the registers in the order they first appear. The numbering only
     // has to be deterministic, and ordering by name means comparing strings
-    // while sorting every register of a stitched function, which is among the
+    // while sorting every register of a large function, which is among the
     // most expensive things the whole pipeline does.
     let mut seen = HashMap::default();
     let mut registers = Vec::new();

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -342,7 +342,7 @@ pub(crate) trait ControlFlowOperand: Clone {
 
 pub(crate) trait ControlFlowOpcode: Clone + fmt::Debug {
     fn operation(&self) -> Operation;
-    fn description(&self) -> InstructionDescription;
+    fn description(&self) -> &'static InstructionDescription;
     fn replacing_operation(&self, operation: Operation) -> Self;
 }
 
@@ -351,7 +351,7 @@ impl ControlFlowOpcode for Operation {
         *self
     }
 
-    fn description(&self) -> InstructionDescription {
+    fn description(&self) -> &'static InstructionDescription {
         self.description()
     }
 
@@ -365,7 +365,7 @@ impl ControlFlowOpcode for SelectedOpcode {
         self.operation()
     }
 
-    fn description(&self) -> InstructionDescription {
+    fn description(&self) -> &'static InstructionDescription {
         self.description()
     }
 

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -394,21 +394,6 @@ macro_rules! emit_instructions {
 
 pub(crate) use emit_instructions;
 
-/// Count appearances of virtual registers in the instruction operand stream.
-pub(crate) fn count_virtual_register_uses<C>(
-    instructions: &[Instruction<Operand, C>],
-) -> HashMap<VirtualRegister, u32> {
-    let mut counts = HashMap::new();
-    for instruction in instructions {
-        for operand in &instruction.operands {
-            visit_virtual_registers(operand, &mut |register| {
-                *counts.entry(register.clone()).or_insert(0) += 1;
-            });
-        }
-    }
-    counts
-}
-
 pub(crate) fn visit_virtual_registers(
     operand: &Operand,
     visit: &mut impl FnMut(&VirtualRegister),

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -6,6 +6,7 @@
 
 //! Target-independent low-level IR before instruction selection.
 
+pub(crate) mod analysis;
 pub(crate) mod cfg;
 pub(crate) mod lowering;
 pub(crate) mod optimize;

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -11,20 +11,16 @@ pub(crate) mod lowering;
 pub(crate) mod optimize;
 pub(crate) mod preallocate;
 
-use crate::ssa as ir;
 use crate::bytecode::BytecodeFieldId;
-use crate::frontend::layout::{
-    KnownLayoutConstant, LayoutConstant, LayoutConstants,
-};
+use crate::frontend::layout::{KnownLayoutConstant, LayoutConstant, LayoutConstants};
+use crate::hash::HashMap;
 use crate::identity::{ExternalSymbol, HandlerId};
-use crate::types::{InterpreterRegister, RegisterClass};
+use crate::ssa as ir;
+use crate::target::description::{InstructionDescription, Operation, SelectedOpcode};
 use crate::target::registers::PhysicalRegister;
-use crate::target::description::{
-    InstructionDescription, Operation, SelectedOpcode,
-};
+use crate::types::{InterpreterRegister, RegisterClass};
 use std::cmp::Ordering;
 use std::collections::hash_map::DefaultHasher;
-use crate::hash::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -104,9 +100,7 @@ impl PartialEq for VirtualRegister {
     fn eq(&self, other: &Self) -> bool {
         match (self.id, other.id) {
             (Some(lhs), Some(rhs)) => lhs == rhs,
-            (None, None) => {
-                self.name == other.name && self.class == other.class
-            }
+            (None, None) => self.name == other.name && self.class == other.class,
             _ => false,
         }
     }
@@ -124,10 +118,7 @@ impl Ord for VirtualRegister {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self.id, other.id) {
             (Some(lhs), Some(rhs)) => lhs.cmp(&rhs),
-            (None, None) => self
-                .name
-                .cmp(&other.name)
-                .then_with(|| self.class.cmp(&other.class)),
+            (None, None) => self.name.cmp(&other.name).then_with(|| self.class.cmp(&other.class)),
             (None, Some(_)) => Ordering::Less,
             (Some(_), None) => Ordering::Greater,
         }
@@ -277,10 +268,7 @@ impl Deref for Label {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum AddressRegister<
-    V = VirtualRegister,
-    I = InterpreterRegister,
-> {
+pub(crate) enum AddressRegister<V = VirtualRegister, I = InterpreterRegister> {
     Virtual(V),
     Interpreter(I),
     Physical(PhysicalRegister),
@@ -331,8 +319,7 @@ pub(crate) enum Operand {
     BytecodeField(BytecodeFieldId),
 }
 
-impl Operand {
-}
+impl Operand {}
 
 pub(crate) trait ControlFlowOperand: Clone {
     fn label(&self) -> Option<&Label>;
@@ -425,10 +412,7 @@ macro_rules! emit_instructions {
 
 pub(crate) use emit_instructions;
 
-pub(crate) fn visit_virtual_registers(
-    operand: &Operand,
-    visit: &mut impl FnMut(&VirtualRegister),
-) {
+pub(crate) fn visit_virtual_registers(operand: &Operand, visit: &mut impl FnMut(&VirtualRegister)) {
     match operand {
         Operand::VirtualRegister(register) => visit(register),
         Operand::Address(address) => {
@@ -442,16 +426,11 @@ pub(crate) fn visit_virtual_registers(
     }
 }
 
-fn visit_virtual_registers_mut(
-    operand: &mut Operand,
-    visit: &mut impl FnMut(&mut VirtualRegister),
-) {
+fn visit_virtual_registers_mut(operand: &mut Operand, visit: &mut impl FnMut(&mut VirtualRegister)) {
     match operand {
         Operand::VirtualRegister(register) => visit(register),
         Operand::Address(address) => {
-            for register in std::iter::once(&mut address.base)
-                .chain(address.index.iter_mut())
-            {
+            for register in std::iter::once(&mut address.base).chain(address.index.iter_mut()) {
                 if let AddressRegister::Virtual(register) = register {
                     visit(register);
                 }
@@ -461,10 +440,7 @@ fn visit_virtual_registers_mut(
     }
 }
 
-pub(crate) fn intern_virtual_registers(
-    function: HandlerId,
-    instructions: &mut [Instruction],
-) {
+pub(crate) fn intern_virtual_registers(function: HandlerId, instructions: &mut [Instruction]) {
     for instruction in instructions.iter_mut() {
         for operand in &mut instruction.operands {
             visit_virtual_registers_mut(operand, &mut |register| {
@@ -495,8 +471,7 @@ pub(crate) fn intern_virtual_registers(
         .map(|(index, register)| {
             let id = VirtualRegisterId {
                 function,
-                index: u32::try_from(index)
-                    .expect("one handler cannot contain more than u32::MAX virtual registers"),
+                index: u32::try_from(index).expect("one handler cannot contain more than u32::MAX virtual registers"),
             };
             (register, id)
         })
@@ -528,8 +503,7 @@ pub(crate) struct RuntimeConstants {
 impl RuntimeConstants {
     pub(crate) fn from_layout(constants: &LayoutConstants) -> Self {
         Self {
-            values: KnownLayoutConstant::ALL
-                .map(|constant| constants.known(constant).map(|value| value.value())),
+            values: KnownLayoutConstant::ALL.map(|constant| constants.known(constant).map(|value| value.value())),
         }
     }
 
@@ -538,9 +512,7 @@ impl RuntimeConstants {
     }
 
     #[cfg(test)]
-    pub(crate) fn from_values(
-        values: impl IntoIterator<Item = (KnownLayoutConstant, i64)>,
-    ) -> Self {
+    pub(crate) fn from_values(values: impl IntoIterator<Item = (KnownLayoutConstant, i64)>) -> Self {
         let mut constants = Self::default();
         for (constant, value) in values {
             constants.values[constant as usize] = Some(value);
@@ -574,15 +546,12 @@ impl Program {
             dispatch_handlers: Vec::new(),
         }
     }
-
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::target::description::{
-        IntegerWidth, Operation as MachineOperation,
-    };
+    use crate::target::description::{IntegerWidth, Operation as MachineOperation};
 
     #[test]
     fn interns_virtual_registers_per_handler() {
@@ -603,8 +572,7 @@ mod tests {
 
         intern_virtual_registers(HandlerId::new(3), &mut instructions);
 
-        let Operand::VirtualRegister(value) = &instructions[0].operands[0]
-        else {
+        let Operand::VirtualRegister(value) = &instructions[0].operands[0] else {
             unreachable!()
         };
         let Operand::Address(address) = &instructions[0].operands[1] else {
@@ -622,8 +590,7 @@ mod tests {
 
         let original = value.id();
         intern_virtual_registers(HandlerId::new(3), &mut instructions);
-        let Operand::VirtualRegister(value) = &instructions[0].operands[0]
-        else {
+        let Operand::VirtualRegister(value) = &instructions[0].operands[0] else {
             unreachable!()
         };
         assert_eq!(value.id(), original);

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -40,6 +40,16 @@ pub(crate) struct VirtualRegisterId {
     index: u32,
 }
 
+impl VirtualRegisterId {
+    pub(crate) fn function(self) -> HandlerId {
+        self.function
+    }
+
+    pub(crate) fn index(self) -> u32 {
+        self.index
+    }
+}
+
 /// A virtual register and its non-semantic debug name.
 #[derive(Debug, Clone)]
 pub(crate) struct VirtualRegister {
@@ -440,42 +450,31 @@ fn visit_virtual_registers_mut(operand: &mut Operand, visit: &mut impl FnMut(&mu
     }
 }
 
-pub(crate) fn intern_virtual_registers(function: HandlerId, instructions: &mut [Instruction]) {
-    for instruction in instructions.iter_mut() {
-        for operand in &mut instruction.operands {
-            visit_virtual_registers_mut(operand, &mut |register| {
-                register.id = None;
-            });
-        }
-    }
-
+pub(crate) fn intern_virtual_registers(function: HandlerId, instructions: &mut [Instruction]) -> Vec<VirtualRegister> {
     // Number the registers in the order they first appear. The numbering only
     // has to be deterministic, and ordering by name means comparing strings
     // while sorting every register of a large function, which is among the
     // most expensive things the whole pipeline does.
-    let mut seen = HashMap::default();
-    let mut registers = Vec::new();
+    let mut ids = HashMap::default();
+    let mut interned_registers = Vec::new();
     for instruction in instructions.iter() {
         for operand in &instruction.operands {
             visit_virtual_registers(operand, &mut |register| {
-                if !seen.contains_key(register) {
-                    seen.insert(register.clone(), ());
-                    registers.push(register.clone());
+                assert!(register.id.is_none(), "virtual registers may only be interned once");
+                if !ids.contains_key(register) {
+                    let id = VirtualRegisterId {
+                        function,
+                        index: u32::try_from(interned_registers.len())
+                            .expect("one handler cannot contain more than u32::MAX virtual registers"),
+                    };
+                    let mut interned = register.clone();
+                    interned.id = Some(id);
+                    ids.insert(register.clone(), id);
+                    interned_registers.push(interned);
                 }
             });
         }
     }
-    let ids = registers
-        .into_iter()
-        .enumerate()
-        .map(|(index, register)| {
-            let id = VirtualRegisterId {
-                function,
-                index: u32::try_from(index).expect("one handler cannot contain more than u32::MAX virtual registers"),
-            };
-            (register, id)
-        })
-        .collect::<HashMap<_, _>>();
 
     for instruction in instructions {
         for operand in &mut instruction.operands {
@@ -484,6 +483,7 @@ pub(crate) fn intern_virtual_registers(function: HandlerId, instructions: &mut [
             });
         }
     }
+    interned_registers
 }
 
 #[derive(Debug, Clone)]
@@ -570,7 +570,7 @@ mod tests {
             ],
         }];
 
-        intern_virtual_registers(HandlerId::new(3), &mut instructions);
+        let registers = intern_virtual_registers(HandlerId::new(3), &mut instructions);
 
         let Operand::VirtualRegister(value) = &instructions[0].operands[0] else {
             unreachable!()
@@ -587,12 +587,6 @@ mod tests {
         assert_eq!(value.id(), base.id());
         assert_ne!(value.id(), index.id());
         assert!(value.id().is_some());
-
-        let original = value.id();
-        intern_virtual_registers(HandlerId::new(3), &mut instructions);
-        let Operand::VirtualRegister(value) = &instructions[0].operands[0] else {
-            unreachable!()
-        };
-        assert_eq!(value.id(), original);
+        assert_eq!(registers, [value.clone(), index.clone()]);
     }
 }

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -23,7 +23,8 @@ use crate::target::description::{
     InstructionDescription, Operation, SelectedOpcode,
 };
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, hash_map::DefaultHasher};
+use std::collections::{BTreeSet, hash_map::DefaultHasher};
+use crate::hash::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -23,7 +23,7 @@ use crate::target::description::{
     InstructionDescription, Operation, SelectedOpcode,
 };
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, hash_map::DefaultHasher};
+use std::collections::hash_map::DefaultHasher;
 use crate::hash::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -473,11 +473,19 @@ pub(crate) fn intern_virtual_registers(
         }
     }
 
-    let mut registers = BTreeSet::new();
+    // Number the registers in the order they first appear. The numbering only
+    // has to be deterministic, and ordering by name means comparing strings
+    // while sorting every register of a stitched function, which is among the
+    // most expensive things the whole pipeline does.
+    let mut seen = HashMap::default();
+    let mut registers = Vec::new();
     for instruction in instructions.iter() {
         for operand in &instruction.operands {
             visit_virtual_registers(operand, &mut |register| {
-                registers.insert(register.clone());
+                if !seen.contains_key(register) {
+                    seen.insert(register.clone(), ());
+                    registers.push(register.clone());
+                }
             });
         }
     }

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -436,7 +436,7 @@ pub(crate) fn visit_virtual_registers(operand: &Operand, visit: &mut impl FnMut(
     }
 }
 
-fn visit_virtual_registers_mut(operand: &mut Operand, visit: &mut impl FnMut(&mut VirtualRegister)) {
+pub(crate) fn visit_virtual_registers_mut(operand: &mut Operand, visit: &mut impl FnMut(&mut VirtualRegister)) {
     match operand {
         Operand::VirtualRegister(register) => visit(register),
         Operand::Address(address) => {

--- a/Libraries/LibJS/Flap/src/low_ir/mod.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/mod.rs
@@ -198,16 +198,55 @@ impl fmt::Display for Relocation {
 }
 
 /// A branch target within a machine function.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) struct Label(String);
+///
+/// Every control-flow pass copies labels around, indexes blocks by them and
+/// compares them, so the name is shared rather than copied and its hash is
+/// taken once, when the label is made.
+#[derive(Debug, Clone)]
+pub(crate) struct Label {
+    name: Arc<str>,
+    hash: u64,
+}
 
 impl Label {
     pub(crate) fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
+        let name: Arc<str> = name.into().into();
+        let mut hasher = DefaultHasher::new();
+        name.hash(&mut hasher);
+        Self {
+            hash: hasher.finish(),
+            name,
+        }
     }
 
     pub(crate) fn as_str(&self) -> &str {
-        &self.0
+        &self.name
+    }
+}
+
+impl PartialEq for Label {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash && self.name == other.name
+    }
+}
+
+impl Eq for Label {}
+
+impl PartialOrd for Label {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Label {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl Hash for Label {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.hash.hash(state);
     }
 }
 
@@ -225,7 +264,7 @@ impl From<String> for Label {
 
 impl fmt::Display for Label {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(formatter)
+        self.name.fmt(formatter)
     }
 }
 

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -609,6 +609,109 @@ mod tests {
         })
     }
 
+    fn evaluate_integer_listing(instructions: &[Instruction]) -> Vec<u64> {
+        let mut registers = HashMap::default();
+        let mut stored = Vec::new();
+        let value = |operand: &Operand, registers: &HashMap<VirtualRegister, u64>| match operand {
+            Operand::VirtualRegister(register) => registers[register],
+            Operand::Immediate(immediate) => *immediate as u64,
+            _ => panic!("unsupported oracle operand: {operand:?}"),
+        };
+        for instruction in instructions {
+            match (instruction.opcode.operation(), instruction.operands.as_slice()) {
+                (Operation::Move(IntegerWidth::U64), [Operand::VirtualRegister(destination), source]) => {
+                    registers.insert(destination.clone(), value(source, &registers));
+                }
+                (
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64,
+                    },
+                    [Operand::VirtualRegister(destination), rhs],
+                ) => {
+                    let result = value(&Operand::VirtualRegister(destination.clone()), &registers)
+                        .wrapping_add(value(rhs, &registers));
+                    registers.insert(destination.clone(), result);
+                }
+                (
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Xor),
+                        width: IntegerWidth::U64,
+                    },
+                    [Operand::VirtualRegister(destination), rhs],
+                ) => {
+                    let result = if rhs == &Operand::VirtualRegister(destination.clone()) {
+                        0
+                    } else {
+                        value(&Operand::VirtualRegister(destination.clone()), &registers) ^ value(rhs, &registers)
+                    };
+                    registers.insert(destination.clone(), result);
+                }
+                (
+                    Operation::LoadEffectiveAddress,
+                    [
+                        Operand::VirtualRegister(destination),
+                        Operand::Address(MemoryAddress {
+                            base: AddressRegister::Virtual(base),
+                            index: None,
+                            scale: None,
+                            displacement: Some(AddressDisplacement::Immediate(displacement)),
+                        }),
+                    ],
+                ) => {
+                    registers.insert(destination.clone(), registers[base].wrapping_add(*displacement as u64));
+                }
+                (Operation::StoreOperand, [Operand::Immediate(_), source]) => {
+                    stored.push(value(source, &registers));
+                }
+                _ => panic!("unsupported oracle instruction: {instruction:?}"),
+            }
+        }
+        stored
+    }
+
+    #[test]
+    fn integer_peepholes_preserve_randomized_listings() {
+        let mut random_state = 0xbb67ae8584caa73bu64;
+        let mut random = || {
+            random_state = random_state.wrapping_mul(2862933555777941757).wrapping_add(3037000493);
+            random_state
+        };
+
+        for _ in 0..250 {
+            let mut instructions = vec![instruction(
+                Operation::Move(IntegerWidth::U64),
+                [register("ssa_0"), Operand::Immediate(random() as i64)],
+            )];
+            let mut current = "ssa_0".to_string();
+            for index in 1..=(random() % 30 + 1) {
+                let next = format!("ssa_{index}");
+                match random() % 3 {
+                    0 => instructions.push(move64(&next, &current)),
+                    1 => {
+                        instructions.push(move64(&next, &current));
+                        instructions.push(add64(&next, Operand::Immediate(random() as i64)));
+                    }
+                    _ => instructions.push(instruction(
+                        Operation::Move(IntegerWidth::U64),
+                        [register(&next), Operand::Immediate(0)],
+                    )),
+                }
+                current = next;
+            }
+            instructions.push(instruction(
+                Operation::StoreOperand,
+                [Operand::Immediate(0), register(&current)],
+            ));
+
+            let expected = evaluate_integer_listing(&instructions);
+            propagate_single_assignment_copies(&mut instructions);
+            select_copy_add_immediates(&mut instructions);
+            select_zero_moves(&mut instructions);
+            assert_eq!(evaluate_integer_listing(&instructions), expected);
+        }
+    }
+
     #[test]
     fn inverts_branches_over_jumps() {
         let mut instructions = vec![

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -6,7 +6,7 @@
 
 //! Machine-level optimizations before register allocation.
 
-use super::{AddressDisplacement, AddressRegister, AddressScale, ControlFlowOpcode, ControlFlowOperand, Instruction, MemoryAddress, Operand, VirtualRegister};
+use super::{AddressDisplacement, AddressRegister, AddressScale, ControlFlowOpcode, ControlFlowOperand, Instruction, Label, MemoryAddress, Operand, VirtualRegister};
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation};
 use crate::target::description::{BinaryOperation, IntegerWidth, MemoryWidth, Operation, PairWidth, SignCondition, OperandKind};
 #[cfg(test)]
@@ -21,44 +21,53 @@ pub(crate) fn invert_branches_over_jumps<
 >(
     instructions: &mut Vec<Instruction<O, C>>,
 ) {
-    let mut index = 0;
-    while index + 2 < instructions.len() {
-        let Some(inverted_operation) = inverted_branch_operation(&instructions[index].opcode) else {
-            index += 1;
-            continue;
-        };
-        let Some(branch_target) = instructions[index].operands.last().and_then(O::label) else {
-            index += 1;
-            continue;
-        };
-        let [jump_target] = &instructions[index + 1].operands[..] else {
-            index += 1;
-            continue;
-        };
-        let Some(jump_target) = jump_target.label() else {
-            index += 1;
-            continue;
-        };
-        let [fallthrough_label] = &instructions[index + 2].operands[..] else {
-            index += 1;
-            continue;
-        };
-        let Some(fallthrough_label) = fallthrough_label.label() else {
-            index += 1;
-            continue;
-        };
-        if instructions[index + 1].opcode.operation() != Operation::Control(crate::intrinsic::ControlOperation::JumpLabel)
-            || instructions[index + 2].opcode.operation() != Operation::Label
-            || branch_target != fallthrough_label
-        {
-            index += 1;
-            continue;
+    let (mut read, mut write) = (0, 0);
+    while read < instructions.len() {
+        let inverted = (read + 2 < instructions.len())
+            .then(|| inverted_branch(instructions, read))
+            .flatten();
+        if write != read {
+            instructions.swap(write, read);
         }
-        let jump_target = jump_target.clone();
-        instructions[index].opcode = instructions[index].opcode.replacing_operation(inverted_operation);
-        *instructions[index].operands.last_mut().unwrap() = O::from_label(jump_target);
-        instructions.remove(index + 1);
+        let Some((operation, jump_target)) = inverted else {
+            read += 1;
+            write += 1;
+            continue;
+        };
+        instructions[write].opcode =
+            instructions[write].opcode.replacing_operation(operation);
+        *instructions[write]
+            .operands
+            .last_mut()
+            .expect("a branch names its target") = O::from_label(jump_target);
+        read += 2;
+        write += 1;
     }
+    instructions.truncate(write);
+}
+
+fn inverted_branch<O: ControlFlowOperand, C: ControlFlowOpcode>(
+    instructions: &[Instruction<O, C>],
+    index: usize,
+) -> Option<(Operation, Label)> {
+    let operation = inverted_branch_operation(&instructions[index].opcode)?;
+    let branch_target = instructions[index].operands.last().and_then(O::label)?;
+    let [jump_target] = &instructions[index + 1].operands[..] else {
+        return None;
+    };
+    let jump_target = jump_target.label()?;
+    let [fallthrough_label] = &instructions[index + 2].operands[..] else {
+        return None;
+    };
+    let fallthrough_label = fallthrough_label.label()?;
+    if instructions[index + 1].opcode.operation()
+        != Operation::Control(crate::intrinsic::ControlOperation::JumpLabel)
+        || instructions[index + 2].opcode.operation() != Operation::Label
+        || branch_target != fallthrough_label
+    {
+        return None;
+    }
+    Some((operation, jump_target.clone()))
 }
 
 pub(crate) fn inverted_branch_operation(

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -6,19 +6,21 @@
 
 //! Machine-level optimizations before register allocation.
 
-use super::{AddressDisplacement, AddressRegister, AddressScale, ControlFlowOpcode, ControlFlowOperand, Instruction, Label, MemoryAddress, Operand, VirtualRegister};
+use super::{
+    AddressDisplacement, AddressRegister, AddressScale, ControlFlowOpcode, ControlFlowOperand, Instruction, Label,
+    MemoryAddress, Operand, VirtualRegister,
+};
+use crate::hash::{HashMap, HashSet};
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation};
-use crate::target::description::{BinaryOperation, IntegerWidth, MemoryWidth, Operation, PairWidth, SignCondition, OperandKind};
 #[cfg(test)]
 use crate::target::description::ZeroCondition;
-use crate::hash::{HashMap, HashSet};
+use crate::target::description::{
+    BinaryOperation, IntegerWidth, MemoryWidth, OperandKind, Operation, PairWidth, SignCondition,
+};
 
 /// Invert a conditional branch when its taken block follows an unconditional
 /// jump. This removes the jump while preserving block order.
-pub(crate) fn invert_branches_over_jumps<
-    O: ControlFlowOperand,
-    C: ControlFlowOpcode,
->(
+pub(crate) fn invert_branches_over_jumps<O: ControlFlowOperand, C: ControlFlowOpcode>(
     instructions: &mut Vec<Instruction<O, C>>,
 ) {
     let (mut read, mut write) = (0, 0);
@@ -34,8 +36,7 @@ pub(crate) fn invert_branches_over_jumps<
             write += 1;
             continue;
         };
-        instructions[write].opcode =
-            instructions[write].opcode.replacing_operation(operation);
+        instructions[write].opcode = instructions[write].opcode.replacing_operation(operation);
         *instructions[write]
             .operands
             .last_mut()
@@ -60,8 +61,7 @@ fn inverted_branch<O: ControlFlowOperand, C: ControlFlowOpcode>(
         return None;
     };
     let fallthrough_label = fallthrough_label.label()?;
-    if instructions[index + 1].opcode.operation()
-        != Operation::Control(crate::intrinsic::ControlOperation::JumpLabel)
+    if instructions[index + 1].opcode.operation() != Operation::Control(crate::intrinsic::ControlOperation::JumpLabel)
         || instructions[index + 2].opcode.operation() != Operation::Label
         || branch_target != fallthrough_label
     {
@@ -70,9 +70,7 @@ fn inverted_branch<O: ControlFlowOperand, C: ControlFlowOpcode>(
     Some((operation, jump_target.clone()))
 }
 
-pub(crate) fn inverted_branch_operation(
-    opcode: &impl ControlFlowOpcode,
-) -> Option<Operation> {
+pub(crate) fn inverted_branch_operation(opcode: &impl ControlFlowOpcode) -> Option<Operation> {
     let operation = opcode.operation();
     Some(match operation {
         Operation::Branch(operation) => Operation::Branch(operation.inverted()?),
@@ -81,10 +79,7 @@ pub(crate) fn inverted_branch_operation(
     })
 }
 
-pub(crate) fn remove_unreferenced_labels<
-    O: ControlFlowOperand,
-    C: ControlFlowOpcode,
->(
+pub(crate) fn remove_unreferenced_labels<O: ControlFlowOperand, C: ControlFlowOpcode>(
     instructions: &mut Vec<Instruction<O, C>>,
 ) {
     let keep = {
@@ -181,19 +176,23 @@ pub(crate) fn propagate_single_assignment_copies(instructions: &mut Vec<Instruct
     let mut pinned = HashSet::default();
     for instruction in instructions.iter() {
         let info = instruction.opcode.description();
-        for (index, _) in info
-            .x86_64
-            .fixed_operands
-            .iter()
-            .chain(info.aarch64.fixed_operands)
-        {
+        for (index, _) in info.x86_64.fixed_operands.iter().chain(info.aarch64.fixed_operands) {
             if let Some(Operand::VirtualRegister(register)) = instruction.operands.get(*index) {
                 pinned.insert(register.clone());
             }
         }
         for (index, operand) in instruction.operands.iter().enumerate() {
             let kind = info.operand_kind(index, instruction.operands.len());
-            if !matches!(kind, Some(OperandKind::GprOut | OperandKind::GprInOut | OperandKind::FprOut | OperandKind::FprInOut | OperandKind::RegisterOut)) {
+            if !matches!(
+                kind,
+                Some(
+                    OperandKind::GprOut
+                        | OperandKind::GprInOut
+                        | OperandKind::FprOut
+                        | OperandKind::FprInOut
+                        | OperandKind::RegisterOut
+                )
+            ) {
                 continue;
             }
             if let Operand::VirtualRegister(register) = operand {
@@ -204,21 +203,21 @@ pub(crate) fn propagate_single_assignment_copies(instructions: &mut Vec<Instruct
     let replacements = instructions
         .iter()
         .filter_map(|instruction| {
-            let [Operand::VirtualRegister(destination), Operand::VirtualRegister(source)] = instruction.operands.as_slice() else {
+            let [Operand::VirtualRegister(destination), Operand::VirtualRegister(source)] =
+                instruction.operands.as_slice()
+            else {
                 return None;
             };
-            let same_class_float_copy = instruction.opcode.operation()
-                == Operation::FloatMove
-                && destination.class() == source.class();
-            ((instruction.opcode.operation() == Operation::Move(IntegerWidth::U64)
-                || same_class_float_copy)
+            let same_class_float_copy =
+                instruction.opcode.operation() == Operation::FloatMove && destination.class() == source.class();
+            ((instruction.opcode.operation() == Operation::Move(IntegerWidth::U64) || same_class_float_copy)
                 && destination.is_ssa()
                 && !destination.is_edge_temporary()
                 && source.is_ssa()
                 && !pinned.contains(destination)
                 && !pinned.contains(source)
                 && definition_counts.get(destination) == Some(&1))
-                .then(|| (destination.clone(), source.clone()))
+            .then(|| (destination.clone(), source.clone()))
         })
         .collect::<HashMap<_, _>>();
     if replacements.is_empty() {
@@ -337,8 +336,7 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
     let adjacent_indices = instructions
         .iter()
         .filter_map(|instruction| {
-            let [Operand::VirtualRegister(destination), Operand::Address(address)] =
-                instruction.operands.as_slice()
+            let [Operand::VirtualRegister(destination), Operand::Address(address)] = instruction.operands.as_slice()
             else {
                 return None;
             };
@@ -349,15 +347,13 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
                 && address.index.is_none()
                 && address.scale.is_none()
                 && address.displacement == Some(AddressDisplacement::Immediate(1)))
-                .then(|| (destination.clone(), base.clone()))
+            .then(|| (destination.clone(), base.clone()))
         })
         .collect::<HashMap<_, _>>();
     rewrite_windows(instructions, 2, |window| {
         let [first, second] = window else { unreachable!() };
-        let (
-            [Operand::Address(first_address), first_value],
-            [Operand::Address(second_address), second_value],
-        ) = (first.operands.as_slice(), second.operands.as_slice())
+        let ([Operand::Address(first_address), first_value], [Operand::Address(second_address), second_value]) =
+            (first.operands.as_slice(), second.operands.as_slice())
         else {
             return None;
         };
@@ -388,16 +384,11 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
 pub(crate) fn fuse_indexed_offset_stores(instructions: &mut Vec<Instruction>) {
     let references = OperandReferences::count(instructions);
     rewrite_windows(instructions, 2, |window| {
-        let [load_address, store] = window else {
-            unreachable!()
-        };
+        let [load_address, store] = window else { unreachable!() };
         let (
             [Operand::VirtualRegister(address), Operand::Address(offset_address)],
             [Operand::Address(store_address), value],
-        ) = (
-            load_address.operands.as_slice(),
-            store.operands.as_slice(),
-        )
+        ) = (load_address.operands.as_slice(), store.operands.as_slice())
         else {
             return None;
         };
@@ -406,9 +397,7 @@ pub(crate) fn fuse_indexed_offset_stores(instructions: &mut Vec<Instruction>) {
         };
         let offset = match &offset_address.displacement {
             Some(AddressDisplacement::Immediate(offset)) => Operand::Immediate(*offset),
-            Some(AddressDisplacement::LayoutConstant(offset)) => {
-                Operand::LayoutConstant(*offset)
-            }
+            Some(AddressDisplacement::LayoutConstant(offset)) => Operand::LayoutConstant(*offset),
             _ => return None,
         };
         let (store_index, scale) = virtual_scaled_index(store_address)?;
@@ -458,13 +447,18 @@ pub(crate) fn select_zero_moves(instructions: &mut [Instruction]) {
 pub(crate) fn fuse_scaled_addresses(instructions: &mut Vec<Instruction>) {
     let references = OperandReferences::count(instructions);
     rewrite_windows(instructions, 3, |window| {
-        let [multiply, copy, add] = window else {
-            unreachable!()
-        };
+        let [multiply, copy, add] = window else { unreachable!() };
         let (
-            [Operand::VirtualRegister(product), Operand::VirtualRegister(scaled_index), Operand::Immediate(scale)],
+            [
+                Operand::VirtualRegister(product),
+                Operand::VirtualRegister(scaled_index),
+                Operand::Immediate(scale),
+            ],
             [Operand::VirtualRegister(destination), Operand::VirtualRegister(base)],
-            [Operand::VirtualRegister(add_destination), Operand::VirtualRegister(addend)],
+            [
+                Operand::VirtualRegister(add_destination),
+                Operand::VirtualRegister(addend),
+            ],
         ) = (
             multiply.operands.as_slice(),
             copy.operands.as_slice(),
@@ -531,22 +525,13 @@ fn virtual_scaled_index(address: &MemoryAddress) -> Option<(&VirtualRegister, i6
 mod tests {
     use super::*;
 
-    fn test_layout_constant(
-        name: &str,
-        value: i64,
-    ) -> crate::frontend::layout::LayoutConstant {
-        crate::frontend::layout::LayoutConstants::from_values([(
-            name.to_string(),
-            value,
-        )])
-        .get(name)
-        .unwrap()
+    fn test_layout_constant(name: &str, value: i64) -> crate::frontend::layout::LayoutConstant {
+        crate::frontend::layout::LayoutConstants::from_values([(name.to_string(), value)])
+            .get(name)
+            .unwrap()
     }
 
-    fn instruction(
-        operation: Operation,
-        operands: impl IntoIterator<Item = Operand>,
-    ) -> Instruction {
+    fn instruction(operation: Operation, operands: impl IntoIterator<Item = Operand>) -> Instruction {
         Instruction {
             opcode: operation,
             operands: operands.into_iter().collect(),
@@ -596,17 +581,11 @@ mod tests {
     }
 
     fn store64(address: Operand, value: &str) -> Instruction {
-        instruction(
-            Operation::store(MemoryWidth::DoubleWord),
-            [address, register(value)],
-        )
+        instruction(Operation::store(MemoryWidth::DoubleWord), [address, register(value)])
     }
 
     fn load_effective_address(destination: &str, address: Operand) -> Instruction {
-        instruction(
-            Operation::LoadEffectiveAddress,
-            [register(destination), address],
-        )
+        instruction(Operation::LoadEffectiveAddress, [register(destination), address])
     }
 
     fn floating_point_register(name: &str) -> Operand {
@@ -637,7 +616,10 @@ mod tests {
                 Operation::branch_zero(IntegerWidth::U64, ZeroCondition::Zero),
                 [register("value"), label("failure")],
             ),
-            instruction(Operation::Control(crate::intrinsic::ControlOperation::JumpLabel), [label("success")]),
+            instruction(
+                Operation::Control(crate::intrinsic::ControlOperation::JumpLabel),
+                [label("success")],
+            ),
             instruction(Operation::Label, [label("failure")]),
         ];
 
@@ -657,7 +639,10 @@ mod tests {
     #[test]
     fn removes_only_unreferenced_labels() {
         let mut instructions = vec![
-            instruction(Operation::Control(crate::intrinsic::ControlOperation::JumpLabel), [label("used")]),
+            instruction(
+                Operation::Control(crate::intrinsic::ControlOperation::JumpLabel),
+                [label("used")],
+            ),
             instruction(Operation::Label, [label("unused")]),
             instruction(Operation::Label, [label("used")]),
         ];
@@ -685,13 +670,12 @@ mod tests {
 
         propagate_single_assignment_copies(&mut instructions);
 
-        assert!(!instructions
-            .iter()
-            .any(|instruction| instruction.opcode.operation() == Operation::Move(IntegerWidth::U64)));
-        assert_eq!(
-            instructions.last().unwrap().operands,
-            [register("ssa_source")]
+        assert!(
+            !instructions
+                .iter()
+                .any(|instruction| instruction.opcode.operation() == Operation::Move(IntegerWidth::U64))
         );
+        assert_eq!(instructions.last().unwrap().operands, [register("ssa_source")]);
     }
 
     #[test]
@@ -705,7 +689,9 @@ mod tests {
                 ],
             ),
             instruction(
-                Operation::Branch(BranchOperation::Float(crate::target::description::FloatCondition::Equal)),
+                Operation::Branch(BranchOperation::Float(
+                    crate::target::description::FloatCondition::Equal,
+                )),
                 vec![
                     floating_point_register("ssa_copy"),
                     floating_point_register("ssa_copy"),
@@ -716,32 +702,35 @@ mod tests {
 
         propagate_single_assignment_copies(&mut instructions);
 
-        assert!(!instructions.iter().any(|instruction| {
-            instruction.opcode.operation()
-                == Operation::FloatMove
-        }));
-        assert_eq!(instructions.last().unwrap().operands[0], floating_point_register("ssa_source"));
-        assert_eq!(instructions.last().unwrap().operands[1], floating_point_register("ssa_source"));
+        assert!(
+            !instructions
+                .iter()
+                .any(|instruction| { instruction.opcode.operation() == Operation::FloatMove })
+        );
+        assert_eq!(
+            instructions.last().unwrap().operands[0],
+            floating_point_register("ssa_source")
+        );
+        assert_eq!(
+            instructions.last().unwrap().operands[1],
+            floating_point_register("ssa_source")
+        );
     }
 
     #[test]
     fn preserves_float_copies_between_register_classes() {
-        let mut instructions = vec![
-            instruction(
-                Operation::FloatMove,
-                vec![
-                    floating_point_register("ssa_double"),
-                    register("ssa_bits"),
-                ],
-            ),
-        ];
+        let mut instructions = vec![instruction(
+            Operation::FloatMove,
+            vec![floating_point_register("ssa_double"), register("ssa_bits")],
+        )];
 
         propagate_single_assignment_copies(&mut instructions);
 
-        assert!(instructions.iter().any(|instruction| {
-            instruction.opcode.operation()
-                == Operation::FloatMove
-        }));
+        assert!(
+            instructions
+                .iter()
+                .any(|instruction| { instruction.opcode.operation() == Operation::FloatMove })
+        );
     }
 
     #[test]
@@ -749,10 +738,7 @@ mod tests {
         let mut instructions = vec![
             instruction(
                 Operation::load(MemoryWidth::DoubleWord, false),
-                vec![
-                    register("ssa_source"),
-                    address("values", None, None, None),
-                ],
+                vec![register("ssa_source"), address("values", None, None, None)],
             ),
             move64("ssa_argument", "ssa_source"),
             instruction(
@@ -765,11 +751,7 @@ mod tests {
 
         assert!(instructions.iter().any(|instruction| {
             instruction.opcode.operation() == Operation::Move(IntegerWidth::U64)
-                && instruction.operands
-                    == [
-                        register("ssa_argument"),
-                        register("ssa_source"),
-                    ]
+                && instruction.operands == [register("ssa_argument"), register("ssa_source")]
         }));
     }
 
@@ -778,7 +760,11 @@ mod tests {
         let mut instructions = vec![
             instruction(
                 Operation::Call(crate::target::description::CallKind::RawNative),
-                [register("ssa_function"), register("ssa_payload"), register("ssa_variant")],
+                [
+                    register("ssa_function"),
+                    register("ssa_payload"),
+                    register("ssa_variant"),
+                ],
             ),
             move64("ssa_saved", "ssa_payload"),
             assert_nonzero("ssa_saved"),
@@ -788,28 +774,18 @@ mod tests {
 
         assert!(instructions.iter().any(|instruction| {
             instruction.opcode.operation() == Operation::Move(IntegerWidth::U64)
-                && instruction.operands
-                    == [
-                        register("ssa_saved"),
-                        register("ssa_payload"),
-                    ]
+                && instruction.operands == [register("ssa_saved"), register("ssa_payload")]
         }));
     }
 
     #[test]
     fn selects_single_instruction_copy_adds() {
-        let mut instructions = vec![
-            move64("next", "index"),
-            add64("next", Operand::Immediate(1)),
-        ];
+        let mut instructions = vec![move64("next", "index"), add64("next", Operand::Immediate(1))];
 
         select_copy_add_immediates(&mut instructions);
 
         assert_eq!(instructions.len(), 1);
-        assert_eq!(
-            instructions[0].opcode.operation(),
-            Operation::LoadEffectiveAddress,
-        );
+        assert_eq!(instructions[0].opcode.operation(), Operation::LoadEffectiveAddress,);
         assert_eq!(
             instructions[0].operands,
             [
@@ -866,22 +842,18 @@ mod tests {
                 width: IntegerWidth::U64,
             },
         );
-        assert_eq!(
-            instructions[0].operands,
-            [register("value"), register("value")]
-        );
+        assert_eq!(instructions[0].operands, [register("value"), register("value")]);
     }
 
     #[test]
     fn fuses_or32_with_a_sign_branch() {
         let mut instructions = vec![
             instruction(
-                Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Or), width: IntegerWidth::U32 },
-                vec![
-                    register("result"),
-                    register("lhs"),
-                    register("rhs"),
-                ],
+                Operation::IntegerBinary {
+                    operation: IntegerBinaryOperation::Binary(BinaryOperation::Or),
+                    width: IntegerWidth::U32,
+                },
+                vec![register("result"), register("lhs"), register("rhs")],
             ),
             instruction(
                 Operation::branch_sign(IntegerWidth::U32, SignCondition::Negative),
@@ -898,12 +870,7 @@ mod tests {
         );
         assert_eq!(
             instructions[0].operands,
-            [
-                register("result"),
-                register("lhs"),
-                register("rhs"),
-                label("negative"),
-            ]
+            [register("result"), register("lhs"), register("rhs"), label("negative"),]
         );
     }
 
@@ -919,15 +886,9 @@ mod tests {
 
         assert_eq!(
             instructions[0].operands,
-            vec![
-                register("address"),
-                address("base", Some("index"), Some(4), None),
-            ]
+            vec![register("address"), address("base", Some("index"), Some(4), None),]
         );
-        assert_eq!(
-            instructions[0].opcode.operation(),
-            Operation::LoadEffectiveAddress,
-        );
+        assert_eq!(instructions[0].opcode.operation(), Operation::LoadEffectiveAddress,);
         assert_eq!(instructions.len(), 1);
     }
 
@@ -961,9 +922,10 @@ mod tests {
                     "base",
                     None,
                     None,
-                    Some(AddressDisplacement::LayoutConstant(
-                        test_layout_constant("FIELD_OFFSET", 24),
-                    )),
+                    Some(AddressDisplacement::LayoutConstant(test_layout_constant(
+                        "FIELD_OFFSET",
+                        24,
+                    ))),
                 ),
             ),
             store64(address("address", Some("index"), Some(8), None), "value"),
@@ -972,20 +934,14 @@ mod tests {
         fuse_indexed_offset_stores(&mut instructions);
 
         assert_eq!(instructions.len(), 1);
-        assert_eq!(
-            instructions[0].opcode.operation(),
-            Operation::Store64IndexedOffset,
-        );
+        assert_eq!(instructions[0].opcode.operation(), Operation::Store64IndexedOffset,);
         assert_eq!(
             instructions[0].operands,
             [
                 register("base"),
                 register("index"),
                 Operand::Immediate(8),
-                Operand::LayoutConstant(test_layout_constant(
-                    "FIELD_OFFSET",
-                    24,
-                )),
+                Operand::LayoutConstant(test_layout_constant("FIELD_OFFSET", 24,)),
                 register("value"),
             ]
         );

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -78,15 +78,25 @@ pub(crate) fn remove_unreferenced_labels<
 >(
     instructions: &mut Vec<Instruction<O, C>>,
 ) {
-    let referenced = instructions
-        .iter()
-        .filter(|instruction| instruction.opcode.operation() != Operation::Label)
-        .flat_map(|instruction| &instruction.operands)
-        .filter_map(|operand| operand.label().cloned())
-        .collect::<HashSet<_>>();
-    instructions.retain(|instruction| {
-        instruction.opcode.operation() != Operation::Label
-            || matches!(instruction.operands.as_slice(), [operand] if operand.label().is_some_and(|label| referenced.contains(label)))
+    let keep = {
+        let referenced = instructions
+            .iter()
+            .filter(|instruction| instruction.opcode.operation() != Operation::Label)
+            .flat_map(|instruction| &instruction.operands)
+            .filter_map(ControlFlowOperand::label)
+            .collect::<HashSet<_>>();
+        instructions
+            .iter()
+            .map(|instruction| {
+                instruction.opcode.operation() != Operation::Label
+                    || matches!(instruction.operands.as_slice(), [operand] if operand.label().is_some_and(|label| referenced.contains(label)))
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut index = 0;
+    instructions.retain(|_| {
+        index += 1;
+        keep[index - 1]
     });
 }
 

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -100,20 +100,72 @@ pub(crate) fn remove_unreferenced_labels<
     });
 }
 
+/// How many operands of a listing name each virtual register.
+///
+/// A peephole rewrite that folds a value away has to know the value is named
+/// nowhere else. Counting that per window means scanning the whole listing per
+/// instruction, which on a large function is thousands of scans of thousands
+/// of instructions.
+#[derive(Default)]
+struct OperandReferences(HashMap<VirtualRegister, usize>);
+
+impl OperandReferences {
+    fn count(instructions: &[Instruction]) -> Self {
+        let mut counts: HashMap<VirtualRegister, usize> = HashMap::new();
+        for instruction in instructions {
+            for operand in &instruction.operands {
+                match operand {
+                    Operand::VirtualRegister(register) => *counts.entry(register.clone()).or_default() += 1,
+                    // An address naming the same register as both base and
+                    // index is still one operand that references it.
+                    Operand::Address(address) => {
+                        let mut counted = None;
+                        for candidate in std::iter::once(&address.base).chain(&address.index) {
+                            let AddressRegister::Virtual(register) = candidate else {
+                                continue;
+                            };
+                            if counted == Some(register) {
+                                continue;
+                            }
+                            counted = Some(register);
+                            *counts.entry(register.clone()).or_default() += 1;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Self(counts)
+    }
+
+    fn get(&self, register: &VirtualRegister) -> usize {
+        self.0.get(register).copied().unwrap_or_default()
+    }
+}
+
 fn rewrite_windows(
     instructions: &mut Vec<Instruction>,
     width: usize,
-    mut rewrite: impl FnMut(&[Instruction], usize) -> Option<Instruction>,
+    mut rewrite: impl FnMut(&[Instruction], &OperandReferences) -> Option<Instruction>,
 ) {
-    let mut index = 0;
-    while index + width <= instructions.len() {
-        let Some(replacement) = rewrite(instructions, index) else {
-            index += 1;
+    let references = OperandReferences::count(instructions);
+    let (mut read, mut write) = (0, 0);
+    while read < instructions.len() {
+        if read + width <= instructions.len()
+            && let Some(replacement) = rewrite(&instructions[read..read + width], &references)
+        {
+            instructions[write] = replacement;
+            read += width;
+            write += 1;
             continue;
-        };
-        instructions.splice(index..index + width, [replacement]);
-        index += 1;
+        }
+        if write != read {
+            instructions.swap(write, read);
+        }
+        read += 1;
+        write += 1;
     }
+    instructions.truncate(write);
 }
 
 pub(crate) fn propagate_single_assignment_copies(instructions: &mut Vec<Instruction>) {
@@ -199,10 +251,8 @@ pub(crate) fn propagate_single_assignment_copies(instructions: &mut Vec<Instruct
 }
 
 pub(crate) fn select_copy_add_immediates(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 2, |instructions, index| {
-        let [copy, add] = &instructions[index..index + 2] else {
-            unreachable!()
-        };
+    rewrite_windows(instructions, 2, |window, _| {
+        let [copy, add] = window else { unreachable!() };
         let (
             [Operand::VirtualRegister(destination), Operand::VirtualRegister(source)],
             [Operand::VirtualRegister(add_destination), Operand::Immediate(immediate)],
@@ -237,10 +287,8 @@ pub(crate) fn select_copy_add_immediates(instructions: &mut Vec<Instruction>) {
 }
 
 pub(crate) fn fuse_or32_sign_branches(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 2, |instructions, index| {
-        let [operation, branch] = &instructions[index..index + 2] else {
-            unreachable!()
-        };
+    rewrite_windows(instructions, 2, |window, _| {
+        let [operation, branch] = window else { unreachable!() };
         let [destination, lhs, rhs] = operation.operands.as_slice() else {
             return None;
         };
@@ -296,10 +344,8 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
                 .then(|| (destination.clone(), base.clone()))
         })
         .collect::<HashMap<_, _>>();
-    rewrite_windows(instructions, 2, |instructions, index| {
-        let [first, second] = &instructions[index..index + 2] else {
-            unreachable!()
-        };
+    rewrite_windows(instructions, 2, |window, _| {
+        let [first, second] = window else { unreachable!() };
         let (
             [Operand::Address(first_address), first_value],
             [Operand::Address(second_address), second_value],
@@ -332,11 +378,17 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
 }
 
 pub(crate) fn fuse_indexed_offset_stores(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 2, |instructions, index| {
+    rewrite_windows(instructions, 2, |window, references| {
+        let [load_address, store] = window else {
+            unreachable!()
+        };
         let (
             [Operand::VirtualRegister(address), Operand::Address(offset_address)],
             [Operand::Address(store_address), value],
-        ) = (instructions[index].operands.as_slice(), instructions[index + 1].operands.as_slice())
+        ) = (
+            load_address.operands.as_slice(),
+            store.operands.as_slice(),
+        )
         else {
             return None;
         };
@@ -351,18 +403,12 @@ pub(crate) fn fuse_indexed_offset_stores(instructions: &mut Vec<Instruction>) {
             _ => return None,
         };
         let (store_index, scale) = virtual_scaled_index(store_address)?;
-        if instructions[index].opcode.operation() != Operation::LoadEffectiveAddress
-            || instructions[index + 1].opcode.operation()
-                != Operation::store(MemoryWidth::DoubleWord)
+        if load_address.opcode.operation() != Operation::LoadEffectiveAddress
+            || store.opcode.operation() != Operation::store(MemoryWidth::DoubleWord)
             || store_address.base != AddressRegister::Virtual(address.clone())
             || offset_address.index.is_some()
             || offset_address.scale.is_some()
-            || instructions
-                .iter()
-                .flat_map(|instruction| &instruction.operands)
-                .filter(|operand| operand.references(address))
-                .count()
-                != 2
+            || references.get(address) != 2
         {
             return None;
         }
@@ -401,10 +447,10 @@ pub(crate) fn select_zero_moves(instructions: &mut [Instruction]) {
 }
 
 pub(crate) fn fuse_scaled_addresses(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 3, |instructions, index| {
-        let multiply = &instructions[index];
-        let copy = &instructions[index + 1];
-        let add = &instructions[index + 2];
+    rewrite_windows(instructions, 3, |window, references| {
+        let [multiply, copy, add] = window else {
+            unreachable!()
+        };
         let (
             [Operand::VirtualRegister(product), Operand::VirtualRegister(scaled_index), Operand::Immediate(scale)],
             [Operand::VirtualRegister(destination), Operand::VirtualRegister(base)],
@@ -431,12 +477,7 @@ pub(crate) fn fuse_scaled_addresses(instructions: &mut Vec<Instruction>) {
             || destination != add_destination
             || product != addend
             || !matches!(scale, 1 | 2 | 4 | 8)
-            || instructions
-                .iter()
-                .flat_map(|instruction| &instruction.operands)
-                .filter(|operand| operand.references(product))
-                .count()
-                != 2
+            || references.get(product) != 2
         {
             return None;
         }

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -155,13 +155,12 @@ impl OperandReferences {
 fn rewrite_windows(
     instructions: &mut Vec<Instruction>,
     width: usize,
-    mut rewrite: impl FnMut(&[Instruction], &OperandReferences) -> Option<Instruction>,
+    mut rewrite: impl FnMut(&[Instruction]) -> Option<Instruction>,
 ) {
-    let references = OperandReferences::count(instructions);
     let (mut read, mut write) = (0, 0);
     while read < instructions.len() {
         if read + width <= instructions.len()
-            && let Some(replacement) = rewrite(&instructions[read..read + width], &references)
+            && let Some(replacement) = rewrite(&instructions[read..read + width])
         {
             instructions[write] = replacement;
             read += width;
@@ -260,7 +259,7 @@ pub(crate) fn propagate_single_assignment_copies(instructions: &mut Vec<Instruct
 }
 
 pub(crate) fn select_copy_add_immediates(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 2, |window, _| {
+    rewrite_windows(instructions, 2, |window| {
         let [copy, add] = window else { unreachable!() };
         let (
             [Operand::VirtualRegister(destination), Operand::VirtualRegister(source)],
@@ -296,7 +295,7 @@ pub(crate) fn select_copy_add_immediates(instructions: &mut Vec<Instruction>) {
 }
 
 pub(crate) fn fuse_or32_sign_branches(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 2, |window, _| {
+    rewrite_windows(instructions, 2, |window| {
         let [operation, branch] = window else { unreachable!() };
         let [destination, lhs, rhs] = operation.operands.as_slice() else {
             return None;
@@ -353,7 +352,7 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
                 .then(|| (destination.clone(), base.clone()))
         })
         .collect::<HashMap<_, _>>();
-    rewrite_windows(instructions, 2, |window, _| {
+    rewrite_windows(instructions, 2, |window| {
         let [first, second] = window else { unreachable!() };
         let (
             [Operand::Address(first_address), first_value],
@@ -387,7 +386,8 @@ pub(crate) fn fuse_adjacent_sequence_stores(instructions: &mut Vec<Instruction>)
 }
 
 pub(crate) fn fuse_indexed_offset_stores(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 2, |window, references| {
+    let references = OperandReferences::count(instructions);
+    rewrite_windows(instructions, 2, |window| {
         let [load_address, store] = window else {
             unreachable!()
         };
@@ -456,7 +456,8 @@ pub(crate) fn select_zero_moves(instructions: &mut [Instruction]) {
 }
 
 pub(crate) fn fuse_scaled_addresses(instructions: &mut Vec<Instruction>) {
-    rewrite_windows(instructions, 3, |window, references| {
+    let references = OperandReferences::count(instructions);
+    rewrite_windows(instructions, 3, |window| {
         let [multiply, copy, add] = window else {
             unreachable!()
         };

--- a/Libraries/LibJS/Flap/src/low_ir/optimize.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/optimize.rs
@@ -11,7 +11,7 @@ use crate::intrinsic::{BranchOperation, IntegerBinaryOperation};
 use crate::target::description::{BinaryOperation, IntegerWidth, MemoryWidth, Operation, PairWidth, SignCondition, OperandKind};
 #[cfg(test)]
 use crate::target::description::ZeroCondition;
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 /// Invert a conditional branch when its taken block follows an unconditional
 /// jump. This removes the jump while preserving block order.
@@ -111,7 +111,7 @@ struct OperandReferences(HashMap<VirtualRegister, usize>);
 
 impl OperandReferences {
     fn count(instructions: &[Instruction]) -> Self {
-        let mut counts: HashMap<VirtualRegister, usize> = HashMap::new();
+        let mut counts: HashMap<VirtualRegister, usize> = HashMap::default();
         for instruction in instructions {
             for operand in &instruction.operands {
                 match operand {
@@ -169,8 +169,8 @@ fn rewrite_windows(
 }
 
 pub(crate) fn propagate_single_assignment_copies(instructions: &mut Vec<Instruction>) {
-    let mut definition_counts = HashMap::new();
-    let mut pinned = HashSet::new();
+    let mut definition_counts = HashMap::default();
+    let mut pinned = HashSet::default();
     for instruction in instructions.iter() {
         let info = instruction.opcode.description();
         for (index, _) in info

--- a/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
@@ -6,7 +6,8 @@
 
 //! Target-aware instruction combining before register allocation.
 
-use super::{Instruction, Operand, VirtualRegister};
+use super::{Instruction, Operand, VirtualRegister, visit_virtual_registers};
+use std::collections::HashMap;
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation, IntegerSignedness};
 use crate::target::description::{
     BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, Operation, OperandKind, PairWidth,
@@ -218,6 +219,24 @@ pub(crate) fn schedule_x86_relational_operand_loads(instructions: &mut Vec<Instr
 /// at the add, reversing the operands lets the allocator coalesce `result`
 /// with `rhs` and removes both an otherwise-required register and the move.
 pub(crate) fn orient_commutative_updates(instructions: &mut [Instruction]) {
+    // Where each register is named for the last time. Asking whether a value
+    // outlives an instruction by scanning the rest of the listing turns this
+    // into a quadratic pass over a stitched function. Reversing a pair of
+    // operands only moves a register between the two instructions of the pair,
+    // both of which lie before every listing suffix later steps look at, so
+    // these positions stay correct as the pass runs.
+    let mut last_reference = HashMap::new();
+    for (index, instruction) in instructions.iter().enumerate() {
+        for operand in &instruction.operands {
+            visit_virtual_registers(operand, &mut |register| {
+                last_reference.insert(register.clone(), index);
+            });
+        }
+    }
+    let referenced_after = |register: &VirtualRegister, position: usize| {
+        last_reference.get(register).is_some_and(|last| *last >= position)
+    };
+
     let mut index = 0;
     while index + 1 < instructions.len() {
         let copy = &instructions[index];
@@ -263,26 +282,12 @@ pub(crate) fn orient_commutative_updates(instructions: &mut [Instruction]) {
             }
             (lhs.clone(), rhs.clone())
         };
-        let lhs_is_live = instructions[index + 2..]
-            .iter()
-            .any(|instruction| instruction_references_register(instruction, &lhs));
-        let rhs_is_dead = !instructions[index + 2..]
-            .iter()
-            .any(|instruction| instruction_references_register(instruction, &rhs));
+        let lhs_is_live = referenced_after(&lhs, index + 2);
+        let rhs_is_dead = !referenced_after(&rhs, index + 2);
         if lhs_is_live && rhs_is_dead {
             instructions[index].operands[1] = Operand::VirtualRegister(rhs);
             instructions[index + 1].operands[1] = Operand::VirtualRegister(lhs);
         }
         index += 1;
     }
-}
-
-fn instruction_references_register(
-    instruction: &Instruction,
-    register: &VirtualRegister,
-) -> bool {
-    instruction
-        .operands
-        .iter()
-        .any(|operand| operand.references(register))
 }

--- a/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
@@ -6,8 +6,8 @@
 
 //! Target-aware instruction combining before register allocation.
 
-use super::{Instruction, Operand, VirtualRegister, visit_virtual_registers};
-use crate::hash::HashMap;
+use super::{Instruction, Operand, VirtualRegister, visit_virtual_registers, visit_virtual_registers_mut};
+use crate::hash::{HashMap, HashSet};
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation, IntegerSignedness};
 use crate::target::description::{
     BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, OperandKind, Operation, PairWidth,
@@ -276,4 +276,263 @@ pub(crate) fn orient_commutative_updates(instructions: &mut [Instruction]) {
         }
         index += 1;
     }
+}
+
+/// Split cheap values around calls when their entire live range is local to
+/// one machine block. This keeps the AOT interpreter spill-free while letting
+/// constants be recreated after caller-saved registers are destroyed.
+pub(crate) fn split_rematerializable_live_ranges_across_calls(instructions: &mut Vec<Instruction>) {
+    let calls = instructions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, instruction)| instruction.opcode.description().is_call.then_some(index))
+        .collect::<Vec<_>>();
+    if calls.is_empty() {
+        return;
+    }
+
+    let instruction_blocks = instruction_blocks(instructions);
+    let mut register_blocks = HashMap::<VirtualRegister, Option<usize>>::default();
+    let mut registers = HashSet::default();
+    for (index, instruction) in instructions.iter().enumerate() {
+        for operand in &instruction.operands {
+            visit_virtual_registers(operand, &mut |register| {
+                registers.insert(register.clone());
+                register_blocks
+                    .entry(register.clone())
+                    .and_modify(|block| {
+                        if *block != Some(instruction_blocks[index]) {
+                            *block = None;
+                        }
+                    })
+                    .or_insert(Some(instruction_blocks[index]));
+            });
+        }
+    }
+
+    let mut split_index = 0u64;
+    for call in calls.into_iter().rev() {
+        let block = instruction_blocks[call];
+        let start = machine_block_start(instructions, call);
+        let end = machine_block_end(instructions, call);
+        let mut recipes = rematerialization_recipes(&instructions[start..call])
+            .into_iter()
+            .collect::<Vec<_>>();
+        recipes.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+        let mut splits = Vec::new();
+        for (register, recipe) in recipes {
+            if register_blocks.get(&register) != Some(&Some(block))
+                || instruction_defines_register(&instructions[call], &register)
+            {
+                continue;
+            }
+            let Some(last_reference) = instructions[call + 1..end]
+                .iter()
+                .rposition(|instruction| instruction_references_register(instruction, &register))
+                .map(|position| call + 1 + position)
+            else {
+                continue;
+            };
+            if instructions[call + 1..=last_reference]
+                .iter()
+                .any(|instruction| instruction.opcode.description().is_call)
+            {
+                continue;
+            }
+            let first_reference = instructions[call + 1..=last_reference]
+                .iter()
+                .find(|instruction| instruction_references_register(instruction, &register))
+                .expect("last reference guarantees a first reference");
+            if !instruction_reads_register(first_reference, &register) {
+                continue;
+            }
+
+            let replacement = loop {
+                let candidate =
+                    VirtualRegister::with_class(format!("{register}_after_call_{split_index}"), register.class());
+                split_index += 1;
+                if registers.insert(candidate.clone()) {
+                    break candidate;
+                }
+            };
+            splits.push((register, replacement, recipe));
+        }
+
+        for (register, replacement, _) in &splits {
+            for instruction in &mut instructions[call + 1..end] {
+                for operand in &mut instruction.operands {
+                    visit_virtual_registers_mut(operand, &mut |candidate| {
+                        if candidate == register {
+                            *candidate = replacement.clone();
+                        }
+                    });
+                }
+            }
+        }
+        let rematerializations = splits
+            .into_iter()
+            .map(|(_, replacement, mut recipe)| {
+                let Operand::VirtualRegister(destination) = &mut recipe.operands[0] else {
+                    unreachable!("rematerialization recipe must define a virtual register")
+                };
+                *destination = replacement;
+                recipe
+            })
+            .collect::<Vec<_>>();
+        instructions.splice(call + 1..call + 1, rematerializations);
+    }
+}
+
+fn instruction_blocks(instructions: &[Instruction]) -> Vec<usize> {
+    let mut blocks = Vec::with_capacity(instructions.len());
+    let mut block = 0usize;
+    for (index, instruction) in instructions.iter().enumerate() {
+        if index > 0
+            && (instruction.opcode.operation() == Operation::Label
+                || machine_instruction_ends_block(&instructions[index - 1]))
+        {
+            block += 1;
+        }
+        blocks.push(block);
+    }
+    blocks
+}
+
+fn machine_block_start(instructions: &[Instruction], instruction: usize) -> usize {
+    (0..=instruction)
+        .rev()
+        .find(|index| {
+            *index == 0
+                || instructions[*index].opcode.operation() == Operation::Label
+                || machine_instruction_ends_block(&instructions[*index - 1])
+        })
+        .unwrap()
+}
+
+fn machine_block_end(instructions: &[Instruction], instruction: usize) -> usize {
+    (instruction..instructions.len())
+        .find_map(|index| {
+            (machine_instruction_ends_block(&instructions[index])
+                || instructions
+                    .get(index + 1)
+                    .is_some_and(|instruction| instruction.opcode.operation() == Operation::Label))
+            .then_some(index + 1)
+        })
+        .unwrap_or(instructions.len())
+}
+
+fn machine_instruction_ends_block(instruction: &Instruction) -> bool {
+    instruction.opcode.description().terminal
+        || (instruction.opcode.operation() != Operation::Label
+            && instruction
+                .operands
+                .iter()
+                .any(|operand| matches!(operand, Operand::Label(_))))
+}
+
+fn rematerialization_recipes(instructions: &[Instruction]) -> HashMap<VirtualRegister, Instruction> {
+    let mut seen = HashSet::default();
+    let mut recipes = HashMap::default();
+    for instruction in instructions {
+        let recipe = rematerialization_recipe(instruction);
+        let mut referenced = Vec::new();
+        for operand in &instruction.operands {
+            visit_virtual_registers(operand, &mut |register| {
+                if !referenced.contains(register) {
+                    referenced.push(register.clone());
+                }
+            });
+        }
+        for register in referenced {
+            let first_reference = seen.insert(register.clone());
+            if recipe
+                .as_ref()
+                .is_some_and(|(recipe_register, _)| *recipe_register == register)
+            {
+                if first_reference {
+                    recipes.insert(register, recipe.as_ref().unwrap().1.clone());
+                } else {
+                    recipes.remove(&register);
+                }
+            } else if instruction_defines_register(instruction, &register) {
+                recipes.remove(&register);
+            }
+        }
+    }
+    recipes
+}
+
+fn rematerialization_recipe(instruction: &Instruction) -> Option<(VirtualRegister, Instruction)> {
+    if !matches!(
+        instruction.opcode.operation(),
+        Operation::Move(IntegerWidth::U32 | IntegerWidth::U64)
+    ) {
+        return None;
+    }
+    let [
+        Operand::VirtualRegister(register),
+        source @ (Operand::Immediate(_) | Operand::ValueConstant(_)),
+    ] = instruction.operands.as_slice()
+    else {
+        return None;
+    };
+    Some((
+        register.clone(),
+        Instruction {
+            opcode: instruction.opcode,
+            operands: vec![Operand::VirtualRegister(register.clone()), source.clone()],
+        },
+    ))
+}
+
+fn instruction_references_register(instruction: &Instruction, register: &VirtualRegister) -> bool {
+    instruction.operands.iter().any(|operand| {
+        let mut references = false;
+        visit_virtual_registers(operand, &mut |candidate| references |= candidate == register);
+        references
+    })
+}
+
+fn instruction_reads_register(instruction: &Instruction, register: &VirtualRegister) -> bool {
+    let description = instruction.opcode.description();
+    instruction.operands.iter().enumerate().any(|(index, operand)| {
+        if matches!(operand, Operand::Address(_)) {
+            let mut reads = false;
+            visit_virtual_registers(operand, &mut |candidate| reads |= candidate == register);
+            return reads;
+        }
+        let Operand::VirtualRegister(candidate) = operand else {
+            return false;
+        };
+        candidate == register
+            && matches!(
+                description.operand_kind(index, instruction.operands.len()),
+                Some(
+                    OperandKind::GprIn
+                        | OperandKind::GprInOut
+                        | OperandKind::FprIn
+                        | OperandKind::FprInOut
+                        | OperandKind::RegisterIn
+                        | OperandKind::GprInOrImm
+                        | OperandKind::GprInOrMemory
+                )
+            )
+    })
+}
+
+fn instruction_defines_register(instruction: &Instruction, register: &VirtualRegister) -> bool {
+    let description = instruction.opcode.description();
+    instruction.operands.iter().enumerate().any(|(index, operand)| {
+        matches!(operand, Operand::VirtualRegister(candidate) if candidate == register)
+            && matches!(
+                description.operand_kind(index, instruction.operands.len()),
+                Some(
+                    OperandKind::GprOut
+                        | OperandKind::GprInOut
+                        | OperandKind::FprOut
+                        | OperandKind::FprInOut
+                        | OperandKind::RegisterOut
+                )
+            )
+    })
 }

--- a/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
@@ -9,6 +9,8 @@
 use super::{Instruction, Operand, VirtualRegister, visit_virtual_registers, visit_virtual_registers_mut};
 use crate::hash::{HashMap, HashSet};
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation, IntegerSignedness};
+use crate::low_ir::analysis::virtual_register_access;
+use crate::low_ir::cfg::instruction_blocks;
 use crate::target::description::{
     BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, OperandKind, Operation, PairWidth,
 };
@@ -291,62 +293,83 @@ pub(crate) fn split_rematerializable_live_ranges_across_calls(instructions: &mut
         return;
     }
 
-    let instruction_blocks = instruction_blocks(instructions);
-    let mut register_blocks = HashMap::<VirtualRegister, Option<usize>>::default();
-    let mut registers = HashSet::default();
+    #[derive(Default)]
+    struct RegisterFacts {
+        block: Option<usize>,
+        crosses_blocks: bool,
+        definitions: Vec<usize>,
+        recipe: Option<(usize, Instruction)>,
+        reads: Vec<usize>,
+    }
+
+    let instruction_references = instructions.iter().collect::<Vec<_>>();
+    let blocks = instruction_blocks(&instruction_references);
+    let mut facts = HashMap::<VirtualRegister, RegisterFacts>::default();
     for (index, instruction) in instructions.iter().enumerate() {
-        for operand in &instruction.operands {
-            visit_virtual_registers(operand, &mut |register| {
-                registers.insert(register.clone());
-                register_blocks
-                    .entry(register.clone())
-                    .and_modify(|block| {
-                        if *block != Some(instruction_blocks[index]) {
-                            *block = None;
-                        }
-                    })
-                    .or_insert(Some(instruction_blocks[index]));
-            });
+        let access = virtual_register_access(instruction, None);
+        for register in access.reads {
+            let facts = facts.entry(register).or_default();
+            facts.reads.push(index);
+            if let Some(block) = facts.block {
+                facts.crosses_blocks |= block != blocks[index];
+            } else {
+                facts.block = Some(blocks[index]);
+            }
+        }
+        for register in access.definitions {
+            let facts = facts.entry(register.clone()).or_default();
+            facts.definitions.push(index);
+            if let Some(block) = facts.block {
+                facts.crosses_blocks |= block != blocks[index];
+            } else {
+                facts.block = Some(blocks[index]);
+            }
+            if let Some((recipe_register, recipe)) = rematerialization_recipe(instruction)
+                && recipe_register == register
+            {
+                facts.recipe = Some((index, recipe));
+            }
         }
     }
 
+    let mut registers = facts.keys().cloned().collect::<HashSet<_>>();
     let mut split_index = 0u64;
-    for call in calls.into_iter().rev() {
-        let block = instruction_blocks[call];
-        let start = machine_block_start(instructions, call);
-        let end = machine_block_end(instructions, call);
-        let mut recipes = rematerialization_recipes(&instructions[start..call])
-            .into_iter()
+    let mut splits = Vec::new();
+    for (register, facts) in facts {
+        let Some((definition, recipe)) = facts.recipe else {
+            continue;
+        };
+        if facts.crosses_blocks {
+            continue;
+        }
+        let block = facts.block.expect("a defined register belongs to a block");
+        let mut split_calls = facts
+            .reads
+            .iter()
+            .filter_map(|read| {
+                let insertion = calls.partition_point(|call| *call < *read);
+                (insertion > 0).then(|| calls[insertion - 1])
+            })
+            .filter(|call| *call > definition && blocks[*call] == block)
+            .filter(|call| {
+                facts.definitions.partition_point(|candidate| *candidate <= *call) == 1
+                    && facts.definitions[0] == definition
+            })
             .collect::<Vec<_>>();
-        recipes.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
-        let mut splits = Vec::new();
-        for (register, recipe) in recipes {
-            if register_blocks.get(&register) != Some(&Some(block))
-                || instruction_defines_register(&instructions[call], &register)
-            {
-                continue;
-            }
-            let Some(last_reference) = instructions[call + 1..end]
-                .iter()
-                .rposition(|instruction| instruction_references_register(instruction, &register))
-                .map(|position| call + 1 + position)
-            else {
-                continue;
-            };
-            if instructions[call + 1..=last_reference]
-                .iter()
-                .any(|instruction| instruction.opcode.description().is_call)
-            {
-                continue;
-            }
-            let first_reference = instructions[call + 1..=last_reference]
-                .iter()
-                .find(|instruction| instruction_references_register(instruction, &register))
-                .expect("last reference guarantees a first reference");
-            if !instruction_reads_register(first_reference, &register) {
-                continue;
-            }
-
+        split_calls.sort_unstable();
+        split_calls.dedup();
+        for call in split_calls {
+            let end = calls
+                .get(calls.partition_point(|candidate| *candidate <= call))
+                .copied()
+                .filter(|next| blocks[*next] == block)
+                .map(|next| next + 1)
+                .unwrap_or_else(|| {
+                    blocks[call + 1..]
+                        .iter()
+                        .position(|candidate| *candidate != block)
+                        .map_or(instructions.len(), |offset| call + 1 + offset)
+                });
             let replacement = loop {
                 let candidate =
                     VirtualRegister::with_class(format!("{register}_after_call_{split_index}"), register.class());
@@ -355,23 +378,29 @@ pub(crate) fn split_rematerializable_live_ranges_across_calls(instructions: &mut
                     break candidate;
                 }
             };
-            splits.push((register, replacement, recipe));
+            splits.push((call, end, register.clone(), replacement, recipe.clone()));
         }
+    }
 
-        for (register, replacement, _) in &splits {
-            for instruction in &mut instructions[call + 1..end] {
-                for operand in &mut instruction.operands {
-                    visit_virtual_registers_mut(operand, &mut |candidate| {
-                        if candidate == register {
-                            *candidate = replacement.clone();
-                        }
-                    });
-                }
+    for (call, end, register, replacement, _) in &splits {
+        for instruction in &mut instructions[call + 1..*end] {
+            for operand in &mut instruction.operands {
+                visit_virtual_registers_mut(operand, &mut |candidate| {
+                    if candidate == register {
+                        *candidate = replacement.clone();
+                    }
+                });
             }
         }
-        let rematerializations = splits
-            .into_iter()
-            .map(|(_, replacement, mut recipe)| {
+    }
+    splits.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0).then_with(|| lhs.2.cmp(&rhs.2)));
+    while let Some(call) = splits.last().map(|split| split.0) {
+        let start = splits.partition_point(|split| split.0 < call);
+        let rematerializations = splits[start..]
+            .iter()
+            .filter(|split| split.0 == call)
+            .cloned()
+            .map(|(_, _, _, replacement, mut recipe)| {
                 let Operand::VirtualRegister(destination) = &mut recipe.operands[0] else {
                     unreachable!("rematerialization recipe must define a virtual register")
                 };
@@ -379,87 +408,10 @@ pub(crate) fn split_rematerializable_live_ranges_across_calls(instructions: &mut
                 recipe
             })
             .collect::<Vec<_>>();
+        let count = rematerializations.len();
         instructions.splice(call + 1..call + 1, rematerializations);
+        splits.truncate(splits.len() - count);
     }
-}
-
-fn instruction_blocks(instructions: &[Instruction]) -> Vec<usize> {
-    let mut blocks = Vec::with_capacity(instructions.len());
-    let mut block = 0usize;
-    for (index, instruction) in instructions.iter().enumerate() {
-        if index > 0
-            && (instruction.opcode.operation() == Operation::Label
-                || machine_instruction_ends_block(&instructions[index - 1]))
-        {
-            block += 1;
-        }
-        blocks.push(block);
-    }
-    blocks
-}
-
-fn machine_block_start(instructions: &[Instruction], instruction: usize) -> usize {
-    (0..=instruction)
-        .rev()
-        .find(|index| {
-            *index == 0
-                || instructions[*index].opcode.operation() == Operation::Label
-                || machine_instruction_ends_block(&instructions[*index - 1])
-        })
-        .unwrap()
-}
-
-fn machine_block_end(instructions: &[Instruction], instruction: usize) -> usize {
-    (instruction..instructions.len())
-        .find_map(|index| {
-            (machine_instruction_ends_block(&instructions[index])
-                || instructions
-                    .get(index + 1)
-                    .is_some_and(|instruction| instruction.opcode.operation() == Operation::Label))
-            .then_some(index + 1)
-        })
-        .unwrap_or(instructions.len())
-}
-
-fn machine_instruction_ends_block(instruction: &Instruction) -> bool {
-    instruction.opcode.description().terminal
-        || (instruction.opcode.operation() != Operation::Label
-            && instruction
-                .operands
-                .iter()
-                .any(|operand| matches!(operand, Operand::Label(_))))
-}
-
-fn rematerialization_recipes(instructions: &[Instruction]) -> HashMap<VirtualRegister, Instruction> {
-    let mut seen = HashSet::default();
-    let mut recipes = HashMap::default();
-    for instruction in instructions {
-        let recipe = rematerialization_recipe(instruction);
-        let mut referenced = Vec::new();
-        for operand in &instruction.operands {
-            visit_virtual_registers(operand, &mut |register| {
-                if !referenced.contains(register) {
-                    referenced.push(register.clone());
-                }
-            });
-        }
-        for register in referenced {
-            let first_reference = seen.insert(register.clone());
-            if recipe
-                .as_ref()
-                .is_some_and(|(recipe_register, _)| *recipe_register == register)
-            {
-                if first_reference {
-                    recipes.insert(register, recipe.as_ref().unwrap().1.clone());
-                } else {
-                    recipes.remove(&register);
-                }
-            } else if instruction_defines_register(instruction, &register) {
-                recipes.remove(&register);
-            }
-        }
-    }
-    recipes
 }
 
 fn rematerialization_recipe(instruction: &Instruction) -> Option<(VirtualRegister, Instruction)> {
@@ -483,56 +435,4 @@ fn rematerialization_recipe(instruction: &Instruction) -> Option<(VirtualRegiste
             operands: vec![Operand::VirtualRegister(register.clone()), source.clone()],
         },
     ))
-}
-
-fn instruction_references_register(instruction: &Instruction, register: &VirtualRegister) -> bool {
-    instruction.operands.iter().any(|operand| {
-        let mut references = false;
-        visit_virtual_registers(operand, &mut |candidate| references |= candidate == register);
-        references
-    })
-}
-
-fn instruction_reads_register(instruction: &Instruction, register: &VirtualRegister) -> bool {
-    let description = instruction.opcode.description();
-    instruction.operands.iter().enumerate().any(|(index, operand)| {
-        if matches!(operand, Operand::Address(_)) {
-            let mut reads = false;
-            visit_virtual_registers(operand, &mut |candidate| reads |= candidate == register);
-            return reads;
-        }
-        let Operand::VirtualRegister(candidate) = operand else {
-            return false;
-        };
-        candidate == register
-            && matches!(
-                description.operand_kind(index, instruction.operands.len()),
-                Some(
-                    OperandKind::GprIn
-                        | OperandKind::GprInOut
-                        | OperandKind::FprIn
-                        | OperandKind::FprInOut
-                        | OperandKind::RegisterIn
-                        | OperandKind::GprInOrImm
-                        | OperandKind::GprInOrMemory
-                )
-            )
-    })
-}
-
-fn instruction_defines_register(instruction: &Instruction, register: &VirtualRegister) -> bool {
-    let description = instruction.opcode.description();
-    instruction.operands.iter().enumerate().any(|(index, operand)| {
-        matches!(operand, Operand::VirtualRegister(candidate) if candidate == register)
-            && matches!(
-                description.operand_kind(index, instruction.operands.len()),
-                Some(
-                    OperandKind::GprOut
-                        | OperandKind::GprInOut
-                        | OperandKind::FprOut
-                        | OperandKind::FprInOut
-                        | OperandKind::RegisterOut
-                )
-            )
-    })
 }

--- a/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
@@ -7,7 +7,7 @@
 //! Target-aware instruction combining before register allocation.
 
 use super::{Instruction, Operand, VirtualRegister, visit_virtual_registers};
-use std::collections::HashMap;
+use crate::hash::HashMap;
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation, IntegerSignedness};
 use crate::target::description::{
     BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, Operation, OperandKind, PairWidth,
@@ -221,11 +221,11 @@ pub(crate) fn schedule_x86_relational_operand_loads(instructions: &mut Vec<Instr
 pub(crate) fn orient_commutative_updates(instructions: &mut [Instruction]) {
     // Where each register is named for the last time. Asking whether a value
     // outlives an instruction by scanning the rest of the listing turns this
-    // into a quadratic pass over a stitched function. Reversing a pair of
+    // into a quadratic pass over a large function. Reversing a pair of
     // operands only moves a register between the two instructions of the pair,
     // both of which lie before every listing suffix later steps look at, so
     // these positions stay correct as the pass runs.
-    let mut last_reference = HashMap::new();
+    let mut last_reference = HashMap::default();
     for (index, instruction) in instructions.iter().enumerate() {
         for operand in &instruction.operands {
             visit_virtual_registers(operand, &mut |register| {

--- a/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
+++ b/Libraries/LibJS/Flap/src/low_ir/preallocate.rs
@@ -10,7 +10,7 @@ use super::{Instruction, Operand, VirtualRegister, visit_virtual_registers};
 use crate::hash::HashMap;
 use crate::intrinsic::{BranchOperation, IntegerBinaryOperation, IntegerSignedness};
 use crate::target::description::{
-    BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, Operation, OperandKind, PairWidth,
+    BinaryOperation, EqualityCondition, IntegerWidth, MemoryWidth, OperandKind, Operation, PairWidth,
 };
 use crate::types::InterpreterRegister;
 
@@ -23,9 +23,7 @@ use crate::types::InterpreterRegister;
 /// A handler that assigns `pc` itself is the exception. Its assignment lands in
 /// the pinned register, and the terminator that dispatches on it reads that
 /// register back, so uses in between must be left alone.
-pub(crate) fn materialize_program_counter_reads(
-    instructions: &mut Vec<Instruction>,
-) -> Result<(), String> {
+pub(crate) fn materialize_program_counter_reads(instructions: &mut Vec<Instruction>) -> Result<(), String> {
     let program_counter = Operand::InterpreterRegister(InterpreterRegister::ProgramCounter);
     let mut index = 0;
     let mut reads = 0;
@@ -74,10 +72,7 @@ pub(crate) fn materialize_program_counter_reads(
             }
             match description.operand_kind(position, operand_count) {
                 Some(
-                    OperandKind::GprIn
-                    | OperandKind::RegisterIn
-                    | OperandKind::GprInOrImm
-                    | OperandKind::GprInOrMemory,
+                    OperandKind::GprIn | OperandKind::RegisterIn | OperandKind::GprInOrImm | OperandKind::GprInOrMemory,
                 ) => read_positions.push(position),
                 Some(OperandKind::GprInOut) => {
                     return Err(format!(
@@ -93,9 +88,7 @@ pub(crate) fn materialize_program_counter_reads(
             continue;
         }
 
-        let temporary = Operand::VirtualRegister(VirtualRegister::from(format!(
-            "program_counter_read_{reads}"
-        )));
+        let temporary = Operand::VirtualRegister(VirtualRegister::from(format!("program_counter_read_{reads}")));
         reads += 1;
         for position in read_positions {
             instructions[index].operands[position] = temporary.clone();
@@ -123,10 +116,8 @@ pub(crate) fn schedule_x86_relational_operand_loads(instructions: &mut Vec<Instr
         let lhs_load = instructions[index + 1].clone();
         let rhs_load = instructions[index + 2].clone();
         if pair.opcode.operation() != Operation::load_pair(PairWidth::Word)
-            || lhs_load.opcode.operation()
-                != Operation::load(MemoryWidth::DoubleWord, false)
-            || rhs_load.opcode.operation()
-                != Operation::load(MemoryWidth::DoubleWord, false)
+            || lhs_load.opcode.operation() != Operation::load(MemoryWidth::DoubleWord, false)
+            || rhs_load.opcode.operation() != Operation::load(MemoryWidth::DoubleWord, false)
             || pair.operands.len() != 4
             || lhs_load.operands.len() != 2
             || rhs_load.operands.len() != 2
@@ -144,15 +135,13 @@ pub(crate) fn schedule_x86_relational_operand_loads(instructions: &mut Vec<Instr
             .unwrap_or(hot_tail.len());
         let hot_tail = &hot_tail[..hot_tail_end];
         let has_lhs_tag_check = hot_tail.iter().any(|instruction| {
-            instruction.opcode.operation()
-                == Operation::branch_tag(EqualityCondition::NotEqual)
+            instruction.opcode.operation() == Operation::branch_tag(EqualityCondition::NotEqual)
                 && instruction.operands.first() == Some(&lhs_value)
         });
         let rhs_tag_check = hot_tail
             .iter()
             .position(|instruction| {
-                instruction.opcode.operation()
-                    == Operation::branch_tag(EqualityCondition::NotEqual)
+                instruction.opcode.operation() == Operation::branch_tag(EqualityCondition::NotEqual)
                     && instruction.operands.first() == Some(&rhs_value)
             })
             .map(|position| index + 3 + position);
@@ -246,10 +235,7 @@ pub(crate) fn orient_commutative_updates(instructions: &mut [Instruction]) {
                 update.opcode.operation(),
                 Operation::IntegerBinary {
                     operation: IntegerBinaryOperation::Binary(
-                        BinaryOperation::Add
-                            | BinaryOperation::And
-                            | BinaryOperation::Or
-                            | BinaryOperation::Xor,
+                        BinaryOperation::Add | BinaryOperation::And | BinaryOperation::Or | BinaryOperation::Xor,
                     ),
                     width: IntegerWidth::U64,
                 }

--- a/Libraries/LibJS/Flap/src/main.rs
+++ b/Libraries/LibJS/Flap/src/main.rs
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use flapc::{
-    Architecture, CompilationUnit, CompileOptions, Compiler, ObjectFormat, OptimizationReportOptions, Target,
-};
+use flapc::{Architecture, CompilationUnit, CompileOptions, Compiler, ObjectFormat, OptimizationReportOptions, Target};
 use std::fs;
 
-const USAGE: &str =
-    "Usage: flapc --arch x86_64 --input <file.flap> --output <file.S> [--constants <file>] [--bytecode-def <file>] [--optimization-report <file>] [--dump-changed-ir]";
+const USAGE: &str = "Usage: flapc --arch x86_64 --input <file.flap> --output <file.S> [--constants <file>] [--bytecode-def <file>] [--optimization-report <file>] [--dump-changed-ir]";
 
 struct CommandLine {
     options: CompileOptions,

--- a/Libraries/LibJS/Flap/src/main.rs
+++ b/Libraries/LibJS/Flap/src/main.rs
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use flapc::{Architecture, CompilationUnit, CompileOptions, Compiler, ObjectFormat, OptimizationReportOptions, Target};
+use flapc::{
+    Architecture, CompilationUnit, CompileOptions, Compiler, ObjectFormat, OptimizationReportOptions, SourceInput,
+    Target,
+};
 use std::fs;
 
 const USAGE: &str = "Usage: flapc --arch x86_64 --input <file.flap> --output <file.S> [--constants <file>] [--bytecode-def <file>] [--optimization-report <file>] [--dump-changed-ir]";
@@ -34,10 +37,20 @@ fn run() -> Result<(), String> {
 
     let compiler = Compiler::new(command_line.options);
     let unit = CompilationUnit {
-        source_name: &command_line.input_path,
-        source: &source,
-        constants: constants.as_deref(),
-        bytecode_def: bytecode_def.as_deref(),
+        source: SourceInput {
+            name: &command_line.input_path,
+            contents: &source,
+        },
+        constants: command_line
+            .constants_path
+            .as_deref()
+            .zip(constants.as_deref())
+            .map(|(name, contents)| SourceInput { name, contents }),
+        bytecode_def: command_line
+            .bytecode_def_path
+            .as_deref()
+            .zip(bytecode_def.as_deref())
+            .map(|(name, contents)| SourceInput { name, contents }),
     };
     let assembly = if let Some(report_path) = &command_line.optimization_report_path {
         let (prepared, report) = compiler

--- a/Libraries/LibJS/Flap/src/ssa/analysis.rs
+++ b/Libraries/LibJS/Flap/src/ssa/analysis.rs
@@ -157,8 +157,8 @@ impl DominatorTree {
         // block has no dominator at all.
         immediate_dominators[function.entry.0] = None;
         let mut children = vec![Vec::new(); block_count];
-        for block_index in 0..block_count {
-            if let Some(immediate_dominator) = immediate_dominators[block_index] {
+        for (block_index, immediate_dominator) in immediate_dominators.iter().copied().enumerate() {
+            if let Some(immediate_dominator) = immediate_dominator {
                 children[immediate_dominator.0].push(BlockId(block_index));
             }
         }

--- a/Libraries/LibJS/Flap/src/ssa/analysis.rs
+++ b/Libraries/LibJS/Flap/src/ssa/analysis.rs
@@ -74,41 +74,68 @@ impl ControlFlowGraph {
 
 #[derive(Debug)]
 pub(crate) struct DominatorTree {
-    dominators: Vec<HashSet<BlockId>>,
     immediate_dominators: Vec<Option<BlockId>>,
     children: Vec<Vec<BlockId>>,
+    /// Depth in the dominator tree, with the entry at zero.
+    depths: Vec<usize>,
+    /// Preorder interval of each block's subtree, which answers a dominance
+    /// question by containment rather than by set membership.
+    entered: Vec<u32>,
+    exited: Vec<u32>,
 }
 
 impl DominatorTree {
+    /// Compute immediate dominators by the Cooper-Harvey-Kennedy algorithm.
+    ///
+    /// Only the immediate dominator of each block is stored. The full dominator
+    /// set of a block is its path to the entry, so keeping the sets themselves
+    /// costs quadratic space and turns every recomputation into set cloning and
+    /// intersection.
     pub(crate) fn compute(function: &Function, cfg: &ControlFlowGraph) -> Self {
-        let all_reachable = cfg.reverse_postorder().iter().copied().collect::<HashSet<_>>();
-        let mut dominators = vec![HashSet::new(); function.blocks.len()];
-        for block in cfg.reverse_postorder() {
-            dominators[block.0] = all_reachable.clone();
+        let block_count = function.blocks.len();
+        let reverse_postorder = cfg.reverse_postorder();
+
+        // Intersection walks two blocks up the tree until they meet, comparing
+        // by postorder number, so a block deeper in the traversal is the one
+        // that moves.
+        let mut postorder_number = vec![0usize; block_count];
+        for (index, block) in reverse_postorder.iter().enumerate() {
+            postorder_number[block.0] = reverse_postorder.len() - index;
         }
-        dominators[function.entry.0] = HashSet::from([function.entry]);
+
+        // A block is its own dominator here so the fixed point has a starting
+        // point to intersect against; the entry keeps that value and every
+        // other block is refined away from it.
+        let mut immediate_dominators = vec![None; block_count];
+        immediate_dominators[function.entry.0] = Some(function.entry);
+
+        let intersect = |immediate_dominators: &[Option<BlockId>], mut lhs: BlockId, mut rhs: BlockId| {
+            while lhs != rhs {
+                while postorder_number[lhs.0] < postorder_number[rhs.0] {
+                    lhs = immediate_dominators[lhs.0].expect("a processed block has an immediate dominator");
+                }
+                while postorder_number[rhs.0] < postorder_number[lhs.0] {
+                    rhs = immediate_dominators[rhs.0].expect("a processed block has an immediate dominator");
+                }
+            }
+            lhs
+        };
 
         loop {
             let mut changed = false;
-            for block in cfg.reverse_postorder().iter().copied().skip(1) {
-                let reachable_predecessors = cfg
-                    .predecessors(block)
-                    .iter()
-                    .copied()
-                    .filter(|predecessor| cfg.is_reachable(*predecessor))
-                    .collect::<Vec<_>>();
-                let mut next = if let Some((first, rest)) = reachable_predecessors.split_first() {
-                    let mut intersection = dominators[first.0].clone();
-                    for predecessor in rest {
-                        intersection.retain(|candidate| dominators[predecessor.0].contains(candidate));
+            for block in reverse_postorder.iter().copied().skip(1) {
+                let mut new_immediate_dominator = None;
+                for predecessor in cfg.predecessors(block).iter().copied() {
+                    if !cfg.is_reachable(predecessor) || immediate_dominators[predecessor.0].is_none() {
+                        continue;
                     }
-                    intersection
-                } else {
-                    HashSet::new()
-                };
-                next.insert(block);
-                if next != dominators[block.0] {
-                    dominators[block.0] = next;
+                    new_immediate_dominator = Some(match new_immediate_dominator {
+                        None => predecessor,
+                        Some(current) => intersect(&immediate_dominators, predecessor, current),
+                    });
+                }
+                if new_immediate_dominator.is_some() && immediate_dominators[block.0] != new_immediate_dominator {
+                    immediate_dominators[block.0] = new_immediate_dominator;
                     changed = true;
                 }
             }
@@ -117,33 +144,53 @@ impl DominatorTree {
             }
         }
 
-        let mut immediate_dominators = vec![None; function.blocks.len()];
-        let mut children = vec![Vec::new(); function.blocks.len()];
-        for block_index in 0..function.blocks.len() {
-            let block = BlockId(block_index);
-            if block == function.entry || !cfg.is_reachable(block) {
+        // The entry dominates itself but is nobody's child, and an unreachable
+        // block has no dominator at all.
+        immediate_dominators[function.entry.0] = None;
+        let mut children = vec![Vec::new(); block_count];
+        for block_index in 0..block_count {
+            if let Some(immediate_dominator) = immediate_dominators[block_index] {
+                children[immediate_dominator.0].push(BlockId(block_index));
+            }
+        }
+
+        // Numbering the tree once turns dominance into an interval containment
+        // test, which is what the passes ask for over and over.
+        let mut depths = vec![0usize; block_count];
+        let mut entered = vec![0u32; block_count];
+        let mut exited = vec![0u32; block_count];
+        let mut clock = 0u32;
+        let mut worklist = vec![(function.entry, false)];
+        while let Some((block, finished)) = worklist.pop() {
+            if finished {
+                exited[block.0] = clock;
                 continue;
             }
-            let immediate_dominator = dominators[block.0]
-                .iter()
-                .copied()
-                .filter(|dominator| *dominator != block)
-                .max_by_key(|dominator| dominators[dominator.0].len());
-            immediate_dominators[block.0] = immediate_dominator;
-            if let Some(immediate_dominator) = immediate_dominator {
-                children[immediate_dominator.0].push(block);
+            clock += 1;
+            entered[block.0] = clock;
+            worklist.push((block, true));
+            for child in children[block.0].iter().copied() {
+                depths[child.0] = depths[block.0] + 1;
+                worklist.push((child, false));
             }
         }
 
         Self {
-            dominators,
             immediate_dominators,
             children,
+            depths,
+            entered,
+            exited,
         }
     }
 
     pub(crate) fn dominates(&self, dominator: BlockId, block: BlockId) -> bool {
-        self.dominators[block.0].contains(&dominator)
+        // An unvisited block was never entered, so it dominates nothing and is
+        // dominated by nothing, which is what the set-based answer used to be.
+        self.entered[block.0] != 0
+            && self.entered[dominator.0] != 0
+            && self.entered[dominator.0] <= self.entered[block.0]
+            && self.exited[block.0] <= self.exited[dominator.0]
     }
 
     pub(crate) fn immediate_dominator(&self, block: BlockId) -> Option<BlockId> {
@@ -155,14 +202,24 @@ impl DominatorTree {
     }
 
     pub(crate) fn depth(&self, block: BlockId) -> usize {
-        self.dominators[block.0].len().saturating_sub(1)
+        self.depths[block.0]
     }
 
-    pub(crate) fn nearest_common_dominator(&self, lhs: BlockId, rhs: BlockId) -> Option<BlockId> {
-        self.dominators[lhs.0]
-            .intersection(&self.dominators[rhs.0])
-            .copied()
-            .max_by_key(|block| self.depth(*block))
+    pub(crate) fn nearest_common_dominator(&self, mut lhs: BlockId, mut rhs: BlockId) -> Option<BlockId> {
+        if self.entered[lhs.0] == 0 || self.entered[rhs.0] == 0 {
+            return None;
+        }
+        while self.depths[lhs.0] > self.depths[rhs.0] {
+            lhs = self.immediate_dominators[lhs.0]?;
+        }
+        while self.depths[rhs.0] > self.depths[lhs.0] {
+            rhs = self.immediate_dominators[rhs.0]?;
+        }
+        while lhs != rhs {
+            lhs = self.immediate_dominators[lhs.0]?;
+            rhs = self.immediate_dominators[rhs.0]?;
+        }
+        Some(lhs)
     }
 }
 

--- a/Libraries/LibJS/Flap/src/ssa/analysis.rs
+++ b/Libraries/LibJS/Flap/src/ssa/analysis.rs
@@ -7,7 +7,7 @@
 //! Reusable analyses over Flap's SSA intermediate representation.
 
 use super::{BlockId, Function, InstructionId, Operation, ValueId};
-use std::collections::HashSet;
+use crate::hash::HashSet;
 
 #[derive(Debug)]
 pub(crate) struct ControlFlowGraph {
@@ -230,7 +230,7 @@ pub(crate) struct NaturalLoop {
 }
 
 pub(crate) fn find_natural_loops(function: &Function, cfg: &ControlFlowGraph, dominators: &DominatorTree) -> Vec<NaturalLoop> {
-    let mut blocks_by_header = vec![HashSet::new(); function.blocks.len()];
+    let mut blocks_by_header = vec![HashSet::default(); function.blocks.len()];
     for source in cfg.reverse_postorder().iter().copied() {
         for header in cfg.successors(source) {
             if !dominators.dominates(*header, source) {
@@ -382,6 +382,6 @@ mod tests {
         assert_eq!(dominators.children(header), [body, exit]);
         assert_eq!(loops.len(), 1);
         assert_eq!(loops[0].header, header);
-        assert_eq!(loops[0].blocks, HashSet::from([header, body]));
+        assert_eq!(loops[0].blocks, HashSet::from_iter([header, body]));
     }
 }

--- a/Libraries/LibJS/Flap/src/ssa/analysis.rs
+++ b/Libraries/LibJS/Flap/src/ssa/analysis.rs
@@ -342,7 +342,11 @@ pub(crate) struct NaturalLoop {
     pub(crate) blocks: HashSet<BlockId>,
 }
 
-pub(crate) fn find_natural_loops(function: &Function, cfg: &ControlFlowGraph, dominators: &DominatorTree) -> Vec<NaturalLoop> {
+pub(crate) fn find_natural_loops(
+    function: &Function,
+    cfg: &ControlFlowGraph,
+    dominators: &DominatorTree,
+) -> Vec<NaturalLoop> {
     let mut blocks_by_header = vec![HashSet::default(); function.blocks.len()];
     for source in cfg.reverse_postorder().iter().copied() {
         for header in cfg.successors(source) {
@@ -462,8 +466,8 @@ pub(crate) fn reachable_blocks(function: &Function, cfg: &ControlFlowGraph) -> V
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Type;
     use crate::ssa::{BlockLayout, Terminator};
+    use crate::types::Type;
 
     #[test]
     fn computes_cfg_dominators_and_natural_loops() {
@@ -471,18 +475,9 @@ mod tests {
         let header = function.create_empty_block("header", BlockLayout::Hot);
         let body = function.create_empty_block("body", BlockLayout::Hot);
         let exit = function.create_empty_block("exit", BlockLayout::Hot);
-        function.set_terminator(
-            function.entry,
-            Terminator::jump(header),
-        );
-        function.set_terminator(
-            header,
-            Terminator::branch(function.parameter(0), body, exit),
-        );
-        function.set_terminator(
-            body,
-            Terminator::jump(header),
-        );
+        function.set_terminator(function.entry, Terminator::jump(header));
+        function.set_terminator(header, Terminator::branch(function.parameter(0), body, exit));
+        function.set_terminator(body, Terminator::jump(header));
         function.set_terminator(exit, Terminator::Return(Vec::new()));
 
         let cfg = ControlFlowGraph::compute(&function);

--- a/Libraries/LibJS/Flap/src/ssa/analysis.rs
+++ b/Libraries/LibJS/Flap/src/ssa/analysis.rs
@@ -443,6 +443,12 @@ impl ValueUses {
     pub(crate) fn count(&self, value: ValueId) -> u32 {
         self.counts[value.0]
     }
+
+    pub(crate) fn remove_use(&mut self, value: ValueId) {
+        self.counts[value.0] = self.counts[value.0]
+            .checked_sub(1)
+            .expect("only recorded SSA uses can be removed");
+    }
 }
 
 pub(crate) fn reachable_blocks(function: &Function, cfg: &ControlFlowGraph) -> Vec<bool> {

--- a/Libraries/LibJS/Flap/src/ssa/analysis.rs
+++ b/Libraries/LibJS/Flap/src/ssa/analysis.rs
@@ -29,6 +29,15 @@ impl ControlFlowGraph {
                 successors[block_index].push(edge.block);
                 predecessors[edge.block.0].push(BlockId(block_index));
             }
+            // A guard leaves the block from the middle of it, so its exit is an
+            // edge as real as the terminator's.
+            for (_, failure) in function.guard_exits(BlockId(block_index)) {
+                if failure.0 >= function.blocks.len() {
+                    continue;
+                }
+                successors[block_index].push(failure);
+                predecessors[failure.0].push(BlockId(block_index));
+            }
         }
 
         let mut reachable = vec![false; function.blocks.len()];
@@ -220,6 +229,110 @@ impl DominatorTree {
             rhs = self.immediate_dominators[rhs.0]?;
         }
         Some(lhs)
+    }
+}
+
+/// Where guards sit, and which blocks a guard can reach around them.
+///
+/// A block containing a guard is entered before the guard and left again from
+/// the middle of it, so the values it defines after a guard are not available
+/// everywhere it dominates: a path that took the exit skipped them. Dominance
+/// alone cannot say that, so every pass that moves or shares a value across
+/// blocks asks this instead.
+#[derive(Debug, Default)]
+pub(crate) struct GuardExits {
+    any: bool,
+    first_guard: Vec<Option<usize>>,
+    reachable_from_exit: Vec<bool>,
+}
+
+impl GuardExits {
+    pub(crate) fn compute(function: &Function, cfg: &ControlFlowGraph) -> Self {
+        let first_guard = (0..function.blocks.len())
+            .map(|index| function.first_guard_position(BlockId(index)))
+            .collect::<Vec<_>>();
+        if first_guard.iter().all(Option::is_none) {
+            return Self {
+                any: false,
+                first_guard,
+                reachable_from_exit: vec![false; function.blocks.len()],
+            };
+        }
+        let mut reachable_from_exit = vec![false; function.blocks.len()];
+        let mut worklist = (0..function.blocks.len())
+            .flat_map(|index| function.guard_exits(BlockId(index)))
+            .map(|(_, failure)| failure)
+            .collect::<Vec<_>>();
+        while let Some(block) = worklist.pop() {
+            if std::mem::replace(&mut reachable_from_exit[block.0], true) {
+                continue;
+            }
+            worklist.extend(cfg.successors(block).iter().copied());
+        }
+        Self {
+            any: true,
+            first_guard,
+            reachable_from_exit,
+        }
+    }
+
+    /// Whether a value defined at `position` in `block` is available in `user`.
+    ///
+    /// The caller has already established that `block` dominates `user`. The
+    /// answer is conservative: it asks whether *any* guard exit reaches `user`
+    /// rather than whether one of this block's does, because the exact question
+    /// costs a walk per block. [`Self::definition_escapes`] asks it exactly.
+    pub(crate) fn definition_reaches(&self, block: BlockId, position: usize, user: BlockId) -> bool {
+        if !self.any || block == user {
+            return true;
+        }
+        match self.first_guard[block.0] {
+            Some(guard) if position > guard => !self.reachable_from_exit[user.0],
+            _ => true,
+        }
+    }
+
+    /// Whether a guard really carries control from before `position` in `block`
+    /// to `user`, skipping the definition that sits between them.
+    ///
+    /// This walks out of each exit, so it costs a pass over the function. Only
+    /// validation asks it, and only where the cheap answer was already "maybe".
+    pub(crate) fn definition_escapes(
+        &self,
+        function: &Function,
+        cfg: &ControlFlowGraph,
+        block: BlockId,
+        position: usize,
+        user: BlockId,
+    ) -> bool {
+        // Coming back around to the block runs the definition after all, so
+        // only paths that stay out of it skip it.
+        let mut reached = vec![false; function.blocks.len()];
+        reached[block.0] = true;
+        let mut worklist = function
+            .guard_exits(block)
+            .filter(|(guard, _)| *guard < position)
+            .map(|(_, failure)| failure)
+            .collect::<Vec<_>>();
+        while let Some(reached_block) = worklist.pop() {
+            if reached_block == user {
+                return true;
+            }
+            if std::mem::replace(&mut reached[reached_block.0], true) {
+                continue;
+            }
+            worklist.extend(cfg.successors(reached_block).iter().copied());
+        }
+        false
+    }
+
+    /// Whether control can leave `block` before its terminator.
+    pub(crate) fn has_guard(&self, block: BlockId) -> bool {
+        self.any && self.first_guard[block.0].is_some()
+    }
+
+    pub(crate) fn is_reachable_from_exit(&self, block: BlockId) -> bool {
+        self.reachable_from_exit[block.0]
     }
 }
 

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -7,7 +7,10 @@
 //! Explicit dependencies between effectful SSA operations.
 
 use super::analysis::{ControlFlowGraph, DominatorTree, InstructionLayout};
-use super::{AggregateOperation, BlockId, Effects, Function, InstructionId, Intrinsic, MemoryEffect, OperandOperation, Operation, Terminator, ValueDefinition, ValueId};
+use super::{
+    AggregateOperation, BlockId, Effects, Function, InstructionId, Intrinsic, MemoryEffect, OperandOperation,
+    Operation, Terminator, ValueDefinition, ValueId,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EffectDomain {
@@ -202,11 +205,7 @@ fn operation_memory_locations(
 
     if let Operation::FieldAccess(field_access) = operation {
         let bytes = field_access.kind.width().bytes();
-        if !add_location(
-            0,
-            bytes,
-            field_access.kind.writes(),
-        ) {
+        if !add_location(0, bytes, field_access.kind.writes()) {
             return unknown_access(effect);
         }
         return access;
@@ -446,8 +445,7 @@ impl DomainDependencies {
                 phi_blocks[failure.0] = true;
             }
         }
-        let (block_inputs, mut block_outputs) =
-            compute_domain_block_states(function, cfg, domain, &phi_blocks);
+        let (block_inputs, mut block_outputs) = compute_domain_block_states(function, cfg, domain, &phi_blocks);
 
         for block_index in 0..function.blocks.len() {
             let block = BlockId(block_index);
@@ -506,7 +504,6 @@ impl DomainDependencies {
     pub(crate) fn block_input(&self, block: BlockId) -> &EffectSet {
         &self.block_inputs[block.0]
     }
-
 }
 
 fn compute_domain_block_states(
@@ -547,7 +544,11 @@ fn compute_domain_block_states(
     // block per sweep. Blocks the entry cannot reach are visited last, since
     // reverse postorder does not name them.
     let mut order = cfg.reverse_postorder().to_vec();
-    order.extend((0..function.blocks.len()).map(BlockId).filter(|block| !cfg.is_reachable(*block)));
+    order.extend(
+        (0..function.blocks.len())
+            .map(BlockId)
+            .filter(|block| !cfg.is_reachable(*block)),
+    );
 
     // Building each block's input into a scratch buffer and only storing it
     // when it actually moved keeps the later sweeps, where almost nothing
@@ -608,8 +609,8 @@ fn terminator_effect(terminator: Option<&Terminator>, domain: EffectDomain) -> M
 mod tests {
     use super::*;
     use crate::intrinsic::{OperandLoad, OperandOperation, OperandStore};
-    use crate::types::Type;
     use crate::ssa::{BlockLayout, Operation};
+    use crate::types::Type;
 
     fn address(function: &mut Function, base: ValueId, offset: i64) -> ValueId {
         let offset = function.add_constant(Type::U64, super::super::Constant::Integer(offset));
@@ -627,10 +628,7 @@ mod tests {
         let header = function.create_empty_block("header", BlockLayout::Hot);
         let body = function.create_empty_block("body", BlockLayout::Hot);
         let exit = function.create_empty_block("exit", BlockLayout::Hot);
-        function.set_terminator(
-            function.entry,
-            Terminator::jump(header),
-        );
+        function.set_terminator(function.entry, Terminator::jump(header));
         let load = function.append_instruction_with_effects(
             header,
             Intrinsic::Operand(OperandOperation::Load(OperandLoad::Field)),
@@ -641,10 +639,7 @@ mod tests {
                 ..Effects::PURE
             },
         );
-        function.set_terminator(
-            header,
-            Terminator::branch(function.parameter(0), body, exit),
-        );
+        function.set_terminator(header, Terminator::branch(function.parameter(0), body, exit));
         function.append_instruction_with_effects(
             body,
             Intrinsic::Operand(OperandOperation::Store(OperandStore::Field)),
@@ -655,10 +650,7 @@ mod tests {
                 ..Effects::PURE
             },
         );
-        function.set_terminator(
-            body,
-            Terminator::jump(header),
-        );
+        function.set_terminator(body, Terminator::jump(header));
         function.set_terminator(exit, Terminator::Return(Vec::new()));
 
         let cfg = ControlFlowGraph::compute(&function);
@@ -735,10 +727,7 @@ mod tests {
                 ..Effects::PURE
             },
         )[0];
-        function.set_terminator(
-            function.entry,
-            Terminator::branch(function.parameter(0), write, clean),
-        );
+        function.set_terminator(function.entry, Terminator::branch(function.parameter(0), write, clean));
         function.append_instruction_with_effects(
             write,
             Intrinsic::Operand(OperandOperation::Store(OperandStore::Field)),
@@ -749,14 +738,8 @@ mod tests {
                 ..Effects::PURE
             },
         );
-        function.set_terminator(
-            write,
-            Terminator::jump(join),
-        );
-        function.set_terminator(
-            clean,
-            Terminator::jump(join),
-        );
+        function.set_terminator(write, Terminator::jump(join));
+        function.set_terminator(clean, Terminator::jump(join));
         function.set_terminator(join, Terminator::Return(Vec::new()));
 
         let cfg = ControlFlowGraph::compute(&function);
@@ -814,5 +797,4 @@ mod tests {
         assert_eq!(locations.reads[0].bytes, 1);
         assert!(!locations.unknown_read);
     }
-
 }

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -63,8 +63,12 @@ impl EffectSet {
 impl FromIterator<EffectDefinition> for EffectSet {
     fn from_iter<I: IntoIterator<Item = EffectDefinition>>(definitions: I) -> Self {
         let mut set = Self(definitions.into_iter().collect());
-        set.0.sort_unstable();
-        set.0.dedup();
+        // A block almost always inherits a single definition, and sorting is
+        // the most expensive thing this pass does per block.
+        if set.0.len() > 1 {
+            set.0.sort_unstable();
+            set.0.dedup();
+        }
         set
     }
 }

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -417,11 +417,35 @@ fn compute_domain_block_states(
     domain: EffectDomain,
     phi_blocks: &[bool],
 ) -> (Vec<BTreeSet<EffectDefinition>>, Vec<BTreeSet<EffectDefinition>>) {
+    // What a block leaves behind, when the block writes at all, is its own
+    // last write and nothing that reached it. That does not depend on the
+    // analysis, so it is found once rather than rediscovered by walking every
+    // instruction on every sweep.
+    let block_writes = function
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(block_index, block)| {
+            if terminator_effect(block.terminator.as_ref(), domain).writes() {
+                return Some(EffectDefinition::Terminator(BlockId(block_index)));
+            }
+            block
+                .instructions
+                .iter()
+                .rev()
+                .find(|instruction| effect_for(function.instructions[instruction.0].effects, domain).writes())
+                .map(|instruction| EffectDefinition::Instruction(*instruction))
+        })
+        .collect::<Vec<_>>();
+
     let mut inputs = vec![BTreeSet::new(); function.blocks.len()];
-    let mut outputs = inputs.clone();
+    let mut outputs = block_writes
+        .iter()
+        .map(|write| write.map(|definition| BTreeSet::from([definition])).unwrap_or_default())
+        .collect::<Vec<_>>();
     loop {
         let mut changed = false;
-        for (block_index, block) in function.blocks.iter().enumerate() {
+        for block_index in 0..function.blocks.len() {
             let id = BlockId(block_index);
             let mut input = if id == function.entry || cfg.predecessors(id).is_empty() {
                 BTreeSet::from([EffectDefinition::Entry])
@@ -436,19 +460,14 @@ fn compute_domain_block_states(
             if input.is_empty() {
                 input.insert(EffectDefinition::Entry);
             }
-            let mut output = input.clone();
-            for instruction in &block.instructions {
-                if effect_for(function.instructions[instruction.0].effects, domain).writes() {
-                    output = BTreeSet::from([EffectDefinition::Instruction(*instruction)]);
-                }
-            }
-            if terminator_effect(block.terminator.as_ref(), domain).writes() {
-                output = BTreeSet::from([EffectDefinition::Terminator(id)]);
-            }
-            if input != inputs[block_index] || output != outputs[block_index] {
+            if input != inputs[block_index] {
                 inputs[block_index] = input;
-                outputs[block_index] = output;
                 changed = true;
+                // A block that writes ends the chain, so only one that does
+                // not passes what reached it along.
+                if block_writes[block_index].is_none() {
+                    outputs[block_index] = inputs[block_index].clone();
+                }
             }
         }
         if !changed {

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -443,10 +443,18 @@ fn compute_domain_block_states(
         .iter()
         .map(|write| write.map(|definition| BTreeSet::from([definition])).unwrap_or_default())
         .collect::<Vec<_>>();
+
+    // A block's input comes from its predecessors, so visiting predecessors
+    // first propagates a change the whole way in one sweep instead of one
+    // block per sweep. Blocks the entry cannot reach are visited last, since
+    // reverse postorder does not name them.
+    let mut order = cfg.reverse_postorder().to_vec();
+    order.extend((0..function.blocks.len()).map(BlockId).filter(|block| !cfg.is_reachable(*block)));
+
     loop {
         let mut changed = false;
-        for block_index in 0..function.blocks.len() {
-            let id = BlockId(block_index);
+        for id in order.iter().copied() {
+            let block_index = id.0;
             let mut input = if id == function.entry || cfg.predecessors(id).is_empty() {
                 BTreeSet::from([EffectDefinition::Entry])
             } else if phi_blocks.get(block_index) == Some(&true) {

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -8,7 +8,6 @@
 
 use super::analysis::{ControlFlowGraph, DominatorTree, InstructionLayout};
 use super::{AggregateOperation, BlockId, Effects, Function, InstructionId, Intrinsic, MemoryEffect, OperandOperation, Operation, Terminator, ValueDefinition, ValueId};
-use std::collections::BTreeSet;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EffectDomain {
@@ -24,10 +23,62 @@ pub(crate) enum EffectDefinition {
     Terminator(BlockId),
 }
 
+/// A set of effect definitions.
+///
+/// These are built and copied once per effectful instruction per domain, and
+/// the analysis is recomputed after every pass that changes anything, so the
+/// set is held as a sorted vector: copying one is a single allocation rather
+/// than a tree walk, and nearly all of them hold a single definition.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct EffectSet(Vec<EffectDefinition>);
+
+impl EffectSet {
+    pub(crate) fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub(crate) fn from_one(definition: EffectDefinition) -> Self {
+        Self(vec![definition])
+    }
+
+    pub(crate) fn insert(&mut self, definition: EffectDefinition) {
+        if let Err(position) = self.0.binary_search(&definition) {
+            self.0.insert(position, definition);
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &EffectDefinition> {
+        self.0.iter()
+    }
+}
+
+impl FromIterator<EffectDefinition> for EffectSet {
+    fn from_iter<I: IntoIterator<Item = EffectDefinition>>(definitions: I) -> Self {
+        let mut set = Self(definitions.into_iter().collect());
+        set.0.sort_unstable();
+        set.0.dedup();
+        set
+    }
+}
+
+impl<const N: usize> From<[EffectDefinition; N]> for EffectSet {
+    fn from(definitions: [EffectDefinition; N]) -> Self {
+        Self::from_iter(definitions)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EffectAccess {
     pub(crate) effect: MemoryEffect,
-    pub(crate) dependencies: BTreeSet<EffectDefinition>,
+    pub(crate) dependencies: EffectSet,
     pub(crate) definition: Option<EffectDefinition>,
 }
 
@@ -336,8 +387,8 @@ fn constant_integer(function: &Function, value: ValueId) -> Option<i64> {
 pub(crate) struct DomainDependencies {
     instruction_accesses: Vec<Option<EffectAccess>>,
     #[cfg(test)]
-    phi_inputs: Vec<Option<BTreeSet<EffectDefinition>>>,
-    block_inputs: Vec<BTreeSet<EffectDefinition>>,
+    phi_inputs: Vec<Option<EffectSet>>,
+    block_inputs: Vec<EffectSet>,
 }
 
 impl DomainDependencies {
@@ -372,7 +423,7 @@ impl DomainDependencies {
                     definition,
                 });
                 if let Some(definition) = definition {
-                    dependencies = BTreeSet::from([definition]);
+                    dependencies = EffectSet::from_one(definition);
                 }
             }
 
@@ -388,7 +439,7 @@ impl DomainDependencies {
             block_outputs[block_index] = if let Some(access) = &terminator_accesses[block_index]
                 && let Some(definition) = access.definition
             {
-                BTreeSet::from([definition])
+                EffectSet::from_one(definition)
             } else {
                 dependencies
             };
@@ -407,11 +458,11 @@ impl DomainDependencies {
     }
 
     #[cfg(test)]
-    pub(crate) fn phi_inputs(&self, block: BlockId) -> Option<&BTreeSet<EffectDefinition>> {
+    pub(crate) fn phi_inputs(&self, block: BlockId) -> Option<&EffectSet> {
         self.phi_inputs[block.0].as_ref()
     }
 
-    pub(crate) fn block_input(&self, block: BlockId) -> &BTreeSet<EffectDefinition> {
+    pub(crate) fn block_input(&self, block: BlockId) -> &EffectSet {
         &self.block_inputs[block.0]
     }
 
@@ -422,7 +473,7 @@ fn compute_domain_block_states(
     cfg: &ControlFlowGraph,
     domain: EffectDomain,
     phi_blocks: &[bool],
-) -> (Vec<BTreeSet<EffectDefinition>>, Vec<BTreeSet<EffectDefinition>>) {
+) -> (Vec<EffectSet>, Vec<EffectSet>) {
     // What a block leaves behind, when the block writes at all, is its own
     // last write and nothing that reached it. That does not depend on the
     // analysis, so it is found once rather than rediscovered by walking every
@@ -444,10 +495,10 @@ fn compute_domain_block_states(
         })
         .collect::<Vec<_>>();
 
-    let mut inputs = vec![BTreeSet::new(); function.blocks.len()];
+    let mut inputs = vec![EffectSet::new(); function.blocks.len()];
     let mut outputs = block_writes
         .iter()
-        .map(|write| write.map(|definition| BTreeSet::from([definition])).unwrap_or_default())
+        .map(|write| write.map(EffectSet::from_one).unwrap_or_default())
         .collect::<Vec<_>>();
 
     // A block's input comes from its predecessors, so visiting predecessors
@@ -462,9 +513,9 @@ fn compute_domain_block_states(
         for id in order.iter().copied() {
             let block_index = id.0;
             let mut input = if id == function.entry || cfg.predecessors(id).is_empty() {
-                BTreeSet::from([EffectDefinition::Entry])
+                EffectSet::from_one(EffectDefinition::Entry)
             } else if phi_blocks.get(block_index) == Some(&true) {
-                BTreeSet::from([EffectDefinition::Phi(id)])
+                EffectSet::from_one(EffectDefinition::Phi(id))
             } else {
                 cfg.predecessors(id)
                     .iter()
@@ -569,15 +620,15 @@ mod tests {
 
         assert_eq!(
             memory.instruction_access(load).unwrap().dependencies,
-            BTreeSet::from([EffectDefinition::Phi(header)])
+            EffectSet::from([EffectDefinition::Phi(header)])
         );
         assert_eq!(
             memory.instruction_access(store).unwrap().dependencies,
-            BTreeSet::from([EffectDefinition::Phi(header)])
+            EffectSet::from([EffectDefinition::Phi(header)])
         );
         assert_eq!(
             memory.phi_inputs(header).unwrap(),
-            &BTreeSet::from([EffectDefinition::Entry, EffectDefinition::Instruction(store)])
+            &EffectSet::from([EffectDefinition::Entry, EffectDefinition::Instruction(store)])
         );
     }
 

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -289,6 +289,11 @@ pub(crate) fn alias(function: &Function, lhs: &MemoryLocation, rhs: &MemoryLocat
             if lhs_base != rhs_base {
                 return AliasResult::May;
             }
+            // Two accesses of the same width off the same base at the same
+            // offset are the same location, however they were spelled.
+            if lhs_offset == rhs_offset && lhs.bytes == rhs.bytes {
+                return AliasResult::Must;
+            }
             let lhs_end = lhs_offset.saturating_add(lhs.bytes as i128);
             let rhs_end = rhs_offset.saturating_add(rhs.bytes as i128);
             if lhs_end <= rhs_offset || rhs_end <= lhs_offset {
@@ -299,7 +304,8 @@ pub(crate) fn alias(function: &Function, lhs: &MemoryLocation, rhs: &MemoryLocat
         }
         (MemoryLocationIdentity::IndexedOperand(lhs), MemoryLocationIdentity::IndexedOperand(rhs)) => {
             match (constant_integer(function, *lhs), constant_integer(function, *rhs)) {
-                (Some(lhs), Some(rhs)) if lhs != rhs => AliasResult::No,
+                (Some(lhs), Some(rhs)) if lhs == rhs => AliasResult::Must,
+                (Some(_), Some(_)) => AliasResult::No,
                 _ => AliasResult::May,
             }
         }

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -440,7 +440,12 @@ impl DomainDependencies {
                 (inputs.len() > 1 && cfg.predecessors(BlockId(block)).len() > 1).then(|| inputs.clone())
             })
             .collect::<Vec<_>>();
-        let phi_blocks = phi_inputs.iter().map(Option::is_some).collect::<Vec<_>>();
+        let mut phi_blocks = phi_inputs.iter().map(Option::is_some).collect::<Vec<_>>();
+        for block in 0..function.blocks.len() {
+            for (_, failure) in function.guard_exits(BlockId(block)) {
+                phi_blocks[failure.0] = true;
+            }
+        }
         let (block_inputs, mut block_outputs) =
             compute_domain_block_states(function, cfg, domain, &phi_blocks);
 

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -329,6 +329,38 @@ fn address_location(function: &Function, value: ValueId, bytes: u8) -> Option<Me
     })
 }
 
+/// What two locations must have in common before `alias` can call them the
+/// same one.
+///
+/// Grouping the locations a pass is tracking by this key turns "is any of these
+/// the same location" from a walk over all of them into a lookup. It has to
+/// agree with `alias`: two locations it gives different keys must never be
+/// `Must`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum LocationKey {
+    /// An address reached through constants: the same base, offset and width
+    /// is the same location however it was spelled.
+    ConstantAddress(ValueId, i128, u8),
+    /// An operand slot named by a constant index.
+    ConstantOperand(i64),
+    /// Anything else, where only being spelled identically makes it the same.
+    AsSpelled(MemoryLocation),
+}
+
+pub(crate) fn location_key(function: &Function, location: &MemoryLocation) -> LocationKey {
+    match &location.identity {
+        MemoryLocationIdentity::Address(components) => match constant_address(function, components) {
+            Some((base, offset)) => LocationKey::ConstantAddress(base, offset, location.bytes),
+            None => LocationKey::AsSpelled(location.clone()),
+        },
+        MemoryLocationIdentity::IndexedOperand(index) => match constant_integer(function, *index) {
+            Some(index) => LocationKey::ConstantOperand(index),
+            None => LocationKey::AsSpelled(location.clone()),
+        },
+        MemoryLocationIdentity::BytecodeField(_) => LocationKey::AsSpelled(location.clone()),
+    }
+}
+
 pub(crate) fn alias(function: &Function, lhs: &MemoryLocation, rhs: &MemoryLocation) -> AliasResult {
     if lhs == rhs {
         return AliasResult::Must;

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -41,14 +41,14 @@ impl EffectSet {
         Self(vec![definition])
     }
 
-    pub(crate) fn insert(&mut self, definition: EffectDefinition) {
-        if let Err(position) = self.0.binary_search(&definition) {
-            self.0.insert(position, definition);
-        }
+    /// Take a set from definitions already sorted and free of duplicates.
+    pub(crate) fn from_sorted(definitions: Vec<EffectDefinition>) -> Self {
+        debug_assert!(definitions.windows(2).all(|pair| pair[0] < pair[1]));
+        Self(definitions)
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+    pub(crate) fn as_slice(&self) -> &[EffectDefinition] {
+        &self.0
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -512,25 +512,33 @@ fn compute_domain_block_states(
     let mut order = cfg.reverse_postorder().to_vec();
     order.extend((0..function.blocks.len()).map(BlockId).filter(|block| !cfg.is_reachable(*block)));
 
+    // Building each block's input into a scratch buffer and only storing it
+    // when it actually moved keeps the later sweeps, where almost nothing
+    // changes, from allocating a set per block and throwing it away.
+    let mut input = Vec::new();
     loop {
         let mut changed = false;
         for id in order.iter().copied() {
             let block_index = id.0;
-            let mut input = if id == function.entry || cfg.predecessors(id).is_empty() {
-                EffectSet::from_one(EffectDefinition::Entry)
+            input.clear();
+            if id == function.entry || cfg.predecessors(id).is_empty() {
+                input.push(EffectDefinition::Entry);
             } else if phi_blocks.get(block_index) == Some(&true) {
-                EffectSet::from_one(EffectDefinition::Phi(id))
+                input.push(EffectDefinition::Phi(id));
             } else {
-                cfg.predecessors(id)
-                    .iter()
-                    .flat_map(|predecessor| outputs[predecessor.0].iter().copied())
-                    .collect()
-            };
-            if input.is_empty() {
-                input.insert(EffectDefinition::Entry);
+                for predecessor in cfg.predecessors(id) {
+                    input.extend(outputs[predecessor.0].iter().copied());
+                }
+                if input.len() > 1 {
+                    input.sort_unstable();
+                    input.dedup();
+                }
             }
-            if input != inputs[block_index] {
-                inputs[block_index] = input;
+            if input.is_empty() {
+                input.push(EffectDefinition::Entry);
+            }
+            if inputs[block_index].as_slice() != input {
+                inputs[block_index] = EffectSet::from_sorted(input.clone());
                 changed = true;
                 // A block that writes ends the chain, so only one that does
                 // not passes what reached it along.

--- a/Libraries/LibJS/Flap/src/ssa/effects.rs
+++ b/Libraries/LibJS/Flap/src/ssa/effects.rs
@@ -323,7 +323,7 @@ fn address_location(function: &Function, value: ValueId, bytes: u8) -> Option<Me
         return None;
     }
     Some(MemoryLocation {
-        identity: MemoryLocationIdentity::Address(instruction.inputs.clone()),
+        identity: MemoryLocationIdentity::Address(instruction.inputs.to_vec()),
         bytes,
     })
 }

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -43,6 +43,7 @@ fn inline_calls_with_budget(
         inline_call(function, block_index, instruction_index, callee)?;
         count += 1;
     }
+    function.recompute_machine_state_dependencies();
     function.validate().map_err(|message| inline_error(function, message))?;
     Ok(count)
 }
@@ -269,7 +270,7 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
             operation,
             inputs,
             result_types,
-            instruction.effects,
+            instruction.base_effects,
         );
         for (old, new) in instruction.results.iter().zip(results) {
             values.insert(*old, new);

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -12,7 +12,7 @@ use super::{BlockId, Edge, Function, Intrinsic, MemoryEffect, Operation, Termina
 use super::{BinaryOperation, IntegerBinaryOperation};
 use crate::types::Type;
 use crate::{CompileError, CompileStage};
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 fn inline_error(function: &Function, message: impl Into<String>) -> CompileError {
     CompileError::new(CompileStage::Ssa, Some(&function.name), message)
@@ -159,9 +159,9 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
     for old in &call.results {
         function.values[old.0].definition = ValueDefinition::Dead;
     }
-    rebuild_instruction_arena(function, &HashSet::from([call_id]), InstructionOrder::ByBlock);
+    rebuild_instruction_arena(function, &HashSet::from_iter([call_id]), InstructionOrder::ByBlock);
 
-    let mut blocks = HashMap::from([(callee.entry, caller_block)]);
+    let mut blocks = HashMap::from_iter([(callee.entry, caller_block)]);
     for (callee_block_index, callee_block) in callee.blocks.iter().enumerate() {
         let callee_block_id = BlockId(callee_block_index);
         if callee_block_id == callee.entry {
@@ -190,7 +190,7 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
         blocks.insert(callee_block_id, cloned);
     }
 
-    let mut values = HashMap::new();
+    let mut values = HashMap::default();
     for (index, input) in call.inputs.iter().enumerate() {
         let input = coerce_value(function, caller_block, *input, &callee.parameter_types[index])?;
         values.insert(callee.parameter(index), input);

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -639,7 +639,7 @@ fn block_reference(function: &Function, value: ValueId) -> Option<Edge> {
     let Operation::BlockReference(block) = &instruction.operation else {
         return None;
     };
-    Some(Edge::with_arguments(*block, instruction.inputs.clone()))
+    Some(Edge::with_arguments(*block, instruction.inputs.to_vec()))
 }
 
 fn coerce_value(

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -266,6 +266,9 @@ fn cloned_operation(
 ) -> Result<Operation, CompileError> {
     match operation {
         Operation::BlockReference(target) => Ok(Operation::BlockReference(blocks[target])),
+        Operation::Guard { failure } => Ok(Operation::Guard {
+            failure: blocks[failure],
+        }),
         Operation::Parameter(parameter) => {
             let parameter_index = parameter.index();
             let value = mapped(function, values, callee.parameter(parameter_index), &callee.name)?;

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -7,36 +7,65 @@
 //! SSA inline expansion.
 
 use super::optimize::{InstructionOrder, rebuild_instruction_arena, rewrite_function_uses};
-use super::{BlockId, Edge, Function, Intrinsic, MemoryEffect, Operation, Terminator, ValueDefinition, ValueId, ValueOperation};
 #[cfg(test)]
 use super::{BinaryOperation, IntegerBinaryOperation};
+use super::{
+    BlockId, Edge, Function, Intrinsic, MemoryEffect, Operation, Terminator, ValueDefinition, ValueId, ValueOperation,
+};
+use crate::hash::{HashMap, HashSet};
 use crate::types::Type;
 use crate::{CompileError, CompileStage};
-use crate::hash::{HashMap, HashSet};
+
+const MAX_INLINED_INSTRUCTION_COUNT: usize = 1_000_000;
 
 fn inline_error(function: &Function, message: impl Into<String>) -> CompileError {
     CompileError::new(CompileStage::Ssa, Some(&function.name), message)
 }
 
 pub(crate) fn inline_calls(function: &mut Function, callees: &[Function]) -> Result<usize, CompileError> {
+    inline_calls_with_budget(function, callees, MAX_INLINED_INSTRUCTION_COUNT)
+}
+
+fn inline_calls_with_budget(
+    function: &mut Function,
+    callees: &[Function],
+    maximum_instruction_count: usize,
+) -> Result<usize, CompileError> {
     let mut count = 0;
     loop {
-        if lower_checked_inline_call(function, callees)? {
+        if lower_checked_inline_call(function, callees, maximum_instruction_count)? {
             continue;
         }
         let Some((block_index, instruction_index, callee)) = find_call(function, callees)? else {
             break;
         };
+        ensure_expansion_budget(function, callee.instructions.len(), maximum_instruction_count)?;
         inline_call(function, block_index, instruction_index, callee)?;
         count += 1;
     }
-    function
-        .validate()
-        .map_err(|message| inline_error(function, message))?;
+    function.validate().map_err(|message| inline_error(function, message))?;
     Ok(count)
 }
 
-fn lower_checked_inline_call(function: &mut Function, callees: &[Function]) -> Result<bool, CompileError> {
+fn ensure_expansion_budget(
+    function: &Function,
+    additional_instruction_count: usize,
+    maximum_instruction_count: usize,
+) -> Result<(), CompileError> {
+    if function.instructions.len().saturating_add(additional_instruction_count) > maximum_instruction_count {
+        return Err(inline_error(
+            function,
+            format!("inline expansion exceeds the {maximum_instruction_count}-instruction limit"),
+        ));
+    }
+    Ok(())
+}
+
+fn lower_checked_inline_call(
+    function: &mut Function,
+    callees: &[Function],
+    maximum_instruction_count: usize,
+) -> Result<bool, CompileError> {
     for block_index in 0..function.blocks.len() {
         let Some(Terminator::CheckedOperation {
             operation: Operation::InlineCall(id),
@@ -66,6 +95,7 @@ fn lower_checked_inline_call(function: &mut Function, callees: &[Function]) -> R
                 ),
             ));
         }
+        ensure_expansion_budget(function, 2, maximum_instruction_count)?;
 
         let block = BlockId(block_index);
         let failure_reference = function.append_instruction(
@@ -472,6 +502,29 @@ mod tests {
         assert_eq!(error.stage, CompileStage::Ssa);
         assert_eq!(error.handler.as_deref(), Some("invalid"));
         assert_eq!(error.message, "inline function #0 has no SSA body");
+    }
+
+    #[test]
+    fn rejects_inline_expansion_beyond_the_instruction_budget() {
+        let (mut handler, callees) = lower(
+            r#"
+inline fn identity(value: i32) -> i32 {
+    value
+}
+
+handler Identity(value: i32) {
+    let result = identity(value);
+    assert_nonzero(result);
+    dispatch_next;
+}
+"#,
+        );
+        let maximum_instruction_count = handler.instructions.len();
+        let error = inline_calls_with_budget(&mut handler, &callees, maximum_instruction_count).unwrap_err();
+        assert_eq!(
+            error.message,
+            format!("inline expansion exceeds the {maximum_instruction_count}-instruction limit")
+        );
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -15,6 +15,8 @@ use super::{
 use crate::hash::{HashMap, HashSet};
 use crate::types::Type;
 use crate::{CompileError, CompileStage};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 
 const MAX_INLINED_INSTRUCTION_COUNT: usize = 1_000_000;
 
@@ -192,16 +194,33 @@ fn inline_calls_with_budget(
     maximum_instruction_count: usize,
 ) -> Result<usize, CompileError> {
     let mut count = 0;
-    loop {
-        if lower_checked_inline_call(function, callees, maximum_instruction_count)? {
+    let mut eliminated = HashSet::default();
+    let mut worklist = (0..function.blocks.len())
+        .map(|index| Reverse(BlockId(index)))
+        .collect::<BinaryHeap<_>>();
+    while let Some(Reverse(block)) = worklist.pop() {
+        if lower_checked_inline_call(function, block, callees, maximum_instruction_count, eliminated.len())? {
+            worklist.push(Reverse(block));
             continue;
         }
-        let Some((block_index, instruction_index, callee)) = find_call(function, callees)? else {
-            break;
+        let Some((instruction_index, callee)) = find_call(function, block, callees)? else {
+            continue;
         };
-        ensure_expansion_budget(function, callee.instructions.len(), maximum_instruction_count)?;
-        inline_call(function, block_index, instruction_index, callee)?;
+        ensure_expansion_budget(
+            function,
+            callee.instructions.len(),
+            maximum_instruction_count,
+            eliminated.len(),
+        )?;
+        let first_new_block = function.blocks.len();
+        let call = inline_call(function, block.0, instruction_index, callee)?;
+        eliminated.insert(call);
+        worklist.extend((first_new_block..function.blocks.len()).map(|index| Reverse(BlockId(index))));
+        worklist.push(Reverse(block));
         count += 1;
+    }
+    if !eliminated.is_empty() {
+        rebuild_instruction_arena(function, &eliminated, InstructionOrder::ByBlock);
     }
     function.recompute_machine_state_dependencies();
     function.validate().map_err(|message| inline_error(function, message))?;
@@ -212,8 +231,10 @@ fn ensure_expansion_budget(
     function: &Function,
     additional_instruction_count: usize,
     maximum_instruction_count: usize,
+    eliminated_instruction_count: usize,
 ) -> Result<(), CompileError> {
-    if function.instructions.len().saturating_add(additional_instruction_count) > maximum_instruction_count {
+    let live_instruction_count = function.instructions.len() - eliminated_instruction_count;
+    if live_instruction_count.saturating_add(additional_instruction_count) > maximum_instruction_count {
         return Err(inline_error(
             function,
             format!("inline expansion exceeds the {maximum_instruction_count}-instruction limit"),
@@ -224,92 +245,89 @@ fn ensure_expansion_budget(
 
 fn lower_checked_inline_call(
     function: &mut Function,
+    block: BlockId,
     callees: &[Function],
     maximum_instruction_count: usize,
+    eliminated_instruction_count: usize,
 ) -> Result<bool, CompileError> {
-    for block_index in 0..function.blocks.len() {
-        let Some(Terminator::CheckedOperation {
-            operation: Operation::InlineCall(id),
-            inputs,
-            results,
-            effects,
-            success,
-            failure,
-        }) = function.blocks[block_index].terminator.clone()
-        else {
+    let Some(Terminator::CheckedOperation {
+        operation: Operation::InlineCall(id),
+        inputs,
+        results,
+        effects,
+        success,
+        failure,
+    }) = function.blocks[block.0].terminator.clone()
+    else {
+        return Ok(false);
+    };
+    let callee = callees
+        .get(id.index())
+        .ok_or_else(|| inline_error(function, format!("inline function #{} has no SSA body", id.index())))?;
+    if callee.parameter_types.len() != inputs.len() + 1
+        || callee.parameter_types.last() != Some(&Type::label())
+        || callee.return_types.len() != results.len()
+    {
+        return Err(inline_error(
+            function,
+            format!(
+                "checked call to inline function '{}' does not match its {} parameters and {} results",
+                callee.name,
+                callee.parameter_types.len(),
+                callee.return_types.len()
+            ),
+        ));
+    }
+    ensure_expansion_budget(function, 2, maximum_instruction_count, eliminated_instruction_count)?;
+
+    let failure_reference = function.append_instruction(
+        block,
+        Operation::BlockReference(failure.block),
+        failure.arguments,
+        vec![Type::label()],
+    )[0];
+    let call_results = function.append_instruction_with_effects(
+        block,
+        Operation::InlineCall(id),
+        inputs.into_iter().chain([failure_reference]).collect(),
+        results
+            .iter()
+            .map(|result| function.values[result.0].ty.clone())
+            .collect(),
+        effects,
+    );
+    let replacements = results.iter().copied().zip(call_results.iter().copied()).collect();
+    rewrite_function_uses(function, &replacements);
+    for old in &results {
+        function.values[old.0].definition = ValueDefinition::Dead;
+    }
+    function.blocks[block.0].terminator = Some(Terminator::jump_with_arguments(
+        success.block,
+        call_results
+            .into_iter()
+            .chain(success.arguments.into_iter().skip(results.len()))
+            .collect(),
+    ));
+    Ok(true)
+}
+
+fn find_call<'a>(
+    function: &Function,
+    block: BlockId,
+    callees: &'a [Function],
+) -> Result<Option<(usize, &'a Function)>, CompileError> {
+    for (instruction_index, instruction_id) in function.blocks[block.0].instructions.iter().enumerate() {
+        let Operation::InlineCall(id) = &function.instructions[instruction_id.0].operation else {
             continue;
         };
         let callee = callees
             .get(id.index())
             .ok_or_else(|| inline_error(function, format!("inline function #{} has no SSA body", id.index())))?;
-        if callee.parameter_types.len() != inputs.len() + 1
-            || callee.parameter_types.last() != Some(&Type::label())
-            || callee.return_types.len() != results.len()
-        {
-            return Err(inline_error(
-                function,
-                format!(
-                    "checked call to inline function '{}' does not match its {} parameters and {} results",
-                    callee.name,
-                    callee.parameter_types.len(),
-                    callee.return_types.len()
-                ),
-            ));
+        let call = &function.instructions[instruction_id.0];
+        if call.inputs.len() != callee.parameter_types.len() || call.results.len() != callee.return_types.len() {
+            continue;
         }
-        ensure_expansion_budget(function, 2, maximum_instruction_count)?;
-
-        let block = BlockId(block_index);
-        let failure_reference = function.append_instruction(
-            block,
-            Operation::BlockReference(failure.block),
-            failure.arguments,
-            vec![Type::label()],
-        )[0];
-        let call_results = function.append_instruction_with_effects(
-            block,
-            Operation::InlineCall(id),
-            inputs.into_iter().chain([failure_reference]).collect(),
-            results
-                .iter()
-                .map(|result| function.values[result.0].ty.clone())
-                .collect(),
-            effects,
-        );
-        let replacements = results.iter().copied().zip(call_results.iter().copied()).collect();
-        rewrite_function_uses(function, &replacements);
-        for old in &results {
-            function.values[old.0].definition = ValueDefinition::Dead;
-        }
-        function.blocks[block_index].terminator = Some(Terminator::jump_with_arguments(
-            success.block,
-            call_results
-                .into_iter()
-                .chain(success.arguments.into_iter().skip(results.len()))
-                .collect(),
-        ));
-        return Ok(true);
-    }
-    Ok(false)
-}
-
-fn find_call<'a>(
-    function: &Function,
-    callees: &'a [Function],
-) -> Result<Option<(usize, usize, &'a Function)>, CompileError> {
-    for (block_index, block) in function.blocks.iter().enumerate() {
-        for (instruction_index, instruction_id) in block.instructions.iter().enumerate() {
-            let Operation::InlineCall(id) = &function.instructions[instruction_id.0].operation else {
-                continue;
-            };
-            let callee = callees
-                .get(id.index())
-                .ok_or_else(|| inline_error(function, format!("inline function #{} has no SSA body", id.index())))?;
-            let call = &function.instructions[instruction_id.0];
-            if call.inputs.len() != callee.parameter_types.len() || call.results.len() != callee.return_types.len() {
-                continue;
-            }
-            return Ok(Some((block_index, instruction_index, callee)));
-        }
+        return Ok(Some((instruction_index, callee)));
     }
     Ok(None)
 }
@@ -319,7 +337,7 @@ fn inline_call(
     block_index: usize,
     instruction_index: usize,
     callee: &Function,
-) -> Result<(), CompileError> {
+) -> Result<super::InstructionId, CompileError> {
     let call_id = function.blocks[block_index].instructions[instruction_index];
     let call = function.instructions[call_id.0].clone();
     if call.inputs.len() != callee.parameter_types.len() || call.results.len() != callee.return_types.len() {
@@ -365,8 +383,6 @@ fn inline_call(
     for old in &call.results {
         function.values[old.0].definition = ValueDefinition::Dead;
     }
-    rebuild_instruction_arena(function, &HashSet::from_iter([call_id]), InstructionOrder::ByBlock);
-
     let mut blocks = HashMap::from_iter([(callee.entry, caller_block)]);
     for (callee_block_index, callee_block) in callee.blocks.iter().enumerate() {
         let callee_block_id = BlockId(callee_block_index);
@@ -474,7 +490,7 @@ fn inline_call(
             &mut values,
         )?;
     }
-    Ok(())
+    Ok(call_id)
 }
 
 fn cloned_operation(
@@ -767,6 +783,32 @@ handler Double(value: i32) {
                     BinaryOperation::Add,
                 )))
         }));
+    }
+
+    #[test]
+    fn inlines_multiple_calls_without_intermediate_compaction() {
+        let (mut handler, callees) = lower(
+            r#"
+inline fn increment(value: i32) -> i32 {
+    value + 1
+}
+
+handler IncrementTwice(value: i32) {
+    let first = increment(value);
+    let second = increment(first);
+    assert_nonzero(second);
+    dispatch_next;
+}
+"#,
+        );
+
+        assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 2);
+        assert!(
+            !handler
+                .instructions
+                .iter()
+                .any(|instruction| matches!(instruction.operation, Operation::InlineCall(_)))
+        );
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -23,7 +23,167 @@ fn inline_error(function: &Function, message: impl Into<String>) -> CompileError
 }
 
 pub(crate) fn inline_calls(function: &mut Function, callees: &[Function]) -> Result<usize, CompileError> {
+    preflight_expansion(function, callees, MAX_INLINED_INSTRUCTION_COUNT)?;
     inline_calls_with_budget(function, callees, MAX_INLINED_INSTRUCTION_COUNT)
+}
+
+fn resolved_inline_callee(
+    operation: &Operation,
+    bindings: &[Option<super::OperationValue>],
+) -> Option<crate::identity::InlineFunctionId> {
+    match operation {
+        Operation::InlineCall(id) => Some(*id),
+        Operation::Parameter(parameter) => {
+            let Some(Some(super::OperationValue::InlineFunction(id))) = bindings.get(parameter.index()) else {
+                return None;
+            };
+            Some(*id)
+        }
+        _ => None,
+    }
+}
+
+fn operation_binding(
+    function: &Function,
+    value: ValueId,
+    bindings: &[Option<super::OperationValue>],
+) -> Option<super::OperationValue> {
+    match &function.values[value.0].definition {
+        ValueDefinition::Constant(super::ir::Constant::Operation(operation)) => Some(operation.clone()),
+        ValueDefinition::FunctionParameter(parameter) => bindings.get(*parameter).cloned().flatten(),
+        _ => None,
+    }
+}
+
+fn callee_bindings(
+    function: &Function,
+    inputs: &[ValueId],
+    callee: &Function,
+    bindings: &[Option<super::OperationValue>],
+) -> Vec<Option<super::OperationValue>> {
+    (0..callee.parameter_types.len())
+        .map(|parameter| {
+            inputs
+                .get(parameter)
+                .and_then(|value| operation_binding(function, *value, bindings))
+        })
+        .collect()
+}
+
+fn expanded_instruction_count(
+    function: &Function,
+    callees: &[Function],
+    bindings: &[Option<super::OperationValue>],
+    active: &mut Vec<crate::identity::InlineFunctionId>,
+    memoized_counts: &mut HashMap<(usize, Vec<Option<super::OperationValue>>), usize>,
+    maximum_instruction_count: usize,
+) -> Result<usize, CompileError> {
+    let mut count = function.instructions.len();
+    for instruction in &function.instructions {
+        let Some(id) = resolved_inline_callee(&instruction.operation, bindings) else {
+            continue;
+        };
+        if active.contains(&id) {
+            return Err(inline_error(
+                function,
+                format!("recursive inline expansion reached inline function #{}", id.index()),
+            ));
+        }
+        let callee = callees
+            .get(id.index())
+            .ok_or_else(|| inline_error(function, format!("inline function #{} has no SSA body", id.index())))?;
+        let callee_bindings = callee_bindings(function, &instruction.inputs, callee, bindings);
+        let key = (id.index(), callee_bindings.clone());
+        let callee_count = if let Some(count) = memoized_counts.get(&key) {
+            *count
+        } else {
+            active.push(id);
+            let count = expanded_instruction_count(
+                callee,
+                callees,
+                &callee_bindings,
+                active,
+                memoized_counts,
+                maximum_instruction_count,
+            )?;
+            active.pop();
+            memoized_counts.insert(key, count);
+            count
+        };
+        count = count
+            .checked_sub(1)
+            .and_then(|count| count.checked_add(callee_count))
+            .ok_or_else(|| inline_error(function, "inline expansion instruction count overflow"))?;
+        if count > maximum_instruction_count {
+            return Err(inline_error(
+                function,
+                format!("inline expansion exceeds the {maximum_instruction_count}-instruction limit"),
+            ));
+        }
+    }
+    for block in &function.blocks {
+        let Some(Terminator::CheckedOperation { operation, inputs, .. }) = &block.terminator else {
+            continue;
+        };
+        let Some(id) = resolved_inline_callee(operation, bindings) else {
+            continue;
+        };
+        if active.contains(&id) {
+            return Err(inline_error(
+                function,
+                format!("recursive inline expansion reached inline function #{}", id.index()),
+            ));
+        }
+        let callee = callees
+            .get(id.index())
+            .ok_or_else(|| inline_error(function, format!("inline function #{} has no SSA body", id.index())))?;
+        let callee_bindings = callee_bindings(function, inputs, callee, bindings);
+        let key = (id.index(), callee_bindings.clone());
+        let callee_count = if let Some(count) = memoized_counts.get(&key) {
+            *count
+        } else {
+            active.push(id);
+            let count = expanded_instruction_count(
+                callee,
+                callees,
+                &callee_bindings,
+                active,
+                memoized_counts,
+                maximum_instruction_count,
+            )?;
+            active.pop();
+            memoized_counts.insert(key, count);
+            count
+        };
+        count = count
+            .checked_add(1)
+            .and_then(|count| count.checked_add(callee_count))
+            .ok_or_else(|| inline_error(function, "inline expansion instruction count overflow"))?;
+        if count > maximum_instruction_count {
+            return Err(inline_error(
+                function,
+                format!("inline expansion exceeds the {maximum_instruction_count}-instruction limit"),
+            ));
+        }
+    }
+    Ok(count)
+}
+
+fn preflight_expansion(
+    function: &Function,
+    callees: &[Function],
+    maximum_instruction_count: usize,
+) -> Result<(), CompileError> {
+    let bindings = vec![None; function.parameter_types.len()];
+    expanded_instruction_count(
+        function,
+        callees,
+        &bindings,
+        &mut Vec::new(),
+        &mut HashMap::default(),
+        maximum_instruction_count,
+    )?;
+    Ok(())
 }
 
 fn inline_calls_with_budget(

--- a/Libraries/LibJS/Flap/src/ssa/inline.rs
+++ b/Libraries/LibJS/Flap/src/ssa/inline.rs
@@ -154,7 +154,12 @@ fn find_call<'a>(
     Ok(None)
 }
 
-fn inline_call(function: &mut Function, block_index: usize, instruction_index: usize, callee: &Function) -> Result<(), CompileError> {
+fn inline_call(
+    function: &mut Function,
+    block_index: usize,
+    instruction_index: usize,
+    callee: &Function,
+) -> Result<(), CompileError> {
     let call_id = function.blocks[block_index].instructions[instruction_index];
     let call = function.instructions[call_id.0].clone();
     if call.inputs.len() != callee.parameter_types.len() || call.results.len() != callee.return_types.len() {
@@ -166,9 +171,19 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
 
     let caller_block = BlockId(block_index);
     let caller_layout = function.blocks[caller_block.0].layout;
-    let continuation_types = call.results.iter().map(|result| function.values[result.0].ty.clone()).collect();
-    let continuation = function.create_named_block(format!("inline_{}_continuation", callee.name), function.blocks[block_index].layout, continuation_types);
-    let tail = function.blocks[block_index].instructions.split_off(instruction_index + 1);
+    let continuation_types = call
+        .results
+        .iter()
+        .map(|result| function.values[result.0].ty.clone())
+        .collect();
+    let continuation = function.create_named_block(
+        format!("inline_{}_continuation", callee.name),
+        function.blocks[block_index].layout,
+        continuation_types,
+    );
+    let tail = function.blocks[block_index]
+        .instructions
+        .split_off(instruction_index + 1);
     function.blocks[block_index].instructions.pop();
     function.blocks[continuation.0].instructions = tail;
     function.blocks[continuation.0].terminator = function.blocks[block_index].terminator.take();
@@ -210,7 +225,10 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
             .map(|parameter| callee.values[parameter.0].ty.clone())
             .collect();
         let cloned = function.create_block(
-            callee_block.name.as_ref().map(|name| format!("inline_{}_{name}", callee.name)),
+            callee_block
+                .name
+                .as_ref()
+                .map(|name| format!("inline_{}_{name}", callee.name)),
             if caller_layout == super::ir::BlockLayout::Cold {
                 super::ir::BlockLayout::Cold
             } else {
@@ -228,7 +246,10 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
     }
     for (index, value) in callee.values.iter().enumerate() {
         if let ValueDefinition::Constant(constant) = &value.definition {
-            values.insert(ValueId(index), function.add_constant(value.ty.clone(), constant.clone()));
+            values.insert(
+                ValueId(index),
+                function.add_constant(value.ty.clone(), constant.clone()),
+            );
         }
     }
     for (callee_block_index, callee_block) in callee.blocks.iter().enumerate() {
@@ -283,7 +304,15 @@ fn inline_call(function: &mut Function, block_index: usize, instruction_index: u
             .terminator
             .as_ref()
             .ok_or_else(|| inline_error(function, format!("callee '{}' has no terminator", callee.name)))?;
-        clone_terminator(function, callee, terminator, cloned_block, continuation, &blocks, &mut values)?;
+        clone_terminator(
+            function,
+            callee,
+            terminator,
+            cloned_block,
+            continuation,
+            &blocks,
+            &mut values,
+        )?;
     }
     Ok(())
 }
@@ -329,8 +358,7 @@ fn clone_terminator(
     let edge = |edge: &Edge| -> Result<Edge, CompileError> {
         Ok(Edge::with_arguments(
             blocks[&edge.block],
-            edge
-                .arguments
+            edge.arguments
                 .iter()
                 .map(|value| mapped(function, values, *value, &callee.name))
                 .collect::<Result<_, _>>()?,
@@ -338,7 +366,11 @@ fn clone_terminator(
     };
     let cloned = match terminator {
         Terminator::Jump(target) => Terminator::Jump(edge(target)?),
-        Terminator::Branch { condition, then_edge, else_edge } => Terminator::branch_edges(
+        Terminator::Branch {
+            condition,
+            then_edge,
+            else_edge,
+        } => Terminator::branch_edges(
             mapped(function, values, *condition, &callee.name)?,
             edge(then_edge)?,
             edge(else_edge)?,
@@ -351,7 +383,14 @@ fn clone_terminator(
                 .collect::<Result<_, CompileError>>()?,
             edge(default)?,
         ),
-        Terminator::CheckedOperation { operation, inputs, results, effects, success, failure } => {
+        Terminator::CheckedOperation {
+            operation,
+            inputs,
+            results,
+            effects,
+            success,
+            failure,
+        } => {
             let inputs = inputs
                 .iter()
                 .map(|value| mapped(function, values, *value, &callee.name))
@@ -369,7 +408,10 @@ fn clone_terminator(
             } else {
                 *effects
             };
-            let result_types = results.iter().map(|result| callee.values[result.0].ty.clone()).collect();
+            let result_types = results
+                .iter()
+                .map(|result| callee.values[result.0].ty.clone())
+                .collect();
             let success_block = blocks[&success.block];
             let extra_success_arguments = success.arguments[results.len()..]
                 .iter()
@@ -424,7 +466,12 @@ fn block_reference(function: &Function, value: ValueId) -> Option<Edge> {
     Some(Edge::with_arguments(*block, instruction.inputs.clone()))
 }
 
-fn coerce_value(function: &mut Function, block: BlockId, value: ValueId, target: &Type) -> Result<ValueId, CompileError> {
+fn coerce_value(
+    function: &mut Function,
+    block: BlockId,
+    value: ValueId,
+    target: &Type,
+) -> Result<ValueId, CompileError> {
     let source = &function.values[value.0].ty;
     if source == target {
         return Ok(value);
@@ -460,12 +507,10 @@ fn mapped(
     value: ValueId,
     callee: &str,
 ) -> Result<ValueId, CompileError> {
-    values.get(&value).copied().ok_or_else(|| {
-        inline_error(
-            function,
-            format!("callee '{callee}' uses unmapped value {value:?}"),
-        )
-    })
+    values
+        .get(&value)
+        .copied()
+        .ok_or_else(|| inline_error(function, format!("callee '{callee}' uses unmapped value {value:?}")))
 }
 
 #[cfg(test)]
@@ -543,16 +588,24 @@ handler Double(value: i32) {
 }
 "#,
         );
-        assert!(handler.instructions.iter().any(|instruction| {
-            matches!(instruction.operation, Operation::InlineCall(_))
-        }));
+        assert!(
+            handler
+                .instructions
+                .iter()
+                .any(|instruction| { matches!(instruction.operation, Operation::InlineCall(_)) })
+        );
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
-        assert!(!handler.instructions.iter().any(|instruction| {
-            matches!(instruction.operation, Operation::InlineCall(_))
-        }));
+        assert!(
+            !handler
+                .instructions
+                .iter()
+                .any(|instruction| { matches!(instruction.operation, Operation::InlineCall(_)) })
+        );
         assert!(handler.instructions.iter().any(|instruction| {
             instruction.operation
-                == Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add)))
+                == Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                    BinaryOperation::Add,
+                )))
         }));
     }
 
@@ -570,7 +623,10 @@ handler Finish() {
 "#,
         );
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
-        assert_eq!(handler.blocks[handler.entry.0].terminator, Some(Terminator::Unreachable));
+        assert_eq!(
+            handler.blocks[handler.entry.0].terminator,
+            Some(Terminator::Unreachable)
+        );
         assert!(handler.instructions.iter().any(|instruction| {
             instruction.operation
                 == Operation::Intrinsic(Intrinsic::Control(crate::intrinsic::ControlOperation::DispatchNext))
@@ -596,9 +652,12 @@ handler Store(dst: out Operand, value: Value) = store_and_finish(dst, value);
                     crate::intrinsic::OperandStore::Field,
                 )))
         }));
-        assert!(!handler.instructions.iter().any(|instruction| {
-            matches!(instruction.operation, Operation::InlineCall(_))
-        }));
+        assert!(
+            !handler
+                .instructions
+                .iter()
+                .any(|instruction| { matches!(instruction.operation, Operation::InlineCall(_)) })
+        );
     }
 
     #[test]
@@ -623,9 +682,12 @@ handler Choose(condition: u32) {
         );
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
         optimize::optimize_function(&mut handler);
-        assert!(!handler.blocks.iter().any(|block| {
-            matches!(block.terminator, Some(Terminator::IndirectJump { .. }))
-        }));
+        assert!(
+            !handler
+                .blocks
+                .iter()
+                .any(|block| { matches!(block.terminator, Some(Terminator::IndirectJump { .. })) })
+        );
         let jump_targets = handler
             .blocks
             .iter()
@@ -634,12 +696,16 @@ handler Choose(condition: u32) {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        assert!(jump_targets.iter().any(|block| {
-            handler.blocks[block.0].layout == super::super::ir::BlockLayout::Hot
-        }));
-        assert!(jump_targets.iter().any(|block| {
-            handler.blocks[block.0].layout == super::super::ir::BlockLayout::Cold
-        }));
+        assert!(
+            jump_targets
+                .iter()
+                .any(|block| { handler.blocks[block.0].layout == super::super::ir::BlockLayout::Hot })
+        );
+        assert!(
+            jump_targets
+                .iter()
+                .any(|block| { handler.blocks[block.0].layout == super::super::ir::BlockLayout::Cold })
+        );
     }
 
     #[test]
@@ -663,10 +729,18 @@ handler Select(condition: u32, lhs: i32, rhs: i32) {
         );
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
         assert!(handler.blocks.len() > 2);
-        assert!(handler.blocks.iter().any(|block| matches!(block.terminator, Some(Terminator::Branch { .. }))));
-        assert!(!handler.instructions.iter().any(|instruction| {
-            matches!(instruction.operation, Operation::InlineCall(_))
-        }));
+        assert!(
+            handler
+                .blocks
+                .iter()
+                .any(|block| matches!(block.terminator, Some(Terminator::Branch { .. })))
+        );
+        assert!(
+            !handler
+                .instructions
+                .iter()
+                .any(|instruction| { matches!(instruction.operation, Operation::InlineCall(_)) })
+        );
     }
 
     #[test]
@@ -688,10 +762,18 @@ handler Add(lhs: i32, rhs: i32) {
 "#,
         );
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
-        assert!(handler.blocks.iter().any(|block| {
-            matches!(block.terminator, Some(Terminator::CheckedOperation { .. }))
-        }));
-        assert!(handler.blocks.iter().any(|block| block.layout == super::super::ir::BlockLayout::Cold));
+        assert!(
+            handler
+                .blocks
+                .iter()
+                .any(|block| { matches!(block.terminator, Some(Terminator::CheckedOperation { .. })) })
+        );
+        assert!(
+            handler
+                .blocks
+                .iter()
+                .any(|block| block.layout == super::super::ir::BlockLayout::Cold)
+        );
     }
 
     #[test]
@@ -723,18 +805,20 @@ handler Apply(value: i32) = apply(value, checked_add);
             )
         }));
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
-        let effects = handler
-            .blocks
-            .iter()
-            .find_map(|block| match &block.terminator {
-                Some(Terminator::CheckedOperation {
-                    operation: Operation::Intrinsic(Intrinsic::CheckedInteger(crate::ssa::CheckedIntegerOperation::Add)),
-                    effects,
-                    ..
-                }) => Some(effects),
-                _ => None,
-            })
-            .expect("expected substituted checked operation");
+        let effects =
+            handler
+                .blocks
+                .iter()
+                .find_map(|block| match &block.terminator {
+                    Some(Terminator::CheckedOperation {
+                        operation:
+                            Operation::Intrinsic(Intrinsic::CheckedInteger(crate::ssa::CheckedIntegerOperation::Add)),
+                        effects,
+                        ..
+                    }) => Some(effects),
+                    _ => None,
+                })
+                .expect("expected substituted checked operation");
         assert_eq!(effects.memory, MemoryEffect::None);
         assert!(!effects.may_call);
         assert!(!effects.may_trap);
@@ -764,12 +848,19 @@ handler Use(value: u64) {
         let inlined_blocks = handler
             .blocks
             .iter()
-            .filter(|block| block.name.as_deref().is_some_and(|name| name.starts_with("inline_helper_")))
+            .filter(|block| {
+                block
+                    .name
+                    .as_deref()
+                    .is_some_and(|name| name.starts_with("inline_helper_"))
+            })
             .collect::<Vec<_>>();
         assert!(!inlined_blocks.is_empty());
-        assert!(inlined_blocks
-            .iter()
-            .all(|block| block.layout == super::super::ir::BlockLayout::Cold));
+        assert!(
+            inlined_blocks
+                .iter()
+                .all(|block| block.layout == super::super::ir::BlockLayout::Cold)
+        );
     }
 
     #[test]
@@ -789,8 +880,7 @@ handler Widen(value: u8) {
         );
         assert_eq!(inline_calls(&mut handler, &callees).unwrap(), 1);
         assert!(handler.instructions.iter().any(|instruction| {
-            instruction.operation
-                == Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse))
+            instruction.operation == Operation::Intrinsic(Intrinsic::Value(ValueOperation::Reuse))
                 && handler.values[instruction.results[0].0].ty == Type::I32
         }));
     }

--- a/Libraries/LibJS/Flap/src/ssa/lowering.rs
+++ b/Libraries/LibJS/Flap/src/ssa/lowering.rs
@@ -16,7 +16,7 @@ use crate::hir::{
     ValueMatchArm, ValueMatchArmKind, ValueMatchFallbackIr, VariableId,
 };
 use crate::{CompileError, CompileStage};
-use std::collections::HashMap;
+use crate::hash::HashMap;
 
 pub(crate) fn lower_handler(handler: &Handler) -> Result<Function, CompileError> {
     lower_body(
@@ -82,13 +82,13 @@ fn lower_body(
         .map(|result| body.variables[*result].ty.clone())
         .collect();
     let mut lowered = Function::new(name, parameter_types, result_types);
-    let mut bindings = HashMap::new();
+    let mut bindings = HashMap::default();
     for (index, parameter) in parameters.iter().enumerate() {
         lowered.set_parameter_name(index, &body.variables[*parameter].name);
         bindings.insert(*parameter, lowered.parameter(index));
     }
     let mut continuations = Vec::new();
-    let mut continuation_indices = HashMap::new();
+    let mut continuation_indices = HashMap::default();
     declare_continuations(
         &body.statements,
         body,
@@ -104,8 +104,8 @@ fn lower_body(
         body,
         continuations,
         continuation_indices,
-        indirect_targets: HashMap::new(),
-        int32_value_sources: HashMap::new(),
+        indirect_targets: HashMap::default(),
+        int32_value_sources: HashMap::default(),
     };
     lowerer.lower_statements(&body.statements)?;
     if let Some(block) = lowerer.current_block.take() {

--- a/Libraries/LibJS/Flap/src/ssa/lowering.rs
+++ b/Libraries/LibJS/Flap/src/ssa/lowering.rs
@@ -512,9 +512,20 @@ impl Lowerer<'_> {
     fn lower_guard(&mut self, condition: &Condition, failure: &str) -> Result<(), String> {
         let condition = self.lower_condition(condition)?;
         let source = self.current()?;
+        let failure = self.continuation_edge(failure)?;
+        if failure.arguments.is_empty() {
+            self.function.append_instruction(
+                source,
+                Operation::Guard {
+                    failure: failure.block,
+                },
+                vec![condition],
+                Vec::new(),
+            );
+            return Ok(());
+        }
         let layout = self.function.blocks[source.0].layout;
         let success = self.function.create_empty_block("guard_success", layout);
-        let failure = self.continuation_edge(failure)?;
         self.function.set_terminator(
             source,
             Terminator::branch_edges(condition, Edge::new(success), failure),
@@ -1777,5 +1788,55 @@ handler Invalid() {
         assert!(error.message.contains("duplicate continuation"));
     }
 
+    fn lower_source(source: &str) -> Function {
+        let ast = parser::parse("test.flap", source).unwrap();
+        let typed = typecheck::check("test.flap", &ast).unwrap();
+        lower_handler(&typed.handlers[0]).unwrap()
+    }
 
+    #[test]
+    fn lowers_a_guard_into_the_block_it_continues() {
+        let function = lower_source(
+            r#"
+handler Check(value: i32) {
+    guard value != 0 else slow;
+    assert_nonzero(value);
+    let slow = || { dispatch_next; };
+    dispatch_next;
+}
+"#,
+        );
+
+        let entry = &function.blocks[function.entry.0];
+        let guards = function.guard_exits(function.entry).collect::<Vec<_>>();
+        assert_eq!(guards.len(), 1);
+        assert!(guards[0].0 < entry.instructions.len() - 1);
+        assert!(
+            !function
+                .blocks
+                .iter()
+                .any(|block| block.name.as_deref() == Some("guard_success"))
+        );
+        function.validate().unwrap();
+    }
+
+    #[test]
+    fn keeps_a_branch_for_a_guard_that_hands_over_values() {
+        let function = lower_source(
+            r#"
+handler Check(value: i32) {
+    let slow = |kept: i32| { assert_nonzero(kept); dispatch_next; };
+    guard value != 0 else slow(value);
+    dispatch_next;
+}
+"#,
+        );
+
+        assert_eq!(function.guard_exits(function.entry).count(), 0);
+        assert!(matches!(
+            function.blocks[function.entry.0].terminator,
+            Some(Terminator::Branch { .. })
+        ));
+        function.validate().unwrap();
+    }
 }

--- a/Libraries/LibJS/Flap/src/ssa/lowering.rs
+++ b/Libraries/LibJS/Flap/src/ssa/lowering.rs
@@ -1127,7 +1127,7 @@ impl Lowerer<'_> {
             self.function.append_instruction_with_effects(
                 block,
                 Intrinsic::Operand(operation),
-                inputs,
+                inputs.to_vec(),
                 vec![self.function.values[value.0].ty.clone()],
                 instruction.effects,
             )[0],

--- a/Libraries/LibJS/Flap/src/ssa/lowering.rs
+++ b/Libraries/LibJS/Flap/src/ssa/lowering.rs
@@ -6,28 +6,28 @@
 
 //! Lower typed HIR into SSA.
 
-use super::{BlockId, BlockLayout, Constant, Edge, Effects, Function, Operation, OperationParameterId, Terminator, ValueDefinition, ValueId};
+use super::{
+    BlockId, BlockLayout, Constant, Edge, Effects, Function, Operation, OperationParameterId, Terminator,
+    ValueDefinition, ValueId,
+};
 use crate::frontend::ast::ParameterMode;
-use crate::intrinsic::{BinaryOperation, ClassificationOperation, ComparisonDomain, ControlOperation, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, LowLevelOperation, OperandLoad, OperandOperation, OperandStore, ValueOperation};
-use crate::types::{BlockTemperature, Type};
+use crate::hash::HashMap;
 use crate::hir as typecheck;
 use crate::hir::{
     CallTarget, Condition, Handler, InlineFunction, ScalarMatchArmIr, StatementKindIr, TagMask, Value, ValueKind,
     ValueMatchArm, ValueMatchArmKind, ValueMatchFallbackIr, VariableId,
 };
+use crate::intrinsic::{
+    BinaryOperation, ClassificationOperation, ComparisonDomain, ControlOperation, IntegerBinaryOperation,
+    IntegerComparisonOperation, Intrinsic, LowLevelOperation, OperandLoad, OperandOperation, OperandStore,
+    ValueOperation,
+};
+use crate::types::{BlockTemperature, Type};
 use crate::{CompileError, CompileStage};
-use crate::hash::HashMap;
 
 pub(crate) fn lower_handler(handler: &Handler) -> Result<Function, CompileError> {
-    lower_body(
-        &handler.name,
-        &handler.body,
-        &handler.parameters,
-        &[],
-    )
-    .map_err(|message| {
-        CompileError::new(CompileStage::Ssa, Some(&handler.name), message)
-    })
+    lower_body(&handler.name, &handler.body, &handler.parameters, &[])
+        .map_err(|message| CompileError::new(CompileStage::Ssa, Some(&handler.name), message))
 }
 
 pub(crate) fn lower_inline_function(function: &InlineFunction) -> Result<Function, CompileError> {
@@ -56,15 +56,8 @@ pub(crate) fn lower_inline_function(function: &InlineFunction) -> Result<Functio
         .chain(&output_parameters)
         .copied()
         .collect::<Vec<_>>();
-    lower_body(
-        &function.name,
-        &function.body,
-        &input_parameters,
-        &result_variables,
-    )
-    .map_err(|message| {
-        CompileError::new(CompileStage::Ssa, Some(&function.name), message)
-    })
+    lower_body(&function.name, &function.body, &input_parameters, &result_variables)
+        .map_err(|message| CompileError::new(CompileStage::Ssa, Some(&function.name), message))
 }
 
 fn lower_body(
@@ -172,13 +165,7 @@ fn declare_continuations(
         let mut result = Ok(());
         statement.kind.for_each_nested_body(|nested| {
             if result.is_ok() {
-                result = declare_continuations(
-                    nested,
-                    body,
-                    function,
-                    continuations,
-                    continuation_indices,
-                );
+                result = declare_continuations(nested, body, function, continuations, continuation_indices);
             }
         });
         result?;
@@ -218,8 +205,7 @@ fn schedule_statement_indices(statements: &[typecheck::Statement]) -> Vec<usize>
     let mut index = 0;
     while index < statements.len() {
         let paired_guard_load = (|| {
-            let StatementKindIr::Call(destinations, call) = &statements.get(index)?.kind
-            else {
+            let StatementKindIr::Call(destinations, call) = &statements.get(index)?.kind else {
                 return None;
             };
             let [destination] = destinations.as_slice() else {
@@ -231,20 +217,17 @@ fn schedule_statement_indices(statements: &[typecheck::Statement]) -> Vec<usize>
             for (second_index, statement) in statements.iter().enumerate().skip(index + 1) {
                 if let StatementKindIr::Call(_, call) = &statement.kind
                     && guard_uses_first
-                    && paired_field_call(call).is_some_and(|(other_pair, other_order)| {
-                        other_pair == pair && other_order != order
-                    })
+                    && paired_field_call(call)
+                        .is_some_and(|(other_pair, other_order)| other_pair == pair && other_order != order)
                     && field_load_base(call) == Some(base)
                 {
                     return Some((second_index, order));
                 }
                 match &statement.kind {
                     StatementKindIr::Guard { condition, .. } => {
-                        guard_uses_first |=
-                            typecheck::condition_uses_and_defs(condition).0.contains(destination);
+                        guard_uses_first |= typecheck::condition_uses_and_defs(condition).0.contains(destination);
                     }
-                    StatementKindIr::Call(_, call)
-                        if call.is_load() && call.return_type.is_some() => {}
+                    StatementKindIr::Call(_, call) if call.is_load() && call.return_type.is_some() => {}
                     _ => break,
                 }
             }
@@ -267,18 +250,20 @@ fn schedule_statement_indices(statements: &[typecheck::Statement]) -> Vec<usize>
 }
 
 fn direct_jump_target(statements: &[typecheck::Statement]) -> Option<&str> {
-    let [typecheck::Statement {
-        kind: StatementKindIr::Call(destinations, call),
-        ..
-    }] = statements
+    let [
+        typecheck::Statement {
+            kind: StatementKindIr::Call(destinations, call),
+            ..
+        },
+    ] = statements
     else {
         return None;
     };
     (destinations.is_empty()
         && call.terminal
         && call.intrinsic() == Some(Intrinsic::Control(ControlOperation::JumpLabel)))
-        .then_some(call.branch_target.as_deref())
-        .flatten()
+    .then_some(call.branch_target.as_deref())
+    .flatten()
 }
 
 impl Lowerer<'_> {
@@ -300,12 +285,7 @@ impl Lowerer<'_> {
             match &statement.kind {
                 StatementKindIr::Call(destinations, call) => {
                     if let Some(failure) = &call.failure {
-                        self.lower_fallible_call(
-                            destinations,
-                            call,
-                            &failure.captures,
-                            &failure.body,
-                        )?;
+                        self.lower_fallible_call(destinations, call, &failure.captures, &failure.body)?;
                     } else if call.intrinsic() == Some(Intrinsic::Control(ControlOperation::JumpLabel))
                         && let Some(target) = call
                             .branch_target
@@ -318,9 +298,9 @@ impl Lowerer<'_> {
                             call.return_type.clone().into_iter().collect()
                         } else {
                             destinations
-                        .iter()
-                        .map(|destination| self.variable_type(*destination))
-                        .collect::<Result<Vec<_>, _>>()?
+                                .iter()
+                                .map(|destination| self.variable_type(*destination))
+                                .collect::<Result<Vec<_>, _>>()?
                         };
                         let results = self.lower_call(call, result_types)?;
                         for (destination, result) in destinations.iter().zip(results) {
@@ -333,7 +313,11 @@ impl Lowerer<'_> {
                         self.current_block = None;
                     }
                 }
-                StatementKindIr::MachineAssign { destination, intrinsic, arguments } => {
+                StatementKindIr::MachineAssign {
+                    destination,
+                    intrinsic,
+                    arguments,
+                } => {
                     self.lower_machine_assign(*destination, *intrinsic, arguments)?;
                 }
                 StatementKindIr::If {
@@ -370,13 +354,7 @@ impl Lowerer<'_> {
                     fallback,
                 } => {
                     if let Some(destination) = destination {
-                        self.lower_value_value_match(
-                            *destination,
-                            value,
-                            captures,
-                            arms,
-                            fallback,
-                        )?;
+                        self.lower_value_value_match(*destination, value, captures, arms, fallback)?;
                     } else {
                         self.lower_value_match(
                             value,
@@ -386,7 +364,9 @@ impl Lowerer<'_> {
                         )?;
                     }
                 }
-                StatementKindIr::ScalarMatch { value, arms, fallback, .. } => {
+                StatementKindIr::ScalarMatch {
+                    value, arms, fallback, ..
+                } => {
                     self.lower_scalar_match(value, arms, fallback)?;
                 }
                 StatementKindIr::ValueRefinement {
@@ -459,13 +439,13 @@ impl Lowerer<'_> {
         let (default, fallback_block) = if let Some(target) = direct_jump_target(fallback) {
             (self.continuation_edge(target)?, None)
         } else {
-            let block = self.function.create_empty_block("scalar_match_fallback", BlockLayout::Hot);
+            let block = self
+                .function
+                .create_empty_block("scalar_match_fallback", BlockLayout::Hot);
             (Edge::new(block), Some(block))
         };
-        self.function.set_terminator(
-            source,
-            Terminator::switch(value, cases, default),
-        );
+        self.function
+            .set_terminator(source, Terminator::switch(value, cases, default));
         self.current_block = None;
         for (arm, block) in arms.iter().zip(arm_blocks) {
             let Some(block) = block else {
@@ -516,9 +496,7 @@ impl Lowerer<'_> {
         if failure.arguments.is_empty() {
             self.function.append_instruction(
                 source,
-                Operation::Guard {
-                    failure: failure.block,
-                },
+                Operation::Guard { failure: failure.block },
                 vec![condition],
                 Vec::new(),
             );
@@ -526,10 +504,8 @@ impl Lowerer<'_> {
         }
         let layout = self.function.blocks[source.0].layout;
         let success = self.function.create_empty_block("guard_success", layout);
-        self.function.set_terminator(
-            source,
-            Terminator::branch_edges(condition, Edge::new(success), failure),
-        );
+        self.function
+            .set_terminator(source, Terminator::branch_edges(condition, Edge::new(success), failure));
         self.current_block = Some(success);
         Ok(())
     }
@@ -545,14 +521,16 @@ impl Lowerer<'_> {
         let source = self.current()?;
         let original_bindings = self.bindings.clone();
         let (capture_types, initial_values) = self.capture_types_and_values(captures)?;
-        let loop_body = self.function.create_named_block("while_body", BlockLayout::Hot, capture_types.clone());
-        let exit = self.function.create_named_block("while_exit", BlockLayout::Hot, capture_types.clone());
+        let loop_body = self
+            .function
+            .create_named_block("while_body", BlockLayout::Hot, capture_types.clone());
+        let exit = self
+            .function
+            .create_named_block("while_exit", BlockLayout::Hot, capture_types.clone());
 
         if post_tested {
-            self.function.set_terminator(
-                source,
-                Terminator::jump_with_arguments(loop_body, initial_values),
-            );
+            self.function
+                .set_terminator(source, Terminator::jump_with_arguments(loop_body, initial_values));
             self.current_block = Some(loop_body);
             self.bindings = self.bindings_for_block(&original_bindings, captures, loop_body);
             self.lower_statements(body)?;
@@ -569,11 +547,11 @@ impl Lowerer<'_> {
                 ),
             );
         } else {
-            let header = self.function.create_named_block("while_header", BlockLayout::Hot, capture_types);
-            self.function.set_terminator(
-                source,
-                Terminator::jump_with_arguments(header, initial_values),
-            );
+            let header = self
+                .function
+                .create_named_block("while_header", BlockLayout::Hot, capture_types);
+            self.function
+                .set_terminator(source, Terminator::jump_with_arguments(header, initial_values));
             self.current_block = Some(header);
             self.bindings = self.bindings_for_block(&original_bindings, captures, header);
             self.lower_statements(condition_setup)?;
@@ -594,10 +572,8 @@ impl Lowerer<'_> {
             self.lower_statements(body)?;
             let body_end = self.current()?;
             let backedge_values = self.capture_values(captures)?;
-            self.function.set_terminator(
-                body_end,
-                Terminator::jump_with_arguments(header, backedge_values),
-            );
+            self.function
+                .set_terminator(body_end, Terminator::jump_with_arguments(header, backedge_values));
         }
 
         self.current_block = Some(exit);
@@ -618,17 +594,15 @@ impl Lowerer<'_> {
         self.bindings.insert(tag, tag_value);
         let original_bindings = self.bindings.clone();
         let arm = |kind| arms.iter().find(|arm| arm.kind == kind);
-        let int32_arm = arm(ValueMatchArmKind::Int32)
-            .expect("control value match must have an Int32 arm");
+        let int32_arm = arm(ValueMatchArmKind::Int32).expect("control value match must have an Int32 arm");
         let int32_block = self.function.create_empty_block("value_match_int32", BlockLayout::Hot);
-        let double_block = arm(ValueMatchArmKind::Double).map(|_| {
-            self.function.create_empty_block("value_match_double", BlockLayout::Hot)
-        });
+        let double_block = arm(ValueMatchArmKind::Double)
+            .map(|_| self.function.create_empty_block("value_match_double", BlockLayout::Hot));
         let boolean_block = arm(ValueMatchArmKind::Boolean).map(|_| {
-            self.function.create_empty_block("value_match_boolean", BlockLayout::Hot)
+            self.function
+                .create_empty_block("value_match_boolean", BlockLayout::Hot)
         });
-        let (fallback_edge, fallback_block) =
-            self.value_match_fallback(fallback, "value_match_fallback", &[], &[])?;
+        let (fallback_edge, fallback_block) = self.value_match_fallback(fallback, "value_match_fallback", &[], &[])?;
 
         let arm_blocks = arms
             .iter()
@@ -646,7 +620,14 @@ impl Lowerer<'_> {
         if let Some((_, block)) = arm_blocks.first() {
             self.function.blocks[block.0].layout = BlockLayout::Preferred;
         }
-        self.lower_value_match_tests(source, tag_value, &arm_blocks, fallback_edge.clone(), &[], "value_match_test")?;
+        self.lower_value_match_tests(
+            source,
+            tag_value,
+            &arm_blocks,
+            fallback_edge.clone(),
+            &[],
+            "value_match_test",
+        )?;
 
         for (arm, block) in [
             (Some(int32_arm), Some(int32_block)),
@@ -701,10 +682,8 @@ impl Lowerer<'_> {
         let tag = self.extract_tag(value, false)?;
         let original_bindings = self.bindings.clone();
         let arm = |kind| arms.iter().find(|arm| arm.kind == kind);
-        let int32_arm = arm(ValueMatchArmKind::Int32)
-            .expect("value-producing match must have an Int32 arm");
-        let double_arm = arm(ValueMatchArmKind::Double)
-            .expect("value-producing match must have a double arm");
+        let int32_arm = arm(ValueMatchArmKind::Int32).expect("value-producing match must have an Int32 arm");
+        let double_arm = arm(ValueMatchArmKind::Double).expect("value-producing match must have a double arm");
         let boolean_arm = arm(ValueMatchArmKind::Boolean);
         let double_first = arms.first().is_some_and(|arm| arm.kind == ValueMatchArmKind::Double);
         let boolean_before_double = arms
@@ -712,18 +691,18 @@ impl Lowerer<'_> {
             .position(|arm| arm.kind == ValueMatchArmKind::Boolean)
             .zip(arms.iter().position(|arm| arm.kind == ValueMatchArmKind::Double))
             .is_some_and(|(boolean, double)| boolean < double);
-        let arm_returns_binding_with = |
-            arm_body: &[super::typecheck::Statement],
-            binding: Option<VariableId>,
-            intrinsic: Intrinsic,
-        | {
+        let arm_returns_binding_with = |arm_body: &[super::typecheck::Statement],
+                                        binding: Option<VariableId>,
+                                        intrinsic: Intrinsic| {
             let Some(binding) = binding else {
                 return false;
             };
-            let [super::typecheck::Statement {
-                kind: StatementKindIr::Call(destinations, call),
-                ..
-            }] = arm_body
+            let [
+                super::typecheck::Statement {
+                    kind: StatementKindIr::Call(destinations, call),
+                    ..
+                },
+            ] = arm_body
             else {
                 return false;
             };
@@ -739,14 +718,12 @@ impl Lowerer<'_> {
                 Intrinsic::LowLevel(LowLevelOperation::Move),
             )
             && boolean_arm.is_some_and(|arm| {
-                arm_returns_binding_with(
-                    &arm.body,
-                    arm.binding,
-                    Intrinsic::Value(super::ValueOperation::ToInt32),
-                )
+                arm_returns_binding_with(&arm.body, arm.binding, Intrinsic::Value(super::ValueOperation::ToInt32))
             });
         let (capture_types, capture_values) = self.capture_types_and_values(captures)?;
-        let int32_block = self.function.create_named_block("value_result_int32", BlockLayout::Hot, capture_types.clone());
+        let int32_block =
+            self.function
+                .create_named_block("value_result_int32", BlockLayout::Hot, capture_types.clone());
         let double_block =
             self.function
                 .create_named_block("value_result_double", double_arm.layout.into(), capture_types.clone());
@@ -754,17 +731,16 @@ impl Lowerer<'_> {
             if shared_integer_boolean_payload {
                 return int32_block;
             }
-            self.function.create_named_block("value_result_boolean", BlockLayout::Hot, capture_types.clone())
+            self.function
+                .create_named_block("value_result_boolean", BlockLayout::Hot, capture_types.clone())
         });
-        let (fallback_edge, fallback_block) = self.value_match_fallback(
-            fallback,
-            "value_result_fallback",
-            &capture_types,
-            &capture_values,
-        )?;
+        let (fallback_edge, fallback_block) =
+            self.value_match_fallback(fallback, "value_result_fallback", &capture_types, &capture_values)?;
         let mut continuation_types = vec![self.variable_type(destination)?];
         continuation_types.extend(capture_types);
-        let continuation = self.function.create_named_block("value_result_continuation", BlockLayout::Hot, continuation_types);
+        let continuation =
+            self.function
+                .create_named_block("value_result_continuation", BlockLayout::Hot, continuation_types);
         let int32_tag = self
             .function
             .add_constant(Type::ValueTag, Constant::symbol("INT32_TAG"));
@@ -793,27 +769,29 @@ impl Lowerer<'_> {
             self.function.blocks[block.0].layout = BlockLayout::Preferred;
         }
         if shared_integer_boolean_payload {
-            let double_test = self.function.create_empty_block("value_result_double_test", BlockLayout::Preferred);
+            let double_test = self
+                .function
+                .create_empty_block("value_result_double_test", BlockLayout::Preferred);
             self.function.blocks[int32_block.0].layout = BlockLayout::Hot;
             let shared_edge = Edge::with_arguments(int32_block, capture_values.clone());
             self.function.set_terminator(
                 source,
                 Terminator::switch(
                     tag,
-                    vec![
-                        (int32_tag, shared_edge.clone()),
-                        (boolean_tag, shared_edge),
-                    ],
+                    vec![(int32_tag, shared_edge.clone()), (boolean_tag, shared_edge)],
                     Edge::new(double_test),
                 ),
             );
             self.current_block = Some(double_test);
             let masked_tag = self.append_pure_operation(
-                Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::And))),
+                Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                    BinaryOperation::And,
+                ))),
                 vec![tag, nan_base_tag],
                 Type::ValueTag,
             )?;
-            let is_not_double = self.append_integer_comparison(IntegerComparisonOperation::Equal, vec![masked_tag, nan_base_tag])?;
+            let is_not_double =
+                self.append_integer_comparison(IntegerComparisonOperation::Equal, vec![masked_tag, nan_base_tag])?;
             self.function.set_terminator(
                 double_test,
                 Terminator::branch_edges(
@@ -823,7 +801,14 @@ impl Lowerer<'_> {
                 ),
             );
         } else {
-            self.lower_value_match_tests(source, tag, &arm_blocks, fallback_edge.clone(), &capture_values, "value_result_test")?;
+            self.lower_value_match_tests(
+                source,
+                tag,
+                &arm_blocks,
+                fallback_edge.clone(),
+                &capture_values,
+                "value_result_test",
+            )?;
         }
 
         self.current_block = Some(int32_block);
@@ -844,9 +829,7 @@ impl Lowerer<'_> {
         self.lower_statements(&double_arm.body)?;
         self.finish_value_result_arm(destination, captures, continuation, "double")?;
 
-        if !shared_integer_boolean_payload
-            && let (Some(block), Some(arm)) = (boolean_block, boolean_arm)
-        {
+        if !shared_integer_boolean_payload && let (Some(block), Some(arm)) = (boolean_block, boolean_arm) {
             self.current_block = Some(block);
             self.bindings = self.bindings_for_block(&original_bindings, captures, block);
             if let Some(binding) = arm.binding {
@@ -885,9 +868,15 @@ impl Lowerer<'_> {
         arguments: &[ValueId],
         block_name: &str,
     ) -> Result<(), String> {
-        let int32_tag = self.function.add_constant(Type::ValueTag, Constant::symbol("INT32_TAG"));
-        let boolean_tag = self.function.add_constant(Type::ValueTag, Constant::symbol("BOOLEAN_TAG"));
-        let nan_base_tag = self.function.add_constant(Type::ValueTag, Constant::symbol("NAN_BASE_TAG"));
+        let int32_tag = self
+            .function
+            .add_constant(Type::ValueTag, Constant::symbol("INT32_TAG"));
+        let boolean_tag = self
+            .function
+            .add_constant(Type::ValueTag, Constant::symbol("BOOLEAN_TAG"));
+        let nan_base_tag = self
+            .function
+            .add_constant(Type::ValueTag, Constant::symbol("NAN_BASE_TAG"));
         let mut test_block = source;
         for (index, (kind, arm)) in arms.iter().enumerate() {
             self.current_block = Some(test_block);
@@ -897,7 +886,9 @@ impl Lowerer<'_> {
                 }
                 ValueMatchArmKind::Double => {
                     let masked_tag = self.append_pure_operation(
-                        Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::And))),
+                        Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                            BinaryOperation::And,
+                        ))),
                         vec![tag, nan_base_tag],
                         Type::ValueTag,
                     )?;
@@ -910,7 +901,10 @@ impl Lowerer<'_> {
             let next = if index + 1 == arms.len() {
                 fallback.clone()
             } else {
-                Edge::new(self.function.create_empty_block(format!("{block_name}_{}", index + 1), BlockLayout::Hot))
+                Edge::new(
+                    self.function
+                        .create_empty_block(format!("{block_name}_{}", index + 1), BlockLayout::Hot),
+                )
             };
             self.function.set_terminator(
                 test_block,
@@ -957,10 +951,8 @@ impl Lowerer<'_> {
             .ok_or_else(|| format!("value-producing {name} arm terminates"))?;
         let mut arguments = vec![self.binding(destination)?];
         arguments.extend(self.capture_values(captures)?);
-        self.function.set_terminator(
-            block,
-            Terminator::jump_with_arguments(continuation, arguments),
-        );
+        self.function
+            .set_terminator(block, Terminator::jump_with_arguments(continuation, arguments));
         Ok(())
     }
 
@@ -978,23 +970,17 @@ impl Lowerer<'_> {
         let tag_value = self.extract_tag(value, false)?;
         self.bindings.insert(tag, tag_value);
         let condition = if let Some(expected_tag) = expected_tag {
-            let expected_tag = self.function.add_constant(
-                Type::ValueTag,
-                Constant::symbol(expected_tag),
-            );
+            let expected_tag = self
+                .function
+                .add_constant(Type::ValueTag, Constant::symbol(expected_tag));
             self.append_integer_comparison(IntegerComparisonOperation::Equal, vec![tag_value, expected_tag])?
         } else {
-            self.append_classification(
-                ClassificationOperation::Float64Tag,
-                vec![tag_value],
-            )?
+            self.append_classification(ClassificationOperation::Float64Tag, vec![tag_value])?
         };
         let success = self.function.create_empty_block("refinement_success", BlockLayout::Hot);
         let failure = self.continuation_edge(failure)?;
-        self.function.set_terminator(
-            source,
-            Terminator::branch_edges(condition, Edge::new(success), failure),
-        );
+        self.function
+            .set_terminator(source, Terminator::branch_edges(condition, Edge::new(success), failure));
         self.current_block = Some(success);
         let payload_type = self.variable_type(binding)?;
         let payload = self.append_unary_value(payload_operation, value, payload_type)?;
@@ -1026,7 +1012,9 @@ impl Lowerer<'_> {
             .position(|variable| variable.name == target && variable.ty == Type::label())
             .ok_or_else(|| format!("unknown continuation or label '{target}'"))?;
         let target_value = self.binding(variable)?;
-        let block = self.function.create_named_block(format!("indirect_{target}"), BlockLayout::Cold, vec![Type::label()]);
+        let block =
+            self.function
+                .create_named_block(format!("indirect_{target}"), BlockLayout::Cold, vec![Type::label()]);
         self.function.set_terminator(
             block,
             Terminator::IndirectJump {
@@ -1059,9 +1047,17 @@ impl Lowerer<'_> {
         let inputs = vec![self.lower_value(lhs)?, self.lower_value(rhs)?];
         let rematerializable_inputs = inputs.clone();
         let result_type = self.variable_type(*result)?;
-        let success = self.function.create_named_block(format!("{}_success", operation.name()), BlockLayout::Hot, vec![result_type.clone()]);
+        let success = self.function.create_named_block(
+            format!("{}_success", operation.name()),
+            BlockLayout::Hot,
+            vec![result_type.clone()],
+        );
         let (capture_types, capture_values) = self.capture_types_and_values(captures)?;
-        let failure = self.function.create_named_block(format!("{}_failure", operation.name()), BlockLayout::Cold, capture_types);
+        let failure = self.function.create_named_block(
+            format!("{}_failure", operation.name()),
+            BlockLayout::Cold,
+            capture_types,
+        );
         self.function.set_checked_operation(
             source,
             Intrinsic::CheckedInteger(operation),
@@ -1121,7 +1117,9 @@ impl Lowerer<'_> {
             //        on cold arithmetic failure paths. Re-enable this for
             //        load and load_operand_pair once allocation weighs the
             //        hot-path lifetime against cold reload cost.
-            Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Load(OperandLoad::Field) | OperandOperation::LoadPair)) => return None,
+            Operation::Intrinsic(Intrinsic::Operand(
+                OperandOperation::Load(OperandLoad::Field) | OperandOperation::LoadPair,
+            )) => return None,
             _ => return None,
         };
         let block = self.current().ok()?;
@@ -1148,16 +1146,18 @@ impl Lowerer<'_> {
         let source = self.current()?;
         let original_bindings = self.bindings.clone();
         let (capture_types, capture_values) = self.capture_types_and_values(captures)?;
-        let then_block = self.function.create_named_block("if_then", if temperature == BlockTemperature::Cold {
+        let then_block = self.function.create_named_block(
+            "if_then",
+            if temperature == BlockTemperature::Cold {
                 BlockLayout::Cold
             } else {
                 BlockLayout::Hot
-            }, capture_types.clone());
+            },
+            capture_types.clone(),
+        );
 
         if terminal {
-            let continuation =
-                self.function
-                    .create_empty_block("if_continuation", BlockLayout::Hot);
+            let continuation = self.function.create_empty_block("if_continuation", BlockLayout::Hot);
             self.function.set_terminator(
                 source,
                 Terminator::branch_edges(
@@ -1177,9 +1177,9 @@ impl Lowerer<'_> {
             return Ok(());
         }
 
-        let continuation =
-            self.function
-                .create_named_block("if_continuation", BlockLayout::Hot, capture_types);
+        let continuation = self
+            .function
+            .create_named_block("if_continuation", BlockLayout::Hot, capture_types);
         self.function.set_terminator(
             source,
             Terminator::branch_edges(
@@ -1195,10 +1195,8 @@ impl Lowerer<'_> {
             .current_block
             .ok_or_else(|| "continuing if body terminates".to_string())?;
         let then_arguments = self.capture_values(captures)?;
-        self.function.set_terminator(
-            then_end,
-            Terminator::jump_with_arguments(continuation, then_arguments),
-        );
+        self.function
+            .set_terminator(then_end, Terminator::jump_with_arguments(continuation, then_arguments));
         self.current_block = Some(continuation);
         self.bindings = self.bindings_for_block(&original_bindings, captures, continuation);
         Ok(())
@@ -1238,11 +1236,10 @@ impl Lowerer<'_> {
                 .into_iter()
                 .collect::<Vec<_>>();
             types.extend(capture_types);
-            Some(self.function.create_named_block(
-                format!("{prefix}_continuation"),
-                BlockLayout::Hot,
-                types,
-            ))
+            Some(
+                self.function
+                    .create_named_block(format!("{prefix}_continuation"), BlockLayout::Hot, types),
+            )
         };
         self.function.set_terminator(
             source,
@@ -1334,7 +1331,11 @@ impl Lowerer<'_> {
                 let lhs = self.lower_value(lhs)?;
                 let rhs = self.lower_value(rhs)?;
                 self.append_integer_comparison(
-                    if *equal { IntegerComparisonOperation::Equal } else { IntegerComparisonOperation::NotEqual },
+                    if *equal {
+                        IntegerComparisonOperation::Equal
+                    } else {
+                        IntegerComparisonOperation::NotEqual
+                    },
                     vec![lhs, rhs],
                 )
             }
@@ -1346,9 +1347,16 @@ impl Lowerer<'_> {
             } => {
                 let lhs = self.lower_value(lhs)?;
                 let rhs = self.lower_value(rhs)?;
-                let domain = if *signed { ComparisonDomain::SignedInteger } else { ComparisonDomain::UnsignedInteger };
+                let domain = if *signed {
+                    ComparisonDomain::SignedInteger
+                } else {
+                    ComparisonDomain::UnsignedInteger
+                };
                 self.append_integer_comparison(
-                    IntegerComparisonOperation::Relational { relation: *relation, domain },
+                    IntegerComparisonOperation::Relational {
+                        relation: *relation,
+                        domain,
+                    },
                     vec![lhs, rhs],
                 )
             }
@@ -1356,7 +1364,11 @@ impl Lowerer<'_> {
                 let value = self.lower_value(value)?;
                 let mask = self.lower_value(mask)?;
                 self.append_integer_comparison(
-                    if *set { IntegerComparisonOperation::BitsSet } else { IntegerComparisonOperation::BitsClear },
+                    if *set {
+                        IntegerComparisonOperation::BitsSet
+                    } else {
+                        IntegerComparisonOperation::BitsClear
+                    },
                     vec![value, mask],
                 )
             }
@@ -1385,7 +1397,9 @@ impl Lowerer<'_> {
                             .add_constant(Type::ValueTag, Constant::symbol(mask.clone())),
                     };
                     self.append_pure_operation(
-                        Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::And))),
+                        Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                            BinaryOperation::And,
+                        ))),
                         vec![raw_tag, mask],
                         Type::ValueTag,
                     )?
@@ -1398,7 +1412,11 @@ impl Lowerer<'_> {
                     .add_constant(Type::ValueTag, Constant::symbol(expected_tag.clone()));
                 let equal = *matches == *matches_when_equal;
                 self.append_integer_comparison(
-                    if equal { IntegerComparisonOperation::Equal } else { IntegerComparisonOperation::NotEqual },
+                    if equal {
+                        IntegerComparisonOperation::Equal
+                    } else {
+                        IntegerComparisonOperation::NotEqual
+                    },
                     vec![compared_tag, expected],
                 )
             }
@@ -1415,7 +1433,11 @@ impl Lowerer<'_> {
                 );
                 self.bindings.insert(*expected, expected_value);
                 self.append_integer_comparison(
-                    if *matches { IntegerComparisonOperation::Equal } else { IntegerComparisonOperation::NotEqual },
+                    if *matches {
+                        IntegerComparisonOperation::Equal
+                    } else {
+                        IntegerComparisonOperation::NotEqual
+                    },
                     vec![value, expected_value],
                 )
             }
@@ -1432,19 +1454,11 @@ impl Lowerer<'_> {
     }
 
     fn extract_tag(&mut self, value: ValueId, rematerialized: bool) -> Result<ValueId, String> {
-        self.append_unary_value(
-            ValueOperation::ExtractTag { rematerialized },
-            value,
-            Type::ValueTag,
-        )
+        self.append_unary_value(ValueOperation::ExtractTag { rematerialized }, value, Type::ValueTag)
     }
 
     fn unbox_int32(&mut self, value: ValueId, rematerialized: bool) -> Result<ValueId, String> {
-        self.append_unary_value(
-            ValueOperation::UnboxInt32 { rematerialized },
-            value,
-            Type::I32,
-        )
+        self.append_unary_value(ValueOperation::UnboxInt32 { rematerialized }, value, Type::I32)
     }
 
     fn unbox_float64(&mut self, value: ValueId) -> Result<ValueId, String> {
@@ -1478,17 +1492,17 @@ impl Lowerer<'_> {
         result_type: Type,
     ) -> Result<ValueId, String> {
         let block = self.current()?;
-        Ok(self.function.append_instruction(
-            block,
-            operation,
-            inputs,
-            vec![result_type],
-        )[0])
+        Ok(self
+            .function
+            .append_instruction(block, operation, inputs, vec![result_type])[0])
     }
 
     fn lower_call(&mut self, call: &super::typecheck::Call, result_types: Vec<Type>) -> Result<Vec<ValueId>, String> {
         if call.arguments.len() != call.effects.len() {
-            return Err(format!("primitive '{}' has incomplete parameter effects", call.display_name()));
+            return Err(format!(
+                "primitive '{}' has incomplete parameter effects",
+                call.display_name()
+            ));
         }
         let accesses_inout_operand = call.arguments.first().is_some_and(|argument| {
             matches!(argument.kind, ValueKind::Variable(variable)
@@ -1578,7 +1592,11 @@ impl Lowerer<'_> {
             } else {
                 BlockLayout::Hot
             };
-            let success = self.function.create_named_block(format!("{}_success", call.display_name()), success_layout, all_result_types.clone());
+            let success = self.function.create_named_block(
+                format!("{}_success", call.display_name()),
+                success_layout,
+                all_result_types.clone(),
+            );
             let failure = self.continuation_edge(failure)?;
             self.function.set_checked_operation(
                 block,
@@ -1593,12 +1611,8 @@ impl Lowerer<'_> {
             self.current_block = Some(success);
             self.function.blocks[success.0].parameters.clone()
         } else {
-            self.function.append_instruction(
-                block,
-                operation,
-                inputs,
-                all_result_types,
-            )
+            self.function
+                .append_instruction(block, operation, inputs, all_result_types)
         };
         for ((variable, _), result) in outputs.iter().zip(&results[explicit_result_count..]) {
             self.bindings.insert(*variable, *result);
@@ -1636,10 +1650,7 @@ impl Lowerer<'_> {
         let block = self.current()?;
         self.function.append_instruction(
             block,
-            Operation::MachineAssign {
-                destination,
-                intrinsic,
-            },
+            Operation::MachineAssign { destination, intrinsic },
             inputs,
             Vec::new(),
         );
@@ -1654,16 +1665,10 @@ impl Lowerer<'_> {
                 .add_constant(value.ty.clone(), Constant::Integer(*integer))),
             ValueKind::LayoutValue(layout_value) => Ok(self
                 .function
-                .add_constant(
-                    value.ty.clone(),
-                    Constant::layout_value(*layout_value),
-                )),
+                .add_constant(value.ty.clone(), Constant::layout_value(*layout_value))),
             ValueKind::Constant(name) => Ok(self
                 .function
-                .add_constant(
-                    value.ty.clone(),
-                    Constant::symbol(name.clone()),
-                )),
+                .add_constant(value.ty.clone(), Constant::symbol(name.clone()))),
             ValueKind::Label(name) => {
                 let target = self.continuation_edge(name)?;
                 let block = self.current()?;
@@ -1692,12 +1697,9 @@ impl Lowerer<'_> {
                     .iter()
                     .map(|component| self.lower_value(component))
                     .collect::<Result<Vec<_>, _>>()?;
-                Ok(self.function.append_instruction(
-                    block,
-                    Operation::Address,
-                    address,
-                    vec![value.ty.clone()],
-                )[0])
+                Ok(self
+                    .function
+                    .append_instruction(block, Operation::Address, address, vec![value.ty.clone()])[0])
             }
         }
     }

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -60,7 +60,7 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
             // NB: A load that traps carries an assertion about what it loaded, so it can only reuse
             //     a load that made the same assertion. Reusing a plain load would drop the check.
             let traps = function.instructions[instruction_id.0].effects.may_trap;
-            let key = location_key(function, &location);
+            let key = location_key(function, location);
             let forwarded_load =
                 available_loads
                     .get(&key)

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -7,7 +7,8 @@
 //! Memory forwarding and dead-store elimination over proven locations.
 
 use super::effects::{
-    AliasResult, EffectDefinition, MemoryAccessLocations, MemoryLocation, alias, instruction_memory_locations,
+    AliasResult, EffectDefinition, LocationKey, MemoryAccessLocations, MemoryLocation, alias,
+    instruction_memory_locations, location_key,
 };
 use super::optimize::{InstructionOrder, rebuild_instruction_arena, rewrite_function_uses};
 use super::pass::{AnalysisManager};
@@ -19,7 +20,11 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
     let memory = analysis.effects.domain(super::effects::EffectDomain::Memory);
     let mut replacements = HashMap::default();
     let mut eliminated = HashSet::default();
-    let mut available_loads = Vec::<(InstructionId, MemoryLocation, ValueId)>::new();
+    // Loads still worth reusing, grouped by what they would have to have in
+    // common with a later load to be the same location. Keeping them in one
+    // list means rescanning every load seen so far for every load reached,
+    // which on a large function is the whole cost of the pass.
+    let mut available_loads = HashMap::<LocationKey, Vec<(InstructionId, MemoryLocation, ValueId)>>::default();
     let mut load_candidates = 0u64;
 
     for block in analysis.cfg.reverse_postorder() {
@@ -55,7 +60,9 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
             // NB: A load that traps carries an assertion about what it loaded, so it can only reuse
             //     a load that made the same assertion. Reusing a plain load would drop the check.
             let traps = function.instructions[instruction_id.0].effects.may_trap;
-            let forwarded_load = available_loads.iter().rev().find_map(|(load, loaded_location, value)| {
+            let key = location_key(function, &location);
+            let forwarded_load = available_loads.get(&key).into_iter().flatten().rev().find_map(
+                |(load, loaded_location, value)| {
                 ((!traps || function.instructions[load.0].effects.may_trap)
                     && dominates_instruction(&analysis, *load, *instruction_id)
                     && alias(function, loaded_location, location) == AliasResult::Must
@@ -78,7 +85,10 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
                 replacements.insert(result, value);
                 eliminated.insert(*instruction_id);
             } else {
-                available_loads.push((*instruction_id, location.clone(), result));
+                available_loads
+                    .entry(key)
+                    .or_default()
+                    .push((*instruction_id, location.clone(), result));
             }
         }
     }

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -12,13 +12,13 @@ use super::effects::{
 use super::optimize::{InstructionOrder, rebuild_instruction_arena, rewrite_function_uses};
 use super::pass::{AnalysisManager};
 use super::{Function, InstructionId, Intrinsic, OperandOperation, Operation, ValueId};
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
     let analysis = analyses.get(function);
     let memory = analysis.effects.domain(super::effects::EffectDomain::Memory);
-    let mut replacements = HashMap::new();
-    let mut eliminated = HashSet::new();
+    let mut replacements = HashMap::default();
+    let mut eliminated = HashSet::default();
     let mut available_loads = Vec::<(InstructionId, MemoryLocation, ValueId)>::new();
     let mut load_candidates = 0u64;
 

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -11,7 +11,7 @@ use super::effects::{
     instruction_memory_locations, location_key,
 };
 use super::optimize::{InstructionOrder, rebuild_instruction_arena, rewrite_function_uses};
-use super::pass::{AnalysisManager};
+use super::pass::AnalysisManager;
 use super::{Function, InstructionId, Intrinsic, OperandOperation, Operation, ValueId};
 use crate::hash::{HashMap, HashSet};
 
@@ -61,25 +61,21 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
             //     a load that made the same assertion. Reusing a plain load would drop the check.
             let traps = function.instructions[instruction_id.0].effects.may_trap;
             let key = location_key(function, &location);
-            let forwarded_load = available_loads.get(&key).into_iter().flatten().rev().find_map(
-                |(load, loaded_location, value)| {
-                ((!traps || function.instructions[load.0].effects.may_trap)
-                    && dominates_instruction(&analysis, *load, *instruction_id)
-                    && alias(function, loaded_location, location) == AliasResult::Must
-                    && function.values[value.0].ty == *result_type
-                    && (memory
-                        .instruction_access(*load)
-                        .map(|access| &access.dependencies)
-                        == dependencies
-                        || memory_unchanged_between(
-                            function,
-                            &analysis,
-                            *load,
-                            *instruction_id,
-                            location,
-                        )))
-                    .then_some(*value)
-            });
+            let forwarded_load =
+                available_loads
+                    .get(&key)
+                    .into_iter()
+                    .flatten()
+                    .rev()
+                    .find_map(|(load, loaded_location, value)| {
+                        ((!traps || function.instructions[load.0].effects.may_trap)
+                            && dominates_instruction(&analysis, *load, *instruction_id)
+                            && alias(function, loaded_location, location) == AliasResult::Must
+                            && function.values[value.0].ty == *result_type
+                            && (memory.instruction_access(*load).map(|access| &access.dependencies) == dependencies
+                                || memory_unchanged_between(function, &analysis, *load, *instruction_id, location)))
+                        .then_some(*value)
+                    });
 
             if let Some(value) = forwarded_store.or(forwarded_load) {
                 replacements.insert(result, value);
@@ -195,15 +191,13 @@ pub(super) fn simple_load<'a>(
         Operation::Intrinsic(Intrinsic::Memory(operation)) => !operation.writes() && operation.address_count() == 1,
         Operation::FieldAccess(access) => !access.kind.writes(),
         Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Load(_))) => true,
-        Operation::Intrinsic(Intrinsic::Operand(OperandOperation::LoadPair | OperandOperation::Decode
-            | OperandOperation::Store(_) | OperandOperation::Copy)) => false,
+        Operation::Intrinsic(Intrinsic::Operand(
+            OperandOperation::LoadPair | OperandOperation::Decode | OperandOperation::Store(_) | OperandOperation::Copy,
+        )) => false,
         _ => false,
     };
-    (instruction.results.len() == 1
-        && access.reads.len() == 1
-        && access.writes.is_empty()
-        && is_single_load)
-    .then(|| &access.reads[0])
+    (instruction.results.len() == 1 && access.reads.len() == 1 && access.writes.is_empty() && is_single_load)
+        .then(|| &access.reads[0])
 }
 
 fn simple_store<'a>(
@@ -216,8 +210,9 @@ fn simple_store<'a>(
         Operation::Intrinsic(Intrinsic::Memory(operation)) => operation.writes() && operation.address_count() == 1,
         Operation::FieldAccess(access) => access.kind.writes(),
         Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Store(_))) => true,
-        Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Decode | OperandOperation::Load(_)
-            | OperandOperation::LoadPair | OperandOperation::Copy)) => false,
+        Operation::Intrinsic(Intrinsic::Operand(
+            OperandOperation::Decode | OperandOperation::Load(_) | OperandOperation::LoadPair | OperandOperation::Copy,
+        )) => false,
         _ => false,
     };
     (instruction.results.is_empty()
@@ -232,18 +227,13 @@ fn simple_store<'a>(
 mod tests {
     use super::*;
     use crate::intrinsic::{MemoryOperation, MemoryWidth};
-    use crate::types::Type;
     use crate::ssa::{BlockId, BlockLayout, Constant, Effects, MemoryEffect, Terminator};
+    use crate::types::Type;
 
     fn address(function: &mut Function, base: ValueId, offset: i64) -> ValueId {
         let block = function.entry;
         let offset = function.add_constant(Type::U64, Constant::Integer(offset));
-        function.append_instruction(
-            block,
-            Operation::Address,
-            vec![base, offset],
-            vec![Type::Memory],
-        )[0]
+        function.append_instruction(block, Operation::Address, vec![base, offset], vec![Type::Memory])[0]
     }
 
     fn load(function: &mut Function, address: ValueId) -> ValueId {
@@ -254,7 +244,10 @@ mod tests {
     fn load_in(function: &mut Function, block: BlockId, address: ValueId) -> ValueId {
         function.append_instruction_with_effects(
             block,
-            Intrinsic::Memory(MemoryOperation::Load { width: MemoryWidth::DoubleWord, signed: false }),
+            Intrinsic::Memory(MemoryOperation::Load {
+                width: MemoryWidth::DoubleWord,
+                signed: false,
+            }),
             vec![address],
             vec![Type::U64],
             Effects {
@@ -316,10 +309,7 @@ mod tests {
         let stored_value = function.parameter(1);
         let location = address(&mut function, base, 0);
         store(&mut function, location, stored_value);
-        function.set_terminator(
-            function.entry,
-            Terminator::jump(successor),
-        );
+        function.set_terminator(function.entry, Terminator::jump(successor));
         let loaded = load_in(&mut function, successor, location);
         function.set_terminator(successor, Terminator::Return(vec![loaded]));
 
@@ -339,10 +329,7 @@ mod tests {
         let base = function.parameter(0);
         let location = address(&mut function, base, 0);
         let first = load(&mut function, location);
-        function.set_terminator(
-            function.entry,
-            Terminator::jump(successor),
-        );
+        function.set_terminator(function.entry, Terminator::jump(successor));
         let second = load_in(&mut function, successor, location);
         function.set_terminator(successor, Terminator::Return(vec![second]));
 

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -147,10 +147,14 @@ fn dominates_instruction(
 ) -> bool {
     let dominator_block = analysis.instruction_layout.block(dominator);
     let instruction_block = analysis.instruction_layout.block(instruction);
+    let position = analysis.instruction_layout.position(dominator);
     if dominator_block == instruction_block {
-        analysis.instruction_layout.position(dominator) < analysis.instruction_layout.position(instruction)
+        position < analysis.instruction_layout.position(instruction)
     } else {
         analysis.dominators.dominates(dominator_block, instruction_block)
+            && analysis
+                .guards
+                .definition_reaches(dominator_block, position, instruction_block)
     }
 }
 

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -122,15 +122,11 @@ fn memory_unchanged_between(
     instruction: InstructionId,
     location: &MemoryLocation,
 ) -> bool {
-    let block = analysis.instruction_layout.block(load);
-    if analysis.instruction_layout.block(instruction) != block {
-        return false;
-    }
-    let start = analysis.instruction_layout.position(load) + 1;
-    let end = analysis.instruction_layout.position(instruction);
-    function.blocks[block.0].instructions[start..end]
-        .iter()
-        .all(|instruction| {
+    let load_block = analysis.instruction_layout.block(load);
+    let use_block = analysis.instruction_layout.block(instruction);
+
+    let untouched = |instructions: &[InstructionId]| {
+        instructions.iter().all(|instruction| {
             let access = instruction_memory_locations(function, *instruction);
             !access.unknown_write
                 && access
@@ -138,6 +134,37 @@ fn memory_unchanged_between(
                     .iter()
                     .all(|write| alias(function, write, location) == AliasResult::No)
         })
+    };
+
+    if load_block == use_block {
+        let start = analysis.instruction_layout.position(load) + 1;
+        let end = analysis.instruction_layout.position(instruction);
+        return untouched(&function.blocks[load_block.0].instructions[start..end]);
+    }
+
+    // Walk back from the use towards the load while each block has exactly one
+    // way in. A second predecessor could carry a write that invalidates it.
+    let mut block = use_block;
+    let end = analysis.instruction_layout.position(instruction);
+    if !untouched(&function.blocks[block.0].instructions[..end]) {
+        return false;
+    }
+    // A chain longer than the function cannot exist, so this also bounds a loop
+    // back to a block already visited.
+    for _ in 0..function.blocks.len() {
+        let [predecessor] = analysis.cfg.predecessors(block) else {
+            return false;
+        };
+        block = *predecessor;
+        if block == load_block {
+            let start = analysis.instruction_layout.position(load) + 1;
+            return untouched(&function.blocks[block.0].instructions[start..]);
+        }
+        if !untouched(&function.blocks[block.0].instructions) {
+            return false;
+        }
+    }
+    false
 }
 
 fn dominates_instruction(

--- a/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/memory_optimize.rs
@@ -25,9 +25,34 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
     // list means rescanning every load seen so far for every load reached,
     // which on a large function is the whole cost of the pass.
     let mut available_loads = HashMap::<LocationKey, Vec<(InstructionId, MemoryLocation, ValueId)>>::default();
+    let mut availability_undo = Vec::<LocationKey>::new();
     let mut load_candidates = 0u64;
 
-    for block in analysis.cfg.reverse_postorder() {
+    enum AvailabilityStep {
+        Enter(super::BlockId),
+        Leave(usize),
+    }
+    let mut worklist = vec![AvailabilityStep::Enter(function.entry)];
+    while let Some(step) = worklist.pop() {
+        let block = match step {
+            AvailabilityStep::Leave(mark) => {
+                while availability_undo.len() > mark {
+                    let key = availability_undo
+                        .pop()
+                        .expect("availability undo log is not empty above its mark");
+                    let loads = available_loads
+                        .get_mut(&key)
+                        .expect("an available load exists until its dominator subtree is left");
+                    loads.pop();
+                    if loads.is_empty() {
+                        available_loads.remove(&key);
+                    }
+                }
+                continue;
+            }
+            AvailabilityStep::Enter(block) => block,
+        };
+        worklist.push(AvailabilityStep::Leave(availability_undo.len()));
         for instruction_id in &function.blocks[block.0].instructions {
             let access = instruction_memory_locations(function, *instruction_id);
             let Some(location) = simple_load(function, *instruction_id, &access) else {
@@ -82,10 +107,14 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
                 eliminated.insert(*instruction_id);
             } else {
                 available_loads
-                    .entry(key)
+                    .entry(key.clone())
                     .or_default()
                     .push((*instruction_id, location.clone(), result));
+                availability_undo.push(key);
             }
+        }
+        for child in analysis.dominators.children(block).iter().rev() {
+            worklist.push(AvailabilityStep::Enter(*child));
         }
     }
 

--- a/Libraries/LibJS/Flap/src/ssa/mod.rs
+++ b/Libraries/LibJS/Flap/src/ssa/mod.rs
@@ -125,6 +125,7 @@ pub(crate) struct Instruction {
     pub(crate) operation: Operation,
     pub(crate) inputs: Vec<ValueId>,
     pub(crate) results: Vec<ValueId>,
+    base_effects: Effects,
     pub(crate) effects: Effects,
 }
 
@@ -200,6 +201,7 @@ struct UseAnalyses<'a> {
 pub(crate) struct Value {
     pub(crate) ty: Type,
     pub(crate) definition: ValueDefinition,
+    depends_on_machine_state: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -427,6 +429,7 @@ impl Function {
             .map(|(index, ty)| Value {
                 ty,
                 definition: ValueDefinition::FunctionParameter(index),
+                depends_on_machine_state: false,
             })
             .collect();
         Self {
@@ -464,6 +467,7 @@ impl Function {
         self.values.push(Value {
             ty: ty.clone(),
             definition: ValueDefinition::Constant(constant.clone()),
+            depends_on_machine_state: matches!(constant, Constant::MachineRegister(_)),
         });
         self.constant_values.insert((ty, constant), id);
         id
@@ -484,6 +488,7 @@ impl Function {
                 self.values.push(Value {
                     ty,
                     definition: ValueDefinition::BlockParameter { block, index },
+                    depends_on_machine_state: false,
                 });
                 value
             })
@@ -519,7 +524,7 @@ impl Function {
         result_types: Vec<Type>,
     ) -> Vec<ValueId> {
         let operation = operation.into();
-        let effects = self.effects_for_operation(&operation, &inputs);
+        let effects = operation.effects();
         self.append_instruction_with_effects(block, operation, inputs, result_types, effects)
     }
 
@@ -532,6 +537,9 @@ impl Function {
         effects: Effects,
     ) -> Vec<ValueId> {
         let operation = operation.into();
+        let base_effects = effects;
+        let effects = self.effects_for_inputs(base_effects, &inputs);
+        let depends_on_machine_state = effects.machine_state != MemoryEffect::None;
         let instruction = InstructionId(self.instructions.len());
         let results = result_types
             .into_iter()
@@ -541,6 +549,7 @@ impl Function {
                 self.values.push(Value {
                     ty,
                     definition: ValueDefinition::InstructionResult { instruction, index },
+                    depends_on_machine_state,
                 });
                 value
             })
@@ -549,6 +558,7 @@ impl Function {
             operation,
             inputs,
             results: results.clone(),
+            base_effects,
             effects,
         });
         self.blocks[block.0].instructions.push(instruction);
@@ -574,17 +584,83 @@ impl Function {
     }
 
     fn value_depends_on_machine_state(&self, value: ValueId) -> bool {
-        match &self.values[value.0].definition {
-            ValueDefinition::Constant(Constant::MachineRegister(_)) => true,
-            ValueDefinition::InstructionResult { instruction, .. } => {
-                let instruction = &self.instructions[instruction.0];
-                instruction.effects.machine_state != MemoryEffect::None
-                    || instruction
-                        .inputs
-                        .iter()
-                        .any(|input| self.value_depends_on_machine_state(*input))
+        self.values[value.0].depends_on_machine_state
+    }
+
+    fn recompute_machine_state_dependencies(&mut self) {
+        let mut dependent_values = vec![false; self.values.len()];
+        let mut dependents = vec![Vec::new(); self.values.len()];
+        let mut worklist = Vec::new();
+
+        for (index, value) in self.values.iter().enumerate() {
+            if matches!(value.definition, ValueDefinition::Constant(Constant::MachineRegister(_))) {
+                dependent_values[index] = true;
+                worklist.push(ValueId(index));
             }
-            _ => false,
+        }
+        for instruction in &self.instructions {
+            for input in &instruction.inputs {
+                dependents[input.0].extend(instruction.results.iter().copied());
+            }
+            if instruction.base_effects.machine_state != MemoryEffect::None {
+                for result in &instruction.results {
+                    if !dependent_values[result.0] {
+                        dependent_values[result.0] = true;
+                        worklist.push(*result);
+                    }
+                }
+            }
+        }
+        for block in &self.blocks {
+            let terminator = block
+                .terminator
+                .as_ref()
+                .expect("machine-state dependencies require complete SSA");
+            if let Terminator::CheckedOperation {
+                inputs,
+                results,
+                effects,
+                ..
+            } = terminator
+            {
+                for input in inputs {
+                    dependents[input.0].extend(results.iter().copied());
+                }
+                if effects.machine_state != MemoryEffect::None {
+                    for result in results {
+                        if !dependent_values[result.0] {
+                            dependent_values[result.0] = true;
+                            worklist.push(*result);
+                        }
+                    }
+                }
+            }
+            for edge in terminator.successors() {
+                for (argument, parameter) in edge.arguments.iter().zip(&self.blocks[edge.block.0].parameters) {
+                    dependents[argument.0].push(*parameter);
+                }
+            }
+        }
+
+        while let Some(value) = worklist.pop() {
+            for dependent in &dependents[value.0] {
+                if !dependent_values[dependent.0] {
+                    dependent_values[dependent.0] = true;
+                    worklist.push(*dependent);
+                }
+            }
+        }
+
+        for (value, dependent) in self.values.iter_mut().zip(&dependent_values) {
+            value.depends_on_machine_state = *dependent;
+        }
+        let effects = self
+            .instructions
+            .iter()
+            .map(|instruction| self.effects_for_inputs(instruction.base_effects, &instruction.inputs))
+            .collect::<Vec<_>>();
+        for (instruction, effects) in self.instructions.iter_mut().zip(effects) {
+            instruction.effects = effects;
         }
     }
 
@@ -636,6 +712,7 @@ impl Function {
                 self.values.push(Value {
                     ty,
                     definition: ValueDefinition::TerminatorResult { block, index },
+                    depends_on_machine_state: false,
                 });
                 value
             })
@@ -1130,6 +1207,90 @@ mod tests {
         function.set_terminator(function.entry, Terminator::Return(vec![value]));
 
         function.validate().unwrap();
+    }
+
+    #[test]
+    fn tracks_machine_state_dependencies_in_linear_time() {
+        let mut function = Function::new("machine-state-dag", Vec::new(), Vec::new());
+        let machine_state = function.add_constant(
+            Type::U64,
+            Constant::MachineRegister(RegisterReference::Interpreter(
+                InterpreterRegister::ProgramBase,
+            )),
+        );
+        let one = function.add_constant(Type::U64, Constant::Integer(1));
+        let mut previous = machine_state;
+        let mut current = one;
+        for _ in 0..100 {
+            let next = function.append_instruction(
+                function.entry,
+                Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add)),
+                vec![previous, current],
+                vec![Type::U64],
+            )[0];
+            previous = current;
+            current = next;
+        }
+        function.set_terminator(function.entry, Terminator::Return(vec![current]));
+
+        assert_eq!(
+            function.instructions.last().unwrap().effects.machine_state,
+            MemoryEffect::Read
+        );
+
+        function.instructions[0].inputs[0] = one;
+        function.recompute_machine_state_dependencies();
+        assert_eq!(
+            function.instructions.last().unwrap().effects.machine_state,
+            MemoryEffect::None
+        );
+    }
+
+    #[test]
+    fn tracks_machine_state_through_checked_results_and_block_parameters() {
+        let mut function = Function::new("checked-machine-state", Vec::new(), Vec::new());
+        let machine_state = function.add_constant(
+            Type::U64,
+            Constant::MachineRegister(RegisterReference::Interpreter(InterpreterRegister::ProgramBase)),
+        );
+        let one = function.add_constant(Type::U64, Constant::Integer(1));
+        let success = function.create_named_block("success", BlockLayout::Hot, vec![Type::U64]);
+        let failure = function.create_empty_block("failure", BlockLayout::Cold);
+        let results = function.set_checked_operation(
+            function.entry,
+            Intrinsic::CheckedInteger(CheckedIntegerOperation::Add),
+            vec![machine_state, one],
+            vec![Type::U64],
+            Effects::PURE,
+            success,
+            Vec::new(),
+            Edge::new(failure),
+        );
+        let parameter = function.blocks[success.0].parameters[0];
+        function.append_instruction(
+            success,
+            Intrinsic::LowLevel(LowLevelOperation::Negate),
+            vec![parameter],
+            vec![Type::U64],
+        );
+        function.set_terminator(success, Terminator::Return(Vec::new()));
+        function.set_terminator(failure, Terminator::Unreachable);
+
+        function.recompute_machine_state_dependencies();
+        assert!(function.values[results[0].0].depends_on_machine_state);
+        assert!(function.values[parameter.0].depends_on_machine_state);
+        assert_eq!(function.instructions[0].effects.machine_state, MemoryEffect::Read);
+
+        let Terminator::CheckedOperation { inputs, .. } =
+            function.blocks[function.entry.0].terminator.as_mut().unwrap()
+        else {
+            unreachable!()
+        };
+        inputs[0] = one;
+        function.recompute_machine_state_dependencies();
+        assert!(!function.values[results[0].0].depends_on_machine_state);
+        assert!(!function.values[parameter.0].depends_on_machine_state);
+        assert_eq!(function.instructions[0].effects.machine_state, MemoryEffect::None);
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/mod.rs
+++ b/Libraries/LibJS/Flap/src/ssa/mod.rs
@@ -252,21 +252,35 @@ impl Terminator {
         }
     }
 
-    pub(crate) fn successors(&self) -> Vec<&Edge> {
+    pub(crate) fn successor_count(&self) -> usize {
         match self {
-            Self::Jump(edge) => vec![edge],
-            Self::Branch {
-                then_edge,
-                else_edge,
-                ..
-            } => vec![then_edge, else_edge],
-            Self::Switch { cases, default, .. } => {
-                cases.iter().map(|(_, edge)| edge).chain([default]).collect()
-            }
-            Self::CheckedOperation {
-                success, failure, ..
-            } => vec![success, failure],
-            Self::IndirectJump { .. } | Self::Return(_) | Self::Unreachable => Vec::new(),
+            Self::Jump(_) => 1,
+            Self::Branch { .. } | Self::CheckedOperation { .. } => 2,
+            Self::Switch { cases, .. } => cases.len() + 1,
+            Self::IndirectJump { .. } | Self::Return(_) | Self::Unreachable => 0,
+        }
+    }
+
+    pub(crate) fn successor(&self, index: usize) -> &Edge {
+        match self {
+            Self::Jump(edge) if index == 0 => edge,
+            Self::Branch { then_edge, .. } if index == 0 => then_edge,
+            Self::Branch { else_edge, .. } if index == 1 => else_edge,
+            Self::CheckedOperation { success, .. } if index == 0 => success,
+            Self::CheckedOperation { failure, .. } if index == 1 => failure,
+            Self::Switch { cases, default, .. } => cases
+                .get(index)
+                .map(|(_, edge)| edge)
+                .unwrap_or_else(|| if index == cases.len() { default } else { panic!("no successor {index}") }),
+            _ => panic!("no successor {index}"),
+        }
+    }
+
+    pub(crate) fn successors(&self) -> Successors<'_> {
+        Successors {
+            terminator: self,
+            front: 0,
+            back: self.successor_count(),
         }
     }
 
@@ -309,6 +323,43 @@ impl Terminator {
         }
     }
 }
+
+#[derive(Clone)]
+pub(crate) struct Successors<'a> {
+    terminator: &'a Terminator,
+    front: usize,
+    back: usize,
+}
+
+impl<'a> Iterator for Successors<'a> {
+    type Item = &'a Edge;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.front == self.back {
+            return None;
+        }
+        let edge = self.terminator.successor(self.front);
+        self.front += 1;
+        Some(edge)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.back - self.front;
+        (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for Successors<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.front == self.back {
+            return None;
+        }
+        self.back -= 1;
+        Some(self.terminator.successor(self.back))
+    }
+}
+
+impl ExactSizeIterator for Successors<'_> {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Block {

--- a/Libraries/LibJS/Flap/src/ssa/mod.rs
+++ b/Libraries/LibJS/Flap/src/ssa/mod.rs
@@ -73,6 +73,17 @@ pub(crate) enum Operation {
     },
     BlockReference(BlockId),
     Address,
+    /// A conditional side exit: control leaves the block for `failure` when the
+    /// condition is false, and falls through to the next instruction otherwise.
+    ///
+    /// A handler is mostly checks, and spelling each one as a branch terminator
+    /// costs two blocks -- the one the check continues into and the one its
+    /// join needs -- for code that is a single conditional jump. Keeping the
+    /// check inside the block leaves the path that passes it straight-line,
+    /// which is what every later phase is indexed by.
+    Guard {
+        failure: BlockId,
+    },
 }
 
 impl From<Intrinsic> for Operation {
@@ -96,7 +107,15 @@ impl Operation {
                 };
                 effects
             }
-            Self::BlockReference(_) | Self::Address => Effects::PURE,
+            Self::BlockReference(_) | Self::Address | Self::Guard { .. } => Effects::PURE,
+        }
+    }
+
+    /// Where control goes when this operation decides not to continue.
+    pub(crate) fn guard_failure(&self) -> Option<BlockId> {
+        match self {
+            Self::Guard { failure } => Some(*failure),
+            _ => None,
         }
     }
 }
@@ -107,6 +126,12 @@ pub(crate) struct Instruction {
     pub(crate) inputs: Vec<ValueId>,
     pub(crate) results: Vec<ValueId>,
     pub(crate) effects: Effects,
+}
+
+impl Instruction {
+    pub(crate) fn can_be_eliminated(&self) -> bool {
+        self.effects.can_be_eliminated() && self.operation.guard_failure().is_none()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -162,6 +187,13 @@ pub(crate) enum ValueDefinition {
         index: usize,
     },
     Constant(Constant),
+}
+
+struct UseAnalyses<'a> {
+    cfg: &'a analysis::ControlFlowGraph,
+    dominators: &'a analysis::DominatorTree,
+    instruction_layout: &'a analysis::InstructionLayout,
+    guards: &'a analysis::GuardExits,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -556,6 +588,28 @@ impl Function {
         }
     }
 
+    /// The blocks a guard in `block` can exit to, with where the guard sits.
+    ///
+    /// A guard exit is an edge the terminator knows nothing about, so anything
+    /// that walks control flow has to ask for these as well.
+    pub(crate) fn guard_exits(&self, block: BlockId) -> impl Iterator<Item = (usize, BlockId)> + '_ {
+        self.blocks[block.0]
+            .instructions
+            .iter()
+            .enumerate()
+            .filter_map(|(position, instruction)| {
+                self.instructions[instruction.0]
+                    .operation
+                    .guard_failure()
+                    .map(|failure| (position, failure))
+            })
+    }
+
+    /// Where the first guard in `block` sits, if it has one.
+    pub(crate) fn first_guard_position(&self, block: BlockId) -> Option<usize> {
+        self.guard_exits(block).next().map(|(position, _)| position)
+    }
+
     pub(crate) fn set_terminator(&mut self, block: BlockId, terminator: Terminator) {
         assert!(self.blocks[block.0].terminator.is_none());
         self.blocks[block.0].terminator = Some(terminator);
@@ -647,7 +701,7 @@ impl Function {
         }
         for (index, instruction) in self.instructions.iter().enumerate() {
             let instruction_id = InstructionId(index);
-            self.validate_operation(&instruction.operation)?;
+            self.validate_instruction(instruction_id, instruction)?;
             for (result_index, result) in instruction.results.iter().enumerate() {
                 let Some(value) = self.values.get(result.0) else {
                     return Err(format!("instruction {instruction_id:?} has an invalid result"));
@@ -665,7 +719,46 @@ impl Function {
         self.validate_uses()
     }
 
+    fn validate_instruction(&self, instruction_id: InstructionId, instruction: &Instruction) -> Result<(), String> {
+        self.validate_operation(&instruction.operation)?;
+        if !matches!(instruction.operation, Operation::Guard { .. }) {
+            return Ok(());
+        }
+        let [condition] = instruction.inputs.as_slice() else {
+            return Err(format!(
+                "guard instruction {instruction_id:?} in '{}' must have exactly one input",
+                self.name
+            ));
+        };
+        let condition_type = &self
+            .values
+            .get(condition.0)
+            .ok_or_else(|| format!("guard instruction {instruction_id:?} uses invalid value {condition:?}"))?
+            .ty;
+        if condition_type != &Type::Bool {
+            return Err(format!(
+                "guard instruction {instruction_id:?} in '{}' uses {condition_type:?}, not Bool",
+                self.name
+            ));
+        }
+        Ok(())
+    }
+
     fn validate_operation(&self, operation: &Operation) -> Result<(), String> {
+        if let Operation::Guard { failure } = operation {
+            let Some(target) = self.blocks.get(failure.0) else {
+                return Err(format!("a guard in '{}' exits to invalid block {failure:?}", self.name));
+            };
+            // A guard exit carries no arguments, so nothing can supply the
+            // parameters of the block it leaves for.
+            if !target.parameters.is_empty() {
+                return Err(format!(
+                    "a guard in '{}' exits to {failure:?}, which takes parameters",
+                    self.name
+                ));
+            }
+            return Ok(());
+        }
         let Operation::Parameter(parameter) = operation else {
             return Ok(());
         };
@@ -827,6 +920,13 @@ impl Function {
         let cfg = analysis::ControlFlowGraph::compute(self);
         let dominators = analysis::DominatorTree::compute(self, &cfg);
         let instruction_layout = analysis::InstructionLayout::compute(self)?;
+        let guards = analysis::GuardExits::compute(self, &cfg);
+        let analyses = UseAnalyses {
+            cfg: &cfg,
+            dominators: &dominators,
+            instruction_layout: &instruction_layout,
+            guards: &guards,
+        };
 
         for (instruction_index, instruction) in self.instructions.iter().enumerate() {
             let instruction_id = InstructionId(instruction_index);
@@ -836,8 +936,7 @@ impl Function {
                     *input,
                     block,
                     Some(instruction_layout.position(instruction_id)),
-                    &dominators,
-                    &instruction_layout,
+                    &analyses,
                 )?;
             }
         }
@@ -847,8 +946,7 @@ impl Function {
                     input,
                     BlockId(block_index),
                     None,
-                    &dominators,
-                    &instruction_layout,
+                    &analyses,
                 )?;
             }
         }
@@ -860,9 +958,14 @@ impl Function {
         value: ValueId,
         use_block: BlockId,
         use_position: Option<usize>,
-        dominators: &analysis::DominatorTree,
-        instruction_layout: &analysis::InstructionLayout,
+        analyses: &UseAnalyses<'_>,
     ) -> Result<(), String> {
+        let UseAnalyses {
+            cfg,
+            dominators,
+            instruction_layout,
+            guards,
+        } = analyses;
         let definition = self
             .values
             .get(value.0)
@@ -894,6 +997,14 @@ impl Function {
         }
         if !dominators.dominates(definition_block, use_block) {
             return Err(format!("value {value:?} does not dominate its use in {use_block:?}"));
+        }
+        let position = definition_position.unwrap_or(0);
+        if !guards.definition_reaches(definition_block, position, use_block)
+            && guards.definition_escapes(self, cfg, definition_block, position, use_block)
+        {
+            return Err(format!(
+                "value {value:?} is defined past a guard in {definition_block:?} and cannot reach {use_block:?}"
+            ));
         }
         Ok(())
     }
@@ -1067,6 +1178,84 @@ mod tests {
         assert_eq!(first, repeated);
         assert_ne!(first, differently_typed);
         assert_eq!(function.values.len(), 2);
+    }
+
+    fn guarded_function() -> (Function, BlockId, ValueId) {
+        let mut function =
+            Function::new("guarded", vec![Type::Bool, Type::I32], vec![Type::I32]);
+        let failure = function.create_empty_block("failure", BlockLayout::Cold);
+        function.append_instruction(
+            function.entry,
+            Operation::Guard { failure },
+            vec![function.parameter(0)],
+            Vec::new(),
+        );
+        let value = function.append_instruction(
+            function.entry,
+            Intrinsic::Value(ValueOperation::Reuse),
+            vec![function.parameter(1)],
+            vec![Type::I32],
+        )[0];
+        function.set_terminator(function.entry, Terminator::Return(vec![value]));
+        (function, failure, value)
+    }
+
+    #[test]
+    fn a_guard_exit_is_an_edge_out_of_the_middle_of_its_block() {
+        let (mut function, failure, _) = guarded_function();
+        function.set_terminator(failure, Terminator::Return(vec![function.parameter(1)]));
+
+        let cfg = analysis::ControlFlowGraph::compute(&function);
+
+        assert_eq!(cfg.successors(function.entry), [failure]);
+        assert_eq!(cfg.predecessors(failure), [function.entry]);
+        assert!(cfg.is_reachable(failure));
+        function.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_guards_without_one_boolean_condition() {
+        let (mut function, failure, _) = guarded_function();
+        function.set_terminator(failure, Terminator::Unreachable);
+        let guard = function.blocks[function.entry.0].instructions[0];
+        function.instructions[guard.0].inputs.clear();
+        assert!(function.validate().unwrap_err().contains("must have exactly one input"));
+
+        let non_boolean = function.parameter(1);
+        function.instructions[guard.0].inputs.push(non_boolean);
+        assert!(function.validate().unwrap_err().contains("uses I32, not Bool"));
+    }
+
+    #[test]
+    fn rejects_a_value_defined_past_a_guard_where_the_guard_leaves_for() {
+        let (mut function, failure, value) = guarded_function();
+        function.set_terminator(failure, Terminator::Return(vec![value]));
+
+        assert!(
+            function
+                .validate()
+                .unwrap_err()
+                .contains("is defined past a guard in BlockId(0)")
+        );
+    }
+
+    #[test]
+    fn accepts_a_value_defined_past_a_guard_no_exit_of_its_own_reaches() {
+        let (mut function, failure, value) = guarded_function();
+        let reader = function.create_empty_block("reader", BlockLayout::Hot);
+        let elsewhere = function.create_empty_block("elsewhere", BlockLayout::Hot);
+        function.blocks[function.entry.0].terminator = Some(Terminator::jump(elsewhere));
+        function.append_instruction(
+            elsewhere,
+            Operation::Guard { failure: reader },
+            vec![function.parameter(0)],
+            Vec::new(),
+        );
+        function.set_terminator(elsewhere, Terminator::jump(reader));
+        function.set_terminator(reader, Terminator::Return(vec![value]));
+        function.set_terminator(failure, Terminator::Unreachable);
+
+        function.validate().unwrap();
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/mod.rs
+++ b/Libraries/LibJS/Flap/src/ssa/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use crate::intrinsic::{
 };
 use crate::ssa as ir;
 use crate::types::{BlockTemperature, InterpreterRegister, RegisterReference, Type};
+use smallvec::SmallVec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct BlockId(pub usize);
@@ -127,8 +128,8 @@ impl Operation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Instruction {
     pub(crate) operation: Operation,
-    pub(crate) inputs: Vec<ValueId>,
-    pub(crate) results: Vec<ValueId>,
+    pub(crate) inputs: SmallVec<[ValueId; 2]>,
+    pub(crate) results: SmallVec<[ValueId; 2]>,
     base_effects: Effects,
     pub(crate) effects: Effects,
 }
@@ -539,8 +540,8 @@ impl Function {
             .collect::<Vec<_>>();
         self.instructions.push(Instruction {
             operation,
-            inputs,
-            results: results.clone(),
+            inputs: inputs.into(),
+            results: results.clone().into(),
             base_effects,
             effects,
         });

--- a/Libraries/LibJS/Flap/src/ssa/mod.rs
+++ b/Libraries/LibJS/Flap/src/ssa/mod.rs
@@ -17,14 +17,18 @@ pub(crate) mod print;
 pub(crate) mod report;
 mod sccp;
 
-use crate::types::{BlockTemperature, InterpreterRegister, RegisterReference, Type};
+use crate::hash::{HashMap, HashSet};
+use crate::hir as typecheck;
 use crate::identity::{ExternalSymbol, InlineFunctionId};
-pub(crate) use crate::intrinsic::{AggregateOperation, BinaryOperation, CheckedIntegerOperation, ComparisonDomain, ComparisonRelation, FieldAccess, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, LowLevelOperation, OperandOperation, OperationValue, ShiftOperation, ValueOperation};
 pub(crate) use crate::intrinsic::IntrinsicEffects as Effects;
 pub(crate) use crate::intrinsic::ModRef as MemoryEffect;
-use crate::hir as typecheck;
+pub(crate) use crate::intrinsic::{
+    AggregateOperation, BinaryOperation, CheckedIntegerOperation, ComparisonDomain, ComparisonRelation, FieldAccess,
+    IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, LowLevelOperation, OperandOperation, OperationValue,
+    ShiftOperation, ValueOperation,
+};
 use crate::ssa as ir;
-use crate::hash::{HashMap, HashSet};
+use crate::types::{BlockTemperature, InterpreterRegister, RegisterReference, Type};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct BlockId(pub usize);
@@ -151,22 +155,15 @@ pub(crate) enum Constant {
 impl Constant {
     fn symbol(name: impl Into<String>) -> Self {
         let name = name.into();
-        crate::frontend::layout::KnownLayoutConstant::from_name(&name)
-            .map_or(Self::Symbol(name), Self::KnownLayout)
+        crate::frontend::layout::KnownLayoutConstant::from_name(&name).map_or(Self::Symbol(name), Self::KnownLayout)
     }
 
-    fn layout_value(
-        value: crate::frontend::layout::LayoutValue,
-    ) -> Self {
+    fn layout_value(value: crate::frontend::layout::LayoutValue) -> Self {
         match value {
             crate::frontend::layout::LayoutValue::Constant(constant) => {
-                constant
-                    .known()
-                    .map_or(Self::LayoutValue(value), Self::KnownLayout)
+                constant.known().map_or(Self::LayoutValue(value), Self::KnownLayout)
             }
-            crate::frontend::layout::LayoutValue::Immediate(_) => {
-                Self::LayoutValue(value)
-            }
+            crate::frontend::layout::LayoutValue::Immediate(_) => Self::LayoutValue(value),
         }
     }
 }
@@ -175,18 +172,9 @@ impl Constant {
 pub(crate) enum ValueDefinition {
     Dead,
     FunctionParameter(usize),
-    BlockParameter {
-        block: BlockId,
-        index: usize,
-    },
-    InstructionResult {
-        instruction: InstructionId,
-        index: usize,
-    },
-    TerminatorResult {
-        block: BlockId,
-        index: usize,
-    },
+    BlockParameter { block: BlockId, index: usize },
+    InstructionResult { instruction: InstructionId, index: usize },
+    TerminatorResult { block: BlockId, index: usize },
     Constant(Constant),
 }
 
@@ -274,16 +262,8 @@ impl Terminator {
         }
     }
 
-    pub(crate) fn switch(
-        value: ValueId,
-        cases: Vec<(ValueId, Edge)>,
-        default: Edge,
-    ) -> Self {
-        Self::Switch {
-            value,
-            cases,
-            default,
-        }
+    pub(crate) fn switch(value: ValueId, cases: Vec<(ValueId, Edge)>, default: Edge) -> Self {
+        Self::Switch { value, cases, default }
     }
 
     pub(crate) fn successor_count(&self) -> usize {
@@ -302,10 +282,13 @@ impl Terminator {
             Self::Branch { else_edge, .. } if index == 1 => else_edge,
             Self::CheckedOperation { success, .. } if index == 0 => success,
             Self::CheckedOperation { failure, .. } if index == 1 => failure,
-            Self::Switch { cases, default, .. } => cases
-                .get(index)
-                .map(|(_, edge)| edge)
-                .unwrap_or_else(|| if index == cases.len() { default } else { panic!("no successor {index}") }),
+            Self::Switch { cases, default, .. } => cases.get(index).map(|(_, edge)| edge).unwrap_or_else(|| {
+                if index == cases.len() {
+                    default
+                } else {
+                    panic!("no successor {index}")
+                }
+            }),
             _ => panic!("no successor {index}"),
         }
     }
@@ -570,10 +553,7 @@ impl Function {
     }
 
     fn effects_for_inputs(&self, mut effects: Effects, inputs: &[ValueId]) -> Effects {
-        if inputs
-            .iter()
-            .any(|input| self.value_depends_on_machine_state(*input))
-        {
+        if inputs.iter().any(|input| self.value_depends_on_machine_state(*input)) {
             effects.machine_state = if effects.machine_state.writes() {
                 MemoryEffect::ReadWrite
             } else {
@@ -593,7 +573,10 @@ impl Function {
         let mut worklist = Vec::new();
 
         for (index, value) in self.values.iter().enumerate() {
-            if matches!(value.definition, ValueDefinition::Constant(Constant::MachineRegister(_))) {
+            if matches!(
+                value.definition,
+                ValueDefinition::Constant(Constant::MachineRegister(_))
+            ) {
                 dependent_values[index] = true;
                 worklist.push(ValueId(index));
             }
@@ -726,11 +709,7 @@ impl Function {
                 effects,
                 success: Edge::with_arguments(
                     success_block,
-                    results
-                    .iter()
-                    .copied()
-                    .chain(success_arguments)
-                    .collect(),
+                    results.iter().copied().chain(success_arguments).collect(),
                 ),
                 failure,
             },
@@ -907,7 +886,9 @@ impl Function {
                         return Err(format!("checked operation in {block:?} does not own result {result:?}"));
                     }
                     if success.arguments.get(index) != Some(result) {
-                        return Err(format!("checked operation result {result:?} is not passed to its success block"));
+                        return Err(format!(
+                            "checked operation result {result:?} is not passed to its success block"
+                        ));
                     }
                     if success
                         .arguments
@@ -917,7 +898,9 @@ impl Function {
                         return Err(format!("checked operation result {result:?} is passed more than once"));
                     }
                     if failure.arguments.contains(result) {
-                        return Err(format!("checked operation result {result:?} is available on its failure edge"));
+                        return Err(format!(
+                            "checked operation result {result:?} is available on its failure edge"
+                        ));
                     }
                 }
             }
@@ -1019,12 +1002,7 @@ impl Function {
         }
         for (block_index, block) in self.blocks.iter().enumerate() {
             for input in block.terminator.as_ref().unwrap().inputs() {
-                self.validate_use(
-                    input,
-                    BlockId(block_index),
-                    None,
-                    &analyses,
-                )?;
+                self.validate_use(input, BlockId(block_index), None, &analyses)?;
             }
         }
         Ok(())
@@ -1059,9 +1037,10 @@ impl Function {
             ValueDefinition::Dead => unreachable!(),
             ValueDefinition::FunctionParameter(_) | ValueDefinition::Constant(_) => return Ok(()),
             ValueDefinition::BlockParameter { block, .. } => (block, None),
-            ValueDefinition::InstructionResult { instruction, .. } => {
-                (instruction_layout.block(instruction), Some(instruction_layout.position(instruction)))
-            }
+            ValueDefinition::InstructionResult { instruction, .. } => (
+                instruction_layout.block(instruction),
+                Some(instruction_layout.position(instruction)),
+            ),
             ValueDefinition::TerminatorResult { .. } => unreachable!(),
         };
         if definition_block == use_block {
@@ -1094,7 +1073,14 @@ mod tests {
 
     #[test]
     fn exposes_intrinsic_properties_to_ssa() {
-        assert_eq!(MemoryOperation::Load { width: MemoryWidth::HalfWord, signed: true }.access_width(), 2);
+        assert_eq!(
+            MemoryOperation::Load {
+                width: MemoryWidth::HalfWord,
+                signed: true
+            }
+            .access_width(),
+            2
+        );
         assert_eq!(MemoryOperation::StorePair(PairWidth::DoubleWord).address_count(), 2);
         assert!(MemoryOperation::StorePair(PairWidth::DoubleWord).writes());
         assert!(!MemoryOperation::LoadPair(PairWidth::DoubleWord).writes());
@@ -1150,14 +1136,8 @@ mod tests {
             vec![function.parameter(1)],
             vec![Type::I32],
         )[0];
-        function.set_terminator(
-            then_block,
-            Terminator::jump(join),
-        );
-        function.set_terminator(
-            else_block,
-            Terminator::jump(join),
-        );
+        function.set_terminator(then_block, Terminator::jump(join));
+        function.set_terminator(else_block, Terminator::jump(join));
         function.set_terminator(join, Terminator::Return(vec![value]));
 
         assert!(function.validate().unwrap_err().contains("does not dominate"));
@@ -1194,7 +1174,10 @@ mod tests {
         let symbol = function.add_constant(Type::U64, Constant::Symbol("CAGE_MASK".to_string()));
         let value = function.append_instruction_with_effects(
             function.entry,
-            Intrinsic::Memory(MemoryOperation::Load { width: MemoryWidth::Word, signed: false }),
+            Intrinsic::Memory(MemoryOperation::Load {
+                width: MemoryWidth::Word,
+                signed: false,
+            }),
             vec![function.parameter(0), offset, symbol],
             vec![Type::U32],
             Effects {
@@ -1214,9 +1197,7 @@ mod tests {
         let mut function = Function::new("machine-state-dag", Vec::new(), Vec::new());
         let machine_state = function.add_constant(
             Type::U64,
-            Constant::MachineRegister(RegisterReference::Interpreter(
-                InterpreterRegister::ProgramBase,
-            )),
+            Constant::MachineRegister(RegisterReference::Interpreter(InterpreterRegister::ProgramBase)),
         );
         let one = function.add_constant(Type::U64, Constant::Integer(1));
         let mut previous = machine_state;
@@ -1317,16 +1298,20 @@ mod tests {
             Vec::new(),
         );
         scalar_function.set_terminator(scalar_function.entry, Terminator::Return(Vec::new()));
-        assert!(scalar_function
-            .validate()
-            .unwrap_err()
-            .contains("references non-operation parameter 0"));
+        assert!(
+            scalar_function
+                .validate()
+                .unwrap_err()
+                .contains("references non-operation parameter 0")
+        );
 
         function.instructions[0].operation = Operation::Parameter(OperationParameterId(1));
-        assert!(function
-            .validate()
-            .unwrap_err()
-            .contains("references invalid operation parameter 1"));
+        assert!(
+            function
+                .validate()
+                .unwrap_err()
+                .contains("references invalid operation parameter 1")
+        );
     }
 
     #[test]
@@ -1342,8 +1327,7 @@ mod tests {
     }
 
     fn guarded_function() -> (Function, BlockId, ValueId) {
-        let mut function =
-            Function::new("guarded", vec![Type::Bool, Type::I32], vec![Type::I32]);
+        let mut function = Function::new("guarded", vec![Type::Bool, Type::I32], vec![Type::I32]);
         let failure = function.create_empty_block("failure", BlockLayout::Cold);
         function.append_instruction(
             function.entry,
@@ -1421,18 +1405,14 @@ mod tests {
 
     #[test]
     fn unifies_known_source_and_layout_constants() {
-        let constants = crate::frontend::layout::LayoutConstants::from_values([
-            ("EMPTY_VALUE".to_string(), 0x7ffb_0000_0000_0000),
-        ]);
+        let constants =
+            crate::frontend::layout::LayoutConstants::from_values([("EMPTY_VALUE".to_string(), 0x7ffb_0000_0000_0000)]);
 
         assert_eq!(
             Constant::symbol("EMPTY_VALUE"),
-            Constant::layout_value(
-                crate::frontend::layout::LayoutValue::Constant(
-                    constants.get("EMPTY_VALUE").unwrap(),
-                )
-            )
+            Constant::layout_value(crate::frontend::layout::LayoutValue::Constant(
+                constants.get("EMPTY_VALUE").unwrap(),
+            ))
         );
     }
-
 }

--- a/Libraries/LibJS/Flap/src/ssa/mod.rs
+++ b/Libraries/LibJS/Flap/src/ssa/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use crate::intrinsic::IntrinsicEffects as Effects;
 pub(crate) use crate::intrinsic::ModRef as MemoryEffect;
 use crate::hir as typecheck;
 use crate::ssa as ir;
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) struct BlockId(pub usize);
@@ -412,7 +412,7 @@ impl Function {
             instructions: Vec::new(),
             values,
             entry: BlockId(0),
-            constant_values: HashMap::new(),
+            constant_values: HashMap::default(),
         }
     }
 
@@ -704,7 +704,7 @@ impl Function {
                     .ok_or_else(|| format!("block {block:?} switches on invalid value {value:?}"))?
                     .ty
                     .clone();
-                let mut seen = HashSet::new();
+                let mut seen = HashSet::default();
                 for (pattern, _) in cases {
                     let pattern_type = self
                         .values

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -19,7 +19,7 @@ use crate::types::Type;
 use crate::{CompileError, CompileStage};
 #[cfg(test)]
 use crate::identity::ExternalSymbol;
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 use std::rc::Rc;
 
 pub(crate) fn resolve_constants(function: &mut Function, constants: &LayoutConstants) {
@@ -149,7 +149,7 @@ pub(crate) fn optimize_function_with_report(
 }
 
 pub(crate) fn fuse_operand_accesses(function: &mut Function) {
-    let mut eliminated = HashSet::new();
+    let mut eliminated = HashSet::default();
     for block in &function.blocks {
         for pair in block.instructions.windows(2) {
             let [first_id, second_id] = pair else { unreachable!() };
@@ -330,7 +330,7 @@ fn eliminate_trivial_block_parameters_pass(function: &mut Function, _: &mut Anal
             }
         }
 
-        let mut replacements = HashMap::new();
+        let mut replacements = HashMap::default();
         for (block_index, block) in function.blocks.iter().enumerate() {
             for (parameter_index, parameter) in block.parameters.iter().enumerate() {
                 let mut replacement = None;
@@ -368,7 +368,7 @@ fn eliminate_trivial_block_parameters_pass(function: &mut Function, _: &mut Anal
         let candidates = replacements.clone();
         replacements.retain(|parameter, _| {
             let mut value = *parameter;
-            let mut visited = HashSet::new();
+            let mut visited = HashSet::default();
             while let Some(replacement) = candidates.get(&value) {
                 if !visited.insert(value) {
                     return false;
@@ -536,15 +536,15 @@ fn eliminate_common_subexpressions_pass(
     function: &mut Function,
     analyses: &mut AnalysisManager,
 ) -> bool {
-    let mut replacements = HashMap::new();
-    let mut eliminated = HashSet::new();
+    let mut replacements = HashMap::default();
+    let mut eliminated = HashSet::default();
     let analyses = analyses.get(function);
     let dominators = analyses.dominators;
     // Availability is scoped to the dominator subtree being walked. Copying the
     // whole table for each child costs a clone of every expression in it per
     // block, so the table is shared and each block records what it has to put
     // back on the way out.
-    let mut available = HashMap::<Rc<Expression>, Vec<ValueId>>::new();
+    let mut available = HashMap::<Rc<Expression>, Vec<ValueId>>::default();
     let mut undo = Vec::<(Rc<Expression>, Option<Vec<ValueId>>)>::new();
     let mut worklist = vec![DominatorStep::Enter(function.entry)];
     while let Some(step) = worklist.pop() {
@@ -760,7 +760,7 @@ fn schedule_global_code_motion_pass(
     let mut schedules = vec![Vec::new(); function.blocks.len()];
     for block_index in 0..function.blocks.len() {
         let block = BlockId(block_index);
-        let mut emitted = HashSet::new();
+        let mut emitted = HashSet::default();
         for instruction in &assigned[block_index] {
             if movable[instruction.0] {
                 continue;

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -318,19 +318,38 @@ pub(crate) fn eliminate_trivial_block_parameters(function: &mut Function) {
 fn eliminate_trivial_block_parameters_pass(function: &mut Function, _: &mut AnalysisManager) -> bool {
     let mut changed = false;
     loop {
+        // Which edges arrive at a block does not change while the round runs,
+        // so it is found once. Rediscovering it by scanning every other block
+        // per parameter is quadratic.
+        let mut incoming_edges = vec![Vec::new(); function.blocks.len()];
+        for (block_index, block) in function.blocks.iter().enumerate() {
+            let terminator = block.terminator.as_ref().unwrap();
+            for index in 0..terminator.successor_count() {
+                incoming_edges[terminator.successor(index).block.0].push((block_index, index));
+            }
+        }
+
         let mut replacements = HashMap::new();
         for (block_index, block) in function.blocks.iter().enumerate() {
-            let block_id = BlockId(block_index);
             for (parameter_index, parameter) in block.parameters.iter().enumerate() {
-                let incoming = function
-                    .blocks
-                    .iter()
-                    .flat_map(|predecessor| predecessor.terminator.as_ref().unwrap().successors())
-                    .filter(|edge| edge.block == block_id)
-                    .map(|edge| edge.arguments[parameter_index])
-                    .filter(|argument| argument != parameter)
-                    .collect::<Vec<_>>();
-                let Some(replacement) = incoming.first().copied() else {
+                let mut replacement = None;
+                let mut uniform = true;
+                for (predecessor, edge_index) in &incoming_edges[block_index] {
+                    let edge = function.blocks[*predecessor]
+                        .terminator
+                        .as_ref()
+                        .unwrap()
+                        .successor(*edge_index);
+                    let argument = edge.arguments[parameter_index];
+                    if argument == *parameter {
+                        continue;
+                    }
+                    match replacement {
+                        None => replacement = Some(argument),
+                        Some(first) => uniform &= argument == first,
+                    }
+                }
+                let Some(replacement) = replacement else {
                     continue;
                 };
                 if matches!(
@@ -339,7 +358,7 @@ fn eliminate_trivial_block_parameters_pass(function: &mut Function, _: &mut Anal
                 ) {
                     continue;
                 }
-                if incoming.iter().all(|incoming| *incoming == replacement) {
+                if uniform {
                     replacements.insert(*parameter, replacement);
                 }
             }

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -239,6 +239,7 @@ fn run_optimization_pipeline(
             }
         };
     }
+    run_pass!("merge-straight-line-blocks", merge_straight_line_blocks_pass);
     run_pass!("sparse-conditional-constant-propagation", super::sccp::run);
 
     let mut iterations = Vec::new();
@@ -503,6 +504,156 @@ pub(super) fn eliminate_unreachable_blocks(function: &mut Function) -> bool {
     function.entry = block_map[function.entry.0].expect("the entry block is always reachable");
     function.blocks = blocks;
     true
+}
+
+#[cfg(test)]
+pub(crate) fn merge_straight_line_blocks(function: &mut Function) {
+    run_single_pass(function, "merge-straight-line-blocks", merge_straight_line_blocks_pass);
+}
+
+/// Merge a block into the only block that jumps to it.
+///
+/// Stitching a bytecode program writes a block per guard and a block per merge,
+/// so a stitched function is thousands of blocks holding two or three
+/// instructions each. A quarter of them are entered from exactly one place that
+/// goes nowhere else: the two are one straight line spelled as two blocks, and
+/// every later phase pays for the split with a terminator, a label in the
+/// machine listing and a row in every block-indexed analysis.
+fn merge_straight_line_blocks_pass(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
+    // A block named as a value is jumped to indirectly, which is not an edge
+    // the control-flow graph knows about, so it stays a block whatever else
+    // reaches it.
+    let mut named_as_value = vec![false; function.blocks.len()];
+    for instruction in &function.instructions {
+        if let Operation::BlockReference(target) = instruction.operation {
+            named_as_value[target.0] = true;
+        }
+    }
+    let cfg = analyses.cfg(function);
+    let mut single_predecessor = (0..function.blocks.len())
+        .map(|index| {
+            let predecessors = cfg.predecessors(BlockId(index));
+            (predecessors.len() == 1).then(|| predecessors[0])
+        })
+        .collect::<Vec<_>>();
+
+    let mut merged_into = vec![None; function.blocks.len()];
+    let mut replacements = HashMap::default();
+    for index in 0..function.blocks.len() {
+        // Follow the chain from a block nothing has merged away, so a run of
+        // straight-line blocks collapses in one visit.
+        if merged_into[index].is_some() {
+            continue;
+        }
+        let head = BlockId(index);
+        while let Some(next) = mergeable_successor(function, head, &single_predecessor, &named_as_value) {
+            let edge = match function.blocks[head.0].terminator.take() {
+                Some(Terminator::Jump(edge)) => edge,
+                _ => unreachable!("only a jump names a mergeable successor"),
+            };
+            let absorbed_parameters = std::mem::take(&mut function.blocks[next.0].parameters);
+            let absorbed_instructions = std::mem::take(&mut function.blocks[next.0].instructions);
+            let absorbed_terminator = function.blocks[next.0].terminator.take();
+            if let Some(Terminator::Jump(edge)) = &absorbed_terminator
+                && single_predecessor[edge.block.0] == Some(next)
+            {
+                single_predecessor[edge.block.0] = Some(head);
+            }
+            for (parameter, argument) in absorbed_parameters.iter().zip(&edge.arguments) {
+                replacements.insert(*parameter, *argument);
+                function.values[parameter.0].definition = ValueDefinition::Dead;
+            }
+            let block = &mut function.blocks[head.0];
+            block.instructions.extend(absorbed_instructions);
+            block.terminator = absorbed_terminator;
+            merged_into[next.0] = Some(head);
+        }
+    }
+
+    if replacements.is_empty() && merged_into.iter().all(Option::is_none) {
+        return false;
+    }
+    analyses.report(
+        super::report::OptimizationRemarkKind::Applied,
+        "block-merging",
+        merged_into.iter().filter(|merged| merged.is_some()).count() as u64,
+        "folded a block into the only block that jumps to it",
+    );
+
+    // A parameter may stand for another parameter that is itself being folded
+    // away, so the substitution is followed to what it finally names.
+    let direct = replacements.clone();
+    for value in replacements.values_mut() {
+        let mut seen = HashSet::default();
+        while let Some(next) = direct.get(value) {
+            if !seen.insert(*value) {
+                break;
+            }
+            *value = *next;
+        }
+    }
+    rewrite_function_uses(function, &replacements);
+
+    let mut block_map = vec![None; function.blocks.len()];
+    let mut blocks = Vec::new();
+    for (old_index, block) in std::mem::take(&mut function.blocks).into_iter().enumerate() {
+        if merged_into[old_index].is_some() {
+            continue;
+        }
+        block_map[old_index] = Some(BlockId(blocks.len()));
+        blocks.push(block);
+    }
+    for (block_index, block) in blocks.iter_mut().enumerate() {
+        let block_id = BlockId(block_index);
+        for (parameter_index, parameter) in block.parameters.iter().enumerate() {
+            function.values[parameter.0].definition = ValueDefinition::BlockParameter {
+                block: block_id,
+                index: parameter_index,
+            };
+        }
+        let terminator = block.terminator.as_mut().expect("a surviving block keeps a terminator");
+        if let Terminator::CheckedOperation { results, .. } = terminator {
+            for (result_index, result) in results.iter().enumerate() {
+                function.values[result.0].definition = ValueDefinition::TerminatorResult {
+                    block: block_id,
+                    index: result_index,
+                };
+            }
+        }
+        for edge in terminator_edges_mut(terminator) {
+            edge.block = block_map[edge.block.0].expect("a merged block is never a branch target");
+        }
+    }
+    for instruction in &mut function.instructions {
+        if let Operation::BlockReference(target) = &mut instruction.operation {
+            *target = block_map[target.0].expect("a merged block is never referenced as a value");
+        }
+    }
+    function.entry = block_map[function.entry.0].expect("the entry block is never merged away");
+    function.blocks = blocks;
+    rebuild_instruction_arena(function, &HashSet::default(), InstructionOrder::ByBlock);
+    true
+}
+
+/// The block `head` can absorb, if there is one.
+fn mergeable_successor(
+    function: &Function,
+    head: BlockId,
+    single_predecessor: &[Option<BlockId>],
+    named_as_value: &[bool],
+) -> Option<BlockId> {
+    let Some(Terminator::Jump(edge)) = &function.blocks[head.0].terminator else {
+        return None;
+    };
+    let next = edge.block;
+    if next == head || next == function.entry || named_as_value[next.0] || single_predecessor[next.0] != Some(head) {
+        return None;
+    }
+    let (head_block, next_block) = (&function.blocks[head.0], &function.blocks[next.0]);
+    if next_block.layout != head_block.layout {
+        return None;
+    }
+    Some(next)
 }
 
 fn terminator_edges_mut(terminator: &mut Terminator) -> Vec<&mut Edge> {
@@ -1127,6 +1278,23 @@ mod tests {
             effects,
         );
         (instruction, results)
+    }
+
+    #[test]
+    fn merges_an_entire_straight_line_block_chain_in_one_pass() {
+        let mut function = Function::new("block-chain", Vec::new(), Vec::new());
+        let middle = function.create_empty_block("middle", BlockLayout::Hot);
+        let tail = function.create_empty_block("tail", BlockLayout::Hot);
+        function.set_terminator(function.entry, Terminator::jump(middle));
+        function.set_terminator(middle, Terminator::jump(tail));
+        function.set_terminator(tail, Terminator::Return(Vec::new()));
+
+        assert!(merge_straight_line_blocks_pass(
+            &mut function,
+            &mut AnalysisManager::default()
+        ));
+        assert_eq!(function.blocks.len(), 1);
+        function.validate().unwrap();
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -686,7 +686,8 @@ fn eliminate_common_subexpressions_pass(function: &mut Function, analyses: &mut 
         // Everything published past a guard is unavailable wherever the guard's
         // exit leads, since taking the exit skipped it.
         let mut guard_mark = None;
-        for instruction_id in function.blocks[block.0].instructions.clone() {
+        for position in 0..function.blocks[block.0].instructions.len() {
+            let instruction_id = function.blocks[block.0].instructions[position];
             let instruction = &mut function.instructions[instruction_id.0];
             if instruction.operation.guard_failure().is_some() && guard_mark.is_none() {
                 guard_mark = Some(undo.len());

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -6,7 +6,7 @@
 
 //! Target-independent SSA optimizations.
 
-use super::analysis::{ControlFlowGraph, reachable_blocks};
+use super::analysis::{ControlFlowGraph, ValueUses, reachable_blocks};
 use super::effects::{EffectDomain, EffectSet};
 use super::pass::{AnalysisManager, FunctionPass, PassManagerOptions, PassRunner};
 use super::report::FunctionOptimizationReport;
@@ -1150,29 +1150,43 @@ pub(crate) fn eliminate_dead_code(function: &mut Function) {
     run_single_pass(function, "dead-code-elimination", eliminate_dead_code_pass);
 }
 
-fn eliminate_dead_code_pass(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
-    let mut changed = false;
-    loop {
-        let uses = analyses.uses(function);
-
-        let eliminated = function
-            .instructions
-            .iter()
-            .enumerate()
-            .filter(|(_, instruction)| {
-                instruction.can_be_eliminated() && instruction.results.iter().all(|result| uses.count(*result) == 0)
-            })
-            .map(|(index, _)| InstructionId(index))
-            .collect::<HashSet<_>>();
-        if eliminated.is_empty() {
-            break;
+fn eliminate_dead_code_pass(function: &mut Function, _analyses: &mut AnalysisManager) -> bool {
+    let mut uses = ValueUses::compute(function);
+    let mut worklist = function
+        .instructions
+        .iter()
+        .enumerate()
+        .filter(|(_, instruction)| {
+            instruction.can_be_eliminated() && instruction.results.iter().all(|result| uses.count(*result) == 0)
+        })
+        .map(|(index, _)| InstructionId(index))
+        .collect::<Vec<_>>();
+    let mut eliminated = HashSet::default();
+    while let Some(instruction_id) = worklist.pop() {
+        if eliminated.contains(&instruction_id) {
+            continue;
         }
-        changed = true;
-        rebuild_instruction_arena(function, &eliminated, InstructionOrder::ByBlock);
-        analyses.invalidate();
+        let instruction = &function.instructions[instruction_id.0];
+        if !instruction.can_be_eliminated() || instruction.results.iter().any(|result| uses.count(*result) != 0) {
+            continue;
+        }
+        eliminated.insert(instruction_id);
+        for input in &instruction.inputs {
+            uses.remove_use(*input);
+            if uses.count(*input) != 0 {
+                continue;
+            }
+            if let ValueDefinition::InstructionResult { instruction, .. } = function.values[input.0].definition {
+                worklist.push(instruction);
+            }
+        }
     }
 
-    changed
+    if eliminated.is_empty() {
+        return false;
+    }
+    rebuild_instruction_arena(function, &eliminated, InstructionOrder::ByBlock);
+    true
 }
 
 pub(super) fn rewrite_values(values: &mut [ValueId], replacements: &HashMap<ValueId, ValueId>) {
@@ -1251,7 +1265,9 @@ pub(super) fn rebuild_instruction_arena(
     order: InstructionOrder,
 ) {
     let old_instructions = std::mem::take(&mut function.instructions);
-    function.instructions.reserve(old_instructions.len() - eliminated.len());
+    function
+        .instructions
+        .reserve(old_instructions.len().saturating_sub(eliminated.len()));
     let mut instruction_map = vec![None; old_instructions.len()];
     let order: Vec<_> = if matches!(order, InstructionOrder::Original) {
         (0..old_instructions.len()).map(InstructionId).collect()

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -7,7 +7,7 @@
 //! Target-independent SSA optimizations.
 
 use super::analysis::{ControlFlowGraph, reachable_blocks};
-use super::effects::{EffectDefinition, EffectDomain};
+use super::effects::{EffectDomain, EffectSet};
 use super::pass::{AnalysisManager, FunctionPass, PassManagerOptions, PassRunner};
 use super::report::FunctionOptimizationReport;
 use super::{BlockId, BlockLayout, Edge, Effects, Function, Instruction, InstructionId, Intrinsic, OperandOperation, Operation, Terminator, ValueDefinition, ValueId, ValueOperation};
@@ -19,7 +19,7 @@ use crate::types::Type;
 use crate::{CompileError, CompileStage};
 #[cfg(test)]
 use crate::identity::ExternalSymbol;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 pub(crate) fn resolve_constants(function: &mut Function, constants: &LayoutConstants) {
     let values = function
@@ -132,8 +132,8 @@ struct Expression {
     inputs: Vec<ValueId>,
     result_types: Vec<Type>,
     effects: Effects,
-    memory_dependencies: BTreeSet<EffectDefinition>,
-    machine_state_dependencies: BTreeSet<EffectDefinition>,
+    memory_dependencies: EffectSet,
+    machine_state_dependencies: EffectSet,
 }
 
 pub(crate) fn optimize_function(function: &mut Function) {

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -495,10 +495,12 @@ pub(super) fn eliminate_unreachable_blocks(function: &mut Function) -> bool {
     }
 
     for instruction in &mut function.instructions {
-        let Operation::BlockReference(target) = &mut instruction.operation else {
-            continue;
-        };
-        *target = block_map[target.0].expect("reachable block reference cannot target an unreachable block");
+        match &mut instruction.operation {
+            Operation::BlockReference(target) | Operation::Guard { failure: target } => {
+                *target = block_map[target.0].expect("a reachable block cannot name an unreachable one");
+            }
+            _ => continue,
+        }
     }
 
     function.entry = block_map[function.entry.0].expect("the entry block is always reachable");
@@ -506,27 +508,21 @@ pub(super) fn eliminate_unreachable_blocks(function: &mut Function) -> bool {
     true
 }
 
-#[cfg(test)]
-pub(crate) fn merge_straight_line_blocks(function: &mut Function) {
-    run_single_pass(function, "merge-straight-line-blocks", merge_straight_line_blocks_pass);
-}
-
 /// Merge a block into the only block that jumps to it.
 ///
-/// Stitching a bytecode program writes a block per guard and a block per merge,
-/// so a stitched function is thousands of blocks holding two or three
-/// instructions each. A quarter of them are entered from exactly one place that
+/// Large generated functions can contain thousands of blocks holding two or
+/// three instructions each. Many are entered from exactly one place that
 /// goes nowhere else: the two are one straight line spelled as two blocks, and
 /// every later phase pays for the split with a terminator, a label in the
 /// machine listing and a row in every block-indexed analysis.
 fn merge_straight_line_blocks_pass(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
-    // A block named as a value is jumped to indirectly, which is not an edge
-    // the control-flow graph knows about, so it stays a block whatever else
-    // reaches it.
-    let mut named_as_value = vec![false; function.blocks.len()];
+    // A block named as a value is jumped to indirectly, and a guard can leave
+    // from the middle of a block. Neither target can be folded into a
+    // terminator predecessor without invalidating that reference.
+    let mut unmergeable = vec![false; function.blocks.len()];
     for instruction in &function.instructions {
-        if let Operation::BlockReference(target) = instruction.operation {
-            named_as_value[target.0] = true;
+        if let Operation::BlockReference(target) | Operation::Guard { failure: target } = instruction.operation {
+            unmergeable[target.0] = true;
         }
     }
     let cfg = analyses.cfg(function);
@@ -546,7 +542,7 @@ fn merge_straight_line_blocks_pass(function: &mut Function, analyses: &mut Analy
             continue;
         }
         let head = BlockId(index);
-        while let Some(next) = mergeable_successor(function, head, &single_predecessor, &named_as_value) {
+        while let Some(next) = mergeable_successor(function, head, &single_predecessor, &unmergeable) {
             let edge = match function.blocks[head.0].terminator.take() {
                 Some(Terminator::Jump(edge)) => edge,
                 _ => unreachable!("only a jump names a mergeable successor"),
@@ -625,8 +621,8 @@ fn merge_straight_line_blocks_pass(function: &mut Function, analyses: &mut Analy
         }
     }
     for instruction in &mut function.instructions {
-        if let Operation::BlockReference(target) = &mut instruction.operation {
-            *target = block_map[target.0].expect("a merged block is never referenced as a value");
+        if let Operation::BlockReference(target) | Operation::Guard { failure: target } = &mut instruction.operation {
+            *target = block_map[target.0].expect("a merged block is never named by another block");
         }
     }
     function.entry = block_map[function.entry.0].expect("the entry block is never merged away");
@@ -640,13 +636,13 @@ fn mergeable_successor(
     function: &Function,
     head: BlockId,
     single_predecessor: &[Option<BlockId>],
-    named_as_value: &[bool],
+    unmergeable: &[bool],
 ) -> Option<BlockId> {
     let Some(Terminator::Jump(edge)) = &function.blocks[head.0].terminator else {
         return None;
     };
     let next = edge.block;
-    if next == head || next == function.entry || named_as_value[next.0] || single_predecessor[next.0] != Some(head) {
+    if next == head || next == function.entry || unmergeable[next.0] || single_predecessor[next.0] != Some(head) {
         return None;
     }
     let (head_block, next_block) = (&function.blocks[head.0], &function.blocks[next.0]);
@@ -691,6 +687,7 @@ fn eliminate_common_subexpressions_pass(
     let mut eliminated = HashSet::default();
     let analyses = analyses.get(function);
     let dominators = analyses.dominators;
+    let guards = analyses.guards;
     // Availability is scoped to the dominator subtree being walked. Copying the
     // whole table for each child costs a clone of every expression in it per
     // block, so the table is shared and each block records what it has to put
@@ -713,8 +710,14 @@ fn eliminate_common_subexpressions_pass(
             DominatorStep::Enter(block) => block,
         };
         worklist.push(DominatorStep::Leave(undo.len()));
+        // Everything published past a guard is unavailable wherever the guard's
+        // exit leads, since taking the exit skipped it.
+        let mut guard_mark = None;
         for instruction_id in function.blocks[block.0].instructions.clone() {
             let instruction = &mut function.instructions[instruction_id.0];
+            if instruction.operation.guard_failure().is_some() && guard_mark.is_none() {
+                guard_mark = Some(undo.len());
+            }
             rewrite_values(&mut instruction.inputs, &replacements);
             // The current allocator cannot preserve virtual registers across
             // calls, and sharing across a trapping check increases pressure on
@@ -789,7 +792,28 @@ fn eliminate_common_subexpressions_pass(
                 available.insert(expression, instruction.results.clone());
             }
         }
-        for child in dominators.children(block).iter().rev() {
+        let children = dominators.children(block);
+        let Some(guard_mark) = guard_mark else {
+            for child in children.iter().rev() {
+                worklist.push(DominatorStep::Enter(*child));
+            }
+            continue;
+        };
+        // Rolling back is one-way, so the children that keep the block's whole
+        // table run first and the ones an exit can reach run after the undo.
+        for child in children
+            .iter()
+            .rev()
+            .filter(|child| guards.is_reachable_from_exit(**child))
+        {
+            worklist.push(DominatorStep::Enter(*child));
+        }
+        worklist.push(DominatorStep::Leave(guard_mark));
+        for child in children
+            .iter()
+            .rev()
+            .filter(|child| !guards.is_reachable_from_exit(**child))
+        {
             worklist.push(DominatorStep::Enter(*child));
         }
     }
@@ -829,6 +853,7 @@ fn schedule_global_code_motion_pass(
     let analyses = analyses.placement(function);
     let dominators = &analyses.dominators;
     let instruction_layout = &analyses.instruction_layout;
+    let guards = analyses.guards;
     let mut loop_depths = vec![0usize; function.blocks.len()];
     for natural_loop in analyses.loops {
         for block in &natural_loop.blocks {
@@ -836,14 +861,26 @@ fn schedule_global_code_motion_pass(
         }
     }
 
-    let movable = function
-        .instructions
-        .iter()
-        .map(instruction_is_globally_movable)
-        .collect::<Vec<_>>();
     let uses = collect_instruction_uses(function);
     let original_placements = (0..function.instructions.len())
         .map(|index| instruction_layout.block(InstructionId(index)))
+        .collect::<Vec<_>>();
+    // A value another block reads along a guard's exit stays where the guard
+    // already passes it. Sinking it towards a use would put it after an exit
+    // that reads it, and forcing it above the guard instead is no better: what
+    // it is computed from can be something that cannot move at all.
+    let movable = (0..function.instructions.len())
+        .map(|index| {
+            instruction_is_globally_movable(&function.instructions[index])
+                && !escapes_through_a_guard(
+                    function,
+                    InstructionId(index),
+                    original_placements[index],
+                    &uses,
+                    &original_placements,
+                    guards,
+                )
+        })
         .collect::<Vec<_>>();
     let mut placements = original_placements.clone();
 
@@ -972,6 +1009,31 @@ fn schedule_global_code_motion_pass(
     true
 }
 
+/// Whether another block reads this instruction's result along a guard's exit.
+fn escapes_through_a_guard(
+    function: &Function,
+    instruction: InstructionId,
+    block: BlockId,
+    uses: &[Vec<InstructionUse>],
+    placements: &[BlockId],
+    guards: &super::analysis::GuardExits,
+) -> bool {
+    // Nothing leaves a block that has no guard before its terminator, so
+    // everything it defines reaches wherever it dominates.
+    if !guards.has_guard(block) {
+        return false;
+    }
+    function.instructions[instruction.0]
+        .results
+        .iter()
+        .flat_map(|result| uses[result.0].iter())
+        .map(|use_site| match use_site {
+            InstructionUse::Instruction(user) => placements[user.0],
+            InstructionUse::Terminator(user) => *user,
+        })
+        .any(|user| user != block && guards.is_reachable_from_exit(user))
+}
+
 fn instruction_is_globally_movable(instruction: &super::Instruction) -> bool {
     instruction.effects == Effects::PURE
         && !instruction.results.is_empty()
@@ -988,7 +1050,8 @@ fn instruction_is_globally_movable(instruction: &super::Instruction) -> bool {
             }
             Operation::Intrinsic(Intrinsic::Aggregate(_)) | Operation::Intrinsic(Intrinsic::Assertion(_)) | Operation::Intrinsic(Intrinsic::Branch(_)) | Operation::Intrinsic(Intrinsic::Bytecode(_)) | Operation::Intrinsic(Intrinsic::Call(_)) | Operation::Intrinsic(Intrinsic::CheckedInteger(_)) | Operation::Intrinsic(Intrinsic::Control(_)) | Operation::Intrinsic(Intrinsic::Memory(_)) | Operation::InlineCall(_) | Operation::Parameter(_)
             | Operation::MachineAssign { .. }
-            | Operation::BlockReference(_) => false,
+            | Operation::BlockReference(_)
+            | Operation::Guard { .. } => false,
         }
 }
 
@@ -1125,8 +1188,7 @@ fn eliminate_dead_code_pass(function: &mut Function, analyses: &mut AnalysisMana
             .iter()
             .enumerate()
             .filter(|(_, instruction)| {
-                instruction.effects.can_be_eliminated()
-                    && instruction.results.iter().all(|result| uses.count(*result) == 0)
+                instruction.can_be_eliminated() && instruction.results.iter().all(|result| uses.count(*result) == 0)
             })
             .map(|(index, _)| InstructionId(index))
             .collect::<HashSet<_>>();
@@ -1278,6 +1340,27 @@ mod tests {
             effects,
         );
         (instruction, results)
+    }
+
+    #[test]
+    fn does_not_merge_a_guard_failure_target_into_its_predecessor() {
+        let mut function = Function::new("guard-target", vec![Type::Bool], Vec::new());
+        let failure = function.create_empty_block("failure", BlockLayout::Cold);
+        function.append_instruction(
+            function.entry,
+            Operation::Guard { failure },
+            vec![function.parameter(0)],
+            Vec::new(),
+        );
+        function.set_terminator(function.entry, Terminator::jump(failure));
+        function.set_terminator(failure, Terminator::Return(Vec::new()));
+
+        assert!(!merge_straight_line_blocks_pass(
+            &mut function,
+            &mut AnalysisManager::default()
+        ));
+        assert_eq!(function.blocks.len(), 2);
+        function.validate().unwrap();
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -20,6 +20,7 @@ use crate::{CompileError, CompileStage};
 #[cfg(test)]
 use crate::identity::ExternalSymbol;
 use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 pub(crate) fn resolve_constants(function: &mut Function, constants: &LayoutConstants) {
     let values = function
@@ -539,8 +540,28 @@ fn eliminate_common_subexpressions_pass(
     let mut eliminated = HashSet::new();
     let analyses = analyses.get(function);
     let dominators = analyses.dominators;
-    let mut worklist = vec![(function.entry, HashMap::<Expression, Vec<ValueId>>::new())];
-    while let Some((block, mut available)) = worklist.pop() {
+    // Availability is scoped to the dominator subtree being walked. Copying the
+    // whole table for each child costs a clone of every expression in it per
+    // block, so the table is shared and each block records what it has to put
+    // back on the way out.
+    let mut available = HashMap::<Rc<Expression>, Vec<ValueId>>::new();
+    let mut undo = Vec::<(Rc<Expression>, Option<Vec<ValueId>>)>::new();
+    let mut worklist = vec![DominatorStep::Enter(function.entry)];
+    while let Some(step) = worklist.pop() {
+        let block = match step {
+            DominatorStep::Leave(mark) => {
+                while undo.len() > mark {
+                    let (expression, previous) = undo.pop().expect("undo log is not empty above its mark");
+                    match previous {
+                        Some(results) => available.insert(expression, results),
+                        None => available.remove(&expression),
+                    };
+                }
+                continue;
+            }
+            DominatorStep::Enter(block) => block,
+        };
+        worklist.push(DominatorStep::Leave(undo.len()));
         for instruction_id in function.blocks[block.0].instructions.clone() {
             let instruction = &mut function.instructions[instruction_id.0];
             rewrite_values(&mut instruction.inputs, &replacements);
@@ -549,7 +570,7 @@ fn eliminate_common_subexpressions_pass(
             // paths that may exit. Keep cheap expressions rematerializable on
             // each side of those boundaries.
             if instruction.effects.may_call || instruction.effects.may_trap {
-                available.clear();
+                undo.extend(available.drain().map(|(expression, results)| (expression, Some(results))));
                 continue;
             }
             if !instruction.effects.can_be_eliminated()
@@ -612,11 +633,13 @@ fn eliminate_common_subexpressions_pass(
                 }
                 eliminated.insert(instruction_id);
             } else {
+                let expression = Rc::new(expression);
+                undo.push((Rc::clone(&expression), None));
                 available.insert(expression, instruction.results.clone());
             }
         }
         for child in dominators.children(block).iter().rev() {
-            worklist.push((*child, available.clone()));
+            worklist.push(DominatorStep::Enter(*child));
         }
     }
 
@@ -627,6 +650,14 @@ fn eliminate_common_subexpressions_pass(
     rewrite_function_uses(function, &replacements);
     rebuild_instruction_arena(function, &eliminated, InstructionOrder::ByBlock);
     true
+}
+
+/// A step of the dominator-tree walk: either a block to process or the point
+/// at which everything that block made available goes out of scope.
+#[derive(Debug, Clone, Copy)]
+enum DominatorStep {
+    Enter(BlockId),
+    Leave(usize),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -225,7 +225,7 @@ fn run_optimization_pipeline(
     let mut converged = false;
     for _ in 1..=2 {
         let mut passes = Vec::new();
-        let mut changed = false;
+        let mut feedback_changed = false;
         for (name, pass) in [
             (
                 "eliminate-trivial-block-parameters",
@@ -234,7 +234,9 @@ fn run_optimization_pipeline(
             ("resolve-block-references", resolve_block_references),
         ] {
             let (pass_changed, report) = runner.run(function, name, pass);
-            changed |= pass_changed;
+            if name == "resolve-block-references" {
+                feedback_changed = pass_changed;
+            }
             if let Some(report) = report {
                 passes.push(report);
             }
@@ -242,7 +244,10 @@ fn run_optimization_pipeline(
         if options.is_some() {
             iterations.push(passes);
         }
-        if !changed {
+        // Parameter elimination reaches its own fixed point. Only resolving
+        // an indirect block reference can expose new work for another outer
+        // iteration.
+        if !feedback_changed {
             converged = true;
             break;
         }

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -548,6 +548,20 @@ fn eliminate_common_subexpressions_pass(
             {
                 continue;
             }
+            // A computation with nothing but constants for inputs is cheaper to
+            // repeat than to keep, and keeping it is actively harmful: sharing
+            // one between distant uses stretches a live range across everything
+            // in between, including calls, which no allocatable register
+            // survives. Availability is cleared at a call, but only along the
+            // dominator path the walk takes, so a call on any other path
+            // between the two uses goes unnoticed.
+            if instruction
+                .inputs
+                .iter()
+                .all(|input| matches!(function.values[input.0].definition, ValueDefinition::Constant(_)))
+            {
+                continue;
+            }
             let effect_dependencies = |domain| {
                 analyses
                     .effects

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -10,16 +10,19 @@ use super::analysis::{ControlFlowGraph, reachable_blocks};
 use super::effects::{EffectDomain, EffectSet};
 use super::pass::{AnalysisManager, FunctionPass, PassManagerOptions, PassRunner};
 use super::report::FunctionOptimizationReport;
-use super::{BlockId, BlockLayout, Edge, Effects, Function, Instruction, InstructionId, Intrinsic, OperandOperation, Operation, Terminator, ValueDefinition, ValueId, ValueOperation};
-use crate::intrinsic::{OperandLoad, OperandStore};
 #[cfg(test)]
 use super::{BinaryOperation, IntegerBinaryOperation};
+use super::{
+    BlockId, BlockLayout, Edge, Effects, Function, Instruction, InstructionId, Intrinsic, OperandOperation, Operation,
+    Terminator, ValueDefinition, ValueId, ValueOperation,
+};
 use crate::frontend::layout::{LayoutConstants, LayoutValue};
-use crate::types::Type;
-use crate::{CompileError, CompileStage};
+use crate::hash::{HashMap, HashSet};
 #[cfg(test)]
 use crate::identity::ExternalSymbol;
-use crate::hash::{HashMap, HashSet};
+use crate::intrinsic::{OperandLoad, OperandStore};
+use crate::types::Type;
+use crate::{CompileError, CompileStage};
 use std::rc::Rc;
 
 pub(crate) fn resolve_constants(function: &mut Function, constants: &LayoutConstants) {
@@ -42,24 +45,17 @@ pub(crate) fn resolve_constants(function: &mut Function, constants: &LayoutConst
     for value_id in values {
         let value = &mut function.values[value_id.0];
         let constant = match &value.definition {
-            ValueDefinition::Constant(
-                super::ir::Constant::KnownLayout(known),
-            ) => constants.known(*known),
-            ValueDefinition::Constant(
-                super::ir::Constant::LayoutValue(
-                    LayoutValue::Constant(constant),
-                ),
-            ) => Some(*constant),
-            ValueDefinition::Constant(
-                super::ir::Constant::Symbol(name),
-            ) => constants.get(name),
+            ValueDefinition::Constant(super::ir::Constant::KnownLayout(known)) => constants.known(*known),
+            ValueDefinition::Constant(super::ir::Constant::LayoutValue(LayoutValue::Constant(constant))) => {
+                Some(*constant)
+            }
+            ValueDefinition::Constant(super::ir::Constant::Symbol(name)) => constants.get(name),
             _ => None,
         };
         let Some(constant) = constant else {
             continue;
         };
-        value.definition =
-            ValueDefinition::Constant(super::ir::Constant::Integer(constant.value()));
+        value.definition = ValueDefinition::Constant(super::ir::Constant::Integer(constant.value()));
     }
 }
 
@@ -68,61 +64,39 @@ pub(crate) fn resolve_layout_constants(
     constants: &LayoutConstants,
 ) -> Result<(), CompileError> {
     for value in &mut function.values {
-        if let ValueDefinition::Constant(
-            super::ir::Constant::KnownLayout(known),
-        ) = value.definition
-        {
-            let constant = constants
-                .known(known)
-                .ok_or_else(|| {
-                    CompileError::new(
-                        CompileStage::Ssa,
-                        Some(&function.name),
-                        format!("unknown constant '{}'", known.name()),
-                    )
-                })?;
-            value.definition = ValueDefinition::Constant(
-                super::ir::Constant::Layout(constant),
-            );
-            continue;
-        }
-        if let ValueDefinition::Constant(
-            super::ir::Constant::LayoutValue(layout_value),
-        ) = value.definition
-        {
-            value.definition = ValueDefinition::Constant(
-                match layout_value {
-                    LayoutValue::Immediate(value) => {
-                        super::ir::Constant::Integer(value)
-                    }
-                    LayoutValue::Constant(constant) => {
-                        super::ir::Constant::Layout(constant)
-                    }
-                },
-            );
-            continue;
-        }
-        let ValueDefinition::Constant(super::ir::Constant::Symbol(name)) =
-            &value.definition
-        else {
-            continue;
-        };
-        if let Ok(integer) = name.parse() {
-            value.definition =
-                ValueDefinition::Constant(super::ir::Constant::Integer(integer));
-            continue;
-        }
-        let constant = constants
-            .get(name)
-            .ok_or_else(|| {
+        if let ValueDefinition::Constant(super::ir::Constant::KnownLayout(known)) = value.definition {
+            let constant = constants.known(known).ok_or_else(|| {
                 CompileError::new(
                     CompileStage::Ssa,
                     Some(&function.name),
-                    format!("unknown constant '{name}'"),
+                    format!("unknown constant '{}'", known.name()),
                 )
             })?;
-        value.definition =
-            ValueDefinition::Constant(super::ir::Constant::Layout(constant));
+            value.definition = ValueDefinition::Constant(super::ir::Constant::Layout(constant));
+            continue;
+        }
+        if let ValueDefinition::Constant(super::ir::Constant::LayoutValue(layout_value)) = value.definition {
+            value.definition = ValueDefinition::Constant(match layout_value {
+                LayoutValue::Immediate(value) => super::ir::Constant::Integer(value),
+                LayoutValue::Constant(constant) => super::ir::Constant::Layout(constant),
+            });
+            continue;
+        }
+        let ValueDefinition::Constant(super::ir::Constant::Symbol(name)) = &value.definition else {
+            continue;
+        };
+        if let Ok(integer) = name.parse() {
+            value.definition = ValueDefinition::Constant(super::ir::Constant::Integer(integer));
+            continue;
+        }
+        let constant = constants.get(name).ok_or_else(|| {
+            CompileError::new(
+                CompileStage::Ssa,
+                Some(&function.name),
+                format!("unknown constant '{name}'"),
+            )
+        })?;
+        value.definition = ValueDefinition::Constant(super::ir::Constant::Layout(constant));
     }
     Ok(())
 }
@@ -162,9 +136,7 @@ pub(crate) fn fuse_operand_accesses(function: &mut Function) {
             let second = &function.instructions[second_id.0];
             let (operation, inputs, results) = if matches!(
                 second.operation,
-                Operation::Intrinsic(Intrinsic::Operand(
-                    OperandOperation::Store(OperandStore::Field),
-                ))
+                Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Store(OperandStore::Field),))
             ) && let [destination, stored] = second.inputs.as_slice()
                 && second.results.is_empty()
                 && *stored == result
@@ -181,8 +153,15 @@ pub(crate) fn fuse_operand_accesses(function: &mut Function) {
             first.operation = Operation::Intrinsic(Intrinsic::Operand(operation));
             first.inputs = inputs;
             first.results = results;
-            let memory = if operation == OperandOperation::Copy { super::MemoryEffect::ReadWrite } else { super::MemoryEffect::Read };
-            first.base_effects = Effects { memory, ..Effects::PURE };
+            let memory = if operation == OperandOperation::Copy {
+                super::MemoryEffect::ReadWrite
+            } else {
+                super::MemoryEffect::Read
+            };
+            first.base_effects = Effects {
+                memory,
+                ..Effects::PURE
+            };
             first.effects = first.base_effects;
             if operation == OperandOperation::Copy {
                 function.values[result.0].definition = ValueDefinition::Dead;
@@ -197,8 +176,14 @@ pub(crate) fn fuse_operand_accesses(function: &mut Function) {
 }
 
 fn operand_field_load(instruction: &Instruction) -> Option<(ValueId, ValueId)> {
-    match (&instruction.operation, instruction.inputs.as_slice(), instruction.results.as_slice()) {
-        (Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Load(OperandLoad::Field))), [input], [result]) => Some((*input, *result)),
+    match (
+        &instruction.operation,
+        instruction.inputs.as_slice(),
+        instruction.results.as_slice(),
+    ) {
+        (Operation::Intrinsic(Intrinsic::Operand(OperandOperation::Load(OperandLoad::Field))), [input], [result]) => {
+            Some((*input, *result))
+        }
         _ => None,
     }
 }
@@ -293,10 +278,8 @@ fn resolve_block_references(function: &mut Function, _: &mut AnalysisManager) ->
         let Operation::BlockReference(target) = instruction.operation else {
             continue;
         };
-        function.blocks[block_index].terminator = Some(Terminator::jump_with_arguments(
-            target,
-            instruction.inputs.clone(),
-        ));
+        function.blocks[block_index].terminator =
+            Some(Terminator::jump_with_arguments(target, instruction.inputs.clone()));
         changed = true;
     }
     changed
@@ -650,16 +633,10 @@ fn terminator_edges_mut(terminator: &mut Terminator) -> Vec<&mut Edge> {
     match terminator {
         Terminator::Jump(edge) => vec![edge],
         Terminator::Branch {
-            then_edge,
-            else_edge,
-            ..
+            then_edge, else_edge, ..
         } => vec![then_edge, else_edge],
-        Terminator::Switch { cases, default, .. } => {
-            cases.iter_mut().map(|(_, edge)| edge).chain([default]).collect()
-        }
-        Terminator::CheckedOperation {
-            success, failure, ..
-        } => vec![success, failure],
+        Terminator::Switch { cases, default, .. } => cases.iter_mut().map(|(_, edge)| edge).chain([default]).collect(),
+        Terminator::CheckedOperation { success, failure, .. } => vec![success, failure],
         Terminator::IndirectJump { .. } | Terminator::Return(_) | Terminator::Unreachable => Vec::new(),
     }
 }
@@ -673,10 +650,7 @@ pub(crate) fn eliminate_common_subexpressions(function: &mut Function) {
     );
 }
 
-fn eliminate_common_subexpressions_pass(
-    function: &mut Function,
-    analyses: &mut AnalysisManager,
-) -> bool {
+fn eliminate_common_subexpressions_pass(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
     let mut replacements = HashMap::default();
     let mut eliminated = HashSet::default();
     let analyses = analyses.get(function);
@@ -718,7 +692,11 @@ fn eliminate_common_subexpressions_pass(
             // paths that may exit. Keep cheap expressions rematerializable on
             // each side of those boundaries.
             if instruction.effects.may_call || instruction.effects.may_trap {
-                undo.extend(available.drain().map(|(expression, results)| (expression, Some(results))));
+                undo.extend(
+                    available
+                        .drain()
+                        .map(|(expression, results)| (expression, Some(results))),
+                );
                 continue;
             }
             if !instruction.effects.can_be_eliminated()
@@ -840,10 +818,7 @@ pub(crate) fn schedule_global_code_motion(function: &mut Function) {
     run_single_pass(function, "global-code-motion", schedule_global_code_motion_pass);
 }
 
-fn schedule_global_code_motion_pass(
-    function: &mut Function,
-    analyses: &mut AnalysisManager,
-) -> bool {
+fn schedule_global_code_motion_pass(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
     let analyses = analyses.placement(function);
     let dominators = &analyses.dominators;
     let instruction_layout = &analyses.instruction_layout;
@@ -904,13 +879,7 @@ fn schedule_global_code_motion_pass(
             if !dominators.dominates(source, latest) {
                 continue;
             }
-            let placement = cheapest_motion_block(
-                function,
-                source,
-                latest,
-                dominators,
-                &loop_depths,
-            );
+            let placement = cheapest_motion_block(function, source, latest, dominators, &loop_depths);
             if placements[instruction.0] != placement {
                 placements[instruction.0] = placement;
                 changed = true;
@@ -1036,13 +1005,24 @@ fn instruction_is_globally_movable(instruction: &super::Instruction) -> bool {
             Operation::Intrinsic(Intrinsic::Address(_)) => true,
             Operation::FieldAccess(_) => true,
             Operation::Intrinsic(Intrinsic::LowLevel(operation)) => *operation != super::LowLevelOperation::Move,
-            Operation::Intrinsic(Intrinsic::Classification(_)) | Operation::Intrinsic(Intrinsic::FloatingPoint(_)) | Operation::Intrinsic(Intrinsic::IntegerBinary(_)) | Operation::Intrinsic(Intrinsic::IntegerComparison(_))
+            Operation::Intrinsic(Intrinsic::Classification(_))
+            | Operation::Intrinsic(Intrinsic::FloatingPoint(_))
+            | Operation::Intrinsic(Intrinsic::IntegerBinary(_))
+            | Operation::Intrinsic(Intrinsic::IntegerComparison(_))
             | Operation::Intrinsic(Intrinsic::Operand(_)) => true,
             Operation::Intrinsic(Intrinsic::Value(operation)) => {
-                *operation != ValueOperation::Reuse
-                    && !operation.is_rematerialized()
+                *operation != ValueOperation::Reuse && !operation.is_rematerialized()
             }
-            Operation::Intrinsic(Intrinsic::Aggregate(_)) | Operation::Intrinsic(Intrinsic::Assertion(_)) | Operation::Intrinsic(Intrinsic::Branch(_)) | Operation::Intrinsic(Intrinsic::Bytecode(_)) | Operation::Intrinsic(Intrinsic::Call(_)) | Operation::Intrinsic(Intrinsic::CheckedInteger(_)) | Operation::Intrinsic(Intrinsic::Control(_)) | Operation::Intrinsic(Intrinsic::Memory(_)) | Operation::InlineCall(_) | Operation::Parameter(_)
+            Operation::Intrinsic(Intrinsic::Aggregate(_))
+            | Operation::Intrinsic(Intrinsic::Assertion(_))
+            | Operation::Intrinsic(Intrinsic::Branch(_))
+            | Operation::Intrinsic(Intrinsic::Bytecode(_))
+            | Operation::Intrinsic(Intrinsic::Call(_))
+            | Operation::Intrinsic(Intrinsic::CheckedInteger(_))
+            | Operation::Intrinsic(Intrinsic::Control(_))
+            | Operation::Intrinsic(Intrinsic::Memory(_))
+            | Operation::InlineCall(_)
+            | Operation::Parameter(_)
             | Operation::MachineAssign { .. }
             | Operation::BlockReference(_)
             | Operation::Guard { .. } => false,
@@ -1126,14 +1106,7 @@ fn schedule_value_dependencies(
     dependencies.dedup();
     for dependency in dependencies {
         schedule_instruction(
-            function,
-            block,
-            dependency,
-            placements,
-            movable,
-            ranks,
-            emitted,
-            schedule,
+            function, block, dependency, placements, movable, ranks, emitted, schedule,
         );
     }
 }
@@ -1267,14 +1240,23 @@ pub(super) enum InstructionOrder {
     Original,
 }
 
-pub(super) fn rebuild_instruction_arena(function: &mut Function, eliminated: &HashSet<InstructionId>, order: InstructionOrder) {
+pub(super) fn rebuild_instruction_arena(
+    function: &mut Function,
+    eliminated: &HashSet<InstructionId>,
+    order: InstructionOrder,
+) {
     let old_instructions = std::mem::take(&mut function.instructions);
     function.instructions.reserve(old_instructions.len() - eliminated.len());
     let mut instruction_map = vec![None; old_instructions.len()];
     let order: Vec<_> = if matches!(order, InstructionOrder::Original) {
         (0..old_instructions.len()).map(InstructionId).collect()
     } else {
-        function.blocks.iter().flat_map(|block| &block.instructions).copied().collect()
+        function
+            .blocks
+            .iter()
+            .flat_map(|block| &block.instructions)
+            .copied()
+            .collect()
     };
     for old_id in order {
         if eliminated.contains(&old_id) {
@@ -1303,7 +1285,12 @@ pub(super) fn rebuild_instruction_arena(function: &mut Function, eliminated: &Ha
             };
         }
     }
-    debug_assert!(instruction_map.iter().enumerate().all(|(index, mapped)| eliminated.contains(&InstructionId(index)) || mapped.is_some()));
+    debug_assert!(
+        instruction_map
+            .iter()
+            .enumerate()
+            .all(|(index, mapped)| eliminated.contains(&InstructionId(index)) || mapped.is_some())
+    );
 }
 
 #[cfg(test)]
@@ -1312,8 +1299,7 @@ mod tests {
     use crate::frontend::parser;
     use crate::hir as typecheck;
     use crate::intrinsic::{
-        AssertionOperation, CallOperation, ControlOperation, OperandLoad, OperandOperation,
-        OperandStore,
+        AssertionOperation, CallOperation, ControlOperation, OperandLoad, OperandOperation, OperandStore,
     };
     use crate::ssa::{Constant, LowLevelOperation, MemoryEffect, lowering as ir_lowering};
 
@@ -1326,13 +1312,7 @@ mod tests {
         effects: Effects,
     ) -> (InstructionId, Vec<ValueId>) {
         let instruction = InstructionId(function.instructions.len());
-        let results = function.append_instruction_with_effects(
-            block,
-            operation,
-            inputs,
-            result_types,
-            effects,
-        );
+        let results = function.append_instruction_with_effects(block, operation, inputs, result_types, effects);
         (instruction, results)
     }
 
@@ -1477,18 +1457,12 @@ mod tests {
             Vec::new(),
             Effects::UNKNOWN,
         );
-        function.set_terminator(
-            entry,
-            Terminator::jump(header),
-        );
+        function.set_terminator(entry, Terminator::jump(header));
         function.set_terminator(
             header,
             Terminator::branch_edges(condition, Edge::new(body), Edge::new(exit)),
         );
-        function.set_terminator(
-            body,
-            Terminator::jump(header),
-        );
+        function.set_terminator(body, Terminator::jump(header));
         function.set_terminator(exit, Terminator::Return(Vec::new()));
 
         schedule_global_code_motion(&mut function);
@@ -1501,10 +1475,7 @@ mod tests {
     #[test]
     fn eliminates_trivial_loop_parameters() {
         let mut function = Function::new("loop", Vec::new(), Vec::new());
-        let constant = function.add_constant(
-            Type::SlowPath,
-            Constant::SlowPath(ExternalSymbol::new("slow")),
-        );
+        let constant = function.add_constant(Type::SlowPath, Constant::SlowPath(ExternalSymbol::new("slow")));
         let header = function.create_named_block("header", BlockLayout::Hot, vec![Type::SlowPath]);
         let parameter = function.blocks[header.0].parameters[0];
         let use_instruction = function.append_instruction(
@@ -1514,14 +1485,8 @@ mod tests {
             Vec::new(),
         );
         assert!(use_instruction.is_empty());
-        function.set_terminator(
-            function.entry,
-            Terminator::jump_with_arguments(header, vec![constant]),
-        );
-        function.set_terminator(
-            header,
-            Terminator::jump_with_arguments(header, vec![parameter]),
-        );
+        function.set_terminator(function.entry, Terminator::jump_with_arguments(header, vec![constant]));
+        function.set_terminator(header, Terminator::jump_with_arguments(header, vec![parameter]));
 
         eliminate_trivial_block_parameters(&mut function);
 
@@ -1723,10 +1688,7 @@ handler Add(lhs: i32) {
         );
         let child = function.create_empty_block("child", BlockLayout::Hot);
         let exit = function.create_empty_block("exit", BlockLayout::Hot);
-        function.set_terminator(
-            function.entry,
-            Terminator::branch(function.parameter(0), child, exit),
-        );
+        function.set_terminator(function.entry, Terminator::branch(function.parameter(0), child, exit));
         function.append_instruction(
             child,
             Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add)),
@@ -1877,11 +1839,7 @@ handler Add(lhs: i32) {
         let case = function.add_constant(Type::U32, Constant::Integer(7));
         function.set_terminator(
             function.entry,
-            Terminator::switch(
-                value,
-                vec![(case, Edge::new(selected))],
-                Edge::new(default),
-            ),
+            Terminator::switch(value, vec![(case, Edge::new(selected))], Edge::new(default)),
         );
         function.set_terminator(selected, Terminator::Unreachable);
         function.set_terminator(default, Terminator::Unreachable);
@@ -1910,10 +1868,7 @@ handler Add(lhs: i32) {
 
         resolve_constants(
             &mut function,
-            &LayoutConstants::from_values([(
-                "FIELD_OFFSET".to_string(),
-                24,
-            )]),
+            &LayoutConstants::from_values([("FIELD_OFFSET".to_string(), 24)]),
         );
 
         assert_eq!(
@@ -1924,22 +1879,14 @@ handler Add(lhs: i32) {
 
     #[test]
     fn preserves_layout_value_resolution_points() {
-        let constants = LayoutConstants::from_values([(
-            "FIELD_OFFSET".to_string(),
-            24,
-        )]);
+        let constants = LayoutConstants::from_values([("FIELD_OFFSET".to_string(), 24)]);
         let mut function = Function::new("constants", Vec::new(), Vec::new());
         let base = function.add_constant(Type::U64, Constant::Integer(0));
         let named = function.add_constant(
             Type::U64,
-            Constant::LayoutValue(LayoutValue::Constant(
-                constants.get("FIELD_OFFSET").unwrap(),
-            )),
+            Constant::LayoutValue(LayoutValue::Constant(constants.get("FIELD_OFFSET").unwrap())),
         );
-        let immediate = function.add_constant(
-            Type::U64,
-            Constant::LayoutValue(LayoutValue::Immediate(8)),
-        );
+        let immediate = function.add_constant(Type::U64, Constant::LayoutValue(LayoutValue::Immediate(8)));
         function.append_instruction(
             function.entry,
             Operation::Address,
@@ -1956,9 +1903,7 @@ handler Add(lhs: i32) {
         );
         assert_eq!(
             function.values[immediate.0].definition,
-            ValueDefinition::Constant(Constant::LayoutValue(
-                LayoutValue::Immediate(8)
-            ))
+            ValueDefinition::Constant(Constant::LayoutValue(LayoutValue::Immediate(8)))
         );
 
         resolve_layout_constants(&mut function, &constants).unwrap();
@@ -1972,16 +1917,9 @@ handler Add(lhs: i32) {
     #[test]
     fn rejects_unknown_layout_constants_during_resolution() {
         let mut function = Function::new("Missing", Vec::new(), Vec::new());
-        function.add_constant(
-            Type::U64,
-            Constant::Symbol("MISSING".to_string()),
-        );
+        function.add_constant(Type::U64, Constant::Symbol("MISSING".to_string()));
 
-        let error = resolve_layout_constants(
-            &mut function,
-            &LayoutConstants::default(),
-        )
-        .unwrap_err();
+        let error = resolve_layout_constants(&mut function, &LayoutConstants::default()).unwrap_err();
 
         assert_eq!(error.stage, CompileStage::Ssa);
         assert_eq!(error.handler.as_deref(), Some("Missing"));

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -687,10 +687,10 @@ fn eliminate_common_subexpressions_pass(function: &mut Function, analyses: &mut 
                 guard_mark = Some(undo.len());
             }
             rewrite_values(&mut instruction.inputs, &replacements);
-            // The current allocator cannot preserve virtual registers across
+            // Allocation only preserves simple rematerializable values across
             // calls, and sharing across a trapping check increases pressure on
-            // paths that may exit. Keep cheap expressions rematerializable on
-            // each side of those boundaries.
+            // paths that may exit. Keep other cheap expressions rematerializable
+            // on each side of those boundaries.
             if instruction.effects.may_call || instruction.effects.may_trap {
                 undo.extend(
                     available

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -151,8 +151,8 @@ pub(crate) fn fuse_operand_accesses(function: &mut Function) {
             };
             let first = &mut function.instructions[first_id.0];
             first.operation = Operation::Intrinsic(Intrinsic::Operand(operation));
-            first.inputs = inputs;
-            first.results = results;
+            first.inputs = inputs.into();
+            first.results = results.into();
             let memory = if operation == OperandOperation::Copy {
                 super::MemoryEffect::ReadWrite
             } else {
@@ -284,7 +284,7 @@ fn resolve_block_references(function: &mut Function, _: &mut AnalysisManager) ->
             continue;
         };
         function.blocks[block_index].terminator =
-            Some(Terminator::jump_with_arguments(target, instruction.inputs.clone()));
+            Some(Terminator::jump_with_arguments(target, instruction.inputs.to_vec()));
         changed = true;
     }
     changed
@@ -743,7 +743,7 @@ fn eliminate_common_subexpressions_pass(function: &mut Function, analyses: &mut 
             };
             let expression = Expression {
                 operation: instruction.operation.clone(),
-                inputs: instruction.inputs.clone(),
+                inputs: instruction.inputs.to_vec(),
                 result_types: instruction
                     .results
                     .iter()
@@ -766,7 +766,7 @@ fn eliminate_common_subexpressions_pass(function: &mut Function, analyses: &mut 
             } else {
                 let expression = Rc::new(expression);
                 undo.push((Rc::clone(&expression), None));
-                available.insert(expression, instruction.results.clone());
+                available.insert(expression, instruction.results.to_vec());
             }
         }
         let children = dominators.children(block);
@@ -1513,7 +1513,7 @@ mod tests {
 
         assert!(function.blocks[header.0].parameters.is_empty());
         assert!(matches!(function.values[parameter.0].definition, ValueDefinition::Dead));
-        assert_eq!(function.instructions[0].inputs, vec![constant]);
+        assert_eq!(function.instructions[0].inputs.as_slice(), [constant]);
         for block in &function.blocks {
             for edge in block.terminator.as_ref().unwrap().successors() {
                 assert!(edge.arguments.is_empty());
@@ -1545,7 +1545,7 @@ handler Add(lhs: i32, rhs: i32) {
         assert_eq!(entry.instructions.len(), 4);
         let first_add = &function.instructions[entry.instructions[0].0];
         let total = &function.instructions[entry.instructions[1].0];
-        assert_eq!(total.inputs, vec![first_add.results[0], first_add.results[0]]);
+        assert_eq!(total.inputs.as_slice(), [first_add.results[0], first_add.results[0]]);
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -182,7 +182,8 @@ pub(crate) fn fuse_operand_accesses(function: &mut Function) {
             first.inputs = inputs;
             first.results = results;
             let memory = if operation == OperandOperation::Copy { super::MemoryEffect::ReadWrite } else { super::MemoryEffect::Read };
-            first.effects = Effects { memory, ..Effects::PURE };
+            first.base_effects = Effects { memory, ..Effects::PURE };
+            first.effects = first.base_effects;
             if operation == OperandOperation::Copy {
                 function.values[result.0].definition = ValueDefinition::Dead;
             }
@@ -203,14 +204,7 @@ fn operand_field_load(instruction: &Instruction) -> Option<(ValueId, ValueId)> {
 }
 
 fn recompute_effects(function: &mut Function) {
-    for index in 0..function.instructions.len() {
-        let instruction = &function.instructions[index];
-        if matches!(instruction.operation, Operation::Intrinsic(Intrinsic::Operand(OperandOperation::LoadPair | OperandOperation::Copy))) {
-            continue;
-        }
-        let effects = function.effects_for_operation(&instruction.operation, &instruction.inputs);
-        function.instructions[index].effects = effects;
-    }
+    function.recompute_machine_state_dependencies();
 }
 
 fn binary_operand_pair(function: &Function, lhs: ValueId, rhs: ValueId) -> bool {

--- a/Libraries/LibJS/Flap/src/ssa/optimize.rs
+++ b/Libraries/LibJS/Flap/src/ssa/optimize.rs
@@ -675,7 +675,7 @@ fn schedule_global_code_motion_pass(
     function: &mut Function,
     analyses: &mut AnalysisManager,
 ) -> bool {
-    let analyses = analyses.get(function);
+    let analyses = analyses.placement(function);
     let dominators = &analyses.dominators;
     let instruction_layout = &analyses.instruction_layout;
     let mut loop_depths = vec![0usize; function.blocks.len()];

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -13,6 +13,7 @@ use super::analysis::{
 use super::effects::EffectDependencies;
 use super::print::function_to_string;
 use super::report::{OptimizationRemark, OptimizationRemarkKind, PassRunReport};
+use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FunctionAnalyses<'a> {
@@ -229,7 +230,9 @@ impl PassRunner {
         if let Some(options) = self.options {
             self.analyses.begin_pass(options.collect_remarks);
         }
+        let started_at = self.options.map(|_| Instant::now());
         let changed = pass(function, &mut self.analyses);
+        let elapsed = started_at.map(|started_at| started_at.elapsed());
         let instrumentation = self.options.map(|_| self.analyses.finish_pass(changed));
         if changed {
             function.recompute_machine_state_dependencies();
@@ -242,6 +245,7 @@ impl PassRunner {
         }
         let report = instrumentation.map(|instrumentation| PassRunReport {
             name: name.to_string(),
+            elapsed: elapsed.expect("pass timing was enabled with instrumentation"),
             changed,
             attempted_transformations: instrumentation.attempted_transformations,
             successful_transformations: instrumentation.successful_transformations,

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -8,7 +8,7 @@
 
 use super::Function;
 use super::analysis::{
-    ControlFlowGraph, DominatorTree, GuardExits, InstructionLayout, NaturalLoop, ValueUses, find_natural_loops,
+    ControlFlowGraph, DominatorTree, GuardExits, InstructionLayout, NaturalLoop, find_natural_loops,
 };
 use super::effects::EffectDependencies;
 use super::print::function_to_string;
@@ -48,7 +48,6 @@ pub(crate) struct AnalysisManager {
     loops: Option<Vec<NaturalLoop>>,
     effects: Option<EffectDependencies>,
     guards: Option<GuardExits>,
-    uses: Option<ValueUses>,
     instrumentation: Option<PassInstrumentation>,
 }
 
@@ -100,10 +99,6 @@ impl AnalysisManager {
         self.guards.as_ref().unwrap()
     }
 
-    pub(crate) fn uses<'a>(&'a mut self, function: &Function) -> &'a ValueUses {
-        self.uses.get_or_insert_with(|| ValueUses::compute(function))
-    }
-
     /// The analyses a pass needs to decide where an instruction belongs.
     ///
     /// Placement says nothing about effects, and computing the effect
@@ -145,7 +140,6 @@ impl AnalysisManager {
         self.loops = None;
         self.effects = None;
         self.guards = None;
-        self.uses = None;
     }
 
     pub(crate) fn report(
@@ -295,7 +289,6 @@ mod tests {
         assert!(analyses.loops.is_none());
         assert!(analyses.effects.is_none());
         assert!(analyses.guards.is_none());
-        assert!(analyses.uses.is_none());
         false
     }
 

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -98,7 +98,7 @@ impl AnalysisManager {
     /// The analyses a pass needs to decide where an instruction belongs.
     ///
     /// Placement says nothing about effects, and computing the effect
-    /// dependencies of a whole stitched function is the most expensive analysis
+    /// dependencies of a whole large function is the most expensive analysis
     /// there is, so asking for the bundle that includes them costs a pass that
     /// never reads them dearly.
     pub(crate) fn placement<'a>(&'a mut self, function: &Function) -> PlacementAnalyses<'a> {

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -53,8 +53,7 @@ pub(crate) struct AnalysisManager {
 
 impl AnalysisManager {
     pub(crate) fn cfg<'a>(&'a mut self, function: &Function) -> &'a ControlFlowGraph {
-        self.cfg
-            .get_or_insert_with(|| ControlFlowGraph::compute(function))
+        self.cfg.get_or_insert_with(|| ControlFlowGraph::compute(function))
     }
 
     pub(crate) fn dominators<'a>(&'a mut self, function: &Function) -> &'a DominatorTree {
@@ -68,8 +67,7 @@ impl AnalysisManager {
 
     pub(crate) fn instruction_layout<'a>(&'a mut self, function: &Function) -> &'a InstructionLayout {
         self.instruction_layout.get_or_insert_with(|| {
-            InstructionLayout::compute(function)
-                .expect("valid SSA has a valid instruction layout")
+            InstructionLayout::compute(function).expect("valid SSA has a valid instruction layout")
         })
     }
 
@@ -77,11 +75,7 @@ impl AnalysisManager {
         if self.loops.is_none() {
             self.cfg(function);
             self.dominators(function);
-            let loops = find_natural_loops(
-                function,
-                self.cfg.as_ref().unwrap(),
-                self.dominators.as_ref().unwrap(),
-            );
+            let loops = find_natural_loops(function, self.cfg.as_ref().unwrap(), self.dominators.as_ref().unwrap());
             self.loops = Some(loops);
         }
         self.loops.as_deref().unwrap()
@@ -187,10 +181,7 @@ impl AnalysisManager {
     }
 
     fn finish_pass(&mut self, changed: bool) -> PassInstrumentation {
-        let mut instrumentation = self
-            .instrumentation
-            .take()
-            .expect("pass instrumentation was enabled");
+        let mut instrumentation = self.instrumentation.take().expect("pass instrumentation was enabled");
         if instrumentation.attempted_transformations == 0 {
             instrumentation.attempted_transformations = 1;
             instrumentation.successful_transformations = u64::from(changed);
@@ -269,12 +260,22 @@ mod tests {
     use crate::ssa::Terminator;
 
     fn report_change(_: &mut Function, analyses: &mut AnalysisManager) -> bool {
-        analyses.report(OptimizationRemarkKind::Applied, "test-change", 1, "changed the test function");
+        analyses.report(
+            OptimizationRemarkKind::Applied,
+            "test-change",
+            1,
+            "changed the test function",
+        );
         true
     }
 
     fn report_no_change(_: &mut Function, analyses: &mut AnalysisManager) -> bool {
-        analyses.report(OptimizationRemarkKind::Missed, "test-change", 1, "the test condition was false");
+        analyses.report(
+            OptimizationRemarkKind::Missed,
+            "test-change",
+            1,
+            "the test condition was false",
+        );
         false
     }
 
@@ -331,11 +332,7 @@ mod tests {
         let mut runner = PassRunner::new(None);
         assert!(
             runner
-                .run(
-                    &mut function,
-                    "compute-and-invalidate",
-                    compute_and_invalidate_analyses,
-                )
+                .run(&mut function, "compute-and-invalidate", compute_and_invalidate_analyses,)
                 .0
         );
         runner.run(&mut function, "assert-invalidated", assert_analyses_were_invalidated);

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -21,6 +21,13 @@ pub(crate) struct FunctionAnalyses<'a> {
     pub(crate) effects: &'a EffectDependencies,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PlacementAnalyses<'a> {
+    pub(crate) dominators: &'a DominatorTree,
+    pub(crate) instruction_layout: &'a InstructionLayout,
+    pub(crate) loops: &'a [NaturalLoop],
+}
+
 #[derive(Debug, Default)]
 struct PassInstrumentation {
     attempted_transformations: u64,
@@ -87,6 +94,23 @@ impl AnalysisManager {
 
     pub(crate) fn uses<'a>(&'a mut self, function: &Function) -> &'a ValueUses {
         self.uses.get_or_insert_with(|| ValueUses::compute(function))
+    }
+
+    /// The analyses a pass needs to decide where an instruction belongs.
+    ///
+    /// Placement says nothing about effects, and computing the effect
+    /// dependencies of a whole stitched function is the most expensive analysis
+    /// there is, so asking for the bundle that includes them costs a pass that
+    /// never reads them dearly.
+    pub(crate) fn placement<'a>(&'a mut self, function: &Function) -> PlacementAnalyses<'a> {
+        self.dominators(function);
+        self.instruction_layout(function);
+        self.loops(function);
+        PlacementAnalyses {
+            dominators: self.dominators.as_ref().unwrap(),
+            instruction_layout: self.instruction_layout.as_ref().unwrap(),
+            loops: self.loops.as_deref().unwrap(),
+        }
     }
 
     pub(crate) fn get<'a>(&'a mut self, function: &Function) -> FunctionAnalyses<'a> {

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -7,7 +7,9 @@
 //! SSA optimization pass orchestration and analysis caching.
 
 use super::Function;
-use super::analysis::{ControlFlowGraph, DominatorTree, InstructionLayout, NaturalLoop, ValueUses, find_natural_loops};
+use super::analysis::{
+    ControlFlowGraph, DominatorTree, GuardExits, InstructionLayout, NaturalLoop, ValueUses, find_natural_loops,
+};
 use super::effects::EffectDependencies;
 use super::print::function_to_string;
 use super::report::{OptimizationRemark, OptimizationRemarkKind, PassRunReport};
@@ -18,6 +20,7 @@ pub(crate) struct FunctionAnalyses<'a> {
     pub(crate) dominators: &'a DominatorTree,
     pub(crate) instruction_layout: &'a InstructionLayout,
     pub(crate) effects: &'a EffectDependencies,
+    pub(crate) guards: &'a GuardExits,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -25,6 +28,7 @@ pub(crate) struct PlacementAnalyses<'a> {
     pub(crate) dominators: &'a DominatorTree,
     pub(crate) instruction_layout: &'a InstructionLayout,
     pub(crate) loops: &'a [NaturalLoop],
+    pub(crate) guards: &'a GuardExits,
 }
 
 #[derive(Debug, Default)]
@@ -42,6 +46,7 @@ pub(crate) struct AnalysisManager {
     instruction_layout: Option<InstructionLayout>,
     loops: Option<Vec<NaturalLoop>>,
     effects: Option<EffectDependencies>,
+    guards: Option<GuardExits>,
     uses: Option<ValueUses>,
     instrumentation: Option<PassInstrumentation>,
 }
@@ -91,6 +96,15 @@ impl AnalysisManager {
         self.effects.as_ref().unwrap()
     }
 
+    pub(crate) fn guards<'a>(&'a mut self, function: &Function) -> &'a GuardExits {
+        if self.guards.is_none() {
+            self.cfg(function);
+            let guards = GuardExits::compute(function, self.cfg.as_ref().unwrap());
+            self.guards = Some(guards);
+        }
+        self.guards.as_ref().unwrap()
+    }
+
     pub(crate) fn uses<'a>(&'a mut self, function: &Function) -> &'a ValueUses {
         self.uses.get_or_insert_with(|| ValueUses::compute(function))
     }
@@ -105,10 +119,12 @@ impl AnalysisManager {
         self.dominators(function);
         self.instruction_layout(function);
         self.loops(function);
+        self.guards(function);
         PlacementAnalyses {
             dominators: self.dominators.as_ref().unwrap(),
             instruction_layout: self.instruction_layout.as_ref().unwrap(),
             loops: self.loops.as_deref().unwrap(),
+            guards: self.guards.as_ref().unwrap(),
         }
     }
 
@@ -117,11 +133,13 @@ impl AnalysisManager {
         self.dominators(function);
         self.instruction_layout(function);
         self.effects(function);
+        self.guards(function);
         FunctionAnalyses {
             cfg: self.cfg.as_ref().unwrap(),
             dominators: self.dominators.as_ref().unwrap(),
             instruction_layout: self.instruction_layout.as_ref().unwrap(),
             effects: self.effects.as_ref().unwrap(),
+            guards: self.guards.as_ref().unwrap(),
         }
     }
 
@@ -131,6 +149,7 @@ impl AnalysisManager {
         self.instruction_layout = None;
         self.loops = None;
         self.effects = None;
+        self.guards = None;
         self.uses = None;
     }
 
@@ -269,6 +288,7 @@ mod tests {
         assert!(analyses.instruction_layout.is_none());
         assert!(analyses.loops.is_none());
         assert!(analyses.effects.is_none());
+        assert!(analyses.guards.is_none());
         assert!(analyses.uses.is_none());
         false
     }

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -241,6 +241,7 @@ impl PassRunner {
         let changed = pass(function, &mut self.analyses);
         let instrumentation = self.options.map(|_| self.analyses.finish_pass(changed));
         if changed {
+            function.recompute_machine_state_dependencies();
             self.analyses.invalidate();
         }
         if cfg!(debug_assertions) {

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -232,11 +232,9 @@ impl PassRunner {
             function.recompute_machine_state_dependencies();
             self.analyses.invalidate();
         }
-        if cfg!(debug_assertions) {
-            function
-                .validate()
-                .unwrap_or_else(|error| panic!("SSA pass '{name}' produced invalid IR: {error}"));
-        }
+        function
+            .validate()
+            .unwrap_or_else(|error| panic!("SSA pass '{name}' produced invalid IR: {error}"));
         let report = instrumentation.map(|instrumentation| PassRunReport {
             name: name.to_string(),
             elapsed: elapsed.expect("pass timing was enabled with instrumentation"),

--- a/Libraries/LibJS/Flap/src/ssa/pass.rs
+++ b/Libraries/LibJS/Flap/src/ssa/pass.rs
@@ -17,7 +17,6 @@ pub(crate) struct FunctionAnalyses<'a> {
     pub(crate) cfg: &'a ControlFlowGraph,
     pub(crate) dominators: &'a DominatorTree,
     pub(crate) instruction_layout: &'a InstructionLayout,
-    pub(crate) loops: &'a [NaturalLoop],
     pub(crate) effects: &'a EffectDependencies,
 }
 
@@ -117,13 +116,11 @@ impl AnalysisManager {
         self.cfg(function);
         self.dominators(function);
         self.instruction_layout(function);
-        self.loops(function);
         self.effects(function);
         FunctionAnalyses {
             cfg: self.cfg.as_ref().unwrap(),
             dominators: self.dominators.as_ref().unwrap(),
             instruction_layout: self.instruction_layout.as_ref().unwrap(),
-            loops: self.loops.as_deref().unwrap(),
             effects: self.effects.as_ref().unwrap(),
         }
     }

--- a/Libraries/LibJS/Flap/src/ssa/print.rs
+++ b/Libraries/LibJS/Flap/src/ssa/print.rs
@@ -156,27 +156,15 @@ impl fmt::Display for DisplayConstant<'_> {
             Constant::KnownLayout(value) => {
                 write!(formatter, "known-layout {}", value.name())
             }
-            Constant::LayoutValue(
-                crate::frontend::layout::LayoutValue::Immediate(value),
-            ) => write!(formatter, "layout-value {value}"),
-            Constant::LayoutValue(
-                crate::frontend::layout::LayoutValue::Constant(value),
-            ) => {
-                write!(
-                    formatter,
-                    "layout-value #{} = {}",
-                    value.id().index(),
-                    value.value()
-                )
+            Constant::LayoutValue(crate::frontend::layout::LayoutValue::Immediate(value)) => {
+                write!(formatter, "layout-value {value}")
+            }
+            Constant::LayoutValue(crate::frontend::layout::LayoutValue::Constant(value)) => {
+                write!(formatter, "layout-value #{} = {}", value.id().index(), value.value())
             }
             Constant::Symbol(value) => write!(formatter, "symbol {value:?}"),
             Constant::Layout(value) => {
-                write!(
-                    formatter,
-                    "layout #{} = {}",
-                    value.id().index(),
-                    value.value()
-                )
+                write!(formatter, "layout #{} = {}", value.id().index(), value.value())
             }
             Constant::SlowPath(value) => write!(formatter, "slow-path {value:?}"),
             Constant::FunctionSymbol(value) => write!(formatter, "function-symbol {value:?}"),
@@ -201,7 +189,12 @@ impl fmt::Display for DisplayOperation<'_> {
             Operation::FieldAccess(access) => write!(formatter, "field-access {access:?}"),
             Operation::InlineCall(id) => write!(formatter, "inline-call #{}", id.index()),
             Operation::MachineAssign { destination, intrinsic } => {
-                write!(formatter, "machine-assign {} {}", destination.as_str(), intrinsic.name())
+                write!(
+                    formatter,
+                    "machine-assign {} {}",
+                    destination.as_str(),
+                    intrinsic.name()
+                )
             }
             Operation::BlockReference(block) => write!(formatter, "block-reference bb{}", block.0),
             Operation::Address => formatter.write_str("address"),

--- a/Libraries/LibJS/Flap/src/ssa/print.rs
+++ b/Libraries/LibJS/Flap/src/ssa/print.rs
@@ -205,6 +205,7 @@ impl fmt::Display for DisplayOperation<'_> {
             }
             Operation::BlockReference(block) => write!(formatter, "block-reference bb{}", block.0),
             Operation::Address => formatter.write_str("address"),
+            Operation::Guard { failure } => write!(formatter, "guard else bb{}", failure.0),
         }
     }
 }

--- a/Libraries/LibJS/Flap/src/ssa/report.rs
+++ b/Libraries/LibJS/Flap/src/ssa/report.rs
@@ -7,6 +7,7 @@
 //! Structured SSA optimization reports and their text formatting.
 
 use std::fmt;
+use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OptimizationRemarkKind {
@@ -24,6 +25,7 @@ pub struct OptimizationRemark {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PassRunReport {
     pub name: String,
+    pub elapsed: Duration,
     pub changed: bool,
     pub attempted_transformations: u64,
     pub successful_transformations: u64,
@@ -162,9 +164,10 @@ impl fmt::Display for FunctionOptimizationReport {
 fn write_pass_report(formatter: &mut impl fmt::Write, pass: &PassRunReport, indent: &str) -> fmt::Result {
     writeln!(
         formatter,
-        "{indent}pass {}: {} attempted={} applied={}",
+        "{indent}pass {}: {} time-us={} attempted={} applied={}",
         pass.name,
         if pass.changed { "changed" } else { "unchanged" },
+        pass.elapsed.as_micros(),
         pass.attempted_transformations,
         pass.successful_transformations
     )?;

--- a/Libraries/LibJS/Flap/src/ssa/report.rs
+++ b/Libraries/LibJS/Flap/src/ssa/report.rs
@@ -91,8 +91,7 @@ impl FunctionOptimizationReport {
 
     pub(crate) fn push_pass(&mut self, pass: &PassRunReport) {
         self.changed |= pass.changed;
-        write_pass_report(&mut self.body, pass, "  ")
-            .expect("writing an optimization report to a string cannot fail");
+        write_pass_report(&mut self.body, pass, "  ").expect("writing an optimization report to a string cannot fail");
     }
 
     pub(crate) fn push_fixed_point(

--- a/Libraries/LibJS/Flap/src/ssa/report.rs
+++ b/Libraries/LibJS/Flap/src/ssa/report.rs
@@ -9,40 +9,54 @@
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum OptimizationRemarkKind {
+pub enum OptimizationRemarkKind {
     Applied,
     Missed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct OptimizationRemark {
-    pub(crate) kind: OptimizationRemarkKind,
-    pub(crate) transformation: String,
-    pub(crate) message: String,
+pub struct OptimizationRemark {
+    pub kind: OptimizationRemarkKind,
+    pub transformation: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PassRunReport {
-    pub(crate) name: String,
-    pub(crate) changed: bool,
-    pub(crate) attempted_transformations: u64,
-    pub(crate) successful_transformations: u64,
-    pub(crate) remarks: Vec<OptimizationRemark>,
-    pub(crate) ir_before: Option<String>,
-    pub(crate) ir_after: Option<String>,
+pub struct PassRunReport {
+    pub name: String,
+    pub changed: bool,
+    pub attempted_transformations: u64,
+    pub successful_transformations: u64,
+    pub remarks: Vec<OptimizationRemark>,
+    pub ir_before: Option<String>,
+    pub ir_after: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FunctionOptimizationReport {
-    pub(crate) function: String,
-    changed: bool,
-    body: String,
+pub struct FixedPointOptimizationReport {
+    pub name: String,
+    pub maximum_iterations: usize,
+    pub converged: bool,
+    pub iterations: Vec<Vec<PassRunReport>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptimizationRecord {
+    Pass(PassRunReport),
+    FixedPoint(FixedPointOptimizationReport),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionOptimizationReport {
+    pub function: String,
+    pub changed: bool,
+    pub records: Vec<OptimizationRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OptimizationReport {
-    pub(crate) pipeline: String,
-    pub(crate) functions: Vec<FunctionOptimizationReport>,
+    pub pipeline: String,
+    pub functions: Vec<FunctionOptimizationReport>,
 }
 
 impl OptimizationReport {
@@ -53,8 +67,8 @@ impl OptimizationReport {
         }
     }
 
-    pub(crate) fn changed_functions(&self) -> impl Iterator<Item = &FunctionOptimizationReport> {
-        self.functions.iter().filter(|function| function.changed())
+    pub fn changed_functions(&self) -> impl Iterator<Item = &FunctionOptimizationReport> {
+        self.functions.iter().filter(|function| function.changed)
     }
 }
 
@@ -81,17 +95,13 @@ impl FunctionOptimizationReport {
         Self {
             function: function.into(),
             changed: false,
-            body: String::new(),
+            records: Vec::new(),
         }
-    }
-
-    pub(crate) fn changed(&self) -> bool {
-        self.changed
     }
 
     pub(crate) fn push_pass(&mut self, pass: &PassRunReport) {
         self.changed |= pass.changed;
-        write_pass_report(&mut self.body, pass, "  ").expect("writing an optimization report to a string cannot fail");
+        self.records.push(OptimizationRecord::Pass(pass.clone()));
     }
 
     pub(crate) fn push_fixed_point(
@@ -101,28 +111,14 @@ impl FunctionOptimizationReport {
         converged: bool,
         iterations: &[Vec<PassRunReport>],
     ) {
-        use std::fmt::Write;
-        writeln!(
-            self.body,
-            "  fixed-point {name}: iterations={}/{} {}",
-            iterations.len(),
-            maximum_iterations,
-            if converged { "converged" } else { "limit-reached" }
-        )
-        .expect("writing an optimization report to a string cannot fail");
-        for (index, iteration) in iterations.iter().enumerate() {
-            writeln!(self.body, "    iteration {}:", index + 1)
-                .expect("writing an optimization report to a string cannot fail");
-            for pass in iteration {
-                self.push_pass_with_indent(pass, "      ");
-            }
-        }
-    }
-
-    fn push_pass_with_indent(&mut self, pass: &PassRunReport, indent: &str) {
-        self.changed |= pass.changed;
-        write_pass_report(&mut self.body, pass, indent)
-            .expect("writing an optimization report to a string cannot fail");
+        self.changed |= iterations.iter().flatten().any(|pass| pass.changed);
+        self.records
+            .push(OptimizationRecord::FixedPoint(FixedPointOptimizationReport {
+                name: name.to_string(),
+                maximum_iterations,
+                converged,
+                iterations: iterations.to_vec(),
+            }));
     }
 }
 
@@ -132,9 +128,34 @@ impl fmt::Display for FunctionOptimizationReport {
             formatter,
             "handler {}: {}",
             self.function,
-            if self.changed() { "changed" } else { "unchanged" }
+            if self.changed { "changed" } else { "unchanged" }
         )?;
-        formatter.write_str(&self.body)
+        for record in &self.records {
+            match record {
+                OptimizationRecord::Pass(pass) => write_pass_report(formatter, pass, "  ")?,
+                OptimizationRecord::FixedPoint(fixed_point) => {
+                    writeln!(
+                        formatter,
+                        "  fixed-point {}: iterations={}/{} {}",
+                        fixed_point.name,
+                        fixed_point.iterations.len(),
+                        fixed_point.maximum_iterations,
+                        if fixed_point.converged {
+                            "converged"
+                        } else {
+                            "limit-reached"
+                        }
+                    )?;
+                    for (index, iteration) in fixed_point.iterations.iter().enumerate() {
+                        writeln!(formatter, "    iteration {}:", index + 1)?;
+                        for pass in iteration {
+                            write_pass_report(formatter, pass, "      ")?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/Libraries/LibJS/Flap/src/ssa/sccp.rs
+++ b/Libraries/LibJS/Flap/src/ssa/sccp.rs
@@ -18,6 +18,11 @@ use super::{
 use crate::types::Type;
 use std::collections::{HashMap, HashSet};
 
+/// How far a boxed value's tag sits above its payload.
+///
+/// This is what `extract_tag` shifts by on every target.
+const VALUE_TAG_SHIFT: u32 = 48;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LatticeValue {
     Unknown,
@@ -192,7 +197,13 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
 
 fn initial_value(ty: &Type, definition: &ValueDefinition) -> LatticeValue {
     match definition {
+        // A layout constant is a number the target's memory layout fixes, and
+        // preparation has already resolved it to one, so it propagates like any
+        // other literal even though it is still named rather than spelled out.
         ValueDefinition::Constant(Constant::Integer(value)) => IntegerFacts::constant(ty, *value)
+            .map(LatticeValue::Integer)
+            .unwrap_or(LatticeValue::Overdefined),
+        ValueDefinition::Constant(Constant::Layout(constant)) => IntegerFacts::constant(ty, constant.value())
             .map(LatticeValue::Integer)
             .unwrap_or(LatticeValue::Overdefined),
         ValueDefinition::FunctionParameter(_) => IntegerFacts::full(ty)
@@ -313,11 +324,23 @@ fn evaluate_value_operation(
             | ValueOperation::TruncateUint8
             | ValueOperation::TruncateUint16
             | ValueOperation::AssumeInt32
-            | ValueOperation::AssumeUint32,
+            | ValueOperation::AssumeUint32
+            // Unboxing an integer keeps the payload bits and drops the tag,
+            // which is what narrowing to the result's width already does.
+            | ValueOperation::UnboxInt32 { .. }
+            | ValueOperation::ReinterpretUint64AsValue,
             [input],
         ) => exact_unary(*input, result, |value| value),
+        (ValueOperation::UnboxObject, [input]) => {
+            exact_unary(*input, result, |value| value & ((1 << VALUE_TAG_SHIFT) - 1))
+        }
         (ValueOperation::LogicalNot, [input]) => {
             exact_unary(*input, result, |value| u64::from(value == 0))
+        }
+        // A value's tag is the top of its bits, so knowing a value is knowing
+        // its type. This lets checks on known values fold.
+        (ValueOperation::ExtractTag { .. }, [input]) => {
+            exact_unary(*input, result, |value| value >> VALUE_TAG_SHIFT)
         }
         _ => result,
     }
@@ -785,7 +808,9 @@ fn integer_type(ty: &Type) -> Option<(u8, bool)> {
         Type::U8 => (8, false),
         Type::U16 | Type::ValueTag => (16, false),
         Type::U32 => (32, false),
-        Type::U64 => (64, false),
+        // A Value is nothing but the 64 bits it is boxed into, so reasoning
+        // about those bits is reasoning about the value.
+        Type::U64 | Type::Value => (64, false),
         Type::Bool => (1, false),
         _ => return None,
     })

--- a/Libraries/LibJS/Flap/src/ssa/sccp.rs
+++ b/Libraries/LibJS/Flap/src/ssa/sccp.rs
@@ -111,6 +111,10 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
     let mut executable_blocks = vec![false; function.blocks.len()];
     let mut executable_edges = HashSet::new();
     executable_blocks[function.entry.0] = true;
+    // Which edges are *selected* changes as the analysis learns, but which
+    // edges *exist* does not, so the graph is walked once. Rediscovering a
+    // block's predecessors by scanning every other block is quadratic.
+    let incoming_edges = incoming_edges(function);
 
     loop {
         let mut changed = false;
@@ -122,11 +126,9 @@ pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bo
             let block = BlockId(block_index);
             for (parameter_index, parameter) in function.blocks[block_index].parameters.iter().enumerate() {
                 let mut incoming = LatticeValue::Unknown;
-                for predecessor_index in 0..function.blocks.len() {
-                    for (edge_index, edge) in selected_edges(function, BlockId(predecessor_index), &values) {
-                        if edge.block == block && executable_edges.contains(&(predecessor_index, edge_index)) {
-                            incoming = join_lattice(incoming, values[edge.arguments[parameter_index].0]);
-                        }
+                for edge in &incoming_edges[block_index] {
+                    if executable_edges.contains(&(edge.predecessor, edge.edge_index)) {
+                        incoming = join_lattice(incoming, values[edge.arguments[parameter_index].0]);
                     }
                 }
                 changed |= merge_value(&mut values[parameter.0], incoming, loop_blocks.contains(&block));
@@ -504,6 +506,46 @@ fn relation(lhs: IntegerFacts, rhs: IntegerFacts, relation: Relation) -> Integer
     value
         .map(IntegerFacts::bool)
         .unwrap_or_else(|| IntegerFacts::full(&Type::Bool).unwrap())
+}
+
+/// An edge arriving at a block, named the way `selected_edges` names it.
+struct IncomingEdge {
+    predecessor: usize,
+    edge_index: usize,
+    arguments: Vec<ValueId>,
+}
+
+/// Every edge in the function, grouped by the block it arrives at.
+fn incoming_edges(function: &Function) -> Vec<Vec<IncomingEdge>> {
+    let mut edges: Vec<Vec<IncomingEdge>> = (0..function.blocks.len()).map(|_| Vec::new()).collect();
+    for (predecessor, block) in function.blocks.iter().enumerate() {
+        for (edge_index, edge) in outgoing_edges(block.terminator.as_ref().unwrap()) {
+            edges[edge.block.0].push(IncomingEdge {
+                predecessor,
+                edge_index,
+                arguments: edge.arguments.clone(),
+            });
+        }
+    }
+    edges
+}
+
+/// A terminator's edges, indexed the way `selected_edges` indexes them.
+fn outgoing_edges(terminator: &Terminator) -> Vec<(usize, &Edge)> {
+    match terminator {
+        Terminator::Jump(edge) => vec![(0, edge)],
+        Terminator::Branch {
+            then_edge, else_edge, ..
+        } => vec![(0, then_edge), (1, else_edge)],
+        Terminator::Switch { cases, default, .. } => cases
+            .iter()
+            .enumerate()
+            .map(|(index, (_, edge))| (index, edge))
+            .chain([(cases.len(), default)])
+            .collect(),
+        Terminator::CheckedOperation { success, failure, .. } => vec![(0, success), (1, failure)],
+        Terminator::IndirectJump { .. } | Terminator::Return(_) | Terminator::Unreachable => Vec::new(),
+    }
 }
 
 fn selected_edges<'a>(function: &'a Function, block: BlockId, values: &[LatticeValue]) -> Vec<(usize, &'a Edge)> {

--- a/Libraries/LibJS/Flap/src/ssa/sccp.rs
+++ b/Libraries/LibJS/Flap/src/ssa/sccp.rs
@@ -6,17 +6,15 @@
 
 //! Sparse conditional constant propagation and integer value analysis.
 
-use super::optimize::{
-    eliminate_unreachable_blocks, rewrite_terminator, rewrite_values,
-};
-use super::pass::{AnalysisManager};
+use super::optimize::{eliminate_unreachable_blocks, rewrite_terminator, rewrite_values};
+use super::pass::AnalysisManager;
 use super::{
     BinaryOperation, BlockId, CheckedIntegerOperation, ComparisonDomain, ComparisonRelation, Constant, Edge, Effects,
-    Function, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, Operation, ShiftOperation,
-    Terminator, ValueDefinition, ValueId, ValueOperation,
+    Function, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, Operation, ShiftOperation, Terminator,
+    ValueDefinition, ValueId, ValueOperation,
 };
 use crate::types::Type;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 /// How far a boxed value's tag sits above its payload.
 ///
@@ -102,96 +100,245 @@ impl IntegerFacts {
     }
 }
 
-pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
-    let loop_blocks = analyses
-        .loops(function)
-        .iter()
-        .flat_map(|natural_loop| natural_loop.blocks.iter().copied())
-        .collect::<HashSet<_>>();
-    let mut values = function
-        .values
-        .iter()
-        .map(|value| initial_value(&value.ty, &value.definition))
-        .collect::<Vec<_>>();
-    let mut executable_blocks = vec![false; function.blocks.len()];
-    let mut executable_edges = HashSet::new();
-    executable_blocks[function.entry.0] = true;
-    // Which edges are *selected* changes as the analysis learns, but which
-    // edges *exist* does not, so the graph is walked once. Rediscovering a
-    // block's predecessors by scanning every other block is quadratic.
-    let incoming_edges = incoming_edges(function);
+/// What has to be revisited when one value's lattice entry moves.
+#[derive(Clone, Copy)]
+enum User {
+    Instruction(usize),
+    Terminator(usize),
+    BlockParameter { block: usize, parameter: usize },
+}
 
-    loop {
-        let mut changed = false;
+/// The solver state for one run.
+///
+/// Constant propagation is a monotone dataflow problem, so the answer does not
+/// depend on the order values are visited in, only on reaching a fixpoint.
+/// Visiting every instruction of every reachable block on every round reaches
+/// it, but costs a full sweep whenever the graph learns about another edge.
+/// Driving the solver from a worklist of values whose entries actually moved
+/// reaches the same fixpoint while looking at each instruction about as many
+/// times as its inputs changed.
+struct Solver<'a> {
+    function: &'a Function,
+    values: Vec<LatticeValue>,
+    widens: Vec<bool>,
+    executable_blocks: Vec<bool>,
+    executable_edges: Vec<Vec<bool>>,
+    edge_targets: Vec<Vec<usize>>,
+    incoming_edges: Vec<Vec<IncomingEdge>>,
+    users: Vec<Vec<User>>,
+    owning_block: Vec<usize>,
+    block_worklist: Vec<usize>,
+    value_worklist: Vec<ValueId>,
+    facts: Vec<IntegerFacts>,
+    selected: Vec<usize>,
+}
 
-        for (block_index, executable) in executable_blocks.iter().copied().enumerate() {
-            if !executable {
-                continue;
+impl<'a> Solver<'a> {
+    fn new(function: &'a Function, analyses: &mut AnalysisManager) -> Self {
+        let mut widens = vec![false; function.blocks.len()];
+        for natural_loop in analyses.loops(function) {
+            for block in &natural_loop.blocks {
+                widens[block.0] = true;
             }
-            let block = BlockId(block_index);
-            for (parameter_index, parameter) in function.blocks[block_index].parameters.iter().enumerate() {
-                let mut incoming = LatticeValue::Unknown;
-                for edge in &incoming_edges[block_index] {
-                    if executable_edges.contains(&(edge.predecessor, edge.edge_index)) {
-                        incoming = join_lattice(incoming, values[edge.arguments[parameter_index].0]);
-                    }
+        }
+        let values = function
+            .values
+            .iter()
+            .map(|value| initial_value(&value.ty, &value.definition))
+            .collect();
+        let edge_targets = function
+            .blocks
+            .iter()
+            .map(|block| {
+                outgoing_edges(block.terminator.as_ref().unwrap())
+                    .into_iter()
+                    .map(|(_, edge)| edge.block.0)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let executable_edges = edge_targets.iter().map(|edges| vec![false; edges.len()]).collect();
+        let mut owning_block = vec![usize::MAX; function.instructions.len()];
+        let mut users = vec![Vec::new(); function.values.len()];
+        for (block_index, block) in function.blocks.iter().enumerate() {
+            for instruction_id in &block.instructions {
+                owning_block[instruction_id.0] = block_index;
+                for input in &function.instructions[instruction_id.0].inputs {
+                    users[input.0].push(User::Instruction(instruction_id.0));
                 }
-                changed |= merge_value(&mut values[parameter.0], incoming, loop_blocks.contains(&block));
             }
-
-            for instruction_id in &function.blocks[block_index].instructions {
-                let instruction = &function.instructions[instruction_id.0];
-                let results = evaluate_operation(
-                    function,
-                    &instruction.operation,
-                    &instruction.inputs,
-                    &instruction.results,
-                    instruction.effects,
-                    &values,
-                );
-                for (result, lattice) in instruction.results.iter().zip(results) {
-                    changed |= merge_value(&mut values[result.0], lattice, loop_blocks.contains(&block));
-                }
+            let terminator = block.terminator.as_ref().unwrap();
+            for input in terminator_conditions(terminator) {
+                users[input.0].push(User::Terminator(block_index));
             }
-
-            if let Terminator::CheckedOperation {
-                operation,
-                inputs,
-                results,
-                effects,
-                ..
-            } = function.blocks[block_index].terminator.as_ref().unwrap()
-            {
-                let result_values = evaluate_operation(function, operation, inputs, results, *effects, &values);
-                for (result, lattice) in results.iter().zip(result_values) {
-                    changed |= merge_value(&mut values[result.0], lattice, loop_blocks.contains(&block));
+            for (_, edge) in outgoing_edges(terminator) {
+                for (parameter, argument) in edge.arguments.iter().enumerate() {
+                    users[argument.0].push(User::BlockParameter {
+                        block: edge.block.0,
+                        parameter,
+                    });
                 }
             }
         }
-
-        let mut predecessor_index = 0;
-        while predecessor_index < function.blocks.len() {
-            if !executable_blocks[predecessor_index] {
-                predecessor_index += 1;
-                continue;
-            }
-            for (edge_index, edge) in selected_edges(function, BlockId(predecessor_index), &values) {
-                if executable_edges.insert((predecessor_index, edge_index)) {
-                    changed = true;
-                }
-                if !executable_blocks[edge.block.0] {
-                    executable_blocks[edge.block.0] = true;
-                    changed = true;
-                }
-            }
-            predecessor_index += 1;
-        }
-
-        if !changed {
-            break;
+        Self {
+            function,
+            values,
+            widens,
+            executable_blocks: vec![false; function.blocks.len()],
+            executable_edges,
+            edge_targets,
+            incoming_edges: incoming_edges(function),
+            users,
+            owning_block,
+            block_worklist: Vec::new(),
+            value_worklist: Vec::new(),
+            facts: Vec::new(),
+            selected: Vec::new(),
         }
     }
 
+    fn solve(&mut self) {
+        self.mark_block(self.function.entry.0);
+        loop {
+            if let Some(block) = self.block_worklist.pop() {
+                self.visit_block(block);
+                continue;
+            }
+            let Some(value) = self.value_worklist.pop() else {
+                break;
+            };
+            // The user lists never change during a run; lifting one out only
+            // releases the borrow on `self` across the visits it drives.
+            let users = std::mem::take(&mut self.users[value.0]);
+            for user in &users {
+                match *user {
+                    User::Instruction(instruction) => self.visit_instruction(instruction),
+                    User::Terminator(block) => self.visit_terminator(block),
+                    User::BlockParameter { block, parameter } => self.visit_block_parameter(block, parameter),
+                }
+            }
+            self.users[value.0] = users;
+        }
+    }
+
+    fn set_value(&mut self, value: ValueId, incoming: LatticeValue, block: usize) {
+        if merge_value(&mut self.values[value.0], incoming, self.widens[block]) {
+            self.value_worklist.push(value);
+        }
+    }
+
+    fn mark_block(&mut self, block: usize) {
+        if !self.executable_blocks[block] {
+            self.executable_blocks[block] = true;
+            self.block_worklist.push(block);
+        }
+    }
+
+    fn mark_edge(&mut self, predecessor: usize, edge_index: usize) {
+        if self.executable_edges[predecessor][edge_index] {
+            return;
+        }
+        self.executable_edges[predecessor][edge_index] = true;
+        let target = self.edge_targets[predecessor][edge_index];
+        if self.executable_blocks[target] {
+            // A newly selected edge brings new arguments to a block already
+            // being analyzed, so its parameters have to take them in.
+            for parameter in 0..self.function.blocks[target].parameters.len() {
+                self.visit_block_parameter(target, parameter);
+            }
+        } else {
+            self.mark_block(target);
+        }
+    }
+
+    fn visit_block(&mut self, block: usize) {
+        for parameter in 0..self.function.blocks[block].parameters.len() {
+            self.visit_block_parameter(block, parameter);
+        }
+        for index in 0..self.function.blocks[block].instructions.len() {
+            let instruction = self.function.blocks[block].instructions[index];
+            self.visit_instruction(instruction.0);
+        }
+        self.visit_terminator(block);
+    }
+
+    fn visit_block_parameter(&mut self, block: usize, parameter: usize) {
+        if !self.executable_blocks[block] {
+            return;
+        }
+        let mut incoming = LatticeValue::Unknown;
+        for edge in &self.incoming_edges[block] {
+            if self.executable_edges[edge.predecessor][edge.edge_index] {
+                incoming = join_lattice(incoming, self.values[edge.arguments[parameter].0]);
+            }
+        }
+        let parameter = self.function.blocks[block].parameters[parameter];
+        self.set_value(parameter, incoming, block);
+    }
+
+    fn visit_instruction(&mut self, index: usize) {
+        let block = self.owning_block[index];
+        if block == usize::MAX || !self.executable_blocks[block] {
+            return;
+        }
+        let function = self.function;
+        let instruction = &function.instructions[index];
+        let mut facts = std::mem::take(&mut self.facts);
+        let evaluation = evaluate_operation(
+            function,
+            &instruction.operation,
+            &instruction.inputs,
+            &instruction.results,
+            instruction.effects,
+            &self.values,
+            &mut facts,
+        );
+        self.facts = facts;
+        for result in &instruction.results {
+            let lattice = evaluation.of(function, *result);
+            self.set_value(*result, lattice, block);
+        }
+    }
+
+    fn visit_terminator(&mut self, block: usize) {
+        if !self.executable_blocks[block] {
+            return;
+        }
+        let function = self.function;
+        let terminator = function.blocks[block].terminator.as_ref().unwrap();
+        if let Terminator::CheckedOperation {
+            operation,
+            inputs,
+            results,
+            effects,
+            ..
+        } = terminator
+        {
+            let mut facts = std::mem::take(&mut self.facts);
+            let evaluation = evaluate_operation(function, operation, inputs, results, *effects, &self.values, &mut facts);
+            self.facts = facts;
+            for result in results {
+                let lattice = evaluation.of(function, *result);
+                self.set_value(*result, lattice, block);
+            }
+        }
+        let mut selected = std::mem::take(&mut self.selected);
+        selected.clear();
+        selected_edges(function, BlockId(block), &self.values, &mut selected);
+        for edge_index in &selected {
+            self.mark_edge(block, *edge_index);
+        }
+        self.selected = selected;
+    }
+}
+
+pub(super) fn run(function: &mut Function, analyses: &mut AnalysisManager) -> bool {
+    let mut solver = Solver::new(function, analyses);
+    solver.solve();
+    let Solver {
+        values,
+        executable_blocks,
+        ..
+    } = solver;
     rewrite(function, &values, &executable_blocks)
 }
 
@@ -258,6 +405,28 @@ fn join_lattice(lhs: LatticeValue, rhs: LatticeValue) -> LatticeValue {
     }
 }
 
+/// What one operation says about its results.
+///
+/// Almost every operation produces exactly one result, so saying that in the
+/// return type keeps evaluation off the heap. Evaluation runs once per changed
+/// input, which is the innermost loop of the whole pass.
+#[derive(Clone, Copy)]
+enum Evaluation {
+    Single(LatticeValue),
+    Unknown,
+    Widest,
+}
+
+impl Evaluation {
+    fn of(self, function: &Function, result: ValueId) -> LatticeValue {
+        match self {
+            Self::Single(lattice) => lattice,
+            Self::Unknown => LatticeValue::Unknown,
+            Self::Widest => integer_or_overdefined(function, result),
+        }
+    }
+}
+
 fn evaluate_operation(
     function: &Function,
     operation: &Operation,
@@ -265,45 +434,42 @@ fn evaluate_operation(
     results: &[ValueId],
     effects: Effects,
     values: &[LatticeValue],
-) -> Vec<LatticeValue> {
+    input_facts: &mut Vec<IntegerFacts>,
+) -> Evaluation {
     if effects != Effects::PURE {
-        return results
-            .iter()
-            .map(|result| integer_or_overdefined(function, *result))
-            .collect();
+        return Evaluation::Widest;
     }
     if inputs.iter().any(|input| values[input.0] == LatticeValue::Unknown) {
-        return vec![LatticeValue::Unknown; results.len()];
+        return Evaluation::Unknown;
     }
-    let Some(result) = results.first() else {
-        return Vec::new();
-    };
     if results.len() != 1 {
-        return results
-            .iter()
-            .map(|result| integer_or_overdefined(function, *result))
-            .collect();
+        return Evaluation::Widest;
     }
+    let result = results[0];
     let Some(result_type) = IntegerFacts::full(&function.values[result.0].ty) else {
-        return vec![LatticeValue::Overdefined];
+        return Evaluation::Single(LatticeValue::Overdefined);
     };
-    let input_facts = inputs
-        .iter()
-        .map(|input| match values[input.0] {
-            LatticeValue::Integer(facts) => Some(facts),
-            LatticeValue::Unknown | LatticeValue::Overdefined => None,
-        })
-        .collect::<Option<Vec<_>>>();
-    let Some(input_facts) = input_facts else {
-        return vec![LatticeValue::Integer(result_type)];
-    };
+    input_facts.clear();
+    for input in inputs {
+        let LatticeValue::Integer(facts) = values[input.0] else {
+            return Evaluation::Single(LatticeValue::Integer(result_type));
+        };
+        input_facts.push(facts);
+    }
+    let input_facts = input_facts.as_slice();
     let facts = match operation {
-        Operation::Intrinsic(Intrinsic::Value(operation)) => evaluate_value_operation(*operation, &input_facts, result_type),
-        Operation::Intrinsic(Intrinsic::IntegerBinary(operation)) => evaluate_integer_binary(*operation, &input_facts, result_type),
-        Operation::Intrinsic(Intrinsic::IntegerComparison(operation)) => evaluate_integer_comparison(*operation, &input_facts, result_type),
+        Operation::Intrinsic(Intrinsic::Value(operation)) => {
+            evaluate_value_operation(*operation, input_facts, result_type)
+        }
+        Operation::Intrinsic(Intrinsic::IntegerBinary(operation)) => {
+            evaluate_integer_binary(*operation, input_facts, result_type)
+        }
+        Operation::Intrinsic(Intrinsic::IntegerComparison(operation)) => {
+            evaluate_integer_comparison(*operation, input_facts, result_type)
+        }
         _ => result_type,
     };
-    vec![LatticeValue::Integer(facts)]
+    Evaluation::Single(LatticeValue::Integer(facts))
 }
 
 fn integer_or_overdefined(function: &Function, value: ValueId) -> LatticeValue {
@@ -312,11 +478,7 @@ fn integer_or_overdefined(function: &Function, value: ValueId) -> LatticeValue {
         .unwrap_or(LatticeValue::Overdefined)
 }
 
-fn evaluate_value_operation(
-    operation: ValueOperation,
-    inputs: &[IntegerFacts],
-    result: IntegerFacts,
-) -> IntegerFacts {
+fn evaluate_value_operation(operation: ValueOperation, inputs: &[IntegerFacts], result: IntegerFacts) -> IntegerFacts {
     match (operation, inputs) {
         (
             ValueOperation::ToInt32
@@ -334,14 +496,11 @@ fn evaluate_value_operation(
         (ValueOperation::UnboxObject, [input]) => {
             exact_unary(*input, result, |value| value & ((1 << VALUE_TAG_SHIFT) - 1))
         }
-        (ValueOperation::LogicalNot, [input]) => {
-            exact_unary(*input, result, |value| u64::from(value == 0))
-        }
+        (ValueOperation::LogicalNot, [input]) => exact_unary(*input, result, |value| u64::from(value == 0)),
         // A value's tag is the top of its bits, so knowing a value is knowing
-        // its type. This lets checks on known values fold.
-        (ValueOperation::ExtractTag { .. }, [input]) => {
-            exact_unary(*input, result, |value| value >> VALUE_TAG_SHIFT)
-        }
+        // its type. This is what lets the type check on a known value fold, and
+        // with it the paths that check guards.
+        (ValueOperation::ExtractTag { .. }, [input]) => exact_unary(*input, result, |value| value >> VALUE_TAG_SHIFT),
         _ => result,
     }
 }
@@ -357,9 +516,10 @@ fn evaluate_integer_comparison(
     match operation {
         IntegerComparisonOperation::Equal => equality(true, *lhs, *rhs),
         IntegerComparisonOperation::NotEqual => equality(false, *lhs, *rhs),
-        IntegerComparisonOperation::Relational { relation: comparison, domain }
-            if domain != ComparisonDomain::UnsignedInteger =>
-        {
+        IntegerComparisonOperation::Relational {
+            relation: comparison,
+            domain,
+        } if domain != ComparisonDomain::UnsignedInteger => {
             let range_relation = match comparison {
                 ComparisonRelation::Less => Relation::Less,
                 ComparisonRelation::LessOrEqual => Relation::LessEqual,
@@ -382,14 +542,20 @@ fn evaluate_integer_binary(
     };
     match operation {
         IntegerBinaryOperation::Binary(BinaryOperation::Add) => arithmetic_range(*lhs, *rhs, result, Arithmetic::Add),
-        IntegerBinaryOperation::Binary(BinaryOperation::Subtract) => arithmetic_range(*lhs, *rhs, result, Arithmetic::Sub),
-        IntegerBinaryOperation::Binary(BinaryOperation::Multiply) => arithmetic_range(*lhs, *rhs, result, Arithmetic::Mul),
+        IntegerBinaryOperation::Binary(BinaryOperation::Subtract) => {
+            arithmetic_range(*lhs, *rhs, result, Arithmetic::Sub)
+        }
+        IntegerBinaryOperation::Binary(BinaryOperation::Multiply) => {
+            arithmetic_range(*lhs, *rhs, result, Arithmetic::Mul)
+        }
         IntegerBinaryOperation::Binary(BinaryOperation::And) => bitwise(*lhs, *rhs, result, Bitwise::And),
         IntegerBinaryOperation::Binary(BinaryOperation::Or) => bitwise(*lhs, *rhs, result, Bitwise::Or),
         IntegerBinaryOperation::Binary(BinaryOperation::Xor) => bitwise(*lhs, *rhs, result, Bitwise::Xor),
         IntegerBinaryOperation::Shift(ShiftOperation::Left) => shift(*lhs, *rhs, result, Shift::Left),
         IntegerBinaryOperation::Shift(ShiftOperation::RightLogical) => shift(*lhs, *rhs, result, Shift::LogicalRight),
-        IntegerBinaryOperation::Shift(ShiftOperation::RightArithmetic) => shift(*lhs, *rhs, result, Shift::ArithmeticRight),
+        IntegerBinaryOperation::Shift(ShiftOperation::RightArithmetic) => {
+            shift(*lhs, *rhs, result, Shift::ArithmeticRight)
+        }
     }
 }
 
@@ -571,59 +737,61 @@ fn outgoing_edges(terminator: &Terminator) -> Vec<(usize, &Edge)> {
     }
 }
 
-fn selected_edges<'a>(function: &'a Function, block: BlockId, values: &[LatticeValue]) -> Vec<(usize, &'a Edge)> {
+/// The edges a terminator can take given what is currently known, by index.
+fn selected_edges(function: &Function, block: BlockId, values: &[LatticeValue], selected: &mut Vec<usize>) {
     match function.blocks[block.0].terminator.as_ref().unwrap() {
-        Terminator::Jump(edge) => vec![(0, edge)],
-        Terminator::Branch {
-            condition,
-            then_edge,
-            else_edge,
-        } => {
+        Terminator::Jump(_) => selected.push(0),
+        Terminator::Branch { condition, .. } => {
             if values[condition.0] == LatticeValue::Unknown {
-                Vec::new()
-            } else {
-                match exact_integer(values[condition.0]) {
-                    Some(0) => vec![(1, else_edge)],
-                    Some(_) => vec![(0, then_edge)],
-                    None => vec![(0, then_edge), (1, else_edge)],
-                }
+                return;
+            }
+            match exact_integer(values[condition.0]) {
+                Some(0) => selected.push(1),
+                Some(_) => selected.push(0),
+                None => selected.extend([0, 1]),
             }
         }
-        Terminator::Switch { value, cases, default } => {
+        Terminator::Switch { value, cases, default: _ } => {
             if values[value.0] == LatticeValue::Unknown {
-                return Vec::new();
+                return;
             }
             let Some(value) = exact_integer(values[value.0]) else {
-                return cases
-                    .iter()
-                    .enumerate()
-                    .map(|(index, (_, edge))| (index, edge))
-                    .chain([(cases.len(), default)])
-                    .collect();
+                selected.extend(0..=cases.len());
+                return;
             };
-            let (index, edge) = cases
+            let index = cases
                 .iter()
-                .enumerate()
-                .find_map(|(index, (pattern, edge))| pattern_matches(function, pattern, value).then_some((index, edge)))
-                .unwrap_or((cases.len(), default));
-            vec![(index, edge)]
+                .position(|(pattern, _)| pattern_matches(function, pattern, value))
+                .unwrap_or(cases.len());
+            selected.push(index);
         }
         Terminator::CheckedOperation {
-            operation,
-            inputs,
-            success,
-            failure,
-            ..
+            operation, inputs, ..
         } => {
             if inputs.iter().any(|input| values[input.0] == LatticeValue::Unknown) {
-                Vec::new()
-            } else if checked_operation_cannot_fail(operation, inputs, values) {
-                vec![(0, success)]
+                return;
+            }
+            if checked_operation_cannot_fail(operation, inputs, values) {
+                selected.push(0);
             } else {
-                vec![(0, success), (1, failure)]
+                selected.extend([0, 1]);
             }
         }
-        Terminator::IndirectJump { .. } | Terminator::Return(_) | Terminator::Unreachable => Vec::new(),
+        Terminator::IndirectJump { .. } | Terminator::Return(_) | Terminator::Unreachable => {}
+    }
+}
+
+/// The values a terminator inspects to decide where control goes, as opposed
+/// to the arguments it merely passes along its edges.
+fn terminator_conditions(terminator: &Terminator) -> Vec<ValueId> {
+    match terminator {
+        Terminator::Branch { condition, .. } => vec![*condition],
+        Terminator::Switch { value, .. } => vec![*value],
+        Terminator::CheckedOperation { inputs, .. } => inputs.clone(),
+        Terminator::Jump(_)
+        | Terminator::IndirectJump { .. }
+        | Terminator::Return(_)
+        | Terminator::Unreachable => Vec::new(),
     }
 }
 
@@ -858,12 +1026,7 @@ mod tests {
         inputs: Vec<ValueId>,
         ty: Type,
     ) -> ValueId {
-        function.append_instruction(
-            block,
-            operation,
-            inputs,
-            vec![ty],
-        )[0]
+        function.append_instruction(block, operation, inputs, vec![ty])[0]
     }
 
     #[test]
@@ -878,7 +1041,9 @@ mod tests {
         let sum = append_pure(
             &mut function,
             entry,
-            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add))),
+            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                BinaryOperation::Add,
+            ))),
             vec![three, four],
             Type::I32,
         );
@@ -920,7 +1085,9 @@ mod tests {
         let masked = append_pure(
             &mut function,
             entry,
-            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::And))),
+            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                BinaryOperation::And,
+            ))),
             vec![input, zero],
             Type::I32,
         );
@@ -956,18 +1123,9 @@ mod tests {
         let ten = function.add_constant(Type::I32, Constant::Integer(10));
         let twenty = function.add_constant(Type::I32, Constant::Integer(20));
         let one = function.add_constant(Type::I32, Constant::Integer(1));
-        function.set_terminator(
-            entry,
-            Terminator::branch(function.parameter(0), left, right),
-        );
-        function.set_terminator(
-            left,
-            Terminator::jump_with_arguments(join, vec![ten]),
-        );
-        function.set_terminator(
-            right,
-            Terminator::jump_with_arguments(join, vec![twenty]),
-        );
+        function.set_terminator(entry, Terminator::branch(function.parameter(0), left, right));
+        function.set_terminator(left, Terminator::jump_with_arguments(join, vec![ten]));
+        function.set_terminator(right, Terminator::jump_with_arguments(join, vec![twenty]));
         function.set_checked_operation(
             join,
             Intrinsic::CheckedInteger(CheckedIntegerOperation::Add),
@@ -987,15 +1145,12 @@ mod tests {
         run_sccp(&mut function);
 
         assert_eq!(function.blocks.len(), 5);
-        assert!(
-            function
-                .instructions
-                .iter()
-                .any(|instruction| {
-                    instruction.operation
-                        == Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add)))
-                })
-        );
+        assert!(function.instructions.iter().any(|instruction| {
+            instruction.operation
+                == Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                    BinaryOperation::Add,
+                )))
+        }));
         assert!(matches!(function.blocks[join.0].terminator, Some(Terminator::Jump(_))));
     }
 
@@ -1008,7 +1163,9 @@ mod tests {
         let shifted = append_pure(
             &mut function,
             entry,
-            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Shift(ShiftOperation::Left))),
+            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Shift(
+                ShiftOperation::Left,
+            ))),
             vec![one, forty],
             Type::U64,
         );
@@ -1052,7 +1209,9 @@ mod tests {
         let doubled = append_pure(
             &mut function,
             success,
-            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add))),
+            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                BinaryOperation::Add,
+            ))),
             vec![results[0], results[0]],
             Type::I32,
         );
@@ -1078,22 +1237,12 @@ mod tests {
         let right = function.create_empty_block("right", super::super::BlockLayout::Hot);
         let join = function.create_named_block("join", super::super::BlockLayout::Hot, vec![Type::I32]);
         let zero_block = function.create_empty_block("zero", super::super::BlockLayout::Hot);
-        let nonzero_block =
-            function.create_empty_block("nonzero", super::super::BlockLayout::Hot);
+        let nonzero_block = function.create_empty_block("nonzero", super::super::BlockLayout::Hot);
         let zero = function.add_constant(Type::I32, Constant::Integer(0));
         let one = function.add_constant(Type::I32, Constant::Integer(1));
-        function.set_terminator(
-            entry,
-            Terminator::branch(function.parameter(0), left, right),
-        );
-        function.set_terminator(
-            left,
-            Terminator::jump_with_arguments(join, vec![zero]),
-        );
-        function.set_terminator(
-            right,
-            Terminator::jump_with_arguments(join, vec![one]),
-        );
+        function.set_terminator(entry, Terminator::branch(function.parameter(0), left, right));
+        function.set_terminator(left, Terminator::jump_with_arguments(join, vec![zero]));
+        function.set_terminator(right, Terminator::jump_with_arguments(join, vec![one]));
         let join_value = function.blocks[join.0].parameters[0];
         let condition = append_pure(
             &mut function,
@@ -1126,15 +1275,14 @@ mod tests {
         let exit = function.create_empty_block("exit", super::super::BlockLayout::Hot);
         let zero = function.add_constant(Type::I32, Constant::Integer(0));
         let one = function.add_constant(Type::I32, Constant::Integer(1));
-        function.set_terminator(
-            entry,
-            Terminator::jump_with_arguments(header, vec![zero]),
-        );
+        function.set_terminator(entry, Terminator::jump_with_arguments(header, vec![zero]));
         let induction = function.blocks[header.0].parameters[0];
         let next = append_pure(
             &mut function,
             header,
-            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Add))),
+            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                BinaryOperation::Add,
+            ))),
             vec![induction, one],
             Type::I32,
         );
@@ -1166,7 +1314,9 @@ mod tests {
         let product = append_pure(
             &mut function,
             entry,
-            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(BinaryOperation::Multiply))),
+            Operation::Intrinsic(Intrinsic::IntegerBinary(IntegerBinaryOperation::Binary(
+                BinaryOperation::Multiply,
+            ))),
             vec![lhs, rhs],
             Type::U64,
         );

--- a/Libraries/LibJS/Flap/src/ssa/sccp.rs
+++ b/Libraries/LibJS/Flap/src/ssa/sccp.rs
@@ -15,8 +15,8 @@ use super::{
     Function, IntegerBinaryOperation, IntegerComparisonOperation, Intrinsic, Operation, ShiftOperation, Terminator,
     ValueDefinition, ValueId, ValueOperation,
 };
-use crate::types::Type;
 use crate::hash::HashMap;
+use crate::types::Type;
 
 /// How far a boxed value's tag sits above its payload.
 ///
@@ -336,7 +336,8 @@ impl<'a> Solver<'a> {
         } = terminator
         {
             let mut facts = std::mem::take(&mut self.facts);
-            let evaluation = evaluate_operation(function, operation, inputs, results, *effects, &self.values, &mut facts);
+            let evaluation =
+                evaluate_operation(function, operation, inputs, results, *effects, &self.values, &mut facts);
             self.facts = facts;
             for result in results {
                 let lattice = evaluation.of(function, *result);
@@ -810,7 +811,11 @@ fn selected_terminator_edges(function: &Function, block: BlockId, values: &[Latt
                 None => selected.extend([0, 1]),
             }
         }
-        Terminator::Switch { value, cases, default: _ } => {
+        Terminator::Switch {
+            value,
+            cases,
+            default: _,
+        } => {
             if values[value.0] == LatticeValue::Unknown {
                 return;
             }
@@ -824,9 +829,7 @@ fn selected_terminator_edges(function: &Function, block: BlockId, values: &[Latt
                 .unwrap_or(cases.len());
             selected.push(index);
         }
-        Terminator::CheckedOperation {
-            operation, inputs, ..
-        } => {
+        Terminator::CheckedOperation { operation, inputs, .. } => {
             if inputs.iter().any(|input| values[input.0] == LatticeValue::Unknown) {
                 return;
             }
@@ -847,10 +850,9 @@ fn terminator_conditions(terminator: &Terminator) -> Vec<ValueId> {
         Terminator::Branch { condition, .. } => vec![*condition],
         Terminator::Switch { value, .. } => vec![*value],
         Terminator::CheckedOperation { inputs, .. } => inputs.clone(),
-        Terminator::Jump(_)
-        | Terminator::IndirectJump { .. }
-        | Terminator::Return(_)
-        | Terminator::Unreachable => Vec::new(),
+        Terminator::Jump(_) | Terminator::IndirectJump { .. } | Terminator::Return(_) | Terminator::Unreachable => {
+            Vec::new()
+        }
     }
 }
 

--- a/Libraries/LibJS/Flap/src/ssa/sccp.rs
+++ b/Libraries/LibJS/Flap/src/ssa/sccp.rs
@@ -14,7 +14,7 @@ use super::{
     ValueDefinition, ValueId, ValueOperation,
 };
 use crate::types::Type;
-use std::collections::HashMap;
+use crate::hash::HashMap;
 
 /// How far a boxed value's tag sits above its payload.
 ///
@@ -837,7 +837,7 @@ fn arithmetic_candidates(lhs: IntegerFacts, rhs: IntegerFacts, operation: Arithm
 
 fn rewrite(function: &mut Function, values: &[LatticeValue], executable_blocks: &[bool]) -> bool {
     let mut changed = false;
-    let mut replacements = HashMap::new();
+    let mut replacements = HashMap::default();
     let mut eliminated_checked_results = Vec::new();
     for (index, lattice) in values.iter().enumerate() {
         let value = ValueId(index);

--- a/Libraries/LibJS/Flap/src/ssa/sccp.rs
+++ b/Libraries/LibJS/Flap/src/ssa/sccp.rs
@@ -6,7 +6,9 @@
 
 //! Sparse conditional constant propagation and integer value analysis.
 
-use super::optimize::{eliminate_unreachable_blocks, rewrite_terminator, rewrite_values};
+use super::optimize::{
+    InstructionOrder, eliminate_unreachable_blocks, rebuild_instruction_arena, rewrite_terminator, rewrite_values,
+};
 use super::pass::AnalysisManager;
 use super::{
     BinaryOperation, BlockId, CheckedIntegerOperation, ComparisonDomain, ComparisonRelation, Constant, Edge, Effects,
@@ -124,6 +126,7 @@ struct Solver<'a> {
     executable_blocks: Vec<bool>,
     executable_edges: Vec<Vec<bool>>,
     edge_targets: Vec<Vec<usize>>,
+    guard_edges: Vec<Vec<(ValueId, usize)>>,
     incoming_edges: Vec<Vec<IncomingEdge>>,
     users: Vec<Vec<User>>,
     owning_block: Vec<usize>,
@@ -146,13 +149,23 @@ impl<'a> Solver<'a> {
             .iter()
             .map(|value| initial_value(&value.ty, &value.definition))
             .collect();
-        let edge_targets = function
-            .blocks
-            .iter()
+        let guard_edges = (0..function.blocks.len())
             .map(|block| {
-                outgoing_edges(block.terminator.as_ref().unwrap())
+                function
+                    .guard_exits(BlockId(block))
+                    .map(|(position, failure)| {
+                        let instruction = &function.instructions[function.blocks[block].instructions[position].0];
+                        (instruction.inputs[0], failure.0)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let edge_targets = (0..function.blocks.len())
+            .map(|block| {
+                outgoing_edges(function.blocks[block].terminator.as_ref().unwrap())
                     .into_iter()
                     .map(|(_, edge)| edge.block.0)
+                    .chain(guard_edges[block].iter().map(|(_, failure)| *failure))
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -162,8 +175,16 @@ impl<'a> Solver<'a> {
         for (block_index, block) in function.blocks.iter().enumerate() {
             for instruction_id in &block.instructions {
                 owning_block[instruction_id.0] = block_index;
-                for input in &function.instructions[instruction_id.0].inputs {
+                let instruction = &function.instructions[instruction_id.0];
+                for input in &instruction.inputs {
                     users[input.0].push(User::Instruction(instruction_id.0));
+                }
+                // A guard decides an edge, so learning what its condition is
+                // has to send the solver back to the block's edges.
+                if instruction.operation.guard_failure().is_some() {
+                    for input in &instruction.inputs {
+                        users[input.0].push(User::Terminator(block_index));
+                    }
                 }
             }
             let terminator = block.terminator.as_ref().unwrap();
@@ -186,6 +207,7 @@ impl<'a> Solver<'a> {
             executable_blocks: vec![false; function.blocks.len()],
             executable_edges,
             edge_targets,
+            guard_edges,
             incoming_edges: incoming_edges(function),
             users,
             owning_block,
@@ -323,7 +345,13 @@ impl<'a> Solver<'a> {
         }
         let mut selected = std::mem::take(&mut self.selected);
         selected.clear();
-        selected_edges(function, BlockId(block), &self.values, &mut selected);
+        selected_edges(
+            function,
+            BlockId(block),
+            &self.guard_edges[block],
+            &self.values,
+            &mut selected,
+        );
         for edge_index in &selected {
             self.mark_edge(block, *edge_index);
         }
@@ -708,11 +736,22 @@ struct IncomingEdge {
 fn incoming_edges(function: &Function) -> Vec<Vec<IncomingEdge>> {
     let mut edges: Vec<Vec<IncomingEdge>> = (0..function.blocks.len()).map(|_| Vec::new()).collect();
     for (predecessor, block) in function.blocks.iter().enumerate() {
-        for (edge_index, edge) in outgoing_edges(block.terminator.as_ref().unwrap()) {
+        let terminator = block.terminator.as_ref().unwrap();
+        for (edge_index, edge) in outgoing_edges(terminator) {
             edges[edge.block.0].push(IncomingEdge {
                 predecessor,
                 edge_index,
                 arguments: edge.arguments.clone(),
+            });
+        }
+        // A guard exit carries no arguments, so it names no block parameter,
+        // but the block it leaves for is only reached when it is taken.
+        let terminator_edges = terminator.successor_count();
+        for (index, (_, failure)) in function.guard_exits(BlockId(predecessor)).enumerate() {
+            edges[failure.0].push(IncomingEdge {
+                predecessor,
+                edge_index: terminator_edges + index,
+                arguments: Vec::new(),
             });
         }
     }
@@ -738,7 +777,27 @@ fn outgoing_edges(terminator: &Terminator) -> Vec<(usize, &Edge)> {
 }
 
 /// The edges a terminator can take given what is currently known, by index.
-fn selected_edges(function: &Function, block: BlockId, values: &[LatticeValue], selected: &mut Vec<usize>) {
+fn selected_edges(
+    function: &Function,
+    block: BlockId,
+    guard_edges: &[(ValueId, usize)],
+    values: &[LatticeValue],
+    selected: &mut Vec<usize>,
+) {
+    selected_terminator_edges(function, block, values, selected);
+    let terminator_edges = function.blocks[block.0].terminator.as_ref().unwrap().successor_count();
+    for (index, (condition, _)) in guard_edges.iter().enumerate() {
+        // A guard whose condition is known to hold never leaves the block.
+        match exact_integer(values[condition.0]) {
+            Some(0) | None if values[condition.0] != LatticeValue::Unknown => {
+                selected.push(terminator_edges + index);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn selected_terminator_edges(function: &Function, block: BlockId, values: &[LatticeValue], selected: &mut Vec<usize>) {
     match function.blocks[block.0].terminator.as_ref().unwrap() {
         Terminator::Jump(_) => selected.push(0),
         Terminator::Branch { condition, .. } => {
@@ -916,6 +975,22 @@ fn rewrite(function: &mut Function, values: &[LatticeValue], executable_blocks: 
             changed = true;
         }
     }
+    // A guard whose condition is known to hold cannot exit, and dropping it
+    // often leaves the block it guarded against unreachable. This reads the
+    // conditions before they are rewritten, since a value the rewrite
+    // introduces has no entry in the lattice.
+    let eliminated_guards = function
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter(|instruction| {
+            let instruction = &function.instructions[instruction.0];
+            instruction.operation.guard_failure().is_some()
+                && exact_integer(values[instruction.inputs[0].0]).is_some_and(|condition| condition != 0)
+        })
+        .copied()
+        .collect::<crate::hash::HashSet<_>>();
+
     // NB: Rewriting after the block loop, so that a checked operation replaced by an unchecked one
     //     also redirects the uses of its results, including in the replacement instruction itself.
     for instruction in &mut function.instructions {
@@ -926,6 +1001,10 @@ fn rewrite(function: &mut Function, values: &[LatticeValue], executable_blocks: 
     }
     for result in eliminated_checked_results {
         function.values[result.0].definition = ValueDefinition::Dead;
+    }
+    if !eliminated_guards.is_empty() {
+        rebuild_instruction_arena(function, &eliminated_guards, InstructionOrder::ByBlock);
+        changed = true;
     }
     changed |= !replacements.is_empty();
     changed |= executable_blocks.iter().any(|executable| !executable) && eliminate_unreachable_blocks(function);

--- a/Libraries/LibJS/Flap/src/target/aarch64.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64.rs
@@ -4,27 +4,26 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::{Architecture, CompileOptions, ObjectFormat};
-use crate::frontend::layout::KnownLayoutConstant;
-use super::description::{BinaryOperation, FloatBinaryOperation, FloatConversion as IntrinsicFloatConversion, FloatUnaryOperation, FloatingPointOperation, IntegerBinaryOperation, IntegerWidth, MemoryOperation, MemoryWidth, Operation, PairWidth, ShiftOperation, SignCondition, TestCondition, ZeroCondition};
-use super::ir::{
-    MachineFunction as Handler, MachineInstruction, MachineProgram as Program,
-    MachineCondition as Condition, MachineMemoryAddress,
-    MachineOperand as Operand, RuntimeConstants,
-};
-use super::machine_verify::{
-    define_machine_opcodes, operands_match,
-};
-use super::registers::{PhysicalRegister, aarch64 as registers};
 use super::description::OperandKind::{
-    FprIn as FR, FuncSymbol as F, GprIn as R, Imm as I, Label as L,
-    Memory as A, RegisterIn as AR,
+    FprIn as FR, FuncSymbol as F, GprIn as R, Imm as I, Label as L, Memory as A, RegisterIn as AR,
+};
+use super::description::{
+    BinaryOperation, FloatBinaryOperation, FloatConversion as IntrinsicFloatConversion, FloatUnaryOperation,
+    FloatingPointOperation, IntegerBinaryOperation, IntegerWidth, MemoryOperation, MemoryWidth, Operation, PairWidth,
+    ShiftOperation, SignCondition, TestCondition, ZeroCondition,
 };
 use super::emitter::{
-    SimpleInstruction, SimpleOperand, emit_file_header, emit_handlers,
-    emit_label, emit_program, emit_simple_instruction, integer, native,
-    pair, simple, single, w, word,
+    SimpleInstruction, SimpleOperand, emit_file_header, emit_handlers, emit_label, emit_program,
+    emit_simple_instruction, integer, native, pair, simple, single, w, word,
 };
+use super::ir::{
+    MachineCondition as Condition, MachineFunction as Handler, MachineInstruction, MachineMemoryAddress,
+    MachineOperand as Operand, MachineProgram as Program, RuntimeConstants,
+};
+use super::machine_verify::{define_machine_opcodes, operands_match};
+use super::registers::{PhysicalRegister, aarch64 as registers};
+use crate::frontend::layout::KnownLayoutConstant;
+use crate::{Architecture, CompileOptions, ObjectFormat};
 use std::fmt::Write;
 
 pub(crate) mod finalize;
@@ -54,9 +53,7 @@ impl LogicalOperation {
             BinaryOperation::And => Some(Self::And),
             BinaryOperation::Or => Some(Self::Or),
             BinaryOperation::Xor => Some(Self::Xor),
-            BinaryOperation::Add
-            | BinaryOperation::Subtract
-            | BinaryOperation::Multiply => None,
+            BinaryOperation::Add | BinaryOperation::Subtract | BinaryOperation::Multiply => None,
         }
     }
 
@@ -142,13 +139,13 @@ pub(crate) enum FloatConversion {
     JavaScriptToSigned32,
 }
 
-fn load_instruction(
-    width: MemoryWidth,
-    signed: bool,
-    addressing: MemoryAddressing,
-) -> SimpleInstruction {
+fn load_instruction(width: MemoryWidth, signed: bool, addressing: MemoryAddressing) -> SimpleInstruction {
     let mnemonic = match (width, signed, addressing) {
-        (MemoryWidth::DoubleWord | MemoryWidth::Float | MemoryWidth::Word, false, MemoryAddressing::UnscaledImmediate) => "ldur",
+        (
+            MemoryWidth::DoubleWord | MemoryWidth::Float | MemoryWidth::Word,
+            false,
+            MemoryAddressing::UnscaledImmediate,
+        ) => "ldur",
         (MemoryWidth::Word, true, MemoryAddressing::UnscaledImmediate) => "ldursw",
         (MemoryWidth::HalfWord, false, MemoryAddressing::UnscaledImmediate) => "ldurh",
         (MemoryWidth::HalfWord, true, MemoryAddressing::UnscaledImmediate) => "ldursh",
@@ -175,7 +172,9 @@ fn load_instruction(
 
 fn store_instruction(width: MemoryWidth, addressing: MemoryAddressing) -> SimpleInstruction {
     let mnemonic = match (width, addressing) {
-        (MemoryWidth::DoubleWord | MemoryWidth::Float | MemoryWidth::Word, MemoryAddressing::UnscaledImmediate) => "stur",
+        (MemoryWidth::DoubleWord | MemoryWidth::Float | MemoryWidth::Word, MemoryAddressing::UnscaledImmediate) => {
+            "stur"
+        }
         (MemoryWidth::HalfWord, MemoryAddressing::UnscaledImmediate) => "sturh",
         (MemoryWidth::Byte, MemoryAddressing::UnscaledImmediate) => "sturb",
         (MemoryWidth::DoubleWord | MemoryWidth::Float | MemoryWidth::Word, _) => "str",
@@ -478,15 +477,13 @@ fn memory_address_is_encodable(
     address: &MachineMemoryAddress,
 ) -> bool {
     match addressing {
-        MemoryAddressing::Base => {
-            address.index.is_none()
-                && address.displacement.is_none()
-                && address.scale.is_none()
-        }
+        MemoryAddressing::Base => address.index.is_none() && address.displacement.is_none() && address.scale.is_none(),
         MemoryAddressing::UnsignedImmediate => {
             address.index.is_none()
                 && address.scale.is_none()
-                && address.displacement.is_some_and(|offset| unsigned_memory_offset_fits(width, offset))
+                && address
+                    .displacement
+                    .is_some_and(|offset| unsigned_memory_offset_fits(width, offset))
         }
         MemoryAddressing::UnscaledImmediate => {
             address.index.is_none()
@@ -496,9 +493,7 @@ fn memory_address_is_encodable(
                     .is_some_and(|offset| (-256..=255).contains(&offset))
         }
         MemoryAddressing::Register => {
-            address.index.is_some()
-                && address.scale.is_none()
-                && address.displacement.is_none()
+            address.index.is_some() && address.scale.is_none() && address.displacement.is_none()
         }
         MemoryAddressing::ShiftedRegister(shift) => {
             AddressIndexShift::for_memory(width, 1 << shift.amount()) == Some(shift)
@@ -525,13 +520,12 @@ pub(crate) fn pair_offset_fits(width: PairWidth, offset: i64) -> bool {
     }
 }
 
-fn pair_address_is_encodable(
-    width: PairWidth,
-    address: &MachineMemoryAddress,
-) -> bool {
+fn pair_address_is_encodable(width: PairWidth, address: &MachineMemoryAddress) -> bool {
     address.index.is_none()
         && address.scale.is_none()
-        && address.displacement.is_none_or(|offset| pair_offset_fits(width, offset))
+        && address
+            .displacement
+            .is_none_or(|offset| pair_offset_fits(width, offset))
 }
 
 impl Opcode {
@@ -543,28 +537,18 @@ impl Opcode {
             Operation::IntegerBinary {
                 operation: IntegerBinaryOperation::Binary(operation),
                 width: IntegerWidth::U64,
-            }
-                if matches!(
-                    operation,
-                    BinaryOperation::Add | BinaryOperation::Subtract
-                ) =>
-            {
+            } if matches!(operation, BinaryOperation::Add | BinaryOperation::Subtract) => {
                 let operation = match operation {
                     BinaryOperation::Add => AddSubtractOperation::Add,
-                    BinaryOperation::Subtract => {
-                        AddSubtractOperation::Subtract
-                    }
+                    BinaryOperation::Subtract => AddSubtractOperation::Subtract,
                     _ => unreachable!(),
                 };
                 match operands.get(1) {
-                    Some(super::ir::Operand::Immediate(0))
-                        if operation == AddSubtractOperation::Add =>
-                    {
+                    Some(super::ir::Operand::Immediate(0)) if operation == AddSubtractOperation::Add => {
                         Self::AddSubtractZero(operation)
                     }
                     Some(super::ir::Operand::Immediate(value))
-                        if operation == AddSubtractOperation::Add
-                            && (1..=4095).contains(value) =>
+                        if operation == AddSubtractOperation::Add && (1..=4095).contains(value) =>
                     {
                         Self::AddSubtractImmediate {
                             operation,
@@ -585,8 +569,7 @@ impl Opcode {
                         }
                     }
                     Some(super::ir::Operand::Immediate(value))
-                        if operation == AddSubtractOperation::Add
-                            && (-4095..0).contains(value) =>
+                        if operation == AddSubtractOperation::Add && (-4095..0).contains(value) =>
                     {
                         Self::AddSubtractImmediate {
                             operation: AddSubtractOperation::Subtract,
@@ -595,8 +578,7 @@ impl Opcode {
                         }
                     }
                     Some(super::ir::Operand::Immediate(value))
-                        if operation == AddSubtractOperation::Subtract
-                            && (1..=4095).contains(value) =>
+                        if operation == AddSubtractOperation::Subtract && (1..=4095).contains(value) =>
                     {
                         Self::AddSubtractImmediate {
                             operation,
@@ -604,16 +586,14 @@ impl Opcode {
                             flags: FlagUpdate::Set,
                         }
                     }
-                    Some(super::ir::Operand::Immediate(_)) => {
-                        Self::AddSubtractLargeImmediate {
-                            operation,
-                            flags: if operation == AddSubtractOperation::Add {
-                                FlagUpdate::Preserve
-                            } else {
-                                FlagUpdate::Set
-                            },
-                        }
-                    }
+                    Some(super::ir::Operand::Immediate(_)) => Self::AddSubtractLargeImmediate {
+                        operation,
+                        flags: if operation == AddSubtractOperation::Add {
+                            FlagUpdate::Preserve
+                        } else {
+                            FlagUpdate::Set
+                        },
+                    },
                     _ => Self::AddSubtractRegister {
                         operation,
                         flags: FlagUpdate::Set,
@@ -631,8 +611,12 @@ impl Opcode {
             }
             Operation::FloatMove => {
                 let is_floating_point = |operand: &super::ir::Operand| match operand {
-                    super::ir::Operand::VirtualRegister(register) => register.class() == crate::types::RegisterClass::FloatingPoint,
-                    super::ir::Operand::PhysicalRegister(register) => register.class() == crate::target::registers::RegisterClass::FloatingPoint,
+                    super::ir::Operand::VirtualRegister(register) => {
+                        register.class() == crate::types::RegisterClass::FloatingPoint
+                    }
+                    super::ir::Operand::PhysicalRegister(register) => {
+                        register.class() == crate::target::registers::RegisterClass::FloatingPoint
+                    }
                     _ => false,
                 };
                 if operands.iter().any(is_floating_point) {
@@ -673,9 +657,7 @@ impl Opcode {
             Operation::Memory(MemoryOperation::Load { .. } | MemoryOperation::Store(_))
             | Operation::Move(_)
             | Operation::IntegerBinary { .. } => {
-                unreachable!(
-                    "operand-sensitive operation must use select_for_operands"
-                )
+                unreachable!("operand-sensitive operation must use select_for_operands")
             }
             _ => Self::Pseudo,
         }
@@ -684,9 +666,7 @@ impl Opcode {
     pub(crate) fn is_pseudo(self) -> bool {
         matches!(
             self,
-            Self::Pseudo
-                | Self::AddSubtractZero(_)
-                | Self::AddSubtractLargeImmediate { .. }
+            Self::Pseudo | Self::AddSubtractZero(_) | Self::AddSubtractLargeImmediate { .. }
         )
     }
 }
@@ -783,13 +763,15 @@ pub(crate) fn generate(program: &Program, options: &CompileOptions) -> String {
         "    ",
         |out| generate_entry_point(out, program, object_format),
         |out| generate_fallback_handler(out, program, object_format),
-        |out| emit_handlers(
-            out,
-            program,
-            "//",
-            |out, _| emit_handler_alignment(out, object_format),
-            emit_instruction,
-        ),
+        |out| {
+            emit_handlers(
+                out,
+                program,
+                "//",
+                |out, _| emit_handler_alignment(out, object_format),
+                emit_instruction,
+            )
+        },
         |out| generate_exit_point(out, object_format),
     )
 }
@@ -887,21 +869,14 @@ fn generate_entry_point(out: &mut String, program: &Program, fmt: ObjectFormat) 
     w!(out, "    // x24 = NAN_BASE_TAG");
 
     // Dispatch to first instruction (x21 = pb + entry_point)
-    w!(
-        out,
-        "    add x21, x26, w1, uxtw   // x21 = pb + entry_point"
-    );
+    w!(out, "    add x21, x26, w1, uxtw   // x21 = pb + entry_point");
     w!(out, "    ldrb w9, [x21]           // w9 = opcode byte");
     w!(out, "    ldr x10, [x19, x9, lsl #3]");
     w!(out, "    br x10");
     w!(out);
 }
 
-fn generate_fallback_handler(
-    out: &mut String,
-    program: &Program,
-    object_format: ObjectFormat,
-) {
+fn generate_fallback_handler(out: &mut String, program: &Program, object_format: ObjectFormat) {
     emit_handler_alignment(out, object_format);
     w!(out, "asm_handler_fallback:");
     // Set up args: x0=vm (x20), w1=pc (ip - pb), x2=instruction (ip)
@@ -941,8 +916,7 @@ fn emit_state_reload(out: &mut String, program: &Program) {
 }
 
 fn emit_sync_pc_to_execution_context(out: &mut String, program: &Program) {
-    let program_counter =
-        runtime(program)[KnownLayoutConstant::ExecutionContextProgramCounter];
+    let program_counter = runtime(program)[KnownLayoutConstant::ExecutionContextProgramCounter];
     emit_str32(out, "w1", "x28", program_counter);
 }
 
@@ -958,55 +932,31 @@ fn emit_dispatch_tail(out: &mut String) {
     w!(out, "    br x10");
 }
 
-fn format_machine_memory_address(
-    address: &MachineMemoryAddress,
-    addressing: MemoryAddressing,
-) -> String {
+fn format_machine_memory_address(address: &MachineMemoryAddress, addressing: MemoryAddressing) -> String {
     match addressing {
         MemoryAddressing::Base => {
-            let (None, None, None) =
-                (address.index, address.scale, address.displacement)
-            else {
-                unreachable!(
-                    "finalized AArch64 base address has extra components"
-                )
+            let (None, None, None) = (address.index, address.scale, address.displacement) else {
+                unreachable!("finalized AArch64 base address has extra components")
             };
             format!("[{}]", address.base)
         }
-        MemoryAddressing::UnsignedImmediate
-        | MemoryAddressing::UnscaledImmediate => {
-            let (None, None, Some(offset)) =
-                (address.index, address.scale, address.displacement)
-            else {
-                unreachable!(
-                    "finalized AArch64 immediate address has invalid components"
-                )
+        MemoryAddressing::UnsignedImmediate | MemoryAddressing::UnscaledImmediate => {
+            let (None, None, Some(offset)) = (address.index, address.scale, address.displacement) else {
+                unreachable!("finalized AArch64 immediate address has invalid components")
             };
             format!("[{}, #{offset}]", address.base)
         }
         MemoryAddressing::Register => {
-            let (Some(index), None, None) =
-                (address.index, address.scale, address.displacement)
-            else {
-                unreachable!(
-                    "finalized AArch64 register address has invalid components"
-                )
+            let (Some(index), None, None) = (address.index, address.scale, address.displacement) else {
+                unreachable!("finalized AArch64 register address has invalid components")
             };
             format!("[{}, {index}]", address.base)
         }
         MemoryAddressing::ShiftedRegister(shift) => {
-            let (Some(index), None, None) =
-                (address.index, address.scale, address.displacement)
-            else {
-                unreachable!(
-                    "finalized AArch64 shifted address has invalid components"
-                )
+            let (Some(index), None, None) = (address.index, address.scale, address.displacement) else {
+                unreachable!("finalized AArch64 shifted address has invalid components")
             };
-            format!(
-                "[{}, {index}, lsl #{}]",
-                address.base,
-                shift.amount()
-            )
+            format!("[{}, {index}, lsl #{}]", address.base, shift.amount())
         }
     }
 }
@@ -1098,7 +1048,10 @@ fn is_replicated_rotated_run(value: u64) -> bool {
     for size in [2u32, 4, 8, 16, 32, 64] {
         let mask = if size == 64 { u64::MAX } else { (1u64 << size) - 1 };
         let element = value & mask;
-        if (size..64).step_by(size as usize).any(|shift| ((value >> shift) & mask) != element) {
+        if (size..64)
+            .step_by(size as usize)
+            .any(|shift| ((value >> shift) & mask) != element)
+        {
             continue;
         }
         let ones = element.count_ones();
@@ -1155,34 +1108,20 @@ fn shift_mnemonic(operation: ShiftOperation) -> &'static str {
     }
 }
 
-fn emit_instruction(
-    out: &mut String,
-    insn: &MachineInstruction,
-    handler: &Handler,
-) {
+fn emit_instruction(out: &mut String, insn: &MachineInstruction, handler: &Handler) {
     let opcode = insn.opcode.aarch64();
     debug_assert!(!opcode.is_pseudo());
-    if emit_simple_instruction(
-        out,
-        insn,
-        opcode.simple_instruction(),
-        |operand| {
-            match operand {
-                Operand::Label(_) => super::emitter::resolve_label(operand, handler),
-                Operand::Address(address) => match opcode {
-                    Opcode::Load { addressing, .. }
-                    | Opcode::Store { addressing, .. } => {
-                        format_machine_memory_address(address, addressing)
-                    }
-                    Opcode::LoadPair(_) | Opcode::StorePair(_) => {
-                        format_pair_memory_address(address)
-                    }
-                    _ => unreachable!("AArch64 opcode has no resolved operand"),
-                }
-                _ => unreachable!("resolved AArch64 operand must be an address or label"),
+    if emit_simple_instruction(out, insn, opcode.simple_instruction(), |operand| match operand {
+        Operand::Label(_) => super::emitter::resolve_label(operand, handler),
+        Operand::Address(address) => match opcode {
+            Opcode::Load { addressing, .. } | Opcode::Store { addressing, .. } => {
+                format_machine_memory_address(address, addressing)
             }
+            Opcode::LoadPair(_) | Opcode::StorePair(_) => format_pair_memory_address(address),
+            _ => unreachable!("AArch64 opcode has no resolved operand"),
         },
-    ) {
+        _ => unreachable!("resolved AArch64 operand must be an address or label"),
+    }) {
         return;
     }
     match opcode {
@@ -1193,14 +1132,14 @@ fn emit_instruction(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::description::{CallKind, EqualityCondition, IntegerSignedness, OrderedCondition};
+    use super::*;
     use crate::low_ir::{
-        AddressDisplacement, AddressRegister, Instruction as SourceInstruction,
-        MemoryAddress as SourceMemoryAddress, Operand as SourceOperand,
+        AddressDisplacement, AddressRegister, Instruction as SourceInstruction, MemoryAddress as SourceMemoryAddress,
+        Operand as SourceOperand,
     };
-    use crate::target::allocator::allocate_program;
     use crate::low_ir::{Handler as SourceHandler, Program as SourceProgram};
+    use crate::target::allocator::allocate_program;
     use crate::target::selection::select_program;
 
     fn test_options() -> CompileOptions {
@@ -1222,12 +1161,7 @@ mod tests {
         let selected = select_program(program.clone(), Architecture::Aarch64).unwrap();
         let allocated = allocate_program(selected).unwrap();
         let options = test_options();
-        let machine =
-            crate::target::finalize::finalize_program(
-                allocated,
-                &options,
-            )
-                .unwrap();
+        let machine = crate::target::finalize::finalize_program(allocated, &options).unwrap();
         super::generate(&machine, &options)
     }
 
@@ -1258,14 +1192,9 @@ mod tests {
     }
 
     fn machine_coff_program(instructions: Vec<SourceInstruction>) -> Program {
-        let selected =
-            select_program(coff_program(instructions), Architecture::Aarch64).unwrap();
+        let selected = select_program(coff_program(instructions), Architecture::Aarch64).unwrap();
         let allocated = allocate_program(selected).unwrap();
-        crate::target::finalize::finalize_program(
-            allocated,
-            &test_options(),
-        )
-        .unwrap()
+        crate::target::finalize::finalize_program(allocated, &test_options()).unwrap()
     }
 
     #[test]
@@ -1297,18 +1226,15 @@ mod tests {
         let program = machine_coff_program(Vec::new());
         let handler = &program.functions[0];
         let instruction = MachineInstruction {
-            opcode: super::super::ir::MachineOpcode::Aarch64(
-                Opcode::MoveRegister(IntegerWidth::U32),
-            ),
-            operands: vec![Operand::PhysicalRegister(crate::target::registers::aarch64::X0), Operand::PhysicalRegister(crate::target::registers::aarch64::X0)],
+            opcode: super::super::ir::MachineOpcode::Aarch64(Opcode::MoveRegister(IntegerWidth::U32)),
+            operands: vec![
+                Operand::PhysicalRegister(crate::target::registers::aarch64::X0),
+                Operand::PhysicalRegister(crate::target::registers::aarch64::X0),
+            ],
         };
         let mut out = String::new();
 
-        emit_instruction(
-            &mut out,
-            &instruction,
-            handler,
-        );
+        emit_instruction(&mut out, &instruction, handler);
 
         assert!(out.contains("mov w0, w0"));
     }
@@ -1343,8 +1269,7 @@ mod tests {
 
     #[test]
     fn dispatching_on_an_assigned_program_counter_reads_it_back() {
-        let program_counter =
-            SourceOperand::InterpreterRegister(crate::types::InterpreterRegister::ProgramCounter);
+        let program_counter = SourceOperand::InterpreterRegister(crate::types::InterpreterRegister::ProgramCounter);
         let output = generate(&coff_program(vec![
             SourceInstruction {
                 opcode: opcode(Operation::Move(IntegerWidth::U32)),
@@ -1453,7 +1378,11 @@ mod tests {
     fn lowers_narrow_signed_branches_at_32_bit_width() {
         let output = generate(&coff_program(vec![
             SourceInstruction {
-                opcode: opcode(Operation::branch_ordered(IntegerWidth::U32, OrderedCondition::Less, IntegerSignedness::Signed)),
+                opcode: opcode(Operation::branch_ordered(
+                    IntegerWidth::U32,
+                    OrderedCondition::Less,
+                    IntegerSignedness::Signed,
+                )),
                 operands: vec![
                     SourceOperand::PhysicalRegister(crate::target::registers::aarch64::X0),
                     SourceOperand::PhysicalRegister(crate::target::registers::aarch64::X1),
@@ -1482,17 +1411,11 @@ mod tests {
 
         for (condition, expected) in cases {
             let instruction = MachineInstruction {
-                opcode: super::super::ir::MachineOpcode::Aarch64(
-                    Opcode::BranchCondition(condition),
-                ),
+                opcode: super::super::ir::MachineOpcode::Aarch64(Opcode::BranchCondition(condition)),
                 operands: vec![Operand::Label(".assert_ok".into())],
             };
             let mut out = String::new();
-            emit_instruction(
-                &mut out,
-                &instruction,
-                handler,
-            );
+            emit_instruction(&mut out, &instruction, handler);
             assert!(out.contains(expected), "{condition:?} emitted:\n{out}");
         }
     }

--- a/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/aarch64/finalize.rs
@@ -6,26 +6,24 @@
 
 //! AArch64 machine instruction finalization.
 
-use crate::target::backend::{Aarch64Backend, Backend};
-use crate::target::description::ArchitectureOpcode;
-use crate::target::finalize_support::{memory_branch, push_plain_move};
 use super::Opcode;
 use super::{AddSubtractOperation, AddressIndexShift, ConditionFlags, FlagUpdate, MemoryAddressing};
 use crate::CompileError;
 use crate::frontend::layout::KnownLayoutConstant;
 use crate::low_ir::Label;
+use crate::target::backend::{Aarch64Backend, Backend};
+use crate::target::description::ArchitectureOpcode;
 use crate::target::description::{
-    AssertionOperation, BinaryOperation, BranchOperation, EqualityCondition, FloatCondition, FloatConversion as IntrinsicFloatConversion,
-    FloatingPointOperation, IntegerWidth, MemoryWidth, Operation, OverflowOperation, PairWidth,
-    ScalarBranchCondition, ShiftOperation, SignCondition, TestCondition, ZeroCondition,
+    AssertionOperation, BinaryOperation, BranchOperation, EqualityCondition, FloatCondition,
+    FloatConversion as IntrinsicFloatConversion, FloatingPointOperation, IntegerWidth, MemoryWidth, Operation,
+    OverflowOperation, PairWidth, ScalarBranchCondition, ShiftOperation, SignCondition, TestCondition, ZeroCondition,
 };
 use crate::target::finalize_support::{
-    Emit,
-    AllocatedOperands, MemoryBranch, finalization_error, finalize_error,
-    indexed_pair_store as decode_indexed_pair_store, machine_address,
-    interpreter_layout, operand_register, pair_access, pair_element_size,
-    verified_label, verified_register,
+    AllocatedOperands, Emit, MemoryBranch, finalization_error, finalize_error,
+    indexed_pair_store as decode_indexed_pair_store, interpreter_layout, machine_address, operand_register,
+    pair_access, pair_element_size, verified_label, verified_register,
 };
+use crate::target::finalize_support::{memory_branch, push_plain_move};
 use crate::target::ir::{
     AllocatedOperand, MachineInstruction, MachineMemoryAddress, MachineOpcode, MachineOperand, RuntimeConstants,
 };
@@ -77,11 +75,7 @@ struct ValueRepresentationBranch {
     target: Label,
 }
 
-fn branch_tag(
-    emit: &mut Emit<'_>,
-    operands: ValueRepresentationBranch,
-    compare_scratch: PhysicalRegister,
-) {
+fn branch_tag(emit: &mut Emit<'_>, operands: ValueRepresentationBranch, compare_scratch: PhysicalRegister) {
     emit!(emit.output, Aarch64;
         Opcode::ShiftImmediate {
         operation: ShiftOperation::RightLogical,
@@ -90,7 +84,6 @@ fn branch_tag(
     );
     compare(
         emit,
-
         operands.scratch,
         &AllocatedOperand::Immediate(operands.representation),
         compare_scratch,
@@ -123,12 +116,7 @@ pub(crate) fn pinned_constant(runtime: &RuntimeConstants, value: i64) -> Option<
     .find_map(|(constant, register)| (constant == Some(value)).then_some(register))
 }
 
-pub(crate) fn move_immediate(
-    emit: &mut Emit<'_>,
-    destination: PhysicalRegister,
-    value: i64,
-    width: IntegerWidth,
-) {
+pub(crate) fn move_immediate(emit: &mut Emit<'_>, destination: PhysicalRegister, value: i64, width: IntegerWidth) {
     for immediate in super::immediate_moves(value, width) {
         let mut operands = vec![
             MachineOperand::PhysicalRegister(destination),
@@ -139,11 +127,7 @@ pub(crate) fn move_immediate(
     }
 }
 
-fn multiply(
-    emit: &mut Emit<'_>,
-    width: IntegerWidth,
-    operands: &[AllocatedOperand],
-) {
+fn multiply(emit: &mut Emit<'_>, width: IntegerWidth, operands: &[AllocatedOperand]) {
     assert_eq!(width, IntegerWidth::U64);
     match operands {
         [destination, source, scratch] => {
@@ -189,20 +173,14 @@ struct LogicalOperands<'a> {
     scratch: PhysicalRegister,
 }
 
-fn logical(
-    emit: &mut Emit<'_>,
-    operation: BinaryOperation,
-    width: IntegerWidth,
-    operands: LogicalOperands<'_>,
-) {
+fn logical(emit: &mut Emit<'_>, operation: BinaryOperation, width: IntegerWidth, operands: LogicalOperands<'_>) {
     let LogicalOperands {
         destination,
         lhs,
         rhs,
         scratch,
     } = operands;
-    let operation = super::LogicalOperation::from_binary(operation)
-        .expect("allocated logical operation was verified");
+    let operation = super::LogicalOperation::from_binary(operation).expect("allocated logical operation was verified");
     match rhs {
         AllocatedOperand::Immediate(value) => {
             let value = match width {
@@ -245,12 +223,7 @@ fn push_logical_register(
     emit!(emit.output, Aarch64; Opcode::LogicalRegister { operation, width } => [register destination, register lhs, register rhs];);
 }
 
-fn push_multiply(
-    emit: &mut Emit<'_>,
-    destination: PhysicalRegister,
-    lhs: PhysicalRegister,
-    rhs: PhysicalRegister,
-) {
+fn push_multiply(emit: &mut Emit<'_>, destination: PhysicalRegister, lhs: PhysicalRegister, rhs: PhysicalRegister) {
     emit!(emit.output, Aarch64; Opcode::Multiply64 => [register destination, register lhs, register rhs];);
 }
 
@@ -342,7 +315,10 @@ pub(crate) fn scratch_register(
 }
 
 pub(crate) fn machine_offset_address(base: PhysicalRegister, offset: i64) -> MachineMemoryAddress {
-    MachineMemoryAddress { displacement: Some(offset), ..MachineMemoryAddress::base(base) }
+    MachineMemoryAddress {
+        displacement: Some(offset),
+        ..MachineMemoryAddress::base(base)
+    }
 }
 
 pub(crate) fn address_add_register(
@@ -366,10 +342,7 @@ struct MemoryBranchOperands<'a> {
     target: &'a Label,
 }
 
-fn emit_memory_branch(
-    emit: &mut Emit<'_>,
-    operands: MemoryBranchOperands<'_>,
-) -> Result<(), MemoryAddressError> {
+fn emit_memory_branch(emit: &mut Emit<'_>, operands: MemoryBranchOperands<'_>) -> Result<(), MemoryAddressError> {
     use super::Condition;
 
     let memory_width = match operands.branch {
@@ -446,14 +419,7 @@ fn branch_any_equal(
 ) {
     use super::Condition;
 
-    compare(
-        emit,
-
-        value,
-        &comparison_values[0],
-        scratch,
-        IntegerWidth::U64,
-    );
+    compare(emit, value, &comparison_values[0], scratch, IntegerWidth::U64);
 
     for comparison_value in &comparison_values[1..] {
         let opcode = match comparison_value {
@@ -506,13 +472,7 @@ fn branch_any_equal(
     emit!(emit.output, Aarch64; Opcode::BranchCondition(Condition::Equal) => [label target.clone()];);
 }
 
-fn branch_bit(
-    emit: &mut Emit<'_>,
-    value: PhysicalRegister,
-    bit: i64,
-    condition: TestCondition,
-    target: &Label,
-) {
+fn branch_bit(emit: &mut Emit<'_>, value: PhysicalRegister, bit: i64, condition: TestCondition, target: &Label) {
     emit!(emit.output, Aarch64;
         Opcode::TestBitAndBranch {
         width: IntegerWidth::U64,
@@ -634,7 +594,7 @@ fn assertion_compare(
     scratch: PhysicalRegister,
     width: IntegerWidth,
 ) {
-    compare(emit,lhs, rhs, scratch, width);
+    compare(emit, lhs, rhs, scratch, width);
 }
 
 fn append_assertion_trap(emit: &mut Emit<'_>, ok_label: Label) {
@@ -724,7 +684,6 @@ fn pair_load(
         first_address.index,
         &[first, second],
         &[base_scratch],
-
     )?;
     let first_offset = first_address.displacement.unwrap_or(0);
     if super::pair_offset_fits(width, first_offset) {
@@ -745,15 +704,8 @@ fn pair_load(
         .ok_or_else(|| finalization_error(emit.handler, "pair-load address offset overflow"))?;
     let second_address = MachineMemoryAddress::offset(base, second_offset);
     let push_load = |emit: &mut Emit<'_>, destination, address| -> Result<(), CompileError> {
-        load(
-            emit,
-            width.into(),
-            false,
-            destination,
-            address,
-            &[address_scratch],
-        )
-        .map_err(|error| memory_address_compile_error(emit.handler, error))
+        load(emit, width.into(), false, destination, address, &[address_scratch])
+            .map_err(|error| memory_address_compile_error(emit.handler, error))
     };
     if first == base {
         push_load(emit, second, second_address)?;
@@ -779,7 +731,6 @@ fn pair_store(
         first_address.index,
         &[first, second],
         &scratch_registers,
-
     )?;
     let first_offset = first_address.displacement.unwrap_or(0);
     if super::pair_offset_fits(width, first_offset) {
@@ -1056,13 +1007,7 @@ impl Backend for Aarch64Backend {
         Ok(())
     }
 
-    fn update_bit(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        bit: u32,
-        operation: Operation,
-    ) {
+    fn update_bit(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, bit: u32, operation: Operation) {
         emit!(emit.output, Aarch64;
             if operation == Operation::ToggleBit {
             Opcode::ExclusiveOr64Immediate
@@ -1072,12 +1017,7 @@ impl Backend for Aarch64Backend {
         );
     }
 
-    fn extract_tag(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        source: PhysicalRegister,
-    ) {
+    fn extract_tag(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister) {
         emit!(emit.output, Aarch64;
             Opcode::ShiftImmediate {
             operation: ShiftOperation::RightLogical,
@@ -1086,12 +1026,7 @@ impl Backend for Aarch64Backend {
         );
     }
 
-    fn unbox_object(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        source: PhysicalRegister,
-    ) {
+    fn unbox_object(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister) {
         emit!(emit.output, Aarch64; Opcode::And64Immediate => [register destination, register source, immediate 0xffff_ffff_ffff];);
     }
 
@@ -1144,19 +1079,11 @@ impl Backend for Aarch64Backend {
         );
     }
 
-    fn helper_call(
-        &self,
-        emit: &mut Emit<'_>,
-        function: crate::low_ir::Relocation,
-    ) {
+    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
         direct_call(emit, function);
     }
 
-    fn interpreter_call(
-        &self,
-        emit: &mut Emit<'_>,
-        function: crate::low_ir::Relocation,
-    ) {
+    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
         interpreter_call_arguments(emit);
         direct_call(emit, function);
     }
@@ -1201,14 +1128,9 @@ impl Backend for Aarch64Backend {
         }
     }
 
-    fn slow_path_call(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn slow_path_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         let function = operands.relocation(0);
-        let [dispatch_register, dispatch_scratch] =
-            [operands.physical_register(1), operands.physical_register(2)];
+        let [dispatch_register, dispatch_scratch] = [operands.physical_register(1), operands.physical_register(2)];
         use crate::target::registers::aarch64::{X0, X1, X20, X26, X27, X28};
 
         let [execution_context, executable, program_counter, bytecode, values_offset] =
@@ -1260,11 +1182,7 @@ impl Backend for Aarch64Backend {
             .map_err(|error| memory_address_compile_error(emit.handler, error))
     }
 
-    fn dispatch_current(
-        &self,
-        emit: &mut Emit<'_>,
-        scratches: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn dispatch_current(&self, emit: &mut Emit<'_>, scratches: &[AllocatedOperand]) -> Result<(), CompileError> {
         let [opcode_scratch, target_scratch] = scratches.physical_registers();
         use crate::target::registers::aarch64::X25;
 
@@ -1314,7 +1232,8 @@ impl Backend for Aarch64Backend {
             flags: FlagUpdate::Preserve,
         } => [register X21, register X21, immediate size];
         );
-        dispatch_tail(emit, opcode_scratch, target_scratch).map_err(|error| memory_address_compile_error(emit.handler, error))
+        dispatch_tail(emit, opcode_scratch, target_scratch)
+            .map_err(|error| memory_address_compile_error(emit.handler, error))
     }
 
     fn finalize_assertion(
@@ -1333,7 +1252,6 @@ impl Backend for Aarch64Backend {
             AssertionOperation::UnsignedLess | AssertionOperation::UnsignedGreaterOrEqual => {
                 assertion_compare(
                     emit,
-
                     operands.physical_register(0),
                     operands.operand(1),
                     operands.physical_register(2),
@@ -1362,14 +1280,7 @@ impl Backend for Aarch64Backend {
                     width: IntegerWidth::U64,
                 } => [register tag_scratch, register value, immediate 48];
                 );
-                assertion_compare(
-                    emit,
-
-                    tag_scratch,
-                    tag,
-                    compare_scratch,
-                    IntegerWidth::U64,
-                );
+                assertion_compare(emit, tag_scratch, tag, compare_scratch, IntegerWidth::U64);
                 Condition::from_assertion(operation)
             }
         };
@@ -1384,16 +1295,13 @@ impl Backend for Aarch64Backend {
         operation: Operation,
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError> {
-        let (width, condition) = operation
-            .scalar_branch()
-            .expect("allocated scalar branch was verified");
+        let (width, condition) = operation.scalar_branch().expect("allocated scalar branch was verified");
         let lhs = operands.physical_register(0);
         let rhs = operands.operand(1);
         let scratch = operands.physical_register(2);
         let target = operands.label(3);
         compare(
             emit,
-
             lhs,
             rhs,
             scratch,
@@ -1452,16 +1360,10 @@ impl Backend for Aarch64Backend {
         operands: &[AllocatedOperand],
     ) {
         let (condition, compare_scratch, target) = match operation {
-            Operation::Branch(BranchOperation::Tag(condition)) => (
-                condition,
-                Some(operands.physical_register(3)),
-                operands.label(4),
-            ),
-            Operation::Branch(BranchOperation::Singleton(condition)) => (
-                condition,
-                None,
-                operands.label(3),
-            ),
+            Operation::Branch(BranchOperation::Tag(condition)) => {
+                (condition, Some(operands.physical_register(3)), operands.label(4))
+            }
+            Operation::Branch(BranchOperation::Singleton(condition)) => (condition, None, operands.label(3)),
             _ => unreachable!("allocated operation and operands were verified"),
         };
         let operands = ValueRepresentationBranch {
@@ -1474,7 +1376,6 @@ impl Backend for Aarch64Backend {
         match operation {
             Operation::Branch(BranchOperation::Tag(_)) => branch_tag(
                 emit,
-
                 operands,
                 compare_scratch.expect("AArch64 tag branch must have two scratches"),
             ),
@@ -1491,9 +1392,7 @@ impl Backend for Aarch64Backend {
     ) -> Result<(), CompileError> {
         use super::super::description::MemoryBranchKind;
 
-        let kind = operation
-            .memory_branch()
-            .expect("allocated memory branch was verified");
+        let kind = operation.memory_branch().expect("allocated memory branch was verified");
         if let MemoryBranchKind::CompareRegister { width, .. } = kind
             && !matches!(width, IntegerWidth::U32 | IntegerWidth::U64)
         {
@@ -1526,7 +1425,6 @@ impl Backend for Aarch64Backend {
         };
         branch_any_equal(
             emit,
-
             verified_register(value),
             comparison_values,
             verified_register(scratch),
@@ -1640,41 +1538,25 @@ impl Backend for Aarch64Backend {
         Ok(())
     }
 
-    fn finalize_vm_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_vm_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         use crate::target::registers::aarch64::X20;
 
         let destination = operands.physical_register(0);
         emit!(emit.output, Aarch64; Opcode::MoveRegister(IntegerWidth::U64) => [register destination, register X20];);
     }
 
-    fn finalize_program_counter_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_program_counter_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         // The dispatch register holds `pb + pc`, so the program counter is the
         // distance between it and the bytecode base.
         let destination = operands.physical_register(0);
         emit!(emit.output, Aarch64; Opcode::Subtract32Register => [register destination, register X21, register X26];);
     }
 
-    fn finalize_operand_store(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
-        operand_store(emit, operands.immediate(0), operands.operand(1), &operands[2..],)
+    fn finalize_operand_store(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
+        operand_store(emit, operands.immediate(0), operands.operand(1), &operands[2..])
     }
 
-    fn finalize_label_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn finalize_label_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         use crate::target::registers::aarch64::X21;
 
         let destination = operands.physical_register(0);
@@ -1691,25 +1573,20 @@ impl Backend for Aarch64Backend {
         .map_err(|error| memory_address_compile_error(emit.handler, error))
     }
 
-    fn goto_handler(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn goto_handler(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         let [target, opcode_scratch, target_scratch] = operands.physical_registers();
         emit!(emit.output, Aarch64; Opcode::SetInstructionPointer => [register target];);
         dispatch_from_instruction_pointer(emit, opcode_scratch, target_scratch)
             .map_err(|error| memory_address_compile_error(emit.handler, error))
     }
 
-    fn goto_bytecode_target(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn goto_bytecode_target(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         let offset = operands.immediate(0);
-        let [bytecode_target_scratch, opcode_scratch, dispatch_target_scratch] =
-            [operands.physical_register(1), operands.physical_register(2), operands.physical_register(3)];
+        let [bytecode_target_scratch, opcode_scratch, dispatch_target_scratch] = [
+            operands.physical_register(1),
+            operands.physical_register(2),
+            operands.physical_register(3),
+        ];
         use crate::target::registers::aarch64::X21;
 
         load(
@@ -1746,13 +1623,8 @@ impl Backend for Aarch64Backend {
         .map_err(|error| memory_address_compile_error(emit.handler, error))
     }
 
-    fn finalize_indexed_offset_store(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
-        let [base, index, source, address_scratch] =
-            [0, 1, 4, 5].map(|index| operands.physical_register(index));
+    fn finalize_indexed_offset_store(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
+        let [base, index, source, address_scratch] = [0, 1, 4, 5].map(|index| operands.physical_register(index));
         let [scale, offset] = [2, 3].map(|index| operands.immediate(index));
         address_offset(emit, address_scratch, base, offset, address_scratch);
 
@@ -1841,9 +1713,7 @@ impl Backend for Aarch64Backend {
         let address_scratch = operands.physical_register(3);
         let source = match source {
             AllocatedOperand::Immediate(value) => StoreSource::Immediate(*value),
-            source => StoreSource::Register(
-                verified_register(source),
-            ),
+            source => StoreSource::Register(verified_register(source)),
         };
         store(emit, width, address, source, [value_scratch, address_scratch])
             .map_err(|error| memory_address_compile_error(emit.handler, error))
@@ -1855,13 +1725,8 @@ impl Backend for Aarch64Backend {
         width: PairWidth,
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError> {
-        let (destinations, address, scratches) = pair_access::<2>(
-            operands,
-            width,
-            true,
-            emit.handler,
-        )?;
-        pair_load(emit, width, destinations, address, scratches,)
+        let (destinations, address, scratches) = pair_access::<2>(operands, width, true, emit.handler)?;
+        pair_load(emit, width, destinations, address, scratches)
     }
 
     fn finalize_pair_store(
@@ -1874,22 +1739,11 @@ impl Backend for Aarch64Backend {
         if indexed {
             let (address_registers, scale, sources, [address_scratch]) =
                 decode_indexed_pair_store::<1>(operands, width, emit.handler)?;
-            indexed_pair_store(
-                emit,
-                address_registers,
-                scale,
-                sources,
-                address_scratch,
-            );
+            indexed_pair_store(emit, address_registers, scale, sources, address_scratch);
             return Ok(());
         }
-        let (sources, address, scratches) = pair_access::<2>(
-            operands,
-            width,
-            false,
-            emit.handler,
-        )?;
-        pair_store(emit, width, sources, address, scratches,)
+        let (sources, address, scratches) = pair_access::<2>(operands, width, false, emit.handler)?;
+        pair_store(emit, width, sources, address, scratches)
     }
 
     fn finalize_or32_branch(
@@ -1905,12 +1759,7 @@ impl Backend for Aarch64Backend {
             emit,
             BinaryOperation::Or,
             IntegerWidth::U32,
-            &[
-                destination.clone(),
-                lhs.clone(),
-                rhs.clone(),
-                scratch.clone(),
-            ],
+            &[destination.clone(), lhs.clone(), rhs.clone(), scratch.clone()],
         )?;
         let destination = verified_register(destination);
         emit!(emit.output, Aarch64; Opcode::BranchOnBit31(condition) => [register destination, label target.clone()];);
@@ -1936,10 +1785,7 @@ impl Backend for Aarch64Backend {
                 let rhs = verified_register(rhs);
                 emit!(emit.output, Aarch64; selected => [register destination, register destination, register rhs];);
             }
-            (
-                Opcode::AddSubtractLargeImmediate { operation, flags },
-                AllocatedOperand::Immediate(value),
-            ) => {
+            (Opcode::AddSubtractLargeImmediate { operation, flags }, AllocatedOperand::Immediate(value)) => {
                 move_immediate(emit, scratch, *value, IntegerWidth::U64);
                 emit!(emit.output, Aarch64; Opcode::AddSubtractRegister { operation, flags } => [register destination, register destination, register scratch];);
             }
@@ -2054,7 +1900,10 @@ impl Backend for Aarch64Backend {
                 }
                 (Opcode::BranchOverflow, verified_label(target_operand), None)
             }
-            (operation @ (OverflowOperation::Increment | OverflowOperation::Decrement), [destination, target_operand]) => {
+            (
+                operation @ (OverflowOperation::Increment | OverflowOperation::Decrement),
+                [destination, target_operand],
+            ) => {
                 let operation = match operation {
                     OverflowOperation::Increment => AddSubtractOperation::Add,
                     OverflowOperation::Decrement => AddSubtractOperation::Subtract,
@@ -2072,7 +1921,11 @@ impl Backend for Aarch64Backend {
                     verified_register(source),
                     verified_register(scratch),
                 );
-                (Opcode::BranchNotEqual, verified_label(target_operand), Some(destination))
+                (
+                    Opcode::BranchNotEqual,
+                    verified_label(target_operand),
+                    Some(destination),
+                )
             }
             (OverflowOperation::MultiplyCopy, [destination, lhs, rhs, scratch, target_operand]) => {
                 let destination = verified_register(destination);
@@ -2083,7 +1936,11 @@ impl Backend for Aarch64Backend {
                     verified_register(rhs),
                     verified_register(scratch),
                 );
-                (Opcode::BranchNotEqual, verified_label(target_operand), Some(destination))
+                (
+                    Opcode::BranchNotEqual,
+                    verified_label(target_operand),
+                    Some(destination),
+                )
             }
             (OverflowOperation::Negate, [destination, target_operand]) => {
                 emit!(emit.output, Aarch64; Opcode::Negate32WithFlags => [register verified_register(destination)];);
@@ -2139,11 +1996,7 @@ impl Backend for Aarch64Backend {
         }
     }
 
-    fn finalize_divide(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_divide(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         let [quotient, remainder, dividend, divisor, scratch] = operands.physical_registers();
         emit!(emit.output, Aarch64; Opcode::SignedDivide64 => [register scratch, register dividend, register divisor];);
         emit!(emit.output, Aarch64; Opcode::MultiplySubtract64 => [register remainder, register scratch, register divisor, register dividend];);

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -22,7 +22,6 @@
 //! Handlers that don't use virtual registers require no register assignment.
 
 use crate::Architecture;
-use crate::hash::{HashMap, HashSet};
 use crate::low_ir::cfg::{ControlFlowGraph, instruction_successors};
 use crate::low_ir::optimize::{invert_branches_over_jumps, remove_unreferenced_labels};
 #[cfg(test)]
@@ -133,34 +132,15 @@ impl UseDef {
     }
 }
 
-/// The dense numbering every later phase of allocation works in.
-struct Names {
-    registers: Vec<VirtualRegister>,
-    indices: HashMap<VirtualRegister, u32>,
+/// The debug names for the dense virtual-register numbering.
+struct Names<'a> {
+    function: crate::identity::HandlerId,
+    registers: &'a [VirtualRegister],
 }
 
-impl Names {
-    fn collect(instructions: &[&MachineInstruction]) -> Self {
-        let mut seen = HashSet::default();
-        for instruction in instructions {
-            for operand in &instruction.operands {
-                visit_virtual_registers(operand, &mut |register| {
-                    if !seen.contains(register) {
-                        seen.insert(register.clone());
-                    }
-                });
-            }
-        }
-        // Sorting keeps the numbering, and with it every tie-break that
-        // depends on it, independent of hash iteration order.
-        let mut registers = seen.into_iter().collect::<Vec<_>>();
-        registers.sort();
-        let indices = registers
-            .iter()
-            .enumerate()
-            .map(|(index, register)| (register.clone(), index as u32))
-            .collect();
-        Self { registers, indices }
+impl<'a> Names<'a> {
+    fn new(function: crate::identity::HandlerId, registers: &'a [VirtualRegister]) -> Self {
+        Self { function, registers }
     }
 
     fn len(&self) -> usize {
@@ -168,7 +148,14 @@ impl Names {
     }
 
     fn index(&self, register: &VirtualRegister) -> u32 {
-        self.indices[register]
+        let id = register.id().expect("target virtual registers must be interned");
+        assert_eq!(
+            id.function(),
+            self.function,
+            "virtual register belongs to another handler"
+        );
+        debug_assert_eq!(self.registers[id.index() as usize], *register);
+        id.index()
     }
 
     fn name(&self, index: u32) -> &VirtualRegister {
@@ -598,7 +585,15 @@ fn records_every_simultaneous_pair(_: &InterferenceGraph, _: &Liveness) -> bool 
 // Interference and allocation
 // ============================================================================
 
-type AllocationPlan = HashMap<VirtualRegister, PhysicalRegister>;
+#[derive(Default)]
+struct AllocationPlan(Vec<Option<PhysicalRegister>>);
+
+impl AllocationPlan {
+    fn physical(&self, register: &VirtualRegister) -> PhysicalRegister {
+        let id = register.id().expect("target virtual registers must be interned");
+        self.0[id.index() as usize].expect("every virtual register must have an allocation")
+    }
+}
 
 /// Coalescing groups, as a dense map from virtual register to the group it
 /// belongs to. A group is a set of move-related values that all take the same
@@ -633,7 +628,7 @@ impl CoalescingGroups {
 struct ColoringContext<'a> {
     handler: &'a TargetFunction,
     interference: &'a InterferenceGraph,
-    names: &'a Names,
+    names: &'a Names<'a>,
     gpr_pool: &'a [PhysicalRegister],
     fpr_pool: &'a [PhysicalRegister],
     gpr_mask: RegisterSet,
@@ -723,7 +718,7 @@ fn allocate(
     successors: &[Vec<usize>],
     arch: Architecture,
 ) -> Result<AllocationPlan, CompileError> {
-    let names = Names::collect(instructions);
+    let names = Names::new(handler.id, &handler.virtual_registers);
     let count = names.len();
     let liveness = compute_liveness(&handler.name, instructions, successors, &names, arch)?;
 
@@ -924,13 +919,13 @@ fn allocate(
     let mut use_order = (0..count as u32).collect::<Vec<_>>();
     use_order.sort_by(|a, b| compare(a, b, AllocationPriority::UseCount));
     if let Ok(plan) = try_color(&use_order, &coalescing_groups) {
-        return Ok(plan.into_named(&names));
+        return Ok(plan);
     }
 
     let mut live_order = use_order.clone();
     live_order.sort_by(|a, b| compare(a, b, AllocationPriority::LiveRange));
     if let Ok(plan) = try_color(&live_order, &coalescing_groups) {
-        return Ok(plan.into_named(&names));
+        return Ok(plan);
     }
 
     let mut groups = coalescing_groups.groups.clone();
@@ -953,31 +948,18 @@ fn allocate(
     }
     if !retained_groups.groups.is_empty() {
         if let Ok(plan) = try_color(&use_order, &retained_groups) {
-            return Ok(plan.into_named(&names));
+            return Ok(plan);
         }
         if let Ok(plan) = try_color(&live_order, &retained_groups) {
-            return Ok(plan.into_named(&names));
+            return Ok(plan);
         }
     }
 
     let no_groups = CoalescingGroups::empty(count);
     if let Ok(plan) = try_color(&use_order, &no_groups) {
-        return Ok(plan.into_named(&names));
+        return Ok(plan);
     }
-    try_color(&live_order, &no_groups).map(|plan| plan.into_named(&names))
-}
-
-/// A coloring, indexed by dense virtual-register number.
-struct Assignments(Vec<Option<PhysicalRegister>>);
-
-impl Assignments {
-    fn into_named(self, names: &Names) -> AllocationPlan {
-        self.0
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, physical)| physical.map(|physical| (names.name(index as u32).clone(), physical)))
-            .collect()
-    }
+    try_color(&live_order, &no_groups)
 }
 
 /// Greedy linear-scan coloring driven by the order in `sorted_virtuals`.
@@ -987,7 +969,7 @@ fn color(
     context: &ColoringContext<'_>,
     sorted_virtuals: &[u32],
     coalescing_groups: &CoalescingGroups,
-) -> Result<Assignments, CompileError> {
+) -> Result<AllocationPlan, CompileError> {
     let ColoringContext {
         handler,
         interference,
@@ -1137,7 +1119,7 @@ fn color(
         assignments[name as usize] = Some(pick);
     }
 
-    Ok(Assignments(assignments))
+    Ok(AllocationPlan(assignments))
 }
 
 // ============================================================================
@@ -1173,15 +1155,11 @@ fn rewrite(
 fn rewrite_operand(
     handler: &TargetFunction,
     op: Operand,
-    table: &HashMap<VirtualRegister, PhysicalRegister>,
+    table: &AllocationPlan,
     runtime: &RuntimeConstants,
 ) -> Result<AllocatedOperand, CompileError> {
     Ok(match op {
-        Operand::VirtualRegister(register) => AllocatedOperand::PhysicalRegister(
-            *table
-                .get(&register)
-                .expect("every virtual register must have an allocation"),
-        ),
+        Operand::VirtualRegister(register) => AllocatedOperand::PhysicalRegister(table.physical(&register)),
         Operand::InterpreterRegister(register) => AllocatedOperand::PhysicalRegister(
             resolve_interpreter_register(register, handler.architecture).ok_or_else(|| {
                 allocation_error(
@@ -1255,12 +1233,10 @@ fn rewrite_operand(
 fn rewrite_address_register(
     handler: &TargetFunction,
     register: AddressRegister,
-    table: &HashMap<VirtualRegister, PhysicalRegister>,
+    table: &AllocationPlan,
 ) -> Result<PhysicalRegister, CompileError> {
     match register {
-        AddressRegister::Virtual(register) => Ok(*table
-            .get(&register)
-            .expect("every virtual register must have an allocation")),
+        AddressRegister::Virtual(register) => Ok(table.physical(&register)),
         AddressRegister::Interpreter(register) => resolve_interpreter_register(register, handler.architecture)
             .ok_or_else(|| {
                 allocation_error(

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -319,11 +319,7 @@ fn build_allocated_graph(
     let mut graph = ControlFlowGraph::from_instructions(instructions)
         .map_err(|message| allocation_error(&handler.name, message))?;
 
-    graph.thread_unconditional_jumps();
-
-    graph.remove_unreferenced_jump_blocks();
-
-    graph.remove_unreachable_blocks();
+    graph.simplify();
 
     Ok(graph)
 }

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -22,6 +22,7 @@
 //! Handlers that don't use virtual registers require no register assignment.
 
 use crate::Architecture;
+use crate::hash::{HashMap, HashSet};
 use crate::low_ir::cfg::{ControlFlowGraph, instruction_successors};
 use crate::low_ir::optimize::{invert_branches_over_jumps, remove_unreferenced_labels};
 #[cfg(test)]
@@ -41,7 +42,6 @@ use crate::target::registers::{PhysicalRegister, register_info_for, resolve_inte
 use crate::types::InterpreterRegister;
 use crate::types::RegisterClass as VirtualRegisterClass;
 use crate::{CompileError, CompileStage};
-use crate::hash::{HashMap, HashSet};
 
 /// A set of physical registers.
 ///
@@ -945,7 +945,8 @@ fn allocate(
     for group in groups {
         let mut candidate_groups = retained_groups.clone();
         candidate_groups.add(group);
-        if color(&context, &use_order, &candidate_groups).is_ok() || color(&context, &live_order, &candidate_groups).is_ok()
+        if color(&context, &use_order, &candidate_groups).is_ok()
+            || color(&context, &live_order, &candidate_groups).is_ok()
         {
             retained_groups = candidate_groups;
         }

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -52,69 +52,38 @@ use crate::hash::{HashMap, HashSet};
 type RegisterSet = u64;
 
 fn register_bit(register: PhysicalRegister) -> RegisterSet {
+    assert!(
+        register != crate::target::registers::aarch64::XZR,
+        "the AArch64 zero register is introduced only after allocation"
+    );
     let class = match register.class() {
         crate::target::registers::RegisterClass::GeneralPurpose => 0,
         crate::target::registers::RegisterClass::FloatingPoint => 32,
     };
-    1 << (class + u32::from(register.number()))
+    let number = u32::from(register.number());
+    assert!(number < 32, "register number {number} does not fit in a RegisterSet");
+    1 << (class + number)
 }
 
-/// A set of virtual registers, held as a bitmap over dense virtual-register
-/// indices. Liveness and interference are the hot inner loops of allocation and
-/// both are set algebra, so they run word at a time rather than element at a
-/// time.
-#[derive(Clone)]
-struct VirtualRegisterSets {
-    words_per_set: usize,
-    words: Vec<u64>,
-}
+/// A set of virtual registers, held sorted.
+///
+/// The obvious representation is a bitmap over the dense numbering, and for a
+/// handler-sized function it is the fastest one. A stitched function is not
+/// handler-sized: the largest in Octane's zlib has 64298 virtual registers over
+/// 286178 instructions, where a bitmap per instruction is half a gigabyte and
+/// sweeping it is gigabytes of traffic. The number of registers live at any one
+/// point stays small whatever the function's size, so the sets are sparse.
+type LiveSet = Vec<u32>;
 
-impl VirtualRegisterSets {
-    fn new(sets: usize, registers: usize) -> Self {
-        let words_per_set = registers.div_ceil(64);
-        Self {
-            words_per_set,
-            words: vec![0; sets * words_per_set],
-        }
+/// Merge `source` into the sorted set `into`, which stays sorted and unique.
+fn merge_into(into: &mut LiveSet, source: &[u32]) {
+    if into.is_empty() {
+        into.extend_from_slice(source);
+        return;
     }
-
-    fn set(&self, index: usize) -> &[u64] {
-        &self.words[index * self.words_per_set..(index + 1) * self.words_per_set]
-    }
-
-    fn set_mut(&mut self, index: usize) -> &mut [u64] {
-        let start = index * self.words_per_set;
-        &mut self.words[start..start + self.words_per_set]
-    }
-
-    fn insert(&mut self, index: usize, register: u32) {
-        let start = index * self.words_per_set;
-        self.words[start + (register as usize) / 64] |= 1 << (register % 64);
-    }
-
-    fn union_into(&mut self, index: usize, source: &[u64]) {
-        let start = index * self.words_per_set;
-        for (word, added) in self.words[start..start + self.words_per_set].iter_mut().zip(source) {
-            *word |= *added;
-        }
-    }
-}
-
-fn members(set: &[u64]) -> impl Iterator<Item = u32> + '_ {
-    set.iter().enumerate().flat_map(|(word_index, word)| {
-        let mut remaining = *word;
-        std::iter::from_fn(move || {
-            (remaining != 0).then(|| {
-                let bit = remaining.trailing_zeros();
-                remaining &= remaining - 1;
-                (word_index as u32) * 64 + bit
-            })
-        })
-    })
-}
-
-fn contains(set: &[u64], register: u32) -> bool {
-    set[(register as usize) / 64] & (1 << (register % 64)) != 0
+    into.extend_from_slice(source);
+    into.sort_unstable();
+    into.dedup();
 }
 
 #[derive(Debug, Default)]
@@ -208,8 +177,8 @@ impl Names {
 }
 
 struct Liveness {
-    live_in: VirtualRegisterSets,
-    live_out: VirtualRegisterSets,
+    live_in: Vec<LiveSet>,
+    live_out: Vec<LiveSet>,
     use_def: Vec<UseDef>,
 }
 
@@ -222,17 +191,17 @@ struct Interference {
 }
 
 struct InterferenceGraph {
-    neighbors: VirtualRegisterSets,
+    neighbors: Vec<LiveSet>,
     nodes: Vec<Interference>,
 }
 
 impl InterferenceGraph {
-    fn neighbors(&self, register: u32) -> &[u64] {
-        self.neighbors.set(register as usize)
+    fn neighbors(&self, register: u32) -> &[u32] {
+        &self.neighbors[register as usize]
     }
 
     fn interferes(&self, register: u32, other: u32) -> bool {
-        contains(self.neighbors(register), other)
+        self.neighbors(register).binary_search(&other).is_ok()
     }
 }
 
@@ -456,29 +425,35 @@ fn compute_liveness(
         .iter()
         .map(|insn| analyze_instruction(insn, names, arch))
         .collect::<Vec<_>>();
-    let mut live_in = VirtualRegisterSets::new(n, names.len());
-    let mut live_out = VirtualRegisterSets::new(n, names.len());
-    let mut next_out = vec![0; live_in.words_per_set];
-    let mut next_in = vec![0; live_in.words_per_set];
+    let mut live_in = vec![LiveSet::new(); n];
+    let mut live_out = vec![LiveSet::new(); n];
+    let mut next_out = LiveSet::new();
+    let mut next_in = LiveSet::new();
     loop {
         let mut changed = false;
         for instruction in (0..n).rev() {
-            next_out.fill(0);
+            next_out.clear();
             for successor in &successors[instruction] {
-                for (word, added) in next_out.iter_mut().zip(live_in.set(*successor)) {
-                    *word |= *added;
-                }
+                merge_into(&mut next_out, &live_in[*successor]);
             }
-            next_in.copy_from_slice(&next_out);
-            for defined in &use_def[instruction].defs {
-                next_in[(*defined as usize) / 64] &= !(1 << (defined % 64));
+            next_in.clear();
+            next_in.extend(
+                next_out
+                    .iter()
+                    .copied()
+                    .filter(|live| !use_def[instruction].defs.contains(live)),
+            );
+            if !use_def[instruction].uses.is_empty() {
+                merge_into(&mut next_in, &use_def[instruction].uses);
             }
-            for used in &use_def[instruction].uses {
-                next_in[(*used as usize) / 64] |= 1 << (used % 64);
+            if live_in[instruction] != next_in {
+                live_in[instruction].clear();
+                live_in[instruction].extend_from_slice(&next_in);
+                changed = true;
             }
-            if live_in.set(instruction) != next_in || live_out.set(instruction) != next_out {
-                live_in.set_mut(instruction).copy_from_slice(&next_in);
-                live_out.set_mut(instruction).copy_from_slice(&next_out);
+            if live_out[instruction] != next_out {
+                live_out[instruction].clear();
+                live_out[instruction].extend_from_slice(&next_out);
                 changed = true;
             }
         }
@@ -495,7 +470,7 @@ fn compute_liveness(
     // Sanity-check: a virtual register must be defined before its first use
     // along every path. We catch the simplest case: no virtual register may
     // be live at handler entry.
-    if let Some(register) = members(liveness.live_in.set(0)).next() {
+    if let Some(register) = liveness.live_in[0].first().copied() {
         // Walk forward and find the first instruction that pulls this
         // virtual register into its live-in without having defined it
         // yet, so the error points at the actual problem.
@@ -520,67 +495,90 @@ fn compute_liveness(
 
 fn build_interference(liveness: &Liveness, count: usize) -> InterferenceGraph {
     let mut graph = InterferenceGraph {
-        neighbors: VirtualRegisterSets::new(count, count),
+        neighbors: vec![LiveSet::new(); count],
         nodes: vec![Interference::default(); count],
     };
-    let words = liveness.live_in.words_per_set;
-    let mut scratch = vec![0; words];
     for instruction in 0..liveness.use_def.len() {
         let use_def = &liveness.use_def[instruction];
-        for live in [
-            liveness.live_in.set(instruction),
-            liveness.live_out.set(instruction),
-        ] {
-            // Everything simultaneously live interferes with everything else
-            // simultaneously live, which is a union of the whole set into each
-            // member's neighbors rather than a walk over pairs.
-            for register in members(live) {
-                graph.nodes[register as usize].live_range_size += 1;
-                graph.neighbors.union_into(register as usize, live);
-                let row = graph.neighbors.set_mut(register as usize);
-                row[(register as usize) / 64] &= !(1 << (register % 64));
+        let live_out = &liveness.live_out[instruction];
+        for live in [&liveness.live_in[instruction], live_out] {
+            for register in live {
+                graph.nodes[*register as usize].live_range_size += 1;
             }
         }
+        // Two values interfere when both are live at once, and one of them was
+        // written while the other was already live: a value live at a point is
+        // written on every path reaching it, so whichever of the two was
+        // written second saw the other live. Recording the conflict where a
+        // value is written therefore records every conflict, without walking
+        // the pairs of every live set at every instruction.
+        //
         // What an instruction writes conflicts with whatever is still live
-        // after it, even when nothing reads the result. A value the branch
-        // conditions on but never names again is defined and immediately dead,
-        // so it appears in no live set at all; without this it would collect no
-        // neighbors and could be handed the register of a value that has to
-        // survive the instruction.
-        if !use_def.defs.is_empty() {
-            scratch.copy_from_slice(liveness.live_out.set(instruction));
-            for defined in &use_def.defs {
-                scratch[(*defined as usize) / 64] |= 1 << (defined % 64);
-            }
-            for defined in &use_def.defs {
-                graph.neighbors.union_into(*defined as usize, &scratch);
-                let row = graph.neighbors.set_mut(*defined as usize);
-                row[(*defined as usize) / 64] &= !(1 << (defined % 64));
-                for other in members(&scratch) {
-                    if other != *defined {
-                        graph.neighbors.insert(other as usize, *defined);
-                    }
+        // after it even when nothing reads the result: a value the branch
+        // conditions on but never names again is written and immediately dead,
+        // so it appears in no live set at all, and without this it would
+        // collect no neighbors and could be handed the register of a value that
+        // has to survive the instruction.
+        for defined in &use_def.defs {
+            for other in live_out.iter().chain(&use_def.defs) {
+                if other == defined {
+                    continue;
                 }
+                graph.neighbors[*defined as usize].push(*other);
+                graph.neighbors[*other as usize].push(*defined);
             }
         }
 
+        // A value that passes through an instruction, live on both sides
+        // without being rewritten, cannot live in a register the instruction
+        // destroys. A value live after the instruction and not written by it is
+        // live before it too, so the live-out set names exactly those.
         if use_def.clobbers != 0 {
-            let live_in = liveness.live_in.set(instruction);
-            let live_out = liveness.live_out.set(instruction);
-            for (word_index, (entering, leaving)) in live_in.iter().zip(live_out).enumerate() {
-                let mut both = entering & leaving;
-                while both != 0 {
-                    let register = (word_index as u32) * 64 + both.trailing_zeros();
-                    both &= both - 1;
-                    if use_def.defs.contains(&register) {
-                        continue;
+            for register in live_out {
+                if use_def.defs.contains(register) {
+                    continue;
+                }
+                graph.nodes[*register as usize].forbidden |= use_def.clobbers;
+            }
+        }
+    }
+    for neighbors in &mut graph.neighbors {
+        neighbors.sort_unstable();
+        neighbors.dedup();
+    }
+    debug_assert!(records_every_simultaneous_pair(&graph, liveness));
+    graph
+}
+
+/// Check the claim `build_interference` rests on: that recording a conflict
+/// where a value is written records every pair of values that are ever live at
+/// the same time.
+///
+/// This walks the pairs of every live set, which is what the real construction
+/// exists to avoid, so it is limited to functions small enough to afford it.
+#[cfg(debug_assertions)]
+fn records_every_simultaneous_pair(graph: &InterferenceGraph, liveness: &Liveness) -> bool {
+    const AFFORDABLE_INSTRUCTIONS: usize = 2000;
+    if liveness.use_def.len() > AFFORDABLE_INSTRUCTIONS {
+        return true;
+    }
+    for instruction in 0..liveness.use_def.len() {
+        for live in [&liveness.live_in[instruction], &liveness.live_out[instruction]] {
+            for (position, register) in live.iter().enumerate() {
+                for other in &live[position + 1..] {
+                    if !graph.interferes(*register, *other) {
+                        return false;
                     }
-                    graph.nodes[register as usize].forbidden |= use_def.clobbers;
                 }
             }
         }
     }
-    graph
+    true
+}
+
+#[cfg(not(debug_assertions))]
+fn records_every_simultaneous_pair(_: &InterferenceGraph, _: &Liveness) -> bool {
+    true
 }
 
 // ============================================================================
@@ -652,8 +650,8 @@ impl ColoringContext<'_> {
     /// interferes with.
     fn assigned_neighbors(&self, register: u32, assignments: &[Option<PhysicalRegister>]) -> RegisterSet {
         let mut taken = 0;
-        for other in members(self.interference.neighbors(register)) {
-            if let Some(physical) = assignments[other as usize] {
+        for other in self.interference.neighbors(register) {
+            if let Some(physical) = assignments[*other as usize] {
                 taken |= register_bit(physical);
             }
         }

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -86,7 +86,7 @@ fn merge_into(into: &mut LiveSet, source: &[u32]) {
     into.dedup();
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct UseDef {
     uses: Vec<u32>,
     defs: Vec<u32>,
@@ -95,18 +95,14 @@ struct UseDef {
 
 impl UseDef {
     fn use_register(&mut self, register: u32) {
-        if !self.uses.contains(&register) {
-            self.uses.push(register);
-        }
+        self.uses.push(register);
     }
 
     fn define_operand(&mut self, operand: &Operand, names: &Names, architecture: Architecture) {
         match operand {
             Operand::VirtualRegister(register) => {
                 let register = names.index(register);
-                if !self.defs.contains(&register) {
-                    self.defs.push(register);
-                }
+                self.defs.push(register);
             }
             Operand::InterpreterRegister(register) => {
                 if let Some(register) = resolve_interpreter_register(*register, architecture) {
@@ -118,6 +114,13 @@ impl UseDef {
             }
             _ => {}
         }
+    }
+
+    fn normalize(&mut self) {
+        self.uses.sort_unstable();
+        self.uses.dedup();
+        self.defs.sort_unstable();
+        self.defs.dedup();
     }
 }
 
@@ -152,6 +155,7 @@ impl<'a> Names<'a> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct Liveness {
     live_in: Vec<LiveSet>,
     live_out: Vec<LiveSet>,
@@ -348,6 +352,40 @@ fn compute_liveness(
         .iter()
         .map(|insn| analyze_instruction(insn, names, arch))
         .collect::<Vec<_>>();
+    let liveness = solve_liveness(use_def, successors);
+
+    // Sanity-check: a virtual register must be defined before its first use
+    // along every path. We catch the simplest case: no virtual register may
+    // be live at handler entry.
+    if let Some(register) = liveness.live_in[0].first().copied() {
+        // Walk forward and find the first instruction that pulls this
+        // virtual register into its live-in without having defined it
+        // yet, so the error points at the actual problem.
+        let mut culprit = String::from("(unknown)");
+        for (i, ud) in liveness.use_def.iter().enumerate() {
+            if ud.uses.binary_search(&register).is_ok() && ud.defs.binary_search(&register).is_err() {
+                culprit = format!("instruction #{i}: {:?}", instructions[i]);
+                break;
+            }
+        }
+        let register = names.name(register);
+        return Err(allocation_error(
+            handler_name,
+            format!(
+                "virtual register '{register}' is used before being assigned (live at handler entry); first use: {culprit}"
+            ),
+        ));
+    }
+
+    Ok(liveness)
+}
+
+fn solve_liveness(mut use_def: Vec<UseDef>, successors: &[Vec<usize>]) -> Liveness {
+    let n = use_def.len();
+    assert_eq!(successors.len(), n);
+    for use_def in &mut use_def {
+        use_def.normalize();
+    }
     let mut predecessors = vec![Vec::new(); n];
     for (instruction, successors) in successors.iter().enumerate() {
         for successor in successors {
@@ -377,7 +415,7 @@ fn compute_liveness(
             next_out
                 .iter()
                 .copied()
-                .filter(|live| !use_def[instruction].defs.contains(live)),
+                .filter(|live| use_def[instruction].defs.binary_search(live).is_err()),
         );
         if !use_def[instruction].uses.is_empty() {
             merge_into(&mut next_in, &use_def[instruction].uses);
@@ -397,36 +435,11 @@ fn compute_liveness(
             }
         }
     }
-    let liveness = Liveness {
+    Liveness {
         live_in,
         live_out,
         use_def,
-    };
-
-    // Sanity-check: a virtual register must be defined before its first use
-    // along every path. We catch the simplest case: no virtual register may
-    // be live at handler entry.
-    if let Some(register) = liveness.live_in[0].first().copied() {
-        // Walk forward and find the first instruction that pulls this
-        // virtual register into its live-in without having defined it
-        // yet, so the error points at the actual problem.
-        let mut culprit = String::from("(unknown)");
-        for (i, ud) in liveness.use_def.iter().enumerate() {
-            if ud.uses.contains(&register) && !ud.defs.contains(&register) {
-                culprit = format!("instruction #{i}: {:?}", instructions[i]);
-                break;
-            }
-        }
-        let register = names.name(register);
-        return Err(allocation_error(
-            handler_name,
-            format!(
-                "virtual register '{register}' is used before being assigned (live at handler entry); first use: {culprit}"
-            ),
-        ));
     }
-
-    Ok(liveness)
 }
 
 fn build_interference(liveness: &Liveness, count: usize) -> InterferenceGraph {
@@ -471,7 +484,7 @@ fn build_interference(liveness: &Liveness, count: usize) -> InterferenceGraph {
         // live before it too, so the live-out set names exactly those.
         if use_def.clobbers != 0 {
             for register in live_out {
-                if use_def.defs.contains(register) {
+                if use_def.defs.binary_search(register).is_ok() {
                     continue;
                 }
                 graph.nodes[*register as usize].forbidden |= use_def.clobbers;
@@ -1785,6 +1798,101 @@ mod tests {
             for neighbor in interference.neighbors(register) {
                 assert_ne!(plan.0[*neighbor as usize], Some(physical));
             }
+        }
+    }
+
+    #[test]
+    fn liveness_normalizes_register_sets_before_solving() {
+        let liveness = solve_liveness(
+            vec![UseDef {
+                uses: vec![2, 0, 2, 1],
+                defs: vec![4, 3, 4],
+                clobbers: 0,
+            }],
+            &[Vec::new()],
+        );
+
+        assert_eq!(liveness.use_def[0].uses, [0, 1, 2]);
+        assert_eq!(liveness.use_def[0].defs, [3, 4]);
+        assert_eq!(liveness.live_in[0], [0, 1, 2]);
+    }
+
+    fn reference_liveness(use_def: Vec<UseDef>, successors: &[Vec<usize>]) -> Liveness {
+        let mut live_in = vec![LiveSet::new(); use_def.len()];
+        let mut live_out = vec![LiveSet::new(); use_def.len()];
+        loop {
+            let mut changed = false;
+            for instruction in (0..use_def.len()).rev() {
+                let mut next_out = successors[instruction]
+                    .iter()
+                    .flat_map(|successor| live_in[*successor].iter().copied())
+                    .collect::<LiveSet>();
+                next_out.sort_unstable();
+                next_out.dedup();
+
+                let mut next_in = use_def[instruction].uses.clone();
+                next_in.extend(
+                    next_out
+                        .iter()
+                        .copied()
+                        .filter(|register| !use_def[instruction].defs.contains(register)),
+                );
+                next_in.sort_unstable();
+                next_in.dedup();
+                changed |= live_in[instruction] != next_in || live_out[instruction] != next_out;
+                live_in[instruction] = next_in;
+                live_out[instruction] = next_out;
+            }
+            if !changed {
+                return Liveness {
+                    live_in,
+                    live_out,
+                    use_def,
+                };
+            }
+        }
+    }
+
+    #[test]
+    fn liveness_matches_reference_solver_on_random_cfgs() {
+        let mut random_state = 0x6a09e667f3bcc909u64;
+        let mut random = || {
+            random_state = random_state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            random_state
+        };
+
+        for _ in 0..250 {
+            let instruction_count = (random() % 20 + 1) as usize;
+            let register_count = (random() % 12 + 1) as u32;
+            let mut use_def = Vec::with_capacity(instruction_count);
+            for _ in 0..instruction_count {
+                let mut instruction = UseDef::default();
+                for register in 0..register_count {
+                    if random() % 5 == 0 {
+                        instruction.uses.push(register);
+                    }
+                    if random() % 7 == 0 {
+                        instruction.defs.push(register);
+                    }
+                }
+                use_def.push(instruction);
+            }
+
+            let mut successors = vec![Vec::new(); instruction_count];
+            for instruction_successors in &mut successors {
+                for successor in 0..instruction_count {
+                    if random() % 9 == 0 {
+                        instruction_successors.push(successor);
+                    }
+                }
+            }
+
+            assert_eq!(
+                solve_liveness(use_def.clone(), &successors),
+                reference_liveness(use_def, &successors)
+            );
         }
     }
 

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -68,7 +68,7 @@ fn register_bit(register: PhysicalRegister) -> RegisterSet {
 /// A set of virtual registers, held sorted.
 ///
 /// The obvious representation is a bitmap over the dense numbering, and for a
-/// handler-sized function it is the fastest one. A stitched function is not
+/// handler-sized function it is the fastest one. A large function is not
 /// handler-sized: the largest in Octane's zlib has 64298 virtual registers over
 /// 286178 instructions, where a bitmap per instruction is half a gigabyte and
 /// sweeping it is gigabytes of traffic. The number of registers live at any one

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -412,6 +412,22 @@ fn build_interference(
                 }
             }
         }
+        // What an instruction writes conflicts with whatever is still live
+        // after it, even when nothing reads the result. A value the branch
+        // conditions on but never names again is defined and immediately dead,
+        // so it appears in no live set at all; without this it would collect no
+        // neighbors and could be handed the register of a value that has to
+        // survive the instruction.
+        for defined in &liveness.use_def[instruction].defs {
+            for other in live_out.iter().chain(&liveness.use_def[instruction].defs) {
+                if other == defined {
+                    continue;
+                }
+                graph.get_mut(defined).unwrap().neighbors.insert(other.clone());
+                graph.get_mut(other).unwrap().neighbors.insert(defined.clone());
+            }
+        }
+
         for register in live_in.intersection(live_out) {
             if liveness.use_def[instruction].defs.contains(register) {
                 continue;
@@ -1665,6 +1681,44 @@ mod tests {
         assert!(
             err.message.contains("could not allocate") || err.message.contains("pool exhausted"),
             "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_result_nothing_reads_still_conflicts_with_what_outlives_it() {
+        // Nothing ever reads `discarded`, so it belongs to no live set, but the
+        // instruction writing it still runs while `survivor` has to survive.
+        // Handing both the same register would destroy `survivor`.
+        let out = build(
+            vec![
+                instruction!(Operation::Move(IntegerWidth::U64), register("survivor"), immediate(7)),
+                instruction!(Operation::Move(IntegerWidth::U64), register("discarded"), immediate(9)),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("survivor"),
+                    immediate(1)
+                ),
+            ],
+            Architecture::X86_64,
+        )
+        .expect("allocation should succeed");
+
+        let survivor = out[0]
+            .operands
+            .first()
+            .and_then(AllocatedOperand::register_name)
+            .expect("the surviving value should be in a register");
+        let discarded = out[1]
+            .operands
+            .first()
+            .and_then(AllocatedOperand::register_name)
+            .expect("the discarded value should be in a register");
+        assert_ne!(
+            survivor, discarded,
+            "a discarded result took the register of a value that outlives it"
         );
     }
 

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -1970,10 +1970,57 @@ mod tests {
     }
 
     #[test]
-    fn rejects_virtual_register_live_across_call() {
-        let err = build(
+    fn rematerializes_virtual_register_live_across_call() {
+        let out = build(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(7)),
+                instruction!(
+                    Operation::Call(CallKind::Helper),
+                    symbol("asm_helper_to_boolean"),
+                    x86_register("rcx"),
+                    x86_register("rax")
+                ),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("value"),
+                    immediate(1)
+                ),
+                instruction!(Operation::Assertion(AssertionOperation::NonZero), register("value")),
+            ],
+            Architecture::X86_64,
+        )
+        .expect("the constant should be rematerialized after the call");
+
+        assert_eq!(
+            out.iter()
+                .map(|instruction| instruction.opcode.operation())
+                .collect::<Vec<_>>(),
+            [
+                Operation::Move(IntegerWidth::U64),
+                Operation::Call(CallKind::Helper),
+                Operation::Move(IntegerWidth::U64),
+                Operation::IntegerBinary {
+                    operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                    width: IntegerWidth::U64,
+                },
+                Operation::Assertion(AssertionOperation::NonZero),
+            ]
+        );
+        assert_eq!(out[0].operands[1], AllocatedOperand::Immediate(7));
+        assert_eq!(out[2].operands[1], AllocatedOperand::Immediate(7));
+        assert_eq!(out[2].operands[0], out[3].operands[0]);
+        assert_eq!(out[3].operands[0], out[4].operands[0]);
+    }
+
+    #[test]
+    fn rejects_nonrematerializable_virtual_register_live_across_call() {
+        let err = build(
+            vec![
+                instruction!(Operation::Move(IntegerWidth::U64), register("seed"), immediate(7)),
+                instruction!(Operation::Move(IntegerWidth::U64), register("value"), register("seed")),
                 instruction!(
                     Operation::Call(CallKind::Helper),
                     symbol("asm_helper_to_boolean"),
@@ -1991,7 +2038,67 @@ mod tests {
             ],
             Architecture::X86_64,
         )
-        .expect_err("should reject value live across call_helper");
+        .expect_err("a nonrematerializable value cannot survive the call");
+        assert!(
+            err.message.contains("could not allocate") || err.message.contains("pool exhausted"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn does_not_rematerialize_over_a_call_result() {
+        let out = allocated(
+            vec![
+                instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(7)),
+                instruction!(
+                    Operation::Call(CallKind::Helper),
+                    symbol("asm_helper_to_boolean"),
+                    x86_register("rcx"),
+                    register("value")
+                ),
+                instruction!(Operation::Assertion(AssertionOperation::NonZero), register("value")),
+            ],
+            Architecture::X86_64,
+        );
+
+        assert_eq!(
+            out.iter()
+                .map(|instruction| instruction.opcode.operation())
+                .collect::<Vec<_>>(),
+            [
+                Operation::Move(IntegerWidth::U64),
+                Operation::Call(CallKind::Helper),
+                Operation::Assertion(AssertionOperation::NonZero),
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_split_a_live_range_across_machine_blocks() {
+        let err = build(
+            vec![
+                instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(7)),
+                instruction!(
+                    Operation::Call(CallKind::Helper),
+                    symbol("asm_helper_to_boolean"),
+                    x86_register("rcx"),
+                    x86_register("rax")
+                ),
+                instruction!(Operation::Control(ControlOperation::JumpLabel), label(".use")),
+                instruction!(Operation::Label, label(".use")),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("value"),
+                    immediate(1)
+                ),
+            ],
+            Architecture::X86_64,
+        )
+        .expect_err("cross-block rematerialization requires edge splitting");
+
         assert!(
             err.message.contains("could not allocate") || err.message.contains("pool exhausted"),
             "unexpected error: {err:?}"

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -22,7 +22,7 @@
 //! Handlers that don't use virtual registers require no register assignment.
 
 use crate::Architecture;
-use crate::low_ir::cfg::ControlFlowGraph;
+use crate::low_ir::cfg::{ControlFlowGraph, instruction_successors};
 use crate::low_ir::optimize::{invert_branches_over_jumps, remove_unreferenced_labels};
 #[cfg(test)]
 use crate::target::description::{
@@ -33,7 +33,7 @@ use crate::target::description::{InstructionDescription, OperandKind, SelectedOp
 use crate::target::ir::{
     AddressRegister, AllocatedFunction, AllocatedInstruction, AllocatedOperand, AllocatedProgram,
     Function as TargetFunction, Instruction as MachineInstruction, MemoryAddress, Operand, PhysicalMemoryAddress,
-    Program as TargetProgram, RuntimeConstants, VirtualRegister, count_virtual_register_uses, visit_virtual_registers,
+    Program as TargetProgram, RuntimeConstants, VirtualRegister, visit_virtual_registers,
 };
 #[cfg(test)]
 use crate::target::registers::physical_register_named;
@@ -171,7 +171,7 @@ struct Names {
 }
 
 impl Names {
-    fn collect(instructions: &[MachineInstruction]) -> Self {
+    fn collect(instructions: &[&MachineInstruction]) -> Self {
         let mut seen = HashSet::new();
         for instruction in instructions {
             for operand in &instruction.operands {
@@ -281,21 +281,30 @@ pub(crate) fn allocate_handler(
     handler: &TargetFunction,
     runtime: &RuntimeConstants,
 ) -> Result<ControlFlowGraph<AllocatedOperand, SelectedOpcode>, CompileError> {
-    let flat = handler.instructions.clone();
     let arch = handler.architecture;
     let mut needs = false;
-    for instruction in &flat {
+    for instruction in &handler.instructions {
         for operand in &instruction.operands {
             visit_virtual_registers(operand, &mut |_| needs = true);
         }
     }
     if !needs {
-        return build_allocated_graph(handler, rewrite(handler, flat, &AllocationPlan::default(), runtime)?);
+        return build_allocated_graph(
+            handler,
+            rewrite(handler, &handler.instructions, &AllocationPlan::default(), runtime)?,
+        );
     }
-    let graph = build_graph(handler, flat.clone())?;
-    let control_flow = graph.linearize_for_analysis();
-    let assignments = allocate(handler, &control_flow.instructions, &control_flow.successors, arch)?;
-    let mut rewritten = rewrite(handler, flat, &assignments, runtime)?;
+    // A cold annotation says where a block belongs in the final layout and
+    // executes nothing, so control never reaches it and liveness must not see
+    // it as an instruction that can branch to the label it names.
+    let analyzed = handler
+        .instructions
+        .iter()
+        .filter(|instruction| instruction.opcode.operation() != crate::target::description::Operation::Cold)
+        .collect::<Vec<_>>();
+    let successors = instruction_successors(&analyzed);
+    let assignments = allocate(handler, &analyzed, &successors, arch)?;
+    let mut rewritten = rewrite(handler, &handler.instructions, &assignments, runtime)?;
     invert_branches_over_jumps(&mut rewritten);
     remove_unreferenced_labels(&mut rewritten);
     invert_branches_over_jumps(&mut rewritten);
@@ -309,17 +318,14 @@ fn build_allocated_graph(
 ) -> Result<ControlFlowGraph<AllocatedOperand, SelectedOpcode>, CompileError> {
     let mut graph = ControlFlowGraph::from_instructions(instructions)
         .map_err(|message| allocation_error(&handler.name, message))?;
-    graph.thread_unconditional_jumps();
-    graph.remove_unreferenced_jump_blocks();
-    graph.remove_unreachable_blocks();
-    Ok(graph)
-}
 
-fn build_graph(
-    handler: &TargetFunction,
-    instructions: Vec<MachineInstruction>,
-) -> Result<ControlFlowGraph<Operand, SelectedOpcode>, CompileError> {
-    ControlFlowGraph::from_instructions(instructions).map_err(|message| allocation_error(&handler.name, message))
+    graph.thread_unconditional_jumps();
+
+    graph.remove_unreferenced_jump_blocks();
+
+    graph.remove_unreachable_blocks();
+
+    Ok(graph)
 }
 
 // ============================================================================
@@ -442,7 +448,7 @@ fn registers_alias(lhs: &Operand, rhs: &Operand, architecture: Architecture) -> 
 
 fn compute_liveness(
     handler_name: &str,
-    instructions: &[MachineInstruction],
+    instructions: &[&MachineInstruction],
     successors: &[Vec<usize>],
     names: &Names,
     arch: Architecture,
@@ -706,7 +712,7 @@ impl Coalescer {
 
 fn allocate(
     handler: &TargetFunction,
-    instructions: &[MachineInstruction],
+    instructions: &[&MachineInstruction],
     successors: &[Vec<usize>],
     arch: Architecture,
 ) -> Result<AllocationPlan, CompileError> {
@@ -800,8 +806,12 @@ fn allocate(
     // On x86_64 each saved use of a low-cost register saves an encoding
     // byte, so hot virtual registers want to land in cheap registers.
     let mut use_counts = vec![0u32; count];
-    for (register, uses) in count_virtual_register_uses(instructions) {
-        use_counts[names.index(&register) as usize] = uses;
+    for insn in instructions {
+        for operand in &insn.operands {
+            visit_virtual_registers(operand, &mut |register| {
+                use_counts[names.index(register) as usize] += 1;
+            });
+        }
     }
 
     // Merge move-related values whenever the combined group remains fully
@@ -1128,23 +1138,23 @@ fn color(
 
 fn rewrite(
     handler: &TargetFunction,
-    instructions: Vec<MachineInstruction>,
+    instructions: &[MachineInstruction],
     plan: &AllocationPlan,
     runtime: &RuntimeConstants,
 ) -> Result<Vec<AllocatedInstruction>, CompileError> {
     instructions
-        .into_iter()
+        .iter()
         .map(|insn| {
             let operands: Vec<_> = insn
                 .operands
-                .into_iter()
-                .map(|op| rewrite_operand(handler, op, plan, runtime))
+                .iter()
+                .map(|op| rewrite_operand(handler, op.clone(), plan, runtime))
                 .collect::<Result<_, _>>()?;
             if insn.opcode.description().identity_if_inputs_alias && operands.len() == 2 && operands[0] == operands[1] {
                 return Ok(None);
             }
             Ok(Some(AllocatedInstruction {
-                opcode: insn.opcode,
+                opcode: insn.opcode.clone(),
                 operands,
             }))
         })

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -41,7 +41,7 @@ use crate::target::registers::{PhysicalRegister, register_info_for, resolve_inte
 use crate::types::InterpreterRegister;
 use crate::types::RegisterClass as VirtualRegisterClass;
 use crate::{CompileError, CompileStage};
-use std::collections::{HashMap, HashSet};
+use crate::hash::{HashMap, HashSet};
 
 /// A set of physical registers.
 ///
@@ -172,7 +172,7 @@ struct Names {
 
 impl Names {
     fn collect(instructions: &[&MachineInstruction]) -> Self {
-        let mut seen = HashSet::new();
+        let mut seen = HashSet::default();
         for instruction in instructions {
             for operand in &instruction.operands {
                 visit_virtual_registers(operand, &mut |register| {

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -22,6 +22,7 @@
 //! Handlers that don't use virtual registers require no register assignment.
 
 use crate::Architecture;
+use crate::low_ir::analysis::virtual_register_access;
 use crate::low_ir::cfg::{ControlFlowGraph, instruction_successors};
 use crate::low_ir::optimize::{invert_branches_over_jumps, remove_unreferenced_labels};
 #[cfg(test)]
@@ -32,7 +33,7 @@ use crate::target::description::{
 use crate::target::description::{InstructionDescription, OperandKind, SelectedOpcode};
 use crate::target::ir::{
     AddressRegister, AllocatedFunction, AllocatedInstruction, AllocatedOperand, AllocatedProgram,
-    Function as TargetFunction, Instruction as MachineInstruction, MemoryAddress, Operand, PhysicalMemoryAddress,
+    Function as TargetFunction, Instruction as MachineInstruction, Operand, PhysicalMemoryAddress,
     Program as TargetProgram, RuntimeConstants, VirtualRegister, visit_virtual_registers,
 };
 #[cfg(test)]
@@ -99,12 +100,6 @@ impl UseDef {
         }
     }
 
-    fn use_operand(&mut self, operand: &Operand, names: &Names) {
-        if let Operand::VirtualRegister(register) = operand {
-            self.use_register(names.index(register));
-        }
-    }
-
     fn define_operand(&mut self, operand: &Operand, names: &Names, architecture: Architecture) {
         match operand {
             Operand::VirtualRegister(register) => {
@@ -122,12 +117,6 @@ impl UseDef {
                 self.clobbers |= register_bit(*register);
             }
             _ => {}
-        }
-    }
-
-    fn use_address_register(&mut self, register: &AddressRegister, names: &Names) {
-        if let AddressRegister::Virtual(register) = register {
-            self.use_register(names.index(register));
         }
     }
 }
@@ -289,23 +278,28 @@ fn build_allocated_graph(
 fn analyze_instruction(insn: &MachineInstruction, names: &Names, arch: Architecture) -> UseDef {
     let mut ud = UseDef::default();
     let info = insn.opcode.description();
-    let zeroes_register = info.zeroes_if_inputs_alias
-        && insn.operands.len() >= 2
-        && registers_alias(&insn.operands[0], &insn.operands[1], arch);
-
+    let access = virtual_register_access(insn, Some(arch));
+    for register in access.reads {
+        ud.use_register(names.index(&register));
+    }
+    for register in access.definitions {
+        ud.defs.push(names.index(&register));
+    }
     for (i, op) in insn.operands.iter().enumerate() {
-        // `xor dst, dst` is the canonical zero-the-register idiom. It
-        // defines the destination without reading either semantic operand.
-        // Target-selected scratch operands still retain their ordinary
-        // definitions.
-        if i < 2 && zeroes_register {
-            if i == 0 {
-                ud.define_operand(op, names, arch);
-            }
-            continue;
-        }
         let kind = operand_kind_at(info, i, insn.operands.len(), arch);
-        apply_operand_kind(&mut ud, op, kind, names, arch);
+        if matches!(
+            kind,
+            OperandKind::GprOut
+                | OperandKind::GprInOut
+                | OperandKind::GprScratch
+                | OperandKind::FprOut
+                | OperandKind::FprInOut
+                | OperandKind::FprScratch
+                | OperandKind::RegisterOut
+        ) && !matches!(op, Operand::VirtualRegister(_))
+        {
+            ud.define_operand(op, names, arch);
+        }
     }
     // Implicit i/o and all-caller-saved kills.
     let arch_spec = info.arch(arch);
@@ -338,64 +332,6 @@ fn operand_kind_at(
     description
         .selected_operand_kind(index, operand_count, architecture)
         .expect("operand index out of range")
-}
-
-fn apply_operand_kind(ud: &mut UseDef, op: &Operand, kind: OperandKind, names: &Names, arch: Architecture) {
-    match kind {
-        OperandKind::GprIn | OperandKind::FprIn | OperandKind::RegisterIn => {
-            ud.use_operand(op, names);
-        }
-        OperandKind::GprOut
-        | OperandKind::GprScratch
-        | OperandKind::FprScratch
-        | OperandKind::FprOut
-        | OperandKind::RegisterOut => {
-            ud.define_operand(op, names, arch);
-        }
-        OperandKind::GprInOut | OperandKind::FprInOut => {
-            ud.use_operand(op, names);
-            ud.define_operand(op, names, arch);
-        }
-        OperandKind::GprInOrImm | OperandKind::GprInOrMemory => {
-            ud.use_operand(op, names);
-            if kind == OperandKind::GprInOrMemory
-                && let Operand::Address(address) = op
-            {
-                for register in address_registers(address) {
-                    ud.use_address_register(register, names);
-                }
-            }
-        }
-        OperandKind::Memory => {
-            if let Operand::Address(address) = op {
-                for register in address_registers(address) {
-                    ud.use_address_register(register, names);
-                }
-            }
-        }
-        OperandKind::Imm | OperandKind::Label | OperandKind::FuncSymbol => {}
-    }
-}
-
-fn address_registers(address: &MemoryAddress) -> impl Iterator<Item = &AddressRegister> {
-    std::iter::once(&address.base).chain(address.index.iter())
-}
-
-fn registers_alias(lhs: &Operand, rhs: &Operand, architecture: Architecture) -> bool {
-    match (lhs, rhs) {
-        (Operand::VirtualRegister(lhs), Operand::VirtualRegister(rhs)) => lhs == rhs,
-        (Operand::InterpreterRegister(lhs), Operand::InterpreterRegister(rhs)) => {
-            resolve_interpreter_register(*lhs, architecture)
-                .zip(resolve_interpreter_register(*rhs, architecture))
-                .is_some_and(|(lhs, rhs)| lhs == rhs)
-        }
-        (Operand::InterpreterRegister(interpreter), Operand::PhysicalRegister(physical))
-        | (Operand::PhysicalRegister(physical), Operand::InterpreterRegister(interpreter)) => {
-            resolve_interpreter_register(*interpreter, architecture) == Some(*physical)
-        }
-        (Operand::PhysicalRegister(lhs), Operand::PhysicalRegister(rhs)) => lhs == rhs,
-        _ => false,
-    }
 }
 
 fn compute_liveness(
@@ -2013,6 +1949,84 @@ mod tests {
         assert_eq!(out[2].operands[1], AllocatedOperand::Immediate(7));
         assert_eq!(out[2].operands[0], out[3].operands[0]);
         assert_eq!(out[3].operands[0], out[4].operands[0]);
+    }
+
+    #[test]
+    fn rematerializes_multiple_widths_after_the_last_of_multiple_calls() {
+        for architecture in [Architecture::X86_64, Architecture::Aarch64] {
+            let out = allocated(
+                vec![
+                    instruction!(Operation::Move(IntegerWidth::U32), register("small"), immediate(7)),
+                    instruction!(Operation::Move(IntegerWidth::U64), register("large"), immediate(9)),
+                    instruction!(Operation::Move(IntegerWidth::U64), register("argument"), immediate(1)),
+                    instruction!(
+                        Operation::Call(CallKind::Helper),
+                        symbol("asm_helper_to_boolean"),
+                        register("argument"),
+                        register("first_result")
+                    ),
+                    instruction!(
+                        Operation::Call(CallKind::Helper),
+                        symbol("asm_helper_to_boolean"),
+                        register("argument"),
+                        register("second_result")
+                    ),
+                    instruction!(Operation::Assertion(AssertionOperation::NonZero), register("small")),
+                    instruction!(Operation::Assertion(AssertionOperation::NonZero), register("large")),
+                ],
+                architecture,
+            );
+
+            assert_eq!(operation_count(&out, Operation::Move(IntegerWidth::U32)), 2);
+            assert_eq!(operation_count(&out, Operation::Move(IntegerWidth::U64)), 4);
+            let second_call = out
+                .iter()
+                .rposition(|instruction| is_operation(instruction, Operation::Call(CallKind::Helper)))
+                .unwrap();
+            let rematerialized = &out[second_call + 1..second_call + 3];
+            assert!(
+                rematerialized
+                    .iter()
+                    .any(|instruction| is_operation(instruction, Operation::Move(IntegerWidth::U32)))
+            );
+            assert!(
+                rematerialized
+                    .iter()
+                    .any(|instruction| is_operation(instruction, Operation::Move(IntegerWidth::U64)))
+            );
+        }
+    }
+
+    #[test]
+    fn rematerializes_a_constant_used_by_an_address() {
+        for architecture in [Architecture::X86_64, Architecture::Aarch64] {
+            let out = allocated(
+                vec![
+                    instruction!(Operation::Move(IntegerWidth::U64), register("index"), immediate(1)),
+                    instruction!(Operation::Move(IntegerWidth::U64), register("argument"), immediate(1)),
+                    instruction!(
+                        Operation::Call(CallKind::Helper),
+                        symbol("asm_helper_to_boolean"),
+                        register("argument"),
+                        register("result")
+                    ),
+                    instruction!(
+                        Operation::load(MemoryWidth::DoubleWord, false),
+                        register("value"),
+                        SourceOperand::Address(SourceMemoryAddress {
+                            base: SourceAddressRegister::Interpreter(InterpreterRegister::Values),
+                            index: Some(SourceAddressRegister::named("index")),
+                            scale: Some(crate::low_ir::AddressScale::Immediate(8)),
+                            displacement: None,
+                        })
+                    ),
+                    instruction!(Operation::Assertion(AssertionOperation::NonZero), register("value")),
+                ],
+                architecture,
+            );
+
+            assert_eq!(operation_count(&out, Operation::Move(IntegerWidth::U64)), 3);
+        }
     }
 
     #[test]

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -425,40 +425,53 @@ fn compute_liveness(
         .iter()
         .map(|insn| analyze_instruction(insn, names, arch))
         .collect::<Vec<_>>();
+    let mut predecessors = vec![Vec::new(); n];
+    for (instruction, successors) in successors.iter().enumerate() {
+        for successor in successors {
+            predecessors[*successor].push(instruction);
+        }
+    }
+
     let mut live_in = vec![LiveSet::new(); n];
     let mut live_out = vec![LiveSet::new(); n];
     let mut next_out = LiveSet::new();
     let mut next_in = LiveSet::new();
-    loop {
-        let mut changed = false;
-        for instruction in (0..n).rev() {
-            next_out.clear();
-            for successor in &successors[instruction] {
-                merge_into(&mut next_out, &live_in[*successor]);
-            }
-            next_in.clear();
-            next_in.extend(
-                next_out
-                    .iter()
-                    .copied()
-                    .filter(|live| !use_def[instruction].defs.contains(live)),
-            );
-            if !use_def[instruction].uses.is_empty() {
-                merge_into(&mut next_in, &use_def[instruction].uses);
-            }
-            if live_in[instruction] != next_in {
-                live_in[instruction].clear();
-                live_in[instruction].extend_from_slice(&next_in);
-                changed = true;
-            }
-            if live_out[instruction] != next_out {
-                live_out[instruction].clear();
-                live_out[instruction].extend_from_slice(&next_out);
-                changed = true;
-            }
+    // What is live before an instruction depends only on what is live before
+    // its successors, so revisiting an instruction is only worthwhile when one
+    // of those moved. Sweeping the whole function instead costs a sweep to
+    // discover that nothing changed, plus one for every step a value has to
+    // travel backwards.
+    let mut queued = vec![true; n];
+    let mut queue = (0..n).collect::<Vec<_>>();
+    while let Some(instruction) = queue.pop() {
+        queued[instruction] = false;
+        next_out.clear();
+        for successor in &successors[instruction] {
+            merge_into(&mut next_out, &live_in[*successor]);
         }
-        if !changed {
-            break;
+        next_in.clear();
+        next_in.extend(
+            next_out
+                .iter()
+                .copied()
+                .filter(|live| !use_def[instruction].defs.contains(live)),
+        );
+        if !use_def[instruction].uses.is_empty() {
+            merge_into(&mut next_in, &use_def[instruction].uses);
+        }
+        if live_out[instruction] != next_out {
+            live_out[instruction].clear();
+            live_out[instruction].extend_from_slice(&next_out);
+        }
+        if live_in[instruction] == next_in {
+            continue;
+        }
+        live_in[instruction].clear();
+        live_in[instruction].extend_from_slice(&next_in);
+        for predecessor in &predecessors[instruction] {
+            if !std::mem::replace(&mut queued[*predecessor], true) {
+                queue.push(*predecessor);
+            }
         }
     }
     let liveness = Liveness {

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -559,6 +559,13 @@ impl CoalescingGroups {
         }
         self.groups.push(members);
     }
+
+    fn remove_last(&mut self) {
+        let members = self.groups.pop().expect("a candidate coalescing group was just added");
+        for member in members {
+            self.group_of[member as usize] = None;
+        }
+    }
 }
 
 struct ColoringContext<'a> {
@@ -873,13 +880,13 @@ fn allocate(
     };
     groups.sort_by(|lhs, rhs| group_score(rhs).cmp(&group_score(lhs)).then_with(|| lhs.cmp(rhs)));
     let mut retained_groups = CoalescingGroups::empty(count);
-    for group in groups {
-        let mut candidate_groups = retained_groups.clone();
-        candidate_groups.add(group);
-        if color(&context, &use_order, &candidate_groups).is_ok()
-            || color(&context, &live_order, &candidate_groups).is_ok()
+    const COALESCING_GROUP_RETENTION_LIMIT: usize = 32;
+    for group in groups.into_iter().take(COALESCING_GROUP_RETENTION_LIMIT) {
+        retained_groups.add(group);
+        if color(&context, &use_order, &retained_groups).is_err()
+            && color(&context, &live_order, &retained_groups).is_err()
         {
-            retained_groups = candidate_groups;
+            retained_groups.remove_last();
         }
     }
     if !retained_groups.groups.is_empty() {
@@ -895,7 +902,29 @@ fn allocate(
     if let Ok(plan) = try_color(&use_order, &no_groups) {
         return Ok(plan);
     }
-    try_color(&live_order, &no_groups)
+    if let Ok(plan) = try_color(&live_order, &no_groups) {
+        return Ok(plan);
+    }
+
+    match exact_color(&context) {
+        ExactColorResult::Colored(plan) => Ok(plan),
+        ExactColorResult::Impossible => Err(spill_free_allocation_error(
+            &handler.name,
+            &liveness,
+            &names,
+            gpr_pool.len(),
+            fpr_pool.len(),
+            "no legal register coloring exists",
+        )),
+        ExactColorResult::SearchLimit => Err(spill_free_allocation_error(
+            &handler.name,
+            &liveness,
+            &names,
+            gpr_pool.len(),
+            fpr_pool.len(),
+            "the bounded exact-coloring fallback reached its search limit",
+        )),
+    }
 }
 
 /// Greedy linear-scan coloring driven by the order in `sorted_virtuals`.
@@ -1056,6 +1085,189 @@ fn color(
     }
 
     Ok(AllocationPlan(assignments))
+}
+
+enum ExactColorResult {
+    Colored(AllocationPlan),
+    Impossible,
+    SearchLimit,
+}
+
+enum ExactSearchResult {
+    Colored,
+    Impossible,
+    SearchLimit,
+}
+
+const EXACT_COLOR_REGISTER_LIMIT: usize = 256;
+const EXACT_COLOR_WORK_LIMIT: u64 = 2_000_000;
+
+struct ExactColorBudget {
+    remaining: u64,
+}
+
+impl ExactColorBudget {
+    fn spend(&mut self, work: usize) -> bool {
+        let Ok(work) = u64::try_from(work) else {
+            return false;
+        };
+        if work > self.remaining {
+            self.remaining = 0;
+            return false;
+        }
+        self.remaining -= work;
+        true
+    }
+}
+
+fn exact_color(context: &ColoringContext<'_>) -> ExactColorResult {
+    if context.interference.nodes.len() > EXACT_COLOR_REGISTER_LIMIT {
+        return ExactColorResult::SearchLimit;
+    }
+    let mut assignments = vec![None; context.interference.nodes.len()];
+    let mut budget = ExactColorBudget {
+        remaining: EXACT_COLOR_WORK_LIMIT,
+    };
+    match exact_color_search(context, &mut assignments, &mut budget) {
+        ExactSearchResult::Colored => ExactColorResult::Colored(AllocationPlan(assignments)),
+        ExactSearchResult::Impossible => ExactColorResult::Impossible,
+        ExactSearchResult::SearchLimit => ExactColorResult::SearchLimit,
+    }
+}
+
+fn exact_color_search(
+    context: &ColoringContext<'_>,
+    assignments: &mut [Option<PhysicalRegister>],
+    budget: &mut ExactColorBudget,
+) -> ExactSearchResult {
+    if !budget.spend(1) {
+        return ExactSearchResult::SearchLimit;
+    }
+
+    let mut selected = None;
+    let mut selected_candidates = Vec::new();
+    let mut selected_degree = 0;
+    for register in 0..assignments.len() as u32 {
+        if !budget.spend(1) {
+            return ExactSearchResult::SearchLimit;
+        }
+        if assignments[register as usize].is_some() {
+            continue;
+        }
+        let class = context.names.name(register).class();
+        let pool = if class == VirtualRegisterClass::GeneralPurpose {
+            context.gpr_pool
+        } else {
+            context.fpr_pool
+        };
+        let mut forbidden = 0;
+        if !budget.spend(context.interference.neighbors(register).len()) {
+            return ExactSearchResult::SearchLimit;
+        }
+        context.forbid_conflicts(register, context.pool_mask(class), assignments, &mut forbidden);
+        let pinned = context.interference.nodes[register as usize].pinned;
+        if !budget.spend(pool.len()) {
+            return ExactSearchResult::SearchLimit;
+        }
+        let mut candidates = pool
+            .iter()
+            .copied()
+            .filter(|candidate| {
+                pinned.is_none_or(|pinned| pinned == *candidate) && forbidden & register_bit(*candidate) == 0
+            })
+            .collect::<Vec<_>>();
+        if candidates.is_empty() {
+            return ExactSearchResult::Impossible;
+        }
+        let affinities = &context.interference.nodes[register as usize].affinities;
+        if !budget.spend(affinities.len()) {
+            return ExactSearchResult::SearchLimit;
+        }
+        let affinity_assignments = affinities
+            .iter()
+            .filter_map(|neighbor| assignments[*neighbor as usize])
+            .fold(0, |set, physical| set | register_bit(physical));
+        if !budget.spend(candidates.len().saturating_mul(candidates.len())) {
+            return ExactSearchResult::SearchLimit;
+        }
+        candidates.sort_by_key(|candidate| {
+            let follows_affinity = affinity_assignments & register_bit(*candidate) != 0;
+            (!follows_affinity, candidate.allocation_cost())
+        });
+        let degree = context.interference.neighbors(register).len();
+        if selected.is_none()
+            || candidates.len() < selected_candidates.len()
+            || (candidates.len() == selected_candidates.len() && degree > selected_degree)
+        {
+            selected = Some(register);
+            selected_candidates = candidates;
+            selected_degree = degree;
+        }
+    }
+
+    let Some(register) = selected else {
+        return ExactSearchResult::Colored;
+    };
+    let mut reached_limit = false;
+    for candidate in selected_candidates {
+        if !budget.spend(1) {
+            return ExactSearchResult::SearchLimit;
+        }
+        assignments[register as usize] = Some(candidate);
+        match exact_color_search(context, assignments, budget) {
+            ExactSearchResult::Colored => return ExactSearchResult::Colored,
+            ExactSearchResult::Impossible => {}
+            ExactSearchResult::SearchLimit => reached_limit = true,
+        }
+        assignments[register as usize] = None;
+        if reached_limit {
+            return ExactSearchResult::SearchLimit;
+        }
+    }
+    ExactSearchResult::Impossible
+}
+
+fn spill_free_allocation_error(
+    handler: &str,
+    liveness: &Liveness,
+    names: &Names,
+    gpr_capacity: usize,
+    fpr_capacity: usize,
+    reason: &str,
+) -> CompileError {
+    let mut peak_gpr = (0, 0);
+    let mut peak_fpr = (0, 0);
+    for (instruction, live) in liveness.live_in.iter().enumerate() {
+        let gpr = live
+            .iter()
+            .filter(|register| names.name(**register).class() == VirtualRegisterClass::GeneralPurpose)
+            .count();
+        let fpr = live.len() - gpr;
+        if gpr > peak_gpr.0 {
+            peak_gpr = (gpr, instruction);
+        }
+        if fpr > peak_fpr.0 {
+            peak_fpr = (fpr, instruction);
+        }
+    }
+    let witness_instruction = if peak_gpr.0.saturating_sub(gpr_capacity) >= peak_fpr.0.saturating_sub(fpr_capacity) {
+        peak_gpr.1
+    } else {
+        peak_fpr.1
+    };
+    let witness = liveness.live_in[witness_instruction]
+        .iter()
+        .take(8)
+        .map(|register| names.name(*register).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    allocation_error(
+        handler,
+        format!(
+            "could not allocate spill-free handler: {reason}; peak GPR pressure {}/{} and FPR pressure {}/{}; values live near instruction #{}: {}",
+            peak_gpr.0, gpr_capacity, peak_fpr.0, fpr_capacity, witness_instruction, witness
+        ),
+    )
 }
 
 // ============================================================================
@@ -1503,6 +1715,138 @@ mod tests {
                 .any(|p| *p == name),
             "expected physical reg, got {name}"
         );
+    }
+
+    #[test]
+    fn exact_fallback_colors_a_graph_that_defeats_greedy_ordering() {
+        let function = crate::identity::HandlerId::new(0);
+        let mut seed = (0..6)
+            .map(|index| {
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register(&format!("crown_{index}")),
+                    immediate(index)
+                )
+            })
+            .collect::<Vec<_>>();
+        let virtual_registers = crate::low_ir::intern_virtual_registers(function, &mut seed);
+        let handler = TargetFunction {
+            id: function,
+            name: "Crown".to_string(),
+            size: None,
+            is_cold: false,
+            architecture: Architecture::X86_64,
+            virtual_registers,
+            instructions: Vec::new(),
+        };
+        let names = Names::new(function, &handler.virtual_registers);
+        let mut interference = InterferenceGraph {
+            neighbors: vec![Vec::new(); 6],
+            nodes: vec![Interference::default(); 6],
+        };
+        for lhs in 0..3u32 {
+            for rhs in 0..3u32 {
+                if lhs == rhs {
+                    continue;
+                }
+                let rhs = rhs + 3;
+                interference.neighbors[lhs as usize].push(rhs);
+                interference.neighbors[rhs as usize].push(lhs);
+            }
+        }
+        for neighbors in &mut interference.neighbors {
+            neighbors.sort_unstable();
+        }
+        let registers = register_info_for(Architecture::X86_64);
+        let gpr_pool = registers.temporaries.to_vec();
+        let fpr_pool = registers.fp_temporaries.to_vec();
+        let gpr_mask = gpr_pool.iter().fold(0, |set, register| set | register_bit(*register));
+        let allowed = register_bit(gpr_pool[0]) | register_bit(gpr_pool[1]);
+        for node in &mut interference.nodes {
+            node.forbidden = gpr_mask & !allowed;
+        }
+        let context = ColoringContext {
+            handler: &handler,
+            interference: &interference,
+            names: &names,
+            gpr_pool: &gpr_pool,
+            fpr_pool: &fpr_pool,
+            gpr_mask,
+            fpr_mask: fpr_pool.iter().fold(0, |set, register| set | register_bit(*register)),
+        };
+        let greedy_order = [0, 3, 1, 4, 2, 5];
+        assert!(color(&context, &greedy_order, &CoalescingGroups::empty(6)).is_err());
+        let ExactColorResult::Colored(plan) = exact_color(&context) else {
+            panic!("the exact fallback should find the two-coloring");
+        };
+        for register in 0..6u32 {
+            let physical = plan.0[register as usize].unwrap();
+            assert_ne!(register_bit(physical) & allowed, 0);
+            for neighbor in interference.neighbors(register) {
+                assert_ne!(plan.0[*neighbor as usize], Some(physical));
+            }
+        }
+    }
+
+    #[test]
+    fn exact_fallback_enforces_resource_limits() {
+        let function = crate::identity::HandlerId::new(0);
+        let mut seed = vec![instruction!(
+            Operation::Move(IntegerWidth::U64),
+            register("value"),
+            immediate(0)
+        )];
+        let virtual_registers = crate::low_ir::intern_virtual_registers(function, &mut seed);
+        let handler = TargetFunction {
+            id: function,
+            name: "Bounded".to_string(),
+            size: None,
+            is_cold: false,
+            architecture: Architecture::X86_64,
+            virtual_registers,
+            instructions: Vec::new(),
+        };
+        let names = Names::new(function, &handler.virtual_registers);
+        let registers = register_info_for(Architecture::X86_64);
+        let gpr_pool = registers.temporaries.to_vec();
+        let fpr_pool = registers.fp_temporaries.to_vec();
+        let gpr_mask = gpr_pool.iter().fold(0, |set, register| set | register_bit(*register));
+        let fpr_mask = fpr_pool.iter().fold(0, |set, register| set | register_bit(*register));
+
+        let oversized_interference = InterferenceGraph {
+            neighbors: vec![Vec::new(); EXACT_COLOR_REGISTER_LIMIT + 1],
+            nodes: vec![Interference::default(); EXACT_COLOR_REGISTER_LIMIT + 1],
+        };
+        let oversized_context = ColoringContext {
+            handler: &handler,
+            interference: &oversized_interference,
+            names: &names,
+            gpr_pool: &gpr_pool,
+            fpr_pool: &fpr_pool,
+            gpr_mask,
+            fpr_mask,
+        };
+        assert!(matches!(exact_color(&oversized_context), ExactColorResult::SearchLimit));
+
+        let interference = InterferenceGraph {
+            neighbors: vec![Vec::new()],
+            nodes: vec![Interference::default()],
+        };
+        let context = ColoringContext {
+            handler: &handler,
+            interference: &interference,
+            names: &names,
+            gpr_pool: &gpr_pool,
+            fpr_pool: &fpr_pool,
+            gpr_mask,
+            fpr_mask,
+        };
+        let mut assignments = vec![None];
+        let mut budget = ExactColorBudget { remaining: 0 };
+        assert!(matches!(
+            exact_color_search(&context, &mut assignments, &mut budget),
+            ExactSearchResult::SearchLimit
+        ));
     }
 
     #[test]
@@ -2054,7 +2398,7 @@ mod tests {
         )
         .expect_err("a nonrematerializable value cannot survive the call");
         assert!(
-            err.message.contains("could not allocate") || err.message.contains("pool exhausted"),
+            err.message.contains("could not allocate spill-free handler") && err.message.contains("peak GPR pressure"),
             "unexpected error: {err:?}"
         );
     }

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -21,83 +21,220 @@
 //!
 //! Handlers that don't use virtual registers require no register assignment.
 
-use crate::low_ir::cfg::ControlFlowGraph;
-use crate::target::description::{
-    InstructionDescription, OperandKind, SelectedOpcode,
-};
-#[cfg(test)]
-use crate::target::description::{AssertionOperation, CallKind, ControlOperation, EqualityCondition, MemoryWidth, PairWidth, TestCondition, ZeroCondition};
-use crate::types::RegisterClass as VirtualRegisterClass;
-use crate::types::InterpreterRegister;
 use crate::Architecture;
-use crate::target::registers::{PhysicalRegister, register_info_for, resolve_interpreter_register};
+use crate::low_ir::cfg::ControlFlowGraph;
+use crate::low_ir::optimize::{invert_branches_over_jumps, remove_unreferenced_labels};
+#[cfg(test)]
+use crate::target::description::{
+    AssertionOperation, CallKind, ControlOperation, EqualityCondition, MemoryWidth, PairWidth, TestCondition,
+    ZeroCondition,
+};
+use crate::target::description::{InstructionDescription, OperandKind, SelectedOpcode};
+use crate::target::ir::{
+    AddressRegister, AllocatedFunction, AllocatedInstruction, AllocatedOperand, AllocatedProgram,
+    Function as TargetFunction, Instruction as MachineInstruction, MemoryAddress, Operand, PhysicalMemoryAddress,
+    Program as TargetProgram, RuntimeConstants, VirtualRegister, count_virtual_register_uses, visit_virtual_registers,
+};
 #[cfg(test)]
 use crate::target::registers::physical_register_named;
-use crate::target::ir::{
-    AddressRegister, AllocatedFunction,
-    AllocatedInstruction, AllocatedOperand,
-    AllocatedProgram,
-    Function as TargetFunction, RuntimeConstants,
-    Instruction as MachineInstruction, MemoryAddress, Operand,
-    PhysicalMemoryAddress, Program as TargetProgram, count_virtual_register_uses,
-    visit_virtual_registers, VirtualRegister,
-};
-use crate::low_ir::optimize::{invert_branches_over_jumps, remove_unreferenced_labels};
+use crate::target::registers::{PhysicalRegister, register_info_for, resolve_interpreter_register};
+use crate::types::InterpreterRegister;
+use crate::types::RegisterClass as VirtualRegisterClass;
 use crate::{CompileError, CompileStage};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
-#[derive(Debug, Default)]
-struct UseDef {
-    uses: BTreeSet<VirtualRegister>,
-    defs: BTreeSet<VirtualRegister>,
-    clobbers: BTreeSet<PhysicalRegister>,
+/// A set of physical registers.
+///
+/// A register is identified by its class and its architecture-local number,
+/// which together fit in six bits, so a whole set is one machine word. Every
+/// function is compiled for a single architecture, so no further qualification
+/// is needed to keep two registers apart.
+type RegisterSet = u64;
+
+fn register_bit(register: PhysicalRegister) -> RegisterSet {
+    let class = match register.class() {
+        crate::target::registers::RegisterClass::GeneralPurpose => 0,
+        crate::target::registers::RegisterClass::FloatingPoint => 32,
+    };
+    1 << (class + u32::from(register.number()))
 }
 
-impl UseDef {
-    fn use_operand(&mut self, operand: &Operand) {
-        if let Operand::VirtualRegister(register) = operand {
-            self.uses.insert(register.clone());
+/// A set of virtual registers, held as a bitmap over dense virtual-register
+/// indices. Liveness and interference are the hot inner loops of allocation and
+/// both are set algebra, so they run word at a time rather than element at a
+/// time.
+#[derive(Clone)]
+struct VirtualRegisterSets {
+    words_per_set: usize,
+    words: Vec<u64>,
+}
+
+impl VirtualRegisterSets {
+    fn new(sets: usize, registers: usize) -> Self {
+        let words_per_set = registers.div_ceil(64);
+        Self {
+            words_per_set,
+            words: vec![0; sets * words_per_set],
         }
     }
 
-    fn define_operand(&mut self, operand: &Operand, architecture: Architecture) {
+    fn set(&self, index: usize) -> &[u64] {
+        &self.words[index * self.words_per_set..(index + 1) * self.words_per_set]
+    }
+
+    fn set_mut(&mut self, index: usize) -> &mut [u64] {
+        let start = index * self.words_per_set;
+        &mut self.words[start..start + self.words_per_set]
+    }
+
+    fn insert(&mut self, index: usize, register: u32) {
+        let start = index * self.words_per_set;
+        self.words[start + (register as usize) / 64] |= 1 << (register % 64);
+    }
+
+    fn union_into(&mut self, index: usize, source: &[u64]) {
+        let start = index * self.words_per_set;
+        for (word, added) in self.words[start..start + self.words_per_set].iter_mut().zip(source) {
+            *word |= *added;
+        }
+    }
+}
+
+fn members(set: &[u64]) -> impl Iterator<Item = u32> + '_ {
+    set.iter().enumerate().flat_map(|(word_index, word)| {
+        let mut remaining = *word;
+        std::iter::from_fn(move || {
+            (remaining != 0).then(|| {
+                let bit = remaining.trailing_zeros();
+                remaining &= remaining - 1;
+                (word_index as u32) * 64 + bit
+            })
+        })
+    })
+}
+
+fn contains(set: &[u64], register: u32) -> bool {
+    set[(register as usize) / 64] & (1 << (register % 64)) != 0
+}
+
+#[derive(Debug, Default)]
+struct UseDef {
+    uses: Vec<u32>,
+    defs: Vec<u32>,
+    clobbers: RegisterSet,
+}
+
+impl UseDef {
+    fn use_register(&mut self, register: u32) {
+        if !self.uses.contains(&register) {
+            self.uses.push(register);
+        }
+    }
+
+    fn use_operand(&mut self, operand: &Operand, names: &Names) {
+        if let Operand::VirtualRegister(register) = operand {
+            self.use_register(names.index(register));
+        }
+    }
+
+    fn define_operand(&mut self, operand: &Operand, names: &Names, architecture: Architecture) {
         match operand {
             Operand::VirtualRegister(register) => {
-                self.defs.insert(register.clone());
+                let register = names.index(register);
+                if !self.defs.contains(&register) {
+                    self.defs.push(register);
+                }
             }
             Operand::InterpreterRegister(register) => {
-                self.clobbers.extend(resolve_interpreter_register(*register, architecture));
+                if let Some(register) = resolve_interpreter_register(*register, architecture) {
+                    self.clobbers |= register_bit(register);
+                }
             }
             Operand::PhysicalRegister(register) => {
-                self.clobbers.insert(*register);
+                self.clobbers |= register_bit(*register);
             }
             _ => {}
         }
     }
 
-    fn use_address_register(&mut self, register: &AddressRegister) {
+    fn use_address_register(&mut self, register: &AddressRegister, names: &Names) {
         if let AddressRegister::Virtual(register) = register {
-            self.uses.insert(register.clone());
+            self.use_register(names.index(register));
         }
     }
 }
 
+/// The dense numbering every later phase of allocation works in.
+struct Names {
+    registers: Vec<VirtualRegister>,
+    indices: HashMap<VirtualRegister, u32>,
+}
+
+impl Names {
+    fn collect(instructions: &[MachineInstruction]) -> Self {
+        let mut seen = HashSet::new();
+        for instruction in instructions {
+            for operand in &instruction.operands {
+                visit_virtual_registers(operand, &mut |register| {
+                    if !seen.contains(register) {
+                        seen.insert(register.clone());
+                    }
+                });
+            }
+        }
+        // Sorting keeps the numbering, and with it every tie-break that
+        // depends on it, independent of hash iteration order.
+        let mut registers = seen.into_iter().collect::<Vec<_>>();
+        registers.sort();
+        let indices = registers
+            .iter()
+            .enumerate()
+            .map(|(index, register)| (register.clone(), index as u32))
+            .collect();
+        Self { registers, indices }
+    }
+
+    fn len(&self) -> usize {
+        self.registers.len()
+    }
+
+    fn index(&self, register: &VirtualRegister) -> u32 {
+        self.indices[register]
+    }
+
+    fn name(&self, index: u32) -> &VirtualRegister {
+        &self.registers[index as usize]
+    }
+}
+
 struct Liveness {
-    live_in: Vec<BTreeSet<VirtualRegister>>,
-    live_out: Vec<BTreeSet<VirtualRegister>>,
+    live_in: VirtualRegisterSets,
+    live_out: VirtualRegisterSets,
     use_def: Vec<UseDef>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct Interference {
-    neighbors: HashSet<VirtualRegister>,
-    forbidden: HashSet<PhysicalRegister>,
-    affinities: Vec<VirtualRegister>,
+    forbidden: RegisterSet,
+    affinities: Vec<u32>,
     pinned: Option<PhysicalRegister>,
     live_range_size: usize,
 }
 
-type InterferenceGraph = HashMap<VirtualRegister, Interference>;
+struct InterferenceGraph {
+    neighbors: VirtualRegisterSets,
+    nodes: Vec<Interference>,
+}
+
+impl InterferenceGraph {
+    fn neighbors(&self, register: u32) -> &[u64] {
+        self.neighbors.set(register as usize)
+    }
+
+    fn interferes(&self, register: u32, other: u32) -> bool {
+        contains(self.neighbors(register), other)
+    }
+}
 
 fn allocation_error(handler: &str, message: impl Into<String>) -> CompileError {
     CompileError::new(CompileStage::Allocation, Some(handler), message)
@@ -153,19 +290,11 @@ pub(crate) fn allocate_handler(
         }
     }
     if !needs {
-        return build_allocated_graph(
-            handler,
-            rewrite(handler, flat, &AllocationPlan::default(), runtime)?,
-        );
+        return build_allocated_graph(handler, rewrite(handler, flat, &AllocationPlan::default(), runtime)?);
     }
     let graph = build_graph(handler, flat.clone())?;
     let control_flow = graph.linearize_for_analysis();
-    let assignments = allocate(
-        handler,
-        &control_flow.instructions,
-        &control_flow.successors,
-        arch,
-    )?;
+    let assignments = allocate(handler, &control_flow.instructions, &control_flow.successors, arch)?;
     let mut rewritten = rewrite(handler, flat, &assignments, runtime)?;
     invert_branches_over_jumps(&mut rewritten);
     remove_unreferenced_labels(&mut rewritten);
@@ -178,9 +307,8 @@ fn build_allocated_graph(
     handler: &TargetFunction,
     instructions: Vec<AllocatedInstruction>,
 ) -> Result<ControlFlowGraph<AllocatedOperand, SelectedOpcode>, CompileError> {
-    let mut graph =
-        ControlFlowGraph::from_instructions(instructions)
-            .map_err(|message| allocation_error(&handler.name, message))?;
+    let mut graph = ControlFlowGraph::from_instructions(instructions)
+        .map_err(|message| allocation_error(&handler.name, message))?;
     graph.thread_unconditional_jumps();
     graph.remove_unreferenced_jump_blocks();
     graph.remove_unreachable_blocks();
@@ -191,8 +319,7 @@ fn build_graph(
     handler: &TargetFunction,
     instructions: Vec<MachineInstruction>,
 ) -> Result<ControlFlowGraph<Operand, SelectedOpcode>, CompileError> {
-    ControlFlowGraph::from_instructions(instructions)
-        .map_err(|message| allocation_error(&handler.name, message))
+    ControlFlowGraph::from_instructions(instructions).map_err(|message| allocation_error(&handler.name, message))
 }
 
 // ============================================================================
@@ -201,10 +328,7 @@ fn build_graph(
 
 /// Compute the physical and virtual register uses, definitions, and clobbers
 /// for one machine instruction.
-fn analyze_instruction(
-    insn: &MachineInstruction,
-    arch: Architecture,
-) -> UseDef {
+fn analyze_instruction(insn: &MachineInstruction, names: &Names, arch: Architecture) -> UseDef {
     let mut ud = UseDef::default();
     let info = insn.opcode.description();
     let zeroes_register = info.zeroes_if_inputs_alias
@@ -216,34 +340,35 @@ fn analyze_instruction(
         // defines the destination without reading either semantic operand.
         // Target-selected scratch operands still retain their ordinary
         // definitions.
-        if i < 2
-            && zeroes_register
-        {
+        if i < 2 && zeroes_register {
             if i == 0 {
-                ud.define_operand(op, arch);
+                ud.define_operand(op, names, arch);
             }
             continue;
         }
-        let kind =
-            operand_kind_at(info, i, insn.operands.len(), arch);
-        apply_operand_kind(&mut ud, op, kind, arch);
+        let kind = operand_kind_at(info, i, insn.operands.len(), arch);
+        apply_operand_kind(&mut ud, op, kind, names, arch);
     }
     // Implicit i/o and all-caller-saved kills.
     let arch_spec = info.arch(arch);
     for r in arch_spec.implicit_outputs {
-        ud.clobbers.insert(*r);
+        ud.clobbers |= register_bit(*r);
     }
     if info.is_call {
-        let registers = register_info_for(arch);
-        for r in registers.caller_saved_gpr {
-            ud.clobbers.insert(*r);
-        }
-        for r in registers.caller_saved_fpr {
-            ud.clobbers.insert(*r);
-        }
+        ud.clobbers |= caller_saved_registers(arch);
     }
 
     ud
+}
+
+/// Every register a C++ call is allowed to destroy, as one set.
+fn caller_saved_registers(architecture: Architecture) -> RegisterSet {
+    let registers = register_info_for(architecture);
+    registers
+        .caller_saved_gpr
+        .iter()
+        .chain(registers.caller_saved_fpr)
+        .fold(0, |set, register| set | register_bit(*register))
 }
 
 fn operand_kind_at(
@@ -257,41 +382,36 @@ fn operand_kind_at(
         .expect("operand index out of range")
 }
 
-fn apply_operand_kind(
-    ud: &mut UseDef,
-    op: &Operand,
-    kind: OperandKind,
-    arch: Architecture,
-) {
+fn apply_operand_kind(ud: &mut UseDef, op: &Operand, kind: OperandKind, names: &Names, arch: Architecture) {
     match kind {
         OperandKind::GprIn | OperandKind::FprIn | OperandKind::RegisterIn => {
-            ud.use_operand(op);
+            ud.use_operand(op, names);
         }
         OperandKind::GprOut
         | OperandKind::GprScratch
         | OperandKind::FprScratch
         | OperandKind::FprOut
         | OperandKind::RegisterOut => {
-            ud.define_operand(op, arch);
+            ud.define_operand(op, names, arch);
         }
         OperandKind::GprInOut | OperandKind::FprInOut => {
-            ud.use_operand(op);
-            ud.define_operand(op, arch);
+            ud.use_operand(op, names);
+            ud.define_operand(op, names, arch);
         }
         OperandKind::GprInOrImm | OperandKind::GprInOrMemory => {
-            ud.use_operand(op);
+            ud.use_operand(op, names);
             if kind == OperandKind::GprInOrMemory
                 && let Operand::Address(address) = op
             {
                 for register in address_registers(address) {
-                    ud.use_address_register(register);
+                    ud.use_address_register(register, names);
                 }
             }
         }
         OperandKind::Memory => {
             if let Operand::Address(address) = op {
                 for register in address_registers(address) {
-                    ud.use_address_register(register);
+                    ud.use_address_register(register, names);
                 }
             }
         }
@@ -324,6 +444,7 @@ fn compute_liveness(
     handler_name: &str,
     instructions: &[MachineInstruction],
     successors: &[Vec<usize>],
+    names: &Names,
     arch: Architecture,
 ) -> Result<Liveness, CompileError> {
     let n = instructions.len();
@@ -331,29 +452,31 @@ fn compute_liveness(
 
     let use_def = instructions
         .iter()
-        .map(|insn| analyze_instruction(insn, arch))
+        .map(|insn| analyze_instruction(insn, names, arch))
         .collect::<Vec<_>>();
-    let mut live_in = vec![BTreeSet::new(); use_def.len()];
-    let mut live_out = live_in.clone();
+    let mut live_in = VirtualRegisterSets::new(n, names.len());
+    let mut live_out = VirtualRegisterSets::new(n, names.len());
+    let mut next_out = vec![0; live_in.words_per_set];
+    let mut next_in = vec![0; live_in.words_per_set];
     loop {
         let mut changed = false;
-        for instruction in (0..use_def.len()).rev() {
-            let mut next_out = BTreeSet::new();
+        for instruction in (0..n).rev() {
+            next_out.fill(0);
             for successor in &successors[instruction] {
-                next_out.extend(live_in[*successor].iter().cloned());
+                for (word, added) in next_out.iter_mut().zip(live_in.set(*successor)) {
+                    *word |= *added;
+                }
             }
-            let mut next_in = use_def[instruction].uses.clone();
-            next_in.extend(
-                next_out
-                    .iter()
-                    .filter(|register| !use_def[instruction].defs.contains(*register))
-                    .cloned(),
-            );
-            if next_in != live_in[instruction]
-                || next_out != live_out[instruction]
-            {
-                live_in[instruction] = next_in;
-                live_out[instruction] = next_out;
+            next_in.copy_from_slice(&next_out);
+            for defined in &use_def[instruction].defs {
+                next_in[(*defined as usize) / 64] &= !(1 << (defined % 64));
+            }
+            for used in &use_def[instruction].uses {
+                next_in[(*used as usize) / 64] |= 1 << (used % 64);
+            }
+            if live_in.set(instruction) != next_in || live_out.set(instruction) != next_out {
+                live_in.set_mut(instruction).copy_from_slice(&next_in);
+                live_out.set_mut(instruction).copy_from_slice(&next_out);
                 changed = true;
             }
         }
@@ -361,23 +484,27 @@ fn compute_liveness(
             break;
         }
     }
-    let liveness = Liveness { live_in, live_out, use_def };
+    let liveness = Liveness {
+        live_in,
+        live_out,
+        use_def,
+    };
 
     // Sanity-check: a virtual register must be defined before its first use
     // along every path. We catch the simplest case: no virtual register may
     // be live at handler entry.
-    let entry_live = &liveness.live_in[0];
-    if let Some(register) = entry_live.iter().next() {
+    if let Some(register) = members(liveness.live_in.set(0)).next() {
         // Walk forward and find the first instruction that pulls this
         // virtual register into its live-in without having defined it
         // yet, so the error points at the actual problem.
         let mut culprit = String::from("(unknown)");
         for (i, ud) in liveness.use_def.iter().enumerate() {
-            if ud.uses.contains(register) && !ud.defs.contains(register) {
+            if ud.uses.contains(&register) && !ud.defs.contains(&register) {
                 culprit = format!("instruction #{i}: {:?}", instructions[i]);
                 break;
             }
         }
+        let register = names.name(register);
         return Err(allocation_error(
             handler_name,
             format!(
@@ -389,27 +516,27 @@ fn compute_liveness(
     Ok(liveness)
 }
 
-fn build_interference(
-    liveness: &Liveness,
-    virtuals: &[VirtualRegister],
-) -> InterferenceGraph {
-    let mut graph = virtuals
-        .iter()
-        .map(|register| (register.clone(), Interference::default()))
-        .collect::<InterferenceGraph>();
-    for (instruction, (live_in, live_out)) in liveness
-        .live_in
-        .iter()
-        .zip(&liveness.live_out)
-        .enumerate()
-    {
-        for live in [live_in, live_out] {
-            for (position, register) in live.iter().enumerate() {
-                graph.get_mut(register).unwrap().live_range_size += 1;
-                for other in live.iter().skip(position + 1) {
-                    graph.get_mut(register).unwrap().neighbors.insert(other.clone());
-                    graph.get_mut(other).unwrap().neighbors.insert(register.clone());
-                }
+fn build_interference(liveness: &Liveness, count: usize) -> InterferenceGraph {
+    let mut graph = InterferenceGraph {
+        neighbors: VirtualRegisterSets::new(count, count),
+        nodes: vec![Interference::default(); count],
+    };
+    let words = liveness.live_in.words_per_set;
+    let mut scratch = vec![0; words];
+    for instruction in 0..liveness.use_def.len() {
+        let use_def = &liveness.use_def[instruction];
+        for live in [
+            liveness.live_in.set(instruction),
+            liveness.live_out.set(instruction),
+        ] {
+            // Everything simultaneously live interferes with everything else
+            // simultaneously live, which is a union of the whole set into each
+            // member's neighbors rather than a walk over pairs.
+            for register in members(live) {
+                graph.nodes[register as usize].live_range_size += 1;
+                graph.neighbors.union_into(register as usize, live);
+                let row = graph.neighbors.set_mut(register as usize);
+                row[(register as usize) / 64] &= !(1 << (register % 64));
             }
         }
         // What an instruction writes conflicts with whatever is still live
@@ -418,22 +545,37 @@ fn build_interference(
         // so it appears in no live set at all; without this it would collect no
         // neighbors and could be handed the register of a value that has to
         // survive the instruction.
-        for defined in &liveness.use_def[instruction].defs {
-            for other in live_out.iter().chain(&liveness.use_def[instruction].defs) {
-                if other == defined {
-                    continue;
+        if !use_def.defs.is_empty() {
+            scratch.copy_from_slice(liveness.live_out.set(instruction));
+            for defined in &use_def.defs {
+                scratch[(*defined as usize) / 64] |= 1 << (defined % 64);
+            }
+            for defined in &use_def.defs {
+                graph.neighbors.union_into(*defined as usize, &scratch);
+                let row = graph.neighbors.set_mut(*defined as usize);
+                row[(*defined as usize) / 64] &= !(1 << (defined % 64));
+                for other in members(&scratch) {
+                    if other != *defined {
+                        graph.neighbors.insert(other as usize, *defined);
+                    }
                 }
-                graph.get_mut(defined).unwrap().neighbors.insert(other.clone());
-                graph.get_mut(other).unwrap().neighbors.insert(defined.clone());
             }
         }
 
-        for register in live_in.intersection(live_out) {
-            if liveness.use_def[instruction].defs.contains(register) {
-                continue;
+        if use_def.clobbers != 0 {
+            let live_in = liveness.live_in.set(instruction);
+            let live_out = liveness.live_out.set(instruction);
+            for (word_index, (entering, leaving)) in live_in.iter().zip(live_out).enumerate() {
+                let mut both = entering & leaving;
+                while both != 0 {
+                    let register = (word_index as u32) * 64 + both.trailing_zeros();
+                    both &= both - 1;
+                    if use_def.defs.contains(&register) {
+                        continue;
+                    }
+                    graph.nodes[register as usize].forbidden |= use_def.clobbers;
+                }
             }
-            let forbidden = &mut graph.get_mut(register).unwrap().forbidden;
-            forbidden.extend(&liveness.use_def[instruction].clobbers);
         }
     }
     graph
@@ -445,32 +587,83 @@ fn build_interference(
 
 type AllocationPlan = HashMap<VirtualRegister, PhysicalRegister>;
 
+/// Coalescing groups, as a dense map from virtual register to the group it
+/// belongs to. A group is a set of move-related values that all take the same
+/// physical register, so the moves relating them disappear.
+#[derive(Default, Clone)]
+struct CoalescingGroups {
+    group_of: Vec<Option<u32>>,
+    groups: Vec<Vec<u32>>,
+}
+
+impl CoalescingGroups {
+    fn empty(count: usize) -> Self {
+        Self {
+            group_of: vec![None; count],
+            groups: Vec::new(),
+        }
+    }
+
+    fn of(&self, register: u32) -> Option<&[u32]> {
+        self.group_of[register as usize].map(|group| self.groups[group as usize].as_slice())
+    }
+
+    fn add(&mut self, members: Vec<u32>) {
+        let group = self.groups.len() as u32;
+        for member in &members {
+            self.group_of[*member as usize] = Some(group);
+        }
+        self.groups.push(members);
+    }
+}
+
 struct ColoringContext<'a> {
     handler: &'a TargetFunction,
     interference: &'a InterferenceGraph,
+    names: &'a Names,
     gpr_pool: &'a [PhysicalRegister],
     fpr_pool: &'a [PhysicalRegister],
+    gpr_mask: RegisterSet,
+    fpr_mask: RegisterSet,
 }
 
 impl ColoringContext<'_> {
+    fn pool_mask(&self, class: VirtualRegisterClass) -> RegisterSet {
+        match class {
+            VirtualRegisterClass::GeneralPurpose => self.gpr_mask,
+            VirtualRegisterClass::FloatingPoint => self.fpr_mask,
+        }
+    }
+
     fn forbid_conflicts(
         &self,
-        member: &VirtualRegister,
-        pool: &[PhysicalRegister],
-        assignments: &HashMap<VirtualRegister, PhysicalRegister>,
-        forbidden: &mut HashSet<PhysicalRegister>,
+        member: u32,
+        pool_mask: RegisterSet,
+        assignments: &[Option<PhysicalRegister>],
+        forbidden: &mut RegisterSet,
     ) {
-        forbidden.extend(
-            self.interference[member]
-                .forbidden
-                .iter()
-                .filter(|register| pool.contains(register)),
-        );
-        for other in &self.interference[member].neighbors {
-            if let Some(&physical) = assignments.get(other) {
-                forbidden.insert(physical);
+        *forbidden |= self.interference.nodes[member as usize].forbidden & pool_mask;
+        *forbidden |= self.assigned_neighbors(member, assignments);
+    }
+
+    /// Every physical register already handed to something this value
+    /// interferes with.
+    fn assigned_neighbors(&self, register: u32, assignments: &[Option<PhysicalRegister>]) -> RegisterSet {
+        let mut taken = 0;
+        for other in members(self.interference.neighbors(register)) {
+            if let Some(physical) = assignments[other as usize] {
+                taken |= register_bit(physical);
             }
         }
+        taken
+    }
+
+    fn cheapest(&self, pool: &[PhysicalRegister], forbidden: RegisterSet) -> Option<PhysicalRegister> {
+        pool.iter()
+            .enumerate()
+            .filter(|(_, candidate)| forbidden & register_bit(**candidate) == 0)
+            .min_by_key(|(index, candidate)| (candidate.allocation_cost(), *index))
+            .map(|(_, candidate)| *candidate)
     }
 }
 
@@ -480,11 +673,35 @@ enum AllocationPriority {
     LiveRange,
 }
 
-fn root_of(parents: &[usize], mut index: usize) -> usize {
-    while parents[index] != index {
-        index = parents[index];
+/// Union-find over virtual registers, carrying each set's members so that
+/// merging two sets never has to rescan every register.
+struct Coalescer {
+    parents: Vec<u32>,
+    members: Vec<Vec<u32>>,
+}
+
+impl Coalescer {
+    fn new(count: usize) -> Self {
+        Self {
+            parents: (0..count as u32).collect(),
+            members: (0..count as u32).map(|index| vec![index]).collect(),
+        }
     }
-    index
+
+    fn root_of(&mut self, mut index: u32) -> u32 {
+        while self.parents[index as usize] != index {
+            let grandparent = self.parents[self.parents[index as usize] as usize];
+            self.parents[index as usize] = grandparent;
+            index = grandparent;
+        }
+        index
+    }
+
+    fn merge(&mut self, into: u32, from: u32) {
+        self.parents[from as usize] = into;
+        let moved = std::mem::take(&mut self.members[from as usize]);
+        self.members[into as usize].extend(moved);
+    }
 }
 
 fn allocate(
@@ -493,34 +710,20 @@ fn allocate(
     successors: &[Vec<usize>],
     arch: Architecture,
 ) -> Result<AllocationPlan, CompileError> {
+    let names = Names::collect(instructions);
+    let count = names.len();
+    let liveness = compute_liveness(&handler.name, instructions, successors, &names, arch)?;
 
-    // Collect typed virtual registers.
-    let mut virtuals = HashSet::new();
-    for insn in instructions {
-        for operand in &insn.operands {
-            visit_virtual_registers(operand, &mut |register| {
-                virtuals.insert(register.clone());
-            });
-        }
-    }
-
-    let liveness = compute_liveness(
-        &handler.name,
-        instructions,
-        successors,
-        arch,
-    )?;
-    let mut all_virtuals = virtuals.iter().cloned().collect::<Vec<_>>();
-    all_virtuals.sort();
-
-    let mut interference = build_interference(&liveness, &all_virtuals);
+    let mut interference = build_interference(&liveness, count);
     let mut move_affinity_edges = Vec::new();
     for insn in instructions {
         let info = insn.opcode.description();
         let arch_spec = info.arch(arch);
         for &(index, physical) in arch_spec.fixed_operands {
             if let Some(Operand::VirtualRegister(register)) = insn.operands.get(index)
-                && let Some(previous) = interference.get_mut(register).unwrap().pinned.replace(physical)
+                && let Some(previous) = interference.nodes[names.index(register) as usize]
+                    .pinned
+                    .replace(physical)
                 && previous != physical
             {
                 return Err(allocation_error(
@@ -532,7 +735,7 @@ fn allocate(
             }
         }
 
-        let mut explicit_scratches = Vec::new();
+        let mut explicit_scratches = 0;
         for (index, operand) in insn.operands.iter().enumerate() {
             if info
                 .selected_operand_kind(index, insn.operands.len(), arch)
@@ -544,54 +747,48 @@ fn allocate(
                         "target-selected scratch operand must be a physical register",
                     ));
                 };
-                explicit_scratches.push(*register);
+                explicit_scratches |= register_bit(*register);
             }
         }
-        if !explicit_scratches.is_empty() {
+        if explicit_scratches != 0 {
             for operand in &insn.operands {
                 visit_virtual_registers(operand, &mut |register| {
-                    interference
-                        .get_mut(register)
-                        .unwrap()
-                        .forbidden
-                        .extend(explicit_scratches.iter().copied());
+                    interference.nodes[names.index(register) as usize].forbidden |= explicit_scratches;
                 });
             }
         }
-        for (index, operand) in insn.operands.iter().enumerate() {
-            if let Operand::VirtualRegister(register) = operand {
-                let pinned_here = arch_spec
-                    .fixed_operands
-                    .iter()
-                    .find_map(|&(operand, physical)| (operand == index).then_some(physical));
-                interference.get_mut(register).unwrap().forbidden.extend(
-                    arch_spec
+        if !arch_spec.implicit_outputs.is_empty() {
+            for (index, operand) in insn.operands.iter().enumerate() {
+                if let Operand::VirtualRegister(register) = operand {
+                    let pinned_here = arch_spec
+                        .fixed_operands
+                        .iter()
+                        .find_map(|&(operand, physical)| (operand == index).then_some(physical));
+                    let forbidden = arch_spec
                         .implicit_outputs
                         .iter()
-                        .copied()
-                        .filter(|physical| Some(*physical) != pinned_here),
-                );
+                        .filter(|physical| Some(**physical) != pinned_here)
+                        .fold(0, |set, physical| set | register_bit(*physical));
+                    interference.nodes[names.index(register) as usize].forbidden |= forbidden;
+                }
             }
         }
         // Only prefer aliases when both backends can omit a copy. For example,
         // mov32 must still execute to zero-extend its input even when both
         // operands share a register.
         for &(output, input) in info.coalescing_pairs {
-            let (
-                Some(Operand::VirtualRegister(output)),
-                Some(Operand::VirtualRegister(input)),
-            ) = (
-                insn.operands.get(output),
-                insn.operands.get(input),
-            ) else {
+            let (Some(Operand::VirtualRegister(output)), Some(Operand::VirtualRegister(input))) =
+                (insn.operands.get(output), insn.operands.get(input))
+            else {
                 continue;
             };
             if output == input || output.class() != input.class() {
                 continue;
             }
-            interference.get_mut(output).unwrap().affinities.push(input.clone());
-            interference.get_mut(input).unwrap().affinities.push(output.clone());
-            move_affinity_edges.push((output.clone(), input.clone()));
+            let (output, input) = (names.index(output), names.index(input));
+            interference.nodes[output as usize].affinities.push(input);
+            interference.nodes[input as usize].affinities.push(output);
+            move_affinity_edges.push((output, input));
         }
     }
 
@@ -602,63 +799,52 @@ fn allocate(
 
     // On x86_64 each saved use of a low-cost register saves an encoding
     // byte, so hot virtual registers want to land in cheap registers.
-    let use_counts = count_virtual_register_uses(instructions);
+    let mut use_counts = vec![0u32; count];
+    for (register, uses) in count_virtual_register_uses(instructions) {
+        use_counts[names.index(&register) as usize] = uses;
+    }
 
     // Merge move-related values whenever the combined group remains fully
     // noninterfering. Greedy compatible subgroups preserve opportunities in
     // affinity graphs where one interfering edge prevents full coalescing.
-    let virtual_indices = all_virtuals
-        .iter()
-        .enumerate()
-        .map(|(index, register)| (register.clone(), index))
-        .collect::<HashMap<_, _>>();
-    let mut parents = (0..all_virtuals.len()).collect::<Vec<_>>();
+    let mut coalescer = Coalescer::new(count);
     for (lhs, rhs) in move_affinity_edges {
-        let lhs = virtual_indices[&lhs];
-        let rhs = virtual_indices[&rhs];
-        let lhs_root = root_of(&parents, lhs);
-        let rhs_root = root_of(&parents, rhs);
+        let lhs_root = coalescer.root_of(lhs);
+        let rhs_root = coalescer.root_of(rhs);
         if lhs_root == rhs_root {
             continue;
         }
-        let members = (0..all_virtuals.len())
-            .filter(|index| {
-                let root = root_of(&parents, *index);
-                root == lhs_root || root == rhs_root
-            })
-            .collect::<Vec<_>>();
-        let can_coalesce_all = members.iter().enumerate().all(|(position, member)| {
-            let member = &all_virtuals[*member];
-            members[position + 1..].iter().all(|other| {
-                let other = &all_virtuals[*other];
-                !interference[member].neighbors.contains(other)
-            })
+        // Members of either set already do not interfere with each other, so
+        // only the pairs that cross between the two sets are new.
+        let can_coalesce_all = coalescer.members[lhs_root as usize].iter().all(|member| {
+            coalescer.members[rhs_root as usize]
+                .iter()
+                .all(|other| !interference.interferes(*member, *other))
         });
-        let pinned_registers = members
+        let mut pinned = None;
+        let mut conflicting_pins = false;
+        for member in coalescer.members[lhs_root as usize]
             .iter()
-            .filter_map(|member| interference[&all_virtuals[*member]].pinned)
-            .collect::<HashSet<_>>();
-        if can_coalesce_all && pinned_registers.len() <= 1 {
-            parents[rhs_root] = lhs_root;
+            .chain(&coalescer.members[rhs_root as usize])
+        {
+            if let Some(physical) = interference.nodes[*member as usize].pinned {
+                conflicting_pins |= pinned.is_some_and(|already| already != physical);
+                pinned = Some(physical);
+            }
+        }
+        if can_coalesce_all && !conflicting_pins {
+            coalescer.merge(lhs_root, rhs_root);
         }
     }
 
-    let mut coalescing_groups = HashMap::new();
-    for root in 0..all_virtuals.len() {
-        if root_of(&parents, root) != root {
+    let mut coalescing_groups = CoalescingGroups::empty(count);
+    for root in 0..count as u32 {
+        if coalescer.parents[root as usize] != root || coalescer.members[root as usize].len() <= 1 {
             continue;
         }
-        let mut members = (0..all_virtuals.len())
-            .filter(|index| root_of(&parents, *index) == root)
-            .map(|index| all_virtuals[index].clone())
-            .collect::<Vec<_>>();
-        if members.len() <= 1 {
-            continue;
-        }
-        members.sort();
-        for member in &members {
-            coalescing_groups.insert(member.clone(), members.clone());
-        }
+        let mut members = std::mem::take(&mut coalescer.members[root as usize]);
+        members.sort_unstable();
+        coalescing_groups.add(members);
     }
 
     // Greedy graph coloring is sensitive to the order virtual registers are
@@ -679,93 +865,101 @@ fn allocate(
     // We then try cost-first and fall back to fit-first only when cost-first
     // can't color. This wins the byte savings when the handler has slack
     // and never regresses fit when it doesn't.
+    let gpr_mask = gpr_pool.iter().fold(0, |set, register| set | register_bit(*register));
+    let fpr_mask = fpr_pool.iter().fold(0, |set, register| set | register_bit(*register));
     let context = ColoringContext {
         handler,
         interference: &interference,
+        names: &names,
         gpr_pool: &gpr_pool,
         fpr_pool: &fpr_pool,
+        gpr_mask,
+        fpr_mask,
     };
-    let try_color = |sorted, groups| color(&context, sorted, groups);
-    let compare = |a: &VirtualRegister, b: &VirtualRegister, priority| {
-        let ap = interference[a].pinned.is_some();
-        let bp = interference[b].pinned.is_some();
-        let aa = interference[a]
-            .affinities
-            .iter()
-            .any(|neighbor| interference[neighbor].pinned.is_some());
-        let ba = interference[b]
-            .affinities
-            .iter()
-            .any(|neighbor| interference[neighbor].pinned.is_some());
-        let au = use_counts.get(a).copied().unwrap_or(0) as usize;
-        let bu = use_counts.get(b).copied().unwrap_or(0) as usize;
-        let aw = interference[a].live_range_size;
-        let bw = interference[b].live_range_size;
+    let try_color = |sorted: &[u32], groups: &CoalescingGroups| color(&context, sorted, groups);
+    let follows_pinned = (0..count)
+        .map(|register| {
+            interference.nodes[register]
+                .affinities
+                .iter()
+                .any(|neighbor| interference.nodes[*neighbor as usize].pinned.is_some())
+        })
+        .collect::<Vec<_>>();
+    let compare = |a: &u32, b: &u32, priority| {
+        let (a, b) = (*a as usize, *b as usize);
+        let ap = interference.nodes[a].pinned.is_some();
+        let bp = interference.nodes[b].pinned.is_some();
+        let au = use_counts[a] as usize;
+        let bu = use_counts[b] as usize;
+        let aw = interference.nodes[a].live_range_size;
+        let bw = interference.nodes[b].live_range_size;
         let ((af, bf), (as_, bs)) = match priority {
             AllocationPriority::UseCount => ((au, bu), (aw, bw)),
             AllocationPriority::LiveRange => ((aw, bw), (au, bu)),
         };
         bp.cmp(&ap)
-            .then_with(|| ba.cmp(&aa))
+            .then_with(|| follows_pinned[b].cmp(&follows_pinned[a]))
             .then_with(|| bf.cmp(&af))
             .then_with(|| bs.cmp(&as_))
-            .then_with(|| a.cmp(b))
+            .then_with(|| a.cmp(&b))
     };
 
-    let mut use_order = all_virtuals.clone();
+    let mut use_order = (0..count as u32).collect::<Vec<_>>();
     use_order.sort_by(|a, b| compare(a, b, AllocationPriority::UseCount));
     if let Ok(plan) = try_color(&use_order, &coalescing_groups) {
-        return Ok(plan);
+        return Ok(plan.into_named(&names));
     }
 
-    let mut live_order = all_virtuals.clone();
+    let mut live_order = use_order.clone();
     live_order.sort_by(|a, b| compare(a, b, AllocationPriority::LiveRange));
     if let Ok(plan) = try_color(&live_order, &coalescing_groups) {
-        return Ok(plan);
+        return Ok(plan.into_named(&names));
     }
 
-    let mut groups = coalescing_groups
-        .iter()
-        .filter(|(member, group)| group.first() == Some(*member))
-        .map(|(_, group)| group.clone())
-        .collect::<Vec<_>>();
-    let group_score = |group: &[VirtualRegister]| {
+    let mut groups = coalescing_groups.groups.clone();
+    let group_score = |group: &[u32]| {
         (
-            group.iter().map(|member| use_counts.get(member).copied().unwrap_or(0)).sum::<u32>(),
+            group.iter().map(|member| use_counts[*member as usize]).sum::<u32>(),
             group.len(),
         )
     };
-    groups.sort_by(|lhs, rhs| {
-        group_score(rhs)
-            .cmp(&group_score(lhs))
-            .then_with(|| lhs.cmp(rhs))
-    });
-    let mut retained_groups = HashMap::new();
+    groups.sort_by(|lhs, rhs| group_score(rhs).cmp(&group_score(lhs)).then_with(|| lhs.cmp(rhs)));
+    let mut retained_groups = CoalescingGroups::empty(count);
     for group in groups {
         let mut candidate_groups = retained_groups.clone();
-        for member in &group {
-            candidate_groups.insert(member.clone(), group.clone());
-        }
-        if color(&context, &use_order, &candidate_groups).is_ok()
-            || color(&context, &live_order, &candidate_groups).is_ok()
+        candidate_groups.add(group);
+        if color(&context, &use_order, &candidate_groups).is_ok() || color(&context, &live_order, &candidate_groups).is_ok()
         {
             retained_groups = candidate_groups;
         }
     }
-    if !retained_groups.is_empty() {
+    if !retained_groups.groups.is_empty() {
         if let Ok(plan) = try_color(&use_order, &retained_groups) {
-            return Ok(plan);
+            return Ok(plan.into_named(&names));
         }
         if let Ok(plan) = try_color(&live_order, &retained_groups) {
-            return Ok(plan);
+            return Ok(plan.into_named(&names));
         }
     }
 
-    let no_groups = HashMap::new();
+    let no_groups = CoalescingGroups::empty(count);
     if let Ok(plan) = try_color(&use_order, &no_groups) {
-        return Ok(plan);
+        return Ok(plan.into_named(&names));
     }
-    try_color(&live_order, &no_groups)
+    try_color(&live_order, &no_groups).map(|plan| plan.into_named(&names))
+}
+
+/// A coloring, indexed by dense virtual-register number.
+struct Assignments(Vec<Option<PhysicalRegister>>);
+
+impl Assignments {
+    fn into_named(self, names: &Names) -> AllocationPlan {
+        self.0
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, physical)| physical.map(|physical| (names.name(index as u32).clone(), physical)))
+            .collect()
+    }
 }
 
 /// Greedy linear-scan coloring driven by the order in `sorted_virtuals`.
@@ -773,66 +967,63 @@ fn allocate(
 /// whether to retry with a different ordering.
 fn color(
     context: &ColoringContext<'_>,
-    sorted_virtuals: &[VirtualRegister],
-    coalescing_groups: &HashMap<VirtualRegister, Vec<VirtualRegister>>,
-) -> Result<AllocationPlan, CompileError> {
+    sorted_virtuals: &[u32],
+    coalescing_groups: &CoalescingGroups,
+) -> Result<Assignments, CompileError> {
     let ColoringContext {
         handler,
         interference,
+        names,
         gpr_pool,
         fpr_pool,
+        ..
     } = context;
-    let mut assignments = HashMap::new();
+    let mut assignments = vec![None; interference.nodes.len()];
 
     for name in sorted_virtuals {
-        if assignments.contains_key(name) {
+        let name = *name;
+        if assignments[name as usize].is_some() {
             continue;
         }
-        let is_gpr = name.class() == VirtualRegisterClass::GeneralPurpose;
+        let class = names.name(name).class();
+        let is_gpr = class == VirtualRegisterClass::GeneralPurpose;
         let pool = if is_gpr { gpr_pool } else { fpr_pool };
-        if let Some(group) = coalescing_groups.get(name) {
-            let mut forbidden = HashSet::new();
+        let pool_mask = context.pool_mask(class);
+        if let Some(group) = coalescing_groups.of(name) {
+            let mut forbidden = 0;
+            let mut pinned = None;
+            let mut conflicting_pins = false;
             for member in group {
-                context.forbid_conflicts(
-                    member,
-                    pool,
-                    &assignments,
-                    &mut forbidden,
-                );
+                context.forbid_conflicts(*member, pool_mask, &assignments, &mut forbidden);
+                if let Some(physical) = interference.nodes[*member as usize].pinned {
+                    conflicting_pins |= pinned.is_some_and(|already| already != physical);
+                    pinned = Some(physical);
+                }
             }
-            let pinned_registers = group
-                .iter()
-                .filter_map(|member| interference[member].pinned)
-                .collect::<HashSet<_>>();
-            let pick = if let Some(&pinned) = pinned_registers.iter().next() {
-                if pinned_registers.len() != 1
-                    || !pool.contains(&pinned)
-                    || forbidden.contains(&pinned)
-                {
+            let pick = if let Some(pinned) = pinned {
+                if conflicting_pins || pool_mask & register_bit(pinned) == 0 || forbidden & register_bit(pinned) != 0 {
                     return Err(allocation_error(
                         &handler.name,
-                        format!("could not coalesce move affinity group containing '{name}'"),
+                        format!(
+                            "could not coalesce move affinity group containing '{}'",
+                            names.name(name)
+                        ),
                     ));
                 }
                 pinned
             } else {
-                *pool
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, candidate)| !forbidden.contains(*candidate))
-                    .min_by_key(|(index, candidate)| {
-                        (candidate.allocation_cost(), *index)
-                    })
-                    .map(|(_, candidate)| candidate)
-                    .ok_or_else(|| {
-                        allocation_error(
-                            &handler.name,
-                            format!("could not coalesce move affinity group containing '{name}'"),
-                        )
-                    })?
+                context.cheapest(pool, forbidden).ok_or_else(|| {
+                    allocation_error(
+                        &handler.name,
+                        format!(
+                            "could not coalesce move affinity group containing '{}'",
+                            names.name(name)
+                        ),
+                    )
+                })?
             };
             for member in group {
-                assignments.insert(member.clone(), pick);
+                assignments[*member as usize] = Some(pick);
             }
             continue;
         }
@@ -850,115 +1041,85 @@ fn color(
         //     operands before writing output operands, so the same physical
         //     register can host an outgoing value and an incoming value at
         //     the same instruction.
-        let mut forbidden = HashSet::new();
-        context.forbid_conflicts(
-            name,
-            pool,
-            &assignments,
-            &mut forbidden,
-        );
+        let mut forbidden = 0;
+        context.forbid_conflicts(name, pool_mask, &assignments, &mut forbidden);
 
-        let pick = if let Some(pinned) = interference[name].pinned {
-            if !pool.contains(&pinned) {
+        let pick = if let Some(pinned) = interference.nodes[name as usize].pinned {
+            if pool_mask & register_bit(pinned) == 0 {
                 return Err(allocation_error(
                     &handler.name,
                     format!(
-                        "virtual register '{name}' must be pinned to '{pinned}', but that register is not in the {} pool",
+                        "virtual register '{}' must be pinned to '{pinned}', but that register is not in the {} pool",
+                        names.name(name),
                         if is_gpr { "GPR" } else { "FPR" }
                     ),
                 ));
             }
-            if forbidden.contains(&pinned) {
-                let mut sorted = forbidden.iter().copied().collect::<Vec<_>>();
-                sorted.sort();
+            if forbidden & register_bit(pinned) != 0 {
                 return Err(allocation_error(
                     &handler.name,
                     format!(
-                        "virtual register '{name}' must be pinned to '{pinned}', but that register is killed or occupied across its live range (forbidden: {sorted:?})"
+                        "virtual register '{}' must be pinned to '{pinned}', but that register is killed or occupied across its live range (forbidden: {forbidden:#x})",
+                        names.name(name),
                     ),
                 ));
             }
             pinned
         } else {
-            let preferred = interference[name]
+            let preferred = interference.nodes[name as usize]
                 .affinities
                 .iter()
-                .filter_map(|other| assignments.get(other).copied())
-                .find(|register| !forbidden.contains(register));
-            let coalescable_neighbors = interference[name]
-                .affinities
-                .iter()
-                .filter(|neighbor| !assignments.contains_key(*neighbor))
-                .filter(|neighbor| !interference[name].neighbors.contains(*neighbor))
-                .collect::<Vec<_>>();
-            let available_for_neighbor =
-                |neighbor: &VirtualRegister, candidate: PhysicalRegister| {
-                if interference[neighbor]
-                    .pinned
-                    .is_some_and(|pinned| pinned != candidate)
-                    || interference[neighbor].forbidden.contains(&candidate)
-                {
-                    return false;
-                }
-                interference[neighbor].neighbors.iter().all(|other| {
-                    assignments.get(other) != Some(&candidate)
-                })
-            };
+                .filter_map(|other| assignments[*other as usize])
+                .find(|register| forbidden & register_bit(*register) == 0);
             // If an affinity neighbor has not been colored yet, choose a
             // register it can use too. This lets continuation parameters
             // follow constrained producers instead of claiming a scratch
             // register that forces a move at the control-flow edge.
-            let future_preferred = (!coalescable_neighbors.is_empty())
-                .then(|| {
-                    pool.iter()
-                        .enumerate()
-                        .filter(|(_, candidate)| {
-                            !forbidden.contains(*candidate)
-                                && coalescable_neighbors
-                                    .iter()
-                                    .all(|neighbor| {
-                                        available_for_neighbor(neighbor, **candidate)
-                                    })
-                        })
-                        .min_by_key(|(i, candidate)| {
-                            (candidate.allocation_cost(), *i)
-                        })
-                        .map(|(_, candidate)| *candidate)
-                })
-                .flatten();
-            // Pick the cheapest available register for this virtual. Pool
-            // position breaks ties so behavior stays deterministic when
-            // several registers tie in cost (e.g. all FPRs, or all
-            // aarch64 GPRs).
+            let future_preferred = preferred.is_none().then(|| {
+                // Each uncolored affinity neighbor rules out the registers
+                // its own neighbors already hold, plus whatever its operand
+                // constraints forbid. Summarizing that per neighbor keeps the
+                // candidate scan out of the neighbor walk.
+                let mut unusable = forbidden;
+                let mut any = false;
+                for neighbor in &interference.nodes[name as usize].affinities {
+                    if assignments[*neighbor as usize].is_some() || interference.interferes(name, *neighbor) {
+                        continue;
+                    }
+                    any = true;
+                    unusable |= interference.nodes[*neighbor as usize].forbidden;
+                    unusable |= context.assigned_neighbors(*neighbor, &assignments);
+                    if let Some(physical) = interference.nodes[*neighbor as usize].pinned {
+                        // A pinned neighbor can follow us into exactly one
+                        // register, so every other register is no help.
+                        unusable |= !register_bit(physical);
+                    }
+                }
+                any.then(|| context.cheapest(pool, unusable)).flatten()
+            });
             if let Some(preferred) = preferred {
                 preferred
-            } else if let Some(preferred) = future_preferred {
+            } else if let Some(preferred) = future_preferred.flatten() {
                 preferred
             } else {
-                *pool
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, p)| !forbidden.contains(*p))
-                    .min_by_key(|(i, p)| (p.allocation_cost(), *i))
-                    .map(|(_, p)| p)
-                    .ok_or_else(|| {
-                        allocation_error(
-                            &handler.name,
-                            format!(
-                                "could not allocate {} virtual register '{name}': {} pool exhausted (forbidden: {:?})",
-                                if is_gpr { "general-purpose" } else { "floating-point" },
-                                if is_gpr { "GPR" } else { "FPR" },
-                                forbidden,
-                            ),
-                        )
-                    })?
+                context.cheapest(pool, forbidden).ok_or_else(|| {
+                    allocation_error(
+                        &handler.name,
+                        format!(
+                            "could not allocate {} virtual register '{}': {} pool exhausted (forbidden: {forbidden:#x})",
+                            if is_gpr { "general-purpose" } else { "floating-point" },
+                            names.name(name),
+                            if is_gpr { "GPR" } else { "FPR" },
+                        ),
+                    )
+                })?
             }
         };
 
-        assignments.insert(name.clone(), pick);
+        assignments[name as usize] = Some(pick);
     }
 
-    Ok(assignments)
+    Ok(Assignments(assignments))
 }
 
 // ============================================================================
@@ -979,10 +1140,7 @@ fn rewrite(
                 .into_iter()
                 .map(|op| rewrite_operand(handler, op, plan, runtime))
                 .collect::<Result<_, _>>()?;
-            if insn.opcode.description().identity_if_inputs_alias
-                && operands.len() == 2
-                && operands[0] == operands[1]
-            {
+            if insn.opcode.description().identity_if_inputs_alias && operands.len() == 2 && operands[0] == operands[1] {
                 return Ok(None);
             }
             Ok(Some(AllocatedInstruction {
@@ -1006,19 +1164,18 @@ fn rewrite_operand(
                 .get(&register)
                 .expect("every virtual register must have an allocation"),
         ),
-        Operand::InterpreterRegister(register) => {
-            AllocatedOperand::PhysicalRegister(resolve_interpreter_register(register, handler.architecture)
-                .ok_or_else(|| {
-                    allocation_error(
-                        &handler.name,
-                        format!(
-                            "interpreter register '{}' is unavailable on {:?}",
-                            register.as_str(),
-                            handler.architecture
-                        ),
-                    )
-                })?)
-        }
+        Operand::InterpreterRegister(register) => AllocatedOperand::PhysicalRegister(
+            resolve_interpreter_register(register, handler.architecture).ok_or_else(|| {
+                allocation_error(
+                    &handler.name,
+                    format!(
+                        "interpreter register '{}' is unavailable on {:?}",
+                        register.as_str(),
+                        handler.architecture
+                    ),
+                )
+            })?,
+        ),
         Operand::PhysicalRegister(register) => {
             if register.architecture() != handler.architecture {
                 return Err(allocation_error(
@@ -1062,19 +1219,13 @@ fn rewrite_operand(
                     crate::frontend::layout::KnownLayoutConstant::SizeOfExecutionContext,
                     &handler.name,
                 )?
-                    .checked_neg()
-                    .ok_or_else(|| finalization_error(
-                        &handler.name,
-                        "execution-context address adjustment overflow",
-                    ))?;
+                .checked_neg()
+                .ok_or_else(|| finalization_error(&handler.name, "execution-context address adjustment overflow"))?;
                 let displacement = address
                     .displacement
                     .unwrap_or(0)
                     .checked_add(adjustment)
-                    .ok_or_else(|| finalization_error(
-                        &handler.name,
-                        "machine address displacement overflow",
-                    ))?;
+                    .ok_or_else(|| finalization_error(&handler.name, "machine address displacement overflow"))?;
                 address.displacement = (displacement != 0).then_some(displacement);
             }
             AllocatedOperand::Address(address)
@@ -1103,11 +1254,7 @@ fn rewrite_address_register(
                     ),
                 )
             }),
-        AddressRegister::Physical(register)
-            if register.architecture() == handler.architecture =>
-        {
-            Ok(register)
-        }
+        AddressRegister::Physical(register) if register.architecture() == handler.architecture => Ok(register),
         AddressRegister::Physical(register) => Err(allocation_error(
             &handler.name,
             format!("register '{register}' belongs to the wrong target architecture"),
@@ -1122,16 +1269,15 @@ fn rewrite_address_register(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::low_ir::{
-        AddressRegister as SourceAddressRegister, Handler,
-        Instruction as SourceInstruction, MemoryAddress as SourceMemoryAddress,
-        Operand as SourceOperand, Program, VirtualRegister as SourceVirtualRegister,
-    };
     use crate::low_ir::preallocate::schedule_x86_relational_operand_loads;
+    use crate::low_ir::{
+        AddressRegister as SourceAddressRegister, Handler, Instruction as SourceInstruction,
+        MemoryAddress as SourceMemoryAddress, Operand as SourceOperand, Program,
+        VirtualRegister as SourceVirtualRegister,
+    };
     use crate::target::description::{
-        BinaryOperation, FloatBinaryOperation, FloatConversion,
-        FloatingPointOperation, IntegerBinaryOperation, IntegerWidth,
-        IntegerSignedness, Operation, ShiftOperation,
+        BinaryOperation, FloatBinaryOperation, FloatConversion, FloatingPointOperation, IntegerBinaryOperation,
+        IntegerSignedness, IntegerWidth, Operation, ShiftOperation,
     };
     use crate::target::ir::AllocatedMemoryAddress;
     use crate::target::selection::select_program;
@@ -1141,7 +1287,7 @@ mod tests {
             SourceInstruction {
                 opcode: $operation.into(),
                 operands: vec![$($operand),*],
-            }
+        }
         };
     }
 
@@ -1158,8 +1304,7 @@ mod tests {
 
     fn x86_register(name: &str) -> SourceOperand {
         SourceOperand::PhysicalRegister(
-            physical_register_named(name, Architecture::X86_64)
-                .expect("test operand must name an x86-64 register"),
+            physical_register_named(name, Architecture::X86_64).expect("test operand must name an x86-64 register"),
         )
     }
 
@@ -1178,11 +1323,7 @@ mod tests {
             "INT32_TAG" => 0x7ffa,
             _ => unreachable!("unknown test constant"),
         };
-        let constants =
-            crate::frontend::layout::LayoutConstants::from_values([(
-                name.to_string(),
-                value,
-            )]);
+        let constants = crate::frontend::layout::LayoutConstants::from_values([(name.to_string(), value)]);
         SourceOperand::LayoutConstant(constants.get(name).unwrap())
     }
 
@@ -1210,8 +1351,16 @@ mod tests {
                 immediate(0),
                 immediate(4)
             ),
-            instruction!(Operation::load(MemoryWidth::DoubleWord, false), register("lhs"), memory("values", Some("lhs_index"))),
-            instruction!(Operation::load(MemoryWidth::DoubleWord, false), register("rhs"), memory("values", Some("rhs_index"))),
+            instruction!(
+                Operation::load(MemoryWidth::DoubleWord, false),
+                register("lhs"),
+                memory("values", Some("lhs_index"))
+            ),
+            instruction!(
+                Operation::load(MemoryWidth::DoubleWord, false),
+                register("rhs"),
+                memory("values", Some("rhs_index"))
+            ),
             instruction!(
                 Operation::branch_tag(EqualityCondition::NotEqual),
                 register("lhs"),
@@ -1225,7 +1374,11 @@ mod tests {
                 label(".slow")
             ),
             instruction!(
-                Operation::branch_ordered(IntegerWidth::U32, crate::target::description::OrderedCondition::Less, IntegerSignedness::Signed),
+                Operation::branch_ordered(
+                    IntegerWidth::U32,
+                    crate::target::description::OrderedCondition::Less,
+                    IntegerSignedness::Signed
+                ),
                 register("lhs"),
                 register("rhs"),
                 label(".true")
@@ -1239,7 +1392,10 @@ mod tests {
         schedule_x86_relational_operand_loads(&mut instructions);
 
         assert_eq!(
-            instructions.iter().map(|instruction| instruction.opcode.operation()).collect::<Vec<_>>(),
+            instructions
+                .iter()
+                .map(|instruction| instruction.opcode.operation())
+                .collect::<Vec<_>>(),
             [
                 Operation::load(MemoryWidth::Word, false),
                 Operation::load(MemoryWidth::DoubleWord, false),
@@ -1248,7 +1404,11 @@ mod tests {
                 Operation::branch_tag(EqualityCondition::NotEqual),
                 Operation::ExtractTag,
                 Operation::branch_equality(IntegerWidth::U16, EqualityCondition::NotEqual),
-                Operation::branch_ordered(IntegerWidth::U32, crate::target::description::OrderedCondition::Less, IntegerSignedness::Signed),
+                Operation::branch_ordered(
+                    IntegerWidth::U32,
+                    crate::target::description::OrderedCondition::Less,
+                    IntegerSignedness::Signed
+                ),
             ]
         );
         assert_eq!(instructions[0].operands[0], register("rhs_index"));
@@ -1256,10 +1416,7 @@ mod tests {
         assert_eq!(instructions[5].operands, [register("rhs_index"), register("rhs")]);
     }
 
-    fn allocated(
-        instructions: Vec<SourceInstruction>,
-        architecture: Architecture,
-    ) -> Vec<AllocatedInstruction> {
+    fn allocated(instructions: Vec<SourceInstruction>, architecture: Architecture) -> Vec<AllocatedInstruction> {
         build(instructions, architecture).expect("allocation should succeed")
     }
 
@@ -1303,9 +1460,7 @@ mod tests {
         let error = build(
             vec![instruction!(
                 Operation::Move(IntegerWidth::U64),
-                SourceOperand::InterpreterRegister(
-                    InterpreterRegister::Int32TagShifted,
-                ),
+                SourceOperand::InterpreterRegister(InterpreterRegister::Int32TagShifted,),
                 immediate(0)
             )],
             Architecture::Aarch64,
@@ -1314,9 +1469,11 @@ mod tests {
 
         assert_eq!(error.stage, CompileStage::Allocation);
         assert_eq!(error.handler.as_deref(), Some("Test"));
-        assert!(error.message.contains(
-            "interpreter register 'int32_tag_shifted' is unavailable on Aarch64"
-        ));
+        assert!(
+            error
+                .message
+                .contains("interpreter register 'int32_tag_shifted' is unavailable on Aarch64")
+        );
     }
 
     fn build(
@@ -1332,9 +1489,7 @@ mod tests {
             instructions,
         });
         program.handlers[0].size = Some(4);
-        crate::low_ir::lowering::materialize_layout_constants(
-            &mut program.handlers[0],
-        );
+        crate::low_ir::lowering::materialize_layout_constants(&mut program.handlers[0]);
         let selected = select_program(program, arch)?;
         allocate_handler(&selected.functions[0], &selected.runtime)
             .map(|graph| graph.linearize_for_analysis().instructions)
@@ -1351,10 +1506,7 @@ mod tests {
             .count()
     }
 
-    fn find_operation(
-        instructions: &[AllocatedInstruction],
-        operation: Operation,
-    ) -> &AllocatedInstruction {
+    fn find_operation(instructions: &[AllocatedInstruction], operation: Operation) -> &AllocatedInstruction {
         instructions
             .iter()
             .find(|instruction| is_operation(instruction, operation))
@@ -1364,9 +1516,10 @@ mod tests {
     fn assignment_for(insns: &[AllocatedInstruction], operation: Operation, op_index: usize) -> String {
         for insn in insns {
             if is_operation(insn, operation)
-                && let Some(name) = insn.operands.get(op_index).and_then(AllocatedOperand::register_name) {
-                    return name.to_string();
-                }
+                && let Some(name) = insn.operands.get(op_index).and_then(AllocatedOperand::register_name)
+            {
+                return name.to_string();
+            }
         }
         panic!("no '{operation:?}' instruction found");
     }
@@ -1375,8 +1528,17 @@ mod tests {
         allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(1)),
-                instruction!(Operation::Call(CallKind::Helper), symbol("asm_helper_to_boolean"), register("value"), register("result")),
-                instruction!(Operation::branch_zero(IntegerWidth::U64, ZeroCondition::NonZero), register("result"), label(".take")),
+                instruction!(
+                    Operation::Call(CallKind::Helper),
+                    symbol("asm_helper_to_boolean"),
+                    register("value"),
+                    register("result")
+                ),
+                instruction!(
+                    Operation::branch_zero(IntegerWidth::U64, ZeroCondition::NonZero),
+                    register("result"),
+                    label(".take")
+                ),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
                 instruction!(Operation::Label, label(".take")),
                 instruction!(Operation::LoadLabel, register("value"), immediate(0)),
@@ -1391,7 +1553,14 @@ mod tests {
         let out = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("foo"), immediate(42)),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("foo"), immediate(1)),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("foo"),
+                    immediate(1)
+                ),
                 instruction!(Operation::StoreOperand, immediate(0), register("foo")),
             ],
             Architecture::X86_64,
@@ -1411,7 +1580,12 @@ mod tests {
         let instructions = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("wide"), immediate(1)),
-                instruction!(Operation::branch_bit(TestCondition::Set), register("wide"), immediate(31), label(".wide")),
+                instruction!(
+                    Operation::branch_bit(TestCondition::Set),
+                    register("wide"),
+                    immediate(31),
+                    label(".wide")
+                ),
                 instruction!(Operation::Move(IntegerWidth::U64), register("narrow"), register("wide")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("narrow")),
                 instruction!(Operation::Control(ControlOperation::JumpLabel), label(".done")),
@@ -1435,8 +1609,15 @@ mod tests {
         let instructions = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("source"), immediate(1)),
-                instruction!(Operation::Move(IntegerWidth::U64), register("destination"), register("source")),
-                instruction!(Operation::Assertion(AssertionOperation::NonZero), register("destination")),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("destination"),
+                    register("source")
+                ),
+                instruction!(
+                    Operation::Assertion(AssertionOperation::NonZero),
+                    register("destination")
+                ),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
             ],
             Architecture::X86_64,
@@ -1449,9 +1630,21 @@ mod tests {
     fn coalesces_noninterfering_float_moves() {
         let instructions = allocated(
             vec![
-                instruction!(Operation::FloatMove, floating_point_register("source"), x86_register("xmm5")),
-                instruction!(Operation::FloatMove, floating_point_register("destination"), floating_point_register("source")),
-                instruction!(Operation::Float(FloatingPointOperation::Binary(FloatBinaryOperation::Add)), floating_point_register("destination"), floating_point_register("destination")),
+                instruction!(
+                    Operation::FloatMove,
+                    floating_point_register("source"),
+                    x86_register("xmm5")
+                ),
+                instruction!(
+                    Operation::FloatMove,
+                    floating_point_register("destination"),
+                    floating_point_register("source")
+                ),
+                instruction!(
+                    Operation::Float(FloatingPointOperation::Binary(FloatBinaryOperation::Add)),
+                    floating_point_register("destination"),
+                    floating_point_register("destination")
+                ),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
             ],
             Architecture::X86_64,
@@ -1470,8 +1663,16 @@ mod tests {
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("blocker")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("blocker")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("blocker")),
-                instruction!(Operation::Move(IntegerWidth::U64), register("middle"), register("producer")),
-                instruction!(Operation::Move(IntegerWidth::U64), register("consumer"), register("middle")),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("middle"),
+                    register("producer")
+                ),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("consumer"),
+                    register("middle")
+                ),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("consumer")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("consumer")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
@@ -1489,7 +1690,14 @@ mod tests {
                 instruction!(Operation::Move(IntegerWidth::U64), register("source"), immediate(2)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("live"), register("source")),
                 instruction!(Operation::Move(IntegerWidth::U64), register("local"), register("live")),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Subtract), width: IntegerWidth::U64 }, register("local"), immediate(1)),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Subtract),
+                        width: IntegerWidth::U64
+                    },
+                    register("local"),
+                    immediate(1)
+                ),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("live")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("local")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
@@ -1507,7 +1715,14 @@ mod tests {
                 instruction!(Operation::Move(IntegerWidth::U64), register("lhs"), immediate(1)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("rhs"), immediate(2)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("result"), register("lhs")),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("result"), register("rhs")),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("result"),
+                    register("rhs")
+                ),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("lhs")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("result")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
@@ -1540,7 +1755,14 @@ mod tests {
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("a"), immediate(1)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("b"), immediate(2)),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("a"), register("b")),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("a"),
+                    register("b")
+                ),
             ],
             Architecture::X86_64,
         );
@@ -1562,11 +1784,24 @@ mod tests {
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(0xff)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("count"), immediate(3)),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Shift(ShiftOperation::RightLogical), width: IntegerWidth::U64 }, register("value"), register("count")),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Shift(ShiftOperation::RightLogical),
+                        width: IntegerWidth::U64
+                    },
+                    register("value"),
+                    register("count")
+                ),
             ],
             Architecture::X86_64,
         );
-        let shift = find_operation(&out, Operation::IntegerBinary { operation: IntegerBinaryOperation::Shift(ShiftOperation::RightLogical), width: IntegerWidth::U64 });
+        let shift = find_operation(
+            &out,
+            Operation::IntegerBinary {
+                operation: IntegerBinaryOperation::Shift(ShiftOperation::RightLogical),
+                width: IntegerWidth::U64,
+            },
+        );
         assert_eq!(shift.operands[1].register_name(), Some("rcx"));
     }
 
@@ -1575,14 +1810,32 @@ mod tests {
         let instructions = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(1)),
-                instruction!(Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)), floating_point_register("value"), register("value")),
+                instruction!(
+                    Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)),
+                    floating_point_register("value"),
+                    register("value")
+                ),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
             ],
             Architecture::X86_64,
         );
 
-        assert!(assignment_for(&instructions, Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)), 0).starts_with("xmm"));
-        assert!(!assignment_for(&instructions, Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)), 1).starts_with("xmm"));
+        assert!(
+            assignment_for(
+                &instructions,
+                Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)),
+                0
+            )
+            .starts_with("xmm")
+        );
+        assert!(
+            !assignment_for(
+                &instructions,
+                Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)),
+                1
+            )
+            .starts_with("xmm")
+        );
     }
 
     #[test]
@@ -1595,7 +1848,10 @@ mod tests {
             Architecture::X86_64,
         );
 
-        assert_ne!(assignment_for(&instructions, Operation::Move(IntegerWidth::U64), 0), "r13");
+        assert_ne!(
+            assignment_for(&instructions, Operation::Move(IntegerWidth::U64), 0),
+            "r13"
+        );
     }
 
     #[test]
@@ -1625,32 +1881,76 @@ mod tests {
         let instructions = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("function"), immediate(1)),
-                instruction!(Operation::Call(CallKind::RawNative), register("function"), register("native_return"), register("variant")),
-                instruction!(Operation::Move(IntegerWidth::U64), register("payload"), register("native_return")),
+                instruction!(
+                    Operation::Call(CallKind::RawNative),
+                    register("function"),
+                    register("native_return"),
+                    register("variant")
+                ),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("payload"),
+                    register("native_return")
+                ),
                 instruction!(Operation::Move(IntegerWidth::U64), register("unrelated"), immediate(2)),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("unrelated"), immediate(3)),
-                instruction!(Operation::branch_zero(IntegerWidth::U64, ZeroCondition::NonZero), register("variant"), label(".exception")),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("unrelated"),
+                    immediate(3)
+                ),
+                instruction!(
+                    Operation::branch_zero(IntegerWidth::U64, ZeroCondition::NonZero),
+                    register("variant"),
+                    label(".exception")
+                ),
                 instruction!(Operation::StoreOperand, immediate(0), register("payload")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
                 instruction!(Operation::Label, label(".exception")),
-                instruction!(Operation::Move(IntegerWidth::U64), register("helper_argument"), register("payload")),
-                instruction!(Operation::Call(CallKind::Helper), symbol("asm_helper_handle_raw_native_exception"), register("helper_argument"), register("helper_result")),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("helper_argument"),
+                    register("payload")
+                ),
+                instruction!(
+                    Operation::Call(CallKind::Helper),
+                    symbol("asm_helper_handle_raw_native_exception"),
+                    register("helper_argument"),
+                    register("helper_result")
+                ),
                 instruction!(Operation::Control(ControlOperation::Exit)),
             ],
             Architecture::Aarch64,
         );
 
-        assert_eq!(assignment_for(&instructions, Operation::Call(CallKind::RawNative), 1), "x0");
+        assert_eq!(
+            assignment_for(&instructions, Operation::Call(CallKind::RawNative), 1),
+            "x0"
+        );
         assert_eq!(assignment_for(&instructions, Operation::StoreOperand, 1), "x0");
-        assert_eq!(assignment_for(&instructions, Operation::Call(CallKind::Helper), 1), "x0");
+        assert_eq!(
+            assignment_for(&instructions, Operation::Call(CallKind::Helper), 1),
+            "x0"
+        );
     }
 
     #[test]
     fn prioritizes_constrained_move_sources() {
         let instructions = allocated(
             vec![
-                instruction!(Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)), register("raw"), x86_register("xmm0"), label(".fail")),
-                instruction!(Operation::Move(IntegerWidth::U64), register("parameter"), register("raw")),
+                instruction!(
+                    Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)),
+                    register("raw"),
+                    x86_register("xmm0"),
+                    label(".fail")
+                ),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("parameter"),
+                    register("raw")
+                ),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("parameter")),
                 instruction!(Operation::Assertion(AssertionOperation::NonZero), register("parameter")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
@@ -1661,10 +1961,18 @@ mod tests {
         );
 
         assert_eq!(
-            assignment_for(&instructions, Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)), 0),
+            assignment_for(
+                &instructions,
+                Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)),
+                0
+            ),
             assignment_for(&instructions, Operation::Assertion(AssertionOperation::NonZero), 0)
         );
-        assert!(!instructions.iter().any(|instruction| is_operation(instruction, Operation::Move(IntegerWidth::U64))));
+        assert!(
+            !instructions
+                .iter()
+                .any(|instruction| is_operation(instruction, Operation::Move(IntegerWidth::U64)))
+        );
     }
 
     #[test]
@@ -1672,8 +1980,20 @@ mod tests {
         let err = build(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("value"), immediate(7)),
-                instruction!(Operation::Call(CallKind::Helper), symbol("asm_helper_to_boolean"), x86_register("rcx"), x86_register("rax")),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("value"), immediate(1)),
+                instruction!(
+                    Operation::Call(CallKind::Helper),
+                    symbol("asm_helper_to_boolean"),
+                    x86_register("rcx"),
+                    x86_register("rax")
+                ),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("value"),
+                    immediate(1)
+                ),
             ],
             Architecture::X86_64,
         )
@@ -1727,7 +2047,11 @@ mod tests {
         let out = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("i"), immediate(1)),
-                instruction!(Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)), floating_point_register("f"), register("i")),
+                instruction!(
+                    Operation::Float(FloatingPointOperation::Convert(FloatConversion::Int32ToFloat64)),
+                    floating_point_register("f"),
+                    register("i")
+                ),
                 instruction!(Operation::FloatMove, register("i"), floating_point_register("f")),
             ],
             Architecture::X86_64,
@@ -1754,8 +2078,22 @@ mod tests {
         for architecture in [Architecture::X86_64, Architecture::Aarch64] {
             allocated(
                 vec![
-                    instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Xor), width: IntegerWidth::U64 }, register("counter"), register("counter")),
-                    instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("counter"), immediate(1)),
+                    instruction!(
+                        Operation::IntegerBinary {
+                            operation: IntegerBinaryOperation::Binary(BinaryOperation::Xor),
+                            width: IntegerWidth::U64
+                        },
+                        register("counter"),
+                        register("counter")
+                    ),
+                    instruction!(
+                        Operation::IntegerBinary {
+                            operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                            width: IntegerWidth::U64
+                        },
+                        register("counter"),
+                        immediate(1)
+                    ),
                     instruction!(Operation::StoreOperand, immediate(0), register("counter")),
                     instruction!(Operation::Control(ControlOperation::DispatchNext)),
                 ],
@@ -1774,7 +2112,13 @@ mod tests {
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("dividend"), immediate(1)),
                 instruction!(Operation::Move(IntegerWidth::U64), register("divisor"), immediate(2)),
-                instruction!(Operation::DivMod, register("quot"), register("rem"), register("dividend"), register("divisor")),
+                instruction!(
+                    Operation::DivMod,
+                    register("quot"),
+                    register("rem"),
+                    register("dividend"),
+                    register("divisor")
+                ),
                 instruction!(Operation::BoxInt32 { clean: false }, register("dst"), register("rem")),
                 instruction!(Operation::StoreOperand, immediate(0), register("dst")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
@@ -1795,30 +2139,16 @@ mod tests {
     fn explicit_scratch_keeps_aarch64_operands_off_x9() {
         let out = allocated(
             vec![
+                instruction!(Operation::Move(IntegerWidth::U64), register("lhs"), immediate(6)),
+                instruction!(Operation::Move(IntegerWidth::U64), register("rhs"), immediate(7)),
                 instruction!(
-                    Operation::Move(IntegerWidth::U64),
-                    register("lhs"),
-                    immediate(6)
-                ),
-                instruction!(
-                    Operation::Move(IntegerWidth::U64),
-                    register("rhs"),
-                    immediate(7)
-                ),
-                instruction!(
-                    Operation::Overflow(
-                        crate::target::description::OverflowOperation::MultiplyCopy,
-                    ),
+                    Operation::Overflow(crate::target::description::OverflowOperation::MultiplyCopy,),
                     register("result"),
                     register("lhs"),
                     register("rhs"),
                     label(".overflow")
                 ),
-                instruction!(
-                    Operation::StoreOperand,
-                    immediate(0),
-                    register("result")
-                ),
+                instruction!(Operation::StoreOperand, immediate(0), register("result")),
                 instruction!(Operation::Label, label(".overflow")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
             ],
@@ -1827,9 +2157,7 @@ mod tests {
 
         let instruction = find_operation(
             &out,
-            Operation::Overflow(
-                crate::target::description::OverflowOperation::MultiplyCopy,
-            ),
+            Operation::Overflow(crate::target::description::OverflowOperation::MultiplyCopy),
         );
         for operand in &instruction.operands[..3] {
             assert_ne!(
@@ -1849,26 +2177,52 @@ mod tests {
         let out = allocated(
             vec![
                 instruction!(Operation::Move(IntegerWidth::U64), register("base"), immediate(100)),
-                instruction!(Operation::Move(IntegerWidth::U64), register("index"), immediate(0x123456789)),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::And), width: IntegerWidth::U64 }, register("index"), immediate(0x3ffffffff)),
-                instruction!(Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::Add), width: IntegerWidth::U64 }, register("index"), register("base")),
+                instruction!(
+                    Operation::Move(IntegerWidth::U64),
+                    register("index"),
+                    immediate(0x123456789)
+                ),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::And),
+                        width: IntegerWidth::U64
+                    },
+                    register("index"),
+                    immediate(0x3ffffffff)
+                ),
+                instruction!(
+                    Operation::IntegerBinary {
+                        operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
+                        width: IntegerWidth::U64
+                    },
+                    register("index"),
+                    register("base")
+                ),
                 instruction!(Operation::StoreOperand, immediate(0), register("index")),
                 instruction!(Operation::Control(ControlOperation::DispatchNext)),
             ],
             Architecture::X86_64,
         );
         for insn in &out {
-            if is_operation(insn, Operation::Move(IntegerWidth::U64)) && insn.operands.len() == 2
+            if is_operation(insn, Operation::Move(IntegerWidth::U64))
+                && insn.operands.len() == 2
                 && let AllocatedOperand::Immediate(100) = insn.operands[1]
-                    && let Some(name) = insn.operands[0].register_name() {
-                        assert_ne!(name, "rax", "live virtual must avoid rax");
-                        assert_ne!(name, "r11", "live virtual must avoid r11");
-                    }
-            if is_operation(insn, Operation::IntegerBinary { operation: IntegerBinaryOperation::Binary(BinaryOperation::And), width: IntegerWidth::U64 })
-                && let Some(name) = insn.operands.first().and_then(AllocatedOperand::register_name) {
-                    assert_ne!(name, "rax", "and dst must avoid rax");
-                    assert_ne!(name, "r11", "and dst must avoid r11");
-                }
+                && let Some(name) = insn.operands[0].register_name()
+            {
+                assert_ne!(name, "rax", "live virtual must avoid rax");
+                assert_ne!(name, "r11", "live virtual must avoid r11");
+            }
+            if is_operation(
+                insn,
+                Operation::IntegerBinary {
+                    operation: IntegerBinaryOperation::Binary(BinaryOperation::And),
+                    width: IntegerWidth::U64,
+                },
+            ) && let Some(name) = insn.operands.first().and_then(AllocatedOperand::register_name)
+            {
+                assert_ne!(name, "rax", "and dst must avoid rax");
+                assert_ne!(name, "r11", "and dst must avoid r11");
+            }
         }
     }
 }

--- a/Libraries/LibJS/Flap/src/target/allocator.rs
+++ b/Libraries/LibJS/Flap/src/target/allocator.rs
@@ -343,7 +343,7 @@ fn caller_saved_registers(architecture: Architecture) -> RegisterSet {
 }
 
 fn operand_kind_at(
-    description: InstructionDescription,
+    description: &InstructionDescription,
     index: usize,
     operand_count: usize,
     architecture: Architecture,

--- a/Libraries/LibJS/Flap/src/target/backend.rs
+++ b/Libraries/LibJS/Flap/src/target/backend.rs
@@ -16,13 +16,12 @@
 //! rejects a backend that forgets an operation, instead of failing only for
 //! the handlers that happen to use it.
 
+use super::description::ArchitectureOpcode;
 use super::description::{
-    AssertionOperation, BinaryOperation, FloatCondition, FloatingPointOperation, IntegerWidth,
-    MemoryWidth, Operation, OverflowOperation, PairWidth, ShiftOperation,
-    SignCondition, ZeroCondition,
+    AssertionOperation, BinaryOperation, FloatCondition, FloatingPointOperation, IntegerWidth, MemoryWidth, Operation,
+    OverflowOperation, PairWidth, ShiftOperation, SignCondition, ZeroCondition,
 };
 use super::finalize_support::Emit;
-use super::description::ArchitectureOpcode;
 use super::ir::AllocatedOperand;
 use super::registers::PhysicalRegister;
 use crate::CompileError;
@@ -65,27 +64,11 @@ pub(crate) trait Backend: Sync {
         clean: bool,
     ) -> Result<(), CompileError>;
 
-    fn update_bit(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        bit: u32,
-        operation: Operation,
-    );
+    fn update_bit(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, bit: u32, operation: Operation);
 
-    fn extract_tag(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        source: PhysicalRegister,
-    );
+    fn extract_tag(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister);
 
-    fn unbox_object(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        source: PhysicalRegister,
-    );
+    fn unbox_object(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister);
 
     fn float_operation(
         &self,
@@ -105,29 +88,15 @@ pub(crate) trait Backend: Sync {
         failure: &Label,
     );
 
-    fn helper_call(
-        &self,
-        emit: &mut Emit<'_>,
-        function: crate::low_ir::Relocation,
-    );
+    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation);
 
-    fn interpreter_call(
-        &self,
-        emit: &mut Emit<'_>,
-        function: crate::low_ir::Relocation,
-    );
+    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation);
 
     fn raw_native_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
 
-    fn slow_path_call(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn slow_path_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError>;
 
-    fn dispatch_current(
-    &self,
-    emit: &mut Emit<'_>, scratches: &[AllocatedOperand]) -> Result<(), CompileError>;
+    fn dispatch_current(&self, emit: &mut Emit<'_>, scratches: &[AllocatedOperand]) -> Result<(), CompileError>;
 
     fn dispatch_variable(
         &self,
@@ -136,12 +105,8 @@ pub(crate) trait Backend: Sync {
         scratches: &[AllocatedOperand],
     ) -> Result<(), CompileError>;
 
-    fn dispatch_next(
-        &self,
-        emit: &mut Emit<'_>,
-        size: u32,
-        scratches: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn dispatch_next(&self, emit: &mut Emit<'_>, size: u32, scratches: &[AllocatedOperand])
+    -> Result<(), CompileError>;
 
     fn finalize_assertion(
         &self,
@@ -179,17 +144,11 @@ pub(crate) trait Backend: Sync {
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError>;
 
-    fn finalize_any_equal_branch(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn finalize_any_equal_branch(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand])
+    -> Result<(), CompileError>;
 
-    fn finalize_canonicalize_nan(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn finalize_canonicalize_nan(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand])
+    -> Result<(), CompileError>;
 
     fn move_instruction(
         &self,
@@ -206,43 +165,19 @@ pub(crate) trait Backend: Sync {
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError>;
 
-    fn finalize_vm_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    );
+    fn finalize_vm_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
 
     /// Materialize the current program counter as a value. Targets that do not
     /// keep it in a register derive it from their dispatch state here.
-    fn finalize_program_counter_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    );
+    fn finalize_program_counter_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
 
-    fn finalize_operand_store(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn finalize_operand_store(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError>;
 
-    fn finalize_label_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn finalize_label_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError>;
 
-    fn goto_handler(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn goto_handler(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError>;
 
-    fn goto_bytecode_target(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn goto_bytecode_target(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError>;
 
     fn finalize_execution_context_store(
         &self,
@@ -250,17 +185,10 @@ pub(crate) trait Backend: Sync {
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError>;
 
-    fn finalize_indexed_offset_store(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    );
+    fn finalize_indexed_offset_store(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
 
-    fn finalize_memory_increment(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError>;
+    fn finalize_memory_increment(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand])
+    -> Result<(), CompileError>;
 
     fn finalize_scalar_load(
         &self,
@@ -331,11 +259,7 @@ pub(crate) trait Backend: Sync {
         operands: &[AllocatedOperand],
     );
 
-    fn finalize_divide(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    );
+    fn finalize_divide(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]);
 }
 
 pub(crate) struct X86_64Backend;

--- a/Libraries/LibJS/Flap/src/target/description.rs
+++ b/Libraries/LibJS/Flap/src/target/description.rs
@@ -56,15 +56,14 @@
 
 use crate::Architecture;
 pub(crate) use crate::intrinsic::{
-    AssertionOperation, BranchOperation, CallOperation as CallKind, ControlOperation, EqualityCondition, FloatBinaryOperation, FloatConversion,
-    FloatUnaryOperation, FloatingPointOperation, IntegerBinaryOperation, SignCondition, MemoryWidth, PairWidth, TestCondition, ZeroCondition,
-    IntegerSignedness, IntegerWidth, MemoryOperation,
+    AssertionOperation, BranchOperation, CallOperation as CallKind, ControlOperation, EqualityCondition,
+    FloatBinaryOperation, FloatConversion, FloatUnaryOperation, FloatingPointOperation, IntegerBinaryOperation,
+    IntegerSignedness, IntegerWidth, MemoryOperation, MemoryWidth, PairWidth, SignCondition, TestCondition,
+    ZeroCondition,
 };
 use crate::target::ir::Operand;
+use crate::target::registers::{PhysicalRegister, RegisterClass, aarch64, x86_64};
 use crate::target::{aarch64 as aarch64_target, x86_64 as x86_64_target};
-use crate::target::registers::{
-    PhysicalRegister, RegisterClass, aarch64, x86_64,
-};
 
 /// An architecture-selected target instruction.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -154,7 +153,10 @@ pub(crate) enum Operation {
     Increment32Memory,
     LoadEffectiveAddress,
     Move(IntegerWidth),
-    IntegerBinary { operation: IntegerBinaryOperation, width: IntegerWidth },
+    IntegerBinary {
+        operation: IntegerBinaryOperation,
+        width: IntegerWidth,
+    },
     Or32Branch(SignCondition),
     Negate,
     Not(IntegerWidth),
@@ -163,7 +165,9 @@ pub(crate) enum Operation {
     ExtractTag,
     UnboxInt32,
     UnboxObject,
-    BoxInt32 { clean: bool },
+    BoxInt32 {
+        clean: bool,
+    },
     ToggleBit,
     ClearBit,
     Float(FloatingPointOperation),
@@ -186,35 +190,28 @@ impl Operation {
         SelectedOpcode {
             operation,
             opcode: match architecture {
-                Architecture::X86_64 => ArchitectureOpcode::X86_64(
-                    x86_64_target::Opcode::select_for_operands(operation, operands),
-                ),
-                Architecture::Aarch64 => ArchitectureOpcode::Aarch64(
-                    aarch64_target::Opcode::select_for_operands(operation, operands),
-                ),
+                Architecture::X86_64 => {
+                    ArchitectureOpcode::X86_64(x86_64_target::Opcode::select_for_operands(operation, operands))
+                }
+                Architecture::Aarch64 => {
+                    ArchitectureOpcode::Aarch64(aarch64_target::Opcode::select_for_operands(operation, operands))
+                }
             },
         }
     }
 
-    pub(crate) fn description(&self) -> InstructionDescription {
+    pub(crate) fn description(&self) -> &'static InstructionDescription {
         lookup_operation(*self)
     }
 }
 
 impl SelectedOpcode {
-    pub(crate) fn for_operation(
-        operation: Operation,
-        architecture: Architecture,
-    ) -> Self {
+    pub(crate) fn for_operation(operation: Operation, architecture: Architecture) -> Self {
         Self {
             operation,
             opcode: match architecture {
-                Architecture::X86_64 => {
-                    ArchitectureOpcode::X86_64(x86_64_target::Opcode::select(operation))
-                }
-                Architecture::Aarch64 => {
-                    ArchitectureOpcode::Aarch64(aarch64_target::Opcode::select(operation))
-                }
+                Architecture::X86_64 => ArchitectureOpcode::X86_64(x86_64_target::Opcode::select(operation)),
+                Architecture::Aarch64 => ArchitectureOpcode::Aarch64(aarch64_target::Opcode::select(operation)),
             },
         }
     }
@@ -239,11 +236,11 @@ impl SelectedOpcode {
         self.opcode
     }
 
-    pub(crate) fn description(&self) -> InstructionDescription {
+    pub(crate) fn description(&self) -> &'static InstructionDescription {
         match self.opcode {
-            ArchitectureOpcode::X86_64(
-                x86_64_target::Opcode::StoreLargeImmediate(_),
-            ) => X86_64_LARGE_IMMEDIATE_STORE_DESCRIPTION,
+            ArchitectureOpcode::X86_64(x86_64_target::Opcode::StoreLargeImmediate(_)) => {
+                &X86_64_LARGE_IMMEDIATE_STORE_DESCRIPTION
+            }
             _ => lookup_operation(self.operation),
         }
     }
@@ -264,9 +261,7 @@ impl SelectedOpcode {
 
         if architecture == Architecture::X86_64 && operation == Operation::StoreOperand {
             match operands.get(1).expect("store_operand must have a source") {
-                Operand::Immediate(value)
-                    if !(i32::MIN as i64..=i32::MAX as i64).contains(value) =>
-                {
+                Operand::Immediate(value) if !(i32::MIN as i64..=i32::MAX as i64).contains(value) => {
                     append_registers(operands, &[x86_64::RAX, x86_64::R11]);
                 }
                 Operand::PhysicalRegister(register) if *register == x86_64::R11 => {
@@ -297,10 +292,7 @@ impl From<PairWidth> for MemoryWidth {
 
 impl Operation {
     pub(crate) const fn load(width: MemoryWidth, signed: bool) -> Self {
-        Self::Memory(MemoryOperation::Load {
-            width,
-            signed,
-        })
+        Self::Memory(MemoryOperation::Load { width, signed })
     }
 
     pub(crate) const fn store(width: MemoryWidth) -> Self {
@@ -400,7 +392,6 @@ impl Operation {
             _ => return None,
         })
     }
-
 }
 
 /// Kind of a single LowIR operand position.
@@ -452,22 +443,16 @@ impl OperandKind {
             _ => None,
         };
         match self {
-            Self::GprIn | Self::GprOut | Self::GprInOut => {
-                register_class == Some(RegisterClass::GeneralPurpose)
-            }
+            Self::GprIn | Self::GprOut | Self::GprInOut => register_class == Some(RegisterClass::GeneralPurpose),
             Self::GprScratch => shape == OperandShape::PhysicalRegister(RegisterClass::GeneralPurpose),
-            Self::FprIn | Self::FprOut | Self::FprInOut => {
-                register_class == Some(RegisterClass::FloatingPoint)
-            }
+            Self::FprIn | Self::FprOut | Self::FprInOut => register_class == Some(RegisterClass::FloatingPoint),
             Self::FprScratch => shape == OperandShape::PhysicalRegister(RegisterClass::FloatingPoint),
             Self::RegisterIn | Self::RegisterOut => register_class.is_some(),
             Self::GprInOrImm => {
-                register_class == Some(RegisterClass::GeneralPurpose)
-                    || shape == OperandShape::Immediate
+                register_class == Some(RegisterClass::GeneralPurpose) || shape == OperandShape::Immediate
             }
             Self::GprInOrMemory => {
-                register_class == Some(RegisterClass::GeneralPurpose)
-                    || shape == OperandShape::Address
+                register_class == Some(RegisterClass::GeneralPurpose) || shape == OperandShape::Address
             }
             Self::Imm => shape == OperandShape::Immediate,
             Self::Memory => shape == OperandShape::Address,
@@ -629,11 +614,7 @@ impl InstructionDescription {
     }
 
     /// Scratch registers appended after every operand, per architecture.
-    const fn scratches(
-        mut self,
-        x86_64: &'static [PhysicalRegister],
-        aarch64: &'static [PhysicalRegister],
-    ) -> Self {
+    const fn scratches(mut self, x86_64: &'static [PhysicalRegister], aarch64: &'static [PhysicalRegister]) -> Self {
         self.x86_64.trailing_scratch_registers = x86_64;
         self.aarch64.trailing_scratch_registers = aarch64;
         self
@@ -671,25 +652,16 @@ impl InstructionDescription {
         })
     }
 
-    pub(crate) fn accepts_selected_operand_count(
-        &self,
-        count: usize,
-        architecture: Architecture,
-    ) -> bool {
+    pub(crate) fn accepts_selected_operand_count(&self, count: usize, architecture: Architecture) -> bool {
         let arch = self.arch(architecture);
-        let scratch_count = arch.trailing_scratch_registers.len()
-            + arch.scratch_registers_before_trailing_operands.len();
+        let scratch_count =
+            arch.trailing_scratch_registers.len() + arch.scratch_registers_before_trailing_operands.len();
         let Some(count) = count.checked_sub(scratch_count) else {
             return false;
         };
-        if let Some(variadic_count) =
-            self.arch(architecture).selected_variadic_operands
-        {
+        if let Some(variadic_count) = self.arch(architecture).selected_variadic_operands {
             return self.variadic_kind.is_some()
-                && count
-                    == self.operands.len()
-                        + variadic_count
-                        + self.trailing_operands.len();
+                && count == self.operands.len() + variadic_count + self.trailing_operands.len();
         }
         self.accepts_operand_count(count)
     }
@@ -711,20 +683,14 @@ impl InstructionDescription {
         operand_count: usize,
         architecture: Architecture,
     ) -> Option<OperandKind> {
-        let scratch_registers =
-            self.arch(architecture).trailing_scratch_registers;
-        let before_trailing = self
-            .arch(architecture)
-            .scratch_registers_before_trailing_operands;
-        let total_scratch_count =
-            scratch_registers.len() + before_trailing.len();
-        let semantic_count =
-            operand_count.checked_sub(total_scratch_count)?;
+        let scratch_registers = self.arch(architecture).trailing_scratch_registers;
+        let before_trailing = self.arch(architecture).scratch_registers_before_trailing_operands;
+        let total_scratch_count = scratch_registers.len() + before_trailing.len();
+        let semantic_count = operand_count.checked_sub(total_scratch_count)?;
         let before_trailing_end = operand_count
             .checked_sub(scratch_registers.len())?
             .checked_sub(self.trailing_operands.len())?;
-        let before_trailing_start =
-            before_trailing_end.checked_sub(before_trailing.len())?;
+        let before_trailing_start = before_trailing_end.checked_sub(before_trailing.len())?;
         if index >= operand_count - scratch_registers.len() {
             return scratch_registers
                 .get(index - (operand_count - scratch_registers.len()))
@@ -771,38 +737,73 @@ use x86_64::{R11, RAX, RCX, RDX, XMM3};
 const X86_64_LARGE_IMMEDIATE_STORE_DESCRIPTION: InstructionDescription =
     plain(&[Memory, GprInOrImm]).scratches(&[R11], &[]);
 
-fn lookup_operation(operation: Operation) -> InstructionDescription {
+fn lookup_operation(operation: Operation) -> &'static InstructionDescription {
     use BinaryOperation::*;
     use IntegerWidth::*;
     use OverflowOperation::*;
 
     match operation {
-        Operation::Cold => plain(&[Label]),
-        Operation::Label => plain(&[Label]),
-        Operation::Control(ControlOperation::JumpLabel) => plain(&[Label]).terminal(),
-        Operation::Control(ControlOperation::Exit) => plain(&[]).terminal(),
-        Operation::Control(ControlOperation::DispatchNext | ControlOperation::Dispatch) => plain(&[])
-            .terminal().scratches(&[RAX], &[X9, X10]),
-        Operation::Control(ControlOperation::DispatchVariable | ControlOperation::GotoHandler) => plain(&[GprIn])
-            .terminal().scratches(&[RAX], &[X9, X10]),
-        Operation::Control(ControlOperation::JumpBytecode) => plain(&[Imm]).terminal()
-            .scratches(&[RAX], &[X0, X9, X10]),
-        Operation::Call(CallKind::SlowPath) => plain(&[FuncSymbol]).terminal().call()
-            .x86_64(spec().scratches(&[RAX, RCX])).aarch64(spec().scratches(&[X9, X10])),
-        Operation::Call(CallKind::Helper) => plain(&[FuncSymbol, GprIn, GprOut]).call()
-            .x86_64(spec().inputs(&[RCX]).outputs(&[RAX]).fixed(&[(1, RCX), (2, RAX)]))
-            .aarch64(spec().inputs(&[X0]).outputs(&[X0]).fixed(&[(1, X0), (2, X0)])),
-        Operation::Call(CallKind::Interpreter) => plain(&[FuncSymbol, GprOut]).call()
-            .x86_64(spec().outputs(&[RAX]).fixed(&[(1, RAX)]))
-            .aarch64(spec().outputs(&[X0]).fixed(&[(1, X0)])),
-        Operation::Call(CallKind::RawNative) => plain(&[GprIn, GprOut, GprOut]).call()
-            .x86_64(spec().outputs(&[RAX, RCX]).fixed(&[(1, RAX), (2, RCX)]).scratches(&[R11]))
-            .aarch64(spec().outputs(&[X0, X1]).fixed(&[(1, X0), (2, X1)]).scratches(&[X9])),
-        Operation::LoadVm => plain(&[GprOut]),
-        Operation::LoadProgramCounter => plain(&[GprOut]),
-        Operation::StoreOperand => plain(&[Imm, GprInOrImm]).variadic(GprScratch, 1, Some(2), &[])
-            .aarch64(spec().selected_variadic(0).scratches(&[X9, X10])),
-        Operation::LoadLabel => plain(&[GprOut, Imm]).scratches(&[], &[X9]),
+        Operation::Cold => &const { plain(&[Label]) },
+        Operation::Label => &const { plain(&[Label]) },
+        Operation::Control(ControlOperation::JumpLabel) => &const { plain(&[Label]).terminal() },
+        Operation::Control(ControlOperation::Exit) => &const { plain(&[]).terminal() },
+        Operation::Control(ControlOperation::DispatchNext | ControlOperation::Dispatch) => {
+            &const { plain(&[]).terminal().scratches(&[RAX], &[X9, X10]) }
+        }
+        Operation::Control(ControlOperation::DispatchVariable | ControlOperation::GotoHandler) => {
+            &const { plain(&[GprIn]).terminal().scratches(&[RAX], &[X9, X10]) }
+        }
+        Operation::Control(ControlOperation::JumpBytecode) => {
+            &const { plain(&[Imm]).terminal().scratches(&[RAX], &[X0, X9, X10]) }
+        }
+        Operation::Call(CallKind::SlowPath) => {
+            &const {
+                plain(&[FuncSymbol])
+                    .terminal()
+                    .call()
+                    .x86_64(spec().scratches(&[RAX, RCX]))
+                    .aarch64(spec().scratches(&[X9, X10]))
+            }
+        }
+        Operation::Call(CallKind::Helper) => {
+            &const {
+                plain(&[FuncSymbol, GprIn, GprOut])
+                    .call()
+                    .x86_64(spec().inputs(&[RCX]).outputs(&[RAX]).fixed(&[(1, RCX), (2, RAX)]))
+                    .aarch64(spec().inputs(&[X0]).outputs(&[X0]).fixed(&[(1, X0), (2, X0)]))
+            }
+        }
+        Operation::Call(CallKind::Interpreter) => {
+            &const {
+                plain(&[FuncSymbol, GprOut])
+                    .call()
+                    .x86_64(spec().outputs(&[RAX]).fixed(&[(1, RAX)]))
+                    .aarch64(spec().outputs(&[X0]).fixed(&[(1, X0)]))
+            }
+        }
+        Operation::Call(CallKind::RawNative) => {
+            &const {
+                plain(&[GprIn, GprOut, GprOut])
+                    .call()
+                    .x86_64(
+                        spec()
+                            .outputs(&[RAX, RCX])
+                            .fixed(&[(1, RAX), (2, RCX)])
+                            .scratches(&[R11]),
+                    )
+                    .aarch64(spec().outputs(&[X0, X1]).fixed(&[(1, X0), (2, X1)]).scratches(&[X9]))
+            }
+        }
+        Operation::LoadVm => &const { plain(&[GprOut]) },
+        Operation::LoadProgramCounter => &const { plain(&[GprOut]) },
+        Operation::StoreOperand => {
+            &const {
+                plain(&[Imm, GprInOrImm])
+                    .variadic(GprScratch, 1, Some(2), &[])
+                    .aarch64(spec().selected_variadic(0).scratches(&[X9, X10]))
+            }
+        }
+        Operation::LoadLabel => &const { plain(&[GprOut, Imm]).scratches(&[], &[X9]) },
         Operation::Memory(MemoryOperation::Load {
             width: MemoryWidth::Word | MemoryWidth::DoubleWord | MemoryWidth::Float,
             signed: true,
@@ -811,36 +812,41 @@ fn lookup_operation(operation: Operation) -> InstructionDescription {
         Operation::Memory(MemoryOperation::Load {
             width: MemoryWidth::Float,
             signed: false,
-        }) => plain(&[FprOut, Memory])
-            .pre_scratches(&[], &[X9]),
-        Operation::Memory(MemoryOperation::Load { .. }) => plain(&[GprOut, Memory])
-            .pre_scratches(&[], &[X9]),
+        }) => &const { plain(&[FprOut, Memory]).pre_scratches(&[], &[X9]) },
+        Operation::Memory(MemoryOperation::Load { .. }) => {
+            &const { plain(&[GprOut, Memory]).pre_scratches(&[], &[X9]) }
+        }
         Operation::Memory(MemoryOperation::Store(
-            MemoryWidth::DoubleWord
-            | MemoryWidth::Word
-            | MemoryWidth::HalfWord
-            | MemoryWidth::Byte,
-        )) => plain(&[Memory, GprInOrImm])
-            .pre_scratches(&[], &[X9, X10]),
-        Operation::StoreExecutionContext => plain(&[Memory]).pre_scratches(&[R11], &[X9, X10]),
-        Operation::Store64IndexedOffset => plain(&[GprIn, GprIn, Imm, Imm, GprIn])
-            .pre_scratches(&[], &[X9]),
-        Operation::Memory(MemoryOperation::Store(MemoryWidth::Float)) => plain(&[Memory, FprIn])
-            .pre_scratches(&[], &[X9, X10]),
-        Operation::Memory(MemoryOperation::LoadPair(_)) => plain(&[GprOut, GprOut, Memory, Memory])
-            .pre_scratches(&[], &[X10, X9]),
-        Operation::Memory(MemoryOperation::StorePair(_)) => plain(&[Memory, Memory, GprIn, GprIn])
-            .pre_scratches(&[], &[X9, X10]),
-        Operation::StorePairIndexed(PairWidth::DoubleWord) => plain(&[GprIn, GprIn, Imm, GprIn, GprIn])
-            .pre_scratches(&[], &[X10]),
-        Operation::Increment32Memory => plain(&[Memory]).pre_scratches(&[], &[X9, X10]),
-        Operation::LoadEffectiveAddress => plain(&[GprOut, GprInOrMemory]).pre_scratches(&[], &[X9]),
-        Operation::Move(U64) => plain(&[GprOut, GprInOrImm]).coalesces(&[(0, 1)])
-            .identity_if_inputs_alias(),
-        Operation::Move(U32) => plain(&[GprOut, GprInOrImm]),
-        Operation::ExtractTag | Operation::UnboxObject | Operation::BoxInt32 { clean: true } => plain(&[GprOut, GprIn])
-            .coalesces(&[(0, 1)]),
-        Operation::UnboxInt32 | Operation::BoxInt32 { clean: false } => plain(&[GprOut, GprIn]),
+            MemoryWidth::DoubleWord | MemoryWidth::Word | MemoryWidth::HalfWord | MemoryWidth::Byte,
+        )) => &const { plain(&[Memory, GprInOrImm]).pre_scratches(&[], &[X9, X10]) },
+        Operation::StoreExecutionContext => &const { plain(&[Memory]).pre_scratches(&[R11], &[X9, X10]) },
+        Operation::Store64IndexedOffset => &const { plain(&[GprIn, GprIn, Imm, Imm, GprIn]).pre_scratches(&[], &[X9]) },
+        Operation::Memory(MemoryOperation::Store(MemoryWidth::Float)) => {
+            &const { plain(&[Memory, FprIn]).pre_scratches(&[], &[X9, X10]) }
+        }
+        Operation::Memory(MemoryOperation::LoadPair(_)) => {
+            &const { plain(&[GprOut, GprOut, Memory, Memory]).pre_scratches(&[], &[X10, X9]) }
+        }
+        Operation::Memory(MemoryOperation::StorePair(_)) => {
+            &const { plain(&[Memory, Memory, GprIn, GprIn]).pre_scratches(&[], &[X9, X10]) }
+        }
+        Operation::StorePairIndexed(PairWidth::DoubleWord) => {
+            &const { plain(&[GprIn, GprIn, Imm, GprIn, GprIn]).pre_scratches(&[], &[X10]) }
+        }
+        Operation::Increment32Memory => &const { plain(&[Memory]).pre_scratches(&[], &[X9, X10]) },
+        Operation::LoadEffectiveAddress => &const { plain(&[GprOut, GprInOrMemory]).pre_scratches(&[], &[X9]) },
+        Operation::Move(U64) => {
+            &const {
+                plain(&[GprOut, GprInOrImm])
+                    .coalesces(&[(0, 1)])
+                    .identity_if_inputs_alias()
+            }
+        }
+        Operation::Move(U32) => &const { plain(&[GprOut, GprInOrImm]) },
+        Operation::ExtractTag | Operation::UnboxObject | Operation::BoxInt32 { clean: true } => {
+            &const { plain(&[GprOut, GprIn]).coalesces(&[(0, 1)]) }
+        }
+        Operation::UnboxInt32 | Operation::BoxInt32 { clean: false } => &const { plain(&[GprOut, GprIn]) },
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Binary(Add | Subtract | Or),
             width: U64,
@@ -848,134 +854,177 @@ fn lookup_operation(operation: Operation) -> InstructionDescription {
         | Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Binary(And),
             width: U16,
-        } => plain(&[GprInOut, GprInOrImm])
-            .scratches(&[], &[X9]),
+        } => &const { plain(&[GprInOut, GprInOrImm]).scratches(&[], &[X9]) },
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Binary(Xor),
             width: U64,
-        } => plain(&[GprInOut, GprInOrImm])
-            .scratches(&[], &[X9]).zeroes_if_inputs_alias(),
+        } => {
+            &const {
+                plain(&[GprInOut, GprInOrImm])
+                    .scratches(&[], &[X9])
+                    .zeroes_if_inputs_alias()
+            }
+        }
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Binary(Multiply),
             width: U64,
-        } => plain(&[GprOut, GprIn])
-            .variadic(GprInOrImm, 0, Some(1), &[]).aarch64(spec().scratches(&[X9]))
-            .coalesces(&[(0, 1), (0, 2)]),
-        Operation::Negate | Operation::Not(U64) | Operation::Not(U32) => plain(&[GprInOut]),
+        } => {
+            &const {
+                plain(&[GprOut, GprIn])
+                    .variadic(GprInOrImm, 0, Some(1), &[])
+                    .aarch64(spec().scratches(&[X9]))
+                    .coalesces(&[(0, 1), (0, 2)])
+            }
+        }
+        Operation::Negate | Operation::Not(U64) | Operation::Not(U32) => &const { plain(&[GprInOut]) },
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Binary(And),
             width: U64,
-        } => plain(&[GprInOut, GprInOrImm])
-            .scratches(&[RAX, R11], &[X9]),
+        } => &const { plain(&[GprInOut, GprInOrImm]).scratches(&[RAX, R11], &[X9]) },
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Binary(And | Or | Xor),
             width: U32,
-        } => plain(&[GprOut, GprIn, GprInOrImm])
-            .scratches(&[], &[X9]).coalesces(&[(0, 1), (0, 2)]),
-        Operation::Or32Branch(_) => plain(&[GprOut, GprIn, GprInOrImm]).trailing(&[Label])
-            .pre_scratches(&[], &[X9]),
+        } => {
+            &const {
+                plain(&[GprOut, GprIn, GprInOrImm])
+                    .scratches(&[], &[X9])
+                    .coalesces(&[(0, 1), (0, 2)])
+            }
+        }
+        Operation::Or32Branch(_) => {
+            &const {
+                plain(&[GprOut, GprIn, GprInOrImm])
+                    .trailing(&[Label])
+                    .pre_scratches(&[], &[X9])
+            }
+        }
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Shift(_),
             width: U64,
-        } => plain(&[GprInOut, GprInOrImm])
-            .x86_64(spec().fixed(&[(1, RCX)])),
+        } => &const { plain(&[GprInOut, GprInOrImm]).x86_64(spec().fixed(&[(1, RCX)])) },
         Operation::IntegerBinary {
             operation: IntegerBinaryOperation::Shift(_),
             width: U32,
-        } => plain(&[GprOut, GprIn, GprInOrImm])
-            .x86_64(spec().fixed(&[(2, RCX)]).scratches(&[R11])).coalesces(&[(0, 1)]),
-        Operation::DivMod => plain(&[GprOut, GprOut, GprIn, GprIn])
-            .x86_64(spec().outputs(&[RAX, RDX]).fixed(&[(0, RAX), (1, RDX)]))
-            .aarch64(spec().scratches(&[X9])),
-        Operation::Overflow(AddWithOverflow) | Operation::Overflow(SubtractWithOverflow) => plain(&[GprInOut, GprInOrImm])
-            .trailing(&[Label]).pre_scratches(&[], &[X9]),
-        Operation::Overflow(Increment)
-        | Operation::Overflow(Decrement)
-        | Operation::Overflow(Negate) => plain(&[GprInOut, Label]),
-        Operation::Overflow(MultiplyWithOverflow) => plain(&[GprInOut, GprIn]).trailing(&[Label])
-            .pre_scratches(&[], &[X9]),
-        Operation::Overflow(MultiplyCopy) => plain(&[GprOut, GprIn, GprIn]).trailing(&[Label])
-            .pre_scratches(&[], &[X9]),
-        Operation::ToggleBit | Operation::ClearBit => plain(&[GprInOut, Imm]),
-        Operation::Float(FloatingPointOperation::Binary(_)) => plain(&[FprInOut, FprIn]),
+        } => {
+            &const {
+                plain(&[GprOut, GprIn, GprInOrImm])
+                    .x86_64(spec().fixed(&[(2, RCX)]).scratches(&[R11]))
+                    .coalesces(&[(0, 1)])
+            }
+        }
+        Operation::DivMod => {
+            &const {
+                plain(&[GprOut, GprOut, GprIn, GprIn])
+                    .x86_64(spec().outputs(&[RAX, RDX]).fixed(&[(0, RAX), (1, RDX)]))
+                    .aarch64(spec().scratches(&[X9]))
+            }
+        }
+        Operation::Overflow(AddWithOverflow) | Operation::Overflow(SubtractWithOverflow) => {
+            &const {
+                plain(&[GprInOut, GprInOrImm])
+                    .trailing(&[Label])
+                    .pre_scratches(&[], &[X9])
+            }
+        }
+        Operation::Overflow(Increment) | Operation::Overflow(Decrement) | Operation::Overflow(Negate) => {
+            &const { plain(&[GprInOut, Label]) }
+        }
+        Operation::Overflow(MultiplyWithOverflow) => {
+            &const { plain(&[GprInOut, GprIn]).trailing(&[Label]).pre_scratches(&[], &[X9]) }
+        }
+        Operation::Overflow(MultiplyCopy) => {
+            &const {
+                plain(&[GprOut, GprIn, GprIn])
+                    .trailing(&[Label])
+                    .pre_scratches(&[], &[X9])
+            }
+        }
+        Operation::ToggleBit | Operation::ClearBit => &const { plain(&[GprInOut, Imm]) },
+        Operation::Float(FloatingPointOperation::Binary(_)) => &const { plain(&[FprInOut, FprIn]) },
         Operation::Float(
             FloatingPointOperation::Unary(_)
-            | FloatingPointOperation::Convert(
-                FloatConversion::Float32ToFloat64 | FloatConversion::Float64ToFloat32,
-            ),
-        ) => plain(&[FprOut, FprIn]),
-        Operation::FloatMove => plain(&[RegisterOut, RegisterIn]).coalesces(&[(0, 1)])
-            .identity_if_inputs_alias(),
+            | FloatingPointOperation::Convert(FloatConversion::Float32ToFloat64 | FloatConversion::Float64ToFloat32),
+        ) => &const { plain(&[FprOut, FprIn]) },
+        Operation::FloatMove => {
+            &const {
+                plain(&[RegisterOut, RegisterIn])
+                    .coalesces(&[(0, 1)])
+                    .identity_if_inputs_alias()
+            }
+        }
         Operation::Float(FloatingPointOperation::Convert(
             FloatConversion::Int32ToFloat64 | FloatConversion::Uint32ToFloat64,
-        )) => plain(&[FprOut, GprIn]),
-        Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)) => plain(&[GprOut, FprIn, Label])
-            .scratches(&[RCX, XMM3], &[D16]),
-        Operation::Float(FloatingPointOperation::Convert(FloatConversion::JavaScriptToInt32)) => plain(&[GprOut, FprIn, Label])
-            .scratches(&[RCX], &[D16]),
-        Operation::Float(FloatingPointOperation::CanonicalizeNan) => plain(&[GprOut, FprIn]),
+        )) => &const { plain(&[FprOut, GprIn]) },
+        Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)) => {
+            &const { plain(&[GprOut, FprIn, Label]).scratches(&[RCX, XMM3], &[D16]) }
+        }
+        Operation::Float(FloatingPointOperation::Convert(FloatConversion::JavaScriptToInt32)) => {
+            &const { plain(&[GprOut, FprIn, Label]).scratches(&[RCX], &[D16]) }
+        }
+        Operation::Float(FloatingPointOperation::CanonicalizeNan) => &const { plain(&[GprOut, FprIn]) },
         Operation::Branch(BranchOperation::Equality {
-            width: U16 | U32 | U64,
-            ..
+            width: U16 | U32 | U64, ..
         })
-        | Operation::Branch(BranchOperation::Ordered {
-            width: U32 | U64,
-            ..
-        }) => scalar_compare_branch(),
-        Operation::Branch(BranchOperation::Tag(_)) => plain(&[GprIn, Imm]).trailing(&[Label])
-            .pre_scratches(&[R11], &[X9, X10]),
-        Operation::Branch(BranchOperation::Singleton(_)) => plain(&[GprIn, Imm]).trailing(&[Label])
-            .pre_scratches(&[R11], &[X9]),
-        Operation::Branch(BranchOperation::Memory { .. }) => plain(&[Memory, GprIn])
-            .trailing(&[Label]).pre_scratches(&[], &[X9]),
-        Operation::Branch(BranchOperation::Equality {
-            width: U8,
-            ..
-        }) => plain(&[Memory, Imm])
-            .trailing(&[Label]).pre_scratches(&[], &[X9]),
+        | Operation::Branch(BranchOperation::Ordered { width: U32 | U64, .. }) => &const { scalar_compare_branch() },
+        Operation::Branch(BranchOperation::Tag(_)) => {
+            &const {
+                plain(&[GprIn, Imm])
+                    .trailing(&[Label])
+                    .pre_scratches(&[R11], &[X9, X10])
+            }
+        }
+        Operation::Branch(BranchOperation::Singleton(_)) => {
+            &const { plain(&[GprIn, Imm]).trailing(&[Label]).pre_scratches(&[R11], &[X9]) }
+        }
+        Operation::Branch(BranchOperation::Memory { .. }) => {
+            &const { plain(&[Memory, GprIn]).trailing(&[Label]).pre_scratches(&[], &[X9]) }
+        }
+        Operation::Branch(BranchOperation::Equality { width: U8, .. }) => {
+            &const { plain(&[Memory, Imm]).trailing(&[Label]).pre_scratches(&[], &[X9]) }
+        }
         Operation::Branch(BranchOperation::Bits {
             width: MemoryWidth::Byte,
             ..
-        }) => plain(&[Memory, Imm])
-            .trailing(&[Label]).pre_scratches(&[], &[X9, X10]),
-        Operation::Branch(BranchOperation::Zero {
-            width: U32 | U64,
-            ..
-        })
-        | Operation::Branch(BranchOperation::Sign {
-            width: U32 | U64,
-            ..
-        })
-        | Operation::Branch(BranchOperation::ValueBitsNegative) => plain(&[GprIn, Label]),
+        }) => &const { plain(&[Memory, Imm]).trailing(&[Label]).pre_scratches(&[], &[X9, X10]) },
+        Operation::Branch(BranchOperation::Zero { width: U32 | U64, .. })
+        | Operation::Branch(BranchOperation::Sign { width: U32 | U64, .. })
+        | Operation::Branch(BranchOperation::ValueBitsNegative) => &const { plain(&[GprIn, Label]) },
         Operation::Branch(BranchOperation::Bits {
             width: MemoryWidth::DoubleWord,
             ..
-        }) => plain(&[GprIn, GprInOrImm])
-            .trailing(&[Label]).pre_scratches(&[], &[X9]),
-        Operation::Branch(BranchOperation::Bit(_)) => plain(&[GprIn, Imm, Label]),
-        Operation::Branch(BranchOperation::AnyEqual) => plain(&[GprIn])
-            .variadic(GprInOrImm, 1, None, &[Label])
-            .pre_scratches(&[], &[X9]),
-        Operation::Branch(BranchOperation::Float(_)) => plain(&[FprIn, FprIn, Label]),
-        Operation::Assertion(AssertionOperation::UnsignedLess | AssertionOperation::UnsignedGreaterOrEqual) => plain(&[GprIn, GprInOrImm])
-            .scratches(&[], &[X9]),
-        Operation::Assertion(AssertionOperation::NonZero) => plain(&[GprIn]),
-        Operation::Assertion(AssertionOperation::TagEqual | AssertionOperation::TagNotEqual) => plain(&[GprIn, GprInOrImm])
-            .scratches(&[R11], &[X9, X10]),
+        }) => &const { plain(&[GprIn, GprInOrImm]).trailing(&[Label]).pre_scratches(&[], &[X9]) },
+        Operation::Branch(BranchOperation::Bit(_)) => &const { plain(&[GprIn, Imm, Label]) },
+        Operation::Branch(BranchOperation::AnyEqual) => {
+            &const {
+                plain(&[GprIn])
+                    .variadic(GprInOrImm, 1, None, &[Label])
+                    .pre_scratches(&[], &[X9])
+            }
+        }
+        Operation::Branch(BranchOperation::Float(_)) => &const { plain(&[FprIn, FprIn, Label]) },
+        Operation::Assertion(AssertionOperation::UnsignedLess | AssertionOperation::UnsignedGreaterOrEqual) => {
+            &const { plain(&[GprIn, GprInOrImm]).scratches(&[], &[X9]) }
+        }
+        Operation::Assertion(AssertionOperation::NonZero) => &const { plain(&[GprIn]) },
+        Operation::Assertion(AssertionOperation::TagEqual | AssertionOperation::TagNotEqual) => {
+            &const { plain(&[GprIn, GprInOrImm]).scratches(&[R11], &[X9, X10]) }
+        }
         Operation::StorePairIndexed(PairWidth::Word) => unreachable!("indexed 32-bit pair stores are unsupported"),
-        Operation::Memory(MemoryOperation::Load64NonZero) => unreachable!("checked loads must be lowered before target selection"),
+        Operation::Memory(MemoryOperation::Load64NonZero) => {
+            unreachable!("checked loads must be lowered before target selection")
+        }
         Operation::Move(U8 | U16) => unreachable!("narrow moves are unsupported"),
         Operation::IntegerBinary { .. } => unreachable!("unsupported integer operation width"),
         Operation::Not(U8 | U16) => unreachable!("narrow not is unsupported"),
-        Operation::Branch(BranchOperation::Ordered {
-            width: U8 | U16, ..
-        }) => unreachable!("narrow ordered branches are unsupported"),
-        Operation::Branch(BranchOperation::Sign {
-            width: U8 | U16, ..
-        }) => unreachable!("narrow sign branches are unsupported"),
-        Operation::Branch(BranchOperation::Zero {
-            width: U8 | U16, ..
-        }) => unreachable!("narrow zero branches are unsupported"),
+        Operation::Branch(BranchOperation::Ordered { width: U8 | U16, .. }) => {
+            unreachable!("narrow ordered branches are unsupported")
+        }
+        Operation::Branch(BranchOperation::Sign { width: U8 | U16, .. }) => {
+            unreachable!("narrow sign branches are unsupported")
+        }
+        Operation::Branch(BranchOperation::Zero { width: U8 | U16, .. }) => {
+            unreachable!("narrow zero branches are unsupported")
+        }
         Operation::Branch(BranchOperation::Bits { .. }) => unreachable!("unsupported branch-bits width"),
     }
 }
@@ -990,10 +1039,7 @@ mod tests {
             operation: IntegerBinaryOperation::Binary(BinaryOperation::And),
             width: IntegerWidth::U64,
         });
-        assert_eq!(
-            info.x86_64.trailing_scratch_registers,
-            &[RAX, R11]
-        );
+        assert_eq!(info.x86_64.trailing_scratch_registers, &[RAX, R11]);
     }
 
     #[test]
@@ -1009,5 +1055,4 @@ mod tests {
             assert!(info.aarch64.trailing_scratch_registers.is_empty());
         }
     }
-
 }

--- a/Libraries/LibJS/Flap/src/target/emitter.rs
+++ b/Libraries/LibJS/Flap/src/target/emitter.rs
@@ -11,7 +11,7 @@ use crate::target::ir::{
 use crate::target::registers::PhysicalRegister;
 use crate::ObjectFormat;
 use crate::intrinsic::{IntegerWidth, PairWidth};
-use std::collections::HashMap;
+use crate::hash::HashMap;
 use std::fmt::Write;
 
 /// Like `writeln!`, but without the `.unwrap()` -- writing to a `String` is infallible.

--- a/Libraries/LibJS/Flap/src/target/emitter.rs
+++ b/Libraries/LibJS/Flap/src/target/emitter.rs
@@ -4,14 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::target::ir::{
-    MachineFunction as Handler, MachineInstruction, MachineOperand as Operand,
-    MachineProgram,
-};
-use crate::target::registers::PhysicalRegister;
 use crate::ObjectFormat;
-use crate::intrinsic::{IntegerWidth, PairWidth};
 use crate::hash::HashMap;
+use crate::intrinsic::{IntegerWidth, PairWidth};
+use crate::target::ir::{MachineFunction as Handler, MachineInstruction, MachineOperand as Operand, MachineProgram};
+use crate::target::registers::PhysicalRegister;
 use std::fmt::Write;
 
 /// Like `writeln!`, but without the `.unwrap()` -- writing to a `String` is infallible.
@@ -95,12 +92,8 @@ fn simple_register_name(register: PhysicalRegister, format: SimpleRegister) -> S
     match format {
         SimpleRegister::Native => register.as_str().to_string(),
         SimpleRegister::Integer(width) => register.integer_name(width),
-        SimpleRegister::Pair(PairWidth::Word) => {
-            register.word_name()
-        }
-        SimpleRegister::Pair(PairWidth::DoubleWord) => {
-            register.as_str().to_string()
-        }
+        SimpleRegister::Pair(PairWidth::Word) => register.word_name(),
+        SimpleRegister::Pair(PairWidth::DoubleWord) => register.as_str().to_string(),
         SimpleRegister::Word => register.word_name(),
         SimpleRegister::Single => register.single_name(),
     }
@@ -177,11 +170,7 @@ pub(crate) fn emit_simple_instruction(
     true
 }
 
-pub(crate) fn emit_label(
-    out: &mut String,
-    instruction: &MachineInstruction,
-    handler: &Handler,
-) {
+pub(crate) fn emit_label(out: &mut String, instruction: &MachineInstruction, handler: &Handler) {
     let Some(Operand::Label(name)) = instruction.operands.first() else {
         unreachable!("machine label operand was verified")
     };
@@ -218,10 +207,7 @@ pub(crate) fn resolve_label(op: &Operand, handler: &Handler) -> String {
                 name.to_string()
             }
         }
-        other => panic!(
-            "expected label operand in handler '{}', got {other:?}",
-            handler.name
-        ),
+        other => panic!("expected label operand in handler '{}', got {other:?}", handler.name),
     }
 }
 

--- a/Libraries/LibJS/Flap/src/target/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/finalize.rs
@@ -29,7 +29,7 @@ use crate::frontend::layout::KnownLayoutConstant;
 use crate::{Architecture, ObjectFormat};
 
 fn finalize_function_for_target(
-    function: AllocatedFunction,
+    mut function: AllocatedFunction,
     runtime: &RuntimeConstants,
     options: &CompileOptions,
 ) -> Result<MachineFunction, CompileError> {
@@ -57,17 +57,12 @@ fn finalize_function_for_target(
             .cfg
             .layout_hot_and_cold()
             .map_err(|message| finalization_error(&function.name, message))?;
+        // Nothing reads the graph after this, so it hands its instructions over
+        // rather than being copied out of.
+        let (hot, cold) = std::mem::take(&mut function.cfg).linearize_hot_and_cold(&layout);
         (
-            finalize_instructions(
-                function.cfg.linearize_omitting_jumps_to_next_block(&layout.hot),
-                backend,
-                &mut emit,
-            )?,
-            finalize_instructions(
-                function.cfg.linearize_omitting_jumps_to_next_block(&layout.cold),
-                backend,
-                &mut emit,
-            )?,
+            finalize_instructions(hot, backend, &mut emit)?,
+            finalize_instructions(cold, backend, &mut emit)?,
         )
     };
 

--- a/Libraries/LibJS/Flap/src/target/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/finalize.rs
@@ -6,27 +6,25 @@
 
 //! Post-allocation control-flow layout and machine instruction finalization.
 
-use super::description::{
-    BinaryOperation, BranchOperation, CallKind, ControlOperation, FloatCondition, FloatConversion, FloatingPointOperation,
-    IntegerBinaryOperation, IntegerWidth, MemoryOperation, MemoryWidth, Operation, SignCondition,
-};
-#[cfg(test)]
-use super::description::{
-    PairWidth,
-};
-use super::ir::{
-    AllocatedFunction, AllocatedInstruction, AllocatedOperand,
-    AllocatedProgram, MachineFunction, MachineInstruction, MachineOpcode,
-    MachineProgram, RuntimeConstants,
-};
 use super::backend::{Backend, backend_for};
+#[cfg(test)]
+use super::description::PairWidth;
+use super::description::{
+    BinaryOperation, BranchOperation, CallKind, ControlOperation, FloatCondition, FloatConversion,
+    FloatingPointOperation, IntegerBinaryOperation, IntegerWidth, MemoryOperation, MemoryWidth, Operation,
+    SignCondition,
+};
 use super::finalize_support::{AllocatedOperands, Emit, finalization_error, verified_register};
+use super::ir::{
+    AllocatedFunction, AllocatedInstruction, AllocatedOperand, AllocatedProgram, MachineFunction, MachineInstruction,
+    MachineOpcode, MachineProgram, RuntimeConstants,
+};
 use crate::CompileOptions;
-use crate::{CompileError, CompileStage};
 #[cfg(test)]
 use crate::frontend::layout::KnownLayoutConstant;
 #[cfg(test)]
 use crate::{Architecture, ObjectFormat};
+use crate::{CompileError, CompileStage};
 
 fn finalize_function_for_target(
     mut function: AllocatedFunction,
@@ -36,12 +34,10 @@ fn finalize_function_for_target(
     let backend = backend_for(options.target.architecture);
     let mut emit = Emit::new(runtime, &function.name, function.size, options);
     let (hot_instructions, mut cold_instructions) = if function.is_cold {
-        let instruction = function.cfg.single_instruction().ok_or_else(|| {
-            finalization_error(
-                &function.name,
-                "cold handler must consist solely of call_slow_path",
-            )
-        })?;
+        let instruction = function
+            .cfg
+            .single_instruction()
+            .ok_or_else(|| finalization_error(&function.name, "cold handler must consist solely of call_slow_path"))?;
         if instruction.opcode.operation() != Operation::Call(CallKind::SlowPath) {
             return Err(finalization_error(
                 &function.name,
@@ -78,10 +74,7 @@ fn finalize_function_for_target(
 }
 
 #[cfg(test)]
-fn finalize_function(
-    function: AllocatedFunction,
-    runtime: &RuntimeConstants,
-) -> Result<MachineFunction, CompileError> {
+fn finalize_function(function: AllocatedFunction, runtime: &RuntimeConstants) -> Result<MachineFunction, CompileError> {
     let options = CompileOptions {
         target: crate::Target {
             architecture: Architecture::X86_64,
@@ -109,9 +102,7 @@ pub(crate) fn finalize_program(
     let functions = program
         .functions
         .into_iter()
-        .map(|function| {
-            finalize_function_for_target(function, &runtime, options)
-        })
+        .map(|function| finalize_function_for_target(function, &runtime, options))
         .collect::<Result<_, _>>()?;
     let machine = MachineProgram {
         runtime,
@@ -215,9 +206,7 @@ fn finalize_float_operation(
 ) {
     if !matches!(
         operation,
-        FloatingPointOperation::Convert(
-            FloatConversion::Float64ToInt32 | FloatConversion::JavaScriptToInt32,
-        )
+        FloatingPointOperation::Convert(FloatConversion::Float64ToInt32 | FloatConversion::JavaScriptToInt32)
     ) {
         backend.float_operation(emit, opcode, operation, operands);
         return;
@@ -282,9 +271,7 @@ fn finalize_instruction(
     let operation = instruction.opcode.operation();
 
     if let Operation::Assertion(operation) = operation {
-        let ok_label = emit
-            .enable_assertions
-            .then(|| emit.unique_label("assert_ok"));
+        let ok_label = emit.enable_assertions.then(|| emit.unique_label("assert_ok"));
         backend.finalize_assertion(emit, operation, &instruction.operands, ok_label)?;
         if emit.enable_assertions {
             emit.last_fp_compare = None;
@@ -357,9 +344,7 @@ fn finalize_instruction(
         Operation::LoadProgramCounter => backend.finalize_program_counter_load(emit, operands),
         Operation::Call(kind) => finalize_call(backend, emit, kind, operands)?,
         Operation::Control(
-            kind @ (ControlOperation::DispatchNext
-            | ControlOperation::Dispatch
-            | ControlOperation::DispatchVariable),
+            kind @ (ControlOperation::DispatchNext | ControlOperation::Dispatch | ControlOperation::DispatchVariable),
         ) => finalize_dispatch(backend, emit, kind, operands)?,
         Operation::StoreOperand => backend.finalize_operand_store(emit, operands)?,
         Operation::LoadLabel => backend.finalize_label_load(emit, operands)?,
@@ -431,28 +416,17 @@ mod tests {
     use super::*;
     use crate::Architecture;
     use crate::low_ir::cfg::ControlFlowGraph;
-    use crate::target::description::{
-        ControlOperation, Operation,
-    };
-    use crate::target::ir::{
-        AllocatedInstruction,
-        AllocatedMemoryAddress, AllocatedOperand as Operand,
-    };
+    use crate::target::description::{ControlOperation, Operation};
+    use crate::target::ir::{AllocatedInstruction, AllocatedMemoryAddress, AllocatedOperand as Operand};
     use crate::target::registers::x86_64;
 
     type Instruction = crate::low_ir::Instruction<Operand>;
 
-    fn allocated_function(
-        instructions: Vec<Instruction>,
-        is_cold: bool,
-    ) -> AllocatedFunction {
+    fn allocated_function(instructions: Vec<Instruction>, is_cold: bool) -> AllocatedFunction {
         let instructions = instructions
             .into_iter()
             .map(|instruction| AllocatedInstruction {
-                opcode: select_allocated_opcode(
-                    instruction.opcode,
-                    &instruction.operands,
-                ),
+                opcode: select_allocated_opcode(instruction.opcode, &instruction.operands),
                 operands: instruction.operands,
             })
             .collect();
@@ -465,22 +439,13 @@ mod tests {
         }
     }
 
-    fn select_allocated_opcode(
-        opcode: Operation,
-        operands: &[Operand],
-    ) -> crate::target::description::SelectedOpcode {
-        let operands = operands
-            .iter()
-            .map(Operand::selection_operand)
-            .collect::<Vec<_>>();
+    fn select_allocated_opcode(opcode: Operation, operands: &[Operand]) -> crate::target::description::SelectedOpcode {
+        let operands = operands.iter().map(Operand::selection_operand).collect::<Vec<_>>();
         opcode.select_for_operands(Architecture::X86_64, &operands)
     }
 
     fn runtime() -> RuntimeConstants {
-        RuntimeConstants::from_values([(
-            KnownLayoutConstant::SizeOfExecutionContext,
-            120,
-        )])
+        RuntimeConstants::from_values([(KnownLayoutConstant::SizeOfExecutionContext, 120)])
     }
 
     fn test_options() -> CompileOptions {
@@ -504,10 +469,7 @@ mod tests {
             operands,
         };
         let instruction = AllocatedInstruction {
-            opcode: select_allocated_opcode(
-                instruction.opcode,
-                &instruction.operands,
-            ),
+            opcode: select_allocated_opcode(instruction.opcode, &instruction.operands),
             operands: instruction.operands,
         };
         let options = test_options();
@@ -543,9 +505,7 @@ mod tests {
                 },
                 Instruction {
                     opcode: Operation::Control(ControlOperation::DispatchNext),
-                    operands: vec![Operand::PhysicalRegister(
-                        x86_64::RAX,
-                    )],
+                    operands: vec![Operand::PhysicalRegister(x86_64::RAX)],
                 },
             ],
             false,
@@ -555,28 +515,21 @@ mod tests {
         assert_eq!(machine.hot_instructions.len(), 3);
         assert!(matches!(
             machine.hot_instructions[0].opcode,
-            MachineOpcode::X86_64(
-                super::super::x86_64::Opcode::AluImmediate {
-                    operation:
-                        super::super::x86_64::AluOperation::Add,
-                    width: IntegerWidth::U32,
-                }
-            )
+            MachineOpcode::X86_64(super::super::x86_64::Opcode::AluImmediate {
+                operation: super::super::x86_64::AluOperation::Add,
+                width: IntegerWidth::U32,
+            })
         ));
         assert!(matches!(
             machine.hot_instructions[1].opcode,
-            MachineOpcode::X86_64(
-                super::super::x86_64::Opcode::Load {
-                    width: MemoryWidth::Byte,
-                    signed: false,
-                }
-            )
+            MachineOpcode::X86_64(super::super::x86_64::Opcode::Load {
+                width: MemoryWidth::Byte,
+                signed: false,
+            })
         ));
         assert!(matches!(
             machine.hot_instructions[2].opcode,
-            MachineOpcode::X86_64(
-                super::super::x86_64::Opcode::JumpMemory
-            )
+            MachineOpcode::X86_64(super::super::x86_64::Opcode::JumpMemory)
         ));
         assert!(machine.cold_instructions.is_empty());
     }
@@ -586,9 +539,7 @@ mod tests {
         let function = allocated_function(
             vec![Instruction {
                 opcode: Operation::Control(ControlOperation::DispatchNext),
-                operands: vec![Operand::PhysicalRegister(
-                    x86_64::RAX,
-                )],
+                operands: vec![Operand::PhysicalRegister(x86_64::RAX)],
             }],
             true,
         );
@@ -608,10 +559,7 @@ mod tests {
                         operation: IntegerBinaryOperation::Binary(BinaryOperation::Add),
                         width: IntegerWidth::U64,
                     },
-                    operands: vec![
-                        Operand::PhysicalRegister(x86_64::RAX),
-                        Operand::Immediate(i64::MAX),
-                    ],
+                    operands: vec![Operand::PhysicalRegister(x86_64::RAX), Operand::Immediate(i64::MAX)],
                 }],
                 false,
             ),
@@ -670,16 +618,8 @@ mod tests {
                     operands: vec![
                         Operand::PhysicalRegister(x86_64::RCX),
                         Operand::PhysicalRegister(x86_64::RDX),
-                        address(
-                            x86_64::RCX,
-                            Some(x86_64::RDX),
-                            None,
-                        ),
-                        address(
-                            x86_64::RCX,
-                            Some(x86_64::RDX),
-                            Some(8),
-                        ),
+                        address(x86_64::RCX, Some(x86_64::RDX), None),
+                        address(x86_64::RCX, Some(x86_64::RDX), Some(8)),
                     ],
                 }],
                 false,
@@ -693,6 +633,4 @@ mod tests {
             "x86-64 pair-load destinations may not both alias the address"
         );
     }
-
-
 }

--- a/Libraries/LibJS/Flap/src/target/finalize_support.rs
+++ b/Libraries/LibJS/Flap/src/target/finalize_support.rs
@@ -6,15 +6,11 @@
 
 //! Shared helpers for architecture-specific machine finalization.
 
-use super::ir::{
-    AllocatedOperand, MachineInstruction, MachineMemoryAddress, RuntimeConstants,
-};
-use super::description::{
-    EqualityCondition, IntegerWidth, PairWidth, TestCondition,
-};
+use super::description::{EqualityCondition, IntegerWidth, PairWidth, TestCondition};
+use super::ir::{AllocatedOperand, MachineInstruction, MachineMemoryAddress, RuntimeConstants};
 use super::registers::PhysicalRegister;
-use crate::low_ir::{Label, Relocation};
 use crate::frontend::layout::KnownLayoutConstant;
+use crate::low_ir::{Label, Relocation};
 use crate::{CompileError, CompileOptions, CompileStage, ObjectFormat};
 
 /// Everything a backend needs while finalizing one function: where machine
@@ -125,8 +121,7 @@ pub(crate) trait AllocatedOperands {
 
 impl AllocatedOperands for [AllocatedOperand] {
     fn operand(&self, index: usize) -> &AllocatedOperand {
-        self.get(index)
-            .expect("allocated instruction operands were verified")
+        self.get(index).expect("allocated instruction operands were verified")
     }
 
     fn physical_register(&self, index: usize) -> PhysicalRegister {
@@ -179,10 +174,7 @@ pub(crate) fn finalize_error<T>(handler: &str, message: impl Into<String>) -> Re
     Err(finalization_error(handler, message))
 }
 
-pub(crate) fn required_byte_immediate(
-    operand: &AllocatedOperand,
-    handler: &str,
-) -> Result<i64, CompileError> {
+pub(crate) fn required_byte_immediate(operand: &AllocatedOperand, handler: &str) -> Result<i64, CompileError> {
     let AllocatedOperand::Immediate(immediate) = operand else {
         return finalize_error(handler, "byte memory branch value must be an immediate");
     };
@@ -197,18 +189,12 @@ pub(crate) fn required_runtime_constant(
     constant: KnownLayoutConstant,
     handler: &str,
 ) -> Result<i64, CompileError> {
-    runtime.get(constant).ok_or_else(|| {
-        finalization_error(
-            handler,
-            format!("{} constant is required", constant.name()),
-        )
-    })
+    runtime
+        .get(constant)
+        .ok_or_else(|| finalization_error(handler, format!("{} constant is required", constant.name())))
 }
 
-pub(crate) fn interpreter_layout(
-    runtime: &RuntimeConstants,
-    handler: &str,
-) -> Result<[i64; 5], CompileError> {
+pub(crate) fn interpreter_layout(runtime: &RuntimeConstants, handler: &str) -> Result<[i64; 5], CompileError> {
     use KnownLayoutConstant::*;
 
     Ok([
@@ -220,11 +206,8 @@ pub(crate) fn interpreter_layout(
     ])
 }
 
-pub(crate) fn machine_address(
-    operand: &AllocatedOperand,
-) -> MachineMemoryAddress {
-    let AllocatedOperand::Address(address) = operand
-    else {
+pub(crate) fn machine_address(operand: &AllocatedOperand) -> MachineMemoryAddress {
+    let AllocatedOperand::Address(address) = operand else {
         unreachable!("allocated memory operand was verified");
     };
     address.clone()
@@ -242,10 +225,7 @@ pub(crate) fn machine_memory_pair_address(
         return finalize_error(handler, "paired memory addresses may not use scaled indices");
     }
     if first.base != second.base || first.index != second.index {
-        return finalize_error(
-            handler,
-            "paired memory addresses must use the same base and index",
-        );
+        return finalize_error(handler, "paired memory addresses must use the same base and index");
     }
     let first_offset = first.displacement.unwrap_or(0);
     let expected_second = first_offset
@@ -277,7 +257,14 @@ pub(crate) fn pair_access<const SCRATCH_COUNT: usize>(
     width: PairWidth,
     is_load: bool,
     handler: &str,
-) -> Result<([PhysicalRegister; 2], MachineMemoryAddress, [PhysicalRegister; SCRATCH_COUNT]), CompileError> {
+) -> Result<
+    (
+        [PhysicalRegister; 2],
+        MachineMemoryAddress,
+        [PhysicalRegister; SCRATCH_COUNT],
+    ),
+    CompileError,
+> {
     let (registers, addresses) = if is_load {
         (&operands[..2], &operands[2..4])
     } else {
@@ -285,18 +272,17 @@ pub(crate) fn pair_access<const SCRATCH_COUNT: usize>(
     };
     Ok((
         std::array::from_fn(|index| verified_register(&registers[index])),
-        machine_memory_pair_address(
-            &addresses[0],
-            &addresses[1],
-            pair_element_size(width),
-            handler,
-        )?,
+        machine_memory_pair_address(&addresses[0], &addresses[1], pair_element_size(width), handler)?,
         std::array::from_fn(|index| verified_register(&operands[4 + index])),
     ))
 }
 
-type IndexedPairStore<const SCRATCH_COUNT: usize> =
-    ([PhysicalRegister; 2], i64, [PhysicalRegister; 2], [PhysicalRegister; SCRATCH_COUNT]);
+type IndexedPairStore<const SCRATCH_COUNT: usize> = (
+    [PhysicalRegister; 2],
+    i64,
+    [PhysicalRegister; 2],
+    [PhysicalRegister; SCRATCH_COUNT],
+);
 
 pub(crate) fn indexed_pair_store<const SCRATCH_COUNT: usize>(
     operands: &[AllocatedOperand],
@@ -306,7 +292,15 @@ pub(crate) fn indexed_pair_store<const SCRATCH_COUNT: usize>(
     if width != PairWidth::DoubleWord {
         return finalize_error(handler, "indexed pair store must use double-word values");
     }
-    let [base, index, AllocatedOperand::Immediate(scale), first, second, scratches @ ..] = operands else {
+    let [
+        base,
+        index,
+        AllocatedOperand::Immediate(scale),
+        first,
+        second,
+        scratches @ ..,
+    ] = operands
+    else {
         return finalize_error(handler, "indexed pair store has invalid target operands");
     };
     if !matches!(scale, 1 | 2 | 4 | 8) {
@@ -323,15 +317,8 @@ pub(crate) fn indexed_pair_store<const SCRATCH_COUNT: usize>(
     ))
 }
 
-pub(crate) fn x86_values_offset(
-    runtime: &RuntimeConstants,
-    handler: &str,
-) -> Result<i64, CompileError> {
-    required_runtime_constant(
-        runtime,
-        KnownLayoutConstant::SizeOfExecutionContext,
-        handler,
-    )
+pub(crate) fn x86_values_offset(runtime: &RuntimeConstants, handler: &str) -> Result<i64, CompileError> {
+    required_runtime_constant(runtime, KnownLayoutConstant::SizeOfExecutionContext, handler)
 }
 
 /// Decode a memory-branch instruction's comparison from its operands.
@@ -346,9 +333,7 @@ pub(crate) fn memory_branch(
 ) -> Result<MemoryBranch, CompileError> {
     use super::description::MemoryBranchKind;
 
-    let kind = operation
-        .memory_branch()
-        .expect("allocated memory branch was verified");
+    let kind = operation.memory_branch().expect("allocated memory branch was verified");
     let rhs = operands.operand(1);
     Ok(match kind {
         MemoryBranchKind::CompareRegister { width, condition } => MemoryBranch::CompareRegister {
@@ -388,5 +373,8 @@ pub(crate) fn push_plain_move(
     {
         return;
     }
-    emit.output.push(MachineInstruction { opcode, operands: operands.to_vec() });
+    emit.output.push(MachineInstruction {
+        opcode,
+        operands: operands.to_vec(),
+    });
 }

--- a/Libraries/LibJS/Flap/src/target/ir.rs
+++ b/Libraries/LibJS/Flap/src/target/ir.rs
@@ -247,6 +247,7 @@ pub(crate) struct Function {
     pub(crate) size: Option<u32>,
     pub(crate) is_cold: bool,
     pub(crate) architecture: Architecture,
+    pub(crate) virtual_registers: Vec<VirtualRegister>,
     pub(crate) instructions: Vec<Instruction>,
 }
 

--- a/Libraries/LibJS/Flap/src/target/ir.rs
+++ b/Libraries/LibJS/Flap/src/target/ir.rs
@@ -15,7 +15,7 @@ use crate::low_ir::{
 };
 pub(crate) use crate::low_ir::{
     AddressRegister, MemoryAddress, Operand, VirtualRegister,
-    count_virtual_register_uses, visit_virtual_registers,
+    visit_virtual_registers,
 };
 use crate::target::description::{ArchitectureOpcode, SelectedOpcode};
 use crate::target::registers::{PhysicalRegister, RegisterClass};

--- a/Libraries/LibJS/Flap/src/target/ir.rs
+++ b/Libraries/LibJS/Flap/src/target/ir.rs
@@ -9,14 +9,8 @@
 use crate::Architecture;
 use crate::frontend::layout::KnownLayoutConstant;
 use crate::identity::HandlerId;
-use crate::low_ir::{
-    Label, Relocation,
-    cfg::ControlFlowGraph,
-};
-pub(crate) use crate::low_ir::{
-    AddressRegister, MemoryAddress, Operand, VirtualRegister,
-    visit_virtual_registers,
-};
+pub(crate) use crate::low_ir::{AddressRegister, MemoryAddress, Operand, VirtualRegister, visit_virtual_registers};
+use crate::low_ir::{Label, Relocation, cfg::ControlFlowGraph};
 use crate::target::description::{ArchitectureOpcode, SelectedOpcode};
 use crate::target::registers::{PhysicalRegister, RegisterClass};
 
@@ -75,9 +69,7 @@ machine_conditions! {
 }
 
 impl MachineCondition {
-    pub(crate) fn from_scalar(
-        condition: crate::target::description::ScalarBranchCondition,
-    ) -> Self {
+    pub(crate) fn from_scalar(condition: crate::target::description::ScalarBranchCondition) -> Self {
         use crate::intrinsic::ComparisonRelation;
         use crate::target::description::ScalarBranchCondition;
 
@@ -108,9 +100,7 @@ impl MachineCondition {
         }
     }
 
-    pub(crate) fn from_assertion(
-        operation: crate::intrinsic::AssertionOperation,
-    ) -> Self {
+    pub(crate) fn from_assertion(operation: crate::intrinsic::AssertionOperation) -> Self {
         use crate::intrinsic::AssertionOperation;
 
         match operation {
@@ -134,36 +124,44 @@ pub(crate) struct PhysicalMemoryAddress {
 impl PhysicalMemoryAddress {
     /// `[base]`
     pub(crate) fn base(base: PhysicalRegister) -> Self {
-        Self { base, index: None, scale: None, displacement: None }
+        Self {
+            base,
+            index: None,
+            scale: None,
+            displacement: None,
+        }
     }
 
     /// `[base + displacement]`, folding a zero displacement away.
     pub(crate) fn offset(base: PhysicalRegister, displacement: i64) -> Self {
-        Self { displacement: (displacement != 0).then_some(displacement), ..Self::base(base) }
+        Self {
+            displacement: (displacement != 0).then_some(displacement),
+            ..Self::base(base)
+        }
     }
 
     /// `[base + index]`
     pub(crate) fn indexed(base: PhysicalRegister, index: PhysicalRegister) -> Self {
-        Self { index: Some(index), ..Self::base(base) }
+        Self {
+            index: Some(index),
+            ..Self::base(base)
+        }
     }
 
     /// `[base + index * scale + displacement]`, folding a zero displacement away.
-    pub(crate) fn scaled(
-        base: PhysicalRegister,
-        index: PhysicalRegister,
-        scale: i64,
-        displacement: i64,
-    ) -> Self {
-        Self { scale: Some(scale), ..Self::indexed_offset(base, index, displacement) }
+    pub(crate) fn scaled(base: PhysicalRegister, index: PhysicalRegister, scale: i64, displacement: i64) -> Self {
+        Self {
+            scale: Some(scale),
+            ..Self::indexed_offset(base, index, displacement)
+        }
     }
 
     /// `[base + index + displacement]`, folding a zero displacement away.
-    pub(crate) fn indexed_offset(
-        base: PhysicalRegister,
-        index: PhysicalRegister,
-        displacement: i64,
-    ) -> Self {
-        Self { index: Some(index), ..Self::offset(base, displacement) }
+    pub(crate) fn indexed_offset(base: PhysicalRegister, index: PhysicalRegister, displacement: i64) -> Self {
+        Self {
+            index: Some(index),
+            ..Self::offset(base, displacement)
+        }
     }
 }
 
@@ -187,8 +185,7 @@ pub(crate) enum OperandShape {
 
 crate::low_ir::impl_control_flow_operand!(PhysicalOperand);
 
-pub(crate) type Instruction =
-    crate::low_ir::Instruction<Operand, SelectedOpcode>;
+pub(crate) type Instruction = crate::low_ir::Instruction<Operand, SelectedOpcode>;
 
 #[cfg(test)]
 pub(crate) type AllocatedMemoryAddress = PhysicalMemoryAddress;
@@ -239,8 +236,7 @@ impl PhysicalOperand {
     }
 }
 
-pub(crate) type AllocatedInstruction =
-    crate::low_ir::Instruction<AllocatedOperand, SelectedOpcode>;
+pub(crate) type AllocatedInstruction = crate::low_ir::Instruction<AllocatedOperand, SelectedOpcode>;
 
 pub(crate) use crate::low_ir::RuntimeConstants;
 
@@ -283,8 +279,7 @@ pub struct AllocatedProgram {
 pub(crate) type MachineOpcode = ArchitectureOpcode;
 
 /// A finalized physical machine instruction.
-pub(crate) type MachineInstruction =
-    crate::low_ir::Instruction<MachineOperand, MachineOpcode>;
+pub(crate) type MachineInstruction = crate::low_ir::Instruction<MachineOperand, MachineOpcode>;
 
 impl crate::low_ir::Instruction<MachineOperand, MachineOpcode> {
     pub(crate) fn operand(&self, index: usize) -> &MachineOperand {
@@ -313,7 +308,6 @@ impl crate::low_ir::Instruction<MachineOperand, MachineOpcode> {
         };
         *immediate
     }
-
 }
 
 /// A finalized physical machine function with resolved hot and cold layout.
@@ -338,28 +332,24 @@ impl MachineProgram {
     pub(crate) fn missing_required_runtime_constant(&self) -> Option<&'static str> {
         use KnownLayoutConstant::*;
 
-        let architecture_constants: &[KnownLayoutConstant] =
-            match self.target.architecture {
-                Architecture::X86_64 => &[Int32TagShifted],
-                Architecture::Aarch64 => &[Int32Tag, BooleanTag, NanBaseTag],
-            };
+        let architecture_constants: &[KnownLayoutConstant] = match self.target.architecture {
+            Architecture::X86_64 => &[Int32TagShifted],
+            Architecture::Aarch64 => &[Int32Tag, BooleanTag, NanBaseTag],
+        };
         architecture_constants
             .iter()
-            .chain([
-                VmRunningExecutionContext,
-                ExecutionContextExecutable,
-                ExecutionContextProgramCounter,
-                ExecutableBytecodeData,
-                SizeOfExecutionContext,
-                CanonicalNanBits,
-            ]
-            .iter())
-            .find_map(|constant| {
-                self.runtime
-                    .get(*constant)
-                    .is_none()
-                    .then_some(constant.name())
-            })
+            .chain(
+                [
+                    VmRunningExecutionContext,
+                    ExecutionContextExecutable,
+                    ExecutionContextProgramCounter,
+                    ExecutableBytecodeData,
+                    SizeOfExecutionContext,
+                    CanonicalNanBits,
+                ]
+                .iter(),
+            )
+            .find_map(|constant| self.runtime.get(*constant).is_none().then_some(constant.name()))
     }
 }
 

--- a/Libraries/LibJS/Flap/src/target/ir.rs
+++ b/Libraries/LibJS/Flap/src/target/ir.rs
@@ -9,7 +9,9 @@
 use crate::Architecture;
 use crate::frontend::layout::KnownLayoutConstant;
 use crate::identity::HandlerId;
-pub(crate) use crate::low_ir::{AddressRegister, MemoryAddress, Operand, VirtualRegister, visit_virtual_registers};
+#[cfg(test)]
+pub(crate) use crate::low_ir::MemoryAddress;
+pub(crate) use crate::low_ir::{AddressRegister, Operand, VirtualRegister, visit_virtual_registers};
 use crate::low_ir::{Label, Relocation, cfg::ControlFlowGraph};
 use crate::target::description::{ArchitectureOpcode, SelectedOpcode};
 use crate::target::registers::{PhysicalRegister, RegisterClass};

--- a/Libraries/LibJS/Flap/src/target/machine_verify.rs
+++ b/Libraries/LibJS/Flap/src/target/machine_verify.rs
@@ -12,12 +12,12 @@ use super::ir::{
 };
 use super::description::OperandKind;
 use crate::{Architecture, CompileError, CompileStage};
-use std::collections::HashSet;
+use crate::hash::HashSet;
 
 pub(crate) fn verify_program(program: &MachineProgram) -> Result<(), CompileError> {
     let architecture = program.target.architecture;
-    let mut handler_ids = HashSet::new();
-    let mut handler_names = HashSet::new();
+    let mut handler_ids = HashSet::default();
+    let mut handler_names = HashSet::default();
     for function in &program.functions {
         if !handler_ids.insert(function.id) {
             return program_error(format!(
@@ -51,7 +51,7 @@ pub(crate) fn verify_function(
         .hot_instructions
         .iter()
         .chain(&function.cold_instructions);
-    let mut definitions = HashSet::new();
+    let mut definitions = HashSet::default();
     let mut references = Vec::new();
     for instruction in instructions {
         verify_instruction(function, instruction, architecture)?;

--- a/Libraries/LibJS/Flap/src/target/machine_verify.rs
+++ b/Libraries/LibJS/Flap/src/target/machine_verify.rs
@@ -6,13 +6,12 @@
 
 //! Verification for finalized physical machine IR.
 
-use super::ir::{
-    MachineFunction, MachineInstruction, MachineMemoryAddress, MachineOpcode,
-    MachineOperand, MachineProgram,
-};
 use super::description::OperandKind;
-use crate::{Architecture, CompileError, CompileStage};
+use super::ir::{
+    MachineFunction, MachineInstruction, MachineMemoryAddress, MachineOpcode, MachineOperand, MachineProgram,
+};
 use crate::hash::HashSet;
+use crate::{Architecture, CompileError, CompileStage};
 
 pub(crate) fn verify_program(program: &MachineProgram) -> Result<(), CompileError> {
     let architecture = program.target.architecture;
@@ -20,65 +19,41 @@ pub(crate) fn verify_program(program: &MachineProgram) -> Result<(), CompileErro
     let mut handler_names = HashSet::default();
     for function in &program.functions {
         if !handler_ids.insert(function.id) {
-            return program_error(format!(
-                "handler id {:?} is defined more than once",
-                function.id
-            ));
+            return program_error(format!("handler id {:?} is defined more than once", function.id));
         }
         if !handler_names.insert(function.name.as_str()) {
-            return program_error(format!(
-                "handler '{}' is defined more than once",
-                function.name
-            ));
+            return program_error(format!("handler '{}' is defined more than once", function.name));
         }
         verify_function(function, architecture)?;
     }
     for handler in program.dispatch_handlers.iter().flatten() {
         if !handler_ids.contains(handler) {
-            return program_error(format!(
-                "dispatch table references missing handler id {handler:?}"
-            ));
+            return program_error(format!("dispatch table references missing handler id {handler:?}"));
         }
     }
     Ok(())
 }
 
-pub(crate) fn verify_function(
-    function: &MachineFunction,
-    architecture: Architecture,
-) -> Result<(), CompileError> {
-    let instructions = function
-        .hot_instructions
-        .iter()
-        .chain(&function.cold_instructions);
+pub(crate) fn verify_function(function: &MachineFunction, architecture: Architecture) -> Result<(), CompileError> {
+    let instructions = function.hot_instructions.iter().chain(&function.cold_instructions);
     let mut definitions = HashSet::default();
     let mut references = Vec::new();
     for instruction in instructions {
         verify_instruction(function, instruction, architecture)?;
         if instruction.opcode.is_label() {
-            let [MachineOperand::Label(label)] =
-                instruction.operands.as_slice()
-            else {
-                return function_error(
-                    function,
-                    "machine label must define exactly one label",
-                );
+            let [MachineOperand::Label(label)] = instruction.operands.as_slice() else {
+                return function_error(function, "machine label must define exactly one label");
             };
             if !definitions.insert(label.clone()) {
-                return function_error(
-                    function,
-                    format!("machine label '{label}' is defined more than once"),
-                );
+                return function_error(function, format!("machine label '{label}' is defined more than once"));
             }
         } else {
-            references.extend(
-                instruction.operands.iter().filter_map(|operand| {
-                    let MachineOperand::Label(label) = operand else {
-                        return None;
-                    };
-                    label.starts_with('.').then(|| label.clone())
-                }),
-            );
+            references.extend(instruction.operands.iter().filter_map(|operand| {
+                let MachineOperand::Label(label) = operand else {
+                    return None;
+                };
+                label.starts_with('.').then(|| label.clone())
+            }));
         }
     }
     for reference in references {
@@ -98,18 +73,12 @@ fn verify_instruction(
     architecture: Architecture,
 ) -> Result<(), CompileError> {
     if instruction.opcode.architecture() != architecture {
-        return function_error(
-            function,
-            "machine instruction opcode belongs to the wrong architecture",
-        );
+        return function_error(function, "machine instruction opcode belongs to the wrong architecture");
     }
     if instruction.opcode.is_pseudo() {
         return function_error(
             function,
-            format!(
-                "target pseudo {:?} remains after finalization",
-                instruction.opcode
-            ),
+            format!("target pseudo {:?} remains after finalization", instruction.opcode),
         );
     }
     if !instruction.opcode.operands_are_valid(&instruction.operands) {
@@ -132,14 +101,10 @@ fn verify_instruction(
     }
     for operand in &instruction.operands {
         match operand {
-            MachineOperand::PhysicalRegister(register)
-                if register.architecture() != architecture =>
-            {
+            MachineOperand::PhysicalRegister(register) if register.architecture() != architecture => {
                 return function_error(
                     function,
-                    format!(
-                        "machine register '{register}' belongs to the wrong architecture"
-                    ),
+                    format!("machine register '{register}' belongs to the wrong architecture"),
                 );
             }
             MachineOperand::Address(address) => {
@@ -157,8 +122,7 @@ fn verify_address(
     architecture: Architecture,
 ) -> Result<(), CompileError> {
     if address.base.architecture() != architecture
-        || address.base.class()
-            != super::registers::RegisterClass::GeneralPurpose
+        || address.base.class() != super::registers::RegisterClass::GeneralPurpose
     {
         return function_error(
             function,
@@ -169,29 +133,19 @@ fn verify_address(
         );
     }
     if let Some(index) = address.index
-        && (index.architecture() != architecture
-            || index.class()
-                != super::registers::RegisterClass::GeneralPurpose)
+        && (index.architecture() != architecture || index.class() != super::registers::RegisterClass::GeneralPurpose)
     {
         return function_error(
             function,
-            format!(
-                "machine address index '{index}' is not a target general-purpose register"
-            ),
+            format!("machine address index '{index}' is not a target general-purpose register"),
         );
     }
     if let Some(scale) = address.scale {
         if !matches!(scale, 1 | 2 | 4 | 8) {
-            return function_error(
-                function,
-                format!("machine address has invalid scale {scale}"),
-            );
+            return function_error(function, format!("machine address has invalid scale {scale}"));
         }
         if address.index.is_none() {
-            return function_error(
-                function,
-                "machine address scale requires an index register",
-            );
+            return function_error(function, "machine address scale requires an index register");
         }
     }
     match architecture {
@@ -200,28 +154,19 @@ fn verify_address(
                 .displacement
                 .is_some_and(|displacement| i32::try_from(displacement).is_err())
             {
-                return function_error(
-                    function,
-                    "x86-64 machine address displacement does not fit in 32 bits",
-                );
+                return function_error(function, "x86-64 machine address displacement does not fit in 32 bits");
             }
         }
         Architecture::Aarch64 => {
             if address.scale.is_some() {
-                return function_error(
-                    function,
-                    "AArch64 machine address must encode its scale in the opcode",
-                );
+                return function_error(function, "AArch64 machine address must encode its scale in the opcode");
             }
         }
     }
     Ok(())
 }
 
-pub(crate) fn operands_match(
-    operands: &[MachineOperand],
-    expected: &[OperandKind],
-) -> bool {
+pub(crate) fn operands_match(operands: &[MachineOperand], expected: &[OperandKind]) -> bool {
     operands.len() == expected.len()
         && operands
             .iter()
@@ -369,8 +314,8 @@ pub(crate) use machine_operand;
 impl MachineOpcode {
     fn operands_are_valid(self, operands: &[MachineOperand]) -> bool {
         match self {
-        MachineOpcode::X86_64(opcode) => opcode.operands_are_valid(operands),
-        MachineOpcode::Aarch64(opcode) => opcode.operands_are_valid(operands),
+            MachineOpcode::X86_64(opcode) => opcode.operands_are_valid(operands),
+            MachineOpcode::Aarch64(opcode) => opcode.operands_are_valid(operands),
         }
     }
 
@@ -391,16 +336,12 @@ impl MachineOpcode {
     fn is_label(self) -> bool {
         matches!(
             self,
-            MachineOpcode::X86_64(super::x86_64::Opcode::Label)
-                | MachineOpcode::Aarch64(super::aarch64::Opcode::Label)
+            MachineOpcode::X86_64(super::x86_64::Opcode::Label) | MachineOpcode::Aarch64(super::aarch64::Opcode::Label)
         )
     }
 }
 
-fn function_error<T>(
-    function: &MachineFunction,
-    message: impl Into<String>,
-) -> Result<T, CompileError> {
+fn function_error<T>(function: &MachineFunction, message: impl Into<String>) -> Result<T, CompileError> {
     Err(CompileError::new(
         CompileStage::Verification,
         Some(&function.name),
@@ -409,11 +350,7 @@ fn function_error<T>(
 }
 
 fn program_error<T>(message: impl Into<String>) -> Result<T, CompileError> {
-    Err(CompileError::new(
-        CompileStage::Verification,
-        None,
-        message,
-    ))
+    Err(CompileError::new(CompileStage::Verification, None, message))
 }
 
 #[cfg(test)]
@@ -423,9 +360,7 @@ mod tests {
     use crate::target::description::MemoryWidth;
     use crate::target::registers::{aarch64, x86_64};
 
-    fn function(
-        instructions: Vec<MachineInstruction>,
-    ) -> MachineFunction {
+    fn function(instructions: Vec<MachineInstruction>) -> MachineFunction {
         MachineFunction {
             id: HandlerId::new(0),
             name: "Test".into(),
@@ -435,10 +370,7 @@ mod tests {
         }
     }
 
-    fn verify_x86_64(
-        opcode: super::super::x86_64::Opcode,
-        operands: Vec<MachineOperand>,
-    ) -> Result<(), CompileError> {
+    fn verify_x86_64(opcode: super::super::x86_64::Opcode, operands: Vec<MachineOperand>) -> Result<(), CompileError> {
         verify_function(
             &function(vec![MachineInstruction {
                 opcode: MachineOpcode::X86_64(opcode),
@@ -450,8 +382,7 @@ mod tests {
 
     #[test]
     fn rejects_target_pseudos() {
-        let error =
-            verify_x86_64(super::super::x86_64::Opcode::Pseudo, Vec::new()).unwrap_err();
+        let error = verify_x86_64(super::super::x86_64::Opcode::Pseudo, Vec::new()).unwrap_err();
         assert_eq!(error.stage, CompileStage::Verification);
         assert_eq!(error.handler.as_deref(), Some("Test"));
         assert!(error.message.contains("remains after finalization"));
@@ -537,23 +468,18 @@ mod tests {
         .unwrap_err();
         assert!(error.message.contains("unencodable operands"));
 
-        let function = function(
-            vec![MachineInstruction {
-                opcode: MachineOpcode::Aarch64(
-                    super::super::aarch64::Opcode::Load {
-                        width: MemoryWidth::DoubleWord,
-                        signed: false,
-                        addressing: super::super::aarch64::MemoryAddressing::UnsignedImmediate,
-                    },
-                ),
-                operands: vec![
-                    MachineOperand::PhysicalRegister(aarch64::X0),
-                    MachineOperand::Address(MachineMemoryAddress::offset(aarch64::X1, 3)),
-                ],
-            }],
-        );
-        let error =
-            verify_function(&function, Architecture::Aarch64).unwrap_err();
+        let function = function(vec![MachineInstruction {
+            opcode: MachineOpcode::Aarch64(super::super::aarch64::Opcode::Load {
+                width: MemoryWidth::DoubleWord,
+                signed: false,
+                addressing: super::super::aarch64::MemoryAddressing::UnsignedImmediate,
+            }),
+            operands: vec![
+                MachineOperand::PhysicalRegister(aarch64::X0),
+                MachineOperand::Address(MachineMemoryAddress::offset(aarch64::X1, 3)),
+            ],
+        }]);
+        let error = verify_function(&function, Architecture::Aarch64).unwrap_err();
         assert!(error.message.contains("unencodable operands"));
     }
 
@@ -564,24 +490,17 @@ mod tests {
             vec![MachineOperand::Label(".missing".into())],
         )
         .unwrap_err();
-        assert_eq!(
-            error.message,
-            "machine branch references undefined label '.missing'"
-        );
+        assert_eq!(error.message, "machine branch references undefined label '.missing'");
     }
 
     #[test]
     fn accepts_labels_across_hot_and_cold_ranges() {
         let mut function = function(vec![MachineInstruction {
-            opcode: MachineOpcode::X86_64(
-                super::super::x86_64::Opcode::Jump,
-            ),
+            opcode: MachineOpcode::X86_64(super::super::x86_64::Opcode::Jump),
             operands: vec![MachineOperand::Label(".cold".into())],
         }]);
         function.cold_instructions.push(MachineInstruction {
-            opcode: MachineOpcode::X86_64(
-                super::super::x86_64::Opcode::Label,
-            ),
+            opcode: MachineOpcode::X86_64(super::super::x86_64::Opcode::Label),
             operands: vec![MachineOperand::Label(".cold".into())],
         });
         verify_function(&function, Architecture::X86_64).unwrap();

--- a/Libraries/LibJS/Flap/src/target/registers.rs
+++ b/Libraries/LibJS/Flap/src/target/registers.rs
@@ -319,8 +319,9 @@ pub(crate) const AARCH64_REGS: TargetRegisterInfo = TargetRegisterInfo {
         Some(aarch64::SP),
         Some(aarch64::X29),
     ],
-    // x9 and x10 are reserved as instruction-expansion scratch. Keep nine
-    // allocatable GPRs to match x86-64.
+    // x9 and x10 are reserved as instruction-expansion scratch, and x16 and
+    // x17 are the procedure call standard's veneer registers. Every other
+    // caller-saved register is available for allocation.
     temporaries: &[
         aarch64::X0,
         aarch64::X1,
@@ -331,6 +332,11 @@ pub(crate) const AARCH64_REGS: TargetRegisterInfo = TargetRegisterInfo {
         aarch64::X6,
         aarch64::X7,
         aarch64::X8,
+        aarch64::X11,
+        aarch64::X12,
+        aarch64::X13,
+        aarch64::X14,
+        aarch64::X15,
     ],
     fp_temporaries: &[aarch64::D0, aarch64::D1, aarch64::D2, aarch64::D3],
     caller_saved_gpr: &[

--- a/Libraries/LibJS/Flap/src/target/registers.rs
+++ b/Libraries/LibJS/Flap/src/target/registers.rs
@@ -100,9 +100,10 @@ impl PhysicalRegister {
         }
     }
 
-    /// A dense number, unique within the register's architecture and class.
-    /// Together with the class it gives every register a small index, which is
-    /// what lets a set of registers be held in a single machine word.
+    /// The architecture's register encoding number.
+    ///
+    /// AArch64 deliberately gives SP and XZR the same number. XZR is introduced
+    /// only during finalization, after allocator register sets are gone.
     pub(crate) fn number(self) -> u8 {
         self.number
     }

--- a/Libraries/LibJS/Flap/src/target/registers.rs
+++ b/Libraries/LibJS/Flap/src/target/registers.rs
@@ -58,16 +58,16 @@ impl PhysicalRegister {
 
     pub(crate) fn byte_name(self) -> String {
         const NAMES: [&str; 16] = [
-            "al", "cl", "dl", "bl", "sil", "dil", "r8b", "r9b",
-            "r10b", "r11b", "r12b", "r13b", "r14b", "r15b", "spl", "bpl",
+            "al", "cl", "dl", "bl", "sil", "dil", "r8b", "r9b", "r10b", "r11b", "r12b", "r13b", "r14b", "r15b", "spl",
+            "bpl",
         ];
         NAMES[self.number as usize].to_string()
     }
 
     pub(crate) fn half_word_name(self) -> String {
         const NAMES: [&str; 16] = [
-            "ax", "cx", "dx", "bx", "si", "di", "r8w", "r9w",
-            "r10w", "r11w", "r12w", "r13w", "r14w", "r15w", "sp", "bp",
+            "ax", "cx", "dx", "bx", "si", "di", "r8w", "r9w", "r10w", "r11w", "r12w", "r13w", "r14w", "r15w", "sp",
+            "bp",
         ];
         NAMES[self.number as usize].to_string()
     }
@@ -81,8 +81,8 @@ impl PhysicalRegister {
             };
         }
         const NAMES: [&str; 16] = [
-            "eax", "ecx", "edx", "ebx", "esi", "edi", "r8d", "r9d",
-            "r10d", "r11d", "r12d", "r13d", "r14d", "r15d", "esp", "ebp",
+            "eax", "ecx", "edx", "ebx", "esi", "edi", "r8d", "r9d", "r10d", "r11d", "r12d", "r13d", "r14d", "r15d",
+            "esp", "ebp",
         ];
         NAMES[self.number as usize].to_string()
     }
@@ -94,12 +94,17 @@ impl PhysicalRegister {
     pub(crate) fn integer_name(self, width: IntegerWidth) -> String {
         match (self.architecture, width) {
             (_, IntegerWidth::U64) => self.as_str().to_string(),
-            (Architecture::Aarch64, _) | (_, IntegerWidth::U32) => {
-                self.word_name()
-            }
+            (Architecture::Aarch64, _) | (_, IntegerWidth::U32) => self.word_name(),
             (_, IntegerWidth::U16) => self.half_word_name(),
             (_, IntegerWidth::U8) => self.byte_name(),
         }
+    }
+
+    /// A dense number, unique within the register's architecture and class.
+    /// Together with the class it gives every register a small index, which is
+    /// what lets a set of registers be held in a single machine word.
+    pub(crate) fn number(self) -> u8 {
+        self.number
     }
 
     /// Relative encoding cost used to break allocation ties.
@@ -128,11 +133,7 @@ pub(crate) mod x86_64 {
 
     // The accumulator has shorter immediate encodings, classic GPRs avoid
     // a REX prefix in 32-bit forms, and extended GPRs always require one.
-    const fn gpr(
-        name: &'static str,
-        number: u8,
-        allocation_cost: u8,
-    ) -> PhysicalRegister {
+    const fn gpr(name: &'static str, number: u8, allocation_cost: u8) -> PhysicalRegister {
         PhysicalRegister::new(
             Architecture::X86_64,
             RegisterClass::GeneralPurpose,
@@ -142,14 +143,8 @@ pub(crate) mod x86_64 {
         )
     }
 
-    const fn fpr(name: &'static str) -> PhysicalRegister {
-        PhysicalRegister::new(
-            Architecture::X86_64,
-            RegisterClass::FloatingPoint,
-            name,
-            0,
-            2,
-        )
+    const fn fpr(name: &'static str, number: u8) -> PhysicalRegister {
+        PhysicalRegister::new(Architecture::X86_64, RegisterClass::FloatingPoint, name, number, 2)
     }
 
     define_registers! {
@@ -169,12 +164,12 @@ pub(crate) mod x86_64 {
         R15 = gpr("r15", 13, 2);
         RSP = gpr("rsp", 14, 2);
         RBP = gpr("rbp", 15, 2);
-        XMM0 = fpr("xmm0");
-        XMM1 = fpr("xmm1");
-        XMM2 = fpr("xmm2");
-        XMM3 = fpr("xmm3");
-        XMM4 = fpr("xmm4");
-        XMM5 = fpr("xmm5");
+        XMM0 = fpr("xmm0", 0);
+        XMM1 = fpr("xmm1", 1);
+        XMM2 = fpr("xmm2", 2);
+        XMM3 = fpr("xmm3", 3);
+        XMM4 = fpr("xmm4", 4);
+        XMM5 = fpr("xmm5", 5);
     }
 }
 
@@ -183,23 +178,11 @@ pub(crate) mod aarch64 {
     use crate::Architecture;
 
     const fn gpr(name: &'static str, number: u8) -> PhysicalRegister {
-        PhysicalRegister::new(
-            Architecture::Aarch64,
-            RegisterClass::GeneralPurpose,
-            name,
-            number,
-            0,
-        )
+        PhysicalRegister::new(Architecture::Aarch64, RegisterClass::GeneralPurpose, name, number, 0)
     }
 
     const fn fpr(name: &'static str, number: u8) -> PhysicalRegister {
-        PhysicalRegister::new(
-            Architecture::Aarch64,
-            RegisterClass::FloatingPoint,
-            name,
-            number,
-            0,
-        )
+        PhysicalRegister::new(Architecture::Aarch64, RegisterClass::FloatingPoint, name, number, 0)
     }
 
     define_registers! {
@@ -298,13 +281,23 @@ pub(crate) const X86_64_REGS: TargetRegisterInfo = TargetRegisterInfo {
     ],
     fp_temporaries: &[x86_64::XMM0, x86_64::XMM1, x86_64::XMM2, x86_64::XMM3],
     caller_saved_gpr: &[
-        x86_64::RAX, x86_64::RCX, x86_64::RDX, x86_64::RSI,
-        x86_64::RDI, x86_64::R8, x86_64::R9, x86_64::R10,
+        x86_64::RAX,
+        x86_64::RCX,
+        x86_64::RDX,
+        x86_64::RSI,
+        x86_64::RDI,
+        x86_64::R8,
+        x86_64::R9,
+        x86_64::R10,
         x86_64::R11,
     ],
     caller_saved_fpr: &[
-        x86_64::XMM0, x86_64::XMM1, x86_64::XMM2,
-        x86_64::XMM3, x86_64::XMM4, x86_64::XMM5,
+        x86_64::XMM0,
+        x86_64::XMM1,
+        x86_64::XMM2,
+        x86_64::XMM3,
+        x86_64::XMM4,
+        x86_64::XMM5,
     ],
 };
 
@@ -320,8 +313,10 @@ pub(crate) const AARCH64_REGS: TargetRegisterInfo = TargetRegisterInfo {
         Some(aarch64::X29),
     ],
     // x9 and x10 are reserved as instruction-expansion scratch, and x16 and
-    // x17 are the procedure call standard's veneer registers. Every other
-    // caller-saved register is available for allocation.
+    // x17 are the procedure call standard's veneer registers, which the
+    // assembler materializes call targets and awkward immediates into. Every
+    // other caller-saved register is free, and larger functions can have far
+    // more live at once than the single handler this pool was sized for.
     temporaries: &[
         aarch64::X0,
         aarch64::X1,
@@ -340,15 +335,34 @@ pub(crate) const AARCH64_REGS: TargetRegisterInfo = TargetRegisterInfo {
     ],
     fp_temporaries: &[aarch64::D0, aarch64::D1, aarch64::D2, aarch64::D3],
     caller_saved_gpr: &[
-        aarch64::X0, aarch64::X1, aarch64::X2, aarch64::X3,
-        aarch64::X4, aarch64::X5, aarch64::X6, aarch64::X7,
-        aarch64::X8, aarch64::X9, aarch64::X10, aarch64::X11,
-        aarch64::X12, aarch64::X13, aarch64::X14, aarch64::X15,
-        aarch64::X16, aarch64::X17,
+        aarch64::X0,
+        aarch64::X1,
+        aarch64::X2,
+        aarch64::X3,
+        aarch64::X4,
+        aarch64::X5,
+        aarch64::X6,
+        aarch64::X7,
+        aarch64::X8,
+        aarch64::X9,
+        aarch64::X10,
+        aarch64::X11,
+        aarch64::X12,
+        aarch64::X13,
+        aarch64::X14,
+        aarch64::X15,
+        aarch64::X16,
+        aarch64::X17,
     ],
     caller_saved_fpr: &[
-        aarch64::D0, aarch64::D1, aarch64::D2, aarch64::D3,
-        aarch64::D4, aarch64::D5, aarch64::D6, aarch64::D7,
+        aarch64::D0,
+        aarch64::D1,
+        aarch64::D2,
+        aarch64::D3,
+        aarch64::D4,
+        aarch64::D5,
+        aarch64::D6,
+        aarch64::D7,
     ],
 };
 

--- a/Libraries/LibJS/Flap/src/target/selection.rs
+++ b/Libraries/LibJS/Flap/src/target/selection.rs
@@ -10,6 +10,7 @@ use super::ir::{Function, Instruction, Operand, Program};
 use crate::Architecture;
 use crate::low_ir::preallocate::{
     materialize_program_counter_reads, orient_commutative_updates, schedule_x86_relational_operand_loads,
+    split_rematerializable_live_ranges_across_calls,
 };
 use crate::low_ir::{self, AddressDisplacement, Operand as LowOperand};
 use crate::target::description::{IntegerWidth, Operation};
@@ -28,6 +29,8 @@ pub(crate) fn select_program(
                 schedule_x86_relational_operand_loads(&mut handler.instructions);
             }
             orient_commutative_updates(&mut handler.instructions);
+            split_rematerializable_live_ranges_across_calls(&mut handler.instructions);
+            // Splitting creates new virtual registers, so interning must follow it.
             let virtual_registers = low_ir::intern_virtual_registers(handler.id, &mut handler.instructions);
             let mut instructions = Vec::with_capacity(handler.instructions.len());
             for mut instruction in handler.instructions {

--- a/Libraries/LibJS/Flap/src/target/selection.rs
+++ b/Libraries/LibJS/Flap/src/target/selection.rs
@@ -24,11 +24,11 @@ pub(crate) fn select_program(
         .map(|mut handler| -> Result<_, CompileError> {
             materialize_program_counter_reads(&mut handler.instructions)
                 .map_err(|message| selection_error(&handler.name, message))?;
-            low_ir::intern_virtual_registers(handler.id, &mut handler.instructions);
             if architecture == Architecture::X86_64 {
                 schedule_x86_relational_operand_loads(&mut handler.instructions);
             }
             orient_commutative_updates(&mut handler.instructions);
+            let virtual_registers = low_ir::intern_virtual_registers(handler.id, &mut handler.instructions);
             let mut instructions = Vec::with_capacity(handler.instructions.len());
             for mut instruction in handler.instructions {
                 let operation = instruction.opcode;
@@ -86,6 +86,7 @@ pub(crate) fn select_program(
                 size: handler.size,
                 is_cold: handler.is_cold,
                 architecture,
+                virtual_registers,
                 instructions,
             })
         })

--- a/Libraries/LibJS/Flap/src/target/selection.rs
+++ b/Libraries/LibJS/Flap/src/target/selection.rs
@@ -8,11 +8,10 @@
 
 use super::ir::{Function, Instruction, Operand, Program};
 use crate::Architecture;
-use crate::low_ir::{self, AddressDisplacement, Operand as LowOperand};
 use crate::low_ir::preallocate::{
-    materialize_program_counter_reads, orient_commutative_updates,
-    schedule_x86_relational_operand_loads,
+    materialize_program_counter_reads, orient_commutative_updates, schedule_x86_relational_operand_loads,
 };
+use crate::low_ir::{self, AddressDisplacement, Operand as LowOperand};
 use crate::target::description::{IntegerWidth, Operation};
 use crate::{CompileError, CompileStage};
 
@@ -34,13 +33,7 @@ pub(crate) fn select_program(
             for mut instruction in handler.instructions {
                 let operation = instruction.opcode;
                 for (index, operand) in instruction.operands.iter_mut().enumerate() {
-                    legalize_operand(
-                        operand,
-                        operation,
-                        index,
-                        architecture,
-                        &handler.name,
-                    )?;
+                    legalize_operand(operand, operation, index, architecture, &handler.name)?;
                 }
                 let mut operands = instruction.operands;
                 if operation == Operation::Move(IntegerWidth::U32)
@@ -48,20 +41,19 @@ pub(crate) fn select_program(
                 {
                     *value = (*value as u64 & 0xffff_ffff) as i64;
                 }
-                let opcode = instruction
-                    .opcode
-                    .select_for_operands(architecture, &operands);
+                let opcode = instruction.opcode.select_for_operands(architecture, &operands);
                 debug_assert_eq!(opcode.architecture(), architecture);
                 if architecture == Architecture::Aarch64
                     && matches!(
                         operation,
                         Operation::IntegerBinary {
-                            operation: crate::intrinsic::IntegerBinaryOperation::Binary(crate::target::description::BinaryOperation::Add),
+                            operation: crate::intrinsic::IntegerBinaryOperation::Binary(
+                                crate::target::description::BinaryOperation::Add
+                            ),
                             width: IntegerWidth::U64,
                         }
                     )
-                    && let Some(Operand::Immediate(value)) =
-                        operands.get_mut(1)
+                    && let Some(Operand::Immediate(value)) = operands.get_mut(1)
                 {
                     match opcode.aarch64() {
                         crate::target::aarch64::Opcode::AddSubtractImmediate {
@@ -86,10 +78,7 @@ pub(crate) fn select_program(
                     }
                 }
                 opcode.add_contract_operands(&mut operands);
-                instructions.push(Instruction {
-                    opcode,
-                    operands,
-                });
+                instructions.push(Instruction { opcode, operands });
             }
             Ok(Function {
                 id: handler.id,
@@ -124,10 +113,14 @@ fn legalize_operand(
             let compares_value_tag = operand_index == 1
                 && (matches!(
                     operation,
-                    Operation::Assertion(crate::intrinsic::AssertionOperation::TagEqual | crate::intrinsic::AssertionOperation::TagNotEqual)
-                        | Operation::Branch(crate::intrinsic::BranchOperation::Tag(_))
-                ) || (matches!(operation, Operation::Branch(crate::intrinsic::BranchOperation::Singleton(_)))
-                    && architecture == Architecture::X86_64));
+                    Operation::Assertion(
+                        crate::intrinsic::AssertionOperation::TagEqual
+                            | crate::intrinsic::AssertionOperation::TagNotEqual
+                    ) | Operation::Branch(crate::intrinsic::BranchOperation::Tag(_))
+                ) || (matches!(
+                    operation,
+                    Operation::Branch(crate::intrinsic::BranchOperation::Singleton(_))
+                ) && architecture == Architecture::X86_64));
             *operand = LowOperand::Immediate(if compares_value_tag {
                 ((*value as u64) >> 48) as i64
             } else {
@@ -137,19 +130,13 @@ fn legalize_operand(
         LowOperand::LayoutConstant(constant) => {
             return Err(selection_error(
                 handler,
-                format!(
-                    "unresolved layout constant #{}",
-                    constant.id().index()
-                ),
+                format!("unresolved layout constant #{}", constant.id().index()),
             ));
         }
         LowOperand::BytecodeField(field) => {
             return Err(selection_error(
                 handler,
-                format!(
-                    "unresolved bytecode field #{}",
-                    field.index()
-                ),
+                format!("unresolved bytecode field #{}", field.index()),
             ));
         }
         LowOperand::Address(address) => {
@@ -158,20 +145,13 @@ fn legalize_operand(
                     debug_assert!(register.id().is_some());
                 }
             }
-            if let Some(crate::low_ir::AddressScale::LayoutConstant(constant)) =
-                &address.scale
-            {
+            if let Some(crate::low_ir::AddressScale::LayoutConstant(constant)) = &address.scale {
                 return Err(selection_error(
                     handler,
-                    format!(
-                        "unresolved address scale layout constant #{}",
-                        constant.id().index()
-                    ),
+                    format!("unresolved address scale layout constant #{}", constant.id().index()),
                 ));
             }
-            if let Some(AddressDisplacement::LayoutConstant(constant)) =
-                &address.displacement
-            {
+            if let Some(AddressDisplacement::LayoutConstant(constant)) = &address.displacement {
                 return Err(selection_error(
                     handler,
                     format!(
@@ -180,15 +160,10 @@ fn legalize_operand(
                     ),
                 ));
             }
-            if let Some(AddressDisplacement::BytecodeField(field)) =
-                &address.displacement
-            {
+            if let Some(AddressDisplacement::BytecodeField(field)) = &address.displacement {
                 return Err(selection_error(
                     handler,
-                    format!(
-                        "unresolved bytecode field #{}",
-                        field.index()
-                    ),
+                    format!("unresolved bytecode field #{}", field.index()),
                 ));
             }
         }

--- a/Libraries/LibJS/Flap/src/target/verify.rs
+++ b/Libraries/LibJS/Flap/src/target/verify.rs
@@ -8,10 +8,10 @@
 
 use super::ir::{AllocatedFunction as Handler, AllocatedProgram as Program};
 use crate::Architecture;
+use crate::hash::HashSet;
 use crate::target::description::{OperandKind, Operation};
 use crate::target::ir::AllocatedOperand as Operand;
 use crate::{CompileError, CompileStage};
-use crate::hash::HashSet;
 
 pub(crate) fn verify_program(program: &Program) -> Result<(), CompileError> {
     for handler in &program.functions {
@@ -20,10 +20,7 @@ pub(crate) fn verify_program(program: &Program) -> Result<(), CompileError> {
     Ok(())
 }
 
-pub(crate) fn verify_handler(
-    handler: &Handler,
-    architecture: Architecture,
-) -> Result<(), CompileError> {
+pub(crate) fn verify_handler(handler: &Handler, architecture: Architecture) -> Result<(), CompileError> {
     let mut definitions = HashSet::default();
     let mut references = Vec::new();
     for instruction in handler.cfg.instructions() {
@@ -39,10 +36,7 @@ pub(crate) fn verify_handler(
             }
         }
         let info = instruction.opcode.description();
-        if !info.accepts_selected_operand_count(
-            instruction.operands.len(),
-            architecture,
-        ) {
+        if !info.accepts_selected_operand_count(instruction.operands.len(), architecture) {
             return error(
                 handler,
                 format!(
@@ -54,11 +48,7 @@ pub(crate) fn verify_handler(
         }
         for (index, operand) in instruction.operands.iter().enumerate() {
             let kind = info
-                .selected_operand_kind(
-                    index,
-                    instruction.operands.len(),
-                    architecture,
-                )
+                .selected_operand_kind(index, instruction.operands.len(), architecture)
                 .expect("verified operand index must have a description");
             verify_operand(
                 handler,
@@ -66,8 +56,13 @@ pub(crate) fn verify_handler(
                 kind,
                 architecture,
                 instruction.opcode.operation() == Operation::LoadEffectiveAddress,
-            ).map_err(|mut error| {
-                error.message = format!("operand {index} of '{:?}': {}", instruction.opcode.operation(), error.message);
+            )
+            .map_err(|mut error| {
+                error.message = format!(
+                    "operand {index} of '{:?}': {}",
+                    instruction.opcode.operation(),
+                    error.message
+                );
                 error
             })?;
             if kind == OperandKind::Label
@@ -77,25 +72,10 @@ pub(crate) fn verify_handler(
                 references.push(label.clone());
             }
         }
-        for (scratch_index, scratch) in instruction
-            .operands
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| {
-                info.selected_operand_kind(
-                    *index,
-                    instruction.operands.len(),
-                    architecture,
-                )
-                    .is_some_and(|kind| {
-                        matches!(
-                            kind,
-                            OperandKind::GprScratch
-                                | OperandKind::FprScratch
-                        )
-                    })
-            })
-        {
+        for (scratch_index, scratch) in instruction.operands.iter().enumerate().filter(|(index, _)| {
+            info.selected_operand_kind(*index, instruction.operands.len(), architecture)
+                .is_some_and(|kind| matches!(kind, OperandKind::GprScratch | OperandKind::FprScratch))
+        }) {
             let Operand::PhysicalRegister(scratch) = scratch else {
                 unreachable!("scratch operand shape was verified");
             };
@@ -103,10 +83,7 @@ pub(crate) fn verify_handler(
                 .operands
                 .iter()
                 .enumerate()
-                .any(|(index, operand)| {
-                    index != scratch_index
-                        && operand_references_register(operand, *scratch)
-                })
+                .any(|(index, operand)| index != scratch_index && operand_references_register(operand, *scratch))
             {
                 return error(
                     handler,
@@ -118,10 +95,7 @@ pub(crate) fn verify_handler(
             }
         }
         for &(index, expected) in info.arch(architecture).fixed_operands {
-            if matches!(
-                instruction.operands[index],
-                Operand::Immediate(_)
-            ) {
+            if matches!(instruction.operands[index], Operand::Immediate(_)) {
                 continue;
             }
             let actual = instruction.operands[index].physical_register();
@@ -145,11 +119,7 @@ pub(crate) fn verify_handler(
     Ok(())
 }
 
-fn verify_operation(
-    handler: &Handler,
-    operation: Operation,
-    operands: &[Operand],
-) -> Result<(), CompileError> {
+fn verify_operation(handler: &Handler, operation: Operation, operands: &[Operand]) -> Result<(), CompileError> {
     let immediate = |index| {
         let Operand::Immediate(value) = operands[index] else {
             unreachable!("allocated immediate operand shape was verified")
@@ -160,9 +130,7 @@ fn verify_operation(
         Operation::Branch(crate::intrinsic::BranchOperation::Bit(_)) if !(0..64).contains(&immediate(1)) => {
             error(handler, "single-bit branch index must be between 0 and 63")
         }
-        Operation::Store64IndexedOffset
-            if !matches!(immediate(2), 1 | 2 | 4 | 8) =>
-        {
+        Operation::Store64IndexedOffset if !matches!(immediate(2), 1 | 2 | 4 | 8) => {
             error(handler, "indexed offset store scale must be 1, 2, 4, or 8")
         }
         _ => Ok(()),
@@ -215,15 +183,10 @@ fn verify_allocated_operand(
     }
 }
 
-fn operand_references_register(
-    operand: &Operand,
-    register: super::registers::PhysicalRegister,
-) -> bool {
+fn operand_references_register(operand: &Operand, register: super::registers::PhysicalRegister) -> bool {
     match operand {
         Operand::PhysicalRegister(candidate) => *candidate == register,
-        Operand::Address(address) => {
-            address.base == register || address.index == Some(register)
-        }
+        Operand::Address(address) => address.base == register || address.index == Some(register),
         _ => false,
     }
 }
@@ -240,22 +203,17 @@ fn error<T>(handler: &Handler, message: impl Into<String>) -> Result<T, CompileE
 mod tests {
     use super::*;
     use crate::low_ir::cfg::ControlFlowGraph;
-    use crate::target::registers::{aarch64, x86_64};
     use crate::target::description::{
-        BinaryOperation, FloatConversion, FloatingPointOperation,
-        IntegerBinaryOperation, IntegerWidth, MemoryWidth, Operation, PairWidth,
+        BinaryOperation, FloatConversion, FloatingPointOperation, IntegerBinaryOperation, IntegerWidth, MemoryWidth,
+        Operation, PairWidth,
     };
-    use crate::target::ir::{
-        AllocatedInstruction, AllocatedMemoryAddress as MemoryAddress,
-    };
+    use crate::target::ir::{AllocatedInstruction, AllocatedMemoryAddress as MemoryAddress};
+    use crate::target::registers::{aarch64, x86_64};
 
     type Instruction = crate::low_ir::Instruction<Operand>;
 
     fn verify_instruction(instruction: Instruction) -> Result<(), CompileError> {
-        verify_instruction_for_architecture(
-            instruction,
-            Architecture::X86_64,
-        )
+        verify_instruction_for_architecture(instruction, Architecture::X86_64)
     }
 
     fn verify_instruction_for_architecture(
@@ -269,8 +227,7 @@ mod tests {
             .map(Operand::selection_operand)
             .collect::<Vec<_>>();
         let instruction = AllocatedInstruction {
-            opcode: operation
-                .select_for_operands(architecture, &operands),
+            opcode: operation.select_for_operands(architecture, &operands),
             operands: instruction.operands,
         };
         let handler = Handler {
@@ -283,10 +240,7 @@ mod tests {
         verify_handler(&handler, architecture)
     }
 
-    fn memory(
-        base: crate::target::registers::PhysicalRegister,
-        displacement: Option<i64>,
-    ) -> Operand {
+    fn memory(base: crate::target::registers::PhysicalRegister, displacement: Option<i64>) -> Operand {
         Operand::Address(MemoryAddress {
             base,
             index: None,
@@ -295,11 +249,7 @@ mod tests {
         })
     }
 
-    fn assert_invalid_arity(
-        architecture: Architecture,
-        operation: Operation,
-        operands: Vec<Operand>,
-    ) {
+    fn assert_invalid_arity(architecture: Architecture, operation: Operation, operands: Vec<Operand>) {
         let error = verify_instruction_for_architecture(
             Instruction {
                 opcode: operation,
@@ -311,12 +261,12 @@ mod tests {
         assert!(error.message.contains("does not accept that arity"));
     }
 
-    fn assert_invalid_operation(
-        operation: Operation,
-        operands: Vec<Operand>,
-        expected: &str,
-    ) {
-        let error = verify_instruction(Instruction { opcode: operation, operands }).unwrap_err();
+    fn assert_invalid_operation(operation: Operation, operands: Vec<Operand>, expected: &str) {
+        let error = verify_instruction(Instruction {
+            opcode: operation,
+            operands,
+        })
+        .unwrap_err();
         assert!(error.message.contains(expected), "{}", error.message);
     }
 
@@ -393,9 +343,7 @@ mod tests {
 
         let error = verify_instruction_for_architecture(
             Instruction {
-                opcode: Operation::Float(FloatingPointOperation::Convert(
-                    FloatConversion::Float64ToInt32,
-                )),
+                opcode: Operation::Float(FloatingPointOperation::Convert(FloatConversion::Float64ToInt32)),
                 operands: vec![
                     Operand::PhysicalRegister(aarch64::X0),
                     Operand::PhysicalRegister(aarch64::D16),

--- a/Libraries/LibJS/Flap/src/target/verify.rs
+++ b/Libraries/LibJS/Flap/src/target/verify.rs
@@ -11,7 +11,7 @@ use crate::Architecture;
 use crate::target::description::{OperandKind, Operation};
 use crate::target::ir::AllocatedOperand as Operand;
 use crate::{CompileError, CompileStage};
-use std::collections::HashSet;
+use crate::hash::HashSet;
 
 pub(crate) fn verify_program(program: &Program) -> Result<(), CompileError> {
     for handler in &program.functions {
@@ -24,7 +24,7 @@ pub(crate) fn verify_handler(
     handler: &Handler,
     architecture: Architecture,
 ) -> Result<(), CompileError> {
-    let mut definitions = HashSet::new();
+    let mut definitions = HashSet::default();
     let mut references = Vec::new();
     for instruction in handler.cfg.instructions() {
         if instruction.opcode.architecture() != architecture {

--- a/Libraries/LibJS/Flap/src/target/verify.rs
+++ b/Libraries/LibJS/Flap/src/target/verify.rs
@@ -24,10 +24,9 @@ pub(crate) fn verify_handler(
     handler: &Handler,
     architecture: Architecture,
 ) -> Result<(), CompileError> {
-    let control_flow = handler.cfg.linearize_for_analysis();
     let mut definitions = HashSet::new();
     let mut references = Vec::new();
-    for instruction in &control_flow.instructions {
+    for instruction in handler.cfg.instructions() {
         if instruction.opcode.architecture() != architecture {
             return error(handler, "instruction opcode belongs to the wrong target architecture");
         }

--- a/Libraries/LibJS/Flap/src/target/x86_64.rs
+++ b/Libraries/LibJS/Flap/src/target/x86_64.rs
@@ -4,29 +4,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use crate::{Architecture, CompileOptions, ObjectFormat};
-use crate::frontend::layout::KnownLayoutConstant;
-use super::description::{BinaryOperation, FloatBinaryOperation, FloatConversion as IntrinsicFloatConversion, FloatUnaryOperation, FloatingPointOperation, IntegerBinaryOperation, IntegerWidth, MemoryOperation, MemoryWidth, Operation, ShiftOperation, SignCondition};
-use super::ir::{
-    MachineFunction as Handler, MachineInstruction, MachineProgram as Program,
-    MachineCondition as Condition, MachineMemoryAddress,
-    MachineOperand as Operand, RuntimeConstants,
-};
-use super::machine_verify::{
-    define_machine_opcodes, operands_match,
-};
 use super::description::OperandKind::{
-    FprIn as FR, FuncSymbol as F, GprIn as R, GprInOrImm as RI,
-    Imm as I, Label as L, Memory as A, RegisterIn as AR,
+    FprIn as FR, FuncSymbol as F, GprIn as R, GprInOrImm as RI, Imm as I, Label as L, Memory as A, RegisterIn as AR,
 };
-use super::registers::x86_64 as registers;
-use super::emitter::{
-    SimpleInstruction, SimpleOperand, emit_file_header, emit_handlers,
-    emit_label, emit_program, emit_simple_instruction, integer, native,
-    simple, w, word,
+use super::description::{
+    BinaryOperation, FloatBinaryOperation, FloatConversion as IntrinsicFloatConversion, FloatUnaryOperation,
+    FloatingPointOperation, IntegerBinaryOperation, IntegerWidth, MemoryOperation, MemoryWidth, Operation,
+    ShiftOperation, SignCondition,
 };
 #[cfg(test)]
 use super::emitter::emit_handler_range;
+use super::emitter::{
+    SimpleInstruction, SimpleOperand, emit_file_header, emit_handlers, emit_label, emit_program,
+    emit_simple_instruction, integer, native, simple, w, word,
+};
+use super::ir::{
+    MachineCondition as Condition, MachineFunction as Handler, MachineInstruction, MachineMemoryAddress,
+    MachineOperand as Operand, MachineProgram as Program, RuntimeConstants,
+};
+use super::machine_verify::{define_machine_opcodes, operands_match};
+use super::registers::x86_64 as registers;
+use crate::frontend::layout::KnownLayoutConstant;
+use crate::{Architecture, CompileOptions, ObjectFormat};
 use std::fmt::Write;
 
 pub(crate) mod finalize;
@@ -66,12 +65,8 @@ impl AluOperation {
 pub(crate) fn alu_immediate_fits(width: IntegerWidth, value: i64) -> bool {
     match width {
         IntegerWidth::U64 => i32::try_from(value).is_ok(),
-        IntegerWidth::U32 => {
-            (i32::MIN as i64..=u32::MAX as i64).contains(&value)
-        }
-        IntegerWidth::U16 => {
-            (i16::MIN as i64..=u16::MAX as i64).contains(&value)
-        }
+        IntegerWidth::U32 => (i32::MIN as i64..=u32::MAX as i64).contains(&value),
+        IntegerWidth::U16 => (i16::MIN as i64..=u16::MAX as i64).contains(&value),
         IntegerWidth::U8 => false,
     }
 }
@@ -346,14 +341,10 @@ impl Opcode {
             Operation::IntegerBinary {
                 operation: IntegerBinaryOperation::Binary(operation),
                 width,
-            }
-                if matches!(
-                    operation,
-                    BinaryOperation::Add | BinaryOperation::Subtract
-                ) && width == IntegerWidth::U64 =>
+            } if matches!(operation, BinaryOperation::Add | BinaryOperation::Subtract)
+                && width == IntegerWidth::U64 =>
             {
-                let operation = AluOperation::from_binary(operation)
-                    .expect("add and subtract have x86-64 ALU opcodes");
+                let operation = AluOperation::from_binary(operation).expect("add and subtract have x86-64 ALU opcodes");
                 if matches!(operands.get(1), Some(super::ir::Operand::Immediate(_))) {
                     Self::AluImmediate { operation, width }
                 } else {
@@ -376,15 +367,11 @@ impl Opcode {
                 }
             }
             Operation::Move(IntegerWidth::U64) => {
-                let Some(super::ir::Operand::Immediate(value)) =
-                    operands.get(1)
-                else {
+                let Some(super::ir::Operand::Immediate(value)) = operands.get(1) else {
                     return Self::Move64Register;
                 };
                 let unsigned_value = *value as u64;
-                if unsigned_value <= 0x7fff_ffff
-                    || (-0x8000_0000..0).contains(value)
-                {
+                if unsigned_value <= 0x7fff_ffff || (-0x8000_0000..0).contains(value) {
                     Self::Move64Immediate
                 } else if unsigned_value <= 0xffff_ffff {
                     Self::Move32Immediate
@@ -434,9 +421,7 @@ impl Opcode {
             Operation::Memory(MemoryOperation::Load { .. } | MemoryOperation::Store(_))
             | Operation::Move(_)
             | Operation::IntegerBinary { .. } => {
-                unreachable!(
-                    "operand-sensitive operation must use select_for_operands"
-                )
+                unreachable!("operand-sensitive operation must use select_for_operands")
             }
             _ => Self::Pseudo,
         }
@@ -477,16 +462,8 @@ impl X86_64Abi {
     }
 }
 
-const SYSV_SAVED_REGISTERS: [(&str, i32); 5] = [
-    ("rbx", -24),
-    ("r12", -32),
-    ("r13", -40),
-    ("r14", -48),
-    ("r15", -56),
-];
-const WIN64_SAVED_REGISTERS: [&str; 7] = [
-    "rbx", "rsi", "rdi", "r12", "r13", "r14", "r15",
-];
+const SYSV_SAVED_REGISTERS: [(&str, i32); 5] = [("rbx", -24), ("r12", -32), ("r13", -40), ("r14", -48), ("r15", -56)];
+const WIN64_SAVED_REGISTERS: [&str; 7] = ["rbx", "rsi", "rdi", "r12", "r13", "r14", "r15"];
 
 fn emit_saved_registers(out: &mut String, abi: X86_64Abi) {
     if abi.is_win64() {
@@ -540,13 +517,15 @@ pub(crate) fn generate(program: &Program, options: &CompileOptions) -> String {
         "",
         |out| generate_entry_point(out, program, abi),
         |out| generate_fallback_handler(out, program, abi),
-        |out| emit_handlers(
-            out,
-            program,
-            "#",
-            |out, cold| w!(out, "{}", if cold { ".p2align 4" } else { ".p2align 6" }),
-            |out, instruction, handler| emit_instruction(out, instruction, handler, program),
-        ),
+        |out| {
+            emit_handlers(
+                out,
+                program,
+                "#",
+                |out, cold| w!(out, "{}", if cold { ".p2align 4" } else { ".p2align 6" }),
+                |out, instruction, handler| emit_instruction(out, instruction, handler, program),
+            )
+        },
         |out| generate_exit_point(out, object_format, abi),
     )
 }
@@ -602,15 +581,14 @@ fn generate_entry_point(out: &mut String, program: &Program, abi: X86_64Abi) {
     w!(out, "    mov r13d, {entry_point}         # pc = entry_point");
     let values_padding = if abi.is_win64() { "           " } else { "          " };
     w!(out, "    mov rbx, {values}{values_padding}# values");
-    let int32_tag_shifted =
-        runtime(program)[KnownLayoutConstant::Int32TagShifted];
+    let int32_tag_shifted = runtime(program)[KnownLayoutConstant::Int32TagShifted];
     let int32_tag_shifted_register = int32_tag_shifted_register();
-    w!(out, "    movabs {int32_tag_shifted_register}, {int32_tag_shifted}  # INT32_TAG_SHIFTED");
-    w!(out, "    mov QWORD PTR {}, {vm}  # save VM*", vm_slot(abi));
     w!(
         out,
-        "    lea r12, [rip + asm_dispatch_table]  # dispatch table"
+        "    movabs {int32_tag_shifted_register}, {int32_tag_shifted}  # INT32_TAG_SHIFTED"
     );
+    w!(out, "    mov QWORD PTR {}, {vm}  # save VM*", vm_slot(abi));
+    w!(out, "    lea r12, [rip + asm_dispatch_table]  # dispatch table");
     emit_dispatch(out);
     w!(out);
 }
@@ -646,25 +624,22 @@ fn generate_fallback_handler(out: &mut String, program: &Program, abi: X86_64Abi
 /// Emit instructions to reload values (rbx) and pb (r14) from the VM*
 /// saved on the stack. Uses rcx as scratch.
 fn emit_state_reload(out: &mut String, program: &Program, abi: X86_64Abi) {
-    let interp_ctx =
-        runtime(program)[KnownLayoutConstant::VmRunningExecutionContext];
-    let exec_executable =
-        runtime(program)[KnownLayoutConstant::ExecutionContextExecutable];
-    let exec_bytecode =
-        runtime(program)[KnownLayoutConstant::ExecutableBytecodeData];
+    let interp_ctx = runtime(program)[KnownLayoutConstant::VmRunningExecutionContext];
+    let exec_executable = runtime(program)[KnownLayoutConstant::ExecutionContextExecutable];
+    let exec_bytecode = runtime(program)[KnownLayoutConstant::ExecutableBytecodeData];
     emit_load_vm(out, "rcx", abi);
     w!(out, "    mov rbx, QWORD PTR [rcx + {interp_ctx}]");
     w!(out, "    add rbx, {}", values_offset(program));
-    w!(out, "    mov rcx, QWORD PTR [rbx + {}]", exec_executable - values_offset(program));
+    w!(
+        out,
+        "    mov rcx, QWORD PTR [rbx + {}]",
+        exec_executable - values_offset(program)
+    );
     w!(out, "    mov r14, QWORD PTR [rcx + {exec_bytecode}]");
 }
 
 fn vm_slot(abi: X86_64Abi) -> &'static str {
-    if abi.is_win64() {
-        WIN64_VM_SLOT
-    } else {
-        SYSV_VM_SLOT
-    }
+    if abi.is_win64() { WIN64_VM_SLOT } else { SYSV_VM_SLOT }
 }
 
 fn emit_load_vm(out: &mut String, dst: &str, abi: X86_64Abi) {
@@ -692,9 +667,12 @@ fn emit_vm_pc_instruction_args(out: &mut String, abi: X86_64Abi) {
 }
 
 fn emit_sync_pc_to_execution_context(out: &mut String, program: &Program) {
-    let program_counter =
-        runtime(program)[KnownLayoutConstant::ExecutionContextProgramCounter];
-    w!(out, "    mov DWORD PTR [rbx + {}], r13d", program_counter - values_offset(program));
+    let program_counter = runtime(program)[KnownLayoutConstant::ExecutionContextProgramCounter];
+    w!(
+        out,
+        "    mov DWORD PTR [rbx + {}], r13d",
+        program_counter - values_offset(program)
+    );
 }
 
 fn emit_dispatch(out: &mut String) {
@@ -736,9 +714,7 @@ fn format_x86_machine_address(address: &MachineMemoryAddress) -> String {
     format_x86_address(&terms, address.displacement.unwrap_or(0))
 }
 
-fn format_x86_machine_address_additive(
-    address: &MachineMemoryAddress,
-) -> String {
+fn format_x86_machine_address_additive(address: &MachineMemoryAddress) -> String {
     let terms = format_x86_machine_address_terms(address);
     match address.displacement {
         Some(displacement) => format!("[{terms} + {displacement}]"),
@@ -746,9 +722,7 @@ fn format_x86_machine_address_additive(
     }
 }
 
-fn format_x86_machine_address_terms(
-    address: &MachineMemoryAddress,
-) -> String {
+fn format_x86_machine_address_terms(address: &MachineMemoryAddress) -> String {
     match (address.index, address.scale) {
         (None, None) => address.base.to_string(),
         (Some(index), None) => format!("{} + {index}", address.base),
@@ -778,27 +752,18 @@ fn float_arithmetic_mnemonic(operation: FloatBinaryOperation) -> &'static str {
     }
 }
 
-fn emit_instruction(
-    out: &mut String,
-    insn: &MachineInstruction,
-    handler: &Handler,
-    program: &Program,
-) {
+fn emit_instruction(out: &mut String, insn: &MachineInstruction, handler: &Handler, program: &Program) {
     let opcode = insn.opcode.x86_64();
     debug_assert!(!opcode.is_pseudo());
-    if emit_simple_instruction(
-        out,
-        insn,
-        opcode.simple_instruction(),
-        |operand| match (opcode, operand) {
+    if emit_simple_instruction(out, insn, opcode.simple_instruction(), |operand| {
+        match (opcode, operand) {
             (
-                Opcode::LoadAdditiveDisplacement { .. }
-                | Opcode::StoreAdditiveDisplacement(_),
+                Opcode::LoadAdditiveDisplacement { .. } | Opcode::StoreAdditiveDisplacement(_),
                 Operand::Address(address),
             ) => format_x86_machine_address_additive(address),
             _ => resolve_op(operand, handler, program),
-        },
-    ) {
+        }
+    }) {
         return;
     }
     match opcode {
@@ -810,20 +775,15 @@ fn emit_instruction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::target::ir::MachineMemoryAddress as MemoryAddress;
-    use crate::target::registers::{
-        physical_register_named, resolve_interpreter_register,
-    };
-    use crate::types::InterpreterRegister;
     use crate::ObjectFormat;
+    use crate::target::ir::MachineMemoryAddress as MemoryAddress;
+    use crate::target::registers::{physical_register_named, resolve_interpreter_register};
+    use crate::types::InterpreterRegister;
 
     fn test_program() -> Program {
         Program {
             runtime: RuntimeConstants::from_values([
-                (
-                    KnownLayoutConstant::Int32TagShifted,
-                    0x7ffa_0000_0000_0000u64 as i64,
-                ),
+                (KnownLayoutConstant::Int32TagShifted, 0x7ffa_0000_0000_0000u64 as i64),
                 (KnownLayoutConstant::SizeOfExecutionContext, 120),
             ]),
             dispatch_handlers: Vec::new(),
@@ -845,20 +805,11 @@ mod tests {
         }
     }
 
-    fn memory(
-        base: &str,
-        index: Option<&str>,
-        scale: Option<i64>,
-        displacement: Option<i64>,
-    ) -> Operand {
+    fn memory(base: &str, index: Option<&str>, scale: Option<i64>, displacement: Option<i64>) -> Operand {
         let register = |name: &str| {
             InterpreterRegister::from_name(name)
-                .and_then(|identity| {
-                    resolve_interpreter_register(identity, Architecture::X86_64)
-                })
-                .or_else(|| {
-                    physical_register_named(name, Architecture::X86_64)
-                })
+                .and_then(|identity| resolve_interpreter_register(identity, Architecture::X86_64))
+                .or_else(|| physical_register_named(name, Architecture::X86_64))
                 .expect("test memory address must name a target register")
         };
         Operand::Address(MemoryAddress {
@@ -879,12 +830,7 @@ mod tests {
     fn emit(instructions: impl IntoIterator<Item = MachineInstruction>) -> String {
         let mut output = String::new();
         for instruction in instructions {
-            emit_instruction(
-                &mut output,
-                &instruction,
-                &call_handler(),
-                &test_program(),
-            );
+            emit_instruction(&mut output, &instruction, &call_handler(), &test_program());
         }
         output
     }
@@ -909,16 +855,9 @@ mod tests {
         // allocation) flow through resolve_op unchanged.
         let scaled_memory = memory("rax", Some("r11"), Some(8), None);
 
-        assert_eq!(
-            resolve_op(&scaled_memory, &handler, &program),
-            "[rax + r11 * 8]"
-        );
-        let offset_memory =
-            memory("rax", Some("r11"), Some(8), Some(8));
-        assert_eq!(
-            resolve_op(&offset_memory, &handler, &program),
-            "[rax + r11 * 8 + 8]"
-        );
+        assert_eq!(resolve_op(&scaled_memory, &handler, &program), "[rax + r11 * 8]");
+        let offset_memory = memory("rax", Some("r11"), Some(8), Some(8));
+        assert_eq!(resolve_op(&offset_memory, &handler, &program), "[rax + r11 * 8 + 8]");
     }
 
     #[test]
@@ -977,23 +916,13 @@ mod tests {
     fn emits_bit_31_branches_as_sign_tests() {
         let mut output = String::new();
 
-        for (condition, branch) in [
-            (Condition::Negative, "js"),
-            (Condition::NotNegative, "jns"),
-        ] {
+        for (condition, branch) in [(Condition::Negative, "js"), (Condition::NotNegative, "jns")] {
             output += &emit([
                 instruction(
                     Opcode::TestRegister(IntegerWidth::U32),
-                    vec![
-                        Operand::PhysicalRegister(crate::target::registers::x86_64::RAX),
-                    ],
+                    vec![Operand::PhysicalRegister(crate::target::registers::x86_64::RAX)],
                 ),
-                instruction(
-                    Opcode::JumpCondition(condition),
-                    vec![
-                        Operand::Label(".slow".into()),
-                    ],
-                ),
+                instruction(Opcode::JumpCondition(condition), vec![Operand::Label(".slow".into())]),
             ]);
             assert!(output.contains("test eax, eax"));
             assert!(output.contains(&format!("{branch} .Lasm_Call.slow")));
@@ -1024,7 +953,10 @@ mod tests {
     fn mov32_zero_extends_even_when_registers_alias() {
         let output = emit([instruction(
             Opcode::Move32Register,
-            vec![Operand::PhysicalRegister(crate::target::registers::x86_64::RAX), Operand::PhysicalRegister(crate::target::registers::x86_64::RAX)],
+            vec![
+                Operand::PhysicalRegister(crate::target::registers::x86_64::RAX),
+                Operand::PhysicalRegister(crate::target::registers::x86_64::RAX),
+            ],
         )]);
 
         assert!(output.contains("mov eax, eax"));
@@ -1033,9 +965,7 @@ mod tests {
     #[test]
     fn emits_finalized_float_conversion() {
         let output = emit([instruction(
-            Opcode::FloatConversion(
-                FloatConversion::DoubleToSigned32Truncate,
-            ),
+            Opcode::FloatConversion(FloatConversion::DoubleToSigned32Truncate),
             vec![
                 Operand::PhysicalRegister(crate::target::registers::x86_64::RDX),
                 Operand::PhysicalRegister(crate::target::registers::x86_64::XMM0),
@@ -1049,13 +979,8 @@ mod tests {
     fn emits_byte_memory_branch_without_a_register_load() {
         let output = emit([
             instruction(
-                Opcode::TestMemoryImmediate(
-                    MemoryWidth::Byte,
-                ),
-                vec![
-                    memory("rcx", None, None, Some(4)),
-                    Operand::Immediate(2),
-                ],
+                Opcode::TestMemoryImmediate(MemoryWidth::Byte),
+                vec![memory("rcx", None, None, Some(4)), Operand::Immediate(2)],
             ),
             instruction(
                 Opcode::JumpCondition(Condition::Zero),

--- a/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
+++ b/Libraries/LibJS/Flap/src/target/x86_64/finalize.rs
@@ -6,28 +6,25 @@
 
 //! x86-64 machine instruction finalization.
 
-use crate::target::backend::{Backend, X86_64Backend};
-use crate::target::description::ArchitectureOpcode;
-use crate::target::description::{FloatConversion, FloatingPointOperation};
-use crate::target::finalize_support::{memory_branch, push_plain_move};
 use super::Opcode;
 use crate::frontend::layout::KnownLayoutConstant;
 use crate::low_ir::Label;
+use crate::target::backend::{Backend, X86_64Backend};
+use crate::target::description::ArchitectureOpcode;
 use crate::target::description::{
-    AssertionOperation, BinaryOperation, BranchOperation, EqualityCondition, FloatCondition, IntegerWidth,
-    MemoryWidth, Operation, OverflowOperation, PairWidth, ScalarBranchCondition, ShiftOperation, SignCondition, TestCondition,
+    AssertionOperation, BinaryOperation, BranchOperation, EqualityCondition, FloatCondition, IntegerWidth, MemoryWidth,
+    Operation, OverflowOperation, PairWidth, ScalarBranchCondition, ShiftOperation, SignCondition, TestCondition,
     ZeroCondition,
 };
+use crate::target::description::{FloatConversion, FloatingPointOperation};
 use crate::target::finalize_support::{
-    Emit,
-    AllocatedOperands, MemoryBranch, finalization_error, finalize_error, machine_address,
-    indexed_pair_store as decode_indexed_pair_store, pair_access,
-    interpreter_layout, required_runtime_constant, verified_label, verified_register,
+    AllocatedOperands, Emit, MemoryBranch, finalization_error, finalize_error,
+    indexed_pair_store as decode_indexed_pair_store, interpreter_layout, machine_address, pair_access,
+    required_runtime_constant, verified_label, verified_register,
 };
+use crate::target::finalize_support::{memory_branch, push_plain_move};
+use crate::target::ir::{AllocatedOperand, MachineInstruction, MachineMemoryAddress, MachineOpcode, MachineOperand};
 use crate::target::machine_verify::emit_machine_instructions as emit;
-use crate::target::ir::{
-    AllocatedOperand, MachineInstruction, MachineMemoryAddress, MachineOpcode, MachineOperand,
-};
 use crate::target::registers::{PhysicalRegister, x86_64::R15};
 use crate::{CompileError, ObjectFormat};
 
@@ -38,13 +35,7 @@ fn machine_instruction(opcode: Opcode, operands: Vec<MachineOperand>) -> Machine
     }
 }
 
-fn branch_bit(
-    emit: &mut Emit<'_>,
-    value: PhysicalRegister,
-    bit: i64,
-    condition: TestCondition,
-    target: &Label,
-) {
+fn branch_bit(emit: &mut Emit<'_>, value: PhysicalRegister, bit: i64, condition: TestCondition, target: &Label) {
     use super::Condition;
 
     if bit == 31 {
@@ -119,12 +110,7 @@ pub(crate) fn compare_immediate(
     Ok(())
 }
 
-pub(crate) fn compare_register(
-    emit: &mut Emit<'_>,
-    lhs: PhysicalRegister,
-    rhs: PhysicalRegister,
-    width: IntegerWidth,
-) {
+pub(crate) fn compare_register(emit: &mut Emit<'_>, lhs: PhysicalRegister, rhs: PhysicalRegister, width: IntegerWidth) {
     emit!(emit.output, X86_64; Opcode::CompareRegister(width) => [register lhs, register rhs];);
 }
 
@@ -157,19 +143,11 @@ fn scalar_compare(
     Ok(())
 }
 
-fn multiply(
-    emit: &mut Emit<'_>,
-    width: IntegerWidth,
-    operands: &[AllocatedOperand],
-) -> Result<(), CompileError> {
+fn multiply(emit: &mut Emit<'_>, width: IntegerWidth, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
     assert_eq!(width, IntegerWidth::U64);
     match operands {
         [destination, source] => {
-            push_multiply(
-                emit,
-                verified_register(destination),
-                verified_register(source),
-            );
+            push_multiply(emit, verified_register(destination), verified_register(source));
         }
         [destination, source, AllocatedOperand::Immediate(value)]
             if *value > 0 && (*value as u64).is_power_of_two() =>
@@ -210,10 +188,7 @@ fn multiply(
     Ok(())
 }
 
-pub(crate) fn move_execution_context(
-    emit: &mut Emit<'_>,
-    operands: &[AllocatedOperand],
-) -> Result<(), CompileError> {
+pub(crate) fn move_execution_context(emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
     let destination = operands.physical_register(0);
     let source = operands.physical_register(1);
     if destination != source {
@@ -308,12 +283,7 @@ fn branch_any_equal(
                     .map_err(|_| AnyEqualBranchError::UnencodableImmediate)?;
             }
             comparison_value => {
-                compare_register(
-                    emit,
-                    value,
-                    verified_register(comparison_value),
-                    IntegerWidth::U64,
-                );
+                compare_register(emit, value, verified_register(comparison_value), IntegerWidth::U64);
             }
         }
         emit!(emit.output, X86_64; Opcode::JumpCondition(Condition::Equal) => [label target.clone()];);
@@ -376,9 +346,7 @@ pub(crate) fn scalar_store(
 ) {
     let source = match source {
         AllocatedOperand::Immediate(value) => StoreSource::Immediate(*value),
-        source => StoreSource::Register(
-            verified_register(source),
-        ),
+        source => StoreSource::Register(verified_register(source)),
     };
     store(emit, width, address, source, value_scratch);
 }
@@ -427,27 +395,14 @@ fn assertion_compare(
     rhs: &AllocatedOperand,
     width: IntegerWidth,
 ) -> Result<(), CompileError> {
-    scalar_compare(
-        emit,
-        verified_register(lhs),
-        rhs,
-        width,
-
-    )
+    scalar_compare(emit, verified_register(lhs), rhs, width)
 }
 
-fn push_overflow_multiply(
-    emit: &mut Emit<'_>,
-    destination: PhysicalRegister,
-    source: PhysicalRegister,
-) {
+fn push_overflow_multiply(emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister) {
     emit!(emit.output, X86_64; Opcode::Multiply32 => [register destination, register source];);
 }
 
-fn vm_load(
-    emit: &mut Emit<'_>,
-    destination: PhysicalRegister,
-) {
+fn vm_load(emit: &mut Emit<'_>, destination: PhysicalRegister) {
     use crate::target::registers::x86_64::RBP;
 
     let displacement = match emit.object_format {
@@ -462,12 +417,7 @@ fn vm_load(
     );
 }
 
-fn operand_store(
-    emit: &mut Emit<'_>,
-    offset: i64,
-    source: &AllocatedOperand,
-    scratches: &[AllocatedOperand],
-) {
+fn operand_store(emit: &mut Emit<'_>, offset: i64, source: &AllocatedOperand, scratches: &[AllocatedOperand]) {
     use crate::target::registers::x86_64::{R13, R14, RBX};
 
     let (index, source) = match source {
@@ -527,24 +477,33 @@ fn pair_load(
     let aliases_address = |register| first_address.base == register || first_address.index == Some(register);
     let first_aliases_address = aliases_address(first);
     if first_aliases_address && aliases_address(second) {
-        return finalize_error(emit.handler, "x86-64 pair-load destinations may not both alias the address");
+        return finalize_error(
+            emit.handler,
+            "x86-64 pair-load destinations may not both alias the address",
+        );
     }
     let memory_width = width.into();
     let second_address = pair_second_address(&first_address, width);
-    let first_instruction = machine_instruction(Opcode::Load {
-        width: memory_width,
-        signed: false,
-    }, vec![
-        MachineOperand::PhysicalRegister(first),
-        MachineOperand::Address(first_address),
-    ]);
-    let second_instruction = machine_instruction(Opcode::Load {
-        width: memory_width,
-        signed: false,
-    }, vec![
-        MachineOperand::PhysicalRegister(second),
-        MachineOperand::Address(second_address),
-    ]);
+    let first_instruction = machine_instruction(
+        Opcode::Load {
+            width: memory_width,
+            signed: false,
+        },
+        vec![
+            MachineOperand::PhysicalRegister(first),
+            MachineOperand::Address(first_address),
+        ],
+    );
+    let second_instruction = machine_instruction(
+        Opcode::Load {
+            width: memory_width,
+            signed: false,
+        },
+        vec![
+            MachineOperand::PhysicalRegister(second),
+            MachineOperand::Address(second_address),
+        ],
+    );
     if first_aliases_address {
         emit.output.extend([second_instruction, first_instruction]);
     } else {
@@ -563,13 +522,7 @@ fn pair_store(
     let memory_width = width.into();
     let second_address = pair_second_address(&first_address, width);
     store(emit, memory_width, first_address, StoreSource::Register(first), None);
-    store(
-        emit,
-        memory_width,
-        second_address,
-        StoreSource::Register(second),
-        None,
-    );
+    store(emit, memory_width, second_address, StoreSource::Register(second), None);
 }
 
 fn indexed_pair_store(
@@ -616,7 +569,7 @@ pub(crate) fn interpreter_call_arguments(emit: &mut Emit<'_>) {
     } else {
         (RDI, RSI, RDX)
     };
-    vm_load(emit, vm,);
+    vm_load(emit, vm);
     emit!(emit.output, X86_64;
         Opcode::Move32Register => [register pc, register R13];
         Opcode::LoadEffectiveAddress => [register instruction, address MachineMemoryAddress::indexed(R14, R13)];
@@ -723,34 +676,18 @@ impl Backend for X86_64Backend {
         Ok(())
     }
 
-    fn update_bit(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        bit: u32,
-        operation: Operation,
-    ) {
+    fn update_bit(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, bit: u32, operation: Operation) {
         emit!(emit.output, X86_64; if operation == Operation::ToggleBit { Opcode::ComplementBit } else { Opcode::ResetBit } => [register destination, immediate bit.into()];);
     }
 
-    fn extract_tag(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        source: PhysicalRegister,
-    ) {
+    fn extract_tag(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister) {
         if destination != source {
             emit!(emit.output, X86_64; Opcode::Move64Register => [register destination, register source];);
         }
         emit!(emit.output, X86_64; Opcode::ShiftImmediate { operation: ShiftOperation::RightLogical, width: IntegerWidth::U64 } => [register destination, immediate 48];);
     }
 
-    fn unbox_object(
-        &self,
-        emit: &mut Emit<'_>,
-        destination: PhysicalRegister,
-        source: PhysicalRegister,
-    ) {
+    fn unbox_object(&self, emit: &mut Emit<'_>, destination: PhysicalRegister, source: PhysicalRegister) {
         if destination != source {
             emit!(emit.output, X86_64; Opcode::Move64Register => [register destination, register source];);
         }
@@ -766,7 +703,10 @@ impl Backend for X86_64Backend {
         _operation: FloatingPointOperation,
         operands: &[AllocatedOperand],
     ) {
-        emit.output.push(MachineInstruction { opcode, operands: operands.to_vec() });
+        emit.output.push(MachineInstruction {
+            opcode,
+            operands: operands.to_vec(),
+        });
     }
 
     fn checked_float_conversion(
@@ -779,29 +719,30 @@ impl Backend for X86_64Backend {
         failure: &Label,
     ) {
         match (operation, scratches) {
-            (
-                FloatingPointOperation::Convert(FloatConversion::Float64ToInt32),
-                [gpr_scratch, fpr_scratch],
-            ) => double_to_int32(
-                emit,
-                destination,
-                source,
-                verified_register(gpr_scratch),
-                verified_register(fpr_scratch),
-                failure.clone(),
-            ),
+            (FloatingPointOperation::Convert(FloatConversion::Float64ToInt32), [gpr_scratch, fpr_scratch]) => {
+                double_to_int32(
+                    emit,
+                    destination,
+                    source,
+                    verified_register(gpr_scratch),
+                    verified_register(fpr_scratch),
+                    failure.clone(),
+                )
+            }
             (FloatingPointOperation::Convert(FloatConversion::JavaScriptToInt32), [gpr_scratch]) => {
-                js_to_int32(emit, destination, source, verified_register(gpr_scratch), failure.clone());
+                js_to_int32(
+                    emit,
+                    destination,
+                    source,
+                    verified_register(gpr_scratch),
+                    failure.clone(),
+                );
             }
             _ => unreachable!("allocated operand shape was verified"),
         }
     }
 
-    fn helper_call(
-        &self,
-        emit: &mut Emit<'_>,
-        function: crate::low_ir::Relocation,
-    ) {
+    fn helper_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
         use crate::target::registers::x86_64::{RCX, RDI};
 
         if emit.object_format != ObjectFormat::Coff {
@@ -810,12 +751,8 @@ impl Backend for X86_64Backend {
         direct_call(emit, function);
     }
 
-    fn interpreter_call(
-        &self,
-        emit: &mut Emit<'_>,
-        function: crate::low_ir::Relocation,
-    ) {
-        interpreter_call_arguments(emit,);
+    fn interpreter_call(&self, emit: &mut Emit<'_>, function: crate::low_ir::Relocation) {
+        interpreter_call_arguments(emit);
         direct_call(emit, function);
     }
 
@@ -828,36 +765,39 @@ impl Backend for X86_64Backend {
         match emit.object_format {
             ObjectFormat::Coff => {
                 emit!(emit.output, X86_64; Opcode::LoadEffectiveAddress => [register RCX, address MachineMemoryAddress::offset(RBP, super::WIN64_RAW_NATIVE_RETURN_SLOT)];);
-                vm_load(emit, RDX,);
+                vm_load(emit, RDX);
                 indirect_call(emit, scratch);
-                push_load(emit, RAX, MachineMemoryAddress::offset(RBP, super::WIN64_RAW_NATIVE_RETURN_SLOT));
-                push_load(emit, RDX, MachineMemoryAddress::offset(RBP, super::WIN64_RAW_NATIVE_VARIANT_SLOT));
+                push_load(
+                    emit,
+                    RAX,
+                    MachineMemoryAddress::offset(RBP, super::WIN64_RAW_NATIVE_RETURN_SLOT),
+                );
+                push_load(
+                    emit,
+                    RDX,
+                    MachineMemoryAddress::offset(RBP, super::WIN64_RAW_NATIVE_VARIANT_SLOT),
+                );
             }
             ObjectFormat::MachO => {
                 push_stack_adjustment(emit, super::AluOperation::Subtract, 16);
                 push_register_move(emit, RDI, RSP);
-                vm_load(emit, RSI,);
+                vm_load(emit, RSI);
                 indirect_call(emit, scratch);
                 push_load(emit, RAX, MachineMemoryAddress::offset(RSP, 0));
                 push_load(emit, RDX, MachineMemoryAddress::offset(RSP, 8));
                 push_stack_adjustment(emit, super::AluOperation::Add, 16);
             }
             ObjectFormat::Elf => {
-                vm_load(emit, RDI,);
+                vm_load(emit, RDI);
                 indirect_call(emit, scratch);
             }
         }
         push_register_move(emit, RCX, RDX);
     }
 
-    fn slow_path_call(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn slow_path_call(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         let function = operands.relocation(0);
-        let [result_scratch, state_scratch] =
-            [operands.physical_register(1), operands.physical_register(2)];
+        let [result_scratch, state_scratch] = [operands.physical_register(1), operands.physical_register(2)];
         use crate::target::registers::x86_64::{R13, R14, RBX};
 
         let [execution_context, executable, program_counter, bytecode, values_offset] =
@@ -867,15 +807,19 @@ impl Backend for X86_64Backend {
             .ok_or_else(|| finalization_error(emit.handler, "execution-context program-counter offset overflow"))?;
         emit!(emit.output, X86_64; Opcode::StoreAdditiveDisplacement(MemoryWidth::Word) => [address MachineMemoryAddress::offset(RBX, program_counter_from_values), register R13];);
 
-        interpreter_call_arguments(emit,);
+        interpreter_call_arguments(emit);
         direct_call(emit, function);
         emit!(emit.output, X86_64;
             Opcode::TestRegister(IntegerWidth::U64) => [register result_scratch];
             Opcode::JumpNegativeToExit => [];
         );
 
-        vm_load(emit, state_scratch,);
-        push_load(emit, RBX, MachineMemoryAddress::offset(state_scratch, execution_context));
+        vm_load(emit, state_scratch);
+        push_load(
+            emit,
+            RBX,
+            MachineMemoryAddress::offset(state_scratch, execution_context),
+        );
         emit!(emit.output, X86_64;
             Opcode::AluImmediate {
             operation: super::AluOperation::Add,
@@ -897,9 +841,7 @@ impl Backend for X86_64Backend {
         Ok(())
     }
 
-    fn dispatch_current(
-    &self,
-    emit: &mut Emit<'_>, scratches: &[AllocatedOperand]) -> Result<(), CompileError> {
+    fn dispatch_current(&self, emit: &mut Emit<'_>, scratches: &[AllocatedOperand]) -> Result<(), CompileError> {
         dispatch_from_instruction_pointer(emit, scratches.physical_register(0));
         Ok(())
     }
@@ -956,13 +898,7 @@ impl Backend for X86_64Backend {
 
         let condition = match operation {
             AssertionOperation::UnsignedLess | AssertionOperation::UnsignedGreaterOrEqual => {
-                assertion_compare(
-                    emit,
-                    operands.operand(0),
-                    operands.operand(1),
-                    IntegerWidth::U64,
-
-                )?;
+                assertion_compare(emit, operands.operand(0), operands.operand(1), IntegerWidth::U64)?;
                 Condition::from_assertion(operation)
             }
             AssertionOperation::NonZero => {
@@ -977,7 +913,7 @@ impl Backend for X86_64Backend {
                     Opcode::Move64Register => [register scratch, register value];
                     Opcode::ShiftImmediate { operation: ShiftOperation::RightLogical, width: IntegerWidth::U64 } => [register scratch, immediate 48];
                 );
-                scalar_compare(emit, scratch, tag, IntegerWidth::U64,)?;
+                scalar_compare(emit, scratch, tag, IntegerWidth::U64)?;
                 Condition::from_assertion(operation)
             }
         };
@@ -995,10 +931,8 @@ impl Backend for X86_64Backend {
         operation: Operation,
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError> {
-        let (width, condition) = operation
-            .scalar_branch()
-            .expect("allocated scalar branch was verified");
-        scalar_compare(emit, operands.physical_register(0), operands.operand(1), width,)?;
+        let (width, condition) = operation.scalar_branch().expect("allocated scalar branch was verified");
+        scalar_compare(emit, operands.physical_register(0), operands.operand(1), width)?;
         branch_scalar(emit, condition, &operands.label(2));
         Ok(())
     }
@@ -1029,7 +963,10 @@ impl Backend for X86_64Backend {
                 if let Err(MaskBranchError::UnencodableImmediate(mask)) =
                     branch_mask_immediate(emit, value, *mask, condition, &target)
                 {
-                    return finalize_error(emit.handler, format!("x86-64 bit mask {:#x} is not encodable", mask as u64));
+                    return finalize_error(
+                        emit.handler,
+                        format!("x86-64 bit mask {:#x} is not encodable", mask as u64),
+                    );
                 }
             }
             mask => {
@@ -1054,14 +991,7 @@ impl Backend for X86_64Backend {
         let representation = operands.immediate(1);
         let scratch = operands.physical_register(2);
         let target = operands.label(3);
-        branch_value_representation(
-            emit,
-            value,
-            representation,
-            scratch,
-            condition,
-            &target,
-        );
+        branch_value_representation(emit, value, representation, scratch, condition, &target);
     }
 
     fn branch_memory(
@@ -1085,7 +1015,9 @@ impl Backend for X86_64Backend {
                 emit!(emit.output, X86_64; Opcode::CompareMemoryImmediate(IntegerWidth::U8) => [address address, immediate immediate];);
                 condition.select(Condition::Zero, Condition::NonZero)
             }
-            MemoryBranch::TestByte { condition, immediate, .. } => {
+            MemoryBranch::TestByte {
+                condition, immediate, ..
+            } => {
                 emit!(emit.output, X86_64; Opcode::TestMemoryImmediate(MemoryWidth::Byte) => [address address, immediate immediate];);
                 condition.select(Condition::NonZero, Condition::Zero)
             }
@@ -1163,40 +1095,24 @@ impl Backend for X86_64Backend {
         Ok(())
     }
 
-    fn finalize_vm_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_vm_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         let destination = operands.physical_register(0);
-        vm_load(emit, destination,);
+        vm_load(emit, destination);
     }
 
-    fn finalize_program_counter_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_program_counter_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         use crate::target::registers::x86_64::R13;
 
         let destination = operands.physical_register(0);
         emit!(emit.output, X86_64; Opcode::Move32Register => [register destination, register R13];);
     }
 
-    fn finalize_operand_store(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn finalize_operand_store(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         operand_store(emit, operands.immediate(0), operands.operand(1), &operands[2..]);
         Ok(())
     }
 
-    fn finalize_label_load(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn finalize_label_load(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         use crate::target::registers::x86_64::{R13, R14};
 
         let destination = operands.physical_register(0);
@@ -1210,11 +1126,7 @@ impl Backend for X86_64Backend {
         Ok(())
     }
 
-    fn goto_handler(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn goto_handler(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         let [target, opcode_scratch] = [operands.physical_register(0), operands.physical_register(1)];
         use crate::target::registers::x86_64::R13;
 
@@ -1225,11 +1137,7 @@ impl Backend for X86_64Backend {
         Ok(())
     }
 
-    fn goto_bytecode_target(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) -> Result<(), CompileError> {
+    fn goto_bytecode_target(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) -> Result<(), CompileError> {
         let offset = operands.immediate(0);
         let opcode_scratch = operands.physical_register(1);
         use crate::target::registers::x86_64::{R13, R14};
@@ -1253,9 +1161,10 @@ impl Backend for X86_64Backend {
 
         let scratch = operands.physical_register(1);
         let address = machine_address(operands.operand(0));
-        let offset = required_runtime_constant(emit.runtime, KnownLayoutConstant::SizeOfExecutionContext, emit.handler)?
-            .checked_neg()
-            .ok_or_else(|| finalization_error(emit.handler, "execution-context offset overflow"))?;
+        let offset =
+            required_runtime_constant(emit.runtime, KnownLayoutConstant::SizeOfExecutionContext, emit.handler)?
+                .checked_neg()
+                .ok_or_else(|| finalization_error(emit.handler, "execution-context offset overflow"))?;
         emit!(emit.output, X86_64;
             Opcode::LoadEffectiveAddress => [register scratch, address MachineMemoryAddress::offset(RBX, offset)];
         );
@@ -1269,11 +1178,7 @@ impl Backend for X86_64Backend {
         Ok(())
     }
 
-    fn finalize_indexed_offset_store(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_indexed_offset_store(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         let [base, index, source] = [0, 1, 4].map(|index| operands.physical_register(index));
         let [scale, offset] = [2, 3].map(|index| operands.immediate(index));
         store(
@@ -1309,13 +1214,13 @@ impl Backend for X86_64Backend {
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError> {
         let opcode = opcode.x86_64();
-        let add_execution_context_offset =
-            matches!(opcode, Opcode::LoadExecutionContext { .. });
+        let add_execution_context_offset = matches!(opcode, Opcode::LoadExecutionContext { .. });
         let destination = operands.physical_register(0);
         let address = machine_address(operands.operand(1));
         emit!(emit.output, X86_64; Opcode::Load { width, signed } => [register destination, address address];);
         if add_execution_context_offset {
-            let offset = required_runtime_constant(emit.runtime, KnownLayoutConstant::SizeOfExecutionContext, emit.handler)?;
+            let offset =
+                required_runtime_constant(emit.runtime, KnownLayoutConstant::SizeOfExecutionContext, emit.handler)?;
             emit!(emit.output, X86_64;
                 Opcode::AluImmediate {
                 operation: super::AluOperation::Add,
@@ -1335,13 +1240,12 @@ impl Backend for X86_64Backend {
     ) -> Result<(), CompileError> {
         let opcode = opcode.x86_64();
         let (address, source, value_scratch) = match (opcode, operands) {
-            (Opcode::Store(selected_width), [address, source]) if selected_width == width => {
-                (address, source, None)
+            (Opcode::Store(selected_width), [address, source]) if selected_width == width => (address, source, None),
+            (Opcode::StoreLargeImmediate(selected_width), [address, source, value_scratch])
+                if selected_width == width =>
+            {
+                (address, source, Some(verified_register(value_scratch)))
             }
-            (
-                Opcode::StoreLargeImmediate(selected_width),
-                [address, source, value_scratch],
-            ) if selected_width == width => (address, source, Some(verified_register(value_scratch))),
             _ => unreachable!("allocated operation and operands were verified"),
         };
         let address = machine_address(address);
@@ -1355,13 +1259,8 @@ impl Backend for X86_64Backend {
         width: PairWidth,
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError> {
-        let (destinations, address, []) = pair_access::<0>(
-            operands,
-            width,
-            true,
-            emit.handler,
-        )?;
-        pair_load(emit, width, destinations, address,)
+        let (destinations, address, []) = pair_access::<0>(operands, width, true, emit.handler)?;
+        pair_load(emit, width, destinations, address)
     }
 
     fn finalize_pair_store(
@@ -1377,12 +1276,7 @@ impl Backend for X86_64Backend {
             indexed_pair_store(emit, address_registers, scale, sources);
             return Ok(());
         }
-        let (sources, address, []) = pair_access::<0>(
-            operands,
-            width,
-            false,
-            emit.handler,
-        )?;
+        let (sources, address, []) = pair_access::<0>(operands, width, false, emit.handler)?;
         pair_store(emit, width, sources, address);
         Ok(())
     }
@@ -1396,13 +1290,7 @@ impl Backend for X86_64Backend {
         let [_, _, _, AllocatedOperand::Label(target)] = operands else {
             unreachable!("allocated OR-branch operands were verified");
         };
-        self.finalize_binary_operation(
-            emit,
-            BinaryOperation::Or,
-            IntegerWidth::U32,
-            &operands[..3],
-
-        )?;
+        self.finalize_binary_operation(emit, BinaryOperation::Or, IntegerWidth::U32, &operands[..3])?;
         emit!(emit.output, X86_64; Opcode::JumpSign(condition) => [label target.clone()];);
         Ok(())
     }
@@ -1452,17 +1340,13 @@ impl Backend for X86_64Backend {
         operands: &[AllocatedOperand],
     ) -> Result<(), CompileError> {
         if operation == BinaryOperation::Multiply {
-            return multiply(emit, width, operands,);
+            return multiply(emit, width, operands);
         }
 
-        let alu_operation = super::AluOperation::from_binary(operation)
-            .expect("allocated x86-64 ALU operation was verified");
+        let alu_operation =
+            super::AluOperation::from_binary(operation).expect("allocated x86-64 ALU operation was verified");
         match (operation, width, operands) {
-            (
-                BinaryOperation::And,
-                IntegerWidth::U64,
-                [destination, rhs, scratch, _reserved_scratch],
-            ) => {
+            (BinaryOperation::And, IntegerWidth::U64, [destination, rhs, scratch, _reserved_scratch]) => {
                 let destination = verified_register(destination);
                 let scratch = verified_register(scratch);
                 match rhs {
@@ -1477,13 +1361,7 @@ impl Backend for X86_64Backend {
                         push_alu_register(emit, alu_operation, width, destination, scratch);
                     }
                     rhs => {
-                        push_alu_register(
-                            emit,
-                            alu_operation,
-                            width,
-                            destination,
-                            verified_register(rhs),
-                        );
+                        push_alu_register(emit, alu_operation, width, destination, verified_register(rhs));
                     }
                 }
             }
@@ -1502,13 +1380,7 @@ impl Backend for X86_64Backend {
                         push_alu_immediate(emit, alu_operation, width, destination, *value);
                     }
                     rhs => {
-                        push_alu_register(
-                            emit,
-                            alu_operation,
-                            width,
-                            destination,
-                            verified_register(rhs),
-                        );
+                        push_alu_register(emit, alu_operation, width, destination, verified_register(rhs));
                     }
                 }
             }
@@ -1574,22 +1446,21 @@ impl Backend for X86_64Backend {
                         } => [register destination, immediate *value];
                         );
                     }
-                    rhs => emit.output.push(machine_instruction(Opcode::AluRegister {
-                        operation,
-                        width: IntegerWidth::U32,
-                    }, vec![
-                        MachineOperand::PhysicalRegister(destination),
-                        MachineOperand::PhysicalRegister(verified_register(rhs)),
-                    ])),
+                    rhs => emit.output.push(machine_instruction(
+                        Opcode::AluRegister {
+                            operation,
+                            width: IntegerWidth::U32,
+                        },
+                        vec![
+                            MachineOperand::PhysicalRegister(destination),
+                            MachineOperand::PhysicalRegister(verified_register(rhs)),
+                        ],
+                    )),
                 }
                 verified_label(target_operand)
             }
             (OverflowOperation::MultiplyWithOverflow, [destination, source, target_operand]) => {
-                push_overflow_multiply(
-                    emit,
-                    verified_register(destination),
-                    verified_register(source),
-                );
+                push_overflow_multiply(emit, verified_register(destination), verified_register(source));
                 verified_label(target_operand)
             }
             (OverflowOperation::MultiplyCopy, [destination, lhs, rhs, target_operand]) => {
@@ -1681,11 +1552,7 @@ impl Backend for X86_64Backend {
         }
     }
 
-    fn finalize_divide(
-        &self,
-        emit: &mut Emit<'_>,
-        operands: &[AllocatedOperand],
-    ) {
+    fn finalize_divide(&self, emit: &mut Emit<'_>, operands: &[AllocatedOperand]) {
         let [_, _, dividend, divisor] = operands.physical_registers();
         use crate::target::registers::x86_64::RAX;
 

--- a/Libraries/LibJS/Flap/src/types.rs
+++ b/Libraries/LibJS/Flap/src/types.rs
@@ -262,14 +262,8 @@ impl Type {
 
     pub(crate) fn width(&self) -> Option<u8> {
         match self {
-            Type::Boxed(_)
-            | Type::Sequence(_)
-            | Type::Pointer(_)
-            | Type::Continuation(_) => Some(8),
-            Type::Field(_)
-            | Type::BinaryOperation(_)
-            | Type::CheckedBinaryOperation(_)
-            | Type::Tuple(_) => None,
+            Type::Boxed(_) | Type::Sequence(_) | Type::Pointer(_) | Type::Continuation(_) => Some(8),
+            Type::Field(_) | Type::BinaryOperation(_) | Type::CheckedBinaryOperation(_) | Type::Tuple(_) => None,
             _ => self.simple_width(),
         }
     }
@@ -294,20 +288,40 @@ impl Type {
     }
 
     pub(crate) fn is_pointer(&self) -> bool {
-        matches!(self, Type::Pointer(_) | Type::Sequence(_))
-            || self.simple_is_pointer()
+        matches!(self, Type::Pointer(_) | Type::Sequence(_)) || self.simple_is_pointer()
     }
 
     pub(crate) fn memory_load(&self) -> Option<MemoryOperation> {
         Some(match self {
-            Type::U8 | Type::Bool => MemoryOperation::Load { width: MemoryWidth::Byte, signed: false },
-            Type::I8 => MemoryOperation::Load { width: MemoryWidth::Byte, signed: true },
-            Type::U16 => MemoryOperation::Load { width: MemoryWidth::HalfWord, signed: false },
-            Type::I16 => MemoryOperation::Load { width: MemoryWidth::HalfWord, signed: true },
-            Type::U32 | Type::I32 | Type::ValueTag => MemoryOperation::Load { width: MemoryWidth::Word, signed: false },
-            Type::F32 => MemoryOperation::Load { width: MemoryWidth::Float, signed: false },
+            Type::U8 | Type::Bool => MemoryOperation::Load {
+                width: MemoryWidth::Byte,
+                signed: false,
+            },
+            Type::I8 => MemoryOperation::Load {
+                width: MemoryWidth::Byte,
+                signed: true,
+            },
+            Type::U16 => MemoryOperation::Load {
+                width: MemoryWidth::HalfWord,
+                signed: false,
+            },
+            Type::I16 => MemoryOperation::Load {
+                width: MemoryWidth::HalfWord,
+                signed: true,
+            },
+            Type::U32 | Type::I32 | Type::ValueTag => MemoryOperation::Load {
+                width: MemoryWidth::Word,
+                signed: false,
+            },
+            Type::F32 => MemoryOperation::Load {
+                width: MemoryWidth::Float,
+                signed: false,
+            },
             Type::F64 => return None,
-            _ if self.width() == Some(8) => MemoryOperation::Load { width: MemoryWidth::DoubleWord, signed: false },
+            _ if self.width() == Some(8) => MemoryOperation::Load {
+                width: MemoryWidth::DoubleWord,
+                signed: false,
+            },
             _ => return None,
         })
     }
@@ -317,8 +331,7 @@ impl Type {
             return Self::from_layout_type_name(inner).map(|inner| Self::Boxed(Box::new(inner)));
         }
         if let Some(element) = name.strip_prefix("Sequence<").and_then(|name| name.strip_suffix('>')) {
-            return Self::from_layout_type_name(element)
-                .map(|element| Self::Sequence(Box::new(element)));
+            return Self::from_layout_type_name(element).map(|element| Self::Sequence(Box::new(element)));
         }
         Some(match name {
             "BindingFlags" => Self::Sequence(Box::new(Self::U8)),
@@ -379,7 +392,10 @@ mod tests {
         assert_eq!(Type::F64.register_class(), Some(RegisterClass::FloatingPoint));
         assert_eq!(
             Type::I32.memory_load().unwrap(),
-            MemoryOperation::Load { width: MemoryWidth::Word, signed: false }
+            MemoryOperation::Load {
+                width: MemoryWidth::Word,
+                signed: false
+            }
         );
         assert_eq!(Type::F64.memory_load(), None);
         assert!(Type::Object.is_pointer());
@@ -391,10 +407,7 @@ mod tests {
             InterpreterRegister::from_name("values").unwrap().value_type(),
             Type::Sequence(Box::new(Type::Value))
         );
-        assert_eq!(
-            InterpreterRegister::from_name("pc").unwrap().value_type(),
-            Type::U32
-        );
+        assert_eq!(InterpreterRegister::from_name("pc").unwrap().value_type(), Type::U32);
         assert_eq!(InterpreterRegister::ProgramBase.as_str(), "pb");
         assert_eq!(InterpreterRegister::Int32TagShifted.source_value_type(), None);
         assert_eq!(InterpreterRegister::from_name("temporary"), None);

--- a/Libraries/LibJS/Flap/tests/interpreter-layout.conf
+++ b/Libraries/LibJS/Flap/tests/interpreter-layout.conf
@@ -1,0 +1,434 @@
+# Copyright (c) 2026-present, the Ladybird developers.
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Stable 64-bit layout fixture for standalone Flap generation tests.
+
+# Object layout
+const OBJECT_SHAPE = 16
+field Object.shape Shape OBJECT_SHAPE nonnull
+const OBJECT_NAMED_PROPERTIES = 24
+field Object.named_properties PropertyStorage OBJECT_NAMED_PROPERTIES nonnull
+const OBJECT_INDEXED_ELEMENTS = 32
+field Object.indexed_elements IndexedElements OBJECT_INDEXED_ELEMENTS nullable
+const OBJECT_INDEXED_STORAGE_KIND = 11
+field Object.indexed_storage_kind u8 OBJECT_INDEXED_STORAGE_KIND nullable
+const OBJECT_INDEXED_ARRAY_LIKE_SIZE = 12
+field Object.indexed_array_like_size u32 OBJECT_INDEXED_ARRAY_LIKE_SIZE nullable
+const OBJECT_SIZE = 64
+
+# Object flags
+const OBJECT_FLAGS = 10
+field Object.flags u8 OBJECT_FLAGS nullable
+const OBJECT_FLAG_HAS_MAGICAL_LENGTH = 4
+const OBJECT_FLAG_MAY_INTERFERE = 16
+const OBJECT_FLAG_IS_TYPED_ARRAY = 8
+const OBJECT_FLAG_IS_FUNCTION = 128
+const OBJECT_FLAG_IS_ECMASCRIPT_FUNCTION_OBJECT = 64
+const OBJECT_FLAG_IS_RAW_NATIVE_FUNCTION = 2
+
+# Shape layout
+const SHAPE_REALM = 16
+field Shape.realm Realm SHAPE_REALM nonnull
+const SHAPE_PROTOTYPE = 64
+const SHAPE_DICTIONARY_GENERATION = 92
+field Shape.dictionary_generation u32 SHAPE_DICTIONARY_GENERATION nullable
+const SHAPE_SIZE = 96
+
+# PropertyLookupCache layout
+const PROPERTY_LOOKUP_CACHE_DATA = 0
+const PROPERTY_LOOKUP_CACHE_DATA_POINTER_MASK = 0xFFFFFFFFFFFFFFFE
+const PROPERTY_LOOKUP_CACHE_SIZE = 8
+
+# PropertyLookupCache::Entry layout
+const PROPERTY_LOOKUP_CACHE_ENTRY_PROPERTY_OFFSET = 4
+field PropertyLookupCache.property_offset u32 PROPERTY_LOOKUP_CACHE_ENTRY_PROPERTY_OFFSET nullable cache_details
+const PROPERTY_LOOKUP_CACHE_ENTRY_DICTIONARY_GENERATION = 8
+field PropertyLookupCache.shape_dictionary_generation u32 PROPERTY_LOOKUP_CACHE_ENTRY_DICTIONARY_GENERATION nullable cache_details
+const PROPERTY_LOOKUP_CACHE_ENTRY_FROM_SHAPE = 16
+const PROPERTY_LOOKUP_CACHE_ENTRY_SHAPE = 24
+field PropertyLookupCache.shape Shape PROPERTY_LOOKUP_CACHE_ENTRY_SHAPE nullable cache_target
+const PROPERTY_LOOKUP_CACHE_ENTRY_PROTOTYPE = 32
+field PropertyLookupCache.prototype Object PROPERTY_LOOKUP_CACHE_ENTRY_PROTOTYPE nullable cache_target
+const PROPERTY_LOOKUP_CACHE_ENTRY_PROTOTYPE_CHAIN_VALIDITY = 40
+field PropertyLookupCache.prototype_chain_validity PrototypeChainValidity PROPERTY_LOOKUP_CACHE_ENTRY_PROTOTYPE_CHAIN_VALIDITY nullable
+const PROPERTY_LOOKUP_CACHE_ENTRY_SIZE = 48
+
+# ObjectPropertyIteratorCacheData layout
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTIES = 16
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES = 40
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_SHAPE = 64
+field ObjectPropertyIteratorCacheData.shape Shape OBJECT_PROPERTY_ITERATOR_CACHE_DATA_SHAPE nonnull
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROTOTYPE_CHAIN_VALIDITY = 72
+field ObjectPropertyIteratorCacheData.prototype_chain_validity PrototypeChainValidity OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROTOTYPE_CHAIN_VALIDITY nullable
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_INDEXED_PROPERTY_COUNT = 80
+field ObjectPropertyIteratorCacheData.indexed_property_count u32 OBJECT_PROPERTY_ITERATOR_CACHE_DATA_INDEXED_PROPERTY_COUNT nullable
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_SHAPE_DICTIONARY_GENERATION = 84
+field ObjectPropertyIteratorCacheData.shape_dictionary_generation u32 OBJECT_PROPERTY_ITERATOR_CACHE_DATA_SHAPE_DICTIONARY_GENERATION nullable
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_FAST_PATH = 89
+field ObjectPropertyIteratorCacheData.fast_path u8 OBJECT_PROPERTY_ITERATOR_CACHE_DATA_FAST_PATH nullable
+
+# ObjectPropertyIteratorCache layout
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PTR = 0
+field ObjectPropertyIteratorCache.data ObjectPropertyIteratorCacheData OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PTR nullable
+const OBJECT_PROPERTY_ITERATOR_CACHE_REUSABLE_PROPERTY_NAME_ITERATOR = 8
+field ObjectPropertyIteratorCache.reusable_property_name_iterator Object OBJECT_PROPERTY_ITERATOR_CACHE_REUSABLE_PROPERTY_NAME_ITERATOR nullable
+
+# PropertyNameIterator layout
+const PROPERTY_NAME_ITERATOR_OBJECT = 72
+field PropertyNameIterator.object Object PROPERTY_NAME_ITERATOR_OBJECT nullable
+const PROPERTY_NAME_ITERATOR_PROPERTY_CACHE = 104
+field PropertyNameIterator.property_cache ObjectPropertyIteratorCacheData PROPERTY_NAME_ITERATOR_PROPERTY_CACHE nullable cache_and_shape
+const PROPERTY_NAME_ITERATOR_SHAPE = 112
+field PropertyNameIterator.shape Shape PROPERTY_NAME_ITERATOR_SHAPE nullable cache_and_shape
+const PROPERTY_NAME_ITERATOR_PROTOTYPE_CHAIN_VALIDITY = 120
+field PropertyNameIterator.prototype_chain_validity PrototypeChainValidity PROPERTY_NAME_ITERATOR_PROTOTYPE_CHAIN_VALIDITY nullable
+const PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT = 128
+field PropertyNameIterator.iterator_cache_slot ObjectPropertyIteratorCache PROPERTY_NAME_ITERATOR_ITERATOR_CACHE_SLOT nullable
+const PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT = 136
+field PropertyNameIterator.indexed_property_count u32 PROPERTY_NAME_ITERATOR_INDEXED_PROPERTY_COUNT nullable indexed_progress
+const PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY = 140
+field PropertyNameIterator.next_indexed_property u32 PROPERTY_NAME_ITERATOR_NEXT_INDEXED_PROPERTY nullable indexed_progress
+const PROPERTY_NAME_ITERATOR_NEXT_PROPERTY = 144
+field PropertyNameIterator.next_property u64 PROPERTY_NAME_ITERATOR_NEXT_PROPERTY nullable
+const PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY = 152
+field PropertyNameIterator.shape_is_dictionary bool PROPERTY_NAME_ITERATOR_SHAPE_IS_DICTIONARY nullable
+const PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION = 156
+field PropertyNameIterator.shape_dictionary_generation u32 PROPERTY_NAME_ITERATOR_SHAPE_DICTIONARY_GENERATION nullable
+const PROPERTY_NAME_ITERATOR_FAST_PATH = 160
+field PropertyNameIterator.fast_path u8 PROPERTY_NAME_ITERATOR_FAST_PATH nullable
+
+# Executable layout
+const EXECUTABLE_CONSTANTS = 296
+const EXECUTABLE_PROPERTY_LOOKUP_CACHES = 120
+const EXECUTABLE_GLOBAL_VARIABLE_CACHES = 144
+const EXECUTABLE_ENVIRONMENT_COORDINATE_CACHES = 168
+const EXECUTABLE_REGISTERS_AND_LOCALS_COUNT = 388
+field Executable.registers_and_locals_count u32 EXECUTABLE_REGISTERS_AND_LOCALS_COUNT nullable slot_counts
+const EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT = 392
+field Executable.registers_and_locals_and_constants_count u32 EXECUTABLE_REGISTERS_AND_LOCALS_AND_CONSTANTS_COUNT nullable slot_counts
+const EXECUTABLE_ASM_CONSTANTS_SIZE = 400
+field Executable.asm_constants_size u64 EXECUTABLE_ASM_CONSTANTS_SIZE nullable constants
+const EXECUTABLE_ASM_CONSTANTS_DATA = 408
+field Executable.asm_constants_data Sequence<Value> EXECUTABLE_ASM_CONSTANTS_DATA nullable constants
+
+# ExecutionContext layout
+const EXECUTION_CONTEXT_FUNCTION = 0
+field ExecutionContext.function Object EXECUTION_CONTEXT_FUNCTION nullable function_and_realm
+const EXECUTION_CONTEXT_REALM = 8
+field ExecutionContext.realm Realm EXECUTION_CONTEXT_REALM nullable function_and_realm
+const EXECUTION_CONTEXT_SCRIPT_OR_MODULE = 16
+field ExecutionContext.script_or_module ScriptOrModule EXECUTION_CONTEXT_SCRIPT_OR_MODULE nullable
+const EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT = 32
+field ExecutionContext.lexical_environment Environment EXECUTION_CONTEXT_LEXICAL_ENVIRONMENT nullable environments
+const EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT = 40
+field ExecutionContext.variable_environment Environment EXECUTION_CONTEXT_VARIABLE_ENVIRONMENT nullable environments
+const EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT = 48
+field ExecutionContext.private_environment PrivateEnvironment EXECUTION_CONTEXT_PRIVATE_ENVIRONMENT nullable
+const EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER = 60
+field ExecutionContext.skip_when_determining_incumbent_counter u32 EXECUTION_CONTEXT_SKIP_WHEN_DETERMINING_INCUMBENT_COUNTER nullable
+const EXECUTION_CONTEXT_YIELD_CONTINUATION = 64
+field ExecutionContext.yield_continuation u32 EXECUTION_CONTEXT_YIELD_CONTINUATION nullable
+const EXECUTION_CONTEXT_YIELD_IS_AWAIT = 68
+field ExecutionContext.yield_is_await bool EXECUTION_CONTEXT_YIELD_IS_AWAIT nullable
+const EXECUTION_CONTEXT_YIELD_VALUE_IS_ITERATOR_RESULT = 69
+field ExecutionContext.yield_value_is_iterator_result bool EXECUTION_CONTEXT_YIELD_VALUE_IS_ITERATOR_RESULT nullable
+const EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT = 70
+field ExecutionContext.caller_is_construct bool EXECUTION_CONTEXT_CALLER_IS_CONSTRUCT nullable
+const EXECUTION_CONTEXT_THIS_VALUE = 72
+field ExecutionContext.this_value Value EXECUTION_CONTEXT_THIS_VALUE nullable this_and_executable
+const EXECUTION_CONTEXT_EXECUTABLE = 80
+field ExecutionContext.executable Executable EXECUTION_CONTEXT_EXECUTABLE nullable this_and_executable
+const EXECUTION_CONTEXT_CALLER_FRAME = 88
+field ExecutionContext.caller_frame ExecutionContext EXECUTION_CONTEXT_CALLER_FRAME nullable
+const EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT = 96
+field ExecutionContext.passed_argument_count u32 EXECUTION_CONTEXT_PASSED_ARGUMENT_COUNT nullable
+const EXECUTION_CONTEXT_CALLER_RETURN_PC = 100
+field ExecutionContext.caller_return_pc u32 EXECUTION_CONTEXT_CALLER_RETURN_PC nullable caller_return
+const EXECUTION_CONTEXT_CALLER_DST_RAW = 104
+field ExecutionContext.caller_dst_raw u32 EXECUTION_CONTEXT_CALLER_DST_RAW nullable caller_return
+const EXECUTION_CONTEXT_PROGRAM_COUNTER = 56
+field ExecutionContext.program_counter u32 EXECUTION_CONTEXT_PROGRAM_COUNTER nullable
+const EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT = 108
+field ExecutionContext.slot_count u32 EXECUTION_CONTEXT_REGISTERS_AND_CONSTANTS_AND_LOCALS_AND_ARGUMENTS_COUNT nullable counts
+const EXECUTION_CONTEXT_ARGUMENT_COUNT = 112
+field ExecutionContext.argument_count u32 EXECUTION_CONTEXT_ARGUMENT_COUNT nullable counts
+const SIZEOF_EXECUTION_CONTEXT = 120
+field ExecutionContext.slots Sequence<Value> SIZEOF_EXECUTION_CONTEXT embedded
+const EXECUTION_CONTEXT_ACCUMULATOR = 120
+const EXECUTION_CONTEXT_EXCEPTION = 128
+const EXECUTION_CONTEXT_THIS_VALUE_REGISTER = 136
+const EXECUTION_CONTEXT_RETURN_VALUE = 144
+const EXECUTION_CONTEXT_SAVED_LEXICAL_ENVIRONMENT = 152
+field ExecutionContext.accumulator Value EXECUTION_CONTEXT_ACCUMULATOR nullable accumulator_and_exception
+field ExecutionContext.exception Value EXECUTION_CONTEXT_EXCEPTION nullable accumulator_and_exception pinned values EXCEPTION_REG_OFFSET
+field ExecutionContext.this_value_register Value EXECUTION_CONTEXT_THIS_VALUE_REGISTER nullable pinned values THIS_VALUE_REG_OFFSET
+field ExecutionContext.return_value Value EXECUTION_CONTEXT_RETURN_VALUE nullable return_and_saved_environment
+field ExecutionContext.saved_lexical_environment Value EXECUTION_CONTEXT_SAVED_LEXICAL_ENVIRONMENT nullable return_and_saved_environment
+const ALIGNOF_EXECUTION_CONTEXT = 8
+const EXECUTION_CONTEXT_NO_YIELD_CONTINUATION = 4294967295
+const SIZEOF_SCRIPT_OR_MODULE = 16
+const SIZEOF_VALUE = 8
+
+# InterpreterStack layout
+const INTERPRETER_STACK_LIMIT = 16
+const INTERPRETER_STACK_TOP = 8
+
+# Realm layout
+const REALM_GLOBAL_ENVIRONMENT = 40
+field Realm.global_environment GlobalEnvironment REALM_GLOBAL_ENVIRONMENT nonnull
+const REALM_GLOBAL_OBJECT = 24
+field Realm.global_object Object REALM_GLOBAL_OBJECT nullable global_state
+const REALM_GLOBAL_DECLARATIVE_ENVIRONMENT = 32
+field Realm.global_declarative_environment DeclarativeEnvironment REALM_GLOBAL_DECLARATIVE_ENVIRONMENT nullable global_state
+
+# VM layout
+const VM_RUNNING_EXECUTION_CONTEXT = 15288
+const VM_INTERPRETER_STACK = 15344
+const VM_STACK_INFO = 15320
+const VM_EXECUTION_GENERATION = 16632
+const VM_PRIMITIVE_STORAGE_CAGE_BASE = 16640
+field VM.primitive_storage_cage_base u64 VM_PRIMITIVE_STORAGE_CAGE_BASE nonnull
+const VM_INTERPRETER_STACK_TOP = 15352
+const VM_INTERPRETER_STACK_LIMIT = 15360
+const VM_STACK_INFO_BASE = 15320
+field VM.running_execution_context ExecutionContext VM_RUNNING_EXECUTION_CONTEXT nullable
+field VM.interpreter_stack_top u64 VM_INTERPRETER_STACK_TOP nonnull interpreter_stack_bounds
+field VM.interpreter_stack_limit u64 VM_INTERPRETER_STACK_LIMIT nonnull interpreter_stack_bounds
+field VM.stack_base u64 VM_STACK_INFO_BASE nullable
+const VM_STACK_SPACE_LIMIT = 32768
+
+# StackInfo layout
+const STACK_INFO_BASE = 0
+
+# IndexedStorageKind enum values
+const INDEXED_STORAGE_KIND_NONE = 0
+const INDEXED_STORAGE_KIND_PACKED = 1
+const INDEXED_STORAGE_KIND_HOLEY = 2
+const INDEXED_STORAGE_KIND_DICTIONARY = 3
+
+# ObjectPropertyIteratorFastPath enum values
+const OBJECT_PROPERTY_ITERATOR_FAST_PATH_NONE = 0
+const OBJECT_PROPERTY_ITERATOR_FAST_PATH_PLAIN_NAMED = 1
+const OBJECT_PROPERTY_ITERATOR_FAST_PATH_PACKED_INDEXED = 2
+
+# Vector<Value> layout
+const VECTOR_DATA = 16
+const VECTOR_SIZE = 0
+const INDEXED_ELEMENTS_CAPACITY = -8
+field IndexedElements.capacity u32 INDEXED_ELEMENTS_CAPACITY nullable
+const EXECUTABLE_BYTECODE_DATA = 104
+field Executable.bytecode_data u64 EXECUTABLE_BYTECODE_DATA nonnull
+const EXECUTABLE_PROPERTY_LOOKUP_CACHES_DATA = 136
+field Executable.property_lookup_caches PropertyLookupCaches EXECUTABLE_PROPERTY_LOOKUP_CACHES_DATA nonnull
+const EXECUTABLE_GLOBAL_VARIABLE_CACHES_DATA = 160
+field Executable.global_variable_caches GlobalVariableCaches EXECUTABLE_GLOBAL_VARIABLE_CACHES_DATA nonnull
+const EXECUTABLE_ENVIRONMENT_COORDINATE_CACHES_DATA = 184
+field Executable.environment_coordinate_caches Sequence<EnvironmentCoordinateEntry> EXECUTABLE_ENVIRONMENT_COORDINATE_CACHES_DATA nullable
+const EXECUTABLE_CONSTANTS_DATA = 312
+const EXECUTABLE_CONSTANTS_SIZE = 296
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA = 56
+const OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE = 40
+field ObjectPropertyIteratorCacheData.property_values Sequence<Value> OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_DATA nullable
+field ObjectPropertyIteratorCacheData.property_value_count u64 OBJECT_PROPERTY_ITERATOR_CACHE_DATA_PROPERTY_VALUES_SIZE nullable
+
+# PutKind enum
+const PUT_KIND_NORMAL = 0
+
+# PrototypeChainValidity layout
+const PROTOTYPE_CHAIN_VALIDITY_VALID = 10
+field PrototypeChainValidity.valid bool PROTOTYPE_CHAIN_VALIDITY_VALID nonnull
+
+# DeclarativeEnvironment layout
+const DECLARATIVE_ENVIRONMENT_RARE_DATA = 56
+field DeclarativeEnvironment.rare_data DeclarativeEnvironmentRareData DECLARATIVE_ENVIRONMENT_RARE_DATA nullable
+const DECLARATIVE_ENVIRONMENT_SERIAL = 64
+field DeclarativeEnvironment.serial_number u64 DECLARATIVE_ENVIRONMENT_SERIAL nullable
+
+# GlobalVariableCache layout
+const GLOBAL_VARIABLE_CACHE_ENTRY = 0
+const GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL = 48
+const GLOBAL_VARIABLE_CACHE_ENVIRONMENT_BINDING_INDEX = 56
+const GLOBAL_VARIABLE_CACHE_HAS_ENVIRONMENT_BINDING = 60
+const GLOBAL_VARIABLE_CACHE_IN_MODULE_ENVIRONMENT = 61
+const GLOBAL_VARIABLE_CACHE_SIZE = 64
+const GLOBAL_VARIABLE_CACHE_ENTRY_PROPERTY_OFFSET = 4
+const GLOBAL_VARIABLE_CACHE_ENTRY_DICTIONARY_GENERATION = 8
+const GLOBAL_VARIABLE_CACHE_ENTRY_SHAPE = 24
+field GlobalVariableCache.property_offset u32 GLOBAL_VARIABLE_CACHE_ENTRY_PROPERTY_OFFSET nullable global_cache_details stride GLOBAL_VARIABLE_CACHE_SIZE
+field GlobalVariableCache.shape_dictionary_generation u32 GLOBAL_VARIABLE_CACHE_ENTRY_DICTIONARY_GENERATION nullable global_cache_details
+field GlobalVariableCache.shape Shape GLOBAL_VARIABLE_CACHE_ENTRY_SHAPE nullable
+field GlobalVariableCache.environment_serial_number u64 GLOBAL_VARIABLE_CACHE_ENVIRONMENT_SERIAL nullable
+field GlobalVariableCache.environment_binding_index u32 GLOBAL_VARIABLE_CACHE_ENVIRONMENT_BINDING_INDEX nullable
+field GlobalVariableCache.has_environment_binding_index u8 GLOBAL_VARIABLE_CACHE_HAS_ENVIRONMENT_BINDING nullable
+field GlobalVariableCache.in_module_environment u8 GLOBAL_VARIABLE_CACHE_IN_MODULE_ENVIRONMENT nullable
+
+# Builtin enum values
+const BUILTIN_MATH_ABS = 0
+const BUILTIN_MATH_FLOOR = 5
+const BUILTIN_MATH_CEIL = 4
+const BUILTIN_MATH_ROUND = 8
+const BUILTIN_MATH_SQRT = 9
+const BUILTIN_MATH_EXP = 3
+const BUILTIN_STRING_FROM_CHAR_CODE = 21
+const BUILTIN_STRING_PROTOTYPE_CHAR_CODE_AT = 22
+const BUILTIN_STRING_PROTOTYPE_CHAR_AT = 23
+
+# FunctionObject layout
+const FUNCTION_OBJECT_BUILTIN = 64
+const FUNCTION_OBJECT_BUILTIN_VALUE = 64
+const FUNCTION_OBJECT_BUILTIN_HAS_VALUE = 65
+field FunctionObject.builtin u8 FUNCTION_OBJECT_BUILTIN_VALUE nullable
+field FunctionObject.has_builtin bool FUNCTION_OBJECT_BUILTIN_HAS_VALUE nullable
+
+# RawNativeFunction layout
+const RAW_NATIVE_FUNCTION_NATIVE_FUNCTION = 96
+field RawNativeFunction.native_function u64 RAW_NATIVE_FUNCTION_NATIVE_FUNCTION nonnull
+
+# ECMAScriptFunctionObject layout
+const ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA = 72
+field ECMAScriptFunctionObject.shared_data SharedFunctionInstanceData ECMASCRIPT_FUNCTION_OBJECT_SHARED_DATA nonnull
+const ECMASCRIPT_FUNCTION_OBJECT_ENVIRONMENT = 96
+field ECMAScriptFunctionObject.environment Environment ECMASCRIPT_FUNCTION_OBJECT_ENVIRONMENT nullable environment_state
+const ECMASCRIPT_FUNCTION_OBJECT_PRIVATE_ENVIRONMENT = 104
+field ECMAScriptFunctionObject.private_environment PrivateEnvironment ECMASCRIPT_FUNCTION_OBJECT_PRIVATE_ENVIRONMENT nullable environment_state
+const ECMASCRIPT_FUNCTION_OBJECT_SCRIPT_OR_MODULE = 112
+field ECMAScriptFunctionObject.script_or_module ScriptOrModule ECMASCRIPT_FUNCTION_OBJECT_SCRIPT_OR_MODULE nullable
+
+# SharedFunctionInstanceData layout
+const SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE = 48
+field SharedFunctionInstanceData.executable Executable SHARED_FUNCTION_INSTANCE_DATA_EXECUTABLE nullable call_data
+const SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA = 56
+field SharedFunctionInstanceData.asm_call_metadata u64 SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA nullable call_data
+const SHARED_FUNCTION_INSTANCE_DATA_FORMAL_PARAMETER_COUNT = 148
+const SHARED_FUNCTION_INSTANCE_DATA_STRICT = 177
+const SHARED_FUNCTION_INSTANCE_DATA_FUNCTION_ENVIRONMENT_NEEDED = 257
+const SHARED_FUNCTION_INSTANCE_DATA_USES_THIS = 259
+const SHARED_FUNCTION_INSTANCE_DATA_CAN_INLINE_CALL = 441
+const SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_CAN_INLINE_CALL = 4294967296
+const SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_NEEDS_ENVIRONMENT_OR_THIS_VALUE_RESOLUTION = 8589934592
+const SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_USES_THIS = 17179869184
+const SHARED_FUNCTION_INSTANCE_DATA_ASM_CALL_METADATA_STRICT = 34359738368
+
+# GlobalEnvironment layout
+const GLOBAL_ENVIRONMENT_GLOBAL_THIS_VALUE = 32
+field GlobalEnvironment.global_this_value Object GLOBAL_ENVIRONMENT_GLOBAL_THIS_VALUE nullable
+
+# PrimitiveString layout
+const PRIMITIVE_STRING_DEFERRED_KIND = 10
+field PrimitiveString.deferred_kind u8 PRIMITIVE_STRING_DEFERRED_KIND nullable
+const PRIMITIVE_STRING_UTF16_STRING = 16
+field PrimitiveString.utf16_data Utf16StringData PRIMITIVE_STRING_UTF16_STRING nullable
+const PRIMITIVE_STRING_DEFERRED_KIND_NONE = 0
+
+# Utf16String layout
+const UTF16_SHORT_STRING_FLAG = 1
+const UTF16_SHORT_STRING_BYTE_COUNT_SHIFT_COUNT = 2
+const UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG = 0
+const UTF16_SHORT_STRING_STORAGE = 1
+const PRIMITIVE_STRING_UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG = 16
+const PRIMITIVE_STRING_UTF16_SHORT_STRING_STORAGE = 17
+field PrimitiveString.utf16_short_string_byte_count_and_flag u8 PRIMITIVE_STRING_UTF16_SHORT_STRING_BYTE_COUNT_AND_FLAG nullable
+field PrimitiveString.utf16_short_string_storage Sequence<u8> PRIMITIVE_STRING_UTF16_SHORT_STRING_STORAGE embedded
+
+# Utf16StringData layout
+const UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS = 8
+const UTF16_STRING_DATA_STRING_STORAGE = 32
+field Utf16StringData.length_in_code_units u64 UTF16_STRING_DATA_LENGTH_IN_CODE_UNITS nullable
+field Utf16StringData.string_storage Sequence<u8> UTF16_STRING_DATA_STRING_STORAGE embedded
+
+# Environment layout
+const ENVIRONMENT_SCREWED_BY_EVAL = 11
+field Environment.permanently_screwed_by_eval bool ENVIRONMENT_SCREWED_BY_EVAL nullable
+const ENVIRONMENT_DECLARATIVE = 12
+field Environment.declarative bool ENVIRONMENT_DECLARATIVE nullable
+const ENVIRONMENT_OUTER = 16
+field Environment.outer Environment ENVIRONMENT_OUTER nullable
+
+# PrivateEnvironment layout
+const PRIVATE_ENVIRONMENT_OUTER = 16
+field PrivateEnvironment.outer PrivateEnvironment PRIVATE_ENVIRONMENT_OUTER nullable
+
+# DeclarativeEnvironment binding storage layout
+const DECLARATIVE_ENVIRONMENT_SHAPE = 24
+field DeclarativeEnvironment.shape EnvironmentShape DECLARATIVE_ENVIRONMENT_SHAPE nullable
+const DECLARATIVE_ENVIRONMENT_BINDING_VALUES = 32
+const DECLARATIVE_ENVIRONMENT_RARE_DATA_BINDING_FLAGS = 24
+const ENVIRONMENT_SHAPE_BINDING_FLAGS = 40
+const BINDING_FLAG_MUTABLE = 2
+const BINDING_VALUES_DATA_PTR = 48
+field DeclarativeEnvironment.binding_values BindingValues BINDING_VALUES_DATA_PTR nonnull
+const BINDING_FLAGS_DATA_PTR = 40
+field DeclarativeEnvironmentRareData.binding_flags BindingFlags BINDING_FLAGS_DATA_PTR nonnull
+const ENVIRONMENT_SHAPE_BINDING_FLAGS_DATA_PTR = 56
+const ENVIRONMENT_SHAPE_BINDING_FLAGS_SIZE = 40
+field EnvironmentShape.binding_flags_size u64 ENVIRONMENT_SHAPE_BINDING_FLAGS_SIZE nullable
+field EnvironmentShape.binding_flags BindingFlags ENVIRONMENT_SHAPE_BINDING_FLAGS_DATA_PTR nonnull
+
+# EnvironmentCoordinate layout
+const ENVIRONMENT_COORDINATE_HOPS = 0
+const ENVIRONMENT_COORDINATE_INDEX = 4
+const ENVIRONMENT_COORDINATE_INVALID = 0xFFFFFFFE
+const ENVIRONMENT_COORDINATE_SIZE = 8
+field EnvironmentCoordinateEntry.hops u32 ENVIRONMENT_COORDINATE_HOPS nullable environment_coordinate stride 8
+field EnvironmentCoordinateEntry.binding_index u32 ENVIRONMENT_COORDINATE_INDEX nullable environment_coordinate
+
+# TypedArrayBase layout
+const TYPED_ARRAY_ELEMENT_SIZE = 88
+const TYPED_ARRAY_ARRAY_LENGTH = 92
+const TYPED_ARRAY_BYTE_OFFSET = 108
+const TYPED_ARRAY_KIND = 116
+field Object.typed_array_kind u8 TYPED_ARRAY_KIND nullable
+const TYPED_ARRAY_CACHED_DATA_OFFSET = 128
+field Object.typed_array_cached_data_offset u64 TYPED_ARRAY_CACHED_DATA_OFFSET nullable
+const TYPED_ARRAY_CACHED_DATA_OFFSET_INVALID = 0xFFFFFFFFFFFFFFFF
+const PRIMITIVE_STORAGE_CAGE_OFFSET_MASK = 0x3FFFFFFFFFF
+
+# ByteLength layout
+const BYTE_LENGTH_U32_INDEX = 2
+const BYTE_LENGTH_SIZE = 8
+const TYPED_ARRAY_ARRAY_LENGTH_VALUE = 92
+field Object.typed_array_array_length u32 TYPED_ARRAY_ARRAY_LENGTH_VALUE nullable
+const TYPED_ARRAY_ARRAY_LENGTH_INDEX = 96
+
+# TypedArrayBase::Kind values
+const TYPED_ARRAY_KIND_UINT8 = 0
+const TYPED_ARRAY_KIND_UINT8_CLAMPED = 1
+const TYPED_ARRAY_KIND_UINT16 = 2
+const TYPED_ARRAY_KIND_UINT32 = 3
+const TYPED_ARRAY_KIND_INT8 = 5
+const TYPED_ARRAY_KIND_INT16 = 6
+const TYPED_ARRAY_KIND_INT32 = 7
+const TYPED_ARRAY_KIND_FLOAT32 = 10
+const TYPED_ARRAY_KIND_FLOAT64 = 11
+
+# Value tags
+const OBJECT_TAG = 0xFFF9
+const STRING_TAG = 0xFFFA
+const SYMBOL_TAG = 0xFFFB
+const BIGINT_TAG = 0xFFFD
+const ACCESSOR_TAG = 0xFFFC
+const IS_CELL_PATTERN = 0xFFF8
+const INT32_TAG = 0x7FFA
+const BOOLEAN_TAG = 0x7FF9
+const UNDEFINED_TAG = 0x7FFE
+const NULL_TAG = 0x7FFF
+
+# Shifted value constants
+const OBJECT_TAG_SHIFTED = 0xFFF9000000000000
+const EMPTY_VALUE = 0x7FFB000000000000
+const INT32_TAG_SHIFTED = 0x7FFA000000000000
+const BOOLEAN_TRUE = 0x7FF9000000000001
+const BOOLEAN_FALSE = 0x7FF9000000000000
+const UNDEFINED_SHIFTED = 0x7FFE000000000000
+const EMPTY_TAG_SHIFTED = 0x7FFB000000000000
+const NAN_BASE_TAG = 0x7FF8
+const CANON_NAN_BITS = 0x7FF8000000000000
+const DOUBLE_ONE = 0x3FF0000000000000
+const NEGATIVE_ZERO = 0x8000000000000000
+const SHIFTED_IS_CELL_PATTERN = 0xFFF8000000000000
+const ACCUMULATOR_REG_OFFSET = 0
+const EXCEPTION_REG_OFFSET = 8
+const THIS_VALUE_REG_OFFSET = 16
+const RETURN_VALUE_REG_OFFSET = 24
+const SAVED_LEXICAL_ENVIRONMENT_REG_OFFSET = 32
+const RESERVED_REGISTER_COUNT = 5

--- a/Libraries/LibJS/Interpreter/interpreter.flap
+++ b/Libraries/LibJS/Interpreter/interpreter.flap
@@ -2402,6 +2402,9 @@ handler Call(
     let callee_slot_count = executable_pointer.registers_and_locals_and_constants_count;
     assert_nonzero(executable_pointer);
     assert_ge_unsigned(callee_slot_count, registers_and_locals_count);
+    let maximum_slot_count: u32 = 4294967295;
+    let available_argument_slot_count: u32 = maximum_slot_count - callee_slot_count;
+    guard available_argument_slot_count >= formal_count else slow;
     let frame_slot_count: u32 = callee_slot_count + formal_count;
     # FIXME: Keep frame size materialization before the VM loads until nested
     #        arithmetic preserves that independent scheduling opportunity.
@@ -2528,6 +2531,7 @@ handler Call(
         guard native_frame_end <= native_stack_limit else slow;
         let native_limit_vm = current_vm();
         let machine_stack_limit: u64 = native_limit_vm.stack_base + VM_STACK_SPACE_LIMIT;
+        assert_ge_unsigned(machine_stack_limit, native_limit_vm.stack_base);
         guard machine_stack_limit <= fp else slow;
         let native_stack_update_vm = current_vm();
         native_stack_update_vm.interpreter_stack_top = native_frame_end;

--- a/Libraries/LibJS/Rust/build.rs
+++ b/Libraries/LibJS/Rust/build.rs
@@ -1341,6 +1341,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .truncate(true) // empties contents of the file
         .open(out_dir.join("instruction_generated.rs"))?;
     let content = fs::read_to_string(&def_path).expect("Failed to read Bytecode.def");
-    let ops = bytecode_def::parse_bytecode_def(&content);
+    let source_name = def_path.to_string_lossy();
+    let ops = bytecode_def::parse_bytecode_def(&source_name, &content)?;
     generate_rust_code(file, &ops)
 }

--- a/Libraries/LibJS/Rust/build.rs
+++ b/Libraries/LibJS/Rust/build.rs
@@ -12,11 +12,8 @@
 
 use bytecode_def::Field;
 use bytecode_def::OpDef;
-use bytecode_def::STRUCT_ALIGN;
 use bytecode_def::compute_layouts;
 use bytecode_def::field_type_info;
-use bytecode_def::find_m_length_offset;
-use bytecode_def::round_up;
 use bytecode_def::user_fields;
 use std::env;
 use std::fs;
@@ -31,29 +28,10 @@ fn rust_field_name(name: &str) -> String {
     }
 }
 
-/// Find the count field corresponding to a given array field, using the same
-/// heuristic as the Python generator: prefer `<name>_count`, fall back to
-/// `<singularized name>_count`. Panics if no matching u32/size_t field is
-/// found, mirroring the Python `find_count_field_name_or_die`.
-fn find_count_field_name(op: &OpDef, array_field: &Field) -> String {
-    let mut candidates = vec![format!("{}_count", array_field.name)];
-    if let Some(stripped) = array_field.name.strip_suffix('s') {
-        candidates.push(format!("{stripped}_count"));
-    }
-    for candidate in &candidates {
-        for f in &op.fields {
-            if f.is_array {
-                continue;
-            }
-            if &f.name == candidate && (f.ty == "u32" || f.ty == "size_t") {
-                return candidate.clone();
-            }
-        }
-    }
-    panic!(
-        "No count field (u32/size_t) found for array field '{}' in op '{}'",
-        array_field.name, op.name
-    );
+fn count_field_name<'a>(op: &'a OpDef, array_field: &Field) -> &'a str {
+    let array = op.array.as_ref().expect("the parser validates array metadata");
+    assert_eq!(op.fields[array.field_index].name, array_field.name);
+    &op.fields[array.count_field_index].name
 }
 
 fn generate_rust_code(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dyn std::error::Error>> {
@@ -132,33 +110,15 @@ fn generate_instruction_length_from_bytes(mut w: impl Write, ops: &[OpDef]) -> R
     writeln!(w, "    match opcode {{")?;
 
     for (i, op) in ops.iter().enumerate() {
-        let has_array = op.fields.iter().any(|f| f.is_array);
-
-        if !has_array {
-            let mut offset: usize = 2;
-            for f in &op.fields {
-                if f.is_array || f.name == "m_type" || f.name == "m_strict" {
-                    continue;
-                }
-                let info = field_type_info(&f.ty);
-                offset = round_up(offset, info.align);
-                offset += info.size;
-            }
-            let final_size = round_up(offset, STRUCT_ALIGN);
+        if let Some(final_size) = op.layout.size {
             let op_name = &op.name;
             writeln!(w, "        {i} => Ok({final_size}), // {op_name}")?;
         } else {
-            let mut fixed_offset: usize = 2;
-            for f in &op.fields {
-                if f.is_array || f.name == "m_type" || f.name == "m_strict" {
-                    continue;
-                }
-                let info = field_type_info(&f.ty);
-                fixed_offset = round_up(fixed_offset, info.align);
-                fixed_offset += info.size;
-            }
-            let minimum_length = round_up(fixed_offset, STRUCT_ALIGN);
-            let m_length_offset = find_m_length_offset(&op.fields);
+            let minimum_length = op.layout.minimum_size;
+            let m_length_offset = op
+                .layout
+                .m_length_offset
+                .expect("the parser requires m_length for array ops");
             let op_name = &op.name;
             writeln!(w, "        {i} => {{ // {op_name} (variable-length)")?;
             writeln!(w, "            let m_length_end = at + {m_length_offset} + 4;")?;
@@ -263,7 +223,7 @@ fn generate_array_bounds(
             continue;
         }
         let rname = rust_field_name(&f.name);
-        let count_name = rust_field_name(&find_count_field_name(op, f));
+        let count_name = rust_field_name(count_field_name(op, f));
         let offset = layout.field_offsets.get(&f.name).expect("array offset missing");
         let elem_size = field_type_info(&f.ty).size;
         writeln!(w, "            let {rname}_offset = at + {offset};")?;
@@ -299,9 +259,9 @@ fn generate_instruction_dump_from_bytes(mut w: impl Write, ops: &[OpDef]) -> Res
         let mut array_to_count = std::collections::HashMap::new();
         let mut count_fields = std::collections::HashSet::new();
         for af in arrays {
-            let count_field_name = find_count_field_name(op, af);
-            count_fields.insert(count_field_name.clone());
-            array_to_count.insert(af.name.clone(), rust_field_name(&count_field_name));
+            let count_field_name = count_field_name(op, af);
+            count_fields.insert(count_field_name);
+            array_to_count.insert(af.name.clone(), rust_field_name(count_field_name));
         }
 
         for f in &op.fields {
@@ -472,7 +432,7 @@ fn generate_instruction_dump_from_bytes(mut w: impl Write, ops: &[OpDef]) -> Res
                     w,
                     "            dumper.append_piece(|dumper| dumper.append_put_kind(\"{label}\", {rname}));"
                 )?,
-                _ if (ty == "u32" || ty == "u64" || ty == "u8") && !count_fields.contains(&f.name) => {
+                _ if (ty == "u32" || ty == "u64" || ty == "u8") && !count_fields.contains(f.name.as_str()) => {
                     writeln!(
                         w,
                         "            dumper.append_piece(|dumper| dumper.append_number(\"{label}\", {rname}));"
@@ -694,7 +654,7 @@ fn generate_validate_instruction(mut w: impl Write, ops: &[OpDef]) -> Result<(),
         // the array bound below) and avoid duplicate work.
         let mut count_field_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         for af in &arrays {
-            count_field_names.insert(find_count_field_name(op, af));
+            count_field_names.insert(count_field_name(op, af).to_string());
         }
 
         let op_name = &op.name;
@@ -723,10 +683,10 @@ fn generate_validate_instruction(mut w: impl Write, ops: &[OpDef]) -> Result<(),
             // array; if that ever changes, this loop validates each independently.
             for af in &arrays {
                 let array_offset = *layout.field_offsets.get(&af.name).expect("missing array offset");
-                let count_field = find_count_field_name(op, af);
+                let count_field = count_field_name(op, af);
                 let count_offset = *layout
                     .field_offsets
-                    .get(&count_field)
+                    .get(count_field)
                     .expect("missing count field offset");
                 let elem_size = field_type_info(&af.ty).size;
 
@@ -884,20 +844,8 @@ fn generate_encoded_size_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), 
 
     for op in ops {
         let fields = user_fields(op);
-        let has_array = op.fields.iter().any(|f| f.is_array);
 
-        if !has_array {
-            // Fixed-length: compute size statically
-            let mut offset: usize = 2; // header
-            for f in &op.fields {
-                if f.is_array || f.name == "m_type" || f.name == "m_strict" {
-                    continue;
-                }
-                let info = field_type_info(&f.ty);
-                offset = round_up(offset, info.align);
-                offset += info.size;
-            }
-            let final_size = round_up(offset, 8);
+        if let Some(final_size) = op.layout.size {
             let pat = if fields.is_empty() {
                 format!("Instruction::{}", op.name)
             } else {
@@ -905,28 +853,9 @@ fn generate_encoded_size_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), 
             };
             writeln!(w, "            {pat} => {final_size},")?;
         } else {
-            // Variable-length: depends on array size
-            // Compute fixed part size
-            let mut fixed_offset: usize = 2;
-            for f in &op.fields {
-                if f.is_array || f.name == "m_type" || f.name == "m_strict" {
-                    continue;
-                }
-                let info = field_type_info(&f.ty);
-                fixed_offset = round_up(fixed_offset, info.align);
-                fixed_offset += info.size;
-            }
-
-            // Find the array field and its element size
-            let Some(array_field) = op.fields.iter().find(|f| f.is_array) else {
-                continue;
-            };
-            let info = field_type_info(&array_field.ty);
+            let array = op.array.as_ref().expect("variable op missing array metadata");
+            let array_field = &op.fields[array.field_index];
             let arr_name = rust_field_name(&array_field.name);
-            // C++ computes m_length as:
-            //   round_up(alignof(void*), sizeof(*this) + sizeof(elem) * count)
-            // sizeof(*this) = round_up(fixed_offset, STRUCT_ALIGN) due to alignas(void*).
-            let sizeof_this = round_up(fixed_offset, STRUCT_ALIGN);
 
             // Bind only the array field
             let bindings: Vec<String> = fields
@@ -949,7 +878,7 @@ fn generate_encoded_size_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), 
             writeln!(
                 w,
                 "                let base = {} + {}.len() * {};",
-                sizeof_this, arr_name, info.size
+                op.layout.minimum_size, arr_name, array.element_size
             )?;
             writeln!(w, "                (base + 7) & !7 // round up to 8")?;
             writeln!(w, "            }}")?;
@@ -974,8 +903,6 @@ fn generate_encode_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dy
 
     for op in ops {
         let fields = user_fields(op);
-        let has_array = op.fields.iter().any(|f| f.is_array);
-        let has_m_length = op.fields.iter().any(|f| f.name == "m_length");
 
         // Generate match arm with field bindings
         if fields.is_empty() {
@@ -1010,14 +937,18 @@ fn generate_encode_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dy
             }
 
             let info = field_type_info(&f.ty);
-
-            // Pad to alignment
-            let aligned_offset = round_up(offset, info.align);
-            let pad = aligned_offset - offset;
+            let field_offset = op.layout.field_offsets[&f.name];
+            assert!(
+                field_offset >= offset,
+                "{}: tracked offset {offset} passed layout offset {field_offset} for {}",
+                op.name,
+                f.name
+            );
+            let pad = field_offset - offset;
             if pad > 0 {
                 writeln!(w, "                buf.extend_from_slice(&[0u8; {pad}]);")?;
             }
-            offset = aligned_offset;
+            offset = field_offset;
 
             if f.name == "m_length" {
                 // Write placeholder (patched at end for variable-length instructions)
@@ -1033,55 +964,53 @@ fn generate_encode_method(mut w: impl Write, ops: &[OpDef]) -> Result<(), Box<dy
         }
 
         // Write trailing array elements
-        if has_array {
-            // sizeof(*this) in C++ = round_up(fixed_offset, STRUCT_ALIGN)
-            let sizeof_this = round_up(offset, STRUCT_ALIGN);
-
-            for f in &op.fields {
-                if !f.is_array {
-                    continue;
-                }
-                let info = field_type_info(&f.ty);
-                let rname = rust_field_name(&f.name);
-
-                // Pad before first element if needed
-                let aligned_offset = round_up(offset, info.align);
-                let pad = aligned_offset - offset;
-                if pad > 0 {
-                    writeln!(w, "                buf.extend_from_slice(&[0u8; {pad}]);")?;
-                }
-
-                writeln!(w, "                for item in {rname} {{")?;
-                emit_field_write(&mut w, "item", info.kind, true)?;
-                writeln!(w, "                }}")?;
-
-                // Compute target size matching C++:
-                //   round_up(STRUCT_ALIGN, sizeof(*this) + count * elem_size)
-                writeln!(
-                    w,
-                    "                let target = ({} + {}.len() * {} + 7) & !7;",
-                    sizeof_this, rname, info.size
-                )?;
-                writeln!(
-                    w,
-                    "                while (buf.len() - start) < target {{ buf.push(0); }}"
-                )?;
+        if let Some(array) = &op.array {
+            let field = &op.fields[array.field_index];
+            let info = field_type_info(&field.ty);
+            let rname = rust_field_name(&field.name);
+            assert!(
+                array.offset >= offset,
+                "{}: tracked offset {offset} passed array offset {} for {}",
+                op.name,
+                array.offset,
+                field.name
+            );
+            let pad = array.offset - offset;
+            if pad > 0 {
+                writeln!(w, "                buf.extend_from_slice(&[0u8; {pad}]);")?;
             }
 
-            if has_m_length {
-                // Patch m_length: it's the first u32 field after the header
-                let m_length_offset = find_m_length_offset(&op.fields);
-                writeln!(w, "                let total_len = (buf.len() - start) as u32;")?;
-                writeln!(
-                    w,
-                    "                buf[start + {}..start + {}].copy_from_slice(&total_len.to_ne_bytes());",
-                    m_length_offset,
-                    m_length_offset + 4
-                )?;
-            }
+            writeln!(w, "                for item in {rname} {{")?;
+            emit_field_write(&mut w, "item", info.kind, true)?;
+            writeln!(w, "                }}")?;
+            writeln!(
+                w,
+                "                let target = ({} + {}.len() * {} + 7) & !7;",
+                op.layout.minimum_size, rname, array.element_size
+            )?;
+            writeln!(
+                w,
+                "                while (buf.len() - start) < target {{ buf.push(0); }}"
+            )?;
+
+            let m_length_offset = op
+                .layout
+                .m_length_offset
+                .expect("the parser requires m_length for array ops");
+            writeln!(w, "                let total_len = (buf.len() - start) as u32;")?;
+            writeln!(
+                w,
+                "                buf[start + {}..start + {}].copy_from_slice(&total_len.to_ne_bytes());",
+                m_length_offset,
+                m_length_offset + 4
+            )?;
         } else {
-            // Fixed-length: pad statically
-            let final_size = round_up(offset, 8);
+            let final_size = op.layout.size.expect("fixed op missing encoded size");
+            assert!(
+                final_size >= offset,
+                "{}: tracked offset {offset} passed final size {final_size}",
+                op.name
+            );
             let tail_pad = final_size - offset;
             if tail_pad > 0 {
                 writeln!(w, "                buf.extend_from_slice(&[0u8; {tail_pad}]);")?;


### PR DESCRIPTION
Rework Flap’s analysis, optimization, lowering, and register-allocation hot paths to avoid repeated graph scans, copied sets, name-based lookups, and redundant computation. Dense identities, cached dependencies, worklist solvers, sparse liveness, scoped availability, and lightweight layout planning reduce full interpreter compilation time from roughly 117 ms to 54 ms in the branch benchmark.

Strengthen compiler correctness with fallible BytecodeDef parsing, complete schema validation, bounded inline expansion and exact coloring, higher-order recursion rejection, checked call-frame sizing, machine-optimization verification, and SSA validation after every pass. Track pointer and nullability facts more precisely while keeping them scoped to paths where they remain valid.

Improve generated code through constant rematerialization, live-range splitting, better register selection, machine-aware layout scoring, load forwarding, and more precise memory-effect analysis. Expose reusable compilation stages, structured diagnostics, optimization reports, and performance telemetry to make failures and performance changes easier to investigate.

Add standalone Flap and BytecodeDef CI coverage, including formatting, linting, unit tests, deterministic interpreter generation, and cross-assembly for x86-64 and AArch64.