### PR TITLE
LibWeb: Return zero scroll offsets for boxes without a scrolling box 

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2633,12 +2633,15 @@ double Element::scroll_top() const
         return window->scroll_y();
 
     // 8. If the element does not have any associated box, return zero and terminate these steps.
-    if (!paintable_box())
+    // NB: A box that is not a scroll container is never scrolled away from its default alignment, even if it keeps a
+    //     stored scroll offset from when it was one for restoration when it becomes one again.
+    auto paintable_box = this->paintable_box();
+    if (!paintable_box || !paintable_box->layout_node().is_scroll_container())
         return 0.0;
 
     // 9. Return the y-coordinate of the scrolling area at the alignment point with the top of the padding edge of the element.
     // FIXME: Is this correct?
-    return paintable_box()->scroll_offset().y().to_double();
+    return paintable_box->scroll_offset().y().to_double();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
@@ -2675,12 +2678,15 @@ double Element::scroll_left() const
         return window->scroll_x();
 
     // 8. If the element does not have any associated box, return zero and terminate these steps.
-    if (!paintable_box())
+    // NB: A box that is not a scroll container is never scrolled away from its default alignment, even if it keeps a
+    //     stored scroll offset from when it was one for restoration when it becomes one again.
+    auto paintable_box = this->paintable_box();
+    if (!paintable_box || !paintable_box->layout_node().is_scroll_container())
         return 0.0;
 
     // 9. Return the x-coordinate of the scrolling area at the alignment point with the left of the padding edge of the element.
     // FIXME: Is this correct?
-    return paintable_box()->scroll_offset().x().to_double();
+    return paintable_box->scroll_offset().x().to_double();
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -4349,12 +4349,13 @@ GC::Ref<WebIDL::Promise> Element::scroll(Bindings::ScrollToOptions options)
     // 10. If the element does not have any associated box, the element has no associated scrolling box, or the element
     //     has no overflow, return a resolved Promise and abort the remaining steps.
     // FIXME: or the element has no overflow
-    if (!paintable_box())
+    auto paintable_box = this->paintable_box();
+    if (!paintable_box || !paintable_box->layout_node().is_scroll_container())
         return WebIDL::create_resolved_promise(realm(), JS::js_undefined());
 
     // 11. Scroll the element to x,y, with the scroll behavior being the value of the behavior dictionary member of
     //     options. Let scrollPromise be the Promise returned from this step.
-    auto scroll_offset = paintable_box()->scroll_offset();
+    auto scroll_offset = paintable_box->scroll_offset();
     scroll_offset.set_x(CSSPixels::nearest_value_for(x));
     scroll_offset.set_y(CSSPixels::nearest_value_for(y));
     auto navigable = document.navigable();

