### PR TITLE
Meta: Build QtPositioning on platforms where qtbase is built by vcpkg

### DIFF
--- a/Meta/Linters/check_flatpak.py
+++ b/Meta/Linters/check_flatpak.py
@@ -45,7 +45,6 @@ flatpak_runtime_libs = [
     "libproxy",
     "nghttp2",
     "qtbase",
-    "qtmultimedia",
     "qtpositioning",
     "qtserialport",
     "sqlite3",

--- a/Meta/Linters/check_flatpak.py
+++ b/Meta/Linters/check_flatpak.py
@@ -46,6 +46,8 @@ flatpak_runtime_libs = [
     "nghttp2",
     "qtbase",
     "qtmultimedia",
+    "qtpositioning",
+    "qtserialport",
     "sqlite3",
     "tiff",
     "vulkan",

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(audio)
-
 set(SOURCES
     ConnectionFromClient.cpp
     ConsoleGlobalEnvironmentExtensions.cpp

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_AUTOUIC ON)
 find_package(Qt6 6.9 REQUIRED COMPONENTS Core Widgets)
 
 if (NOT APPLE)
-    find_package(Qt6 6.9 OPTIONAL_COMPONENTS Positioning)
+    find_package(Qt6 6.9 REQUIRED COMPONENTS Positioning)
 endif()
 
 if (APPLE OR HAS_DIRECTX)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -172,6 +172,11 @@
       ]
     },
     {
+      "name": "qtpositioning",
+      "platform": "windows | freebsd",
+      "default-features": false
+    },
+    {
       "name": "sdl3",
       "default-features": false
     },
@@ -374,6 +379,14 @@
     {
       "name": "qtbase",
       "version": "6.10.0#1"
+    },
+    {
+      "name": "qtpositioning",
+      "version": "6.10.0#0"
+    },
+    {
+      "name": "qtserialport",
+      "version": "6.10.0#0"
     },
     {
       "name": "sdl3",


### PR DESCRIPTION
At the moment, this is Windows. The BSD support is mostly theoretical. Note that qtserialport is a dependency of qtpositioning, so its version must be pinned to match the other qt modules.

Also, fix up the flatpak linter to remove a special case for qtmultimedia, which is no longer used.