### PR TITLE
LibJS: Optimize same-width integer TypedArray copying

### DIFF
--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1434,6 +1434,24 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::reverse)
     return typed_array;
 }
 
+static bool typed_array_element_types_have_same_bit_encoding(TypedArrayBase const& source, TypedArrayBase const& target)
+{
+    if (source.kind() == target.kind())
+        return true;
+
+    if ((source.kind() == TypedArrayBase::Kind::Uint8Array && target.kind() == TypedArrayBase::Kind::Uint8ClampedArray)
+        || (source.kind() == TypedArrayBase::Kind::Uint8ClampedArray && target.kind() == TypedArrayBase::Kind::Uint8Array))
+        return true;
+
+    if (source.element_size() != target.element_size())
+        return false;
+
+    if (source.is_unclamped_integer_element_type() && target.is_unclamped_integer_element_type())
+        return true;
+
+    return source.is_bigint_element_type() && target.is_bigint_element_type();
+}
+
 // 23.2.3.26.1 SetTypedArrayFromTypedArray ( target, targetOffset, source ), https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray
 static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArrayBase& target, double target_offset, TypedArrayBase const& source)
 {
@@ -1537,9 +1555,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
     auto limit = checked_limit.value();
 
     // 23. If srcType is targetType, then
-    if (source.kind() == target.kind()
-        || (source.kind() == TypedArrayBase::Kind::Uint8Array && target.kind() == TypedArrayBase::Kind::Uint8ClampedArray)
-        || (source.kind() == TypedArrayBase::Kind::Uint8ClampedArray && target.kind() == TypedArrayBase::Kind::Uint8Array)) {
+    if (typed_array_element_types_have_same_bit_encoding(source, target)) {
         // a. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
         // b. Repeat, while targetByteIndex < limit,
         //     i. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, Uint8, true, Unordered).

--- a/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.set.js
+++ b/Tests/LibJS/Runtime/builtins/TypedArray/TypedArray.prototype.set.js
@@ -103,6 +103,40 @@ describe("normal behavior", () => {
         BIGINT_TYPED_ARRAYS.forEach(T => argumentTests(T));
     });
 
+    test("set preserves bit encodings between same-width signed and unsigned integer arrays", () => {
+        const pairs = [
+            [Uint8Array, Int8Array, [0, 127, 128, 255], [0, 127, -128, -1]],
+            [Uint16Array, Int16Array, [0, 32767, 32768, 65535], [0, 32767, -32768, -1]],
+            [Uint32Array, Int32Array, [0, 2147483647, 2147483648, 4294967295], [0, 2147483647, -2147483648, -1]],
+            [
+                BigUint64Array,
+                BigInt64Array,
+                [0n, 9223372036854775807n, 9223372036854775808n, 18446744073709551615n],
+                [0n, 9223372036854775807n, -9223372036854775808n, -1n],
+            ],
+        ];
+
+        for (const [UnsignedArray, SignedArray, unsignedValues, signedValues] of pairs) {
+            const signedTarget = new SignedArray(unsignedValues.length);
+            signedTarget.set(new UnsignedArray(unsignedValues));
+            expect(Array.from(signedTarget)).toEqual(signedValues);
+
+            const unsignedTarget = new UnsignedArray(signedValues.length);
+            unsignedTarget.set(new SignedArray(signedValues));
+            expect(Array.from(unsignedTarget)).toEqual(unsignedValues);
+        }
+    });
+
+    test("set snapshots overlapping same-width signed and unsigned integer arrays", () => {
+        const buffer = new ArrayBuffer(4);
+        const source = new Uint8Array(buffer);
+        source.set([1, 2, 3, 4]);
+
+        new Int8Array(buffer, 1).set(source.subarray(0, 3));
+
+        expect(Array.from(source)).toEqual([1, 1, 2, 3]);
+    });
+
     test("set works when source is Array", () => {
         function argumentTests({ array, maxUnsignedInteger }) {
             const firstTypedArray = new array(1);


### PR DESCRIPTION
typed-array-prototype-set-equal-width microbench goes from 9.957s to 0.032s.

Cuts 10 seconds off d3wasm's load time, going from 30 seconds to 20 seconds for the first level.