### PR TITLE
LibWeb: Fix assorted style, layout, and painting issues

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -185,6 +185,7 @@ set(SOURCES
     CSS/HypotheticalElement.cpp
     CSS/Invalidation/AdoptedStyleSheetInvalidator.cpp
     CSS/Invalidation/AttributeInvalidator.cpp
+    CSS/Invalidation/ContainerQueryInvalidator.cpp
     CSS/Invalidation/CustomElementInvalidator.cpp
     CSS/Invalidation/EmbeddedContentInvalidator.cpp
     CSS/Invalidation/ElementStateInvalidator.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -184,6 +184,7 @@ set(SOURCES
     CSS/HypotheticalElement.cpp
     CSS/Invalidation/AdoptedStyleSheetInvalidator.cpp
     CSS/Invalidation/AttributeInvalidator.cpp
+    CSS/Invalidation/ContainerQueryInvalidator.cpp
     CSS/Invalidation/CustomElementInvalidator.cpp
     CSS/Invalidation/EmbeddedContentInvalidator.cpp
     CSS/Invalidation/ElementStateInvalidator.cpp

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1587,7 +1587,20 @@ public:
         RefPtr<AbstractImageStyleValue const> list_style_image;
         QuotesData quotes { InitialValues::quotes() };
 
-        bool operator==(InheritedListValues const&) const = default;
+        bool operator==(InheritedListValues const& other) const
+        {
+            // The image is compared by value: recomputation builds a fresh one for the same
+            // declaration, and comparing the addresses would call the group different for it.
+            auto images_equal = [](auto const& first, auto const& second) {
+                if (!first || !second)
+                    return !first && !second;
+                return *first == *second;
+            };
+            return list_style_type == other.list_style_type
+                && list_style_position == other.list_style_position
+                && images_equal(list_style_image, other.list_style_image)
+                && quotes == other.quotes;
+        }
     };
 
     struct InheritedUIValues {

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1595,7 +1595,20 @@ public:
         RefPtr<AbstractImageStyleValue const> list_style_image;
         QuotesData quotes { InitialValues::quotes() };
 
-        bool operator==(InheritedListValues const&) const = default;
+        bool operator==(InheritedListValues const& other) const
+        {
+            // The image is compared by value: recomputation builds a fresh one for the same
+            // declaration, and comparing the addresses would call the group different for it.
+            auto images_equal = [](auto const& first, auto const& second) {
+                if (!first || !second)
+                    return !first && !second;
+                return *first == *second;
+            };
+            return list_style_type == other.list_style_type
+                && list_style_position == other.list_style_position
+                && images_equal(list_style_image, other.list_style_image)
+                && quotes == other.quotes;
+        }
     };
 
     struct InheritedUIValues {

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -770,6 +770,11 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
         // The value the query compares against is resolved too, and that resolution can read the
         // root - `style(--length: calc(1rem * 10))` moves when the root font size does - so the root
         // is named as well.
+        // A size feature asks about the container's own box, and the scan a resize does for the
+        // dependents under it starts from the same fact: whether anything ever asked.
+        if (m_feature_requirements.contains_size_feature())
+            const_cast<DOM::Element&>(*container).set_is_size_query_container();
+
         if (m_feature_requirements.contains_style_feature()) {
             const_cast<DOM::Element&>(*container).set_is_style_query_container();
             if (auto* root = element.document().document_element())

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -764,6 +764,18 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
         if (!container_satisfies_requirements(*container, m_feature_requirements))
             continue;
 
+        // A style feature asks about the container's own computed style, so the container has to know
+        // that a style change on it is a change for something under it. Nothing else says so: the
+        // dependency is recorded on the element that asked, which is not the element that moves.
+        // The value the query compares against is resolved too, and that resolution can read the
+        // root - `style(--length: calc(1rem * 10))` moves when the root font size does - so the root
+        // is named as well.
+        if (m_feature_requirements.contains_style_feature()) {
+            const_cast<DOM::Element&>(*container).set_is_style_query_container();
+            if (auto* root = element.document().document_element())
+                root->set_is_style_query_container();
+        }
+
         // Once an eligible query container has been selected for an element, each container feature in the
         // <container-query> is evaluated against that query container.
         return m_condition->evaluate({

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -764,6 +764,10 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
         if (!container_satisfies_requirements(*container, m_feature_requirements))
             continue;
 
+        // A size feature asks about the container's own box, and the scan a resize does for the
+        // dependents under it starts from the same fact: whether anything ever asked.
+        if (m_feature_requirements.contains_size_feature())
+            const_cast<DOM::Element&>(*container).set_is_size_query_container();
         // Once an eligible query container has been selected for an element, each container feature in the
         // <container-query> is evaluated against that query container.
         return m_condition->evaluate({

--- a/Libraries/LibWeb/CSS/ContainerQuery.cpp
+++ b/Libraries/LibWeb/CSS/ContainerQuery.cpp
@@ -768,6 +768,18 @@ MatchResult ContainerQuery::evaluate(DOM::AbstractElement const& element, Option
         // dependents under it starts from the same fact: whether anything ever asked.
         if (m_feature_requirements.contains_size_feature())
             const_cast<DOM::Element&>(*container).set_is_size_query_container();
+        // A style feature asks about the container's own computed style, so the container has to know
+        // that a style change on it is a change for something under it. Nothing else says so: the
+        // dependency is recorded on the element that asked, which is not the element that moves.
+        // The value the query compares against is resolved too, and that resolution can read the
+        // root - `style(--length: calc(1rem * 10))` moves when the root font size does - so the root
+        // is named as well.
+        if (m_feature_requirements.contains_style_feature()) {
+            const_cast<DOM::Element&>(*container).set_is_style_query_container();
+            if (auto* root = element.document().document_element())
+                root->set_is_style_query_container();
+        }
+
         // Once an eligible query container has been selected for an element, each container feature in the
         // <container-query> is evaluated against that query container.
         return m_condition->evaluate({

--- a/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+#include <LibWeb/DOM/Text.h>
+#include <LibWeb/HTML/HTMLSlotElement.h>
+
+namespace Web::CSS::Invalidation {
+
+// The children of a node in the flat tree: a host's are its shadow tree's, a slot's are the nodes
+// assigned to it, and everything else's are its DOM children. This is the inverse of the walk that
+// selects a query container, which is what makes it the right one for finding that container's
+// dependents.
+static void append_flat_tree_children(DOM::Node& node, Vector<DOM::Node*>& out)
+{
+    if (auto* element = as_if<DOM::Element>(node)) {
+        if (auto shadow_root = element->shadow_root()) {
+            for (auto* child = shadow_root->first_child(); child; child = child->next_sibling())
+                out.append(child);
+            return;
+        }
+        if (auto* slot = as_if<HTML::HTMLSlotElement>(*element); slot && !slot->assigned_nodes_internal().is_empty()) {
+            for (auto const& slottable : slot->assigned_nodes_internal())
+                slottable.visit([&](auto const& assigned) { out.append(static_cast<DOM::Node*>(assigned.ptr())); });
+            return;
+        }
+    }
+
+    for (auto* child = node.first_child(); child; child = child->next_sibling())
+        out.append(child);
+}
+
+void invalidate_descendant_styles_depending_on_size_container_query(DOM::Element& query_container)
+{
+    // Only an element some size query or container-relative unit resolved against can have a
+    // dependent under it, and `container-type` is set far more widely than it is asked about.
+    if (!query_container.is_size_query_container())
+        return;
+
+    auto& counters = query_container.document().style_invalidation_counters();
+
+    Vector<DOM::Node*> stack;
+    append_flat_tree_children(query_container, stack);
+    while (!stack.is_empty()) {
+        auto* node = stack.take_last();
+        if (auto* element = as_if<DOM::Element>(*node)) {
+            ++counters.size_query_container_scan_visits;
+            if (element->style_depends_on_size_container_query())
+                element->set_needs_style_update(true);
+        }
+        append_flat_tree_children(*node, stack);
+    }
+}
+
+}

--- a/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.cpp
+++ b/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.cpp
@@ -37,6 +37,19 @@ static void append_flat_tree_children(DOM::Node& node, Vector<DOM::Node*>& out)
         out.append(child);
 }
 
+template<typename Callback>
+static void for_each_flat_tree_descendant_element(DOM::Element& query_container, Callback&& callback)
+{
+    Vector<DOM::Node*> stack;
+    append_flat_tree_children(query_container, stack);
+    while (!stack.is_empty()) {
+        auto* node = stack.take_last();
+        if (auto* element = as_if<DOM::Element>(*node))
+            callback(*element);
+        append_flat_tree_children(*node, stack);
+    }
+}
+
 void invalidate_descendant_styles_depending_on_size_container_query(DOM::Element& query_container)
 {
     // Only an element some size query or container-relative unit resolved against can have a
@@ -46,17 +59,26 @@ void invalidate_descendant_styles_depending_on_size_container_query(DOM::Element
 
     auto& counters = query_container.document().style_invalidation_counters();
 
-    Vector<DOM::Node*> stack;
-    append_flat_tree_children(query_container, stack);
-    while (!stack.is_empty()) {
-        auto* node = stack.take_last();
-        if (auto* element = as_if<DOM::Element>(*node)) {
-            ++counters.size_query_container_scan_visits;
-            if (element->style_depends_on_size_container_query())
-                element->set_needs_style_update(true);
-        }
-        append_flat_tree_children(*node, stack);
-    }
+    for_each_flat_tree_descendant_element(query_container, [&](DOM::Element& element) {
+        ++counters.size_query_container_scan_visits;
+        if (element.style_depends_on_size_container_query())
+            element.set_needs_style_update(true);
+    });
+}
+
+void invalidate_descendant_styles_depending_on_style_container_query(DOM::Element& query_container)
+{
+    // Only an element some style container query resolved against can be what a dependent under it
+    // was asking about, and most documents have no style container queries at all.
+    if (!query_container.is_style_query_container())
+        return;
+
+    ++query_container.document().style_invalidation_counters().style_query_container_scans;
+
+    for_each_flat_tree_descendant_element(query_container, [](DOM::Element& element) {
+        if (element.style_depends_on_style_container_query())
+            element.set_needs_style_update(true);
+    });
 }
 
 }

--- a/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web::DOM {
+
+class Element;
+
+}
+
+namespace Web::CSS::Invalidation {
+
+// A query container's size moved, so every element whose size query or container-relative unit
+// resolved against it has to be recomputed. Which elements those are is not a selector question:
+// the container is chosen by walking the flat tree upwards, so the dependents are its flat-tree
+// descendants, and a container no query ever selected has none at all.
+void invalidate_descendant_styles_depending_on_size_container_query(DOM::Element& query_container);
+
+}

--- a/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h
+++ b/Libraries/LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h
@@ -19,5 +19,6 @@ namespace Web::CSS::Invalidation {
 // the container is chosen by walking the flat tree upwards, so the dependents are its flat-tree
 // descendants, and a container no query ever selected has none at all.
 void invalidate_descendant_styles_depending_on_size_container_query(DOM::Element& query_container);
+void invalidate_descendant_styles_depending_on_style_container_query(DOM::Element& query_container);
 
 }

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -148,6 +148,10 @@ double Length::container_relative_length_to_px_without_rounding(ResolutionContex
         const_cast<DOM::Element&>(subject).set_style_depends_on_size_container_query();
 
         auto query_container = get_or_compute_query_container_for_axis(context, physical_axis);
+        // A container unit asks about the container's box exactly as a size query does, so the
+        // container has to know that a resize of it is a change for something under it.
+        if (query_container)
+            const_cast<DOM::Element&>(*query_container).set_is_size_query_container();
         if (!query_container) {
             context.record_viewport_relative_length_resolution();
             auto viewport_length = physical_axis == ContainerRelativeAxis::Width ? context.viewport_rect.width() : context.viewport_rect.height();

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1336,7 +1336,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             .transform_reference_box_width = 0,
             .transform_reference_box_height = 0,
         };
-        if (auto paintable = prepared_values.first().effect->target()->unsafe_paintable(); paintable) {
+        if (auto paintable = prepared_values.first().effect->target()->unsafe_paintable(); paintable && paintable->has_layout_node()) {
             auto reference_box = paintable->transform_reference_box();
             animation_context.has_transform_reference_box = true;
             animation_context.transform_reference_box_width = reference_box.width().to_double();
@@ -1626,7 +1626,12 @@ Vector<GC::Ref<Animations::KeyframeEffect>> StyleComputer::start_needed_transiti
         .transform_reference_box_width = 0,
         .transform_reference_box_height = 0,
     };
-    if (auto paintable = abstract_element.element().unsafe_paintable(); paintable) {
+    // A paintable outlives the layout node it was made for, and a style recompute can reach an
+    // element whose layout node is already gone: the layout tree builder updates the style of an
+    // element a bypass path reached, and `display: none` leaves the flag set until then. A reference
+    // box is a fact about a layout box, so without one there is none - exactly as when the element
+    // was never painted at all.
+    if (auto paintable = abstract_element.element().unsafe_paintable(); paintable && paintable->has_layout_node()) {
         auto reference_box = paintable->transform_reference_box();
         transition_animation_context.has_transform_reference_box = true;
         transition_animation_context.transform_reference_box_width = reference_box.width().to_double();

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1334,7 +1334,7 @@ void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract
             .transform_reference_box_width = 0,
             .transform_reference_box_height = 0,
         };
-        if (auto paintable = prepared_values.first().effect->target()->unsafe_paintable(); paintable) {
+        if (auto paintable = prepared_values.first().effect->target()->unsafe_paintable(); paintable && paintable->has_layout_node()) {
             auto reference_box = paintable->transform_reference_box();
             animation_context.has_transform_reference_box = true;
             animation_context.transform_reference_box_width = reference_box.width().to_double();
@@ -1623,7 +1623,12 @@ void StyleComputer::start_needed_transitions(ComputedValues const& previous_styl
         .transform_reference_box_width = 0,
         .transform_reference_box_height = 0,
     };
-    if (auto paintable = abstract_element.element().unsafe_paintable(); paintable) {
+    // A paintable outlives the layout node it was made for, and a style recompute can reach an
+    // element whose layout node is already gone: the layout tree builder updates the style of an
+    // element a bypass path reached, and `display: none` leaves the flag set until then. A reference
+    // box is a fact about a layout box, so without one there is none - exactly as when the element
+    // was never painted at all.
+    if (auto paintable = abstract_element.element().unsafe_paintable(); paintable && paintable->has_layout_node()) {
         auto reference_box = paintable->transform_reference_box();
         transition_animation_context.has_transform_reference_box = true;
         transition_animation_context.transform_reference_box_width = reference_box.width().to_double();

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -48,6 +48,14 @@ void StylePropertyMapReadOnly::visit_edges(Cell::Visitor& visitor)
         [&visitor](GC::Ref<CSSStyleDeclaration>& declaration) { visitor.visit(declaration); });
 }
 
+// A computed style map describes an element's computed style, and a disconnected element has none.
+// `getComputedStyle` refuses one outright rather than reporting a style nothing decided, and the map
+// answers the same way: empty, with every property absent.
+static bool has_computed_style(DOM::AbstractElement const& abstract_element)
+{
+    return abstract_element.element().is_connected();
+}
+
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
 WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> StylePropertyMapReadOnly::get(Utf16FlyString property_name)
 {
@@ -117,6 +125,8 @@ WebIDL::ExceptionOr<bool> StylePropertyMapReadOnly::has(Utf16FlyString property_
     // 4. If props[property] exists, return true. Otherwise, return false.
     return props.visit(
         [&property](DOM::AbstractElement& element) {
+            if (!has_computed_style(element))
+                return false;
             // From https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap we need to include:
             // "the name and computed value of every longhand CSS property supported by the User Agent, every
             // registered custom property, and every non-registered custom property which is not set to its initial
@@ -143,6 +153,8 @@ WebIDL::UnsignedLong StylePropertyMapReadOnly::size() const
     // 1. Return the size of the value of this’s [[declarations]] internal slot.
     return m_declarations.visit(
         [](DOM::AbstractElement const& element) {
+            if (!has_computed_style(element))
+                return size_t { 0 };
             // From https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap we need to include:
             // "the name and computed value of every longhand CSS property supported by the User Agent, every
             // registered custom property, and every non-registered custom property which is not set to its initial
@@ -170,6 +182,8 @@ RefPtr<StyleValue const> StylePropertyMapReadOnly::get_style_value(Source& sourc
 {
     return source.visit(
         [&property](DOM::AbstractElement& element) -> RefPtr<StyleValue const> {
+            if (!has_computed_style(element))
+                return nullptr;
             // From https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap we need to include:
             // "the name and computed value of every longhand CSS property supported by the User Agent, every
             // registered custom property, and every non-registered custom property which is not set to its initial

--- a/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
+++ b/Libraries/LibWeb/CSS/StylePropertyMapReadOnly.cpp
@@ -41,6 +41,14 @@ void StylePropertyMapReadOnly::visit_edges(GC::Cell::Visitor& visitor)
         [&visitor](GC::Ref<CSSStyleDeclaration>& declaration) { visitor.visit(declaration); });
 }
 
+// A computed style map describes an element's computed style, and a disconnected element has none.
+// `getComputedStyle` refuses one outright rather than reporting a style nothing decided, and the map
+// answers the same way: empty, with every property absent.
+static bool has_computed_style(DOM::AbstractElement const& abstract_element)
+{
+    return abstract_element.element().is_connected();
+}
+
 // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
 WebIDL::ExceptionOr<Variant<GC::Ref<CSSStyleValue>, Empty>> StylePropertyMapReadOnly::get(Utf16String property_name)
 {
@@ -113,6 +121,8 @@ WebIDL::ExceptionOr<bool> StylePropertyMapReadOnly::has(Utf16String property_nam
     // 4. If props[property] exists, return true. Otherwise, return false.
     return props.visit(
         [&property](DOM::AbstractElement& element) {
+            if (!has_computed_style(element))
+                return false;
             // From https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap we need to include:
             // "the name and computed value of every longhand CSS property supported by the User Agent, every
             // registered custom property, and every non-registered custom property which is not set to its initial
@@ -139,6 +149,8 @@ WebIDL::UnsignedLong StylePropertyMapReadOnly::size() const
     // 1. Return the size of the value of this’s [[declarations]] internal slot.
     return m_declarations.visit(
         [](DOM::AbstractElement const& element) {
+            if (!has_computed_style(element))
+                return size_t { 0 };
             // From https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap we need to include:
             // "the name and computed value of every longhand CSS property supported by the User Agent, every
             // registered custom property, and every non-registered custom property which is not set to its initial
@@ -166,6 +178,8 @@ RefPtr<StyleValue const> StylePropertyMapReadOnly::get_style_value(Source& sourc
 {
     return source.visit(
         [&property](DOM::AbstractElement& element) -> RefPtr<StyleValue const> {
+            if (!has_computed_style(element))
+                return nullptr;
             // From https://drafts.css-houdini.org/css-typed-om-1/#dom-element-computedstylemap we need to include:
             // "the name and computed value of every longhand CSS property supported by the User Agent, every
             // registered custom property, and every non-registered custom property which is not set to its initial

--- a/Libraries/LibWeb/CSS/StyleScope.cpp
+++ b/Libraries/LibWeb/CSS/StyleScope.cpp
@@ -295,6 +295,17 @@ void StyleScope::populate_rule_cache(StyleRuleCache& rule_cache)
 {
     build_user_style_sheet_if_needed();
 
+    // A user-agent sheet is a process-wide singleton with no owning document, so nothing that walks a
+    // document's own sheets ever evaluates its media rules. Its `@media` answers are still per
+    // document - `(scripting)` is - so they are evaluated here, where the rule cache that consumes
+    // them is built. Without this the cache is built against whatever state some other document
+    // happened to leave behind, and `noscript` keeps the UA sheet's `display: none` only by accident.
+    for (auto origin : { CascadeOrigin::UserAgent, CascadeOrigin::User }) {
+        for_each_stylesheet(origin, [&](CSSStyleSheet& sheet) {
+            sheet.evaluate_media_queries(document());
+        });
+    }
+
     build_qualified_layer_names_cache(rule_cache);
 
     rule_cache.pseudo_class_rule_cache[to_underlying(PseudoClass::Hover)] = make<RuleCache>();

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -53,6 +53,7 @@
 #include <LibWeb/CSS/CustomPropertyRegistration.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFaceSet.h>
+#include <LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/MediaQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/PseudoClassInvalidator.h>
 #include <LibWeb/CSS/Invalidation/StyleInvalidator.h>
@@ -2189,12 +2190,7 @@ void Document::update_layout(UpdateLayoutReason reason)
                 if (!query_container->is_connected())
                     continue;
 
-                query_container->for_each_shadow_including_descendant([](Node& node) {
-                    if (auto* element = as_if<Element>(node); element && element->style_depends_on_size_container_query())
-                        element->set_needs_style_update(true);
-
-                    return TraversalDecision::Continue;
-                });
+                CSS::Invalidation::invalidate_descendant_styles_depending_on_size_container_query(query_container);
             }
         }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -58,6 +58,7 @@
 #include <LibWeb/CSS/CustomPropertyRegistration.h>
 #include <LibWeb/CSS/FontComputer.h>
 #include <LibWeb/CSS/FontFaceSet.h>
+#include <LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/MediaQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/PseudoClassInvalidator.h>
 #include <LibWeb/CSS/Invalidation/StyleInvalidator.h>
@@ -2233,12 +2234,7 @@ void Document::update_layout(UpdateLayoutReason reason)
                 if (!query_container->is_connected())
                     continue;
 
-                query_container->for_each_shadow_including_descendant([](Node& node) {
-                    if (auto* element = as_if<Element>(node); element && element->style_depends_on_size_container_query())
-                        element->set_needs_style_update(true);
-
-                    return TraversalDecision::Continue;
-                });
+                CSS::Invalidation::invalidate_descendant_styles_depending_on_size_container_query(query_container);
             }
         }
 

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1048,6 +1048,7 @@ public:
         u64 style_sheet_invalidation_set_builds { 0 };
         u64 scope_rule_cache_builds { 0 };
         u64 style_query_container_scans { 0 };
+        u64 size_query_container_scan_visits { 0 };
         u64 relayouts_performed { 0 };
         u64 scrollable_overflow_recalculations { 0 };
     };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1047,6 +1047,7 @@ public:
         u64 registered_properties_cache_rebuilds { 0 };
         u64 style_sheet_invalidation_set_builds { 0 };
         u64 scope_rule_cache_builds { 0 };
+        u64 style_query_container_scans { 0 };
         u64 relayouts_performed { 0 };
         u64 scrollable_overflow_recalculations { 0 };
     };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1028,6 +1028,7 @@ public:
         u64 registered_properties_cache_rebuilds { 0 };
         u64 style_sheet_invalidation_set_builds { 0 };
         u64 scope_rule_cache_builds { 0 };
+        u64 size_query_container_scan_visits { 0 };
         u64 relayouts_performed { 0 };
         u64 scrollable_overflow_recalculations { 0 };
     };

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1029,6 +1029,7 @@ public:
         u64 style_sheet_invalidation_set_builds { 0 };
         u64 scope_rule_cache_builds { 0 };
         u64 size_query_container_scan_visits { 0 };
+        u64 style_query_container_scans { 0 };
         u64 relayouts_performed { 0 };
         u64 scrollable_overflow_recalculations { 0 };
     };

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1487,6 +1487,13 @@ void Element::mark_descendants_with_stale_styles_for_style_update()
 
 void Element::invalidate_descendant_styles_depending_on_style_container_query()
 {
+    // Only an element some style container query resolved against can be what a dependent under it
+    // was asking about, and most documents have no style container queries at all.
+    if (!m_is_style_query_container)
+        return;
+
+    ++document().style_invalidation_counters().style_query_container_scans;
+
     for_each_shadow_including_descendant([](auto& node) {
         auto* element = as_if<Element>(node);
         if (element && element->style_depends_on_style_container_query())

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -33,6 +33,7 @@
 #include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/CustomPropertyData.h>
 #include <LibWeb/CSS/Invalidation/AttributeInvalidator.h>
+#include <LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h>
 #include <LibWeb/CSS/Invalidation/CustomElementInvalidator.h>
 #include <LibWeb/CSS/Invalidation/ElementStateInvalidator.h>
 #include <LibWeb/CSS/Invalidation/LanguageInvalidator.h>
@@ -1468,12 +1469,7 @@ void Element::mark_descendants_with_stale_styles_for_style_update()
 
 void Element::invalidate_descendant_styles_depending_on_style_container_query()
 {
-    for_each_shadow_including_descendant([](auto& node) {
-        auto* element = as_if<Element>(node);
-        if (element && element->style_depends_on_style_container_query())
-            element->set_needs_style_update(true);
-        return TraversalDecision::Continue;
-    });
+    CSS::Invalidation::invalidate_descendant_styles_depending_on_style_container_query(*this);
 }
 
 CSS::RequiredInvalidationAfterStyleChange Element::recompute_inherited_style(ScheduleAnimationUpdate schedule_animation_update)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -428,11 +428,13 @@ public:
     void set_style_depends_on_size_container_query() { m_style_depends_on_size_container_query = true; }
     bool style_depends_on_style_container_query() const { return m_style_depends_on_style_container_query; }
     void set_style_depends_on_style_container_query() { m_style_depends_on_style_container_query = true; }
-    // Set on the element a style container query selected as its query container, so a style change
-    // on it knows whether anything under it was ever asking. It is never cleared: a dependent that
-    // stops asking republishes nothing, and answering "maybe" costs the scan the element used to pay
+    // Set on the element a container query selected as its query container, so a change on it knows
+    // whether anything under it was ever asking. Neither is ever cleared: a dependent that stops
+    // asking republishes nothing, and answering "maybe" costs the scan the element used to pay
     // unconditionally.
     void set_is_style_query_container() { m_is_style_query_container = true; }
+    bool is_size_query_container() const { return m_is_size_query_container; }
+    void set_is_size_query_container() { m_is_size_query_container = true; }
     void invalidate_descendant_styles_depending_on_style_container_query();
 
     bool child_style_uses_tree_counting_function() const { return m_child_style_uses_tree_counting_function; }
@@ -867,6 +869,7 @@ private:
     bool m_style_depends_on_size_container_query : 1 { false };
     bool m_style_depends_on_style_container_query : 1 { false };
     bool m_is_style_query_container : 1 { false };
+    bool m_is_size_query_container : 1 { false };
     bool m_child_style_uses_tree_counting_function : 1 { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
     bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -428,6 +428,11 @@ public:
     void set_style_depends_on_size_container_query() { m_style_depends_on_size_container_query = true; }
     bool style_depends_on_style_container_query() const { return m_style_depends_on_style_container_query; }
     void set_style_depends_on_style_container_query() { m_style_depends_on_style_container_query = true; }
+    // Set on the element a style container query selected as its query container, so a style change
+    // on it knows whether anything under it was ever asking. It is never cleared: a dependent that
+    // stops asking republishes nothing, and answering "maybe" costs the scan the element used to pay
+    // unconditionally.
+    void set_is_style_query_container() { m_is_style_query_container = true; }
     void invalidate_descendant_styles_depending_on_style_container_query();
 
     bool child_style_uses_tree_counting_function() const { return m_child_style_uses_tree_counting_function; }
@@ -861,6 +866,7 @@ private:
     bool m_style_uses_inherit_css_function : 1 { false };
     bool m_style_depends_on_size_container_query : 1 { false };
     bool m_style_depends_on_style_container_query : 1 { false };
+    bool m_is_style_query_container : 1 { false };
     bool m_child_style_uses_tree_counting_function : 1 { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
     bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -364,6 +364,8 @@ public:
     void set_style_depends_on_size_container_query() { m_style_depends_on_size_container_query = true; }
     bool style_depends_on_style_container_query() const { return m_style_depends_on_style_container_query; }
     void set_style_depends_on_style_container_query() { m_style_depends_on_style_container_query = true; }
+    bool is_size_query_container() const { return m_is_size_query_container; }
+    void set_is_size_query_container() { m_is_size_query_container = true; }
     void invalidate_descendant_styles_depending_on_style_container_query();
 
     bool child_style_uses_tree_counting_function() const { return m_child_style_uses_tree_counting_function; }
@@ -788,6 +790,7 @@ private:
     bool m_style_uses_inherit_css_function : 1 { false };
     bool m_style_depends_on_size_container_query : 1 { false };
     bool m_style_depends_on_style_container_query : 1 { false };
+    bool m_is_size_query_container : 1 { false };
     bool m_child_style_uses_tree_counting_function : 1 { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
     bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -366,6 +366,12 @@ public:
     void set_style_depends_on_style_container_query() { m_style_depends_on_style_container_query = true; }
     bool is_size_query_container() const { return m_is_size_query_container; }
     void set_is_size_query_container() { m_is_size_query_container = true; }
+    // Set on the element a style container query selected as its query container, so a style change
+    // on it knows whether anything under it was ever asking. It is never cleared: a dependent that
+    // stops asking republishes nothing, and answering "maybe" costs the scan the element used to pay
+    // unconditionally.
+    void set_is_style_query_container() { m_is_style_query_container = true; }
+    bool is_style_query_container() const { return m_is_style_query_container; }
     void invalidate_descendant_styles_depending_on_style_container_query();
 
     bool child_style_uses_tree_counting_function() const { return m_child_style_uses_tree_counting_function; }
@@ -791,6 +797,7 @@ private:
     bool m_style_depends_on_size_container_query : 1 { false };
     bool m_style_depends_on_style_container_query : 1 { false };
     bool m_is_size_query_container : 1 { false };
+    bool m_is_style_query_container : 1 { false };
     bool m_child_style_uses_tree_counting_function : 1 { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
     bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -116,7 +116,6 @@ Node::Node(JS::Realm& realm, Document& document, NodeType type)
     : EventTarget(realm)
     , m_document(&document)
     , m_type(type)
-    , m_unique_id(allocate_unique_id(*this))
 {
     // A Document is its own shadow-including root, so it is always connected.
     if (type == NodeType::DOCUMENT_NODE)
@@ -187,7 +186,15 @@ CSS::UserSelect Node::user_select_used_value() const
 void Node::finalize()
 {
     Base::finalize();
-    deallocate_unique_id(m_unique_id);
+    if (m_unique_id.has_value())
+        deallocate_unique_id(*m_unique_id);
+}
+
+UniqueNodeID Node::unique_id() const
+{
+    if (!m_unique_id.has_value())
+        m_unique_id = allocate_unique_id(const_cast<Node&>(*this));
+    return *m_unique_id;
 }
 
 void Node::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -117,7 +117,6 @@ Node::Node(Document& document, NodeType type)
     : EventTarget()
     , m_document(&document)
     , m_type(type)
-    , m_unique_id(allocate_unique_id(*this))
 {
     // A Document is its own shadow-including root, so it is always connected.
     if (type == NodeType::DOCUMENT_NODE)
@@ -162,7 +161,15 @@ CSS::UserSelect Node::user_select_used_value() const
 void Node::finalize()
 {
     Base::finalize();
-    deallocate_unique_id(m_unique_id);
+    if (m_unique_id.has_value())
+        deallocate_unique_id(*m_unique_id);
+}
+
+UniqueNodeID Node::unique_id() const
+{
+    if (!m_unique_id.has_value())
+        m_unique_id = allocate_unique_id(const_cast<Node&>(*this));
+    return *m_unique_id;
 }
 
 void Node::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -441,7 +441,7 @@ public:
     bool is_shadow_including_ancestor_of(Node const&) const;
     bool is_shadow_including_inclusive_ancestor_of(Node const&) const;
 
-    [[nodiscard]] UniqueNodeID unique_id() const { return m_unique_id; }
+    [[nodiscard]] UniqueNodeID unique_id() const;
     static Node* from_unique_id(UniqueNodeID);
 
     WebIDL::ExceptionOr<Utf16String> serialize_fragment(HTML::RequireWellFormed, FragmentSerializationMode = FragmentSerializationMode::Inner) const;
@@ -559,7 +559,7 @@ protected:
     bool m_is_connected { false };
     bool m_inside_blocking_wheel_event_handler { false };
 
-    UniqueNodeID m_unique_id;
+    mutable Optional<UniqueNodeID> m_unique_id;
 
     // https://dom.spec.whatwg.org/#registered-observer-list
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -434,7 +434,7 @@ public:
     bool is_shadow_including_ancestor_of(Node const&) const;
     bool is_shadow_including_inclusive_ancestor_of(Node const&) const;
 
-    [[nodiscard]] UniqueNodeID unique_id() const { return m_unique_id; }
+    [[nodiscard]] UniqueNodeID unique_id() const;
     static Node* from_unique_id(UniqueNodeID);
 
     WebIDL::ExceptionOr<Utf16String> serialize_fragment(HTML::RequireWellFormed, FragmentSerializationMode = FragmentSerializationMode::Inner) const;
@@ -552,7 +552,7 @@ protected:
     bool m_is_connected { false };
     bool m_inside_blocking_wheel_event_handler { false };
 
-    UniqueNodeID m_unique_id;
+    mutable Optional<UniqueNodeID> m_unique_id;
 
     // https://dom.spec.whatwg.org/#registered-observer-list
     // "Nodes have a strong reference to registered observers in their registered observer list." https://dom.spec.whatwg.org/#garbage-collection

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1283,6 +1283,7 @@ JS::Object* Internals::style_invalidation_counters_object() const
     object->define_direct_property("styleSheetInvalidationSetBuilds"_utf16_fly_string, JS::Value(counters.style_sheet_invalidation_set_builds), JS::default_attributes);
     object->define_direct_property("scopeRuleCacheBuilds"_utf16_fly_string, JS::Value(counters.scope_rule_cache_builds), JS::default_attributes);
     object->define_direct_property("styleQueryContainerScans"_utf16_fly_string, JS::Value(counters.style_query_container_scans), JS::default_attributes);
+    object->define_direct_property("sizeQueryContainerScanVisits"_utf16_fly_string, JS::Value(counters.size_query_container_scan_visits), JS::default_attributes);
     object->define_direct_property("relayoutsPerformed"_utf16_fly_string, JS::Value(counters.relayouts_performed), JS::default_attributes);
     object->define_direct_property("scrollableOverflowRecalculations"_utf16_fly_string, JS::Value(counters.scrollable_overflow_recalculations), JS::default_attributes);
     return object;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -1282,6 +1282,7 @@ JS::Object* Internals::style_invalidation_counters_object() const
     object->define_direct_property("registeredPropertiesCacheRebuilds"_utf16_fly_string, JS::Value(counters.registered_properties_cache_rebuilds), JS::default_attributes);
     object->define_direct_property("styleSheetInvalidationSetBuilds"_utf16_fly_string, JS::Value(counters.style_sheet_invalidation_set_builds), JS::default_attributes);
     object->define_direct_property("scopeRuleCacheBuilds"_utf16_fly_string, JS::Value(counters.scope_rule_cache_builds), JS::default_attributes);
+    object->define_direct_property("styleQueryContainerScans"_utf16_fly_string, JS::Value(counters.style_query_container_scans), JS::default_attributes);
     object->define_direct_property("relayoutsPerformed"_utf16_fly_string, JS::Value(counters.relayouts_performed), JS::default_attributes);
     object->define_direct_property("scrollableOverflowRecalculations"_utf16_fly_string, JS::Value(counters.scrollable_overflow_recalculations), JS::default_attributes);
     return object;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -958,6 +958,7 @@ JS::Object* Internals::get_style_invalidation_counters()
     object->define_direct_property("styleSheetInvalidationSetBuilds"_utf16_fly_string, JS::Value(counters.style_sheet_invalidation_set_builds), JS::default_attributes);
     object->define_direct_property("scopeRuleCacheBuilds"_utf16_fly_string, JS::Value(counters.scope_rule_cache_builds), JS::default_attributes);
     object->define_direct_property("sizeQueryContainerScanVisits"_utf16_fly_string, JS::Value(counters.size_query_container_scan_visits), JS::default_attributes);
+    object->define_direct_property("styleQueryContainerScans"_utf16_fly_string, JS::Value(counters.style_query_container_scans), JS::default_attributes);
     object->define_direct_property("relayoutsPerformed"_utf16_fly_string, JS::Value(counters.relayouts_performed), JS::default_attributes);
     object->define_direct_property("scrollableOverflowRecalculations"_utf16_fly_string, JS::Value(counters.scrollable_overflow_recalculations), JS::default_attributes);
     return object;

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -957,6 +957,7 @@ JS::Object* Internals::get_style_invalidation_counters()
     object->define_direct_property("registeredPropertiesCacheRebuilds"_utf16_fly_string, JS::Value(counters.registered_properties_cache_rebuilds), JS::default_attributes);
     object->define_direct_property("styleSheetInvalidationSetBuilds"_utf16_fly_string, JS::Value(counters.style_sheet_invalidation_set_builds), JS::default_attributes);
     object->define_direct_property("scopeRuleCacheBuilds"_utf16_fly_string, JS::Value(counters.scope_rule_cache_builds), JS::default_attributes);
+    object->define_direct_property("sizeQueryContainerScanVisits"_utf16_fly_string, JS::Value(counters.size_query_container_scan_visits), JS::default_attributes);
     object->define_direct_property("relayoutsPerformed"_utf16_fly_string, JS::Value(counters.relayouts_performed), JS::default_attributes);
     object->define_direct_property("scrollableOverflowRecalculations"_utf16_fly_string, JS::Value(counters.scrollable_overflow_recalculations), JS::default_attributes);
     return object;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -614,6 +614,11 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             VERIFY(index < frame.resolved_content.data.size());
             auto& item = frame.resolved_content.data[index];
             if (auto const* string = item.get_pointer<Utf16String>()) {
+                // An empty generated text node carries the inline fragment of an ordinary inline pseudo-element.
+                // Other pseudo-element boxes exist independently of their contents, so avoid giving them a
+                // zero-length child that would force layout to measure an otherwise empty box.
+                if (string->is_empty() && !(frame.display.is_inline_outside() && frame.display.is_flow_inside()))
+                    return Node::slot_id(nullptr);
                 frame.content_item = make_ref_counted<GeneratedTextNode>(element.document(), *string);
             } else {
                 auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -527,6 +527,11 @@ RustFFI::FfiPseudoTreeBuilderCallbacks LayoutTreeBuildBridge::make_ffi_pseudo_tr
             VERIFY(index < frame.resolved_content.data.size());
             auto& item = frame.resolved_content.data[index];
             if (auto const* string = item.get_pointer<Utf16String>()) {
+                // An empty generated text node carries the inline fragment of an ordinary inline pseudo-element.
+                // Other pseudo-element boxes exist independently of their contents, so avoid giving them a
+                // zero-length child that would force layout to measure an otherwise empty box.
+                if (string->is_empty() && !(frame.display.is_inline_outside() && frame.display.is_flow_inside()))
+                    return Node::slot_id(nullptr);
                 frame.content_item = make_ref_counted<GeneratedTextNode>(element.document(), *string);
             } else {
                 auto& image = *item.get<NonnullRefPtr<CSS::AbstractImageStyleValue>>();

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -15,6 +15,7 @@
 #include <LibGfx/Font/Font.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/CSS/Invalidation/ContainerQueryInvalidator.h>
 #include <LibWeb/CSS/StyleScope.h>
 #include <LibWeb/CSS/StyleValues/BorderImageSliceStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorSchemeStyleValue.h>
@@ -551,13 +552,8 @@ static void invalidate_descendant_styles_for_container_query_size_change(Paintab
     if (!content_size_change_affects_container_queries(paintable_box, old_size, new_size))
         return;
 
-    if (auto* element = as_if<DOM::Element>(paintable_box.dom_node().ptr())) {
-        element->for_each_shadow_including_descendant([](DOM::Node& node) {
-            if (auto* descendant_element = as_if<DOM::Element>(node); descendant_element && descendant_element->style_depends_on_size_container_query())
-                descendant_element->set_needs_style_update(true);
-            return TraversalDecision::Continue;
-        });
-    }
+    if (auto* element = as_if<DOM::Element>(paintable_box.dom_node().ptr()))
+        CSS::Invalidation::invalidate_descendant_styles_depending_on_size_container_query(*element);
 }
 
 void set_paint_viewport_scrollbars(bool const enabled)

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -81,6 +81,10 @@ void SVGSVGPaintable::paint_descendants(DisplayListRecordingContext& context, Pa
         return;
 
     paintable.for_each_child_of_type<Paintable>([&](Paintable& child) {
+        // A child that establishes a stacking context is painted by that context, in the order the
+        // painting algorithm gives it, and painting it here as well would draw it twice.
+        if (child.has_stacking_context())
+            return IterationDecision::Continue;
         paint_svg_box(context, child, phase);
         return IterationDecision::Continue;
     });

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
+#include <LibWeb/Painting/StackingContext.h>
 
 namespace Web::Painting {
 
@@ -81,6 +82,18 @@ void SVGSVGPaintable::paint_descendants(DisplayListRecordingContext& context, Pa
         return;
 
     paintable.for_each_child_of_type<Paintable>([&](Paintable& child) {
+        // A child that establishes a stacking context is painted by that context, in the order the
+        // painting algorithm gives it, and painting it here as well would draw it twice.
+        if (child.has_stacking_context()) {
+            // If this SVG root does not establish a stacking context of its own, the child context belongs to the
+            // enclosing CSS stacking context and will be painted there in the appropriate stack level.
+            if (paintable.has_stacking_context()) {
+                auto stacking_context = child.stacking_context();
+                VERIFY(stacking_context);
+                StackingContext::paint_child(context, *stacking_context);
+            }
+            return IterationDecision::Continue;
+        }
         paint_svg_box(context, child, phase);
         return IterationDecision::Continue;
     });

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -399,6 +399,12 @@ void StackingContext::paint_internal(DisplayListRecordingContext& context) const
 
         SVGSVGPaintable::paint_svg_box(context, svg_svg_paintable, PaintPhase::Foreground);
 
+        // An `<svg>` that establishes a stacking context still has descendants that establish one
+        // of their own - a `<foreignObject>` always does - and those are painted by their own
+        // context rather than by the SVG walk, so this has to paint them like any other root.
+        for (auto& child : m_children)
+            paint_child(context, *child);
+
         paint_node(svg_svg_paintable, context, PaintPhase::Outline);
         if (context.should_paint_overlay()) {
             paint_node(svg_svg_paintable, context, PaintPhase::Overlay);

--- a/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Libraries/LibWeb/Painting/StackingContext.h
@@ -48,6 +48,7 @@ public:
     static void paint_node_as_stacking_context(Paintable const&, DisplayListRecordingContext&);
     static void paint_descendants(DisplayListRecordingContext&, Paintable const&, StackingContextPaintPhase);
     static void paint_svg(DisplayListRecordingContext&, Paintable const&, PaintPhase);
+    static void paint_child(DisplayListRecordingContext&, StackingContext const&);
     void paint(DisplayListRecordingContext&) const;
 
     void dump(StringBuilder&, int indent = 0) const;
@@ -69,7 +70,6 @@ private:
     Vector<WeakPtr<Paintable>> m_non_positioned_floating_descendants;
     bool m_contains_inline_or_replaced_descendants { false };
 
-    static void paint_child(DisplayListRecordingContext&, StackingContext const&);
     void paint_internal(DisplayListRecordingContext&) const;
 };
 

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1869,9 +1869,11 @@ fn create_pseudo_element_with_frame(
     if resolved_content.content_is_list && decision != FfiPseudoElementDecision::ContentReplacement {
         state.ancestor_stack.push(layout_node);
         for index in 0..resolved_content.content_item_count {
-            // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
+            // SAFETY: `index` is below the resolved content item count and the frame retains any returned node.
             let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
-            assert!(!content_item.is_invalid());
+            if content_item.is_invalid() {
+                continue;
+            }
             let layout_host = host.layout();
             let current_parent = state.current_parent();
             let is_inline_outside = node_is_inline_outside(&layout_host, content_item);

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -1852,9 +1852,11 @@ fn create_pseudo_element_with_frame(
     if resolved_content.content_is_list && decision != FfiPseudoElementDecision::ContentReplacement {
         state.ancestor_stack.push(layout_node);
         for index in 0..resolved_content.content_item_count {
-            // SAFETY: `index` is below the resolved content item count and the frame retains the returned node.
+            // SAFETY: `index` is below the resolved content item count and the frame retains any returned node.
             let content_item = unsafe { (callbacks.create_content_item)(frame, element, pseudo_element, index) };
-            assert!(!content_item.is_invalid());
+            if content_item.is_invalid() {
+                continue;
+            }
             let layout_host = host.layout();
             let current_parent = state.current_parent();
             let is_inline_outside = node_is_inline_outside(&layout_host, content_item);

--- a/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-inline-as-abspos-containing-block.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-pseudo-element-with-inline-as-abspos-containing-block.txt
@@ -5,8 +5,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         frag 0 from TextNode start: 0, length: 8, rect: [8,8 74.125x16] baseline: 12.796875
             "Features"
         TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [85.625,15.1875] positioned [0+0+0 8 0+0+0] [0+0+0 5 0+0+0] [BFC] children: inline
-        GeneratedTextNode <(anonymous)> (not painted)
+      BlockContainer <(anonymous)> at [85.625,15.1875] positioned [0+0+0 8 0+0+0] [0+0+0 5 0+0+0] [BFC] children: not-inline
       TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
@@ -5,8 +5,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <button> at [29,29] positioned inline-block [0+1+20 0 20+1+0] [0+1+20 0 20+1+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> at [29,29] flex-container(column) [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [FFC] children: not-inline
           BlockContainer <(anonymous)> at [29,29] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
-            BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 40 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
-              GeneratedTextNode <(anonymous)> (not painted)
+            BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 40 0+0+0] [0+0+0 40 0+0+0] [BFC] children: not-inline
       TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
@@ -8,8 +8,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.703125x50] baseline: 39.984375
                 "See more games"
             TextNode <#text> (not painted)
-            BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 422.703125 0+0+0] [0+0+0 52 0+0+0] [BFC] children: inline
-              GeneratedTextNode <(anonymous)> (not painted)
+            BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 422.703125 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x70]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
@@ -7,8 +7,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> at [13,10] flex-item [0+0+0 414.703125 0+0+0] [0+0+0 50 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.703125x50] baseline: 39.984375
                 "See more games"
-            BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 422.703125 0+0+0] [0+0+0 52 0+0+0] [BFC] children: inline
-              GeneratedTextNode <(anonymous)> (not painted)
+            BlockContainer <(anonymous)> at [9,9] positioned [0+0+0 422.703125 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
             TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-stress-test.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-stress-test.txt
@@ -269,8 +269,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 TextNode <#text> (not painted)
         BlockContainer <(anonymous)> at [2,680] [0+0+0 827.75 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)
-        BlockContainer <(anonymous)> at [2,680] [0+0+0 827.75 0+0+0] [0+0+0 0 0+0+0] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [2,680] [0+0+0 827.75 0+0+0] [0+0+0 0 0+0+0] children: not-inline
       BlockContainer <(anonymous)> at [0,692] [0+0+0 831.75 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-inline-style.txt
@@ -2,8 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [1,1] [0+1+0 798 0+1+0] [0+1+0 120 0+1+0] [BFC] children: not-inline
     BlockContainer <body> at [10,10] [8+1+0 780 0+1+8] [8+1+0 102 0+1+8] children: not-inline
       BlockContainer <div.outer> at [11,11] [0+1+0 100 0+1+678] [0+1+0 100 0+1+0] children: not-inline
-        BlockContainer <(anonymous)> at [12,12] [0+1+0 50 0+1+48] [0+1+0 50 0+1+0] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [12,12] [0+1+0 50 0+1+48] [0+1+0 50 0+1+0] children: not-inline
         BlockContainer <div.inner> at [12,64] [0+1+0 98 0+1+0] [0+1+0 0 0+1+0] children: inline
           TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -6,8 +6,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           Box <tbody> at [13,13] table-row-group [0+0+0 104 0+0+0] [0+0+0 100 0+0+0] children: not-inline
             Box <tr> at [13,13] table-row [0+0+0 104 0+0+0] [0+0+0 100 0+0+0] children: not-inline
               BlockContainer <td> at [15,62] table-cell [0+1+1 100 1+1+0] [0+1+48 2 48+1+0] [BFC] children: not-inline
-                BlockContainer <(anonymous)> at [16,63] [0+1+0 98 0+1+0] [0+1+0 0 0+1+0] children: inline
-                  GeneratedTextNode <(anonymous)> (not painted)
+                BlockContainer <(anonymous)> at [16,63] [0+1+0 98 0+1+0] [0+1+0 0 0+1+0] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x126]

--- a/Tests/LibWeb/Layout/expected/empty-pseudo-element-content.txt
+++ b/Tests/LibWeb/Layout/expected/empty-pseudo-element-content.txt
@@ -1,0 +1,32 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 44 0+0+8] children: not-inline
+      BlockContainer <div.inline> at [8,8] [0+0+0 784 0+0+0] [0+0+0 20 0+0+0] children: inline
+        frag 0 from TextNode start: 0, length: 6, rect: [15,8 51.640625x20] baseline: 16
+            "inline"
+        InlineNode <(anonymous)> at [8,8] [0+2+5 0 5+2+0] [0+2+5 0 5+2+0]
+          GeneratedTextNode <(anonymous)> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,28] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      BlockContainer <div.inline-block> at [8,28] [0+0+0 784 0+0+0] [0+0+0 24 0+0+0] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,28 20x20] baseline: 20
+        frag 1 from TextNode start: 0, length: 12, rect: [28,32 110.609375x20] baseline: 16
+            "inline-block"
+        BlockContainer <(anonymous)> at [8,28] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,52] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
+      PaintableWithLines (BlockContainer<DIV>.inline) [8,8 784x20]
+        InlinePaintable (InlineNode(anonymous)) [8,8 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
+      PaintableWithLines (BlockContainer<DIV>.inline-block) [8,28 784x24]
+        PaintableWithLines (BlockContainer(anonymous)) [8,28 20x20]
+      PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x60] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid/fit-content-3.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-3.txt
@@ -8,10 +8,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
           BlockContainer <div.item> at [8,10] [0+0+0 78 0+0+0] [0+0+0 104 0+0+0] [BFC] children: not-inline
-            BlockContainer <(anonymous)> at [9,11] floating [0+1+0 50 0+1+0] [0+1+0 50 0+1+0] [BFC] children: inline
-              GeneratedTextNode <(anonymous)> (not painted)
-            BlockContainer <(anonymous)> at [9,63] floating [0+1+0 50 0+1+0] [0+1+0 50 0+1+0] [BFC] children: inline
-              GeneratedTextNode <(anonymous)> (not painted)
+            BlockContainer <(anonymous)> at [9,11] floating [0+1+0 50 0+1+0] [0+1+0 50 0+1+0] [BFC] children: not-inline
+            BlockContainer <(anonymous)> at [9,63] floating [0+1+0 50 0+1+0] [0+1+0 50 0+1+0] [BFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
             TextNode <#text> (not painted)
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -26,8 +26,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                     BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
                     Box <button#viewsManagerToggleButton.toolbarButton> at [9,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                      BlockContainer <(anonymous)> at [15,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                        GeneratedTextNode <(anonymous)> (not painted)
+                      BlockContainer <(anonymous)> at [15,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       BlockContainer <span> at [31,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -49,8 +48,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> at [69,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
                         TextNode <#text> (not painted)
                       Box <button#viewFindButton.toolbarButton> at [69,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [75,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [75,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [91,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -69,8 +67,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       Box <button#previous.toolbarButton> at [98,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [104,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [104,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [120,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -85,8 +82,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       Box <button#next.toolbarButton> at [129,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [135,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [135,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [151,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -134,8 +130,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       Box <button#zoomOutButton.toolbarButton> at [313.9375,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [319.9375,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [319.9375,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [335.9375,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -152,8 +147,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       Box <button#zoomInButton.toolbarButton> at [344.9375,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [350.9375,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [350.9375,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [366.9375,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -179,8 +173,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                             TextNode <#text> (not painted)
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
-                      BlockContainer <(anonymous)> at [500.421875,8] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                        GeneratedTextNode <(anonymous)> (not painted)
+                      BlockContainer <(anonymous)> at [500.421875,8] positioned [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                       TextNode <#text> (not painted)
                   BlockContainer <(anonymous)> (not painted) [BFC] children: inline
@@ -197,8 +190,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                         BlockContainer <(anonymous)> at [585,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
                           TextNode <#text> (not painted)
                         Box <button#editorHighlightButton.toolbarButton> at [585,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                          BlockContainer <(anonymous)> at [591,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                            GeneratedTextNode <(anonymous)> (not painted)
+                          BlockContainer <(anonymous)> at [591,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                             TextNode <#text> (not painted)
                           BlockContainer <span> at [607,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -216,8 +208,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                         BlockContainer <(anonymous)> at [614,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
                           TextNode <#text> (not painted)
                         Box <button#editorFreeTextButton.toolbarButton> at [614,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                          BlockContainer <(anonymous)> at [620,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                            GeneratedTextNode <(anonymous)> (not painted)
+                          BlockContainer <(anonymous)> at [620,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                             TextNode <#text> (not painted)
                           BlockContainer <span> at [636,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -235,8 +226,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                         BlockContainer <(anonymous)> at [643,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
                           TextNode <#text> (not painted)
                         Box <button#editorInkButton.toolbarButton> at [643,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                          BlockContainer <(anonymous)> at [649,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                            GeneratedTextNode <(anonymous)> (not painted)
+                          BlockContainer <(anonymous)> at [649,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                             TextNode <#text> (not painted)
                           BlockContainer <span> at [665,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -254,8 +244,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                         BlockContainer <(anonymous)> at [672,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
                           TextNode <#text> (not painted)
                         Box <button#editorStampButton.toolbarButton> at [672,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                          BlockContainer <(anonymous)> at [678,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                            GeneratedTextNode <(anonymous)> (not painted)
+                          BlockContainer <(anonymous)> at [678,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                           BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                             TextNode <#text> (not painted)
                           BlockContainer <span> at [694,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -284,8 +273,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       Box <button#printButton.toolbarButton> at [707,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [713,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [713,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [729,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -297,8 +285,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                         TextNode <#text> (not painted)
                       Box <button#downloadButton.toolbarButton> at [736,2] positioned flex-container(row) flex-item [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [742,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [742,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [758,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline
@@ -318,8 +305,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                       BlockContainer <(anonymous)> at [771,2] [0+0+0 28 0+0+0] [0+0+0 0 0+0+0] children: inline
                         TextNode <#text> (not painted)
                       Box <button#secondaryToolbarToggleButton.toolbarButton> at [771,2] positioned flex-container(row) [0+0+0 28 0+0+0] [0+0+0 28 0+0+0] [FFC] children: not-inline
-                        BlockContainer <(anonymous)> at [777,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
-                          GeneratedTextNode <(anonymous)> (not painted)
+                        BlockContainer <(anonymous)> at [777,8] flex-item [0+0+0 16 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
                         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
                           TextNode <#text> (not painted)
                         BlockContainer <span> at [793,16] flex-item [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
@@ -2,8 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 175 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,25] [8+0+0 784 0+0+8] [8+0+0 125 0+0+8] children: not-inline
       BlockContainer <div.empty_content> at [33,25] [25+0+0 50 0+0+709] [25+0+0 50 0+0+25] children: not-inline
-        BlockContainer <(anonymous)> at [33,75] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [33,75] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: not-inline
       BlockContainer <div.content_with_space> at [33,100] [25+0+0 50 0+0+709] [25+0+0 50 0+0+25] children: not-inline
         BlockContainer <(anonymous)> at [33,150] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: inline
           GeneratedTextNode <(anonymous)> (not painted)

--- a/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
@@ -2,8 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 175 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,25] [8+0+0 784 0+0+8] [8+0+0 125 0+0+25] children: not-inline
       BlockContainer <div.empty_content> at [33,25] [25+0+0 50 0+0+709] [25+0+0 50 0+0+25] children: not-inline
-        BlockContainer <(anonymous)> at [33,75] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [33,75] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: not-inline
       BlockContainer <div.content_with_space> at [33,100] [25+0+0 50 0+0+709] [25+0+0 50 0+0+25] children: not-inline
         BlockContainer <(anonymous)> at [33,150] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: inline
           GeneratedTextNode <(anonymous)> (not painted)

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties-2.txt
@@ -9,8 +9,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       BlockContainer <div.a> at [8,28] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,28 200x100] baseline: 100
-        BlockContainer <(anonymous)> at [8,28] inline-block [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [8,28] inline-block [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [8,128] [0+0+0 784 0+0+0] [0+0+0 60 0+0+0] children: inline
         frag 0 from TextNode start: 1, length: 42, rect: [8,168 441.40625x20] baseline: 16
             "Variable set by CSS rule matching element:"
@@ -22,8 +21,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       BlockContainer <div.b> at [8,188] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,188 200x100] baseline: 100
-        BlockContainer <(anonymous)> at [8,188] inline-block [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [8,188] inline-block [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [8,288] [0+0+0 784 0+0+0] [0+0+0 60 0+0+0] children: inline
         frag 0 from TextNode start: 1, length: 49, rect: [8,328 520.765625x20] baseline: 16
             "Variable set by CSS rule matching pseudo element:"
@@ -35,8 +33,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       BlockContainer <div.c> at [8,348] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,348 200x100] baseline: 100
-        BlockContainer <(anonymous)> at [8,348] inline-block [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [8,348] inline-block [0+0+0 200 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
       BlockContainer <(anonymous)> at [8,448] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-custom-properties.txt
@@ -2,8 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 0 0+0+8] children: not-inline
       BlockContainer <div.hello> at [8,8] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: not-inline
-        BlockContainer <(anonymous)> at [8,8] positioned [0+0+0 500 0+0+0] [0+0+0 100 0+0+0] [BFC] children: inline
-          GeneratedTextNode <(anonymous)> (not painted)
+        BlockContainer <(anonymous)> at [8,8] positioned [0+0+0 500 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]

--- a/Tests/LibWeb/Layout/expected/pseudo-element-with-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/pseudo-element-with-display-block.txt
@@ -6,8 +6,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           frag 0 from TextNode start: 0, length: 6, rect: [8,8 54.796875x16] baseline: 12.796875
               "foobar"
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,24] [0+0+0 50 0+0+734] [0+0+0 50 0+0+0] children: inline
-        GeneratedTextNode <(anonymous)> (not painted)
+      BlockContainer <(anonymous)> at [8,24] [0+0+0 50 0+0+734] [0+0+0 50 0+0+0] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x82]

--- a/Tests/LibWeb/Layout/expected/table/abspos-pseudo-element-inside-table.txt
+++ b/Tests/LibWeb/Layout/expected/table/abspos-pseudo-element-inside-table.txt
@@ -6,8 +6,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           Box <thead> at [10,10] table-header-group [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: not-inline
             Box <tr> at [10,10] table-row [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] children: not-inline
               BlockContainer <(anonymous)> at [10,10] table-cell [0+0+0 780 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
-                BlockContainer <(anonymous)> at [0,590] positioned [0+0+0 800 0+0+0] [0+0+0 10 0+0+0] [BFC] children: inline
-                  GeneratedTextNode <(anonymous)> (not painted)
+                BlockContainer <(anonymous)> at [0,590] positioned [0+0+0 800 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x20]

--- a/Tests/LibWeb/Layout/input/empty-pseudo-element-content.html
+++ b/Tests/LibWeb/Layout/input/empty-pseudo-element-content.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    * {
+        font: 20px SerenitySans;
+    }
+
+    .inline::before {
+        content: "";
+        padding: 5px;
+        border: 2px solid black;
+    }
+
+    .inline-block::before {
+        content: "";
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+    }
+</style>
+<div class="inline">inline</div>
+<div class="inline-block">inline-block</div>

--- a/Tests/LibWeb/Text/expected/css/disconnected-node-mutation-no-style-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/css/disconnected-node-mutation-no-style-invalidation.txt
@@ -7,5 +7,7 @@ div:has(> .flag) outline color: rgb(1, 2, 3)
 custom element :defined color: rgb(128, 0, 128)
 un-classed child color: rgb(0, 0, 0)
 detached child initial color: rgb(255, 0, 0)
-detached child inline color: rgb(0, 128, 0)
-detached child ancestor class color: rgb(0, 0, 255)
+detached child inline color: undefined
+detached child ancestor class color: undefined
+detached child map size: 0
+detached child map has color: false

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/size-query-container-scans.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/size-query-container-scans.txt
@@ -1,0 +1,4 @@
+dependent before: rgb(0, 0, 0)
+elements walked after resizing a container no query names: 1
+elements walked after resizing the query container: 1
+dependent after: rgb(1, 2, 3)

--- a/Tests/LibWeb/Text/expected/css/style-invalidation/style-query-container-scans.txt
+++ b/Tests/LibWeb/Text/expected/css/style-invalidation/style-query-container-scans.txt
@@ -1,0 +1,4 @@
+dependent before: rgb(0, 0, 0)
+scans after a change on an element no query names: 0
+scans after a change on the query container: 1
+dependent after: rgb(1, 2, 3)

--- a/Tests/LibWeb/Text/expected/css/user-agent-sheet-media-rule-is-evaluated.txt
+++ b/Tests/LibWeb/Text/expected/css/user-agent-sheet-media-rule-is-evaluated.txt
@@ -1,0 +1,3 @@
+before: none
+in the frame: inline
+after: none

--- a/Tests/LibWeb/Text/input/css/disconnected-node-mutation-no-style-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/disconnected-node-mutation-no-style-invalidation.html
@@ -83,6 +83,8 @@
         host.appendChild(detachedTree);
         println(`detached child initial color: ${detachedChild.computedStyleMap().get("color")}`);
 
+        // A disconnected element has no computed style at all: getComputedStyle refuses one, and the
+        // computed style map answers the same way rather than reporting a style nothing decided.
         detachedTree.remove();
         detachedChild.style.color = "rgb(0, 128, 0)";
         println(`detached child inline color: ${detachedChild.computedStyleMap().get("color")}`);
@@ -90,5 +92,7 @@
         detachedChild.style.color = "";
         detachedTree.className = "detached-blue";
         println(`detached child ancestor class color: ${detachedChild.computedStyleMap().get("color")}`);
+        println(`detached child map size: ${detachedChild.computedStyleMap().size}`);
+        println(`detached child map has color: ${detachedChild.computedStyleMap().has("color")}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/size-query-container-scans.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/size-query-container-scans.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script src="structural-matrix.js"></script>
+<style>
+    #queried, #unqueried { container-type: inline-size; width: 200px }
+    @container (min-width: 300px) {
+        #dependent { color: rgb(1, 2, 3) }
+    }
+</style>
+<div id="unqueried"></div>
+<div id="queried"><span id="dependent"></span></div>
+<script>
+    test(() => {
+        const dependent = document.getElementById("dependent");
+        const queried = document.getElementById("queried");
+        const unqueried = document.getElementById("unqueried");
+        for (let i = 0; i < 50; ++i)
+            unqueried.appendChild(document.createElement("span"));
+
+        // Resizing a query container has to reach the descendants whose size queries resolved
+        // against it, which means walking the subtree looking for them. `container-type` is set far
+        // more widely than it is asked about, so a container no query ever named is not walked at
+        // all - what the count answers for is which subtrees the resize had to look through.
+        println(`dependent before: ${getComputedStyle(dependent).color}`);
+
+        flushPendingStyleWork();
+        unqueried.style.width = "400px";
+        internals.updateStyle();
+        document.body.offsetWidth;
+        println(`elements walked after resizing a container no query names: ${styleCounters().sizeQueryContainerScanVisits}`);
+
+        flushPendingStyleWork();
+        queried.style.width = "400px";
+        internals.updateStyle();
+        document.body.offsetWidth;
+        println(`elements walked after resizing the query container: ${styleCounters().sizeQueryContainerScanVisits}`);
+        println(`dependent after: ${getComputedStyle(dependent).color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/style-query-container-scans.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/style-query-container-scans.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<script src="structural-matrix.js"></script>
+<style>
+    #queried { --state: off }
+    #queried.changed { --state: on }
+    #unqueried.changed { background-color: blue }
+    @container style(--state: on) {
+        #dependent { color: rgb(1, 2, 3) }
+    }
+</style>
+<div id="unqueried"><div><span></span><span></span></div></div>
+<div id="queried"><div><span id="dependent"></span></div></div>
+<script>
+    test(() => {
+        const dependent = document.getElementById("dependent");
+        const queried = document.getElementById("queried");
+        const unqueried = document.getElementById("unqueried");
+
+        // A style change on an element has to reach the descendants whose style container queries
+        // resolved against it, which means scanning the subtree for them. Only an element some query
+        // actually selected can be one of those, so a change on anything else scans nothing.
+        println(`dependent before: ${getComputedStyle(dependent).color}`);
+
+        flushPendingStyleWork();
+        unqueried.classList.add("changed");
+        internals.updateStyle();
+        println(`scans after a change on an element no query names: ${styleCounters().styleQueryContainerScans}`);
+
+        flushPendingStyleWork();
+        queried.classList.add("changed");
+        internals.updateStyle();
+        println(`scans after a change on the query container: ${styleCounters().styleQueryContainerScans}`);
+        println(`dependent after: ${getComputedStyle(dependent).color}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/user-agent-sheet-media-rule-is-evaluated.html
+++ b/Tests/LibWeb/Text/input/css/user-agent-sheet-media-rule-is-evaluated.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<noscript id="noscript">hidden while scripting is enabled</noscript>
+<iframe id="frame" sandbox="allow-same-origin" srcdoc="<noscript id=inner>visible in here</noscript>"></iframe>
+<script>
+asyncTest(done => {
+    const noscript = document.getElementById("noscript");
+    println("before: " + getComputedStyle(noscript).display);
+
+    document.getElementById("frame").onload = () => {
+        const frameDocument = document.getElementById("frame").contentDocument;
+        const inner = frameDocument.getElementById("inner");
+        println("in the frame: " + frameDocument.defaultView.getComputedStyle(inner).display);
+
+        document.head.appendChild(document.createElement("style"));
+        println("after: " + getComputedStyle(noscript).display);
+        done();
+    };
+});
+</script>


### PR DESCRIPTION
This branch collects various LibWeb correctness fixes that I accumulated while investigating StyleBench:

- Make container-query invalidation dependency-aware and traverse relevant flat-tree descendants only.
- Correct computed style maps for disconnected elements.
- Evaluate user-agent stylesheet media rules per document.
- Fix pseudo-elements with empty generated content.
- Correct SVG child stacking-context painting.
- Avoid invalid paintable reference-box lookups when no layout node exists.
- Compare list marker images by value and allocate DOM node IDs lazily.
- Add and update LibWeb layout and text regression tests, including container-query invalidation coverage.