### PR TITLE
CI: Bump CI docker image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         toolchain: ['GNU']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'Linux'

--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
         toolchain: ['Clang']
         package_type: ['Linux-x86_64']
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "js-benchmarks", "self-hosted"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: 'blacksmith-16vcpu-ubuntu-2404'
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -31,7 +31,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -24,7 +24,7 @@ jobs:
         toolchain: ['Clang']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404-arm"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'Linux'

--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
         os_name: ['Linux']
         arch: ['x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "web-benchmarks", "self-hosted"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.04"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'macOS'


### PR DESCRIPTION
Follow on from #10849.

For reference, I noticed that `Meta/Docker/ci/VERSION` was previously changed in #10536 but we never switched to using that new version. So this bump includes the removal of Gtk as well as including `qt6-base-private-dev`. 