--- a/Tests/LibWeb/Text/expected/css/scroll-offset-of-non-scroll-container.txt
+++ b/Tests/LibWeb/Text/expected/css/scroll-offset-of-non-scroll-container.txt
@@ -1,0 +1,10 @@
+scroll() on a non-scroll-container: scrollLeft=0 scrollTop=0
+scrollBy() on a non-scroll-container: scrollLeft=0 scrollTop=0
+scrollLeft/scrollTop on a non-scroll-container: scrollLeft=0 scrollTop=0
+scroll events on a non-scroll-container: 0
+scrollend events on a non-scroll-container: 0
+after becoming a scroll container: scrollLeft=0 scrollTop=0
+scroll() on a scroll container: scrollLeft=40 scrollTop=50
+after ceasing to be a scroll container: scrollLeft=0 scrollTop=0
+after scrolling while not a scroll container: scrollLeft=0 scrollTop=0
+after becoming a scroll container again: scrollLeft=40 scrollTop=50

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/dom-element-scroll.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/dom-element-scroll.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	Element test for having scrolling box
+Pass	Element test for having overflow
+Pass	Element test for not having scrolling box
+Pass	Element test for not having overflow

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrolling-quirks-vs-nonquirks.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/scrolling-quirks-vs-nonquirks.txt
@@ -1,0 +1,35 @@
+Harness status: OK
+
+Found 30 tests
+
+30 Pass
+Pass	Execution of tests in quirks mode
+Pass	Execution of tests in non-quirks mode
+Pass	scrollingElement in quirks mode
+Pass	scroll() on the root element in quirks mode
+Pass	scrollBy() on the root element in quirks mode
+Pass	scrollLeft/scrollTop on the root element in quirks mode
+Pass	scrollWidth/scrollHeight on the root element in quirks mode
+Pass	clientWidth/clientHeight on the root element in quirks mode
+Pass	scroll() on the HTML body element in quirks mode
+Pass	scrollBy() on the HTML body element in quirks mode
+Pass	scrollLeft/scrollTop on the HTML body element in quirks mode
+Pass	scrollWidth/scrollHeight on the HTML body element in quirks mode
+Pass	clientWidth/clientHeight on the HTML body element in quirks mode
+Pass	scrollLeft/scrollRight of the content in quirks mode
+Pass	scrollWidth/scrollHeight of the content in quirks mode
+Pass	clientWidth/clientHeight of the content in quirks mode
+Pass	scrollingElement in non-quirks mode
+Pass	scroll() on the root element in non-quirks mode
+Pass	scrollBy() on the root element in non-quirks mode
+Pass	scrollLeft/scrollTop on the root element in non-quirks mode
+Pass	scrollWidth/scrollHeight on the root element in non-quirks mode
+Pass	clientWidth/clientHeight on the root element in non-quirks mode
+Pass	scroll() on the HTML body element in non-quirks mode
+Pass	scrollBy() on the HTML body element in non-quirks mode
+Pass	scrollLeft/scrollTop on the HTML body element in non-quirks mode
+Pass	scrollWidth/scrollHeight on the HTML body element in non-quirks mode
+Pass	clientWidth/clientHeight on the HTML body element in non-quirks mode
+Pass	scrollLeft/scrollRight of the content in non-quirks mode
+Pass	scrollWidth/scrollHeight of the content in non-quirks mode
+Pass	clientWidth/clientHeight of the content in non-quirks mode

