### PR TITLE
LibWeb: Drop the post-pass anchor-inset writeback into computed values

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -1019,49 +1019,10 @@ bool layout_pass_currently_running()
     return s_active_layout_pass_count > 0;
 }
 
-// Resolved anchor() insets recorded by the pass for writeback into computed
-// values. The pass only records; the bridge applies the batch once the
-// outermost pass has returned, so computed values are never replaced while
-// any layout pass can still read style (see NodeWithStyle::set_computed_values).
-static Vector<RustFFI::FfiDeferredResolvedAnchorInsets>& pending_resolved_anchor_insets()
-{
-    static NeverDestroyed<Vector<RustFFI::FfiDeferredResolvedAnchorInsets>> pending;
-    return *pending;
-}
-
-static void apply_pending_resolved_anchor_insets()
-{
-    auto pending = move(pending_resolved_anchor_insets());
-    for (auto const& entry : pending) {
-        auto& box = *static_cast<Box*>(entry.node);
-        auto const& resolved = entry.resolved;
-        auto const& existing = box.computed_values().inset();
-        auto resolve = [](bool resolves, bool is_auto, i32 value, CSS::LengthPercentageOrAuto const& existing_value) {
-            if (!resolves)
-                return existing_value;
-            if (is_auto)
-                return CSS::LengthPercentageOrAuto::make_auto();
-            return CSS::LengthPercentageOrAuto { CSS::LengthPercentage { CSS::Length::make_px(CSSPixels::from_raw(value)) } };
-        };
-        box.modify_computed_values([&](auto& values) {
-            values.set_inset({
-                resolve(resolved.resolves_top, resolved.top_is_auto, resolved.top, existing.top()),
-                resolve(resolved.resolves_right, resolved.right_is_auto, resolved.right, existing.right()),
-                resolve(resolved.resolves_bottom, resolved.bottom_is_auto, resolved.bottom, existing.bottom()),
-                resolve(resolved.resolves_left, resolved.left_is_auto, resolved.left, existing.left()),
-            });
-        });
-    }
-}
-
 class ActiveLayoutPassScope {
 public:
     ActiveLayoutPassScope() { ++s_active_layout_pass_count; }
-    ~ActiveLayoutPassScope()
-    {
-        if (--s_active_layout_pass_count == 0)
-            apply_pending_resolved_anchor_insets();
-    }
+    ~ActiveLayoutPassScope() { --s_active_layout_pass_count; }
 };
 
 LayoutRustBridge::LayoutRustBridge() = default;
@@ -1998,7 +1959,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
                 .fraction = 0,
                 .value = fallback->rust_style_value_data(),
             }; },
