### PR TITLE
Read display from the box payload and drop the style snapshot

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -3824,6 +3824,35 @@ TouchActionData ComputedProperties::touch_action() const
     return TouchActionData {};
 }
 
+AspectRatio ComputedProperties::aspect_ratio() const
+{
+    auto const& value = property(PropertyID::AspectRatio);
+
+    if (value.is_value_list()) {
+        auto const& values = value.as_value_list().values();
+        if (values.size() == 2
+            && values[0]->is_keyword() && values[0]->as_keyword().keyword() == Keyword::Auto
+            && values[1]->is_ratio()) {
+            auto ratio = values[1]->as_ratio().resolved();
+            if (ratio.is_degenerate())
+                return { true, {}, true, ratio };
+            return { true, ratio, true, ratio };
+        }
+        return InitialValues::aspect_ratio();
+    }
+
+    if (value.is_ratio()) {
+        // https://drafts.csswg.org/css-sizing-4/#aspect-ratio
+        // If the <ratio> is degenerate, the property instead behaves as auto.
+        auto ratio = value.as_ratio().resolved();
+        if (ratio.is_degenerate())
+            return { true, {}, false, ratio };
+        return { false, ratio, false, ratio };
+    }
+
+    return InitialValues::aspect_ratio();
+}
+
 Containment ComputedProperties::contain() const
 {
     Containment containment = {};

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -274,6 +274,7 @@ public:
     UserSelect user_select() const;
     Isolation isolation() const;
     TouchActionData touch_action() const;
+    AspectRatio aspect_ratio() const;
     Containment contain() const;
     Vector<Utf16FlyString> container_name() const;
     ContainerType container_type() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -367,25 +367,6 @@ static constexpr Array anchor_group_properties {
     PropertyID::PositionVisibility,
 };
 
-// The properties feeding the box group's descriptors, in registration
-// order.
-static constexpr Array box_group_properties {
-    PropertyID::AspectRatio,
-    PropertyID::Float,
-    PropertyID::Clear,
-    PropertyID::Position,
-    PropertyID::ZIndex,
-    PropertyID::Display,
-    PropertyID::OverflowX,
-    PropertyID::OverflowY,
-    PropertyID::BoxSizing,
-    PropertyID::VerticalAlign,
-    PropertyID::Contain,
-    PropertyID::ContainerName,
-    PropertyID::ContainerType,
-    PropertyID::Resize,
-};
-
 // The properties feeding the border group's descriptors, in registration
 // order; each side's color feeds both the resolved color and the retained
 // shell.
@@ -625,25 +606,6 @@ static void register_style_group_field_descriptors()
     add(anchor, PropertyID::PositionTryOrder, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Normal), nullptr);
     add(anchor, PropertyID::PositionVisibility, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Always), nullptr);
 
