### PR TITLE
Meta: Isolate IDL dictionary declaration order from python determinism

### DIFF
--- a/Meta/Generators/libweb_bindings/to_idl_value.py
+++ b/Meta/Generators/libweb_bindings/to_idl_value.py
@@ -175,12 +175,12 @@ def dictionaries_in_dependency_order(dictionaries: List[Dictionary], context: Ge
     visiting: set[str] = set()
     ordered_dictionaries: List[Dictionary] = []
 
-    def dependency_names_for(dictionary: Dictionary) -> set[str]:
+    def dependency_names_for(dictionary: Dictionary) -> List[str]:
         dependency_names = {dictionary.parent_name} if dictionary.parent_name else set()
         for member in dictionary.members:
             dependency_names.update(context.dictionary_type_names(member.type))
         dependency_names.discard(dictionary.name)
-        return dependency_names
+        return sorted(dependency_names)
 
     def visit(dictionary: Dictionary) -> None:
         if dictionary.name in emitted:


### PR DESCRIPTION
When visiting dictionary dependencies, we previously iterated over a set() of names, which is a non-deterministic iteration in python3.

By sorting the list of dependency dictionaries before visting them, we can ensure that there is no unnecessary header file churn from the order dictionary structs are laid out in the generated header files.

Fixes #10899