### PR TITLE
LibWeb: Scroll by a page when the spacebar is pressed

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -32,12 +32,15 @@
 #include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLAnchorElement.h>
+#include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLDialogElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
+#include <LibWeb/HTML/HTMLSelectElement.h>
+#include <LibWeb/HTML/HTMLSummaryElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/LocalNavigable.h>
@@ -1375,6 +1378,21 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
             break;
         scroll_by_for_key_input(0, key == UIEvents::KeyCode::Key_PageUp ? -page_scroll_distance : page_scroll_distance);
         return EventResult::Handled;
+    case UIEvents::KeyCode::Key_Space: {
+        if ((modifiers_without_keypad & ~UIEvents::KeyModifier::Mod_Shift) != UIEvents::KeyModifier::Mod_None)
+            break;
+        auto const* focused_area = document->focused_area().ptr();
+        // FIXME: These elements must run their activation behavior instead of merely swallowing the key.
+        auto const focused_area_activates_on_space = is<HTML::HTMLButtonElement>(focused_area)
+            || is<HTML::HTMLInputElement>(focused_area)
+            || is<HTML::HTMLSelectElement>(focused_area)
+            || is<HTML::HTMLSummaryElement>(focused_area);
+        if (focused_area_activates_on_space)
+            break;
+        bool scroll_backward = (modifiers_without_keypad & UIEvents::KeyModifier::Mod_Shift) != UIEvents::KeyModifier::Mod_None;
+        scroll_by_for_key_input(0, scroll_backward ? -page_scroll_distance : page_scroll_distance);
+        return EventResult::Handled;
+    }
     case UIEvents::KeyCode::Key_Home:
         scroll_to_the_beginning_for_key_input();
         return EventResult::Handled;

--- a/Tests/LibWeb/Text/expected/spacebar-scroll.txt
+++ b/Tests/LibWeb/Text/expected/spacebar-scroll.txt
@@ -1,0 +1,8 @@
+viewport offset after space, in pages: 1
+viewport offset after shift+space, in pages: 0
+viewport offset after ctrl+space, in pages: 0
+focused scroll container offset after space, in pages: 1
+viewport offset while the scroll container scrolled, in pages: 0
+focused scroll container offset after shift+space, in pages: 0
+viewport offset after space with a button focused, in pages: 0
+viewport offset after space with a summary element focused, in pages: 0

--- a/Tests/LibWeb/Text/input/spacebar-scroll.html
+++ b/Tests/LibWeb/Text/input/spacebar-scroll.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        height: 2000px;
+    }
+
+    #scroller {
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+    }
+
+    #content {
+        height: 2000px;
+    }
+
+    #button {
+        position: absolute;
+        top: 0;
+        left: 300px;
+    }
+</style>
+<div id="scroller" tabindex="0"><div id="content"></div></div>
+<button id="button">button</button>
+<details><summary id="summary">summary</summary>details content</details>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const pageDistance = window.innerHeight - (window.outerHeight - window.innerHeight);
+        const scroller = document.getElementById("scroller");
+        const button = document.getElementById("button");
+        const summary = document.getElementById("summary");
+
+        // Scroll offsets are reported in page scrolls so that the expectations do not depend on the size of the
+        // window the test runs in.
+        const viewportOffsetInPages = () => window.scrollY / pageDistance;
+        const scrollerOffsetInPages = () => scroller.scrollTop / pageDistance;
+
+        internals.sendKey(document.body, "Space");
+        println(`viewport offset after space, in pages: ${viewportOffsetInPages()}`);
+
+        internals.sendKey(document.body, "Space", internals.MOD_SHIFT);
+        println(`viewport offset after shift+space, in pages: ${viewportOffsetInPages()}`);
+
+        internals.sendKey(document.body, "Space", internals.MOD_CTRL);
+        println(`viewport offset after ctrl+space, in pages: ${viewportOffsetInPages()}`);
+
+        scroller.focus();
+        internals.sendKey(scroller, "Space");
+        println(`focused scroll container offset after space, in pages: ${scrollerOffsetInPages()}`);
+        println(`viewport offset while the scroll container scrolled, in pages: ${viewportOffsetInPages()}`);
+
+        internals.sendKey(scroller, "Space", internals.MOD_SHIFT);
+        println(`focused scroll container offset after shift+space, in pages: ${scrollerOffsetInPages()}`);
+
+        button.focus();
+        internals.sendKey(button, "Space");
+        println(`viewport offset after space with a button focused, in pages: ${viewportOffsetInPages()}`);
+
+        summary.focus();
+        internals.sendKey(summary, "Space");
+        println(`viewport offset after space with a summary element focused, in pages: ${viewportOffsetInPages()}`);
+    });
+</script>


### PR DESCRIPTION
Pressing the spacebar now scrolls the page down, while Shift+Space scrolls the page up. This matches the behavior of the Page Down and Page Up keys respectively.