-    using Box = ComputedValues::BoxValues;
-    constexpr auto box = to_underlying(StyleGroupIndex::BoxValues);
-    add(box, PropertyID::AspectRatio, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Auto), nullptr);
-    add(box, PropertyID::Float, offsetof(Box, float_), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_float>());
-    add(box, PropertyID::Clear, offsetof(Box, clear), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_clear>());
-    add(box, PropertyID::Position, offsetof(Box, position), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_positioning>());
-    add(box, PropertyID::ZIndex, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Auto), nullptr);
-    // NB: An untouched display also pins display_before_box_type_transformation to
-    //     its default, since the box type transformation replaces the stored value.
-    add(box, PropertyID::Display, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
-    add(box, PropertyID::OverflowX, offsetof(Box, overflow_x), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_overflow>());
-    add(box, PropertyID::OverflowY, offsetof(Box, overflow_y), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_overflow>());
-    add(box, PropertyID::BoxSizing, offsetof(Box, box_sizing), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_box_sizing>());
-    add(box, PropertyID::VerticalAlign, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Baseline), nullptr);
-    add(box, PropertyID::Contain, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
-    add(box, PropertyID::ContainerName, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
-    add(box, PropertyID::ContainerType, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Normal), nullptr);
-    add(box, PropertyID::Resize, offsetof(Box, resize), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_resize>());
-
     using Border = ComputedValues::BorderValues;
     constexpr auto border = to_underlying(StyleGroupIndex::BorderValues);
     struct BorderSide {
@@ -705,6 +667,8 @@ static_assert(sizeof(ComputedValues::SVGResetValues) == sizeof(ComputedValuesFFI
 static_assert(alignof(ComputedValues::SVGResetValues) == alignof(ComputedValuesFFI::SVGResetValues));
 static_assert(sizeof(ComputedValues::SurroundValues) == sizeof(ComputedValuesFFI::SurroundValues));
 static_assert(alignof(ComputedValues::SurroundValues) == alignof(ComputedValuesFFI::SurroundValues));
+static_assert(sizeof(ComputedValues::BoxValues) == sizeof(ComputedValuesFFI::BoxValues));
+static_assert(alignof(ComputedValues::BoxValues) == alignof(ComputedValuesFFI::BoxValues));
 static_assert(sizeof(Size) == sizeof(ComputedValuesFFI::ComputedSize));
 static_assert(alignof(Size) == alignof(ComputedValuesFFI::ComputedSize));
 static_assert(sizeof(RustStyleValueHandle) == sizeof(StyleValueFFI::StyleValueData const*));
@@ -991,16 +955,42 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     VERIFY(surround_payload);
     computed_values.adopt_surround_group(const_cast<void*>(surround_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, box_group_properties.size()> box_group_values;
-    gather_group_values(box_group_properties, box_group_values);
-    auto* box_payload = ComputedValuesFFI::rust_build_style_group(
+    auto containment = computed_style.contain();
+    auto container_type = computed_style.container_type();
+    auto z_index = computed_style.z_index();
+    ComputedValuesFFI::BoxValues box_group_values {
+        .display = to_ffi_display(computed_style.display()),
+        .display_before_box_type_transformation = to_ffi_display(computed_style.display_before_box_type_transformation()),
+        .float_ = static_cast<u8>(to_underlying(computed_style.float_())),
+        .clear = static_cast<u8>(to_underlying(computed_style.clear())),
+        .position = static_cast<u8>(to_underlying(computed_style.position())),
+        .overflow_x = static_cast<u8>(to_underlying(computed_style.overflow_x())),
+        .overflow_y = static_cast<u8>(to_underlying(computed_style.overflow_y())),
+        .box_sizing = static_cast<u8>(to_underlying(computed_style.box_sizing())),
+        .resize = static_cast<u8>(to_underlying(computed_style.resize())),
+        .has_z_index = z_index.has_value(),
+        .z_index = z_index.value_or(0),
+        .vertical_align = to_ffi_vertical_align(computed_style.vertical_align()),
+        .aspect_ratio = to_ffi_aspect_ratio(computed_style.aspect_ratio()),
+        .size_containment = containment.size_containment,
+        .inline_size_containment = containment.inline_size_containment,
+        .layout_containment = containment.layout_containment,
+        .style_containment = containment.style_containment,
+        .paint_containment = containment.paint_containment,
+        .is_size_container = container_type.is_size_container,
+        .is_inline_size_container = container_type.is_inline_size_container,
+        .is_scroll_state_container = container_type.is_scroll_state_container,
+        .container_name = { .pointer = nullptr, .length = 0 },
+    };
+    auto leaked_container_name_raws = to_leaked_fly_string_raws(computed_style.container_name());
+    ComputedValuesFFI::rust_replace_computed_fly_string_list(
+        &box_group_values.container_name, leaked_container_name_raws.data(), leaked_container_name_raws.size());
+    auto* box_payload = ComputedValuesFFI::rust_build_box_group(
         BoxValues::style_group_index,
-        box_group_values.data(),
-        box_group_values.size(),
+        &box_group_values,
         inherit_parent ? static_cast<void const*>(inherit_parent->m_noninherited.box.operator->()) : nullptr);
-    bool const box_adopted = box_payload != nullptr;
-    if (box_adopted)
-        computed_values.adopt_box_group(const_cast<void*>(box_payload));
+    VERIFY(box_payload);
+    computed_values.adopt_box_group(const_cast<void*>(box_payload));
 
     auto* alignment_payload = ComputedValuesFFI::rust_build_alignment_group(
         AlignmentValues::style_group_index,
@@ -1486,9 +1476,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_accent_color(move(accent_color));
     }
 
-    if (!box_adopted)
-        computed_values.set_vertical_align(computed_style.vertical_align());
-
     if (!background_adopted) {
         auto background_layers = computed_style.background_layers();
         computed_values.set_background_layers(move(background_layers));
@@ -1560,9 +1547,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!background_adopted)
         computed_values.set_background_color_clip(computed_style.background_color_clip());
 
-    if (!box_adopted)
-        computed_values.set_box_sizing(computed_style.box_sizing());
-
     if (auto maybe_font_language_override = computed_style.font_language_override(); maybe_font_language_override.has_value())
         computed_values.set_font_language_override(maybe_font_language_override.release_value());
     computed_values.set_font_variation_settings(computed_style.font_variation_settings());
@@ -1590,10 +1574,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_corner_top_left_shape(computed_style.property(CSS::PropertyID::CornerTopLeftShape).as_superellipse().parameter());
     if (!border_adopted)
         computed_values.set_corner_top_right_shape(computed_style.property(CSS::PropertyID::CornerTopRightShape).as_superellipse().parameter());
-    if (!box_adopted)
-        computed_values.set_display(computed_style.display());
-    if (!box_adopted)
-        computed_values.set_display_before_box_type_transformation(computed_style.display_before_box_type_transformation());
 
     if (!effects_adopted)
         computed_values.set_clip(computed_style.clip());
@@ -1607,9 +1587,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_appearance(computed_style.appearance());
     if (!misc_reset_adopted)
         computed_values.set_computed_appearance(keyword_to_appearance(computed_style.property(PropertyID::Appearance).to_keyword()).release_value());
-
-    if (!box_adopted)
-        computed_values.set_position(computed_style.position());
 
     // https://drafts.csswg.org/css-anchor-position-1/#position-anchor
     auto const& position_anchor_value = computed_style.property(CSS::PropertyID::PositionAnchor);
@@ -1893,9 +1870,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!inherited_text_adopted)
         computed_values.set_letter_spacing_style_value(computed_style.property(PropertyID::LetterSpacing));
 
-    if (!box_adopted)
-        computed_values.set_float(computed_style.float_());
-
     if (!inherited_table_adopted) {
         computed_values.set_border_spacing_horizontal(computed_style.border_spacing_horizontal());
         computed_values.set_border_spacing_vertical(computed_style.border_spacing_vertical());
@@ -1903,12 +1877,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
 
     if (!inherited_table_adopted)
         computed_values.set_caption_side(computed_style.caption_side());
-    if (!box_adopted)
-        computed_values.set_clear(computed_style.clear());
-    if (!box_adopted)
-        computed_values.set_overflow_x(computed_style.overflow_x());
-    if (!box_adopted)
-        computed_values.set_overflow_y(computed_style.overflow_y());
     if (!inherited_box_adopted)
         computed_values.set_content_visibility(computed_style.content_visibility());
     auto cursor = computed_style.cursor();
@@ -1963,8 +1931,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!inherited_text_adopted)
         computed_values.set_text_shadow(computed_style.text_shadow(color_resolution_context));
 
-    if (!box_adopted)
-        computed_values.set_z_index(computed_style.z_index());
     if (!effects_adopted)
         computed_values.set_opacity(computed_style.opacity());
 
@@ -2214,9 +2180,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!misc_reset_adopted)
         computed_values.set_table_layout(computed_style.table_layout());
 
-    if (!box_adopted)
-        computed_values.set_aspect_ratio(computed_style.aspect_ratio());
-
     if (!misc_reset_adopted)
         computed_values.set_touch_action(computed_style.touch_action());
 
@@ -2287,12 +2250,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_mix_blend_mode(computed_style.mix_blend_mode());
     if (!misc_reset_adopted)
         computed_values.set_view_transition_name(computed_style.view_transition_name());
-    if (!box_adopted)
-        computed_values.set_contain(computed_style.contain());
-    if (!box_adopted)
-        computed_values.set_container_name(computed_style.container_name());
-    if (!box_adopted)
-        computed_values.set_container_type(computed_style.container_type());
     if (!misc_reset_adopted)
         computed_values.set_will_change(computed_style.will_change());
     if (!inherited_ui_adopted) {
@@ -2307,9 +2264,6 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_color_interpolation(computed_style.color_interpolation());
     if (!inherited_svg_adopted)
         computed_values.set_color_interpolation_filters(computed_style.color_interpolation_filters());
-    if (!box_adopted)
-        computed_values.set_resize(computed_style.resize());
-
     for (auto i = to_underlying(first_longhand_property_id); i <= to_underlying(last_longhand_property_id); ++i) {
         auto property_id = static_cast<PropertyID>(i);
         computed_values.set_property_important(property_id, computed_style.is_property_important(property_id));

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -2214,30 +2214,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!misc_reset_adopted)
         computed_values.set_table_layout(computed_style.table_layout());
 
-    auto const& aspect_ratio = computed_style.property(CSS::PropertyID::AspectRatio);
-    if (box_adopted) {
-        // The constraint left the constructor's auto default standing.
-    } else if (aspect_ratio.is_value_list()) {
-        auto const& values_list = aspect_ratio.as_value_list().values();
-        if (values_list.size() == 2
-            && values_list[0]->is_keyword() && values_list[0]->as_keyword().keyword() == CSS::Keyword::Auto
-            && values_list[1]->is_ratio()) {
-            auto ratio = values_list[1]->as_ratio().resolved();
-            if (ratio.is_degenerate())
-                computed_values.set_aspect_ratio({ true, {}, true, ratio });
-            else
-                computed_values.set_aspect_ratio({ true, ratio, true, ratio });
-        }
-    } else if (aspect_ratio.is_keyword() && aspect_ratio.as_keyword().keyword() == CSS::Keyword::Auto) {
-        computed_values.set_aspect_ratio({ true, {}, true, {} });
-    } else if (aspect_ratio.is_ratio()) {
-        // https://drafts.csswg.org/css-sizing-4/#aspect-ratio
-        // If the <ratio> is degenerate, the property instead behaves as auto.
-        if (aspect_ratio.as_ratio().resolved().is_degenerate())
-            computed_values.set_aspect_ratio({ true, {}, false, aspect_ratio.as_ratio().resolved() });
-        else
-            computed_values.set_aspect_ratio({ false, aspect_ratio.as_ratio().resolved(), false, aspect_ratio.as_ratio().resolved() });
-    }
+    if (!box_adopted)
+        computed_values.set_aspect_ratio(computed_style.aspect_ratio());
 
     if (!misc_reset_adopted)
         computed_values.set_touch_action(computed_style.touch_action());

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -182,6 +182,7 @@ static constexpr Array misc_reset_group_properties {
     PropertyID::ShapeImageThreshold,
     PropertyID::ShapeMargin,
     PropertyID::ShapeOutside,
+    PropertyID::WillChange,
 };
 
 // overflow-wrap has no generated keyword converter; the mapping matches the
@@ -382,7 +383,6 @@ static constexpr Array box_group_properties {
     PropertyID::Contain,
     PropertyID::ContainerName,
     PropertyID::ContainerType,
-    PropertyID::WillChange,
     PropertyID::Resize,
 };
 
@@ -509,6 +509,7 @@ static void register_style_group_field_descriptors()
     add(misc_reset, PropertyID::ShapeImageThreshold, offsetof(MiscReset, shape_image_threshold), GROUP_FIELD_RESOLVED_F64, 0, nullptr);
     add(misc_reset, PropertyID::ShapeMargin, 0, GROUP_FIELD_REQUIRE_PX, 0, nullptr, 0);
     add(misc_reset, PropertyID::ShapeOutside, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
+    add(misc_reset, PropertyID::WillChange, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Auto), nullptr);
 
     using InheritedText = ComputedValues::InheritedTextValues;
     constexpr auto inherited_text = to_underlying(StyleGroupIndex::InheritedTextValues);
@@ -641,7 +642,6 @@ static void register_style_group_field_descriptors()
     add(box, PropertyID::Contain, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
     add(box, PropertyID::ContainerName, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
     add(box, PropertyID::ContainerType, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Normal), nullptr);
-    add(box, PropertyID::WillChange, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::Auto), nullptr);
     add(box, PropertyID::Resize, offsetof(Box, resize), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_resize>());
 
     using Border = ComputedValues::BorderValues;
@@ -2315,9 +2315,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_container_name(computed_style.container_name());
     if (!box_adopted)
         computed_values.set_container_type(computed_style.container_type());
-    if (!box_adopted)
+    if (!misc_reset_adopted)
         computed_values.set_will_change(computed_style.will_change());
-
     if (!inherited_ui_adopted) {
         auto const& caret_color_value = computed_style.property(CSS::PropertyID::CaretColor);
         CSS::ColorOrAuto caret_color;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -945,6 +945,96 @@ enum class StyleGroupIndex : size_t {
         Count,
 };
 
+// The box group payload stores display values in the Rust-defined explicit
+// form; these pins keep the tag discriminants aligned with Display::Type.
+inline ComputedValuesFFI::FfiDisplay to_ffi_display(Display const& display)
+{
+    static_assert(to_underlying(Display::Type::OutsideAndInside) == 0);
+    static_assert(to_underlying(Display::Type::Internal) == 1);
+    static_assert(to_underlying(Display::Type::Box) == 2);
+
+    switch (display.type()) {
+    case Display::Type::OutsideAndInside:
+        return {
+            .tag = to_underlying(display.type()),
+            .outside = to_underlying(display.outside()),
+            .inside = to_underlying(display.inside()),
+            .list_item = display.is_list_item(),
+            .internal = 0,
+            .box_value = 0,
+        };
+    case Display::Type::Internal:
+        return {
+            .tag = to_underlying(display.type()),
+            .outside = 0,
+            .inside = 0,
+            .list_item = false,
+            .internal = to_underlying(display.internal()),
+            .box_value = 0,
+        };
+    case Display::Type::Box:
+        return {
+            .tag = to_underlying(display.type()),
+            .outside = 0,
+            .inside = 0,
+            .list_item = false,
+            .internal = 0,
+            .box_value = display.is_none() ? to_underlying(DisplayBox::None) : to_underlying(DisplayBox::Contents),
+        };
+    }
+    VERIFY_NOT_REACHED();
+}
+
+inline Display display_from_ffi_display(ComputedValuesFFI::FfiDisplay const& display)
+{
+    switch (static_cast<Display::Type>(display.tag)) {
+    case Display::Type::OutsideAndInside:
+        return Display {
+            static_cast<DisplayOutside>(display.outside),
+            static_cast<DisplayInside>(display.inside),
+            display.list_item ? Display::ListItem::Yes : Display::ListItem::No,
+        };
+    case Display::Type::Internal:
+        return Display { static_cast<DisplayInternal>(display.internal) };
+    case Display::Type::Box:
+        return Display { static_cast<DisplayBox>(display.box_value) };
+    }
+    VERIFY_NOT_REACHED();
+}
+
+inline ComputedValuesFFI::ComputedAspectRatio to_ffi_aspect_ratio(AspectRatio const& aspect_ratio)
+{
+    return {
+        .use_natural_aspect_ratio_if_available = aspect_ratio.use_natural_aspect_ratio_if_available,
+        .has_preferred_ratio = aspect_ratio.preferred_ratio.has_value(),
+        .preferred_ratio_numerator = aspect_ratio.preferred_ratio.has_value() ? aspect_ratio.preferred_ratio->numerator() : 0.0,
+        .preferred_ratio_denominator = aspect_ratio.preferred_ratio.has_value() ? aspect_ratio.preferred_ratio->denominator() : 0.0,
+        .computed_use_natural_aspect_ratio_if_available = aspect_ratio.computed_use_natural_aspect_ratio_if_available,
+        .has_computed_ratio = aspect_ratio.computed_ratio.has_value(),
+        .computed_ratio_numerator = aspect_ratio.computed_ratio.has_value() ? aspect_ratio.computed_ratio->numerator() : 0.0,
+        .computed_ratio_denominator = aspect_ratio.computed_ratio.has_value() ? aspect_ratio.computed_ratio->denominator() : 0.0,
+    };
+}
+
+inline ComputedValuesFFI::ComputedVerticalAlign to_ffi_vertical_align(Variant<VerticalAlign, LengthPercentage> const& value)
+{
+    if (value.has<VerticalAlign>())
+        return { .is_keyword = true, .keyword = to_underlying(value.get<VerticalAlign>()), .value = { nullptr } };
+    auto retained = value.get<LengthPercentage>();
+    return { .is_keyword = false, .keyword = 0, .value = { retained.leak_data() } };
+}
+
+// Each returned raw carries one leaked reference for a Rust-owned fly string
+// list to assume ownership of.
+inline Vector<size_t> to_leaked_fly_string_raws(Vector<Utf16FlyString> const& names)
+{
+    Vector<size_t> raws;
+    raws.ensure_capacity(names.size());
+    for (auto const& name : names)
+        raws.unchecked_append(name.to_raw_leaked());
+    return raws;
+}
+
 class WEB_API ComputedValues final : public RefCounted<ComputedValues> {
     AK_MAKE_NONCOPYABLE(ComputedValues);
     AK_MAKE_NONMOVABLE(ComputedValues);
@@ -1028,7 +1118,16 @@ public:
 
     ~ComputedValues();
 
-    AspectRatio aspect_ratio() const { return m_noninherited.box->aspect_ratio; }
+    AspectRatio aspect_ratio() const
+    {
+        auto const& value = m_noninherited.box->aspect_ratio;
+        return AspectRatio {
+            value.use_natural_aspect_ratio_if_available,
+            value.has_preferred_ratio ? Optional<Ratio> { Ratio { value.preferred_ratio_numerator, value.preferred_ratio_denominator } } : OptionalNone {},
+            value.computed_use_natural_aspect_ratio_if_available,
+            value.has_computed_ratio ? Optional<Ratio> { Ratio { value.computed_ratio_numerator, value.computed_ratio_denominator } } : OptionalNone {},
+        };
+    }
     Vector<Utf16FlyString> const& anchor_names() const { return m_noninherited.anchor->anchor_names; }
     AnchorScopeData const& anchor_scope() const { return m_noninherited.anchor->anchor_scope; }
     Vector<ComputedAnimationName> const& animation_names() const { return m_noninherited.animation->animation_names; }
@@ -1051,13 +1150,13 @@ public:
         return box_sizing();
     }
 
-    Float float_() const { return m_noninherited.box->float_; }
+    Float float_() const { return static_cast<Float>(m_noninherited.box->float_); }
     CSSPixels border_spacing_horizontal() const { return CSSPixels::from_raw(m_inherited.table->border_spacing_horizontal); }
     CSSPixels border_spacing_vertical() const { return CSSPixels::from_raw(m_inherited.table->border_spacing_vertical); }
     CaptionSide caption_side() const { return static_cast<CaptionSide>(m_inherited.table->caption_side); }
     ColorOrAuto const& caret_color_value() const { return m_inherited.ui->caret_color; }
     Color caret_color() const { return m_inherited.ui->caret_color.used_value; }
-    Clear clear() const { return m_noninherited.box->clear; }
+    Clear clear() const { return static_cast<Clear>(m_noninherited.box->clear); }
     Clip clip() const { return m_noninherited.effects->clip; }
     ColorInterpolation color_interpolation() const { return m_inherited.svg->color_interpolation; }
     ColorInterpolation color_interpolation_filters() const { return m_inherited.svg->color_interpolation_filters; }
@@ -1073,9 +1172,14 @@ public:
     Vector<CounterData, 0> const& counter_reset() const { return m_noninherited.content_data->counter_reset; }
     Vector<CounterData, 0> const& counter_set() const { return m_noninherited.content_data->counter_set; }
     PointerEvents pointer_events() const { return m_inherited.ui->pointer_events; }
-    Display display() const { return m_noninherited.box->display; }
-    Display display_before_box_type_transformation() const { return m_noninherited.box->display_before_box_type_transformation; }
-    Optional<int> const& z_index() const { return m_noninherited.box->z_index; }
+    Display display() const { return display_from_ffi_display(m_noninherited.box->display); }
+    Display display_before_box_type_transformation() const { return display_from_ffi_display(m_noninherited.box->display_before_box_type_transformation); }
+    Optional<int> z_index() const
+    {
+        if (!m_noninherited.box->has_z_index)
+            return {};
+        return m_noninherited.box->z_index;
+    }
     Variant<CSSPixels, double> tab_size() const { return m_inherited.text->tab_size; }
     TextAlign text_align() const { return m_inherited.text->text_align; }
     TextJustify text_justify() const { return m_inherited.text->text_justify; }
@@ -1093,7 +1197,7 @@ public:
     TextTransform text_transform() const { return m_inherited.text->text_transform; }
     TextOverflow text_overflow() const { return m_noninherited.text_reset->text_overflow; }
     Vector<ShadowData> const& text_shadow() const { return m_inherited.text->text_shadow; }
-    Positioning position() const { return m_noninherited.box->position; }
+    Positioning position() const { return static_cast<Positioning>(m_noninherited.box->position); }
     PositionAnchor const& position_anchor_value() const { return m_noninherited.anchor->position_anchor; }
     Optional<Utf16FlyString> const& position_anchor() const { return m_noninherited.anchor->position_anchor.name; }
     PositionAreaData const& position_area() const { return m_noninherited.anchor->position_area; }
@@ -1155,14 +1259,20 @@ public:
     Filter const& backdrop_filter() const { return m_noninherited.effects->backdrop_filter; }
     Filter const& filter() const { return m_noninherited.effects->filter; }
     Vector<ShadowData> const& box_shadow() const { return m_noninherited.effects->box_shadow; }
-    BoxSizing box_sizing() const { return m_noninherited.box->box_sizing; }
+    BoxSizing box_sizing() const { return static_cast<BoxSizing>(m_noninherited.box->box_sizing); }
     Size const& width() const { return Size::view(m_noninherited.sizing->width); }
     Size const& min_width() const { return Size::view(m_noninherited.sizing->min_width); }
     Size const& max_width() const { return Size::view(m_noninherited.sizing->max_width); }
     Size const& height() const { return Size::view(m_noninherited.sizing->height); }
     Size const& min_height() const { return Size::view(m_noninherited.sizing->min_height); }
     Size const& max_height() const { return Size::view(m_noninherited.sizing->max_height); }
-    Variant<VerticalAlign, LengthPercentage> const& vertical_align() const { return m_noninherited.box->vertical_align; }
+    Variant<VerticalAlign, LengthPercentage> vertical_align() const
+    {
+        auto const& value = m_noninherited.box->vertical_align;
+        if (value.is_keyword)
+            return static_cast<VerticalAlign>(value.keyword);
+        return LengthPercentage::view(value.value);
+    }
     GridTrackSizeList const& grid_auto_columns() const { return m_noninherited.grid->grid_auto_columns; }
     GridTrackSizeList const& grid_auto_rows() const { return m_noninherited.grid->grid_auto_rows; }
     GridAutoFlow const& grid_auto_flow() const { return m_noninherited.grid->grid_auto_flow; }
@@ -1218,9 +1328,44 @@ public:
 
     UserSelect user_select() const { return m_noninherited.misc->user_select; }
     Isolation isolation() const { return m_noninherited.effects->isolation; }
-    Containment const& contain() const { return m_noninherited.box->contain; }
-    Vector<Utf16FlyString> const& container_name() const { return m_noninherited.box->container_name; }
-    ContainerType const& container_type() const { return m_noninherited.box->container_type; }
+    Containment contain() const
+    {
+        auto const& box = *m_noninherited.box;
+        return Containment {
+            .size_containment = box.size_containment,
+            .inline_size_containment = box.inline_size_containment,
+            .layout_containment = box.layout_containment,
+            .style_containment = box.style_containment,
+            .paint_containment = box.paint_containment,
+        };
+    }
+    bool container_name_contains(Utf16FlyString const& name) const
+    {
+        auto const& list = m_noninherited.box->container_name;
+        for (size_t i = 0; i < list.length; ++i) {
+            if (Utf16FlyString::from_raw(list.pointer[i].raw) == name)
+                return true;
+        }
+        return false;
+    }
+    Vector<Utf16FlyString> container_name() const
+    {
+        auto const& list = m_noninherited.box->container_name;
+        Vector<Utf16FlyString> names;
+        names.ensure_capacity(list.length);
+        for (size_t i = 0; i < list.length; ++i)
+            names.unchecked_append(Utf16FlyString::from_raw(list.pointer[i].raw));
+        return names;
+    }
+    ContainerType container_type() const
+    {
+        auto const& box = *m_noninherited.box;
+        return ContainerType {
+            .is_size_container = box.is_size_container,
+            .is_inline_size_container = box.is_inline_size_container,
+            .is_scroll_state_container = box.is_scroll_state_container,
+        };
+    }
     MixBlendMode mix_blend_mode() const { return m_noninherited.effects->mix_blend_mode; }
     Optional<Utf16FlyString> view_transition_name() const { return m_noninherited.misc->view_transition_name; }
     TouchActionData touch_action() const { return m_noninherited.misc->touch_action; }
@@ -1274,8 +1419,8 @@ public:
     double corner_top_left_shape() const { return m_noninherited.border->corner_top_left_shape; }
     double corner_top_right_shape() const { return m_noninherited.border->corner_top_right_shape; }
 
-    Overflow overflow_x() const { return m_noninherited.box->overflow_x; }
-    Overflow overflow_y() const { return m_noninherited.box->overflow_y; }
+    Overflow overflow_x() const { return static_cast<Overflow>(m_noninherited.box->overflow_x); }
+    Overflow overflow_y() const { return static_cast<Overflow>(m_noninherited.box->overflow_y); }
 
     Color color() const { return m_inherited.text->color; }
     Color background_color() const { return m_noninherited.background->background_color; }
@@ -1368,7 +1513,7 @@ public:
     ScrollbarColorData scrollbar_color() const { return m_inherited.ui->scrollbar_color; }
     ScrollbarGutter scrollbar_gutter() const { return m_noninherited.misc->scrollbar_gutter; }
     ScrollbarWidth scrollbar_width() const { return m_noninherited.misc->scrollbar_width; }
-    Resize resize() const { return m_noninherited.box->resize; }
+    Resize resize() const { return static_cast<Resize>(m_noninherited.box->resize); }
     double shape_image_threshold() const { return m_noninherited.misc->shape_image_threshold; }
     LengthPercentage const& shape_margin() const { return m_noninherited.misc->shape_margin; }
     ShapeOutsideData const& shape_outside() const { return m_noninherited.misc->shape_outside; }
@@ -1870,27 +2015,14 @@ public:
         }
     };
 
-    struct BoxValues {
+    struct BoxValues : ComputedValuesFFI::BoxValues {
         static constexpr size_t style_group_index = to_underlying(StyleGroupIndex::BoxValues);
-        AspectRatio aspect_ratio { InitialValues::aspect_ratio() };
-        Float float_ { InitialValues::float_() };
+        static constexpr auto style_group_lifecycle = ComputedValuesFFI::StyleGroupLifecycle::Box;
 
-        Clear clear { InitialValues::clear() };
-        Positioning position { InitialValues::position() };
-        Optional<int> z_index;
-        // FIXME: Store these as flags in a u8.
-        Display display { InitialValues::display() };
-        Display display_before_box_type_transformation { InitialValues::display() };
-        Overflow overflow_x { InitialValues::overflow() };
-        Overflow overflow_y { InitialValues::overflow() };
-        BoxSizing box_sizing { InitialValues::box_sizing() };
-        Variant<VerticalAlign, LengthPercentage> vertical_align { InitialValues::vertical_align() };
-        Containment contain { InitialValues::contain() };
-        Vector<Utf16FlyString> container_name { InitialValues::container_name() };
-        ContainerType container_type { InitialValues::container_type() };
-        Resize resize { InitialValues::resize() };
-
-        bool operator==(BoxValues const&) const = default;
+        bool operator==(BoxValues const& other) const
+        {
+            return ComputedValuesFFI::rust_style_group_payloads_equal(style_group_index, this, &other);
+        }
     };
 
 private:
@@ -1987,9 +2119,9 @@ public:
 
     void set_aspect_ratio(AspectRatio aspect_ratio)
     {
-        if (m_values.m_noninherited.box->aspect_ratio == aspect_ratio)
+        if (m_values.aspect_ratio() == aspect_ratio)
             return;
-        m_values.m_noninherited.box.access().aspect_ratio = move(aspect_ratio);
+        m_values.m_noninherited.box.access().aspect_ratio = to_ffi_aspect_ratio(aspect_ratio);
     }
     void set_anchor_names(Vector<Utf16FlyString> value)
     {
@@ -2296,21 +2428,23 @@ public:
     }
     void set_float(Float value)
     {
-        if (m_values.m_noninherited.box->float_ == value)
+        if (m_values.m_noninherited.box->float_ == to_underlying(value))
             return;
-        m_values.m_noninherited.box.access().float_ = value;
+        m_values.m_noninherited.box.access().float_ = to_underlying(value);
     }
     void set_clear(Clear value)
     {
-        if (m_values.m_noninherited.box->clear == value)
+        if (m_values.m_noninherited.box->clear == to_underlying(value))
             return;
-        m_values.m_noninherited.box.access().clear = value;
+        m_values.m_noninherited.box.access().clear = to_underlying(value);
     }
     void set_z_index(Optional<int> value)
     {
-        if (m_values.m_noninherited.box->z_index == value)
+        if (m_values.z_index() == value)
             return;
-        m_values.m_noninherited.box.access().z_index = move(value);
+        auto& box = m_values.m_noninherited.box.access();
+        box.has_z_index = value.has_value();
+        box.z_index = value.value_or(0);
     }
     void set_tab_size(Variant<CSSPixels, double> value)
     {
@@ -2418,9 +2552,9 @@ public:
     }
     void set_position(Positioning position)
     {
-        if (m_values.m_noninherited.box->position == position)
+        if (m_values.m_noninherited.box->position == to_underlying(position))
             return;
-        m_values.m_noninherited.box.access().position = position;
+        m_values.m_noninherited.box.access().position = to_underlying(position);
     }
     void set_position_anchor(PositionAnchor value)
     {
@@ -2628,15 +2762,15 @@ public:
     }
     void set_overflow_x(Overflow value)
     {
-        if (m_values.m_noninherited.box->overflow_x == value)
+        if (m_values.m_noninherited.box->overflow_x == to_underlying(value))
             return;
-        m_values.m_noninherited.box.access().overflow_x = value;
+        m_values.m_noninherited.box.access().overflow_x = to_underlying(value);
     }
     void set_overflow_y(Overflow value)
     {
-        if (m_values.m_noninherited.box->overflow_y == value)
+        if (m_values.m_noninherited.box->overflow_y == to_underlying(value))
             return;
-        m_values.m_noninherited.box.access().overflow_y = value;
+        m_values.m_noninherited.box.access().overflow_y = to_underlying(value);
     }
     void set_list_style_type(ListStyleType value)
     {
@@ -2658,15 +2792,15 @@ public:
     }
     void set_display(Display value)
     {
-        if (m_values.m_noninherited.box->display == value)
+        if (m_values.display() == value)
             return;
-        m_values.m_noninherited.box.access().display = value;
+        m_values.m_noninherited.box.access().display = to_ffi_display(value);
     }
     void set_display_before_box_type_transformation(Display value)
     {
-        if (m_values.m_noninherited.box->display_before_box_type_transformation == value)
+        if (m_values.display_before_box_type_transformation() == value)
             return;
-        m_values.m_noninherited.box.access().display_before_box_type_transformation = value;
+        m_values.m_noninherited.box.access().display_before_box_type_transformation = to_ffi_display(value);
     }
     void set_backdrop_filter(Filter const& backdrop_filter)
     {
@@ -2968,15 +3102,17 @@ public:
     }
     void set_box_sizing(BoxSizing value)
     {
-        if (m_values.m_noninherited.box->box_sizing == value)
+        if (m_values.m_noninherited.box->box_sizing == to_underlying(value))
             return;
-        m_values.m_noninherited.box.access().box_sizing = value;
+        m_values.m_noninherited.box.access().box_sizing = to_underlying(value);
     }
     void set_vertical_align(Variant<VerticalAlign, LengthPercentage> value)
     {
-        if (m_values.m_noninherited.box->vertical_align == value)
+        if (m_values.vertical_align() == value)
             return;
-        m_values.m_noninherited.box.access().vertical_align = move(value);
+        auto& slot = m_values.m_noninherited.box.access().vertical_align;
+        StyleValueFFI::rust_style_value_release(static_cast<StyleValueFFI::StyleValueData const*>(slot.value.pointer));
+        slot = to_ffi_vertical_align(value);
     }
     void set_visibility(Visibility value)
     {
@@ -3142,21 +3278,41 @@ public:
     }
     void set_contain(Containment value)
     {
-        if (m_values.m_noninherited.box->contain == value)
+        if (m_values.contain() == value)
             return;
-        m_values.m_noninherited.box.access().contain = move(value);
+        auto& box = m_values.m_noninherited.box.access();
+        box.size_containment = value.size_containment;
+        box.inline_size_containment = value.inline_size_containment;
+        box.layout_containment = value.layout_containment;
+        box.style_containment = value.style_containment;
+        box.paint_containment = value.paint_containment;
     }
     void set_container_name(Vector<Utf16FlyString> value)
     {
-        if (m_values.m_noninherited.box->container_name == value)
+        auto const& stored = m_values.m_noninherited.box->container_name;
+        auto stored_names_equal_value = [&] {
+            if (stored.length != value.size())
+                return false;
+            for (size_t i = 0; i < stored.length; ++i) {
+                if (Utf16FlyString::from_raw(stored.pointer[i].raw) != value[i])
+                    return false;
+            }
+            return true;
+        };
+        if (stored_names_equal_value())
             return;
-        m_values.m_noninherited.box.access().container_name = move(value);
+        auto leaked_raws = to_leaked_fly_string_raws(value);
+        ComputedValuesFFI::rust_replace_computed_fly_string_list(
+            &m_values.m_noninherited.box.access().container_name, leaked_raws.data(), leaked_raws.size());
     }
     void set_container_type(ContainerType value)
     {
-        if (m_values.m_noninherited.box->container_type == value)
+        if (m_values.container_type() == value)
             return;
-        m_values.m_noninherited.box.access().container_type = move(value);
+        auto& box = m_values.m_noninherited.box.access();
+        box.is_size_container = value.is_size_container;
+        box.is_inline_size_container = value.is_inline_size_container;
+        box.is_scroll_state_container = value.is_scroll_state_container;
     }
     void set_mix_blend_mode(MixBlendMode value)
     {
@@ -3369,9 +3525,9 @@ public:
     }
     void set_resize(Resize value)
     {
-        if (m_values.m_noninherited.box->resize == value)
+        if (m_values.m_noninherited.box->resize == to_underlying(value))
             return;
-        m_values.m_noninherited.box.access().resize = value;
+        m_values.m_noninherited.box.access().resize = to_underlying(value);
     }
     void set_shape_image_threshold(double value)
     {

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1372,7 +1372,7 @@ public:
     double shape_image_threshold() const { return m_noninherited.misc->shape_image_threshold; }
     LengthPercentage const& shape_margin() const { return m_noninherited.misc->shape_margin; }
     ShapeOutsideData const& shape_outside() const { return m_noninherited.misc->shape_outside; }
-    WillChange const& will_change() const { return m_noninherited.box->will_change; }
+    WillChange const& will_change() const { return m_noninherited.misc->will_change; }
 
 private:
     ComputedValues();
@@ -1823,6 +1823,7 @@ public:
         double shape_image_threshold { InitialValues::shape_image_threshold() };
         LengthPercentage shape_margin { InitialValues::shape_margin() };
         ShapeOutsideData shape_outside { InitialValues::shape_outside() };
+        WillChange will_change { InitialValues::will_change() };
 
         bool operator==(MiscResetValues const&) const = default;
     };
@@ -1887,7 +1888,6 @@ public:
         Containment contain { InitialValues::contain() };
         Vector<Utf16FlyString> container_name { InitialValues::container_name() };
         ContainerType container_type { InitialValues::container_type() };
-        WillChange will_change { InitialValues::will_change() };
         Resize resize { InitialValues::resize() };
 
         bool operator==(BoxValues const&) const = default;
@@ -3413,9 +3413,9 @@ public:
 
     void set_will_change(WillChange value)
     {
-        if (m_values.m_noninherited.box->will_change == value)
+        if (m_values.m_noninherited.misc->will_change == value)
             return;
-        m_values.m_noninherited.box.access().will_change = move(value);
+        m_values.m_noninherited.misc.access().will_change = move(value);
     }
 
 private:

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -795,7 +795,7 @@ bool container_name_matches(DOM::Element const& element, Optional<Utf16FlyString
         return true;
 
     if (auto style = element.computed_values())
-        return style->container_name().contains_slow(*container_name);
+        return style->container_name_contains(*container_name);
 
     return false;
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2890,44 +2890,6 @@ static void compute_text_align(ComputedProperties::Builder& builder, DOM::Abstra
     }
 }
 
-static ComputedValuesFFI::FfiDisplay to_ffi_display(Display const& display)
-{
-    // The Rust mirror uses the same tag discriminants as Display::Type.
-    static_assert(to_underlying(Display::Type::OutsideAndInside) == 0);
-    static_assert(to_underlying(Display::Type::Internal) == 1);
-    static_assert(to_underlying(Display::Type::Box) == 2);
-
-    ComputedValuesFFI::FfiDisplay result {};
-    result.tag = to_underlying(display.type());
-    switch (display.type()) {
-    case Display::Type::OutsideAndInside:
-        result.outside = to_underlying(display.outside());
-        result.inside = to_underlying(display.inside());
-        result.list_item = display.is_list_item();
-        break;
-    case Display::Type::Internal:
-        result.internal = to_underlying(display.internal());
-        break;
-    case Display::Type::Box:
-        result.box_value = display.is_none() ? to_underlying(DisplayBox::None) : to_underlying(DisplayBox::Contents);
-        break;
-    }
-    return result;
-}
-
-static Display from_ffi_display(ComputedValuesFFI::FfiDisplay const& display)
-{
-    switch (static_cast<Display::Type>(display.tag)) {
-    case Display::Type::OutsideAndInside:
-        return Display { static_cast<DisplayOutside>(display.outside), static_cast<DisplayInside>(display.inside), display.list_item ? Display::ListItem::Yes : Display::ListItem::No };
-    case Display::Type::Internal:
-        return Display { static_cast<DisplayInternal>(display.internal) };
-    case Display::Type::Box:
-        return Display { static_cast<DisplayBox>(display.box_value) };
-    }
-    VERIFY_NOT_REACHED();
-}
-
 static ComputedValuesFFI::FfiDisplay decode_ffi_display(u32 encoded)
 {
     ComputedValuesFFI::FfiDisplay display {};
@@ -3035,11 +2997,11 @@ static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transforma
 
 static void apply_box_type_transformation(ComputedProperties::Builder& builder, ComputedValuesFFI::FfiDisplay const& display_before, ComputedValuesFFI::FfiBoxTypeTransformation const& transformation)
 {
-    builder.set_display_before_box_type_transformation(from_ffi_display(display_before));
+    builder.set_display_before_box_type_transformation(display_from_ffi_display(display_before));
     if (transformation.set_float_none)
         builder.set_property(PropertyID::Float, KeywordStyleValue::create(Keyword::None));
     if (transformation.changed_display)
-        builder.set_property(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(transformation.display)));
+        builder.set_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(transformation.display)));
 }
 
 static ComputedValuesFFI::FfiInputLineHeightMetrics input_line_height_metrics(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, bool should_measure)
@@ -3641,7 +3603,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
                 builder.set_property_without_modifying_flags(property_id, KeywordStyleValue::create(static_cast<Keyword>(static_cast<u16>(entry.value))));
                 break;
             case ComputedValuesFFI::COMPUTED_KIND_DISPLAY:
-                builder.set_property_without_modifying_flags(property_id, DisplayStyleValue::create(from_ffi_display(decode_ffi_display(static_cast<u32>(entry.value)))));
+                builder.set_property_without_modifying_flags(property_id, DisplayStyleValue::create(display_from_ffi_display(decode_ffi_display(static_cast<u32>(entry.value)))));
                 break;
             case ComputedValuesFFI::COMPUTED_KIND_SUPERELLIPSE: {
                 // NB: The round value is cached since it is the initial value of the corner-*-shape properties.
@@ -3691,7 +3653,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
             text_align_before_adjustments = static_cast<Keyword>(request->text_align_before);
             position_before_adjustments = static_cast<Keyword>(request->position_before);
             line_height_before_adjustments = builder.style().property(PropertyID::LineHeight);
-            builder.set_display_before_box_type_transformation(from_ffi_display(request->display_before));
+            builder.set_display_before_box_type_transformation(display_from_ffi_display(request->display_before));
             *request->out_input_line_height_metrics = input_line_height_metrics(builder, abstract_element, request->check_input_line_height);
             break;
         }
@@ -3771,7 +3733,7 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
         VERIFY(text_align_before_adjustments.has_value());
         VERIFY(position_before_adjustments.has_value());
         VERIFY(line_height_before_adjustments);
-        builder.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(from_ffi_display(*display_before_adjustments)));
+        builder.set_property_without_modifying_flags(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(*display_before_adjustments)));
         builder.set_property_without_modifying_flags(PropertyID::Float, KeywordStyleValue::create(*float_before_adjustments));
         builder.set_property_without_modifying_flags(PropertyID::OverflowX, KeywordStyleValue::create(*overflow_x_before_adjustments));
         builder.set_property_without_modifying_flags(PropertyID::OverflowY, KeywordStyleValue::create(*overflow_y_before_adjustments));

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -120,9 +120,6 @@ static_assert(to_underlying(CSS::StyleGroupIndex::Count) == RustFFI::STYLE_GROUP
     F(BorderRightStyle, CSS::ComputedValues::BorderValues, border_right.line_style, offsetof(CSS::ComputedValues::BorderValues, border_right) + offsetof(CSS::BorderData, line_style), U8)    \
     F(BorderBottomStyle, CSS::ComputedValues::BorderValues, border_bottom.line_style, offsetof(CSS::ComputedValues::BorderValues, border_bottom) + offsetof(CSS::BorderData, line_style), U8) \
     F(BorderLeftStyle, CSS::ComputedValues::BorderValues, border_left.line_style, offsetof(CSS::ComputedValues::BorderValues, border_left) + offsetof(CSS::BorderData, line_style), U8)       \
-    F(Position, CSS::ComputedValues::BoxValues, position, offsetof(CSS::ComputedValues::BoxValues, position), U8)                                                                             \
-    F(Float, CSS::ComputedValues::BoxValues, float_, offsetof(CSS::ComputedValues::BoxValues, float_), U8)                                                                                    \
-    F(Clear, CSS::ComputedValues::BoxValues, clear, offsetof(CSS::ComputedValues::BoxValues, clear), U8)                                                                                      \
     F(TextAlign, CSS::ComputedValues::InheritedTextValues, text_align, offsetof(CSS::ComputedValues::InheritedTextValues, text_align), U8)                                                    \
     F(TextJustify, CSS::ComputedValues::InheritedTextValues, text_justify, offsetof(CSS::ComputedValues::InheritedTextValues, text_justify), U8)                                              \
     F(WhiteSpaceCollapse, CSS::ComputedValues::InheritedTextValues, white_space_collapse, offsetof(CSS::ComputedValues::InheritedTextValues, white_space_collapse), U8)                       \
@@ -131,9 +128,6 @@ static_assert(to_underlying(CSS::StyleGroupIndex::Count) == RustFFI::STYLE_GROUP
     F(FontVariantEmoji, CSS::ComputedValues::FontValues, font_variant_emoji, offsetof(CSS::ComputedValues::FontValues, font_variant_emoji), U8)                                               \
     F(LineHeight, CSS::ComputedValues::FontValues, line_height.used_value, offsetof(CSS::ComputedValues::FontValues, line_height) + offsetof(CSS::LineHeightData, used_value), CssPixels)     \
     F(FontSize, CSS::ComputedValues::FontValues, font_size, offsetof(CSS::ComputedValues::FontValues, font_size), CssPixels)                                                                  \
-    F(BoxSizing, CSS::ComputedValues::BoxValues, box_sizing, offsetof(CSS::ComputedValues::BoxValues, box_sizing), U8)                                                                        \
-    F(OverflowX, CSS::ComputedValues::BoxValues, overflow_x, offsetof(CSS::ComputedValues::BoxValues, overflow_x), U8)                                                                        \
-    F(OverflowY, CSS::ComputedValues::BoxValues, overflow_y, offsetof(CSS::ComputedValues::BoxValues, overflow_y), U8)                                                                        \
     F(TextOverflow, CSS::ComputedValues::TextResetValues, text_overflow, offsetof(CSS::ComputedValues::TextResetValues, text_overflow), U8)                                                   \
     F(TableLayout, CSS::ComputedValues::MiscResetValues, table_layout, offsetof(CSS::ComputedValues::MiscResetValues, table_layout), U8)                                                      \
     F(LetterSpacing, CSS::ComputedValues::InheritedTextValues, letter_spacing, offsetof(CSS::ComputedValues::InheritedTextValues, letter_spacing), CssPixels)                                 \
@@ -761,22 +755,6 @@ RustFFI::FfiSizeValue build_style_size_value(CSS::Size const& value)
         return size_value_with_kind(RustFFI::FfiSizeKind::None_);
     }
     VERIFY_NOT_REACHED();
-}
-
-StyleVerticalAlignFacts build_style_vertical_align_value(Variant<CSS::VerticalAlign, CSS::LengthPercentage> const& value)
-{
-    if (value.has<CSS::VerticalAlign>()) {
-        return {
-            .is_keyword = true,
-            .keyword = to_underlying(value.get<CSS::VerticalAlign>()),
-            .value = size_value_with_kind(RustFFI::FfiSizeKind::Auto),
-        };
-    }
-    return {
-        .is_keyword = false,
-        .keyword = 0,
-        .value = build_style_size_value(value.get<CSS::LengthPercentage>()),
-    };
 }
 
 static RustFFI::FfiDisplay encode_display(CSS::Display const& display)
@@ -2158,33 +2136,6 @@ static RustFFI::FfiResidualStyleValues decode_residual_style(RustFFI::FfiStylePa
         ++s_outstanding_anchor_name_handles;
         result.position_anchor_retained_name = anchor.name->to_raw_leaked();
     }
-
-    auto const& box = group.operator()<CSS::ComputedValues::BoxValues>();
-    auto vertical_align = build_style_vertical_align_value(box.vertical_align);
-    result.vertical_align_is_keyword = vertical_align.is_keyword;
-    result.vertical_align_keyword = vertical_align.keyword;
-    result.vertical_align_value = vertical_align.value;
-    result.box_sizing_for_aspect_ratio = to_underlying(box.aspect_ratio.use_natural_aspect_ratio_if_available
-            ? CSS::BoxSizing::ContentBox
-            : box.box_sizing);
-    result.aspect_ratio_uses_natural_when_available = box.aspect_ratio.use_natural_aspect_ratio_if_available;
-    if (box.aspect_ratio.preferred_ratio.has_value() && !box.aspect_ratio.preferred_ratio->is_degenerate()) {
-        // The floating-point CSSPixelFraction constructor rescues denominators that
-        // round to zero CSSPixels, and the converted fraction can still collapse to
-        // zero even though is_degenerate() (which operates on doubles) passed.
-        auto fraction = CSSPixelFraction(box.aspect_ratio.preferred_ratio->numerator(), box.aspect_ratio.preferred_ratio->denominator());
-        if (fraction != 0) {
-            result.css_preferred_aspect_ratio_numerator = fraction.numerator().raw_value();
-            result.css_preferred_aspect_ratio_denominator = fraction.denominator().raw_value();
-        }
-    }
-    result.containment_bits = static_cast<u8>(static_cast<u8>(box.contain.size_containment)
-        | static_cast<u8>(box.contain.inline_size_containment) << 1
-        | static_cast<u8>(box.contain.layout_containment) << 2
-        | static_cast<u8>(box.contain.style_containment) << 3
-        | static_cast<u8>(box.contain.paint_containment) << 4
-        | static_cast<u8>(box.container_type.is_size_container) << 5
-        | static_cast<u8>(box.container_type.is_inline_size_container) << 6);
 
     auto const& font_values = group.operator()<CSS::ComputedValues::FontValues>();
     VERIFY(font_values.font_list);

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -757,44 +757,6 @@ RustFFI::FfiSizeValue build_style_size_value(CSS::Size const& value)
     VERIFY_NOT_REACHED();
 }
 
-static RustFFI::FfiDisplay encode_display(CSS::Display const& display)
-{
-    static_assert(to_underlying(CSS::Display::Type::OutsideAndInside) == 0);
-    static_assert(to_underlying(CSS::Display::Type::Internal) == 1);
-    static_assert(to_underlying(CSS::Display::Type::Box) == 2);
-
-    switch (display.type()) {
-    case CSS::Display::Type::OutsideAndInside:
-        return {
-            .tag = to_underlying(display.type()),
-            .outside = to_underlying(display.outside()),
-            .inside = to_underlying(display.inside()),
-            .list_item = display.is_list_item(),
-            .internal = 0,
-            .box_value = 0,
-        };
-    case CSS::Display::Type::Internal:
-        return {
-            .tag = to_underlying(display.type()),
-            .outside = 0,
-            .inside = 0,
-            .list_item = false,
-            .internal = to_underlying(display.internal()),
-            .box_value = 0,
-        };
-    case CSS::Display::Type::Box:
-        return {
-            .tag = to_underlying(display.type()),
-            .outside = 0,
-            .inside = 0,
-            .list_item = false,
-            .internal = 0,
-            .box_value = display.is_none() ? to_underlying(CSS::DisplayBox::None) : to_underlying(CSS::DisplayBox::Contents),
-        };
-    }
-    VERIFY_NOT_REACHED();
-}
-
 static RustFFI::FfiAffineTransform to_ffi_affine_transform(Gfx::AffineTransform const& transform)
 {
     return {
@@ -1739,12 +1701,7 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             return decode_residual_style(*payloads); },
         .release_calc_handle = ladybird_layout_release_calc_handle,
         .release_anchor_name_handle = ladybird_layout_release_anchor_name_handle,
-        .build_style_snapshot = [](void*, void const* style) {
-            auto const& values = *static_cast<CSS::ComputedValues const*>(style);
-            return RustFFI::FfiStyleSnapshot {
-                .payloads = style_payloads(values),
-                .display = encode_display(values.display()),
-            }; },
+        .build_style_payloads = [](void*, void const* style) { return style_payloads(*static_cast<CSS::ComputedValues const*>(style)); },
         .build_replaced_content_facts = [](void*, void* node) {
             RustFFI::FfiReplacedContentFacts facts {};
             auto const* box = as_if<Box>(*static_cast<Node const*>(node));

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -48,16 +48,9 @@ private:
     RefPtr<Painting::Paintable> m_commit_insert_before_paintable;
 };
 
-struct StyleVerticalAlignFacts {
-    bool is_keyword;
-    u8 keyword;
-    RustFFI::FfiSizeValue value;
-};
-
 [[nodiscard]] RustFFI::FfiSizeValue build_style_size_value(CSS::Size const&);
 [[nodiscard]] RustFFI::FfiSizeValue build_style_size_value(CSS::LengthPercentage const&);
 [[nodiscard]] RustFFI::FfiSizeValue build_style_size_value(CSS::LengthPercentageOrAuto const&);
-[[nodiscard]] StyleVerticalAlignFacts build_style_vertical_align_value(Variant<CSS::VerticalAlign, CSS::LengthPercentage> const&);
 
 [[nodiscard]] RustFFI::FfiTableBoxFacts build_table_box_facts(NodeWithStyle const&);
 [[nodiscard]] Optional<RustFFI::FfiFormattingContextType> formatting_context_type_created_by_box(Box const&);

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -923,6 +923,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         style_value_config,
         &[
             manifest_dir.join("src/css/style_value.rs"),
+            manifest_dir.join("src/css/retained_fly_string.rs"),
             manifest_dir.join("src/css/color_interpolation.rs"),
             manifest_dir.join("src/css/animation.rs"),
             manifest_dir.join("src/css/transition.rs"),
@@ -957,6 +958,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             manifest_dir.join("src/css/style_compute.rs"),
             manifest_dir.join("src/css/display.rs"),
             manifest_dir.join("src/css/computed_value_types.rs"),
+            manifest_dir.join("src/css/retained_fly_string.rs"),
             manifest_dir.join("src/css/css_pixels.rs"),
             manifest_dir.join("src/css/cascaded_properties.rs"),
             manifest_dir.join("src/css/custom_properties.rs"),

--- a/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
@@ -106,6 +106,58 @@ pub struct SurroundValues {
     pub padding: ComputedLengthBox,
 }
 
+/// A computed vertical-align value: an alignment keyword or a retained
+/// length-percentage offset.
+#[repr(C)]
+pub struct ComputedVerticalAlign {
+    pub is_keyword: bool,
+    pub keyword: u8,
+    pub value: ComputedStyleValueHandle,
+}
+
+/// The computed aspect-ratio value, carrying both the used form and the
+/// as-computed form the serialization path reports. Absent ratios keep both
+/// components at zero so payload equality stays field-wise.
+#[repr(C)]
+#[derive(Clone, Copy, PartialEq)]
+pub struct ComputedAspectRatio {
+    pub use_natural_aspect_ratio_if_available: bool,
+    pub has_preferred_ratio: bool,
+    pub preferred_ratio_numerator: f64,
+    pub preferred_ratio_denominator: f64,
+    pub computed_use_natural_aspect_ratio_if_available: bool,
+    pub has_computed_ratio: bool,
+    pub computed_ratio_numerator: f64,
+    pub computed_ratio_denominator: f64,
+}
+
+/// Layout of the computed box-level properties.
+#[repr(C)]
+pub struct BoxValues {
+    pub display: crate::css::display::FfiDisplay,
+    pub display_before_box_type_transformation: crate::css::display::FfiDisplay,
+    pub float_: u8,
+    pub clear: u8,
+    pub position: u8,
+    pub overflow_x: u8,
+    pub overflow_y: u8,
+    pub box_sizing: u8,
+    pub resize: u8,
+    pub has_z_index: bool,
+    pub z_index: i32,
+    pub vertical_align: ComputedVerticalAlign,
+    pub aspect_ratio: ComputedAspectRatio,
+    pub size_containment: bool,
+    pub inline_size_containment: bool,
+    pub layout_containment: bool,
+    pub style_containment: bool,
+    pub paint_containment: bool,
+    pub is_size_container: bool,
+    pub is_inline_size_container: bool,
+    pub is_scroll_state_container: bool,
+    pub container_name: crate::css::retained_fly_string::RetainedUtf16FlyStringList,
+}
+
 /// Layout of the non-inherited SVG geometry and painting properties.
 #[repr(C)]
 pub struct SVGResetValues {

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -31,9 +31,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::abort_on_panic;
 pub use crate::css::computed_value_types::{
-    AlignmentValues, ComputedFlexBasis, ComputedGap, ComputedLengthBox, ComputedLengthPercentageOrAuto, ComputedSize,
-    ComputedSizeKind, ComputedStyleValueHandle, SVGResetValues, SizingValues, SurroundValues,
+    AlignmentValues, BoxValues, ComputedAspectRatio, ComputedFlexBasis, ComputedGap, ComputedLengthBox,
+    ComputedLengthPercentageOrAuto, ComputedSize, ComputedSizeKind, ComputedStyleValueHandle, ComputedVerticalAlign,
+    SVGResetValues, SizingValues, SurroundValues,
 };
+use crate::css::retained_fly_string::RetainedUtf16FlyStringList;
 
 /// Reference count value marking an intentionally leaked payload.
 pub const STYLE_GROUP_STATIC_REFCOUNT: usize = usize::MAX;
@@ -196,6 +198,35 @@ impl_computed_payload_clone_and_eq!(SVGResetValues {
     vector_effect,
     shape_rendering,
 });
+impl_computed_payload_clone_and_eq!(ComputedVerticalAlign {
+    is_keyword,
+    keyword,
+    value,
+});
+impl_computed_payload_clone_and_eq!(BoxValues {
+    display,
+    display_before_box_type_transformation,
+    float_,
+    clear,
+    position,
+    overflow_x,
+    overflow_y,
+    box_sizing,
+    resize,
+    has_z_index,
+    z_index,
+    vertical_align,
+    aspect_ratio,
+    size_containment,
+    inline_size_containment,
+    layout_containment,
+    style_containment,
+    paint_containment,
+    is_size_container,
+    is_inline_size_container,
+    is_scroll_state_container,
+    container_name,
+});
 
 /// Selects the language that owns a style group's payload lifecycle.
 #[repr(u8)]
@@ -208,6 +239,7 @@ pub enum StyleGroupLifecycle {
     Alignment,
     SVGReset,
     Surround,
+    Box,
 }
 
 /// Size, alignment and optional C++ lifecycle callbacks for one style value
@@ -277,6 +309,7 @@ fn payload_size(table: &StyleGroupVTable) -> usize {
         StyleGroupLifecycle::Alignment => size_of::<AlignmentValues>(),
         StyleGroupLifecycle::SVGReset => size_of::<SVGResetValues>(),
         StyleGroupLifecycle::Surround => size_of::<SurroundValues>(),
+        StyleGroupLifecycle::Box => size_of::<BoxValues>(),
     }
 }
 
@@ -289,6 +322,7 @@ fn payload_align(table: &StyleGroupVTable) -> usize {
         StyleGroupLifecycle::Alignment => align_of::<AlignmentValues>(),
         StyleGroupLifecycle::SVGReset => align_of::<SVGResetValues>(),
         StyleGroupLifecycle::Surround => align_of::<SurroundValues>(),
+        StyleGroupLifecycle::Box => align_of::<BoxValues>(),
     }
 }
 
@@ -314,6 +348,9 @@ unsafe fn default_construct(table: &StyleGroupVTable, payload: *mut c_void) {
         },
         StyleGroupLifecycle::Surround => unsafe {
             (payload as *mut SurroundValues).write(SurroundValues::initial());
+        },
+        StyleGroupLifecycle::Box => unsafe {
+            (payload as *mut BoxValues).write(BoxValues::initial());
         },
     }
 }