-        .record_deferred_resolved_anchor_insets = [](void*, RustFFI::FfiDeferredResolvedAnchorInsets const* entries, size_t count) { pending_resolved_anchor_insets().append(entries, count); },
         .set_default_scroll_shift = [](void*, void* node, void* anchor, bool horizontal, bool vertical) {
             auto& box = *static_cast<Box*>(node);
             if (!anchor) {

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -716,10 +716,6 @@ impl AbsposEngine<'_> {
             resolved.left = value.unwrap_or_default();
         }
 
-        // The computed-values writeback waits until the pass has committed;
-        // the pass itself reads the resolved insets from the replaced cache
-        // entries below.
-        self.state.defer_resolved_anchor_insets(&self.callbacks, node, resolved);
         self.state
             .replace_resolved_anchor_insets(&self.callbacks, node, resolved);
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -86,16 +86,6 @@ pub struct FfiResolvedAnchorInsets {
     pub left: CssPixels,
 }
 
-/// One node's resolved anchor() insets, reported to C++ in a batch after the
-/// pass commits so the computed-values writeback never runs while layout can
-/// still read style.
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct FfiDeferredResolvedAnchorInsets {
-    pub node: *mut c_void,
-    pub resolved: FfiResolvedAnchorInsets,
-}
-
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct LineFragmentFacts {
     layout_node: Node,
@@ -2868,8 +2858,6 @@ pub struct FfiLayoutFcCallbacks {
     pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
     pub build_anchor_function_facts: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFunctionFacts,
     pub anchor_function_fallback: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFallbackFacts,
-    pub record_deferred_resolved_anchor_insets:
-        unsafe extern "C" fn(*mut c_void, *const FfiDeferredResolvedAnchorInsets, usize),
     pub set_default_scroll_shift: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool, bool),
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -877,10 +877,6 @@ pub(crate) struct LayoutState {
     contained_abspos_children: PagedStore<RefCell<VecDeque<PendingAbsposChild>>>,
     abspos_layout_pass_queue_in_completion_order: RefCell<VecDeque<Node>>,
     abspos_layout_pass_is_active: Cell<bool>,
-    /// Resolved anchor() insets awaiting the post-commit computed-values
-    /// writeback, one merged entry per node so a node resolved twice keeps
-    /// its final values and gets a single writeback.
-    deferred_resolved_anchor_insets: RefCell<Vec<crate::layout::FfiDeferredResolvedAnchorInsets>>,
     anchor_inset_store: AnchorInsetStore,
     replaced_content_facts: PagedStore<crate::layout::FfiReplacedContentFacts>,
     list_item_facts: PagedStore<crate::layout::FfiListItemFacts>,
@@ -936,7 +932,6 @@ impl LayoutState {
             contained_abspos_children: PagedStore::default(),
             abspos_layout_pass_queue_in_completion_order: RefCell::new(VecDeque::new()),
             abspos_layout_pass_is_active: Cell::new(false),
-            deferred_resolved_anchor_insets: RefCell::new(Vec::new()),
             anchor_inset_store: AnchorInsetStore::default(),
             replaced_content_facts: PagedStore::default(),
             list_item_facts: PagedStore::default(),
@@ -1264,54 +1259,6 @@ impl LayoutState {
         }
         if resolved.resolves_left {
             replace(SizeField::InsetLeft, resolved.left_is_auto, resolved.left);
-        }
-    }
-
-    pub(crate) fn defer_resolved_anchor_insets(
-        &self,
-        callbacks: &FfiLayoutFcCallbacks,
-        node: Node,
-        resolved: crate::layout::FfiResolvedAnchorInsets,
-    ) {
-        let node_shell = callbacks.shell(node);
-        let mut deferred = self.deferred_resolved_anchor_insets.borrow_mut();
-        let Some(entry) = deferred.iter_mut().find(|entry| entry.node == node_shell) else {
-            deferred.push(crate::layout::FfiDeferredResolvedAnchorInsets {
-                node: node_shell,
-                resolved,
-            });
-            return;
-        };
-        let earlier = &mut entry.resolved;
-        if resolved.resolves_top {
-            (earlier.resolves_top, earlier.top_is_auto, earlier.top) = (true, resolved.top_is_auto, resolved.top);
-        }
-        if resolved.resolves_right {
-            (earlier.resolves_right, earlier.right_is_auto, earlier.right) =
-                (true, resolved.right_is_auto, resolved.right);
-        }
-        if resolved.resolves_bottom {
-            (earlier.resolves_bottom, earlier.bottom_is_auto, earlier.bottom) =
-                (true, resolved.bottom_is_auto, resolved.bottom);
-        }
-        if resolved.resolves_left {
-            (earlier.resolves_left, earlier.left_is_auto, earlier.left) = (true, resolved.left_is_auto, resolved.left);
-        }
-    }
-
-    /// Hands the deferred resolved-anchor-inset batch to C++ once the pass
-    /// has committed, so the computed-values writeback runs only after layout
-    /// is done reading style. Passes that never commit drop their deferrals
-    /// with the state, exactly as their writebacks never happened before.
-    fn report_deferred_resolved_anchor_insets(&self, callbacks: &FfiLayoutFcCallbacks) {
-        let deferred = self.deferred_resolved_anchor_insets.borrow();
-        if deferred.is_empty() {
-            return;
-        }
-        // SAFETY: The entries stay alive for this synchronous call, and the
-        // C++ side only records them for application after the pass returns.
-        unsafe {
-            (callbacks.record_deferred_resolved_anchor_insets)(callbacks.context, deferred.as_ptr(), deferred.len());
         }
     }
 
@@ -1806,7 +1753,6 @@ impl LayoutState {
         unsafe {
             (sink.finish_commit)(sink.context);
         }
-        self.report_deferred_resolved_anchor_insets(callbacks);
     }
 }
 


### PR DESCRIPTION
Once the outermost layout pass returned, the bridge rewrote the computed inset values of every anchor-positioned box, replacing their anchor() functions with the pixel values the pass had resolved. The writeback dates from when the style itself was the carrier of resolved anchor insets: resolution overwrote the inset properties so that every later read, inside or after the pass, would see resolved pixels.

Since 0d4228609f6 the pass no longer works that way. Resolved anchor insets go into a per-pass override store, and every inset read inside the pass is masked by that store, so the pass is self-sufficient and the writeback could only matter to code running after layout. Neither of its two remaining consumers actually wants it:

- getComputedStyle reports resolved insets through the used-value path, which reads the box model of the laid-out box. It does not need resolved pixels smuggled into computed values.

- Later layout passes are actively harmed by it. With resolved pixels persisted in computed values, a relayout that skipped style recalc reused the previous pass's anchor positions even if the anchor had moved since, and the resolution early-out then cleared the stored default-anchor scroll shift without re-establishing it, silently losing scroll compensation.

So the writeback machinery can simply go: the deferred-inset batch and its recording callback, the bridge's pending vector, and the writeback in ActiveLayoutPassScope's destructor. Anchor insets now resolve fresh in every pass from the pristine computed values, fixing the stale anchor positions and the lost scroll shift, and computed values become immutable from the moment a layout pass first reads them until the next style recalculation.