### PR TITLE
LibWeb: Reuse intrinsic inline measurements

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -3362,7 +3362,7 @@ impl<'pass> SizingContext<'pass> {
             - used.border_bottom.get()
     }
 
-    fn intrinsic_cache_get(
+    fn intrinsic_block_cache_get(
         &self,
         node: Node,
         kind: IntrinsicSizeCacheKind,
@@ -3370,10 +3370,10 @@ impl<'pass> SizingContext<'pass> {
     ) -> Option<CssPixels> {
         self.callbacks
             .arena()
-            .intrinsic_size_cache_get(self.callbacks.node_data(node), kind, key)
+            .intrinsic_block_size_cache_get(self.callbacks.node_data(node), kind, key)
     }
 
-    fn intrinsic_cache_put(
+    fn intrinsic_block_cache_put(
         &self,
         node: Node,
         kind: IntrinsicSizeCacheKind,
@@ -3382,7 +3382,102 @@ impl<'pass> SizingContext<'pass> {
     ) {
         self.callbacks
             .arena()
-            .intrinsic_size_cache_put(self.callbacks.node_data(node), kind, key, value);
+            .intrinsic_block_size_cache_put(self.callbacks.node_data(node), kind, key, value);
+    }
+
+    fn intrinsic_inline_measurement_cache_get(
+        &self,
+        node: Node,
+        kind: IntrinsicSizeCacheKind,
+        key: IntrinsicSizeCacheKey,
+    ) -> Option<IntrinsicInlineSizeMeasurement> {
+        self.callbacks.arena().intrinsic_inline_size_measurement_cache_get(
+            self.callbacks.node_data(node),
+            kind,
+            key,
+        )
+    }
+
+    fn intrinsic_inline_measurement_cache_put(
+        &self,
+        node: Node,
+        kind: IntrinsicSizeCacheKind,
+        key: IntrinsicSizeCacheKey,
+        value: IntrinsicInlineSizeMeasurement,
+    ) {
+        self.callbacks.arena().intrinsic_inline_size_measurement_cache_put(
+            self.callbacks.node_data(node),
+            kind,
+            key,
+            value,
+        );
+    }
+
+    fn cache_intrinsic_inline_measurement(
+        &self,
+        node: Node,
+        kind: IntrinsicSizeCacheKind,
+        key: IntrinsicSizeCacheKey,
+        measurement: &MeasurementState,
+        result: ChildLayoutResult,
+        available_block_size: AvailableSize,
+    ) {
+        let used = measurement.root_used();
+        self.intrinsic_inline_measurement_cache_put(
+            node,
+            kind,
+            key,
+            IntrinsicInlineSizeMeasurement {
+                automatic_content_inline_size: result.automatic_content_inline_size,
+                available_block_size,
+                content_inline_size: used.content_inline_size.get(),
+                content_block_size: used.content_block_size.get(),
+                automatic_content_block_size: result.automatic_content_block_size,
+                uses_collapsing_borders_model: used.uses_collapsing_borders_model.get(),
+                has_first_baseline: used.has_first_baseline.get(),
+                first_baseline: used.first_baseline.get(),
+                has_last_baseline: used.has_last_baseline.get(),
+                last_baseline: used.last_baseline.get(),
+            },
+        );
+    }
+
+    pub(crate) fn apply_cached_intrinsic_inline_measurement(
+        &self,
+        node: Node,
+        available_inline_size: AvailableSize,
+        available_block_size: AvailableSize,
+        constraints: ContainingBlockConstraints,
+    ) -> Option<CssPixels> {
+        // OPTIMIZATION: Calculating an intrinsic inline size already performs a complete measurement layout.
+        // A later equivalent intrinsic line build only consumes the atomic box's measured dimensions and
+        // baselines, so retain that summary instead of formatting the same descendants again. Commit layout
+        // must still create all descendant geometry.
+        if !self.state.is_measurement() {
+            return None;
+        }
+        let kind = match available_inline_size {
+            AvailableSize::MinContent => IntrinsicSizeCacheKind::MinContentInline,
+            AvailableSize::MaxContent => IntrinsicSizeCacheKind::MaxContentInline,
+            AvailableSize::Definite(_) | AvailableSize::Indefinite => return None,
+        };
+        let measurement = self.intrinsic_inline_measurement_cache_get(node, kind, cache_key(None, constraints))?;
+        if measurement.available_block_size != available_block_size {
+            return None;
+        }
+        let used = self.used_mut(node);
+        if used.content_inline_size.get() != measurement.content_inline_size {
+            return None;
+        }
+
+        used.set_content_block_size(measurement.content_block_size);
+        used.uses_collapsing_borders_model
+            .set(measurement.uses_collapsing_borders_model);
+        used.has_first_baseline.set(measurement.has_first_baseline);
+        used.first_baseline.set(measurement.first_baseline);
+        used.has_last_baseline.set(measurement.has_last_baseline);
+        used.last_baseline.set(measurement.last_baseline);
+        Some(measurement.automatic_content_block_size)
     }
 
     fn calculate_transferred_inline_size_for_replaced_element(
@@ -3473,8 +3568,10 @@ impl<'pass> SizingContext<'pass> {
             return CssPixels::default();
         }
         let key = cache_key(None, constraints);
-        if let Some(cached) = self.intrinsic_cache_get(node, IntrinsicSizeCacheKind::MinContentInline, key) {
-            return cached;
+        if let Some(cached) =
+            self.intrinsic_inline_measurement_cache_get(node, IntrinsicSizeCacheKind::MinContentInline, key)
+        {
+            return cached.automatic_content_inline_size;
         }
 
         let measurement = MeasurementState::create(self.callbacks, node, constraints);
@@ -3486,7 +3583,7 @@ impl<'pass> SizingContext<'pass> {
         } else {
             AvailableSize::Indefinite
         };
-        let result = measurement.run(
+        let mut result = measurement.run(
             node,
             LayoutInput {
                 available_space: AvailableSpace {
@@ -3498,8 +3595,16 @@ impl<'pass> SizingContext<'pass> {
                 table_grid_min_border_box_block_size: None,
             },
         );
-        let value = clamp_to_max_dimension_value(result.automatic_content_inline_size);
-        self.intrinsic_cache_put(node, IntrinsicSizeCacheKind::MinContentInline, key, value);
+        result.automatic_content_inline_size = clamp_to_max_dimension_value(result.automatic_content_inline_size);
+        let value = result.automatic_content_inline_size;
+        self.cache_intrinsic_inline_measurement(
+            node,
+            IntrinsicSizeCacheKind::MinContentInline,
+            key,
+            &measurement,
+            result,
+            block_size,
+        );
         value
     }
 
@@ -3663,8 +3768,10 @@ impl<'pass> SizingContext<'pass> {
             return CssPixels::default();
         }
         let key = cache_key(None, constraints);
-        if let Some(cached) = self.intrinsic_cache_get(node, IntrinsicSizeCacheKind::MaxContentInline, key) {
-            return cached;
+        if let Some(cached) =
+            self.intrinsic_inline_measurement_cache_get(node, IntrinsicSizeCacheKind::MaxContentInline, key)
+        {
+            return cached.automatic_content_inline_size;
         }
 
         let measurement = MeasurementState::create(self.callbacks, node, constraints);
@@ -3676,7 +3783,7 @@ impl<'pass> SizingContext<'pass> {
         } else {
             AvailableSize::Indefinite
         };
-        let result = measurement.run(
+        let mut result = measurement.run(
             node,
             LayoutInput {
                 available_space: AvailableSpace {
@@ -3688,8 +3795,16 @@ impl<'pass> SizingContext<'pass> {
                 table_grid_min_border_box_block_size: None,
             },
         );
-        let value = clamp_to_max_dimension_value(result.automatic_content_inline_size);
-        self.intrinsic_cache_put(node, IntrinsicSizeCacheKind::MaxContentInline, key, value);
+        result.automatic_content_inline_size = clamp_to_max_dimension_value(result.automatic_content_inline_size);
+        let value = result.automatic_content_inline_size;
+        self.cache_intrinsic_inline_measurement(
+            node,
+            IntrinsicSizeCacheKind::MaxContentInline,
+            key,
+            &measurement,
+            result,
+            block_size,
+        );
         value
     }
 
@@ -3714,7 +3829,7 @@ impl<'pass> SizingContext<'pass> {
             return CssPixels::default();
         }
         let key = cache_key(Some(inline_size), constraints);
-        if let Some(cached) = self.intrinsic_cache_get(node, IntrinsicSizeCacheKind::MinContentBlock, key) {
+        if let Some(cached) = self.intrinsic_block_cache_get(node, IntrinsicSizeCacheKind::MinContentBlock, key) {
             return cached;
         }
 
@@ -3736,7 +3851,7 @@ impl<'pass> SizingContext<'pass> {
             },
         );
         let value = clamp_to_max_dimension_value(result.automatic_content_block_size);
-        self.intrinsic_cache_put(node, IntrinsicSizeCacheKind::MinContentBlock, key, value);
+        self.intrinsic_block_cache_put(node, IntrinsicSizeCacheKind::MinContentBlock, key, value);
         value
     }
 
@@ -3766,7 +3881,7 @@ impl<'pass> SizingContext<'pass> {
             return CssPixels::default();
         }
         let key = cache_key(Some(inline_size), constraints);
-        if let Some(cached) = self.intrinsic_cache_get(node, IntrinsicSizeCacheKind::MaxContentBlock, key) {
+        if let Some(cached) = self.intrinsic_block_cache_get(node, IntrinsicSizeCacheKind::MaxContentBlock, key) {
             return cached;
         }
 
@@ -3788,7 +3903,7 @@ impl<'pass> SizingContext<'pass> {
             },
         );
         let value = clamp_to_max_dimension_value(result.automatic_content_block_size);
-        self.intrinsic_cache_put(node, IntrinsicSizeCacheKind::MaxContentBlock, key, value);
+        self.intrinsic_block_cache_put(node, IntrinsicSizeCacheKind::MaxContentBlock, key, value);
         value
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -730,13 +730,19 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         next.map(|next| next - containing_block_offset_in_root)
     }
 
-    fn parent_resolve_used_block_size(&self, node: Node, treated_as_auto: bool, available_space: AvailableSpace) {
+    fn parent_resolve_used_block_size(
+        &self,
+        node: Node,
+        treated_as_auto: bool,
+        available_space: AvailableSpace,
+        child_automatic_block_size: Option<CssPixels>,
+    ) {
         if treated_as_auto {
             self.parent.resolve_used_block_size_if_treated_as_auto(
                 node,
                 available_space,
                 self.input.containing_block_constraints,
-                None,
+                child_automatic_block_size,
             );
         } else {
             self.parent.resolve_used_block_size_if_not_treated_as_auto(
@@ -898,19 +904,32 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
             inline_size: crate::layout::AvailableSize::definite(inline_size),
             block_size: crate::layout::AvailableSize::Indefinite,
         };
-        self.parent_resolve_used_block_size(node, false, inline_definite_space);
+        self.parent_resolve_used_block_size(node, false, inline_definite_space, None);
         if style.display.is_flex_inside() {
-            self.parent_resolve_used_block_size(node, true, inline_definite_space);
+            self.parent_resolve_used_block_size(node, true, inline_definite_space, None);
         }
         sizing.make_button_content_box_definite(node, self.layout_mode, available_space, constraints, None);
+        let inner_before_cached_measurement = self
+            .used(node)
+            .available_inner_space_or_constraints_from(available_space);
+        let cached_automatic_block_size = sizing.apply_cached_intrinsic_inline_measurement(
+            node,
+            available_space.inline_size,
+            inner_before_cached_measurement.block_size,
+            constraints,
+        );
         let inner = self
             .used(node)
             .available_inner_space_or_constraints_from(available_space);
-        let child_layout = self.layout_inside(node, inner);
-        if sizing.should_treat_block_size_as_auto(node, available_space, constraints) {
-            self.parent_resolve_used_block_size(node, true, available_space);
+        let child_layout = if cached_automatic_block_size.is_some() {
+            None
         } else {
-            self.parent_resolve_used_block_size(node, false, available_space);
+            self.layout_inside(node, inner)
+        };
+        if sizing.should_treat_block_size_as_auto(node, available_space, constraints) {
+            self.parent_resolve_used_block_size(node, true, available_space, cached_automatic_block_size);
+        } else {
+            self.parent_resolve_used_block_size(node, false, available_space, None);
         }
         if let Some(child_layout) = child_layout {
             child_layout.finish();

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -6,6 +6,7 @@
 
 use crate::abort_on_panic;
 use crate::layout::AbsposLayoutInputs;
+use crate::layout::AvailableSize;
 use crate::layout::CssPixels;
 use crate::layout::kind_is_box;
 use crate::layout::node_data::{MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeSlotId};
@@ -52,30 +53,67 @@ pub(crate) enum IntrinsicSizeCacheKind {
     MaxContentBlock,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct IntrinsicInlineSizeMeasurement {
+    pub(crate) automatic_content_inline_size: CssPixels,
+    pub(crate) available_block_size: AvailableSize,
+    pub(crate) content_inline_size: CssPixels,
+    pub(crate) content_block_size: CssPixels,
+    pub(crate) automatic_content_block_size: CssPixels,
+    pub(crate) uses_collapsing_borders_model: bool,
+    pub(crate) has_first_baseline: bool,
+    pub(crate) first_baseline: CssPixels,
+    pub(crate) has_last_baseline: bool,
+    pub(crate) last_baseline: CssPixels,
+}
+
 #[derive(Default)]
 struct IntrinsicSizeMaps {
-    min_content_inline_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
-    max_content_inline_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
+    min_content_inline_size: HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>,
+    max_content_inline_size: HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>,
     min_content_block_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
     max_content_block_size: HashMap<IntrinsicSizeCacheKey, CssPixels>,
 }
 
 impl IntrinsicSizeMaps {
-    fn values(&self, kind: IntrinsicSizeCacheKind) -> &HashMap<IntrinsicSizeCacheKey, CssPixels> {
+    fn block_sizes(&self, kind: IntrinsicSizeCacheKind) -> Option<&HashMap<IntrinsicSizeCacheKey, CssPixels>> {
         match kind {
-            IntrinsicSizeCacheKind::MinContentInline => &self.min_content_inline_size,
-            IntrinsicSizeCacheKind::MaxContentInline => &self.max_content_inline_size,
-            IntrinsicSizeCacheKind::MinContentBlock => &self.min_content_block_size,
-            IntrinsicSizeCacheKind::MaxContentBlock => &self.max_content_block_size,
+            IntrinsicSizeCacheKind::MinContentInline | IntrinsicSizeCacheKind::MaxContentInline => None,
+            IntrinsicSizeCacheKind::MinContentBlock => Some(&self.min_content_block_size),
+            IntrinsicSizeCacheKind::MaxContentBlock => Some(&self.max_content_block_size),
         }
     }
 
-    fn values_mut(&mut self, kind: IntrinsicSizeCacheKind) -> &mut HashMap<IntrinsicSizeCacheKey, CssPixels> {
+    fn block_sizes_mut(
+        &mut self,
+        kind: IntrinsicSizeCacheKind,
+    ) -> Option<&mut HashMap<IntrinsicSizeCacheKey, CssPixels>> {
         match kind {
-            IntrinsicSizeCacheKind::MinContentInline => &mut self.min_content_inline_size,
-            IntrinsicSizeCacheKind::MaxContentInline => &mut self.max_content_inline_size,
-            IntrinsicSizeCacheKind::MinContentBlock => &mut self.min_content_block_size,
-            IntrinsicSizeCacheKind::MaxContentBlock => &mut self.max_content_block_size,
+            IntrinsicSizeCacheKind::MinContentInline | IntrinsicSizeCacheKind::MaxContentInline => None,
+            IntrinsicSizeCacheKind::MinContentBlock => Some(&mut self.min_content_block_size),
+            IntrinsicSizeCacheKind::MaxContentBlock => Some(&mut self.max_content_block_size),
+        }
+    }
+
+    fn inline_measurements(
+        &self,
+        kind: IntrinsicSizeCacheKind,
+    ) -> Option<&HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>> {
+        match kind {
+            IntrinsicSizeCacheKind::MinContentInline => Some(&self.min_content_inline_size),
+            IntrinsicSizeCacheKind::MaxContentInline => Some(&self.max_content_inline_size),
+            IntrinsicSizeCacheKind::MinContentBlock | IntrinsicSizeCacheKind::MaxContentBlock => None,
+        }
+    }
+
+    fn inline_measurements_mut(
+        &mut self,
+        kind: IntrinsicSizeCacheKind,
+    ) -> Option<&mut HashMap<IntrinsicSizeCacheKey, IntrinsicInlineSizeMeasurement>> {
+        match kind {
+            IntrinsicSizeCacheKind::MinContentInline => Some(&mut self.min_content_inline_size),
+            IntrinsicSizeCacheKind::MaxContentInline => Some(&mut self.max_content_inline_size),
+            IntrinsicSizeCacheKind::MinContentBlock | IntrinsicSizeCacheKind::MaxContentBlock => None,
         }
     }
 }
@@ -420,12 +458,19 @@ impl LayoutNodeArena {
         false
     }
 
-    pub(crate) fn intrinsic_size_cache_get(
+    pub(crate) fn intrinsic_block_size_cache_get(
         &self,
         data: &NodeData,
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
     ) -> Option<CssPixels> {
+        assert!(
+            matches!(
+                kind,
+                IntrinsicSizeCacheKind::MinContentBlock | IntrinsicSizeCacheKind::MaxContentBlock
+            ),
+            "block size cache kind must use the block axis"
+        );
         if data.intrinsic_cache_epoch == u16::MAX {
             return None;
         }
@@ -436,16 +481,15 @@ impl LayoutNodeArena {
         if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
             return None;
         }
-        slot.sizes.as_ref()?.values(kind).get(&key).copied()
+        slot.sizes
+            .as_ref()?
+            .block_sizes(kind)
+            .expect("block size cache kind must use the block axis")
+            .get(&key)
+            .copied()
     }
 
-    pub(crate) fn intrinsic_size_cache_put(
-        &self,
-        data: &NodeData,
-        kind: IntrinsicSizeCacheKind,
-        key: IntrinsicSizeCacheKey,
-        value: CssPixels,
-    ) {
+    fn with_intrinsic_size_maps_mut(&self, data: &NodeData, callback: impl FnOnce(&mut IntrinsicSizeMaps)) {
         if data.intrinsic_cache_epoch == u16::MAX {
             return;
         }
@@ -463,10 +507,66 @@ impl LayoutNodeArena {
                 sizes: Some(Box::default()),
             };
         }
+        callback(slot.sizes.get_or_insert_with(Box::default));
+    }
+
+    pub(crate) fn intrinsic_block_size_cache_put(
+        &self,
+        data: &NodeData,
+        kind: IntrinsicSizeCacheKind,
+        key: IntrinsicSizeCacheKey,
+        value: CssPixels,
+    ) {
+        self.with_intrinsic_size_maps_mut(data, |maps| {
+            maps.block_sizes_mut(kind)
+                .expect("block size cache kind must use the block axis")
+                .insert(key, value);
+        });
+    }
+
+    pub(crate) fn intrinsic_inline_size_measurement_cache_get(
+        &self,
+        data: &NodeData,
+        kind: IntrinsicSizeCacheKind,
+        key: IntrinsicSizeCacheKey,
+    ) -> Option<IntrinsicInlineSizeMeasurement> {
+        assert!(
+            matches!(
+                kind,
+                IntrinsicSizeCacheKind::MinContentInline | IntrinsicSizeCacheKind::MaxContentInline
+            ),
+            "inline measurement cache kind must use the inline axis"
+        );
+        if data.intrinsic_cache_epoch == u16::MAX {
+            return None;
+        }
+
+        let (index, metadata) = self.slot_for_data(std::ptr::from_ref(data));
+        let caches = self.intrinsic_size_caches.borrow();
+        let slot = caches.get(index as usize)?;
+        if slot.generation != metadata.generation || slot.epoch != data.intrinsic_cache_epoch {
+            return None;
+        }
         slot.sizes
-            .get_or_insert_with(Box::default)
-            .values_mut(kind)
-            .insert(key, value);
+            .as_ref()?
+            .inline_measurements(kind)
+            .expect("inline measurement cache kind must use the inline axis")
+            .get(&key)
+            .copied()
+    }
+
+    pub(crate) fn intrinsic_inline_size_measurement_cache_put(
+        &self,
+        data: &NodeData,
+        kind: IntrinsicSizeCacheKind,
+        key: IntrinsicSizeCacheKey,
+        value: IntrinsicInlineSizeMeasurement,
+    ) {
+        self.with_intrinsic_size_maps_mut(data, |maps| {
+            maps.inline_measurements_mut(kind)
+                .expect("inline measurement cache kind must use the inline axis")
+                .insert(key, value);
+        });
     }
 
     pub(crate) fn saved_abspos_layout_inputs(&self, data: *const NodeData) -> Option<AbsposLayoutInputs> {
@@ -754,15 +854,16 @@ pub unsafe extern "C" fn layout_arena_transfer_saved_abspos_layout_inputs(
 
 #[cfg(test)]
 mod tests {
-    use crate::layout::CssPixels;
     use crate::layout::layout_node_arena::{
-        Chunk, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena, SLOTS_PER_CHUNK,
+        Chunk, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena,
+        SLOTS_PER_CHUNK,
     };
     use crate::layout::node_data::{NodeFlag, NodeKind};
     use crate::layout::{
         AbsposAlignment, AbsposAxisMode, AbsposContainingBlockInfo, AbsposLayoutInputs, StaticPositionAlignment,
         StaticPositionRect,
     };
+    use crate::layout::{AvailableSize, CssPixels};
 
     #[test]
     fn node_data_addresses_remain_stable_when_chunks_are_added() {
@@ -831,18 +932,52 @@ mod tests {
             ..Default::default()
         };
         let value = CssPixels::from_raw(128);
+        let inline_measurement = IntrinsicInlineSizeMeasurement {
+            automatic_content_inline_size: CssPixels::from_raw(192),
+            available_block_size: AvailableSize::MaxContent,
+            content_inline_size: CssPixels::from_raw(192),
+            content_block_size: CssPixels::from_raw(256),
+            automatic_content_block_size: CssPixels::from_raw(320),
+            uses_collapsing_borders_model: true,
+            has_first_baseline: true,
+            first_baseline: CssPixels::from_raw(64),
+            has_last_baseline: true,
+            last_baseline: CssPixels::from_raw(128),
+        };
 
         // SAFETY: The allocation remains live until it is explicitly freed below.
         let first_data = unsafe { &mut *first.data };
-        arena.intrinsic_size_cache_put(first_data, IntrinsicSizeCacheKind::MinContentBlock, key, value);
+        arena.intrinsic_block_size_cache_put(first_data, IntrinsicSizeCacheKind::MinContentBlock, key, value);
+        arena.intrinsic_inline_size_measurement_cache_put(
+            first_data,
+            IntrinsicSizeCacheKind::MaxContentInline,
+            key,
+            inline_measurement,
+        );
         assert_eq!(
-            arena.intrinsic_size_cache_get(first_data, IntrinsicSizeCacheKind::MinContentBlock, key),
+            arena.intrinsic_block_size_cache_get(first_data, IntrinsicSizeCacheKind::MinContentBlock, key),
             Some(value)
+        );
+        assert_eq!(
+            arena.intrinsic_inline_size_measurement_cache_get(
+                first_data,
+                IntrinsicSizeCacheKind::MaxContentInline,
+                key
+            ),
+            Some(inline_measurement)
         );
 
         first_data.intrinsic_cache_epoch += 1;
         assert_eq!(
-            arena.intrinsic_size_cache_get(first_data, IntrinsicSizeCacheKind::MinContentBlock, key),
+            arena.intrinsic_block_size_cache_get(first_data, IntrinsicSizeCacheKind::MinContentBlock, key),
+            None
+        );
+        assert_eq!(
+            arena.intrinsic_inline_size_measurement_cache_get(
+                first_data,
+                IntrinsicSizeCacheKind::MaxContentInline,
+                key
+            ),
             None
         );
         arena.free(first.slot, first.generation);
@@ -853,7 +988,15 @@ mod tests {
         // SAFETY: The second allocation is live and reuses the first allocation's slot.
         let second_data = unsafe { &*second.data };
         assert_eq!(
-            arena.intrinsic_size_cache_get(second_data, IntrinsicSizeCacheKind::MinContentBlock, key),
+            arena.intrinsic_block_size_cache_get(second_data, IntrinsicSizeCacheKind::MinContentBlock, key),
+            None
+        );
+        assert_eq!(
+            arena.intrinsic_inline_size_measurement_cache_get(
+                second_data,
+                IntrinsicSizeCacheKind::MaxContentInline,
+                key
+            ),
             None
         );
         arena.free(second.slot, second.generation);

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -39,6 +39,7 @@ mod tree_builder;
 
 include!("used_values.rs");
 
+use crate::layout::layout_node_arena::IntrinsicInlineSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKey;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKind;
 use crate::layout::layout_node_arena::LayoutNodeArena;


### PR DESCRIPTION
Intrinsic inline sizing performs a complete measurement layout, but its cache retained only the resulting scalar size. Nested atomic inline boxes therefore repeated descendant line building when a parent consumed their block size and baseline during its own intrinsic measurement.

Store the automatic sizes, resolved content sizes, collapsing-border mode, and baselines as one indivisible inline cache entry. Reapply that summary only to an equivalent measurement layout; committed layout still formats the full subtree and produces all persistent geometry.

Cover the expanded entry with the existing epoch and generation validation test.