@@ -341,6 +378,9 @@ unsafe fn copy_construct(table: &StyleGroupVTable, payload: *mut c_void, source:
         StyleGroupLifecycle::Surround => unsafe {
             (payload as *mut SurroundValues).write((*(source as *const SurroundValues)).clone());
         },
+        StyleGroupLifecycle::Box => unsafe {
+            (payload as *mut BoxValues).write((*(source as *const BoxValues)).clone());
+        },
     }
 }
 
@@ -353,6 +393,7 @@ unsafe fn destruct(table: &StyleGroupVTable, payload: *mut c_void) {
         StyleGroupLifecycle::Alignment => unsafe { std::ptr::drop_in_place(payload as *mut AlignmentValues) },
         StyleGroupLifecycle::SVGReset => unsafe { std::ptr::drop_in_place(payload as *mut SVGResetValues) },
         StyleGroupLifecycle::Surround => unsafe { std::ptr::drop_in_place(payload as *mut SurroundValues) },
+        StyleGroupLifecycle::Box => unsafe { std::ptr::drop_in_place(payload as *mut BoxValues) },
     }
 }
 
@@ -369,6 +410,7 @@ unsafe fn payloads_equal(table: &StyleGroupVTable, a: *const c_void, b: *const c
         StyleGroupLifecycle::Alignment => unsafe { *(a as *const AlignmentValues) == *(b as *const AlignmentValues) },
         StyleGroupLifecycle::SVGReset => unsafe { *(a as *const SVGResetValues) == *(b as *const SVGResetValues) },
         StyleGroupLifecycle::Surround => unsafe { *(a as *const SurroundValues) == *(b as *const SurroundValues) },
+        StyleGroupLifecycle::Box => unsafe { *(a as *const BoxValues) == *(b as *const BoxValues) },
     }
 }
 
