### PR TITLE
LibWeb; Handle calculated number values for `stroke-width` and `stroke-dashoffset`

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -2287,6 +2287,19 @@ Optional<SVGPaint> ComputedProperties::stroke(ColorResolutionContext const& colo
     return SVGPaint::from_style_value(value, color_resolution_context);
 }
 
+LengthPercentage ComputedProperties::stroke_width() const
+{
+    auto const& value = property(PropertyID::StrokeWidth);
+
+    if (value.is_number() || (value.is_calculated() && value.as_calculated().resolves_to_number())) {
+        // FIXME: Converting to pixels isn't really correct - values should be in "user units"
+        //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
+        return CSS::Length::make_px(CSSPixels::nearest_value_for(number_from_style_value(value, {})));
+    }
+
+    return CSS::LengthPercentage::from_style_value(value);
+}
+
 Vector<Variant<LengthPercentage, float>> ComputedProperties::stroke_dasharray() const
 {
     auto const& value = property(PropertyID::StrokeDasharray);

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -2555,8 +2555,8 @@ BorderImageData ComputedProperties::border_image() const
         .source = source.is_abstract_image() ? RefPtr { source.as_abstract_image() } : nullptr,
         .slice = { convert_slice(slice.top()), convert_slice(slice.right()), convert_slice(slice.bottom()), convert_slice(slice.left()) },
         .width = expand_sides(property(PropertyID::BorderImageWidth), [](StyleValue const& value) -> BorderImageWidthValue {
-            if (value.is_number())
-                return value.as_number().number();
+            if (value.is_number() || (value.is_calculated() && value.as_calculated().resolves_to_number()))
+                return number_from_style_value(value, {});
             if (value.to_keyword() == Keyword::Auto)
                 return BorderImageWidthAuto {};
             return LengthPercentage::from_style_value(value);

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -2562,8 +2562,8 @@ BorderImageData ComputedProperties::border_image() const
             return LengthPercentage::from_style_value(value);
         }),
         .outset = expand_sides(property(PropertyID::BorderImageOutset), [](StyleValue const& value) -> BorderImageOutsetValue {
-            if (value.is_number())
-                return value.as_number().number();
+            if (value.is_number() || (value.is_calculated() && value.as_calculated().resolves_to_number()))
+                return number_from_style_value(value, {});
             return Length::from_style_value(value, {});
         }),
         .width_value_count = component_count(property(PropertyID::BorderImageWidth)),

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -2336,6 +2336,19 @@ Vector<Variant<LengthPercentage, float>> ComputedProperties::stroke_dasharray() 
     return dashes;
 }
 
+LengthPercentage ComputedProperties::stroke_dashoffset() const
+{
+    auto const& value = property(PropertyID::StrokeDashoffset);
+
+    if (value.is_number() || (value.is_calculated() && value.as_calculated().resolves_to_number())) {
+        // FIXME: Converting to pixels isn't really correct - values should be in "user units"
+        //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
+        return CSS::Length::make_px(CSSPixels::nearest_value_for(number_from_style_value(value, {})));
+    }
+
+    return CSS::LengthPercentage::from_style_value(value);
+}
+
 StrokeLinecap ComputedProperties::stroke_linecap() const
 {
     auto const& value = property(PropertyID::StrokeLinecap);

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -302,6 +302,7 @@ public:
     float fill_opacity() const;
     Optional<SVGPaint> stroke(ColorResolutionContext const&) const;
     Vector<Variant<LengthPercentage, float>> stroke_dasharray() const;
+    LengthPercentage stroke_dashoffset() const;
     StrokeLinecap stroke_linecap() const;
     StrokeLinejoin stroke_linejoin() const;
     LengthPercentage stroke_width() const;

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -304,6 +304,7 @@ public:
     Vector<Variant<LengthPercentage, float>> stroke_dasharray() const;
     StrokeLinecap stroke_linecap() const;
     StrokeLinejoin stroke_linejoin() const;
+    LengthPercentage stroke_width() const;
     VectorEffect vector_effect() const;
     double stroke_miterlimit() const;
     float stroke_opacity() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -2218,15 +2218,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!inherited_svg_adopted)
         computed_values.set_stroke_dasharray(computed_style.stroke_dasharray());
 
