### PR TITLE
LibWeb: Use FfiDisplay directly for table roles

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1013,11 +1013,6 @@ RustFFI::FfiDomTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_dom_tree_bui
                 break;
             case RustFFI::FfiPrincipalBoxPlacement::ReplaceExisting:
                 VERIFY(frame.old_layout_node);
-                VERIFY(frame.old_layout_node->arena_handle() == frame.layout_node->arena_handle());
-                RustFFI::layout_arena_transfer_saved_abspos_layout_inputs(
-                    frame.old_layout_node->arena_handle(),
-                    Node::slot_id(frame.old_layout_node.ptr()),
-                    Node::slot_id(frame.layout_node.ptr()));
                 transfer_saved_layout_state_to_replacement_box(*frame.old_layout_node, *frame.layout_node);
                 frame.old_layout_node->prepare_subtree_for_detach_from_layout_tree();
                 frame.old_layout_node->parent()->replace_child(*frame.layout_node, *frame.old_layout_node);

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -3086,7 +3086,10 @@ pub(crate) fn formatting_context_type_created_by_node_data(
         return None;
     }
     if crate::layout::has_flag(data, NodeFlag::IsReplacedElement)
-        && style.is_some_and(|style| style.table_display_before() != FfiTableDisplay::Other)
+        && style.is_some_and(|style| {
+            let display = style.display_before_box_type_transformation();
+            display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
+        })
     {
         return Some(if crate::layout::kind_is_block_container(data.kind) {
             FfiFormattingContextType::Block
@@ -3098,8 +3101,7 @@ pub(crate) fn formatting_context_type_created_by_node_data(
     if display.is_some_and(|display| display.is_flex_inside()) {
         return Some(FfiFormattingContextType::Flex);
     }
-    let table_display = display.map_or(FfiTableDisplay::Other, crate::layout::table_display_of);
-    if table_display == FfiTableDisplay::TableRoot {
+    if display.is_some_and(|display| display.is_table_inside()) {
         return Some(FfiFormattingContextType::Table);
     }
     if display.is_some_and(|display| display.is_grid_inside()) {
@@ -3111,15 +3113,14 @@ pub(crate) fn formatting_context_type_created_by_node_data(
         return Some(FfiFormattingContextType::Block);
     }
     if crate::layout::has_flag(data, NodeFlag::ChildrenAreInline)
-        || matches!(
-            table_display,
-            FfiTableDisplay::TableColumn
-                | FfiTableDisplay::TableColumnGroup
-                | FfiTableDisplay::TableRow
-                | FfiTableDisplay::TableRowGroup
-                | FfiTableDisplay::TableHeaderGroup
-                | FfiTableDisplay::TableFooterGroup
-        )
+        || display.is_some_and(|display| {
+            display.is_table_column()
+                || display.is_table_column_group()
+                || display.is_table_row()
+                || display.is_table_row_group()
+                || display.is_table_header_group()
+                || display.is_table_footer_group()
+        })
     {
         return None;
     }

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -8,7 +8,6 @@ use crate::abort_on_panic;
 use crate::layout::AbsposLayoutInputs;
 use crate::layout::AvailableSize;
 use crate::layout::CssPixels;
-use crate::layout::kind_is_box;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeSlotId};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -739,21 +738,6 @@ impl LayoutNodeArena {
         unsafe { std::slice::from_raw_parts(entry.chunks.as_ptr(), entry.chunks.len()) }
     }
 
-    pub(crate) fn transfer_saved_abspos_layout_inputs(&self, old: NodeSlotId, new: NodeSlotId) {
-        self.assert_owner_thread();
-        assert_ne!(old, new, "cannot transfer saved abspos inputs to the same arena slot");
-
-        let old_data = self.data(old);
-        let new_data = self.data(new);
-        // SAFETY: data() returns pointers to live slots.
-        if !unsafe { kind_is_box((*old_data).kind) && kind_is_box((*new_data).kind) } {
-            return;
-        }
-        if let Some(inputs) = self.saved_abspos_layout_inputs(old_data) {
-            self.set_saved_abspos_layout_inputs(new_data, Some(inputs));
-        }
-    }
-
     pub(crate) unsafe fn from_handle<'a>(arena: *mut c_void) -> &'a Self {
         assert!(!arena.is_null(), "layout node arena handle is null");
         // SAFETY: Layout passes borrow the document's arena synchronously,
@@ -866,30 +850,11 @@ pub unsafe extern "C" fn layout_arena_set_text_content(
     });
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_transfer_saved_abspos_layout_inputs(
-    arena: *mut c_void,
-    old: NodeSlotId,
-    new: NodeSlotId,
-) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: Both slots belong to this live arena for the duration of
-        // the synchronous replacement callback.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }.transfer_saved_abspos_layout_inputs(old, new);
-    });
-}
-
 #[cfg(test)]
 mod tests {
     use crate::layout::layout_node_arena::{
         Chunk, IntrinsicInlineSizeMeasurement, IntrinsicSizeCacheKey, IntrinsicSizeCacheKind, LayoutNodeArena,
         SLOTS_PER_CHUNK,
-    };
-    use crate::layout::node_data::{NodeFlag, NodeKind};
-    use crate::layout::{
-        AbsposAlignment, AbsposAxisMode, AbsposContainingBlockInfo, AbsposLayoutInputs, StaticPositionAlignment,
-        StaticPositionRect,
     };
     use crate::layout::{AvailableSize, CssPixels};
 
@@ -1028,69 +993,5 @@ mod tests {
             None
         );
         arena.free(second.slot, second.generation);
-    }
-
-    #[test]
-    fn saved_abspos_inputs_transfer_and_validate_generation() {
-        let mut arena = LayoutNodeArena::new();
-        let old = arena.allocate();
-        let new = arena.allocate();
-        // SAFETY: Both allocations remain live.
-        unsafe {
-            (*old.data).kind = NodeKind::Box;
-            (*new.data).kind = NodeKind::Box;
-        }
-        let inputs = AbsposLayoutInputs {
-            static_position_rect: StaticPositionRect {
-                rect: Default::default(),
-                inline_alignment: StaticPositionAlignment::Center,
-                block_alignment: StaticPositionAlignment::End,
-                alignment_derives_from_own_computed_values: true,
-            },
-            containing_block_info: AbsposContainingBlockInfo {
-                rect: Default::default(),
-                inline_axis_mode: AbsposAxisMode::StaticPosition,
-                block_axis_mode: AbsposAxisMode::InsetFromRect,
-                inline_alignment: Some(AbsposAlignment::Center),
-                block_alignment: None,
-                derives_from_own_computed_values: true,
-            },
-        };
-
-        arena.set_saved_abspos_layout_inputs(old.data, Some(inputs));
-        assert_eq!(arena.saved_abspos_layout_inputs(old.data), Some(inputs));
-        // SAFETY: Both allocations remain live.
-        unsafe {
-            assert_ne!((*old.data).flags & NodeFlag::HasSavedAbsposLayoutInputs as u32, 0);
-            assert_ne!(
-                (*old.data).flags & NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32,
-                0
-            );
-            assert_ne!(
-                (*old.data).flags & NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32,
-                0
-            );
-        }
-
-        arena.transfer_saved_abspos_layout_inputs(old.slot, new.slot);
-        assert_eq!(arena.saved_abspos_layout_inputs(new.data), Some(inputs));
-
-        arena.set_saved_abspos_layout_inputs(old.data, None);
-        assert_eq!(arena.saved_abspos_layout_inputs(old.data), None);
-        // SAFETY: The old allocation remains live.
-        unsafe {
-            let saved_abspos_flags = NodeFlag::HasSavedAbsposLayoutInputs as u32
-                | NodeFlag::SavedAbsposCbDerivesFromOwnComputedValues as u32
-                | NodeFlag::SavedAbsposAlignmentDerivesFromOwnComputedValues as u32;
-            assert_eq!((*old.data).flags & saved_abspos_flags, 0);
-        }
-        arena.free(old.slot, old.generation);
-
-        let reused = arena.allocate();
-        assert_eq!(reused.slot.slot_index(), old.slot.slot_index());
-        assert_ne!(reused.slot, old.slot);
-        assert_eq!(arena.saved_abspos_layout_inputs(reused.data), None);
-        arena.free(reused.slot, reused.generation);
-        arena.free(new.slot, new.generation);
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -436,11 +436,6 @@ impl<'pass> NodeFacts<'pass> {
         self.callbacks.style_reader_if_styled(parent)
     }
 
-    fn table_display(&self) -> FfiTableDisplay {
-        self.style_reader_if_styled()
-            .map_or(FfiTableDisplay::Other, |style| style.table_display())
-    }
-
     fn replaced_content(&self) -> crate::layout::FfiReplacedContentFacts {
         self.state.replaced_content_facts(self.callbacks, self.node)
     }
@@ -543,10 +538,11 @@ impl<'pass> NodeFacts<'pass> {
         {
             return false;
         }
-        if self.display().is_contents() {
+        let display = self.display();
+        if display.is_contents() {
             return false;
         }
-        if !matches!(self.table_display(), FfiTableDisplay::Other | FfiTableDisplay::TableRoot) {
+        if display.is_internal_table() || display.is_table_caption() {
             return false;
         }
         if parent.kind == NodeKind::SVGForeignObjectBox {
@@ -623,7 +619,10 @@ impl<'pass> NodeFacts<'pass> {
         crate::layout::has_flag(self.data(), NodeFlag::IsReplacedElement)
             && self
                 .style_reader_if_styled()
-                .is_some_and(|style| style.table_display_before() != FfiTableDisplay::Other)
+                .is_some_and(|style| {
+                    let display = style.display_before_box_type_transformation();
+                    display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
+                })
     }
 
     pub(crate) fn creates_block_formatting_context(&self) -> bool {
@@ -736,10 +735,8 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     fn node_has_size_containment(&self) -> bool {
-        if !matches!(
-            self.table_display(),
-            FfiTableDisplay::Other | FfiTableDisplay::TableCaption
-        ) {
+        let display = self.display();
+        if display.is_table_inside() || display.is_internal_table() {
             return false;
         }
         let style = self.style();
@@ -812,7 +809,7 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_table_box(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableRoot
+        self.display().is_table_inside()
     }
 
     pub(crate) fn is_table_wrapper(&self) -> bool {
@@ -820,35 +817,35 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     pub(crate) fn is_table_row_group(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableRowGroup
+        self.display().is_table_row_group()
     }
 
     pub(crate) fn is_table_header_group(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableHeaderGroup
+        self.display().is_table_header_group()
     }
 
     pub(crate) fn is_table_footer_group(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableFooterGroup
+        self.display().is_table_footer_group()
     }
 
     pub(crate) fn is_table_row(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableRow
+        self.display().is_table_row()
     }
 
     pub(crate) fn is_table_cell(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableCell
+        self.display().is_table_cell()
     }
 
     pub(crate) fn is_table_column_group(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableColumnGroup
+        self.display().is_table_column_group()
     }
 
     pub(crate) fn is_table_column(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableColumn
+        self.display().is_table_column()
     }
 
     pub(crate) fn is_table_caption(&self) -> bool {
-        self.table_display() == FfiTableDisplay::TableCaption
+        self.display().is_table_caption()
     }
 
     pub(crate) fn is_viewport(&self) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -108,8 +108,7 @@ pub(crate) fn node_creates_block_formatting_context(
     }
     if let Some(style) = style {
         let display = style.display();
-        if style.table_display() == FfiTableDisplay::TableRoot || display.is_flex_inside() || display.is_grid_inside()
-        {
+        if display.is_table_inside() || display.is_flex_inside() || display.is_grid_inside() {
             return false;
         }
         if (style.is_floating() && !has_flag(data, NodeFlag::IsFlexItem))

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -243,23 +243,6 @@ pub(crate) enum SizeField {
     VerticalAlign,
 }
 
-/// Classification of a computed display value into the table-structure roles
-/// the tree builder and table layout consult, derived on demand from the box
-/// group payload.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FfiTableDisplay {
-    Other,
-    TableRoot,
-    TableRowGroup,
-    TableHeaderGroup,
-    TableFooterGroup,
-    TableColumnGroup,
-    TableColumn,
-    TableRow,
-    TableCell,
-    TableCaption,
-}
-
 // https://drafts.csswg.org/css-contain-2/#containment-types
 fn containment_applies_to_principal_box(display: crate::css::display::FfiDisplay) -> bool {
     if display.is_internal_table() && !display.is_table_cell() {
@@ -269,30 +252,6 @@ fn containment_applies_to_principal_box(display: crate::css::display::FfiDisplay
         return false;
     }
     true
-}
-
-pub(crate) fn table_display_of(display: crate::css::display::FfiDisplay) -> FfiTableDisplay {
-    if display.is_table_inside() {
-        FfiTableDisplay::TableRoot
-    } else if display.is_table_row_group() {
-        FfiTableDisplay::TableRowGroup
-    } else if display.is_table_header_group() {
-        FfiTableDisplay::TableHeaderGroup
-    } else if display.is_table_footer_group() {
-        FfiTableDisplay::TableFooterGroup
-    } else if display.is_table_column_group() {
-        FfiTableDisplay::TableColumnGroup
-    } else if display.is_table_column() {
-        FfiTableDisplay::TableColumn
-    } else if display.is_table_row() {
-        FfiTableDisplay::TableRow
-    } else if display.is_table_cell() {
-        FfiTableDisplay::TableCell
-    } else if display.is_table_caption() {
-        FfiTableDisplay::TableCaption
-    } else {
-        FfiTableDisplay::Other
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -371,14 +330,6 @@ impl<'a> StyleReader<'a> {
 
     pub(crate) fn display_before_box_type_transformation(&self) -> crate::css::display::FfiDisplay {
         self.box_values().display_before_box_type_transformation
-    }
-
-    pub(crate) fn table_display(&self) -> FfiTableDisplay {
-        table_display_of(self.display())
-    }
-
-    pub(crate) fn table_display_before(&self) -> FfiTableDisplay {
-        table_display_of(self.display_before_box_type_transformation())
     }
 
     pub(crate) fn is_floating(&self) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -590,12 +590,12 @@ pub(crate) struct TableGrid {
 fn matching_children<T: TableTree>(
     tree: &T,
     parent: Node,
-    predicate: impl Fn(FfiTableDisplay) -> bool,
+    predicate: impl Fn(FfiDisplay) -> bool,
 ) -> Vec<Node> {
     let mut result = Vec::new();
     let mut child = tree.first_child(parent);
     while !child.is_invalid() {
-        if kind_is_box(tree.node_data(child).kind) && predicate(tree.table_display(child)) {
+        if kind_is_box(tree.node_data(child).kind) && predicate(tree.display(child)) {
             result.push(child);
         }
         child = tree.next_sibling(child);
@@ -614,7 +614,7 @@ fn count_columns_in_subtree<T: TableTree>(tree: &T, root: Node) -> usize {
             child = tree.next_sibling(child);
         }
         for child in children.into_iter().rev() {
-            if kind_is_box(tree.node_data(child).kind) && tree.table_display(child) == FfiTableDisplay::TableColumn {
+            if kind_is_box(tree.node_data(child).kind) && tree.display(child).is_table_column() {
                 count = count.saturating_add(tree.table_column_span(child));
             }
             stack.push(child);
@@ -631,9 +631,7 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
     let mut row_count = 0usize;
     let mut current_row = 0usize;
 
-    for column_group in matching_children(tree, table, |table_display| {
-        table_display == FfiTableDisplay::TableColumnGroup
-    }) {
+    for column_group in matching_children(tree, table, |display| display.is_table_column_group()) {
         column_count = column_count.saturating_add(count_columns_in_subtree(tree, column_group));
     }
 
@@ -650,7 +648,7 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
             *row_count += 1;
         }
         let mut current_column = 0usize;
-        for cell_box in matching_children(tree, row, |table_display| table_display == FfiTableDisplay::TableCell) {
+        for cell_box in matching_children(tree, row, |display| display.is_table_cell()) {
             while current_column < *column_count && occupancy.contains(&(current_column, *current_row)) {
                 current_column += 1;
             }
@@ -693,16 +691,13 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
     let mut child = tree.first_child(table);
     while !child.is_invalid() {
         let child_is_box = kind_is_box(tree.node_data(child).kind);
-        let child_table_display = tree.table_display(child);
+        let child_display = tree.display(child);
         if child_is_box
-            && matches!(
-                child_table_display,
-                FfiTableDisplay::TableRowGroup | FfiTableDisplay::TableHeaderGroup | FfiTableDisplay::TableFooterGroup
-            )
+            && (child_display.is_table_row_group()
+                || child_display.is_table_header_group()
+                || child_display.is_table_footer_group())
         {
-            for row in matching_children(tree, child, |table_display| {
-                table_display == FfiTableDisplay::TableRow
-            }) {
+            for row in matching_children(tree, child, |display| display.is_table_row()) {
                 process_row(
                     tree,
                     row,
@@ -715,7 +710,7 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
                     &mut current_row,
                 );
             }
-        } else if child_is_box && child_table_display == FfiTableDisplay::TableRow {
+        } else if child_is_box && child_display.is_table_row() {
             process_row(
                 tree,
                 child,
@@ -758,7 +753,7 @@ pub(crate) trait TableTree {
     fn first_child(&self, node: Node) -> Node;
     fn next_sibling(&self, node: Node) -> Node;
     fn node_data(&self, node: Node) -> &NodeData;
-    fn table_display(&self, node: Node) -> FfiTableDisplay;
+    fn display(&self, node: Node) -> FfiDisplay;
 
     fn table_column_span(&self, node: Node) -> usize {
         self.node_data(node).table_column_span as usize
@@ -811,10 +806,10 @@ impl TableTree for TableFormattingContext<'_> {
         self.callbacks.node_data(node)
     }
 
-    fn table_display(&self, node: Node) -> FfiTableDisplay {
+    fn display(&self, node: Node) -> FfiDisplay {
         self.callbacks
             .style_reader_if_styled(node)
-            .map_or(FfiTableDisplay::Other, |style| style.table_display())
+            .map_or_else(FfiDisplay::block, |style| style.display())
     }
 
     fn row_is_collapsed(&self, row: Node, row_group: Option<Node>) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1452,6 +1452,18 @@ fn update_principal_node_after_entry(
                 FfiInsertionMode::Append,
             );
         } else {
+            if placement.placement == FfiPrincipalBoxPlacement::ReplaceExisting {
+                // SAFETY: The tree-builder entry point keeps the arena alive, and both slots name live nodes in it.
+                let arena = unsafe { &*host.arena };
+                let old_data = arena.data(old_layout_node);
+                let new_data = arena.data(layout_node);
+                // SAFETY: data() returned pointers to live slots.
+                if unsafe { node_kind_is_box((*old_data).kind) && node_kind_is_box((*new_data).kind) }
+                    && let Some(inputs) = arena.saved_abspos_layout_inputs(old_data)
+                {
+                    arena.set_saved_abspos_layout_inputs(new_data, Some(inputs));
+                }
+            }
             unsafe {
                 (host.callbacks.place_principal_layout)(
                     host.callbacks.builder,

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -7,7 +7,7 @@
 use crate::abort_on_panic;
 use crate::layout::layout_node_arena::LayoutNodeArena;
 use crate::layout::node_data::{GENERATED_FOR_MARKER, NodeData, NodeFlag, NodeKind, NodeSlotId};
-use crate::layout::{FfiTableDisplay, StyleReader, kind_is_replaced_box, node_can_have_children};
+use crate::layout::{FfiDisplay, StyleReader, kind_is_replaced_box, node_can_have_children};
 use std::ffi::c_void;
 
 type LayoutNode = NodeSlotId;
@@ -1861,10 +1861,6 @@ fn create_pseudo_element_with_frame(
     layout_node
 }
 
-fn is_internal_table_display(display: FfiTableDisplay) -> bool {
-    is_table_track(display) || is_table_track_group(display) || display == FfiTableDisplay::TableCell
-}
-
 fn replaced_element_display_adjustment(
     host: &TreeBuilderHost<'_>,
     node: LayoutNode,
@@ -1872,14 +1868,14 @@ fn replaced_element_display_adjustment(
     if !node_has_flag(host.data(node), NodeFlag::IsReplacedElement) {
         return FfiReplacedElementDisplayAdjustment::None;
     }
-    let table_display = host.table_display(node);
+    let display = host.display(node);
     adjusted_table_display_for_replaced_element(
-        table_display == FfiTableDisplay::TableRoot,
+        display.is_table_inside(),
         !host
             .style(node)
             .is_some_and(|style| style.display().is_inline_outside()),
-        is_internal_table_display(table_display),
-        table_display == FfiTableDisplay::TableCaption,
+        display.is_internal_table(),
+        display.is_table_caption(),
     )
 }
 
@@ -2122,9 +2118,10 @@ fn node_is_out_of_flow(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
 
 fn node_has_replaced_element_table_display_adjustment(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     node_has_flag(host.data(node), NodeFlag::IsReplacedElement)
-        && host
-            .style(node)
-            .is_some_and(|style| style.table_display_before() != FfiTableDisplay::Other)
+        && host.style(node).is_some_and(|style| {
+            let display = style.display_before_box_type_transformation();
+            display.is_table_inside() || display.is_internal_table() || display.is_table_caption()
+        })
 }
 
 fn node_is_fragmented_inline(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
@@ -2152,14 +2149,14 @@ impl TreeBuilderHost<'_> {
         unsafe { (*self.arena).style_payloads(node) }.map(StyleReader::new)
     }
 
-    fn table_display(&self, node: LayoutNode) -> FfiTableDisplay {
-        self.style(node)
-            .map_or(FfiTableDisplay::Other, |style| style.table_display())
+    fn display(&self, node: LayoutNode) -> FfiDisplay {
+        self.style(node).map_or_else(FfiDisplay::block, |style| style.display())
     }
 
-    fn table_display_before(&self, node: LayoutNode) -> FfiTableDisplay {
-        self.style(node)
-            .map_or(FfiTableDisplay::Other, |style| style.table_display_before())
+    fn display_before_box_type_transformation(&self, node: LayoutNode) -> FfiDisplay {
+        self.style(node).map_or_else(FfiDisplay::block, |style| {
+            style.display_before_box_type_transformation()
+        })
     }
 
     fn shell(&self, node: LayoutNode) -> *mut c_void {
@@ -2280,8 +2277,8 @@ impl crate::layout::TableTree for TreeBuilderHost<'_> {
         self.data(node)
     }
 
-    fn table_display(&self, node: LayoutNode) -> FfiTableDisplay {
-        TreeBuilderHost::table_display(self, node)
+    fn display(&self, node: LayoutNode) -> FfiDisplay {
+        TreeBuilderHost::display(self, node)
     }
 }
 
@@ -2338,12 +2335,12 @@ fn is_out_of_flow_table_internal_child_of_table_root(
     child: LayoutNode,
 ) -> bool {
     let child_data = host.data(child);
-    host.table_display(parent) == FfiTableDisplay::TableRoot
+    host.display(parent).is_table_inside()
         && node_has_flag(child_data, NodeFlag::HasStyle)
         && !node_has_flag(child_data, NodeFlag::Anonymous)
         && node_is_out_of_flow(host, child)
         && !node_has_replaced_element_table_display_adjustment(host, child)
-        && is_table_non_root_box_with_display(host.table_display_before(child))
+        && is_table_non_root_box_with_display(host.display_before_box_type_transformation(child))
 }
 
 fn create_anonymous_wrapper(host: &TreeBuilderHost<'_>, parent: LayoutNode) -> LayoutNode {
@@ -2839,23 +2836,20 @@ fn wrap_fieldset_contents_if_needed(host: &TreeBuilderHost<'_>, layout_node: Lay
     }
 }
 
-fn is_table_track(display: FfiTableDisplay) -> bool {
-    matches!(display, FfiTableDisplay::TableRow | FfiTableDisplay::TableColumn)
+fn is_table_track(display: FfiDisplay) -> bool {
+    display.is_table_row() || display.is_table_column()
 }
 
-fn is_table_track_group(display: FfiTableDisplay) -> bool {
+fn is_table_track_group(display: FfiDisplay) -> bool {
     // Unless explicitly mentioned otherwise, mentions of table-row-groups in this spec also encompass the specialized
     // table-header-groups and table-footer-groups.
-    matches!(
-        display,
-        FfiTableDisplay::TableRowGroup
-            | FfiTableDisplay::TableHeaderGroup
-            | FfiTableDisplay::TableFooterGroup
-            | FfiTableDisplay::TableColumnGroup
-    )
+    display.is_table_row_group()
+        || display.is_table_header_group()
+        || display.is_table_footer_group()
+        || display.is_table_column_group()
 }
 
-fn display_for_table_fixup(host: &TreeBuilderHost<'_>, node: LayoutNode) -> FfiTableDisplay {
+fn display_for_table_fixup(host: &TreeBuilderHost<'_>, node: LayoutNode) -> FfiDisplay {
     // https://drafts.csswg.org/css-tables-3/#fixup-algorithm
     // For the purposes of these rules, out-of-flow elements are represented as inline elements of zero width and
     // height. Their containing blocks are chosen accordingly.
@@ -2865,45 +2859,33 @@ fn display_for_table_fixup(host: &TreeBuilderHost<'_>, node: LayoutNode) -> FfiT
     if node_has_replaced_element_table_display_adjustment(host, node)
         || node_has_flag(host.data(node), NodeFlag::Anonymous)
     {
-        host.table_display(node)
+        host.display(node)
     } else {
-        host.table_display_before(node)
+        host.display_before_box_type_transformation(node)
     }
 }
 
 fn is_proper_table_child(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     let display = display_for_table_fixup(host, node);
-    is_table_track_group(display) || is_table_track(display) || display == FfiTableDisplay::TableCaption
+    is_table_track_group(display) || is_table_track(display) || display.is_table_caption()
 }
 
-fn is_table_non_root_box_with_display(display: FfiTableDisplay) -> bool {
-    matches!(
-        display,
-        FfiTableDisplay::TableRow
-            | FfiTableDisplay::TableColumn
-            | FfiTableDisplay::TableRowGroup
-            | FfiTableDisplay::TableHeaderGroup
-            | FfiTableDisplay::TableFooterGroup
-            | FfiTableDisplay::TableColumnGroup
-            | FfiTableDisplay::TableCell
-            | FfiTableDisplay::TableCaption
-    )
+fn is_table_non_root_box_with_display(display: FfiDisplay) -> bool {
+    display.is_internal_table() || display.is_table_caption()
 }
 
 fn is_table_non_root_box(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
-    is_table_non_root_box_with_display(host.table_display(node))
+    is_table_non_root_box_with_display(host.display(node))
 }
 
 fn is_tabular_container(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
     // https://drafts.csswg.org/css-tables-3/#tabular-container
-    matches!(
-        host.table_display(node),
-        FfiTableDisplay::TableRoot
-            | FfiTableDisplay::TableRow
-            | FfiTableDisplay::TableRowGroup
-            | FfiTableDisplay::TableHeaderGroup
-            | FfiTableDisplay::TableFooterGroup
-    )
+    let display = host.display(node);
+    display.is_table_inside()
+        || display.is_table_row()
+        || display.is_table_row_group()
+        || display.is_table_header_group()
+        || display.is_table_footer_group()
 }
 
 fn is_ignorable_whitespace(host: &TreeBuilderHost<'_>, node: LayoutNode) -> bool {
@@ -2987,7 +2969,7 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
         let data = host.data(node);
 
         // 1. Children of a table-column.
-        if node_kind_is_box(data.kind) && host.table_display(node) == FfiTableDisplay::TableColumn {
+        if node_kind_is_box(data.kind) && host.display(node).is_table_column() {
             let mut child = host.first_child(node);
             while !child.is_invalid() {
                 to_remove.push(child);
@@ -2996,10 +2978,10 @@ fn remove_irrelevant_boxes(host: &TreeBuilderHost<'_>, root: LayoutNode) {
         }
 
         // 2. Children of a table-column-group which are not a table-column.
-        if node_kind_is_box(data.kind) && host.table_display(node) == FfiTableDisplay::TableColumnGroup {
+        if node_kind_is_box(data.kind) && host.display(node).is_table_column_group() {
             let mut child = host.first_child(node);
             while !child.is_invalid() {
-                if host.table_display(child) != FfiTableDisplay::TableColumn {
+                if !host.display(child).is_table_column() {
                     to_remove.push(child);
                 }
                 child = host.next_sibling(child);
@@ -3037,50 +3019,40 @@ fn generate_missing_child_wrappers(host: &TreeBuilderHost<'_>, root: LayoutNode)
             return TraversalDecision::Continue;
         }
 
-        match host.table_display(parent) {
-            FfiTableDisplay::TableRoot => {
-                // 1. An anonymous table-row box must be generated around each sequence of consecutive children of a
-                //    table-root box which are not proper table child boxes.
-                for_each_sequence_of_consecutive_children_matching(
-                    host,
-                    parent,
-                    |child| !node_has_flag(host.data(child), NodeFlag::HasStyle) || !is_proper_table_child(host, child),
-                    |sequence, nearest_sibling| {
-                        host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
-                    },
-                );
-            }
-            FfiTableDisplay::TableRowGroup | FfiTableDisplay::TableHeaderGroup | FfiTableDisplay::TableFooterGroup => {
-                // 2. An anonymous table-row box must be generated around each sequence of consecutive children of a
-                //    table-row-group box which are not table-row boxes.
-                for_each_sequence_of_consecutive_children_matching(
-                    host,
-                    parent,
-                    |child| {
-                        !node_has_flag(host.data(child), NodeFlag::HasStyle)
-                            || host.table_display(child) != FfiTableDisplay::TableRow
-                    },
-                    |sequence, nearest_sibling| {
-                        host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
-                    },
-                );
-            }
-            FfiTableDisplay::TableRow => {
-                // 3. An anonymous table-cell box must be generated around each sequence of consecutive children of a
-                //    table-row box which are not table-cell boxes.
-                for_each_sequence_of_consecutive_children_matching(
-                    host,
-                    parent,
-                    |child| {
-                        !node_has_flag(host.data(child), NodeFlag::HasStyle)
-                            || host.table_display(child) != FfiTableDisplay::TableCell
-                    },
-                    |sequence, nearest_sibling| {
-                        host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableCell);
-                    },
-                );
-            }
-            _ => {}
+        let display = host.display(parent);
+        if display.is_table_inside() {
+            // 1. An anonymous table-row box must be generated around each sequence of consecutive children of a
+            //    table-root box which are not proper table child boxes.
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| !node_has_flag(host.data(child), NodeFlag::HasStyle) || !is_proper_table_child(host, child),
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
+                },
+            );
+        } else if display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group() {
+            // 2. An anonymous table-row box must be generated around each sequence of consecutive children of a
+            //    table-row-group box which are not table-row boxes.
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| !node_has_flag(host.data(child), NodeFlag::HasStyle) || !host.display(child).is_table_row(),
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
+                },
+            );
+        } else if display.is_table_row() {
+            // 3. An anonymous table-cell box must be generated around each sequence of consecutive children of a
+            //    table-row box which are not table-cell boxes.
+            for_each_sequence_of_consecutive_children_matching(
+                host,
+                parent,
+                |child| !node_has_flag(host.data(child), NodeFlag::HasStyle) || !host.display(child).is_table_cell(),
+                |sequence, nearest_sibling| {
+                    host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableCell);
+                },
+            );
         }
         TraversalDecision::Continue
     });
@@ -3099,7 +3071,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
                 node_has_flag(data, NodeFlag::HasBeenWrappedInTableWrapper),
             )
         };
-        let current_display = host.table_display(parent);
+        let current_display = host.display(parent);
         let is_inline_outside = node_is_inline_outside(host, parent);
         if !has_style {
             return TraversalDecision::Continue;
@@ -3107,14 +3079,11 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
 
         // 1. An anonymous table-row box must be generated around each sequence of consecutive table-cell boxes whose
         //    parent is not a table-row.
-        if current_display != FfiTableDisplay::TableRow {
+        if !current_display.is_table_row() {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
-                |child| {
-                    node_has_flag(host.data(child), NodeFlag::HasStyle)
-                        && host.table_display(child) == FfiTableDisplay::TableCell
-                },
+                |child| node_has_flag(host.data(child), NodeFlag::HasStyle) && host.display(child).is_table_cell(),
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, FfiAnonymousTableBoxKind::TableRow);
                 },
@@ -3132,19 +3101,15 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
             FfiAnonymousTableBoxKind::Table
         };
 
-        let is_table_row_group = matches!(
-            current_display,
-            FfiTableDisplay::TableRowGroup | FfiTableDisplay::TableHeaderGroup | FfiTableDisplay::TableFooterGroup
-        );
+        let is_table_row_group = current_display.is_table_row_group()
+            || current_display.is_table_header_group()
+            || current_display.is_table_footer_group();
         // A table-row is misparented if its parent is neither a table-row-group nor a table-root box.
-        if !is_table_row_group && current_display != FfiTableDisplay::TableRoot {
+        if !is_table_row_group && !current_display.is_table_inside() {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
-                |child| {
-                    node_has_flag(host.data(child), NodeFlag::HasStyle)
-                        && host.table_display(child) == FfiTableDisplay::TableRow
-                },
+                |child| node_has_flag(host.data(child), NodeFlag::HasStyle) && host.display(child).is_table_row(),
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
                 },
@@ -3152,14 +3117,11 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         }
 
         // A table-column box is misparented if its parent is neither a table-column-group box nor a table-root box.
-        if current_display != FfiTableDisplay::TableColumnGroup && current_display != FfiTableDisplay::TableRoot {
+        if !current_display.is_table_column_group() && !current_display.is_table_inside() {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
-                |child| {
-                    node_has_flag(host.data(child), NodeFlag::HasStyle)
-                        && host.table_display(child) == FfiTableDisplay::TableColumn
-                },
+                |child| node_has_flag(host.data(child), NodeFlag::HasStyle) && host.display(child).is_table_column(),
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
                 },
@@ -3168,7 +3130,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
 
         // A table-row-group, table-column-group, or table-caption box is misparented if its parent is not a table-root
         // box.
-        if current_display != FfiTableDisplay::TableRoot {
+        if !current_display.is_table_inside() {
             for_each_sequence_of_consecutive_children_matching(
                 host,
                 parent,
@@ -3177,7 +3139,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
                         return false;
                     }
                     let display = display_for_table_fixup(host, child);
-                    is_table_track_group(display) || display == FfiTableDisplay::TableCaption
+                    is_table_track_group(display) || display.is_table_caption()
                 },
                 |sequence, nearest_sibling| {
                     host.wrap_in_anonymous(sequence, nearest_sibling, anonymous_table_kind);
@@ -3186,7 +3148,7 @@ fn generate_missing_parents(host: &TreeBuilderHost<'_>, root: LayoutNode) -> Vec
         }
 
         // 3. An anonymous table-wrapper box must be generated around each table-root.
-        if is_box && current_display == FfiTableDisplay::TableRoot {
+        if is_box && current_display.is_table_inside() {
             if has_been_wrapped_in_table_wrapper {
                 let parent = host.parent(parent);
                 assert!(!parent.is_invalid());


### PR DESCRIPTION
Rust layout classified displays into table-specific enum before checking
their roles. This duplicated predicates already available on FfiDisplay
and forced every consumer through an unnecessary conversion layer.

Remove FfiTableDisplay and table_display_of. Tree construction and
formatting context selection, node facts, and table grid construction
now query FfiDisplay directly. Spec-level grouping helpers remain only
where they express table concepts instead of mirroring display roles.