@@ -491,6 +533,21 @@ pub unsafe extern "C" fn rust_style_group_free(group_index: usize, payload: *mut
         let allocation = (payload as *mut u8).sub(header_size(payload_align(table)));
         dealloc(allocation, allocation_layout(table));
     });
+}
+
+/// Compares two payloads of the same style group for value equality, letting
+/// C++ group structs that inherit a Rust-native payload layout reuse the Rust
+/// field-wise equality instead of hand-writing a second one.
+///
+/// # Safety
+/// `a` and `b` must be valid payloads of the given group type.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_style_group_payloads_equal(
+    group_index: usize,
+    a: *const c_void,
+    b: *const c_void,
+) -> bool {
+    abort_on_panic(|| unsafe { payloads_equal(vtable(group_index), a, b) })
 }
 
 /// One field of a style group the generic builder can populate or check: a
@@ -1133,6 +1190,57 @@ impl SurroundValues {
     }
 }
 
+impl ComputedAspectRatio {
+    fn auto() -> Self {
+        Self {
+            use_natural_aspect_ratio_if_available: true,
+            has_preferred_ratio: false,
+            preferred_ratio_numerator: 0.0,
+            preferred_ratio_denominator: 0.0,
+            computed_use_natural_aspect_ratio_if_available: true,
+            has_computed_ratio: false,
+            computed_ratio_numerator: 0.0,
+            computed_ratio_denominator: 0.0,
+        }
+    }
+}
+
+impl BoxValues {
+    fn initial() -> Self {
+        use crate::css::css_enums::{box_sizing, clear, float, overflow, positioning, resize, vertical_align};
+        use crate::css::display::FfiDisplay;
+
+        Self {
+            display: FfiDisplay::inline(),
+            display_before_box_type_transformation: FfiDisplay::inline(),
+            float_: float::NONE,
+            clear: clear::NONE,
+            position: positioning::STATIC,
+            overflow_x: overflow::VISIBLE,
+            overflow_y: overflow::VISIBLE,
+            box_sizing: box_sizing::CONTENT_BOX,
+            resize: resize::NONE,
+            has_z_index: false,
+            z_index: 0,
+            vertical_align: ComputedVerticalAlign {
+                is_keyword: true,
+                keyword: vertical_align::BASELINE,
+                value: ComputedStyleValueHandle::empty(),
+            },
+            aspect_ratio: ComputedAspectRatio::auto(),
+            size_containment: false,
+            inline_size_containment: false,
+            layout_containment: false,
+            style_containment: false,
+            paint_containment: false,
+            is_size_container: false,
+            is_inline_size_container: false,
+            is_scroll_state_container: false,
+            container_name: RetainedUtf16FlyStringList::from_retained_strings(Vec::new()),
+        }
+    }
+}
+
 impl SVGResetValues {
     fn initial() -> Self {
         use crate::css::css_enums::{shape_rendering, vector_effect};
@@ -1364,6 +1472,61 @@ pub unsafe extern "C" fn rust_build_surround_group(
         Some(payload.cast_const())
     })
     .unwrap_or(std::ptr::null())
+}
+
+/// Builds the box group from a fully materialized payload value. C++ resolves
+/// every field directly into the payload layout (box type transformation,
+/// ratio degeneracy handling and the vertical-align representation live
+/// there), and ownership of the value's retained references transfers here in
+/// every outcome.
+///
+/// The returned payload carries one reference for the caller; fresh payloads
+/// start at one, shared payloads are retained, and default payloads are
+/// intentionally leaked and never counted.
+///
+/// # Safety
+/// `values` must point at a fully initialized box payload whose ownership
+/// transfers to this call, and `parent_payload` must be a valid box payload
+/// or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_build_box_group(
+    group_index: usize,
+    values: *const BoxValues,
+    parent_payload: *const c_void,
+) -> *const c_void {
+    abort_on_panic(|| {
+        let built = unsafe { values.read() };
+
+        if !parent_payload.is_null() && built.eq(unsafe { &*parent_payload.cast::<BoxValues>() }) {
+            retain_group_payload(group_index, parent_payload);
+            return parent_payload;
+        }
+        let default_payload = default_group_payload(group_index);
+        if built.eq(unsafe { &*default_payload.cast::<BoxValues>() }) {
+            return default_payload;
+        }
+
+        let payload = allocate_payload(vtable(group_index), 1);
+        unsafe { payload.cast::<BoxValues>().write(built) };
+        payload.cast_const()
+    })
+}
+
+/// Replaces a box group's container-name list, taking ownership of one leaked
+/// reference per raw and releasing the previous entries.
+///
+/// # Safety
+/// `target` must be a valid list slot and `raws` must point at `count` leaked
+/// fly-string raws.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_replace_computed_fly_string_list(
+    target: *mut RetainedUtf16FlyStringList,
+    raws: *const usize,
+    count: usize,
+) {
+    abort_on_panic(|| unsafe {
+        *target = RetainedUtf16FlyStringList::from_raw(raws, count);
+    });
 }
 
 /// Builds the complete sizing group from its six computed values. Accepted
