### PR TITLE
UI/Qt: Stop the New Tab button's hover highlight from getting stuck

### DIFF
--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -259,11 +259,6 @@ public:
     }
 
 private:
-    bool is_hovered() const
-    {
-        return rect().contains(mapFromGlobal(QCursor::pos()));
-    }
-
     virtual void enterEvent(QEnterEvent* event) override
     {
         QToolButton::enterEvent(event);
@@ -296,7 +291,7 @@ private:
                       ? horizontal_new_tab_button_shape_rect(QRectF(rect()))
                       : QRectF(rect()).adjusted(4.0, 3.0, -4.0, -3.0));
         auto tab_path = tab_shape_path(shape_rect, 9.0, 9.0);
-        auto hovered = is_hovered();
+        auto hovered = underMouse();
 
         if (isDown()) {
             painter.setBrush(ChromeStyle::chrome_surface_pressed(palette()));


### PR DESCRIPTION
The New Tab button's hover highlight could stay lit after the pointer moved away to a tab. It decided whether to paint the highlight by testing the global cursor position against its own rect, but only repainted on enter and leave, so any unrelated repaint could latch the highlight on with no matching repaint to clear it. Paint from underMouse() instead, which Qt updates in lockstep with the very enter and leave events that trigger our repaints.