### PR TITLE
LibWeb: Don't autoscroll for middle-clicked text-fragment links

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -475,14 +475,14 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
     Optional<int> start_index;
-    bool hit_text_node = false;
+    bool hit_text_fragment = false;
 
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
         paintable = result->paintable;
         chrome_widget = result->chrome_widget;
         node = result->dom_node;
         start_index = result->index_in_node;
-        hit_text_node = node && node->is_text();
+        hit_text_fragment = result->is_text_fragment;
     }
 
     ArmedScopeGuard clear_cursor = [&] {
@@ -517,7 +517,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint visual_viewport_positio
         bool found_parent_element = parent_element_for_event_dispatch(*paintable, node, layout_node);
 
         if (found_parent_element) {
-            update_cursor(*paintable, *node, chrome_widget, hit_text_node);
+            update_cursor(*paintable, *node, chrome_widget, hit_text_fragment);
             clear_cursor.disarm();
 
             auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
@@ -953,12 +953,12 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
     RefPtr<Painting::Paintable> paintable;
     RefPtr<Painting::ChromeWidget> chrome_widget;
     GC::Ptr<DOM::Node> node;
-    bool hit_text_node = false;
+    bool hit_text_fragment = false;
     if (auto result = target_for_mouse_position(visual_viewport_position); result.has_value()) {
         paintable = result->paintable;
         chrome_widget = result->chrome_widget;
         node = result->dom_node;
-        hit_text_node = node && node->is_text();
+        hit_text_fragment = result->is_text_fragment;
     }
 
     ArmedScopeGuard clear_hover = [&] {
@@ -987,7 +987,7 @@ void EventHandler::update_hover_after_scroll(CSSPixelPoint visual_viewport_posit
         return;
 
     update_hovered_chrome_widget(chrome_widget);
-    update_cursor(*paintable, *node, chrome_widget, hit_text_node);
+    update_cursor(*paintable, *node, chrome_widget, hit_text_fragment);
 
     auto coordinates = compute_mouse_event_coordinates(visual_viewport_position, viewport_position, *paintable, *layout_node);
     track_the_effective_position_of_the_legacy_mouse_pointer(node, DOM::HoverEventData {
@@ -2073,7 +2073,13 @@ Optional<EventHandler::Target> EventHandler::target_for_mouse_position(CSSPixelP
         return {};
 
     if (auto result = document->hit_test(position, Painting::HitTestType::Exact); result.has_value())
-        return Target { .paintable = result->paintable.ptr(), .chrome_widget = result->chrome_widget, .dom_node = result->dom_node(), .index_in_node = result->index_in_node };
+        return Target {
+            .paintable = result->paintable.ptr(),
+            .chrome_widget = result->chrome_widget,
+            .dom_node = result->dom_node(),
+            .index_in_node = result->index_in_node,
+            .is_text_fragment = result->is_text_fragment,
+        };
     return {};
 }
 
@@ -2119,16 +2125,7 @@ void EventHandler::run_mousedown_default_actions(DOM::Document& document, CSSPix
         if (!hit.has_value())
             return;
 
-        // NB: Generated pseudo-elements don't have a DOM node, so we first have to walk up to find one.
-        GC::Ptr<DOM::Node const> start_node = nullptr;
-        for (RefPtr<Painting::Paintable> paintable = hit->paintable; paintable; paintable = paintable->parent()) {
-            if (paintable->dom_node()) {
-                start_node = paintable->dom_node();
-                break;
-            }
-        }
-
-        for (GC::Ptr<DOM::Node const> node = start_node; node; node = node->parent_or_shadow_host_node()) {
+        for (GC::Ptr<DOM::Node const> node = hit->dom_node(); node; node = node->parent_or_shadow_host_node()) {
             if (node->is_editable_or_editing_host() || is<HTML::FormAssociatedTextControlElement>(*node))
                 return;
             if (auto const* anchor = as_if<HTML::HTMLAnchorElement>(*node); anchor && anchor->has_attribute(HTML::AttributeNames::href))
@@ -3373,7 +3370,7 @@ static Gfx::Cursor resolve_cursor(Layout::NodeWithStyle const& layout_node, Read
 }
 
 void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<DOM::Node> host_element,
-    RefPtr<Painting::ChromeWidget> chrome_widget, bool hit_text_node)
+    RefPtr<Painting::ChromeWidget> chrome_widget, bool hit_text_fragment)
 {
     // AD-HOC: Update the cursor image based on the CSS rules before the steps terminate if the target hasn't changed.
     auto cursor = [&] -> Gfx::Cursor {
@@ -3385,15 +3382,15 @@ void EventHandler::update_cursor(RefPtr<Painting::Paintable> paintable, GC::Ptr<
         if (paintable) {
             auto* host_layout_node = host_element ? host_element->layout_node() : nullptr;
             auto const* cursor_data = &paintable->computed_values().cursor();
-            if (hit_text_node && host_layout_node)
+            if (hit_text_fragment && host_layout_node)
                 cursor_data = &as<Layout::NodeWithStyle>(*host_layout_node).computed_values().cursor();
 
             auto* host_node_with_style = host_layout_node ? as_if<Layout::NodeWithStyle>(*host_layout_node) : nullptr;
-            auto is_selectable_text_node = hit_text_node
+            auto is_selectable_text_fragment = hit_text_fragment
                 && host_layout_node
                 && host_layout_node->user_select_used_value() != CSS::UserSelect::None;
 
-            if (is_selectable_text_node || host_element->is_editable_or_editing_host()) {
+            if (is_selectable_text_fragment || host_element->is_editable_or_editing_host()) {
                 if (host_node_with_style)
                     return resolve_cursor(*host_node_with_style, *cursor_data, Gfx::StandardCursor::IBeam);
                 return resolve_cursor(*paintable->layout_node().parent(), *cursor_data, Gfx::StandardCursor::IBeam);

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -113,6 +113,7 @@ private:
         RefPtr<Painting::ChromeWidget> chrome_widget;
         GC::Ptr<DOM::Node> dom_node;
         Optional<int> index_in_node;
+        bool is_text_fragment { false };
     };
     Optional<Target> target_for_mouse_position(CSSPixelPoint position);
     GC::Ptr<DOM::Node> focus_candidate_for_position(CSSPixelPoint) const;
@@ -162,7 +163,7 @@ private:
     bool dispatch_chrome_widget_pointer_event(RefPtr<Painting::ChromeWidget>, Utf16FlyString const& type, unsigned button, CSSPixelPoint visual_viewport_position);
     void update_hovered_chrome_widget(RefPtr<Painting::ChromeWidget>);
 
-    void update_cursor(RefPtr<Painting::Paintable>, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget>, bool hit_text_node = false);
+    void update_cursor(RefPtr<Painting::Paintable>, GC::Ptr<DOM::Node> host_element, RefPtr<Painting::ChromeWidget>, bool hit_text_fragment = false);
     void record_last_known_mouse_position(CSSPixelPoint visual_viewport_position, CSSPixelPoint screen_position, unsigned buttons, unsigned modifiers);
     EventResult cancel_drag_and_drop_event(CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers);
 

--- a/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
+++ b/Libraries/LibWeb/Painting/HitTestDisplayList.cpp
@@ -632,7 +632,17 @@ DOM::Node const* HitTestDisplayList::item_dom_node(Item const& item) const
 
 DOM::Node const* HitTestDisplayList::event_dispatch_dom_node_for_item(Item const& item) const
 {
-    if (item.kind == ItemKind::TextFragment || item.kind == ItemKind::EmptyLine)
+    if (item.kind == ItemKind::TextFragment) {
+        VERIFY(item.text_fragment);
+        auto const& layout_node = item.text_fragment->layout_node();
+        if (auto const* node = layout_node.dom_node())
+            return node;
+        if (layout_node.is_generated_for_pseudo_element())
+            return layout_node.pseudo_element_generator();
+        return nullptr;
+    }
+
+    if (item.kind == ItemKind::EmptyLine)
         return item_dom_node(item);
 
     for (auto const* current = item.paintable.ptr(); current; current = current->parent()) {
@@ -658,8 +668,9 @@ HitTestResult HitTestDisplayList::hit_test_result_for_item(Item const& item, CSS
         VERIFY(item.text_fragment);
         return HitTestResult {
             .paintable = item.paintable,
-            .dom_node_override = const_cast<DOM::Node*>(item_dom_node(item)),
+            .dom_node_override = const_cast<DOM::Node*>(event_dispatch_dom_node_for_item(item)),
             .index_in_node = item.text_fragment->index_in_node_for_point(local_point),
+            .is_text_fragment = true,
         };
     case ItemKind::EmptyLine:
         // NB: Not reachable through regular hit testing; see item_contains().

--- a/Libraries/LibWeb/Painting/HitTestResult.h
+++ b/Libraries/LibWeb/Painting/HitTestResult.h
@@ -26,6 +26,7 @@ struct HitTestResult {
     RefPtr<ChromeWidget> chrome_widget {};
     GC::Ptr<DOM::Node> dom_node_override {};
     size_t index_in_node { 0 };
+    bool is_text_fragment { false };
     enum InternalPosition {
         None,
         Before,

--- a/Tests/LibWeb/Text/expected/UIEvents/middle-click-generated-content-link-autoscroll.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/middle-click-generated-content-link-autoscroll.txt
@@ -1,2 +1,3 @@
 plain link scrollY: 0
+generated-content link cursor: Hand
 generated-content link scrollY: 0

--- a/Tests/LibWeb/Text/input/UIEvents/middle-click-generated-content-link-autoscroll.html
+++ b/Tests/LibWeb/Text/input/UIEvents/middle-click-generated-content-link-autoscroll.html
@@ -6,7 +6,6 @@
     }
 
     a {
-        display: inline-block;
         margin: 20px;
         padding: 8px;
     }
@@ -36,6 +35,10 @@
         println(`plain link scrollY: ${scrollY}`);
 
         scrollTo(0, 0);
+
+        const generatedRect = generated.getBoundingClientRect();
+        internals.mouseMove(generatedRect.left + generatedRect.width / 2, generatedRect.top + generatedRect.height / 2);
+        println(`generated-content link cursor: ${internals.currentCursor()}`);
 
         await middleDragFrom(generated);
         println(`generated-content link scrollY: ${scrollY}`);


### PR DESCRIPTION
The fix in 3f2861714d5bf4090bc8207781b63de3ef0f54ee was only partial: the bug actually affected any text fragment, not just ones in generated pseudo-elements. This was hidden by the fact the test (reduced from a real page) sets `a { display: inline-block }`.

Inline text fragments are owned by their containing block's paintable, so walking the paintable ancestry can skip inline DOM ancestors. So instead of that, we modify hit testing to return the pseudo-element's generator DOM node, and then we use that for deciding whether to suppress middle-click autoscroll.

Preserve text-fragment provenance separately from the resolved DOM target so cursor selection continues to use the correct element style.

Fixes #10910.