@@ -1661,8 +1824,17 @@ mod tests {
                 destruct: None,
                 equals: None,
             },
+            StyleGroupVTable {
+                lifecycle: StyleGroupLifecycle::Box,
+                size: size_of::<BoxValues>(),
+                align: align_of::<BoxValues>(),
+                default_construct: None,
+                copy_construct: None,
+                destruct: None,
+                equals: None,
+            },
         ];
-        let mut defaults = [std::ptr::null::<c_void>(); 7];
+        let mut defaults = [std::ptr::null::<c_void>(); 8];
         unsafe {
             rust_style_group_registry_register(vtables.as_ptr(), vtables.len(), defaults.as_mut_ptr());
             let default_payload = defaults[0];
@@ -1722,6 +1894,13 @@ mod tests {
             assert!((*(surround_clone as *const SurroundValues)).eq(surround_default));
             refcount_of(surround_clone, align_of::<SurroundValues>()).store(0, Ordering::Relaxed);
             rust_style_group_free(6, surround_clone);
+
+            let box_default = &*(defaults[7] as *const BoxValues);
+            assert!(box_default.eq(&BoxValues::initial()));
+            let box_clone = rust_style_group_clone(7, defaults[7]);
+            assert!((*(box_clone as *const BoxValues)).eq(box_default));
+            refcount_of(box_clone, align_of::<BoxValues>()).store(0, Ordering::Relaxed);
+            rust_style_group_free(7, box_clone);
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/css/css_pixels.rs
+++ b/Libraries/LibWeb/Rust/src/css/css_pixels.rs
@@ -138,6 +138,17 @@ impl CssPixels {
     pub fn scaled(self, factor: f64) -> Self {
         Self::nearest_value_for(self.to_double() * factor)
     }
+
+    /// Matches the floating-point `CSSPixelFraction(double, double)`
+    /// constructor: a denominator that rounds to zero CSSPixels is rescued by
+    /// folding it into the numerator before the fixed-point conversion.
+    pub(crate) fn fraction_nearest_values_for(mut numerator: f64, mut denominator: f64) -> (CssPixels, CssPixels) {
+        if Self::nearest_value_for(denominator).raw_value() == 0 {
+            numerator /= denominator;
+            denominator = 1.0;
+        }
+        (Self::nearest_value_for(numerator), Self::nearest_value_for(denominator))
+    }
 }
 
 const MAX_DIMENSION_RAW: i32 = 17_895_700 * 64;

--- a/Libraries/LibWeb/Rust/src/css/mod.rs
+++ b/Libraries/LibWeb/Rust/src/css/mod.rs
@@ -19,6 +19,7 @@ pub mod display;
 pub mod ffi_stats;
 pub mod ffi_support;
 pub mod property_metadata;
+pub(crate) mod retained_fly_string;
 pub(crate) mod selector_engine;
 pub mod style_compute;
 pub(crate) mod style_value;

--- a/Libraries/LibWeb/Rust/src/css/retained_fly_string.rs
+++ b/Libraries/LibWeb/Rust/src/css/retained_fly_string.rs
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+//! Retained AK::Utf16FlyString types shared by generated FFI headers.
+//!
+//! Both the style-value and computed-values cbindgen invocations parse this
+//! module so the same struct layout is emitted into each header's namespace,
+//! the same arrangement `display.rs` uses for `FfiDisplay`.
+
+use crate::css::style_value::{retained_list_drop, retained_list_partial_eq};
+
+unsafe extern "C" {
+    fn ladybird_utf16_fly_string_unref(raw: usize);
+    fn ladybird_utf16_fly_string_ref(raw: usize);
+}
+
+/// A retained AK::Utf16FlyString, stored as its one-word raw representation. Owns one reference
+/// to the underlying string data unless it is a short string, which needs none; the C++ bridge
+/// handles both cases.
+#[repr(C)]
+#[derive(PartialEq)]
+pub struct RetainedUtf16FlyString {
+    raw: usize,
+}
+
+impl RetainedUtf16FlyString {
+    /// The raw one-word representation; fly strings are interned, so equal raw
+    /// values mean equal strings.
+    pub(crate) fn raw(&self) -> usize {
+        self.raw
+    }
+
+    /// Assumes ownership of one leaked reference to the underlying string data.
+    pub(crate) unsafe fn from_leaked_raw(raw: usize) -> Self {
+        Self { raw }
+    }
+
+    /// Retains a new reference to the underlying string data.
+    ///
+    /// # Safety
+    /// `raw` must be the raw representation of a live fly string.
+    pub(crate) unsafe fn from_borrowed_raw(raw: usize) -> Self {
+        crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StringRetainReleaseCallback);
+        unsafe { ladybird_utf16_fly_string_ref(raw) };
+        Self { raw }
+    }
+}
+
+impl Drop for RetainedUtf16FlyString {
+    fn drop(&mut self) {
+        crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StringRetainReleaseCallback);
+        unsafe { ladybird_utf16_fly_string_unref(self.raw) };
+    }
+}
+
+/// A Rust-owned array of retained AK::Utf16FlyString values.
+#[repr(C)]
+pub struct RetainedUtf16FlyStringList {
+    pointer: *mut RetainedUtf16FlyString,
+    length: usize,
+}
+
+impl RetainedUtf16FlyStringList {
+    pub(crate) fn from_retained_strings(strings: Vec<RetainedUtf16FlyString>) -> Self {
+        let slice = strings.into_boxed_slice();
+        let length = slice.len();
+        let pointer = Box::into_raw(slice) as *mut RetainedUtf16FlyString;
+        Self { pointer, length }
+    }
+
+    /// Takes ownership of one leaked reference to each string.
+    ///
+    /// # Safety
+    /// `strings` must point to `length` valid leaked string raws.
+    pub(crate) unsafe fn from_raw(strings: *const usize, length: usize) -> Self {
+        let slice: Box<[RetainedUtf16FlyString]> = (0..length)
+            .map(|i| RetainedUtf16FlyString {
+                raw: unsafe { *strings.add(i) },
+            })
+            .collect();
+        let length = slice.len();
+        let pointer = Box::into_raw(slice) as *mut RetainedUtf16FlyString;
+        Self { pointer, length }
+    }
+
+    pub(crate) fn clone_retained(&self) -> Self {
+        Self::from_retained_strings(
+            self.as_slice()
+                .iter()
+                .map(|string| unsafe { RetainedUtf16FlyString::from_borrowed_raw(string.raw()) })
+                .collect(),
+        )
+    }
+
+    pub(crate) fn as_slice(&self) -> &[RetainedUtf16FlyString] {
+        if self.pointer.is_null() {
+            return &[];
+        }
+        unsafe { std::slice::from_raw_parts(self.pointer, self.length) }
+    }
+}
+
+impl Clone for RetainedUtf16FlyStringList {
+    fn clone(&self) -> Self {
+        self.clone_retained()
+    }
+}
+
+retained_list_drop!(RetainedUtf16FlyStringList);
+retained_list_partial_eq!(RetainedUtf16FlyStringList, RetainedUtf16FlyString);

