### PR TITLE
LibWeb: Bound realtime audio trimming to rendered frames

### DIFF
--- a/Libraries/LibWeb/WebAudio/Rendering/RealtimeAudioRenderer.cpp
+++ b/Libraries/LibWeb/WebAudio/Rendering/RealtimeAudioRenderer.cpp
@@ -139,8 +139,10 @@ ReadonlySpan<float> RealtimeAudioRenderer::fill_output_buffer(Span<float> buffer
         m_playhead += m_playhead_step;
     }
 
-    // Trim fully consumed frames, keeping the frame under the playhead for interpolation continuity.
-    auto consumed_frames = static_cast<size_t>(m_playhead);
+    // Trim rendered frames preceding the playhead. If resampling advances the playhead beyond the rendered frames,
+    // carry the remaining offset into the next callback.
+    auto rendered_frames = m_pending_samples.size() / channel_count;
+    auto consumed_frames = min(static_cast<size_t>(m_playhead), rendered_frames);
     if (consumed_frames > 0) {
         m_pending_samples.remove(0, consumed_frames * channel_count);
         m_playhead -= consumed_frames;

--- a/Tests/LibWeb/Crash/WebAudio/AudioContext-high-sample-rate-resampling.html
+++ b/Tests/LibWeb/Crash/WebAudio/AudioContext-high-sample-rate-resampling.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<script>
+    const context = new AudioContext({ sampleRate: 763000 });
+
+    function waitForOutput() {
+        if (context.getOutputTimestamp().contextTime === 0) {
+            requestAnimationFrame(waitForOutput);
+            return;
+        }
+        document.documentElement.classList.remove("test-wait");
+    }
+    requestAnimationFrame(waitForOutput);
+</script>


### PR DESCRIPTION
Realtime resampling allowed the playhead to advance beyond the rendered pending samples. The renderer then removed more samples than the buffer contained and crashed.

Trimming is limited to rendered frames, carrying any remaining playhead offset into the next callback.