### PR TITLE
Meta: Pin sdl3 back to 3.2.28 so it builds on Linux again

### DIFF
--- a/Meta/CMake/flatpak/org.ladybird.Ladybird.json
+++ b/Meta/CMake/flatpak/org.ladybird.Ladybird.json
@@ -596,7 +596,7 @@
         {
           "type": "git",
           "url": "https://github.com/libsdl-org/SDL.git",
-          "tag": "release-3.4.12"
+          "tag": "release-3.2.28"
         }
       ],
       "config-opts": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -377,7 +377,7 @@
     },
     {
       "name": "sdl3",
-      "version": "3.4.12#0"
+      "version": "3.2.28#0"
     },
     {
       "name": "simdjson",


### PR DESCRIPTION
**Problem:** All Linux CI jobs failed whenever the vcpkg binary cache missed, because building `sdl3` 3.4.12 from source dies with _“static declaration of ‘getresuid’ follows non-static declaration”_ while compiling `src/core/unix/SDL_gtk.c`.

**Cause:** `SDL_gtk.c` defines static inline fallbacks for `getresuid()` and `getresgid()` when `HAVE_GETRESUID` isn’t defined. Our CI image doesn’t detect those at configure time, but glibc declares them when the file’s compiled. So, the fallbacks redeclare functions that already exist. That file arrived with the GTK backend in the 3.4 series; it’s absent from 3.2.28, which is what we pinned until 92206a2249a bumped us to 3.4.12.

**Fix:** Pin `sdl3` back to 3.2.28.