--- a/Libraries/LibWeb/Rust/src/css/style_value.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_value.rs
@@ -20,10 +20,10 @@ use std::sync::Arc;
 
 use crate::abort_on_panic;
 
+pub(crate) use crate::css::retained_fly_string::{RetainedUtf16FlyString, RetainedUtf16FlyStringList};
+
 unsafe extern "C" {
-    fn ladybird_utf16_fly_string_unref(raw: usize);
     fn ladybird_string_unref(raw: usize);
-    fn ladybird_utf16_fly_string_ref(raw: usize);
 }
 
 /// A strong reference to immutable Rust-owned style value data.
@@ -140,45 +140,6 @@ impl RetainedStyleValueDataList {
     }
 }
 
-/// A retained AK::Utf16FlyString, stored as its one-word raw representation. Owns one reference
-/// to the underlying string data unless it is a short string, which needs none; the C++ bridge
-/// handles both cases.
-#[repr(C)]
-#[derive(PartialEq)]
-pub struct RetainedUtf16FlyString {
-    raw: usize,
-}
-
-impl RetainedUtf16FlyString {
-    /// The raw one-word representation; fly strings are interned, so equal raw
-    /// values mean equal strings.
-    pub(crate) fn raw(&self) -> usize {
-        self.raw
-    }
-
-    /// Assumes ownership of one leaked reference to the underlying string data.
-    pub(crate) unsafe fn from_leaked_raw(raw: usize) -> Self {
-        Self { raw }
-    }
-
-    /// Retains a new reference to the underlying string data.
-    ///
-    /// # Safety
-    /// `raw` must be the raw representation of a live fly string.
-    pub(crate) unsafe fn from_borrowed_raw(raw: usize) -> Self {
-        crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StringRetainReleaseCallback);
-        unsafe { ladybird_utf16_fly_string_ref(raw) };
-        Self { raw }
-    }
-}
-
-impl Drop for RetainedUtf16FlyString {
-    fn drop(&mut self) {
-        crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::StringRetainReleaseCallback);
-        unsafe { ladybird_utf16_fly_string_unref(self.raw) };
-    }
-}
-
 /// Implements `Drop` for a `Retained*List` struct: releases the Rust-owned boxed slice,
 /// dropping each element (which releases the element's own retained references).
 macro_rules! retained_list_drop {
@@ -192,6 +153,7 @@ macro_rules! retained_list_drop {
         }
     };
 }
+pub(crate) use retained_list_drop;
 
 retained_list_drop!(RetainedStyleValueDataList);
 
@@ -367,55 +329,6 @@ pub struct RetainedByteList {
 }
 
 retained_list!(RetainedByteList, u8);
-
-/// A Rust-owned array of retained AK::Utf16FlyString values.
-#[repr(C)]
-pub struct RetainedUtf16FlyStringList {
-    pointer: *mut RetainedUtf16FlyString,
-    length: usize,
-}
-
-impl RetainedUtf16FlyStringList {
-    pub(crate) fn from_retained_strings(strings: Vec<RetainedUtf16FlyString>) -> Self {
-        let slice = strings.into_boxed_slice();
-        let length = slice.len();
-        let pointer = Box::into_raw(slice) as *mut RetainedUtf16FlyString;
-        Self { pointer, length }
-    }
-
-    /// Takes ownership of one leaked reference to each string.
-    ///
-    /// # Safety
-    /// `strings` must point to `length` valid leaked string raws.
-    unsafe fn from_raw(strings: *const usize, length: usize) -> Self {
-        let slice: Box<[RetainedUtf16FlyString]> = (0..length)
-            .map(|i| RetainedUtf16FlyString {
-                raw: unsafe { *strings.add(i) },
-            })
-            .collect();
-        let length = slice.len();
-        let pointer = Box::into_raw(slice) as *mut RetainedUtf16FlyString;
-        Self { pointer, length }
-    }
-
-    pub(crate) fn clone_retained(&self) -> Self {
-        Self::from_retained_strings(
-            self.as_slice()
-                .iter()
-                .map(|string| unsafe { RetainedUtf16FlyString::from_borrowed_raw(string.raw()) })
-                .collect(),
-        )
-    }
-
-    pub(crate) fn as_slice(&self) -> &[RetainedUtf16FlyString] {
-        if self.pointer.is_null() {
-            return &[];
-        }
-        unsafe { std::slice::from_raw_parts(self.pointer, self.length) }
-    }
-}
-
-retained_list_drop!(RetainedUtf16FlyStringList);
 
 impl RetainedByteList {
     pub(crate) fn as_slice(&self) -> &[u8] {
@@ -843,12 +756,12 @@ macro_rules! retained_list_partial_eq {
         }
     };
 }
