### PR TITLE
LibWeb: Stop rebuilding table box facts on every measurement pass

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -993,25 +993,6 @@ StringView formatting_context_type_name(RustFFI::FfiFormattingContextType type)
     VERIFY_NOT_REACHED();
 }
 
-RustFFI::FfiTableBoxFacts build_table_box_facts(NodeWithStyle const& node)
-{
-    auto const& values = node.computed_values();
-
-    u32 raw_column_span = 1;
-    if (auto const* dom_node = node.dom_node()) {
-        if (auto const* element = as_if<HTML::HTMLElement>(*dom_node))
-            raw_column_span = element->get_attribute_value(HTML::AttributeNames::span).to_number<u32>().value_or(1);
-    }
-
-    return {
-        .raw_column_span = raw_column_span,
-        .border_top_color = values.border_top().color.value(),
-        .border_right_color = values.border_right().color.value(),
-        .border_bottom_color = values.border_bottom().color.value(),
-        .border_left_color = values.border_left().color.value(),
-    };
-}
-
 static size_t s_active_layout_pass_count { 0 };
 
 bool layout_pass_currently_running()
@@ -1710,10 +1691,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
                 return false;
             auto cursor_position = dom_node->document().cursor_position();
             return cursor_position && cursor_position->node() == dom_node; },
