### PR TITLE
LibWeb: Don’t navigate frames from creation/destruction bookkeeping

### DIFF
--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -980,6 +980,20 @@ void ApplyHistoryStepState::start()
         if (!target_entry)
             continue;
 
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction
+        // AD-HOC: Unconditionally populating a document here could unload and re-navigate a frame because an unrelated
+        //         navigable was created or destroyed — which no other engine does. So we skip such applying-the-target-
+        //         entry-would-cross-documents navigables here. A navigable still showing the initial about:blank
+        //         Document is the exception — activating its populated document is this update's job.
+        //         https://github.com/whatwg/html/issues/12724
+        if (!m_navigation_type.has_value()) {
+            bool would_cross_documents = target_entry->document_state()->document_id() != navigable->active_document_id()
+                || target_entry->document_state()->reload_pending();
+            auto active_document = navigable->active_document();
+            if (would_cross_documents && !(active_document && active_document->is_initial_about_blank()))
+                continue;
+        }
+
         // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event
         // NB: Same-document traversals are synchronous in browser engines, but the specification routes them through
         //     the traversal queue. If a later cross-document navigation has already claimed the navigable by the time

--- a/Tests/LibWeb/Crash/HTML/iframe-creation-bookkeeping-after-stale-push-step.html
+++ b/Tests/LibWeb/Crash/HTML/iframe-creation-bookkeeping-after-stale-push-step.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<!-- A same-document replace jumps the session history traversal queue while frameB's cross-document push is applying
+     its history step, and the nested run's newer generation keeps the outer push run from committing its step — pinning
+     the traversable's current session history step behind frameB's pushed entry's step. Appending an iframe then queues
+     the navigable-creation bookkeeping (a null-navigationType apply-history-step run), which sees frameB's target entry
+     pointing at a document other than the displayed one. It must not populate and swap documents for frameB: that fails
+     the spec step-11 assert that a creation/destruction update never performs a cross-document change. See #10893. -->
+<html class="test-wait">
+<iframe id="frameB" src="../../Assets/blank.html?b1"></iframe>
+<script>
+    window.onload = () => {
+        const frameB = document.getElementById("frameB");
+        const initialHistoryLength = history.length;
+        let storming = true;
+
+        window.onmessage = () => {
+            if (!storming)
+                return;
+            if (history.length > initialHistoryLength) {
+                storming = false;
+                return;
+            }
+            history.replaceState(null, "", "#storm");
+            window.postMessage(0, "*");
+        };
+
+        frameB.onload = () => {
+            storming = false;
+            const f = document.createElement("iframe");
+            document.body.append(f);
+            // Whether the bookkeeping run skips frameB (correct) or populates its target entry (the regression),
+            // nothing observable signals that it has finished; give it ample time.
+            setTimeout(() => {
+                document.documentElement.classList.remove("test-wait");
+            }, 500);
+        };
+
+        window.postMessage(0, "*");
+        frameB.contentWindow.location.href = "../../Assets/blank.html?b2";
+    };
+</script>
+</html>

--- a/Tests/LibWeb/Crash/HTML/iframe-creation-bookkeeping-during-pending-reload.html
+++ b/Tests/LibWeb/Crash/HTML/iframe-creation-bookkeeping-during-pending-reload.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!-- Appending an iframe queues the navigable-creation bookkeeping — a null-navigationType apply-history-step run.
+     reload() marks the reloading frame's active entry as reload-pending synchronously, before the reload's own history
+     step enters the session history traversal queue. The earlier-queued bookkeeping run must not pick up the pending
+     reload. Performing that would populate a fresh document, and fail the spec step-11 assert that a creation/
+     destruction update never performs a cross-document change. See #10893. -->
+<html class="test-wait">
+<iframe id="x" srcdoc="reloadable"></iframe>
+<script>
+    window.onload = () => {
+        setTimeout(() => {
+            const f = document.createElement("iframe");
+            document.body.append(f);
+            x.onload = () => document.documentElement.classList.remove("test-wait");
+            x.contentWindow.location.reload();
+        }, 0);
+    };
+</script>
+</html>


### PR DESCRIPTION
**Problem:** Crash with _“navigationType is not null”_ on pages creating/removing iframes while other session-history work is pending.

**Cause:** The update-for-navigable-creation/destruction bookkeeping applies the history step with a null `navigationType`, and the spec asserts such a run never performs a cross-document change. But the changing-navigables selection could in fact actually still hand it document-crossing work:

- A reload marks a frame’s active entry reload-pending synchronously — before the reload’s own history step enters the session history traversal queue. So, an already-queued bookkeeping run sees the flag first, populates a fresh document, and trips an assert.

- A same-document navigation that jumps the traversal queue mid-run can supersede an in-flight run’s step commit (e61a91c017e) — leaving the traversable’s current step selecting an entry other than a frame’s active entry. The next bookkeeping run then tries to populate that entry’s document and swap it in.

We inherited the inconsistency from the spec: It sets the reload-pending flag before the reload’s steps enter the traversal queue. No engine navigates, unloads, or reloads a sibling frame because an unrelated frame was created or destroyed: In all engines, frame creation and removal is pure session-history bookkeeping — and a pending reload is only ever executed by the reloading frame’s own task.

**Fix:** Skip a navigable in a null-`navigationType` apply-history-step run when applying its target entry would cross documents (the target entry’s document isn’t the active document, or a reload is pending) — leaving that work to the navigation, reload, or traversal that owns it. Except, don’t skip a navigable still showing the initial `about:blank` Document; activating the populated document for that is the creation update’s job. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10893.

The root cause of this is a spec bug; see https://github.com/whatwg/html/issues/12724.
