### PR TITLE
LibWeb: Return slot ids instead of shells from layout FC callbacks

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -1184,7 +1184,7 @@ void LayoutRustBridge::compute_subtree_layout(Box& root, Painting::Paintable& pa
     };
 
     root.document().invalidate_stacking_context_tree();
-    auto callbacks = formatting_context_callbacks(&root);
+    auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
     RustFFI::rust_layout_compute_subtree_layout(
         Node::slot_id(&root),
@@ -1204,7 +1204,7 @@ void LayoutRustBridge::replay_saved_abspos_layout(Box& box, Painting::Paintable&
     };
 
     box.document().invalidate_stacking_context_tree();
-    auto callbacks = formatting_context_callbacks(&box);
+    auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
     RustFFI::rust_layout_replay_saved_abspos_layout(Node::slot_id(&box), &paintable_to_replace, &callbacks, &sink);
     VERIFY(!m_line_commit_context);
@@ -1668,7 +1668,7 @@ static bool can_skip_is_anonymous_text_run(Box& box)
     return false;
 }
 
-RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks(Node const* subtree_root)
+RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
 {
     static_assert(to_underlying(Painting::Paintable::ConflictingElementKind::Cell) == 0);
     static_assert(to_underlying(Painting::Paintable::ConflictingElementKind::Row) == 1);
@@ -1731,45 +1731,12 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks(Nod
     static_assert(offsetof(RustFFI::FfiDrawGlyph, glyph_id) == offsetof(Gfx::DrawGlyph, glyph_id));
     static_assert(offsetof(RustFFI::FfiDrawGlyph, should_paint) == offsetof(Gfx::DrawGlyph, should_paint));
 
-    size_t node_data_displacement = Node::node_data_displacement(*m_commit_root);
-
-    auto verify_node_data_displacement = [&](Node const& node) {
-        auto* data = *reinterpret_cast<RustFFI::NodeData* const*>(reinterpret_cast<u8 const*>(&node) + node_data_displacement);
-        VERIFY(data);
-        VERIFY(data->shell == const_cast<Node*>(&node));
-    };
-    verify_node_data_displacement(*m_commit_root);
-
-    // The displacement is one process-wide constant because every layout node
-    // derives from Node through a single non-virtual inheritance chain. Sample
-    // distinct vtables rather than class_name(), which not every subclass
-    // overrides, to catch that chain ever growing an offset-shifting base.
-    Array<void const*, 4> sampled_vtables {};
-    size_t sampled_vtable_count = 0;
-    m_commit_root->root().for_each_in_inclusive_subtree([&](Node const& node) {
-        auto const* vtable = *reinterpret_cast<void const* const*>(&node);
-        for (size_t index = 0; index < sampled_vtable_count; ++index) {
-            if (sampled_vtables[index] == vtable)
-                return TraversalDecision::Continue;
-        }
-        verify_node_data_displacement(node);
-        sampled_vtables[sampled_vtable_count++] = vtable;
-        if (sampled_vtable_count < sampled_vtables.size())
-            return TraversalDecision::Continue;
-        return TraversalDecision::Break;
-    });
-    if (subtree_root)
-        verify_node_data_displacement(*subtree_root);
-
     return {
         .context = this,
         .arena = m_commit_root->arena_handle(),
-        .node_data_displacement = node_data_displacement,
         .initial_containing_block_inline_size = m_commit_root->document().viewport_rect().width().raw_value(),
         .document_in_quirks_mode = m_commit_root->document().in_quirks_mode(),
-        .static_position_containing_block = [](void*, void* node) -> void* {
-            return const_cast<Box*>(static_cast<Box const*>(node)->static_position_containing_block());
-        },
+        .static_position_containing_block = [](void*, void* node) { return Node::slot_id(static_cast<Box const*>(node)->static_position_containing_block()); },
         .dom_node_is_inclusive_ancestor = [](void*, void* ancestor, void* node) {
             auto const* ancestor_dom_node = static_cast<Node const*>(ancestor)->dom_node();
             auto const* dom_node = static_cast<Node const*>(node)->dom_node();
@@ -1836,7 +1803,7 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks(Nod
             RustFFI::FfiListItemFacts facts {};
             auto const& layout_node = *static_cast<Node const*>(node);
             if (auto const* list_item_box = as_if<ListItemBox>(layout_node)) {
-                facts.marker = list_item_box->marker() ? const_cast<ListItemMarkerBox*>(list_item_box->marker()) : nullptr;
+                facts.marker = Node::slot_id(list_item_box->marker());
                 if (auto const* element = as_if<DOM::Element>(layout_node.dom_node())) {
                     if (auto const computed_values = element->computed_values(CSS::PseudoElement::Marker))
                         facts.has_css_marker_content = computed_values->content().has_value();
@@ -2003,16 +1970,14 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks(Nod
                 .width = bounding_box.width(),
                 .height = bounding_box.height(),
             }; },
-        .anchor_lookup = [](void*, void* node, size_t anchor_name, void* const* eligible_anchor_boxes, size_t eligible_anchor_box_count, void** out_anchor_box) {
-            VERIFY(out_anchor_box);
-            *out_anchor_box = nullptr;
+        .anchor_lookup = [](void*, void* node, size_t anchor_name, void* const* eligible_anchor_boxes, size_t eligible_anchor_box_count) {
             auto const& box = *static_cast<Box const*>(node);
             auto abstract_element = abstract_element_for_abspos_box(box);
             if (!abstract_element.has_value())
-                return false;
+                return RustFFI::NodeSlotId_INVALID;
             auto const* containing_block = box.containing_block();
             if (!containing_block)
-                return false;
+                return RustFFI::NodeSlotId_INVALID;
             Function<bool(DOM::Element&)> is_acceptable_anchor_element = [&](DOM::Element& candidate) {
                 auto const* anchor_box = as_if<Box>(candidate.unsafe_layout_node());
                 if (!anchor_box || anchor_box == &box)
@@ -2037,12 +2002,11 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks(Nod
                 abstract_element->element(),
                 is_acceptable_anchor_element);
             if (!anchor_element)
-                return false;
-            auto* anchor_box = as_if<Box>(anchor_element->unsafe_layout_node());
+                return RustFFI::NodeSlotId_INVALID;
+            auto const* anchor_box = as_if<Box>(anchor_element->unsafe_layout_node());
             if (!anchor_box)
-                return false;
-            *out_anchor_box = anchor_box;
-            return true; },
+                return RustFFI::NodeSlotId_INVALID;
+            return Node::slot_id(anchor_box); },
         .build_anchor_function_facts = [](void*, void const* shell) {
             auto value = CSS::StyleValue::adopt_rust_style_value_data(
                 CSS::StyleValueFFI::rust_style_value_retain(

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -37,7 +37,7 @@ public:
     void replay_saved_abspos_layout(Box&, Painting::Paintable& paintable_to_replace);
 
 private:
-    [[nodiscard]] RustFFI::FfiLayoutFcCallbacks formatting_context_callbacks(Node const* subtree_root = nullptr);
+    [[nodiscard]] RustFFI::FfiLayoutFcCallbacks formatting_context_callbacks();
     [[nodiscard]] RustFFI::FfiCommitSink commit_sink();
 
     struct LineCommitContext;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -209,11 +209,6 @@ RustFFI::NodeSlotId Node::slot_id(Node const* node)
     return node ? node->m_slot : RustFFI::NodeSlotId_INVALID;
 }
 
-size_t Node::node_data_displacement(Node const& node)
-{
-    return reinterpret_cast<u8 const*>(&node.m_data) - reinterpret_cast<u8 const*>(&node);
-}
-
 void Node::set_node_kind(RustFFI::NodeKind kind)
 {
     m_data->kind = kind;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -104,7 +104,6 @@ public:
 
     static RustFFI::NodeSlotId slot_id(Node const*);
     u32 arena_slot_index() const { return m_slot.index; }
-    static size_t node_data_displacement(Node const&);
     void* arena_handle() const;
 
     bool is_anonymous() const { return has_flag(RustFFI::NodeFlag::Anonymous); }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -285,10 +285,7 @@ impl<'a, 'pass> AbsposEngine<'a, 'pass> {
     }
 
     fn static_position_containing_block(&self, node: Node) -> Node {
-        let shell = unsafe {
-            (self.callbacks.static_position_containing_block)(self.callbacks.context, self.callbacks.shell(node))
-        };
-        self.callbacks.node_for_shell_or_invalid(shell)
+        unsafe { (self.callbacks.static_position_containing_block)(self.callbacks.context, self.callbacks.shell(node)) }
     }
 
     fn inline_containing_block(&self, node: Node) -> Node {
@@ -657,31 +654,24 @@ struct AnchorCalcCallbackContext<'a, 'pass> {
 
 impl AbsposEngine<'_, '_> {
     fn anchor_lookup(&self, positioned_box: Node, anchor_name: usize) -> Option<Node> {
-        let mut anchor_box = std::ptr::null_mut();
         let eligible_anchor_boxes = self.state.used_value_nodes();
         let eligible_anchor_shells = eligible_anchor_boxes
             .iter()
             .map(|&node| self.callbacks.shell(node))
             .collect::<Vec<_>>();
         // SAFETY: The name handle is retained by either the style snapshot or
-        // the live anchor() shell. The eligible-node slice and out pointer
-        // are borrowed only for this synchronous lookup.
-        let found = unsafe {
+        // the live anchor() shell. The eligible-node slice is borrowed only
+        // for this synchronous lookup.
+        let anchor_box = unsafe {
             (self.callbacks.anchor_lookup)(
                 self.callbacks.context,
                 self.callbacks.shell(positioned_box),
                 anchor_name,
                 eligible_anchor_shells.as_ptr(),
                 eligible_anchor_shells.len(),
-                &raw mut anchor_box,
             )
         };
-        if found {
-            assert!(!anchor_box.is_null());
-            Some(self.callbacks.node_for_shell(anchor_box))
-        } else {
-            None
-        }
+        (!anchor_box.is_invalid()).then_some(anchor_box)
     }
 
     fn nearest_scroll_container_ancestor(&self, node: Node) -> Node {
@@ -4762,10 +4752,9 @@ pub type FfiBuildTableBoxFactsCallback = unsafe extern "C" fn(*mut c_void, *mut 
 pub struct FfiLayoutFcCallbacks {
     pub context: *mut c_void,
     pub arena: *mut c_void,
-    pub node_data_displacement: usize,
     pub initial_containing_block_inline_size: CssPixels,
     pub document_in_quirks_mode: bool,
-    pub static_position_containing_block: unsafe extern "C" fn(*mut c_void, *mut c_void) -> *mut c_void,
+    pub static_position_containing_block: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub dom_node_is_inclusive_ancestor: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> bool,
     pub needs_inset_resolution: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub report_unexpected_fragmented_inline: unsafe extern "C" fn(*mut c_void, *mut c_void),
@@ -4792,8 +4781,7 @@ pub struct FfiLayoutFcCallbacks {
     pub compute_svg_path: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiSvgPathRequest) -> FfiSvgPathResult,
     pub release_svg_path: crate::layout::ReleaseRetainedLayoutHandle,
     pub svg_image_bounding_box: unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> FfiFloatRect,
-    pub anchor_lookup:
-        unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize, *mut *mut c_void) -> bool,
+    pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
     pub build_anchor_function_facts: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFunctionFacts,
     pub anchor_function_fallback: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFallbackFacts,
     pub set_resolved_anchor_insets: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiResolvedAnchorInsets),
@@ -4806,36 +4794,6 @@ impl FfiLayoutFcCallbacks {
         // SAFETY: C++ borrows the document arena for the synchronous layout
         // pass represented by this callback table.
         unsafe { LayoutNodeArena::from_handle(self.arena) }
-    }
-
-    fn node_data_pointer_for_shell(&self, shell: *mut c_void) -> *mut NodeData {
-        assert!(!shell.is_null());
-        // SAFETY: Every shell passed here comes from the single Layout::Node
-        // inheritance chain and outlives the synchronous layout pass.
-        let data = unsafe {
-            shell
-                .cast::<u8>()
-                .add(self.node_data_displacement)
-                .cast::<*mut NodeData>()
-                .read()
-        };
-        assert!(!data.is_null());
-        data
-    }
-
-    pub(crate) fn node_for_shell(&self, shell: *mut c_void) -> Node {
-        let data = self.node_data_pointer_for_shell(shell);
-        // SAFETY: node_data_pointer_for_shell() returned a live arena slot.
-        let generation = unsafe { (*data).slot_generation };
-        NodeSlotId::new(self.arena().slot_index_for_data(unsafe { &*data }), generation)
-    }
-
-    pub(crate) fn node_for_shell_or_invalid(&self, shell: *mut c_void) -> Node {
-        if shell.is_null() {
-            NodeSlotId::INVALID
-        } else {
-            self.node_for_shell(shell)
-        }
     }
 
     pub(crate) fn node_data(&self, node: Node) -> &NodeData {

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -316,10 +316,6 @@ impl LayoutNodeArena {
         (index, metadata)
     }
 
-    pub(crate) fn slot_index_for_data(&self, data: &NodeData) -> u32 {
-        self.slot_for_data(std::ptr::from_ref(data)).0
-    }
-
     pub(crate) fn is_before(&self, node: &NodeData, other: &NodeData) -> bool {
         let (node_index, node_metadata) = self.slot_for_data(std::ptr::from_ref(node));
         let (other_index, other_metadata) = self.slot_for_data(std::ptr::from_ref(other));

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -640,7 +640,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn list_item_marker(&self) -> Node {
-        self.callbacks.node_for_shell_or_invalid(self.list_item().marker)
+        self.list_item().marker
     }
 
     pub(crate) fn has_css_marker_content(&self) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -25,13 +25,13 @@ pub struct FfiReplacedContentFacts {
 }
 
 /// Marker linkage and font-measured marker metrics, fetched lazily once per
-/// pass for list items and their marker boxes only. The marker link mirrors
-/// the C++ WeakPtr so a marker detached mid-lifetime reads as absent instead
-/// of tripping a stale-slot assertion.
+/// pass for list items and their marker boxes only. The marker slot id is
+/// read from the C++ WeakPtr at fetch time, so a marker detached before the
+/// pass reads as INVALID instead of tripping a stale-slot assertion.
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiListItemFacts {
-    pub marker: *mut c_void,
+    pub marker: NodeSlotId,
     pub has_css_marker_content: bool,
     pub marker_content_inline_size: CssPixels,
     pub marker_content_block_size: CssPixels,
@@ -42,7 +42,7 @@ pub struct FfiListItemFacts {
 impl Default for FfiListItemFacts {
     fn default() -> Self {
         Self {
-            marker: std::ptr::null_mut(),
+            marker: NodeSlotId::INVALID,
             has_css_marker_content: false,
             marker_content_inline_size: CssPixels::default(),
             marker_content_block_size: CssPixels::default(),


### PR DESCRIPTION
The formatting-context callbacks handed raw Layout::Node pointers back into Rust in three places (static position containing block, anchor lookup, and the list item marker in the list item facts), forcing the Rust side to reconstruct arena slot ids by reading the NodeData pointer at a byte displacement inside the C++ object. That displacement had to be computed at runtime and defended by a vtable-sampling verification walk over the layout tree, all resting on the assumption that every layout node class keeps its NodeData member at one process-wide offset.

Slot ids are already the canonical cross-boundary node reference: the topology synchronization writes them into NodeData, and Node::slot_id() is a single field read carrying the packed index and generation. Return slot ids from the three callbacks directly, which lets the displacement field, the verification walk, and the Rust-side unsafe pointer arithmetic all be deleted with no replacement. The anchor lookup's bool-plus-out-pointer shape collapses into returning an invalid slot id for "not found", and the marker link in the list item facts still reads the C++ WeakPtr at fetch time, so a detached marker stays absent rather than becoming a stale slot reference.