-        .build_table_box_facts = [](void*, void* node) {
-            auto const* node_with_style = as_if<NodeWithStyle>(*static_cast<Node const*>(node));
-            VERIFY(node_with_style);
-            return build_table_box_facts(*node_with_style); },
         .build_grid_facts = [](void*, void* node) {
             auto const* node_with_style = as_if<NodeWithStyle>(*static_cast<Node const*>(node));
             VERIFY(node_with_style);

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -52,7 +52,6 @@ private:
 [[nodiscard]] RustFFI::FfiSizeValue build_style_size_value(CSS::LengthPercentage const&);
 [[nodiscard]] RustFFI::FfiSizeValue build_style_size_value(CSS::LengthPercentageOrAuto const&);
 
-[[nodiscard]] RustFFI::FfiTableBoxFacts build_table_box_facts(NodeWithStyle const&);
 [[nodiscard]] Optional<RustFFI::FfiFormattingContextType> formatting_context_type_created_by_box(Box const&);
 [[nodiscard]] StringView formatting_context_type_name(RustFFI::FfiFormattingContextType);
 [[nodiscard]] bool box_inset_properties_contain_anchor_functions(Box const&);

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -973,6 +973,7 @@ void NodeWithStyle::synchronize_table_span_data()
 {
     u16 column_span = 1;
     u16 row_span = 1;
+    u32 raw_column_span = 1;
     if (auto const* node = dom_node()) {
         if (auto const* cell = as_if<HTML::HTMLTableCellElement>(*node)) {
             column_span = static_cast<u16>(cell->col_span());
@@ -980,9 +981,12 @@ void NodeWithStyle::synchronize_table_span_data()
         } else if (auto const* column = as_if<HTML::HTMLTableColElement>(*node)) {
             column_span = static_cast<u16>(column->span());
         }
+        if (auto const* element = as_if<HTML::HTMLElement>(*node))
+            raw_column_span = element->get_attribute_value(HTML::AttributeNames::span).to_number<u32>().value_or(1);
     }
     node_data().table_column_span = column_span;
     node_data().table_row_span = row_span;
+    RustFFI::layout_arena_set_raw_table_column_span(arena_handle(), slot_id(this), raw_column_span);
 }
 
 void NodeWithStyle::set_display(CSS::Display display)

--- a/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
@@ -170,8 +170,8 @@ pub struct BoxValues {
 }
 
 /// One computed border side, mirroring the C++ BorderData member layout:
-/// color, line style, used width. Layout reads the line style and width;
-/// the color rides along because the mirror covers whole sides.
+/// color, line style, used width. Layout reads the line style and width
+/// everywhere, and table border conflict resolution also reads the color.
 #[repr(C)]
 pub struct ComputedBorderSide {
     pub color: u32,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -726,16 +726,6 @@ pub struct FfiBordersData {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(C)]
-pub struct FfiTableBoxFacts {
-    pub raw_column_span: u32,
-    pub border_top_color: u32,
-    pub border_right_color: u32,
-    pub border_bottom_color: u32,
-    pub border_left_color: u32,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct ChildLayoutResult {
     pub automatic_content_inline_size: CssPixels,
     pub automatic_content_block_size: CssPixels,
@@ -897,8 +887,6 @@ impl OwnedFlexLayoutData {
     }
 }
 
-pub type FfiBuildTableBoxFactsCallback = unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiTableBoxFacts;
-
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct FfiLayoutFcCallbacks {
@@ -915,7 +903,6 @@ pub struct FfiLayoutFcCallbacks {
     pub build_list_item_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiListItemFacts,
     pub text_node_is_empty_editable: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub document_cursor_is_on_node: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
-    pub build_table_box_facts: FfiBuildTableBoxFactsCallback,
     pub build_grid_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiGridStyleFacts,
     pub release_grid_facts_snapshot: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub release_grid_name_handle: unsafe extern "C" fn(usize),

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -209,6 +209,7 @@ pub(crate) struct LayoutNodeArena {
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
+    raw_table_column_spans: HashMap<NodeSlotId, u32>,
     owner_thread: thread::ThreadId,
 }
 
@@ -225,6 +226,7 @@ impl LayoutNodeArena {
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
+            raw_table_column_spans: HashMap::new(),
             owner_thread: thread::current().id(),
         }
     }
@@ -317,6 +319,7 @@ impl LayoutNodeArena {
         if let Some(slot) = self.text_chunk_caches.get_mut().get_mut(index as usize) {
             *slot = TextChunkCacheSlot::default();
         }
+        self.raw_table_column_spans.remove(&id);
         *self.data_mut(index) = NodeData::default();
 
         self.live_count = self
@@ -669,6 +672,22 @@ impl LayoutNodeArena {
         }
     }
 
+    pub(crate) fn set_raw_table_column_span(&mut self, id: NodeSlotId, value: u32) {
+        self.assert_owner_thread();
+        self.data(id);
+        if value == 1 {
+            self.raw_table_column_spans.remove(&id);
+        } else {
+            self.raw_table_column_spans.insert(id, value);
+        }
+    }
+
+    pub(crate) fn raw_table_column_span(&self, id: NodeSlotId) -> u32 {
+        // data() validates that id names a live slot with a matching generation.
+        self.data(id);
+        self.raw_table_column_spans.get(&id).copied().unwrap_or(1)
+    }
+
     pub(crate) fn text_content(&self, id: NodeSlotId) -> Option<&TextContent> {
         assert!(!id.is_invalid(), "invalid layout node arena slot ID");
         self.text_contents
@@ -847,6 +866,20 @@ pub unsafe extern "C" fn layout_arena_set_text_content(
             untransformed_text_is_ascii_whitespace,
             may_require_bidi_processing,
         );
+    });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_raw_table_column_span(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    raw_column_span: u32,
+) {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_raw_table_column_span(id, raw_column_span);
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -797,7 +797,6 @@ pub(crate) struct LayoutState {
     anchor_inset_store: AnchorInsetStore,
     replaced_content_facts: PagedStore<crate::layout::FfiReplacedContentFacts>,
     list_item_facts: PagedStore<crate::layout::FfiListItemFacts>,
-    table_facts: PagedStore<FfiTableBoxFacts>,
     grid_facts: PagedStore<GridStyleFacts>,
     line_data: PagedStore<RefCell<LineData>>,
     block_rare_data: PagedStore<RefCell<BlockRareData>>,
@@ -852,7 +851,6 @@ impl LayoutState {
             anchor_inset_store: AnchorInsetStore::default(),
             replaced_content_facts: PagedStore::default(),
             list_item_facts: PagedStore::default(),
-            table_facts: PagedStore::default(),
             grid_facts: PagedStore::default(),
             line_data: PagedStore::default(),
             block_rare_data: PagedStore::default(),
@@ -1223,19 +1221,6 @@ impl LayoutState {
             crate::layout::FfiListItemFacts::default()
         };
         self.list_item_facts.allocate(slot_index, facts);
-        facts
-    }
-
-    pub(crate) fn table_facts(&self, callbacks: &FfiLayoutFcCallbacks, node: Node) -> FfiTableBoxFacts {
-        let slot_index = callbacks.slot_index(node);
-        let facts = self.table_facts.get(slot_index);
-        if let Some(facts) = facts {
-            return *facts;
-        }
-        // SAFETY: The callback table and node are supplied by the live C++
-        // formatting-context shim and remain valid for this layout pass.
-        let facts = unsafe { (callbacks.build_table_box_facts)(callbacks.context, callbacks.shell(node)) };
-        self.table_facts.allocate(slot_index, facts);
         facts
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -663,6 +663,10 @@ scalar_accessors! {
         border_right_style: u8 => border_right.line_style,
         border_bottom_style: u8 => border_bottom.line_style,
         border_left_style: u8 => border_left.line_style,
+        border_top_color: u32 => border_top.color,
+        border_right_color: u32 => border_right.color,
+        border_bottom_color: u32 => border_bottom.color,
+        border_left_color: u32 => border_left.color,
     }
     inherited_box: {
         writing_mode: u8 => writing_mode,

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -828,8 +828,8 @@ impl<'pass> TableFormattingContext<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
 
-    fn table_facts(&self, node: Node) -> crate::layout::FfiTableBoxFacts {
-        self.state.table_facts(&self.callbacks, node)
+    fn raw_column_span(&self, column: Node) -> usize {
+        self.callbacks.arena().raw_table_column_span(column) as usize
     }
 
     fn new(frame: &FcFrame<'pass>, pending_table_offset: Option<crate::layout::LogicalOffset>) -> Self {
@@ -921,25 +921,24 @@ impl<'pass> TableFormattingContext<'pass> {
 
     fn element_borders(&mut self, node: Node) -> ElementBorders {
         let style = self.style_facts(node);
-        let table = self.table_facts(node);
         ElementBorders {
             top: FfiBorderData {
-                color: table.border_top_color,
+                color: style.border_top_color(),
                 line_style: style.border_top_style(),
                 width: style.border_top_width(),
             },
             right: FfiBorderData {
-                color: table.border_right_color,
+                color: style.border_right_color(),
                 line_style: style.border_right_style(),
                 width: style.border_right_width(),
             },
             bottom: FfiBorderData {
-                color: table.border_bottom_color,
+                color: style.border_bottom_color(),
                 line_style: style.border_bottom_style(),
                 width: style.border_bottom_width(),
             },
             left: FfiBorderData {
-                color: table.border_left_color,
+                color: style.border_left_color(),
                 line_style: style.border_left_style(),
                 width: style.border_left_width(),
             },
@@ -1081,7 +1080,7 @@ impl<'pass> TableFormattingContext<'pass> {
                 if self.style_facts(column).width().is_length() {
                     self.columns[column_index].is_constrained = true;
                 }
-                column_index += self.table_facts(column).raw_column_span as usize;
+                column_index += self.raw_column_span(column);
             }
         }
         for row_index in 0..self.rows.len() {
@@ -1281,7 +1280,7 @@ impl<'pass> TableFormattingContext<'pass> {
                 self.columns[column_index].min_size = min_size.max(size);
                 // The outer max-content inline size of a table-column or table-column-group is max(min-width, min(max-width, width)).
                 self.columns[column_index].max_size = min_size.max(max_size.min(size));
-                column_index += self.table_facts(column).raw_column_span as usize;
+                column_index += self.raw_column_span(column);
             }
         }
         self.initialize_row_content_sizes();
@@ -1410,7 +1409,7 @@ impl<'pass> TableFormattingContext<'pass> {
                     self.columns[column_index].has_intrinsic_percentage =
                         style.max_width().is_percentage() || style.width().is_percentage();
                     self.columns[column_index].intrinsic_percentage = Self::cell_percentage(style, axis);
-                    column_index += self.table_facts(column).raw_column_span as usize;
+                    column_index += self.raw_column_span(column);
                 }
             }
         }


### PR DESCRIPTION
Table box facts were cached per LayoutState, and every intrinsic measurement pass creates a fresh LayoutState, so they were rebuilt through the FFI over and over. Now border colors are read directly from the mirrored border style group and the raw span is stamped into an arena side table at layout node construction and on span attribute changes, so layout no longer rebuilds facts at all.