--- a/Tests/LibWeb/Text/input/css/scroll-offset-of-non-scroll-container.html
+++ b/Tests/LibWeb/Text/input/css/scroll-offset-of-non-scroll-container.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .scroller {
+        width: 100px;
+        height: 100px;
+    }
+
+    .content {
+        width: 300px;
+        height: 300px;
+    }
+</style>
+<div id="target" class="scroller"><div class="content"></div></div>
+<script>
+    promiseTest(async () => {
+        const target = document.getElementById("target");
+
+        let scrollEvents = 0;
+        let scrollEndEvents = 0;
+        target.addEventListener("scroll", () => scrollEvents++);
+        target.addEventListener("scrollend", () => scrollEndEvents++);
+
+        // #target has overflow: visible, so it is not a scroll container.
+        target.scroll(40, 50);
+        println(`scroll() on a non-scroll-container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        target.scrollBy(40, 50);
+        println(`scrollBy() on a non-scroll-container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        target.scrollLeft = 40;
+        target.scrollTop = 50;
+        println(`scrollLeft/scrollTop on a non-scroll-container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        await animationFrame();
+        println(`scroll events on a non-scroll-container: ${scrollEvents}`);
+        println(`scrollend events on a non-scroll-container: ${scrollEndEvents}`);
+
+        // Becoming a scroll container must not reveal an offset written while the box was not one.
+        target.style.overflow = "hidden";
+        println(`after becoming a scroll container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        // An offset established while the box is a scroll container is restored when it becomes one again.
+        target.scroll(40, 50);
+        println(`scroll() on a scroll container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        target.style.overflow = "visible";
+        println(`after ceasing to be a scroll container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        // Scrolling while the box is not a scroll container must leave the stored offset alone.
+        target.scroll(10, 20);
+        target.scrollBy(10, 20);
+        target.scrollLeft = 10;
+        target.scrollTop = 20;
+        println(`after scrolling while not a scroll container: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+
+        target.style.overflow = "hidden";
+        println(`after becoming a scroll container again: scrollLeft=${target.scrollLeft} scrollTop=${target.scrollTop}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/dom-element-scroll.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/dom-element-scroll.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>dom-element-scroll tests</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrolltop">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+    #section1 {
+        width: 300px;
+        height: 500px;
+        top: 16px;
+        left: 16px;
+        border: inset gray 3px;
+        background: white;
+    }
+
+    #scrollable {
+        width: 400px;
+        height: 700px;
+        background: linear-gradient(135deg, red, blue);
+    }
+
+    #section2 {
+        width: 300px;
+        height: 500px;
+        top: 16px;
+        left: 16px;
+        border: inset gray 3px;
+        background: white;
+    }
+
+    #unscrollable {
+        width: 200px;
+        height: 300px;
+        background: linear-gradient(135deg, red, blue);
+    }
+</style>
+<section id="section1">
+    <div id="scrollable"></div>
+</section>
+<section id="section2">
+    <div id="unscrollable"></div>
+</section>
+<script>
+    var section1 = document.getElementById("section1");
+    var section2 = document.getElementById("section2");
+
+    test(function () {
+        // let it be "hidden" to have scrolling box
+        section1.style.overflow = "hidden";
+
+        section1.scroll(50, 60);
+        assert_equals(section1.scrollLeft, 50, "changed scrollLeft should be 50");
+        assert_equals(section1.scrollTop, 60, "changed scrollTop should be 60");
+
+        section1.scroll(0, 0); // back to the origin
+    }, "Element test for having scrolling box");
+
+    test(function () {
+        section1.scroll(10, 20);
+        assert_equals(section1.scrollLeft, 10, "changed scrollLeft should be 10");
+        assert_equals(section1.scrollTop, 20, "changed scrollTop should be 20");
+
+        section1.scroll(0, 0); // back to the origin
+    }, "Element test for having overflow");
+
+    test(function () {
+        // make it not "hidden" to not have scrolling box
+        section1.style.overflow = "visible";
+
+        section1.scroll(50, 0);
+        assert_equals(section1.scrollLeft, 0, "changed scrollLeft should be 0");
+        assert_equals(section1.scrollTop, 0, "changed scrollTop should be 0");
+
+        section1.scroll(0, 60);
+        assert_equals(section1.scrollLeft, 0, "changed scrollLeft should be 0");
+        assert_equals(section1.scrollTop, 0, "changed scrollTop should be 0");
+
+        section1.scroll(50, 60);
+        assert_equals(section1.scrollLeft, 0, "changed scrollLeft should be 0");
+        assert_equals(section1.scrollTop, 0, "changed scrollTop should be 0");
+
+        section1.scroll(0, 0); // back to the origin
+    }, "Element test for not having scrolling box");
+
+    test(function () {
+        section2.scroll(0, 20);
+        assert_equals(section2.scrollLeft, 0, "changed scrollLeft should be 0");
+        assert_equals(section2.scrollTop, 0, "changed scrollTop should be 0");
+
+        section2.scroll(10, 0);
+        assert_equals(section2.scrollLeft, 0, "changed scrollLeft should be 0");
+        assert_equals(section2.scrollTop, 0, "changed scrollTop should be 0");
+
+        section2.scroll(10, 20);
+        assert_equals(section2.scrollLeft, 0, "changed scrollLeft should be 0");
+        assert_equals(section2.scrollTop, 0, "changed scrollTop should be 0");
+    }, "Element test for not having overflow");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrolling-quirks-vs-nonquirks.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom-view/scrolling-quirks-vs-nonquirks.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>cssom-view - scrolling quirks VS nonquirks mode</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  iframe {
+    width: 300px;
+    height: 500px;
+  }
+</style>
+<iframe id="quirksframe"></iframe>
+<iframe id="nonquirksframe"></iframe>
+<div id="log"></div>
+<script>
+function setBodyContent(body)  {
+  // Hide scrollbars and remove body margin to make measures more reliable.
+  body.style.overflow = "hidden";
+  body.style.margin = 0;
+
+  // Add an orange border to the body.
+  body.style.borderWidth = "10px 0px 0px 20px";
+  body.style.borderColor = "orange";
+  body.style.borderStyle = "solid";
+
+  // Create a 700x900 box with a green border.
+  body.innerHTML = "<div id='content' style='border-width: 30px 0px 0px 40px; border-style: solid; border-color: green; width: 660px; height: 870px; background: linear-gradient(135deg, red, blue);'></div>";
+}
+
+var quirksModeTest = async_test("Execution of tests in quirks mode");
+var quirksFrame = document.getElementById("quirksframe");
+quirksFrame.onload = function() {
+  var doc = quirksFrame.contentDocument;
+  setBodyContent(doc.body);
+  var content = doc.getElementById("content");
+
+  quirksModeTest.step(function () {
+    assert_equals(doc.compatMode, "BackCompat", "Should be in quirks mode.");
+  });
+
+  test(function () {
+    assert_equals(doc.scrollingElement, doc.body, "scrollingElement should be HTML body");
+  }, "scrollingElement in quirks mode");
+
+  test(function () {
+    doc.documentElement.scroll(50, 60);
+    assert_equals(doc.documentElement.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.documentElement.scrollTop, 0, "scrollTop should be 0");
+  }, "scroll() on the root element in quirks mode");
+
+  test(function () {
+    doc.documentElement.scrollBy(10, 20);
+    assert_equals(doc.documentElement.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.documentElement.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollBy() on the root element in quirks mode");
+
+  test(function () {
+    doc.documentElement.scrollLeft = 70;
+    doc.documentElement.scrollTop = 80;
+    assert_equals(doc.documentElement.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.documentElement.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollLeft/scrollTop on the root element in quirks mode");
+
+  test(function () {
+    assert_equals(doc.documentElement.scrollWidth, 720, "scrollWidth should be 720");
+    assert_equals(doc.documentElement.scrollHeight, 910, "scrollHeight should be 910");
+  }, "scrollWidth/scrollHeight on the root element in quirks mode");
+
+  test(function () {
+    assert_equals(doc.documentElement.clientWidth, 300, "clientWidth should be 300");
+    assert_equals(doc.documentElement.clientHeight, 910, "clientHeight should be 910");
+  }, "clientWidth/clientHeight on the root element in quirks mode");
+
+  test(function () {
+    doc.body.scroll(90, 100);
+    assert_equals(doc.body.scrollLeft, 90, "scrollLeft should be 90");
+    assert_equals(doc.body.scrollTop, 100, "scrollTop should be 100");
+  }, "scroll() on the HTML body element in quirks mode");
+
+  test(function () {
+    doc.body.scrollBy(10, 20);
+    assert_equals(doc.body.scrollLeft, 100, "scrollLeft should be 100");
+    assert_equals(doc.body.scrollTop, 120, "scrollTop should be 120");
+  }, "scrollBy() on the HTML body element in quirks mode");
+
+  test(function () {
+    doc.body.scrollLeft = 120;
+    doc.body.scrollTop = 110;
+    assert_equals(doc.body.scrollLeft, 120, "scrollLeft should be 120");
+    assert_equals(doc.body.scrollTop, 110, "scrollTop should be 110");
+  }, "scrollLeft/scrollTop on the HTML body element in quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.scrollWidth, 720, "scrollWidth should be 720");
+    assert_equals(doc.body.scrollHeight, 910, "scrollHeight should be 910");
+  }, "scrollWidth/scrollHeight on the HTML body element in quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.clientWidth, 300, "clientWidth should be 300");
+    assert_equals(doc.body.clientHeight, 500, "clientHeight should be 500");
+  }, "clientWidth/clientHeight on the HTML body element in quirks mode");
+
+  test(function () {
+    doc.scrollingElement.scroll(0, 0);
+    content.scrollLeft = 130;
+    content.scrollTop = 140;
+    assert_equals(content.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(content.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollLeft/scrollRight of the content in quirks mode");
+
+  test(function () {
+    assert_equals(content.scrollWidth, 660, "scrollWidth should be 660");
+    assert_equals(content.scrollHeight, 870, "scrollHeight should be 870");
+  }, "scrollWidth/scrollHeight of the content in quirks mode");
+
+  test(function () {
+    assert_equals(content.clientWidth, 660, "clientWidth should be 660");
+    assert_equals(content.clientHeight, 870, "clientHeight should be 870");
+  }, "clientWidth/clientHeight of the content in quirks mode");
+
+  quirksModeTest.done();
+}
+quirksFrame.src = URL.createObjectURL(new Blob([""], { type: "text/html" }));
+
+var nonQuirksModeTest = async_test("Execution of tests in non-quirks mode");
+var nonQuirksFrame = document.getElementById("nonquirksframe");
+nonQuirksFrame.onload = function() {
+  var doc = nonQuirksFrame.contentDocument;
+  setBodyContent(doc.body);
+  var content = doc.getElementById("content");
+
+  nonQuirksModeTest.step(function() {
+    assert_equals(doc.compatMode, "CSS1Compat", "Should be in standards mode.");
+  });
+
+  test(function () {
+    assert_equals(doc.scrollingElement, doc.documentElement, "scrollingElement should be documentElement");
+  }, "scrollingElement in non-quirks mode");
+
+  test(function () {
+    doc.documentElement.scroll(50, 60);
+    assert_equals(doc.documentElement.scrollLeft, 50, "scrollLeft should be 50");
+    assert_equals(doc.documentElement.scrollTop, 60, "scrollTop should be 60");
+  }, "scroll() on the root element in non-quirks mode");
+
+  test(function () {
+    doc.documentElement.scrollBy(10, 20);
+    assert_equals(doc.documentElement.scrollLeft, 60, "scrollLeft should be 60");
+    assert_equals(doc.documentElement.scrollTop, 80, "scrollTop should be 80");
+  }, "scrollBy() on the root element in non-quirks mode");
+
+  test(function () {
+    doc.documentElement.scrollLeft = 70;
+    doc.documentElement.scrollTop = 80;
+    assert_equals(doc.documentElement.scrollLeft, 70, "scrollLeft should be 70");
+    assert_equals(doc.documentElement.scrollTop, 80, "scrollTop should be 80");
+  }, "scrollLeft/scrollTop on the root element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.documentElement.scrollWidth, 720, "scrollWidth should be 720");
+    assert_equals(doc.documentElement.scrollHeight, 910, "scrollHeight should be 910");
+  }, "scrollWidth/scrollHeight on the root element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.documentElement.clientWidth, 300, "clientWidth should be 300");
+    assert_equals(doc.documentElement.clientHeight, 500, "clientHeight should be 500");
+  }, "clientWidth/clientHeight on the root element in non-quirks mode");
+
+  test(function () {
+    doc.body.scroll(90, 100);
+    assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
+  }, "scroll() on the HTML body element in non-quirks mode");
+
+  test(function () {
+    doc.body.scrollBy(10, 20);
+    assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollBy() on the HTML body element in non-quirks mode");
+
+  test(function () {
+    doc.body.scrollLeft = 120;
+    doc.body.scrollTop = 110;
+    assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollLeft/scrollTop on the HTML body element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.scrollWidth, 700, "scrollWidth should be 700");
+    assert_equals(doc.body.scrollHeight, 900, "scrollHeight should be 900");
+  }, "scrollWidth/scrollHeight on the HTML body element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.clientWidth, 280, "clientWidth should be 280");
+    assert_equals(doc.body.clientHeight, 900, "clientHeight should be 900");
+  }, "clientWidth/clientHeight on the HTML body element in non-quirks mode");
+
+  test(function () {
+    doc.scrollingElement.scroll(0, 0);
+    content.scrollLeft = 130;
+    content.scrollTop = 140;
+    assert_equals(content.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(content.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollLeft/scrollRight of the content in non-quirks mode");
+
+  test(function () {
+    assert_equals(content.scrollWidth, 660, "scrollWidth should be 660");
+    assert_equals(content.scrollHeight, 870, "scrollHeight should be 870");
+  }, "scrollWidth/scrollHeight of the content in non-quirks mode");
+
+  test(function () {
+    assert_equals(content.clientWidth, 660, "clientWidth should be ");
+    assert_equals(content.clientHeight, 870, "clientHeight should be 870");
+  }, "clientWidth/clientHeight of the content in non-quirks mode");
+
+  nonQuirksModeTest.done();
+}
+nonQuirksFrame.src = URL.createObjectURL(new Blob(["<!doctype html>"], { type: "text/html" }));
+
+</script>


### PR DESCRIPTION
A box that is not a scroll container has no scroll position, but the scroll offset getters returned the offset stored from when it was one. Return zero for such boxes, while keeping the stored offset so that it is restored when the box becomes a scroll container again.

This is something else that I came across while debugging CSS scroll-snap issues.