### PR TITLE
LibWeb: Honor the `sizes` attribute on `<source>` elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1388,7 +1388,7 @@ static void update_the_source_set(DOM::Element& element)
         }
 
         // 7. Parse child's sizes attribute with img, and let source set's source size be the returned value.
-        source_set.m_source_size = parse_a_sizes_attribute(element, child->get_attribute_value_view(HTML::AttributeNames::sizes).value_or({}), img);
+        source_set.m_source_size = parse_a_sizes_attribute(*child, child->get_attribute_value_view(HTML::AttributeNames::sizes).value_or({}), img);
 
         // 8. If child has a type attribute, and its value is an unknown or unsupported MIME type, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::type)) {

--- a/Tests/LibWeb/Text/expected/HTML/picture-source-sizes-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/picture-source-sizes-attribute.txt
@@ -1,0 +1,3 @@
+sizes on source: 120.png?candidate, natural size 60x60
+sizes on img: 120.png?candidate, natural size 60x60
+sizes on source and img: 120.png?candidate, natural size 60x60

--- a/Tests/LibWeb/Text/input/HTML/picture-source-sizes-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/picture-source-sizes-attribute.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const srcset = "../../../Assets/120.png?candidate 120w";
+        const fallback = "../../../Assets/120.png?fallback";
+
+        function selectedImage({ sourceSizes, imageSizes }) {
+            return new Promise(resolve => {
+                const picture = document.createElement("picture");
+                const image = document.createElement("img");
+
+                if (sourceSizes === undefined) {
+                    image.srcset = srcset;
+                } else {
+                    const source = document.createElement("source");
+                    source.sizes = sourceSizes;
+                    source.srcset = srcset;
+                    picture.appendChild(source);
+                }
+
+                if (imageSizes !== undefined)
+                    image.sizes = imageSizes;
+
+                image.addEventListener("load", () => {
+                    const url = image.currentSrc;
+                    resolve(`${url.substring(url.lastIndexOf("/") + 1)}, natural size ${image.naturalWidth}x${image.naturalHeight}`);
+                });
+
+                image.src = fallback;
+                picture.appendChild(image);
+                document.body.appendChild(picture);
+            });
+        }
+
+        println(`sizes on source: ${await selectedImage({ sourceSizes: "60px" })}`);
+        println(`sizes on img: ${await selectedImage({ imageSizes: "60px" })}`);
+        println(`sizes on source and img: ${await selectedImage({ sourceSizes: "60px", imageSizes: "240px" })}`);
+    });
+</script>


### PR DESCRIPTION
Previously, we were parsing the `sizes` attribute from the `<img>` element rather than the matching `<source>` element, so a source size declared on a `<source>` was discarded in favor of 100vw.

Fixes #10894