-    auto const& stroke_dashoffset = computed_style.property(CSS::PropertyID::StrokeDashoffset);
-    // FIXME: Converting to pixels isn't really correct - values should be in "user units"
-    //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
-    if (!inherited_svg_adopted) {
-        if (stroke_dashoffset.is_number())
-            computed_values.set_stroke_dashoffset(CSS::Length::make_px(CSSPixels::nearest_value_for(stroke_dashoffset.as_number().number())));
-        else
-            computed_values.set_stroke_dashoffset(CSS::LengthPercentage::from_style_value(stroke_dashoffset));
-    }
+    if (!inherited_svg_adopted)
+        computed_values.set_stroke_dashoffset(computed_style.stroke_dashoffset());
 
     if (!inherited_svg_adopted)
         computed_values.set_stroke_linecap(computed_style.stroke_linecap());

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -2167,15 +2167,9 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (!inherited_svg_adopted)
         computed_values.set_stroke(computed_style.stroke(color_resolution_context));
 
-    auto const& stroke_width = computed_style.property(CSS::PropertyID::StrokeWidth);
-    // FIXME: Converting to pixels isn't really correct - values should be in "user units"
-    //        https://svgwg.org/svg2-draft/coords.html#TermUserUnits
-    if (!inherited_svg_adopted) {
-        if (stroke_width.is_number())
-            computed_values.set_stroke_width(CSS::Length::make_px(CSSPixels::nearest_value_for(stroke_width.as_number().number())));
-        else
-            computed_values.set_stroke_width(CSS::LengthPercentage::from_style_value(stroke_width));
-    }
+    if (!inherited_svg_adopted)
+        computed_values.set_stroke_width(computed_style.stroke_width());
+
     if (!inherited_svg_adopted) {
         computed_values.set_paint_order(computed_style.paint_order());
         auto const& paint_order = computed_style.property(PropertyID::PaintOrder);

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -96,7 +96,7 @@ public:
 
     static LengthPercentage from_style_value(NonnullRefPtr<StyleValue const> const& style_value)
     {
-        VERIFY(style_value->is_percentage() || style_value->is_length() || style_value->is_calculated());
+        VERIFY(style_value->is_percentage() || style_value->is_length() || (style_value->is_calculated() && style_value->as_calculated().resolves_to_length()));
         return from_retained_data(StyleValueFFI::rust_style_value_retain(style_value->rust_style_value_data()));
     }
 

--- a/Tests/LibWeb/Crash/CSS/calculated-number-border-image-outset.html
+++ b/Tests/LibWeb/Crash/CSS/calculated-number-border-image-outset.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<style>
+    #foo {
+        border-image-outset: calc(42);
+    }
+</style>
+<div id="foo"></div>

--- a/Tests/LibWeb/Crash/CSS/calculated-number-border-image-width.html
+++ b/Tests/LibWeb/Crash/CSS/calculated-number-border-image-width.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<style>
+    #foo {
+        border-image-width: calc(42);
+    }
+</style>
+<div id="foo"></div>

--- a/Tests/LibWeb/Crash/CSS/calculated-number-stroke-dashoffset.html
+++ b/Tests/LibWeb/Crash/CSS/calculated-number-stroke-dashoffset.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<style>
+    #foo {
+        stroke-dashoffset: calc(1);
+    }
+</style>
+<svg id="foo">
+    <path d=""></path>
+</svg>

--- a/Tests/LibWeb/Crash/CSS/calculated-number-stroke-width.html
+++ b/Tests/LibWeb/Crash/CSS/calculated-number-stroke-width.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<style>
+    #foo {
+        stroke-width: calc(1);
+    }
+</style>
+<svg id="foo">
+    <path d=""></path>
+</svg>


### PR DESCRIPTION
Previously we only checked for literal `<number>` values and fell back to storing calculated number values within a `LengthPercentage` which subsequently crashed when resolving the value.

We also introduce a `VERIFY` to ensure calculated values in a `LengthPercentage` resolve to a length.

Fixes #10909