+pub(crate) use retained_list_partial_eq;
 
 retained_list_partial_eq!(RetainedStyleValueDataList, RetainedStyleValueData);
 retained_list_partial_eq!(RetainedPropertyIdList, u16);
 retained_list_partial_eq!(RetainedRequestUrlModifierList, RetainedRequestUrlModifier);
 retained_list_partial_eq!(RetainedByteList, u8);
-retained_list_partial_eq!(RetainedUtf16FlyStringList, RetainedUtf16FlyString);
 retained_list_partial_eq!(RetainedCounterDefinitionList, RetainedCounterDefinition);
 retained_list_partial_eq!(RetainedImageSetOptionList, RetainedImageSetOption);
 retained_list_partial_eq!(RetainedColorStopList, RetainedColorStop);
@@ -1638,7 +1551,7 @@ pub unsafe extern "C" fn rust_style_value_create_border_radius_rect(
 pub extern "C" fn rust_style_value_create_string(string: usize) -> *const StyleValueData {
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::String {
-            string: RetainedUtf16FlyString { raw: string },
+            string: unsafe { RetainedUtf16FlyString::from_leaked_raw(string) },
         }))
     })
 }
@@ -1648,7 +1561,7 @@ pub extern "C" fn rust_style_value_create_string(string: usize) -> *const StyleV
 pub extern "C" fn rust_style_value_create_custom_ident(custom_ident: usize) -> *const StyleValueData {
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::CustomIdent {
-            custom_ident: RetainedUtf16FlyString { raw: custom_ident },
+            custom_ident: unsafe { RetainedUtf16FlyString::from_leaked_raw(custom_ident) },
         }))
     })
 }
@@ -1661,7 +1574,7 @@ pub unsafe extern "C" fn rust_style_value_create_function(
 ) -> *const StyleValueData {
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::Function {
-            name: RetainedUtf16FlyString { raw: name },
+            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
             value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
         }))
     })
@@ -1678,7 +1591,7 @@ pub unsafe extern "C" fn rust_style_value_create_open_type_tagged(
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::OpenTypeTagged {
             mode,
-            tag: RetainedUtf16FlyString { raw: tag },
+            tag: unsafe { RetainedUtf16FlyString::from_leaked_raw(tag) },
             packed_tag,
             value: unsafe { RetainedStyleValueData::from_retained_pointer(value) },
         }))
@@ -1796,7 +1709,7 @@ pub unsafe extern "C" fn rust_style_value_create_anchor_size(
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::AnchorSize {
             has_anchor_name,
-            anchor_name: RetainedUtf16FlyString { raw: anchor_name },
+            anchor_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(anchor_name) },
             has_anchor_size,
             anchor_size,
             fallback_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fallback_value) },
@@ -1816,7 +1729,7 @@ pub unsafe extern "C" fn rust_style_value_create_anchor(
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::Anchor {
             has_anchor_name,
-            anchor_name: RetainedUtf16FlyString { raw: anchor_name },
+            anchor_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(anchor_name) },
             anchor_side: unsafe { RetainedStyleValueData::from_retained_pointer(anchor_side) },
             fallback_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fallback_value) },
         }))
@@ -1888,9 +1801,9 @@ pub unsafe extern "C" fn rust_style_value_create_counter(
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::Counter {
             function,
-            counter_name: RetainedUtf16FlyString { raw: counter_name },
+            counter_name: unsafe { RetainedUtf16FlyString::from_leaked_raw(counter_name) },
             counter_style: unsafe { RetainedStyleValueData::from_retained_pointer(counter_style) },
-            join_string: RetainedUtf16FlyString { raw: join_string },
+            join_string: unsafe { RetainedUtf16FlyString::from_leaked_raw(join_string) },
         }))
     })
 }
@@ -1932,7 +1845,7 @@ pub unsafe extern "C" fn rust_style_value_create_random_value_sharing(
             fixed_value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(fixed_value) },
             is_auto,
             has_name,
-            name: RetainedUtf16FlyString { raw: name },
+            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
             element_shared,
         }))
     })
@@ -2097,7 +2010,7 @@ pub unsafe extern "C" fn rust_style_value_create_font_source(
             url_type,
             url_modifiers: unsafe { RetainedRequestUrlModifierList::from_raw(url_modifiers, url_modifier_count) },
             has_format,
-            format: RetainedUtf16FlyString { raw: format },
+            format: unsafe { RetainedUtf16FlyString::from_leaked_raw(format) },
             tech: unsafe { RetainedByteList::from_raw(tech, tech_count) },
         }))
     })
@@ -2189,7 +2102,7 @@ pub unsafe extern "C" fn rust_style_value_create_grid_track_placement(
             kind,
             value: unsafe { RetainedStyleValueData::from_retained_optional_pointer(value) },
             has_name,
-            name: RetainedUtf16FlyString { raw: name },
+            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
         }))
     })
 }
@@ -2208,7 +2121,7 @@ pub unsafe extern "C" fn rust_style_value_create_counter_style_system(
             kind,
             system,
             first_symbol: unsafe { RetainedStyleValueData::from_retained_optional_pointer(first_symbol) },
-            name: RetainedUtf16FlyString { raw: name },
+            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
         }))
     })
 }
@@ -2226,7 +2139,7 @@ pub unsafe extern "C" fn rust_style_value_create_counter_style(
     abort_on_panic(|| {
         Arc::into_raw(Arc::new(StyleValueData::CounterStyle {
             is_symbols,
-            name: RetainedUtf16FlyString { raw: name },
+            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
             symbols_type,
             symbols: unsafe { RetainedUtf16FlyStringList::from_raw(symbols, symbol_count) },
         }))
@@ -2276,7 +2189,7 @@ pub unsafe extern "C" fn rust_style_value_create_color_function(
             channel_2: unsafe { RetainedStyleValueData::from_retained_pointer(channel_2) },
             alpha: unsafe { RetainedStyleValueData::from_retained_optional_pointer(alpha) },
             has_name,
-            name: RetainedUtf16FlyString { raw: name },
+            name: unsafe { RetainedUtf16FlyString::from_leaked_raw(name) },
             origin_color: unsafe { RetainedStyleValueData::from_retained_optional_pointer(origin_color) },
         }))
     })
@@ -2496,7 +2409,7 @@ pub unsafe extern "C" fn rust_style_value_create_basic_shape(
             v4: unsafe { RetainedStyleValueData::from_retained_optional_pointer(v4) },
             fill_rule,
             points: unsafe { RetainedShapePointList::from_raw(points, point_count) },
-            path_string: RetainedUtf16FlyString { raw: path_string },
+            path_string: unsafe { RetainedUtf16FlyString::from_leaked_raw(path_string) },
         }))
     })
 }

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -2356,7 +2356,7 @@ impl<'pass> BlockFormattingContext<'pass> {
                     .sizing()
                     .should_treat_block_size_as_auto(caption, available_space, constraints)
                 {
-                    let content_block_size = if self.style(caption).containment_bits() & 1 != 0 {
+                    let content_block_size = if self.style(caption).has_size_containment() {
                         CssPixels::default()
                     } else {
                         child_layout.result().automatic_content_block_size

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -4853,7 +4853,7 @@ impl OwnedFlexLayoutData {
     }
 }
 
-pub type FfiBuildStyleSnapshotCallback = unsafe extern "C" fn(*mut c_void, *const c_void) -> crate::layout::FfiStyleSnapshot;
+pub type FfiBuildStylePayloadsCallback = unsafe extern "C" fn(*mut c_void, *const c_void) -> crate::layout::FfiStylePayloads;
 pub type FfiBuildTableBoxFactsCallback = unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiTableBoxFacts;
 
 #[derive(Clone, Copy)]
@@ -4869,7 +4869,7 @@ pub struct FfiLayoutFcCallbacks {
     pub decode_residual_style: crate::layout::FfiDecodeResidualStyleCallback,
     pub release_calc_handle: crate::layout::FfiReleaseCalcHandleCallback,
     pub release_anchor_name_handle: crate::layout::FfiReleaseAnchorNameHandleCallback,
-    pub build_style_snapshot: FfiBuildStyleSnapshotCallback,
+    pub build_style_payloads: FfiBuildStylePayloadsCallback,
     pub build_replaced_content_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiReplacedContentFacts,
     pub build_list_item_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiListItemFacts,
     pub text_node_is_empty_editable: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -706,8 +706,8 @@ impl<'pass> NodeFacts<'pass> {
         ) {
             return false;
         }
-        let containment_bits = self.style().containment_bits();
-        containment_bits & 1 != 0 || containment_bits & (1 << 5) != 0
+        let style = self.style();
+        style.has_size_containment() || style.is_size_container()
     }
 
     pub(crate) fn has_preferred_aspect_ratio(&self) -> bool {
@@ -1265,8 +1265,8 @@ impl LayoutState {
         // Size containment gives any box an auto content box size of zero, so
         // size-contained boxes join the replaced kinds in fetching real facts.
         let size_containment_may_apply = crate::layout::kind_is_box(data.kind) && !data.style.is_null() && {
-            let containment_bits = self.style_facts(callbacks, node).containment_bits();
-            containment_bits & 1 != 0 || containment_bits & (1 << 5) != 0
+            let style = self.style_facts(callbacks, node);
+            style.has_size_containment() || style.is_size_container()
         };
         let facts = if crate::layout::node_may_have_replaced_content_facts(data) || size_containment_may_apply {
             // SAFETY: The callback table and node are supplied by the live C++

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -767,7 +767,7 @@ impl<'pass> NodeFacts<'pass> {
         if self.data().style.is_null() {
             return crate::layout::FfiDisplay::block();
         }
-        self.state.style_snapshot(self.callbacks, self.node).display
+        self.state.style_facts(self.callbacks, self.node).display
     }
 
     pub(crate) fn is_svg_box(&self) -> bool {
@@ -843,7 +843,6 @@ pub(crate) struct LayoutState {
     used_values: PagedStore<UsedValues>,
     contained_abspos_children: PagedStore<RefCell<Vec<ContainedAbsposChild>>>,
     style_decode_values: PagedStore<StyleDecodeValues>,
-    style_snapshots: PagedStore<FfiStyleSnapshot>,
     replaced_content_facts: PagedStore<crate::layout::FfiReplacedContentFacts>,
     list_item_facts: PagedStore<crate::layout::FfiListItemFacts>,
     table_facts: PagedStore<FfiTableBoxFacts>,
@@ -896,7 +895,6 @@ impl LayoutState {
             used_values: PagedStore::default(),
             contained_abspos_children: PagedStore::default(),
             style_decode_values: PagedStore::default(),
-            style_snapshots: PagedStore::default(),
             replaced_content_facts: PagedStore::default(),
             list_item_facts: PagedStore::default(),
             table_facts: PagedStore::default(),
@@ -1191,32 +1189,21 @@ impl LayoutState {
         let cache = if let Some(cache) = self.style_decode_values.get(slot_index) {
             cache
         } else {
-            let snapshot = self.style_snapshot(callbacks, node);
+            let data = callbacks.node_data(node);
+            assert!(!data.style.is_null());
+            // SAFETY: NodeData retains the node's immutable ComputedValues for
+            // the synchronous layout pass.
+            let payloads = unsafe { (callbacks.build_style_payloads)(callbacks.context, data.style) };
             self.style_decode_values.allocate(
                 slot_index,
                 StyleDecodeValues::new(
-                    snapshot.payloads,
-                    snapshot.display,
+                    payloads,
                     callbacks.release_calc_handle,
                     callbacks.release_anchor_name_handle,
                 ),
             )
         };
         StyleValues::new(cache, callbacks.context, callbacks.decode_residual_style)
-    }
-
-    fn style_snapshot(&self, callbacks: &FfiLayoutFcCallbacks, node: Node) -> &FfiStyleSnapshot {
-        let data = callbacks.node_data(node);
-        assert!(!data.style.is_null());
-        let slot_index = callbacks.slot_index(node);
-        let snapshot = self.style_snapshots.get(slot_index);
-        if let Some(snapshot) = snapshot {
-            return snapshot;
-        }
-        // SAFETY: NodeData retains the node's immutable ComputedValues for the
-        // synchronous layout pass.
-        let snapshot = unsafe { (callbacks.build_style_snapshot)(callbacks.context, data.style) };
-        self.style_snapshots.allocate(slot_index, snapshot)
     }
 
     pub(crate) fn replace_resolved_anchor_insets(

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -297,22 +297,6 @@ pub struct FfiStylePayloads {
     pub groups: [*const c_void; STYLE_GROUP_COUNT],
 }
 
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct FfiStyleSnapshot {
-    pub payloads: FfiStylePayloads,
-    pub display: FfiDisplay,
-}
-
-impl Default for FfiStyleSnapshot {
-    fn default() -> Self {
-        Self {
-            payloads: FfiStylePayloads::default(),
-            display: FfiDisplay::block(),
-        }
-    }
-}
-
 impl Default for FfiStylePayloads {
     fn default() -> Self {
         Self {
@@ -826,13 +810,12 @@ pub(crate) struct StyleDecodeValues {
 impl StyleDecodeValues {
     pub(crate) fn new(
         payloads: FfiStylePayloads,
-        display: FfiDisplay,
         release_calc_handle: FfiReleaseCalcHandleCallback,
         release_anchor_name_handle: FfiReleaseAnchorNameHandleCallback,
     ) -> Self {
         let reader = StyleReader::new(payloads, style_schema());
         Self {
-            scalars: DecodedStyleScalars::decode(&reader, display),
+            scalars: DecodedStyleScalars::decode(&reader),
             cache: StyleDecodeCache::new(reader, release_calc_handle, release_anchor_name_handle),
         }
     }
@@ -858,7 +841,7 @@ pub(crate) struct StyleValues<'a> {
 }
 
 impl DecodedStyleScalars {
-    fn decode(reader: &StyleReader, display: FfiDisplay) -> Self {
+    fn decode(reader: &StyleReader) -> Self {
         let inherited_box = reader.inherited_box();
         let alignment = reader.alignment();
         let inherited_table = reader.inherited_table();
@@ -866,7 +849,7 @@ impl DecodedStyleScalars {
         let (css_preferred_aspect_ratio_numerator, css_preferred_aspect_ratio_denominator) =
             decode_css_preferred_aspect_ratio(&box_values.aspect_ratio);
         Self {
-            display,
+            display: box_values.display,
             border_top_width: reader.css_pixels(FfiStyleField::BorderTopWidth),
             border_right_width: reader.css_pixels(FfiStyleField::BorderRightWidth),
             border_bottom_width: reader.css_pixels(FfiStyleField::BorderBottomWidth),

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -215,9 +215,6 @@ pub enum FfiStyleField {
     BorderRightStyle,
     BorderBottomStyle,
     BorderLeftStyle,
-    Position,
-    Float,
-    Clear,
     TextAlign,
     TextJustify,
     WhiteSpaceCollapse,
@@ -226,9 +223,6 @@ pub enum FfiStyleField {
     FontVariantEmoji,
     LineHeight,
     FontSize,
-    BoxSizing,
-    OverflowX,
-    OverflowY,
     TextOverflow,
     TableLayout,
     LetterSpacing,
@@ -270,6 +264,7 @@ pub(crate) enum SizeField {
     TextIndent,
     X,
     Y,
+    VerticalAlign,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -345,6 +340,7 @@ struct NativeGroupIndices {
     svg_reset: usize,
     inherited_box: usize,
     inherited_table: usize,
+    box_values: usize,
 }
 
 static NATIVE_GROUP_INDICES: OnceLock<NativeGroupIndices> = OnceLock::new();
@@ -358,6 +354,7 @@ fn native_group_indices() -> &'static NativeGroupIndices {
         svg_reset: style_group_index_with_lifecycle(StyleGroupLifecycle::SVGReset),
         inherited_box: style_group_index_with_lifecycle(StyleGroupLifecycle::InheritedBox),
         inherited_table: style_group_index_with_lifecycle(StyleGroupLifecycle::InheritedTable),
+        box_values: style_group_index_with_lifecycle(StyleGroupLifecycle::Box),
     })
 }
 
@@ -412,24 +409,14 @@ pub struct FfiResidualStyleValues {
     pub position_anchor_has_value: bool,
     /// A transferred Utf16FlyString reference, when non-zero.
     pub position_anchor_retained_name: usize,
-    pub vertical_align_is_keyword: bool,
-    pub vertical_align_keyword: u8,
-    pub vertical_align_value: FfiSizeValue,
     pub first_available_font: *const c_void,
     pub font_cascade_list: *const c_void,
     pub font_ascent: f32,
     pub font_descent: f32,
     pub font_x_height: f32,
-    pub box_sizing_for_aspect_ratio: u8,
-    /// The computed `aspect-ratio` <ratio> term. A zero denominator means no
-    /// usable ratio (either none was specified or the value was degenerate).
-    pub css_preferred_aspect_ratio_numerator: CssPixels,
-    pub css_preferred_aspect_ratio_denominator: CssPixels,
-    pub aspect_ratio_uses_natural_when_available: bool,
     pub column_width: FfiSizeValue,
     pub column_count_has_value: bool,
     pub column_count: i32,
-    pub containment_bits: u8,
     pub text_indent: FfiSizeValue,
     pub text_indent_each_line: bool,
     pub text_indent_hanging: bool,
@@ -447,22 +434,14 @@ impl Default for FfiResidualStyleValues {
             anchor_inset_left: FfiSizeValue::auto_value(),
             position_anchor_has_value: false,
             position_anchor_retained_name: 0,
-            vertical_align_is_keyword: false,
-            vertical_align_keyword: 0,
-            vertical_align_value: FfiSizeValue::auto_value(),
             first_available_font: std::ptr::null(),
             font_cascade_list: std::ptr::null(),
             font_ascent: 0.0,
             font_descent: 0.0,
             font_x_height: 0.0,
-            box_sizing_for_aspect_ratio: 0,
-            css_preferred_aspect_ratio_numerator: CssPixels::default(),
-            css_preferred_aspect_ratio_denominator: CssPixels::default(),
-            aspect_ratio_uses_natural_when_available: false,
             column_width: FfiSizeValue::auto_value(),
             column_count_has_value: false,
             column_count: 0,
-            containment_bits: 0,
             text_indent: FfiSizeValue::auto_value(),
             text_indent_each_line: false,
             text_indent_hanging: false,
@@ -483,7 +462,6 @@ impl FfiResidualStyleValues {
         self.anchor_inset_right.release_bridge_calc_handle(release_calc_handle);
         self.anchor_inset_bottom.release_bridge_calc_handle(release_calc_handle);
         self.anchor_inset_left.release_bridge_calc_handle(release_calc_handle);
-        self.vertical_align_value.release_bridge_calc_handle(release_calc_handle);
         self.column_width.release_bridge_calc_handle(release_calc_handle);
         self.text_indent.release_bridge_calc_handle(release_calc_handle);
         if self.position_anchor_retained_name != 0 {
@@ -576,9 +554,14 @@ impl StyleReader {
     fn inherited_table(&self) -> &crate::css::computed_values::InheritedTableValues {
         self.native_group(native_group_indices().inherited_table)
     }
+
+    #[inline]
+    fn box_values(&self) -> &crate::layout::BoxValues {
+        self.native_group(native_group_indices().box_values)
+    }
 }
 
-const SIZE_FIELD_COUNT: usize = 25;
+const SIZE_FIELD_COUNT: usize = 26;
 
 pub(crate) struct StyleDecodeCache {
     reader: StyleReader,
@@ -808,6 +791,31 @@ pub(crate) struct DecodedStyleScalars {
     pub unicode_bidi: u8,
     pub grid_auto_flow_row: bool,
     pub grid_auto_flow_dense: bool,
+    pub css_preferred_aspect_ratio_numerator: CssPixels,
+    pub css_preferred_aspect_ratio_denominator: CssPixels,
+}
+
+/// The computed `aspect-ratio` <ratio> term as a CSSPixels fraction. A zero
+/// denominator means no usable ratio (none specified, degenerate, or collapsed
+/// to zero by the fixed-point conversion).
+fn decode_css_preferred_aspect_ratio(
+    ratio: &crate::css::computed_value_types::ComputedAspectRatio,
+) -> (CssPixels, CssPixels) {
+    let no_usable_ratio = (CssPixels::default(), CssPixels::default());
+    if !ratio.has_preferred_ratio {
+        return no_usable_ratio;
+    }
+    let numerator = ratio.preferred_ratio_numerator;
+    let denominator = ratio.preferred_ratio_denominator;
+    let is_degenerate = !numerator.is_finite() || numerator == 0.0 || !denominator.is_finite() || denominator == 0.0;
+    if is_degenerate {
+        return no_usable_ratio;
+    }
+    let (numerator, denominator) = CssPixels::fraction_nearest_values_for(numerator, denominator);
+    if numerator.raw_value() == 0 {
+        return no_usable_ratio;
+    }
+    (numerator, denominator)
 }
 
 pub(crate) struct StyleDecodeValues {
@@ -854,6 +862,9 @@ impl DecodedStyleScalars {
         let inherited_box = reader.inherited_box();
         let alignment = reader.alignment();
         let inherited_table = reader.inherited_table();
+        let box_values = reader.box_values();
+        let (css_preferred_aspect_ratio_numerator, css_preferred_aspect_ratio_denominator) =
+            decode_css_preferred_aspect_ratio(&box_values.aspect_ratio);
         Self {
             display,
             border_top_width: reader.css_pixels(FfiStyleField::BorderTopWidth),
@@ -864,9 +875,9 @@ impl DecodedStyleScalars {
             border_right_style: reader.u8(FfiStyleField::BorderRightStyle),
             border_bottom_style: reader.u8(FfiStyleField::BorderBottomStyle),
             border_left_style: reader.u8(FfiStyleField::BorderLeftStyle),
-            position: reader.u8(FfiStyleField::Position),
-            float_: reader.u8(FfiStyleField::Float),
-            clear: reader.u8(FfiStyleField::Clear),
+            position: box_values.position,
+            float_: box_values.float_,
+            clear: box_values.clear,
             writing_mode: inherited_box.writing_mode,
             direction: inherited_box.direction,
             text_align: reader.u8(FfiStyleField::TextAlign),
@@ -877,9 +888,9 @@ impl DecodedStyleScalars {
             font_variant_emoji: reader.u8(FfiStyleField::FontVariantEmoji),
             line_height: reader.css_pixels(FfiStyleField::LineHeight),
             font_size: reader.css_pixels(FfiStyleField::FontSize),
-            box_sizing: reader.u8(FfiStyleField::BoxSizing),
-            overflow_x: reader.u8(FfiStyleField::OverflowX),
-            overflow_y: reader.u8(FfiStyleField::OverflowY),
+            box_sizing: box_values.box_sizing,
+            overflow_x: box_values.overflow_x,
+            overflow_y: box_values.overflow_y,
             text_overflow: reader.u8(FfiStyleField::TextOverflow),
             flex_direction: alignment.flex_direction,
             flex_wrap: alignment.flex_wrap,
@@ -903,6 +914,8 @@ impl DecodedStyleScalars {
             unicode_bidi: reader.u8(FfiStyleField::UnicodeBidi),
             grid_auto_flow_row: reader.bool(FfiStyleField::GridAutoFlowRow),
             grid_auto_flow_dense: reader.bool(FfiStyleField::GridAutoFlowDense),
+            css_preferred_aspect_ratio_numerator,
+            css_preferred_aspect_ratio_denominator,
         }
     }
 }
@@ -1025,6 +1038,7 @@ impl<'a> StyleValues<'a> {
                 let values = self.cache.reader.svg_reset();
                 decode_length_percentage(if field == SizeField::X { &values.x } else { &values.y })
             }
+            SizeField::VerticalAlign => decode_length_percentage(&self.cache.reader.box_values().vertical_align.value),
             SizeField::ColumnWidth | SizeField::TextIndent => unreachable!(),
         }
     }
@@ -1062,19 +1076,19 @@ impl<'a> StyleValues<'a> {
     }
 
     pub(crate) fn vertical_align_is_keyword(self) -> bool {
-        self.vertical_align_override != u16::MAX || self.residual().vertical_align_is_keyword
+        self.vertical_align_override != u16::MAX || self.cache.reader.box_values().vertical_align.is_keyword
     }
 
     pub(crate) fn vertical_align_keyword(self) -> u8 {
         if self.vertical_align_override != u16::MAX {
             self.vertical_align_override as u8
         } else {
-            self.residual().vertical_align_keyword
+            self.cache.reader.box_values().vertical_align.keyword
         }
     }
 
     pub(crate) fn vertical_align_value(self) -> FfiSizeValue {
-        self.residual().vertical_align_value
+        self.size_value(SizeField::VerticalAlign)
     }
 
     pub(crate) fn has_position_anchor(self) -> bool {
@@ -1106,19 +1120,28 @@ impl<'a> StyleValues<'a> {
     }
 
     pub(crate) fn box_sizing_for_aspect_ratio(self) -> u8 {
-        self.residual().box_sizing_for_aspect_ratio
+        let values = self.cache.reader.box_values();
+        if values.aspect_ratio.use_natural_aspect_ratio_if_available {
+            crate::css::css_enums::box_sizing::CONTENT_BOX
+        } else {
+            values.box_sizing
+        }
     }
 
     pub(crate) fn css_preferred_aspect_ratio_numerator(self) -> CssPixels {
-        self.residual().css_preferred_aspect_ratio_numerator
+        self.scalars.css_preferred_aspect_ratio_numerator
     }
 
     pub(crate) fn css_preferred_aspect_ratio_denominator(self) -> CssPixels {
-        self.residual().css_preferred_aspect_ratio_denominator
+        self.scalars.css_preferred_aspect_ratio_denominator
     }
 
     pub(crate) fn aspect_ratio_uses_natural_when_available(self) -> bool {
-        self.residual().aspect_ratio_uses_natural_when_available
+        self.cache
+            .reader
+            .box_values()
+            .aspect_ratio
+            .use_natural_aspect_ratio_if_available
     }
 
     pub(crate) fn flex_basis_is_content(self) -> bool {
@@ -1137,8 +1160,12 @@ impl<'a> StyleValues<'a> {
         self.residual().column_count
     }
 
-    pub(crate) fn containment_bits(self) -> u8 {
-        self.residual().containment_bits
+    pub(crate) fn has_size_containment(self) -> bool {
+        self.cache.reader.box_values().size_containment
+    }
+
+    pub(crate) fn is_size_container(self) -> bool {
+        self.cache.reader.box_values().is_size_container
     }
 
     pub(crate) fn text_indent_each_line(self) -> bool {


### PR DESCRIPTION
Display was the box group's last field to cross the FFI in a bespoke
form: C++ hand-encoded it into a third representation carried alongside
the payload pointers in every per-node style snapshot, even though the
Rust-native box payload now stores the same FfiDisplay layout directly.
Reading it from the payload reduces the snapshot to the bare payload
pointer array, which leaves the per-node snapshot store with a single
caller that never revisits a slot — so the store, the FfiStyleSnapshot
struct, and the C++ display encoder all go, and the fetch callback is
renamed build_style_payloads to match what it now returns.