### PR TITLE
LibWeb: Implement the CSS `d` property

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1074,6 +1074,8 @@ RefPtr<StyleValue const> ComputedValues::computed_style_value(PropertyID propert
         return length_percentage_style_value(cx());
     case PropertyID::Cy:
         return length_percentage_style_value(cy());
+    case PropertyID::D:
+        return d();
     case PropertyID::Direction:
         return KeywordStyleValue::create(to_keyword(direction()));
     case PropertyID::EmptyCells:

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -1439,6 +1439,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         SVGResetValues::style_group_index,
         computed_style.property(PropertyID::Cx).rust_style_value_data(),
         computed_style.property(PropertyID::Cy).rust_style_value_data(),
+        computed_style.property(PropertyID::D).rust_style_value_data(),
         computed_style.property(PropertyID::R).rust_style_value_data(),
         computed_style.property(PropertyID::Rx).rust_style_value_data(),
         computed_style.property(PropertyID::Ry).rust_style_value_data(),

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1480,6 +1480,12 @@ public:
 
     LengthPercentage const& cx() const { return LengthPercentage::view(m_noninherited.svg_reset->cx); }
     LengthPercentage const& cy() const { return LengthPercentage::view(m_noninherited.svg_reset->cy); }
+    NonnullRefPtr<StyleValue const> d() const
+    {
+        auto const* handle = &m_noninherited.svg_reset->d;
+        static_assert(sizeof(RustStyleValueHandle) == sizeof(*handle));
+        return style_value_from_handle(PropertyID::D, reinterpret_cast<RustStyleValueHandle const&>(*handle)).release_nonnull();
+    }
     LengthPercentage const& r() const { return LengthPercentage::view(m_noninherited.svg_reset->r); }
     LengthPercentageOrAuto rx() const { return m_noninherited.svg_reset->rx.is_auto ? LengthPercentageOrAuto::make_auto() : LengthPercentage::view(m_noninherited.svg_reset->rx.value); }
     LengthPercentageOrAuto ry() const { return m_noninherited.svg_reset->ry.is_auto ? LengthPercentageOrAuto::make_auto() : LengthPercentage::view(m_noninherited.svg_reset->ry.value); }

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1782,24 +1782,7 @@ public:
 
         bool operator==(SVGResetValues const& other) const
         {
-            auto length_percentage_or_auto_equal = [](auto const& first, auto const& second) {
-                if (first.is_auto || second.is_auto)
-                    return first.is_auto == second.is_auto;
-                return LengthPercentage::view(first.value) == LengthPercentage::view(second.value);
-            };
-            return LengthPercentage::view(cx) == LengthPercentage::view(other.cx)
-                && LengthPercentage::view(cy) == LengthPercentage::view(other.cy)
-                && LengthPercentage::view(r) == LengthPercentage::view(other.r)
-                && length_percentage_or_auto_equal(rx, other.rx)
-                && length_percentage_or_auto_equal(ry, other.ry)
-                && LengthPercentage::view(x) == LengthPercentage::view(other.x)
-                && LengthPercentage::view(y) == LengthPercentage::view(other.y)
-                && stop_color == other.stop_color
-                && stop_opacity == other.stop_opacity
-                && flood_color == other.flood_color
-                && flood_opacity == other.flood_opacity
-                && vector_effect == other.vector_effect
-                && shape_rendering == other.shape_rendering;
+            return ComputedValuesFFI::rust_style_group_payloads_equal(style_group_index, this, &other);
         }
     };
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -542,6 +542,7 @@ private:
     RefPtr<StyleValue const> parse_counter_reset_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_counter_set_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_cursor_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue const> parse_d_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_display_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_flex_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue const> parse_flex_flow_value(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -510,6 +510,8 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue const>> Parser::parse_css_value(Pr
         return parse_all_as(tokens, [this](auto& tokens) { return parse_counter_set_value(tokens); });
     case PropertyID::Cursor:
         return parse_all_as(tokens, [this](auto& tokens) { return parse_cursor_value(tokens); });
+    case PropertyID::D:
+        return parse_all_as(tokens, [this](auto& tokens) { return parse_d_value(tokens); });
     case PropertyID::Display:
         return parse_all_as(tokens, [this](auto& tokens) { return parse_display_value(tokens); });
     case PropertyID::Flex:
@@ -1938,6 +1940,32 @@ RefPtr<StyleValue const> Parser::parse_single_shadow_value(TokenStream<Component
 
     transaction.commit();
     return ShadowStyleValue::create(shadow_type, color, offset_x.release_nonnull(), offset_y.release_nonnull(), blur_radius, spread_distance, placement.release_value());
+}
+
+// https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty
+RefPtr<StyleValue const> Parser::parse_d_value(TokenStream<ComponentValue>& tokens)
+{
+    // none | string
+    // AD-HOC: All browsers instead implement this as "none | path()" so we do too, see
+    //         https://github.com/w3c/svgwg/issues/939
+    auto transaction = tokens.begin_transaction();
+
+    if (auto none = parse_all_as_single_keyword_value(tokens, Keyword::None)) {
+        transaction.commit();
+        return none;
+    }
+
+    tokens.discard_whitespace();
+
+    if (!tokens.has_next_token() || !tokens.next_token().is_function("path"_utf16))
+        return nullptr;
+
+    auto path = parse_basic_shape_value(tokens);
+    if (!path)
+        return nullptr;
+
+    transaction.commit();
+    return path;
 }
 
 RefPtr<StyleValue const> Parser::parse_shape_outside_value(TokenStream<ComponentValue>& tokens)

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1828,6 +1828,12 @@
       "unitless-length"
     ]
   },
+  "d": {
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "none",
+    "requires-computation": "never"
+  },
   "direction": {
     "animation-type": "none",
     "inherited": true,

--- a/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
@@ -240,6 +240,7 @@ pub struct FontLayoutFacts {
 pub struct SVGResetValues {
     pub cx: ComputedStyleValueHandle,
     pub cy: ComputedStyleValueHandle,
+    pub d: ComputedStyleValueHandle,
     pub r: ComputedStyleValueHandle,
     pub rx: ComputedLengthPercentageOrAuto,
     pub ry: ComputedLengthPercentageOrAuto,

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -79,6 +79,12 @@ impl ComputedStyleValueHandle {
         }
     }
 
+    fn keyword(value: u16) -> Self {
+        Self {
+            pointer: crate::css::style_value::rust_style_value_create_keyword(value).cast(),
+        }
+    }
+
     fn data(&self) -> Option<&crate::css::style_value::StyleValueData> {
         unsafe { self.pointer.cast::<crate::css::style_value::StyleValueData>().as_ref() }
     }
@@ -187,6 +193,7 @@ impl_computed_payload_clone_and_eq!(SurroundValues {
 impl_computed_payload_clone_and_eq!(SVGResetValues {
     cx,
     cy,
+    d,
     r,
     rx,
     ry,
@@ -1374,7 +1381,7 @@ impl BoxValues {
 
 impl SVGResetValues {
     fn initial() -> Self {
-        use crate::css::css_enums::{shape_rendering, vector_effect};
+        use crate::css::css_enums::{keyword, shape_rendering, vector_effect};
 
         const OPAQUE_BLACK_BGRA: u32 = 0xff00_0000;
 
@@ -1382,6 +1389,7 @@ impl SVGResetValues {
         Self {
             cx: zero.clone(),
             cy: zero.clone(),
+            d: ComputedStyleValueHandle::keyword(keyword::NONE),
             r: zero.clone(),
             rx: ComputedLengthPercentageOrAuto {
                 is_auto: true,
@@ -1488,6 +1496,7 @@ pub unsafe extern "C" fn rust_build_svg_reset_group(
     group_index: usize,
     cx: *const c_void,
     cy: *const c_void,
+    d: *const c_void,
     r: *const c_void,
     rx: *const c_void,
     ry: *const c_void,
@@ -1514,6 +1523,7 @@ pub unsafe extern "C" fn rust_build_svg_reset_group(
         let built = SVGResetValues {
             cx: retained(cx),
             cy: retained(cy),
+            d: retained(d),
             r: retained(r),
             rx: ComputedLengthPercentageOrAuto::from_data(rx),
             ry: ComputedLengthPercentageOrAuto::from_data(ry),

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -70,6 +70,7 @@ static ReadonlySpan<NamedPropertyID> attribute_style_properties()
         NamedPropertyID(CSS::PropertyID::Cursor),
         NamedPropertyID(CSS::PropertyID::Cx, { SVG::TagNames::circle, SVG::TagNames::ellipse }),
         NamedPropertyID(CSS::PropertyID::Cy, { SVG::TagNames::circle, SVG::TagNames::ellipse }),
+        NamedPropertyID(CSS::PropertyID::D, { SVG::TagNames::path }),
         NamedPropertyID(CSS::PropertyID::Direction),
         NamedPropertyID(CSS::PropertyID::Display),
         NamedPropertyID(CSS::PropertyID::DominantBaseline),
@@ -156,7 +157,17 @@ void SVGElement::apply_presentational_hints(Vector<CSS::StyleProperty>& properti
     CSS::Parser::ParsingParams parsing_context { document(), CSS::Parser::ParsingMode::SVGPresentationAttribute };
     for_each_attribute([&](Utf16FlyString const& name, Utf16View const& value) {
         if (auto property_id = property_id_for_presentational_attribute(name, local_name()); property_id.has_value()) {
-            if (auto style_value = parse_css_value(parsing_context, value, property_id.value()))
+            auto style_value = [&] {
+                // NB: <path>'s `d` presentational attribute is a special case - the attribute and the CSS properties
+                //     syntaxes differ with the attribute being a raw path string but the CSS property only accepting a
+                //     path() function. To account for this we wrap the attribute value in a path function before parsing.
+                if (property_id == CSS::PropertyID::D)
+                    return parse_css_value(parsing_context, Utf16String::formatted("path({})", CSS::serialize_a_string(value)), property_id.value());
+
+                return parse_css_value(parsing_context, value, property_id.value());
+            }();
+
+            if (style_value)
                 properties.append({ .property_id = property_id.value(), .value = style_value.release_nonnull() });
         }
     });

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -28,19 +28,18 @@ void SVGPathElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-void SVGPathElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)
-{
-    Base::attribute_changed(name, old_value, value, namespace_);
-
-    if (name == AttributeNames::d) {
-        m_path = AttributeParser::parse_path_data(value.value_or({}));
-        set_needs_layout_update(DOM::SetNeedsLayoutReason::StyleChange);
-    }
-}
-
 Gfx::Path SVGPathElement::get_path(CSSPixelSize)
 {
-    return m_path.to_gfx_path();
+    auto computed_d = this->computed_values()->d();
+
+    if (computed_d->is_keyword()) {
+        VERIFY(computed_d->as_keyword().keyword() == CSS::Keyword::None);
+        return {};
+    }
+
+    // NB: The reference box is not used for path() values and is only required to maintain compatibility with other
+    //     basic shapes.
+    return computed_d->as_basic_shape().basic_shape().get<CSS::Path>().to_path({ 0, 0, 0, 0 });
 }
 
 }

--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -18,16 +18,12 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPathElement() override = default;
 
-    virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
-
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 
 private:
     SVGPathElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-
-    Path m_path {};
 };
 
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/path/property/d-none-ref.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/path/property/d-none-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+</svg>

--- a/Tests/LibWeb/Ref/expected/wpt-import/svg/path/property/priority-ref.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/svg/path/property/priority-ref.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <style>
+    path {
+      stroke-width: 3;
+      stroke: blue;
+    }
+  </style>
+  <path d="M 20 10 h 70" />
+  <path d="M 20 80 h 70" />
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/path/property/d-none.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/path/property/d-none.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="match" href="../../../../../expected/wpt-import/svg/path/property/d-none-ref.svg"/>
+    <h:meta name="assert" content="Setting 'd: none' overrides the 'd' SVG attribute."/>
+  </metadata>
+  <path d="M 0 0 H 100 V 100 H 0 Z" fill="green" />
+  <path d="M 0 0 H 100 V 100 H 0 Z" fill="red" style="d: none" />
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/svg/path/property/priority.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/svg/path/property/priority.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml" width="100" height="100">
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
+    <h:link rel="match" href="../../../../../expected/wpt-import/svg/path/property/priority-ref.svg"/>
+    <h:meta name="assert" content="Property overrides attribute."/>
+  </metadata>
+  <style>
+    path {
+      stroke-width: 3;
+      stroke: blue;
+    }
+    #top {
+      d: path('M 20 10 h 70');
+    }
+  </style>
+  <path id="top" d="M 10 20 h 70" />
+  <path d="M 10 90 h 70" style="d: path('M 20 80 h 70')" />
+</svg>

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
@@ -174,6 +174,7 @@ All properties associated with getComputedStyle(document.body):
     "counter-set",
     "cx",
     "cy",
+    "d",
     "display",
     "filter",
     "flex-basis",

--- a/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
@@ -446,6 +446,7 @@ All supported properties and their default values exposed from CSSStylePropertie
 'cursor': 'auto'
 'cx': '0px'
 'cy': '0px'
+'d': 'none'
 'direction': 'ltr'
 'display': 'block'
 'dominantBaseline': 'auto'

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -172,6 +172,7 @@ counter-reset: none
 counter-set: none
 cx: 0px
 cy: 0px
+d: none
 display: block
 filter: none
 flex-basis: auto
@@ -192,7 +193,7 @@ grid-row-start: auto
 grid-template-areas: none
 grid-template-columns: none
 grid-template-rows: none
-height: 2522px
+height: 2535px
 inline-size: 784px
 inset-block-end: auto
 inset-block-start: auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 307 tests
+Found 308 tests
 
-303 Pass
+304 Pass
 4 Fail
 Pass	accent-color
 Pass	border-collapse
@@ -162,6 +162,7 @@ Pass	counter-reset
 Pass	counter-set
 Pass	cx
 Pass	cy
+Pass	d
 Pass	display
 Pass	filter
 Pass	flex-basis

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-discrete.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-discrete.txt
@@ -1,0 +1,33 @@
+Harness status: OK
+
+Found 28 tests
+
+28 Fail
+Fail	"path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" are valid d values
+Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress -1
+Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0
+Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0.125
+Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0.875
+Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 1
+Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 2
+Fail	"path("M 1 2 L 3 4 Z")" and "none" are valid d values
+Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress -1
+Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0
+Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0.125
+Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0.875
+Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 1
+Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 2
+Fail	"path("M 10 0 H 11")" and "path("M 20 0 V 2")" are valid d values
+Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress -1
+Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0
+Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0.125
+Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0.875
+Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 1
+Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 2
+Fail	"path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" are valid d values
+Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress -1
+Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0
+Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0.125
+Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0.875
+Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 1
+Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 2

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-discrete.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-discrete.txt
@@ -2,32 +2,32 @@ Harness status: OK
 
 Found 28 tests
 
-28 Fail
-Fail	"path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" are valid d values
-Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress -1
-Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0
-Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0.125
-Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0.875
-Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 1
-Fail	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 2
-Fail	"path("M 1 2 L 3 4 Z")" and "none" are valid d values
-Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress -1
-Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0
-Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0.125
-Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0.875
-Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 1
-Fail	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 2
-Fail	"path("M 10 0 H 11")" and "path("M 20 0 V 2")" are valid d values
-Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress -1
-Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0
-Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0.125
-Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0.875
-Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 1
-Fail	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 2
-Fail	"path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" are valid d values
-Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress -1
-Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0
-Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0.125
-Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0.875
-Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 1
-Fail	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 2
+28 Pass
+Pass	"path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" are valid d values
+Pass	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress -1
+Pass	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0
+Pass	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0.125
+Pass	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 0.875
+Pass	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 1
+Pass	Animation between "path("M 0 0 H 1 H 2")" and "path("M 0 0 H 3")" at progress 2
+Pass	"path("M 1 2 L 3 4 Z")" and "none" are valid d values
+Pass	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress -1
+Pass	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0
+Pass	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0.125
+Pass	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 0.875
+Pass	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 1
+Pass	Animation between "path("M 1 2 L 3 4 Z")" and "none" at progress 2
+Pass	"path("M 10 0 H 11")" and "path("M 20 0 V 2")" are valid d values
+Pass	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress -1
+Pass	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0
+Pass	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0.125
+Pass	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 0.875
+Pass	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 1
+Pass	Animation between "path("M 10 0 H 11")" and "path("M 20 0 V 2")" at progress 2
+Pass	"path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" are valid d values
+Pass	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress -1
+Pass	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0
+Pass	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0.125
+Pass	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 0.875
+Pass	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 1
+Pass	Animation between "path("M 1 2 L 4 6 Z")" and "path("M 1 2 H 4 V 6")" at progress 2

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-relative-absolute.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-relative-absolute.txt
@@ -1,0 +1,61 @@
+Harness status: OK
+
+Found 56 tests
+
+56 Fail
+Fail	"path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" are valid d values
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress -1
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0.125
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0.875
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 1
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 2
+Fail	"path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" are valid d values
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress -1
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0.125
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0.875
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 1
+Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 2
+Fail	"path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" are valid d values
+Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress -1
+Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 0
+Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 0.125
+Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 0.875
+Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 1
+Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 2
+Fail	"path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" are valid d values
+Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress -1
+Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 0
+Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 0.125
+Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 0.875
+Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 1
+Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 2
+Fail	"path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" are valid d values
+Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress -1
+Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 0
+Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 0.125
+Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 0.875
+Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 1
+Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 2
+Fail	"path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" are valid d values
+Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress -1
+Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 0
+Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 0.125
+Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 0.875
+Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 1
+Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 2
+Fail	"path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" are valid d values
+Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress -1
+Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 0
+Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 0.125
+Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 0.875
+Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 1
+Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 2
+Fail	"path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" are valid d values
+Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress -1
+Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0
+Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0.125
+Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0.875
+Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 1
+Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 2

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-relative-absolute.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-relative-absolute.txt
@@ -2,57 +2,58 @@ Harness status: OK
 
 Found 56 tests
 
-56 Fail
-Fail	"path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" are valid d values
+10 Pass
+46 Fail
+Pass	"path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" are valid d values
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress -1
-Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0
+Pass	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0.125
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 0.875
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 1
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")" at progress 2
-Fail	"path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" are valid d values
+Pass	"path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" are valid d values
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress -1
-Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0
+Pass	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0.125
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 0.875
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 1
 Fail	Animation between "path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")" and "path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")" at progress 2
-Fail	"path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" are valid d values
+Pass	"path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" are valid d values
 Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress -1
 Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 0
 Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 0.125
 Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 0.875
 Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 1
 Fail	Animation between "path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")" and "path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")" at progress 2
-Fail	"path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" are valid d values
+Pass	"path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" are valid d values
 Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress -1
 Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 0
 Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 0.125
 Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 0.875
 Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 1
 Fail	Animation between "path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")" and "path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")" at progress 2
-Fail	"path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" are valid d values
+Pass	"path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" are valid d values
 Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress -1
 Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 0
 Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 0.125
 Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 0.875
 Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 1
 Fail	Animation between "path("m 10 20 q 30 60 40 50 q 110 80 90 80")" and "path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")" at progress 2
-Fail	"path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" are valid d values
+Pass	"path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" are valid d values
 Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress -1
 Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 0
 Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 0.125
 Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 0.875
 Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 1
 Fail	Animation between "path("m 10 20 s 30 60 40 50 s 110 60 90 70")" and "path("M 130 140 S 120 160 130 150 S 200 170 140 180")" at progress 2
-Fail	"path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" are valid d values
+Pass	"path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" are valid d values
 Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress -1
 Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 0
 Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 0.125
 Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 0.875
 Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 1
 Fail	Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 2
-Fail	"path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" are valid d values
+Pass	"path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" are valid d values
 Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress -1
 Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0
 Fail	Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0.125

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-single.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-single.txt
@@ -1,0 +1,131 @@
+Harness status: OK
+
+Found 126 tests
+
+126 Fail
+Fail	"path("M 20 70")" and "path("M 100 30")" are valid d values
+Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress -1
+Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0
+Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0.125
+Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0.875
+Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 1
+Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 2
+Fail	"path("m 20 70")" and "path("m 100 30")" are valid d values
+Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress -1
+Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 0
+Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 0.125
+Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 0.875
+Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 1
+Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 2
+Fail	"path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" are valid d values
+Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress -1
+Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 0
+Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 0.125
+Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 0.875
+Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 1
+Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 2
+Fail	"path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" are valid d values
+Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress -1
+Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 0
+Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 0.125
+Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 0.875
+Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 1
+Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 2
+Fail	"path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" are valid d values
+Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress -1
+Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 0
+Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 0.125
+Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 0.875
+Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 1
+Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 2
+Fail	"path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" are valid d values
+Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress -1
+Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 0
+Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 0.125
+Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 0.875
+Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 1
+Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 2
+Fail	"path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" are valid d values
+Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress -1
+Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 0
+Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 0.125
+Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 0.875
+Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 1
+Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 2
+Fail	"path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" are valid d values
+Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress -1
+Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 0
+Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 0.125
+Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 0.875
+Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 1
+Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 2
+Fail	"path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" are valid d values
+Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress -1
+Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0
+Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0.125
+Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0.875
+Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 1
+Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 2
+Fail	"path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" are valid d values
+Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress -1
+Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0
+Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0.125
+Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0.875
+Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 1
+Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 2
+Fail	"path("M 50 60 H 70")" and "path("M 10 140 H 270")" are valid d values
+Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress -1
+Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 0
+Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 0.125
+Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 0.875
+Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 1
+Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 2
+Fail	"path("m 50 60 h 20")" and "path("m 10 140 h 260")" are valid d values
+Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress -1
+Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 0
+Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 0.125
+Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 0.875
+Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 1
+Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 2
+Fail	"path("M 50 60 V 70")" and "path("M 10 140 V 270")" are valid d values
+Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress -1
+Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 0
+Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 0.125
+Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 0.875
+Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 1
+Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 2
+Fail	"path("m 50 60 v 10")" and "path("m 10 140 v 130")" are valid d values
+Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress -1
+Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 0
+Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 0.125
+Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 0.875
+Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 1
+Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 2
+Fail	"path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" are valid d values
+Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress -1
+Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 0
+Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 0.125
+Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 0.875
+Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 1
+Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 2
+Fail	"path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" are valid d values
+Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress -1
+Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 0
+Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 0.125
+Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 0.875
+Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 1
+Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 2
+Fail	"path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" are valid d values
+Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress -1
+Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 0
+Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 0.125
+Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 0.875
+Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 1
+Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 2
+Fail	"path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" are valid d values
+Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress -1
+Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 0
+Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 0.125
+Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 0.875
+Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 1
+Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 2

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-single.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/d-interpolation-single.txt
@@ -2,127 +2,128 @@ Harness status: OK
 
 Found 126 tests
 
-126 Fail
-Fail	"path("M 20 70")" and "path("M 100 30")" are valid d values
+20 Pass
+106 Fail
+Pass	"path("M 20 70")" and "path("M 100 30")" are valid d values
 Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress -1
-Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0
+Pass	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0
 Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0.125
 Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 0.875
-Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 1
+Pass	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 1
 Fail	Animation between "path("M 20 70")" and "path("M 100 30")" at progress 2
-Fail	"path("m 20 70")" and "path("m 100 30")" are valid d values
+Pass	"path("m 20 70")" and "path("m 100 30")" are valid d values
 Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress -1
 Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 0
 Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 0.125
 Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 0.875
 Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 1
 Fail	Animation between "path("m 20 70")" and "path("m 100 30")" at progress 2
-Fail	"path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" are valid d values
+Pass	"path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" are valid d values
 Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress -1
 Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 0
 Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 0.125
 Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 0.875
 Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 1
 Fail	Animation between "path("m 100 200 L 120 270")" and "path("m 100 200 L 200 230")" at progress 2
-Fail	"path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" are valid d values
+Pass	"path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" are valid d values
 Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress -1
 Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 0
 Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 0.125
 Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 0.875
 Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 1
 Fail	Animation between "path("m 100 200 l 20 70")" and "path("m 100 200 l 100 30")" at progress 2
-Fail	"path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" are valid d values
+Pass	"path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" are valid d values
 Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress -1
 Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 0
 Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 0.125
 Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 0.875
 Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 1
 Fail	Animation between "path("M 20 10 C 32 42 52 62 120 2200")" and "path("M 20 10 C 40 50 60 70 200 3000")" at progress 2
-Fail	"path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" are valid d values
+Pass	"path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" are valid d values
 Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress -1
 Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 0
 Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 0.125
 Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 0.875
 Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 1
 Fail	Animation between "path("m 20 10 c 12 32 32 52 100 2190")" and "path("m 20 10 c 20 40 40 60 180 2990")" at progress 2
-Fail	"path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" are valid d values
+Pass	"path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" are valid d values
 Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress -1
 Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 0
 Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 0.125
 Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 0.875
 Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 1
 Fail	Animation between "path("M 20 10 Q 32 42 120 2200")" and "path("M 20 10 Q 40 50 200 3000")" at progress 2
-Fail	"path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" are valid d values
+Pass	"path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" are valid d values
 Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress -1
 Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 0
 Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 0.125
 Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 0.875
 Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 1
 Fail	Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 2
-Fail	"path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" are valid d values
+Pass	"path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" are valid d values
 Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress -1
 Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0
 Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0.125
 Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0.875
 Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 1
 Fail	Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 2
-Fail	"path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" are valid d values
+Pass	"path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" are valid d values
 Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress -1
 Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0
 Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0.125
 Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0.875
 Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 1
 Fail	Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 2
-Fail	"path("M 50 60 H 70")" and "path("M 10 140 H 270")" are valid d values
+Pass	"path("M 50 60 H 70")" and "path("M 10 140 H 270")" are valid d values
 Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress -1
 Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 0
 Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 0.125
 Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 0.875
 Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 1
 Fail	Animation between "path("M 50 60 H 70")" and "path("M 10 140 H 270")" at progress 2
-Fail	"path("m 50 60 h 20")" and "path("m 10 140 h 260")" are valid d values
+Pass	"path("m 50 60 h 20")" and "path("m 10 140 h 260")" are valid d values
 Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress -1
 Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 0
 Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 0.125
 Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 0.875
 Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 1
 Fail	Animation between "path("m 50 60 h 20")" and "path("m 10 140 h 260")" at progress 2
-Fail	"path("M 50 60 V 70")" and "path("M 10 140 V 270")" are valid d values
+Pass	"path("M 50 60 V 70")" and "path("M 10 140 V 270")" are valid d values
 Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress -1
 Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 0
 Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 0.125
 Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 0.875
 Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 1
 Fail	Animation between "path("M 50 60 V 70")" and "path("M 10 140 V 270")" at progress 2
-Fail	"path("m 50 60 v 10")" and "path("m 10 140 v 130")" are valid d values
+Pass	"path("m 50 60 v 10")" and "path("m 10 140 v 130")" are valid d values
 Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress -1
 Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 0
 Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 0.125
 Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 0.875
 Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 1
 Fail	Animation between "path("m 50 60 v 10")" and "path("m 10 140 v 130")" at progress 2
-Fail	"path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" are valid d values
+Pass	"path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" are valid d values
 Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress -1
 Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 0
 Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 0.125
 Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 0.875
 Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 1
 Fail	Animation between "path("M 12 34 S 45 67 89 123")" and "path("M 20 26 S 61 51 113 99")" at progress 2
-Fail	"path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" are valid d values
+Pass	"path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" are valid d values
 Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress -1
 Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 0
 Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 0.125
 Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 0.875
 Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 1
 Fail	Animation between "path("m 12 34 s 33 33 77 89")" and "path("m 20 26 s 41 25 93 73")" at progress 2
-Fail	"path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" are valid d values
+Pass	"path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" are valid d values
 Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress -1
 Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 0
 Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 0.125
 Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 0.875
 Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 1
 Fail	Animation between "path("M 12 34 T 45 67")" and "path("M 20 26 T 61 51")" at progress 2
-Fail	"path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" are valid d values
+Pass	"path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" are valid d values
 Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress -1
 Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 0
 Fail	Animation between "path("m 12 34 t 33 33")" and "path("m 20 26 t 41 25")" at progress 0.125

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/getComputedStyle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/getComputedStyle.txt
@@ -1,0 +1,13 @@
+Harness status: OK
+
+Found 8 tests
+
+8 Fail
+Fail	d property of g0 should be none.
+Fail	d property of p1 should be none.
+Fail	d property of p2 should be path("M 10 2 H 20").
+Fail	d property of p3 should be path("M 10 3 H 30").
+Fail	d property of p4 should be path("M 10 4 H 40").
+Fail	d property of g5 should be path("M 10 5 H 50").
+Fail	d property of p6 should be path("M 10 5 H 50").
+Fail	d property of p7 should be none.

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/getComputedStyle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/getComputedStyle.txt
@@ -2,11 +2,11 @@ Harness status: OK
 
 Found 8 tests
 
-5 Pass
-3 Fail
+6 Pass
+2 Fail
 Pass	d property of g0 should be none.
 Pass	d property of p1 should be none.
-Fail	d property of p2 should be path("M 10 2 H 20").
+Pass	d property of p2 should be path("M 10 2 H 20").
 Pass	d property of p3 should be path("M 10 3 H 30").
 Pass	d property of p4 should be path("M 10 4 H 40").
 Fail	d property of g5 should be path("M 10 5 H 50").

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/getComputedStyle.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/path/property/getComputedStyle.txt
@@ -2,12 +2,13 @@ Harness status: OK
 
 Found 8 tests
 
-8 Fail
-Fail	d property of g0 should be none.
-Fail	d property of p1 should be none.
+5 Pass
+3 Fail
+Pass	d property of g0 should be none.
+Pass	d property of p1 should be none.
 Fail	d property of p2 should be path("M 10 2 H 20").
-Fail	d property of p3 should be path("M 10 3 H 30").
-Fail	d property of p4 should be path("M 10 4 H 40").
+Pass	d property of p3 should be path("M 10 3 H 30").
+Pass	d property of p4 should be path("M 10 4 H 40").
 Fail	d property of g5 should be path("M 10 5 H 50").
 Fail	d property of p6 should be path("M 10 5 H 50").
-Fail	d property of p7 should be none.
+Pass	d property of p7 should be none.

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
@@ -1,9 +1,9 @@
 Harness status: OK
 
-Found 61 tests
+Found 62 tests
 
 60 Pass
-1 Fail
+2 Fail
 Pass	clip-path presentation attribute supported on a relevant element
 Pass	clip-rule presentation attribute supported on a relevant element
 Pass	color presentation attribute supported on a relevant element
@@ -14,6 +14,7 @@ Pass	cx presentation attribute supported on a relevant element
 Pass	cy presentation attribute supported on a relevant element
 Pass	direction presentation attribute supported on a relevant element
 Pass	display presentation attribute supported on a relevant element
+Fail	d presentation attribute supported on a relevant element
 Pass	dominant-baseline presentation attribute supported on a relevant element
 Pass	fill presentation attribute supported on a relevant element
 Pass	fill-opacity presentation attribute supported on a relevant element

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-relevant.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 62 tests
 
-60 Pass
-2 Fail
+61 Pass
+1 Fail
 Pass	clip-path presentation attribute supported on a relevant element
 Pass	clip-rule presentation attribute supported on a relevant element
 Pass	color presentation attribute supported on a relevant element
@@ -14,7 +14,7 @@ Pass	cx presentation attribute supported on a relevant element
 Pass	cy presentation attribute supported on a relevant element
 Pass	direction presentation attribute supported on a relevant element
 Pass	display presentation attribute supported on a relevant element
-Fail	d presentation attribute supported on a relevant element
+Pass	d presentation attribute supported on a relevant element
 Pass	dominant-baseline presentation attribute supported on a relevant element
 Pass	fill presentation attribute supported on a relevant element
 Pass	fill-opacity presentation attribute supported on a relevant element

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-special-cases.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-special-cases.txt
@@ -1,9 +1,9 @@
 Harness status: OK
 
-Found 24 tests
+Found 26 tests
 
-19 Pass
-5 Fail
+20 Pass
+6 Fail
 Pass	cx and cy presentation attributes supported on circle element
 Pass	cx and cy presentation attributes supported on ellipse element
 Pass	x, y, width, and height presentation attributes supported on foreignObject element
@@ -13,10 +13,12 @@ Pass	x, y, width, and height presentation attributes supported on svg element
 Pass	r presentation attribute supported on circle element
 Pass	rx and ry presentation attributes supported on ellipse element
 Pass	rx and ry presentation attributes supported on rect element
+Fail	d presentation attribute supported on path element
 Pass	cx and cy presentation attributes not supported on other elements
 Pass	x, y, width, and height presentation attributes not supported on other elements
 Pass	r presentation attribute not supported on other elements
 Pass	rx and ry presentation attributes not supported on other elements
+Pass	d presentation attribute not supported on other elements
 Fail	fill presentation attribute not supported on animate
 Fail	fill presentation attribute not supported on animateMotion
 Fail	fill presentation attribute not supported on animateTransform

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-special-cases.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/styling/presentation-attributes-special-cases.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 26 tests
 
-20 Pass
-6 Fail
+21 Pass
+5 Fail
 Pass	cx and cy presentation attributes supported on circle element
 Pass	cx and cy presentation attributes supported on ellipse element
 Pass	x, y, width, and height presentation attributes supported on foreignObject element
@@ -13,7 +13,7 @@ Pass	x, y, width, and height presentation attributes supported on svg element
 Pass	r presentation attribute supported on circle element
 Pass	rx and ry presentation attributes supported on ellipse element
 Pass	rx and ry presentation attributes supported on rect element
-Fail	d presentation attribute supported on path element
+Pass	d presentation attribute supported on path element
 Pass	cx and cy presentation attributes not supported on other elements
 Pass	x, y, width, and height presentation attributes not supported on other elements
 Pass	r presentation attribute not supported on other elements

--- a/Tests/LibWeb/Text/input/wpt-import/svg/path/property/d-interpolation-discrete.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/path/property/d-interpolation-discrete.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
+    <h:meta name="assert" content="d falls back to step interpolation when no interpolation is possible."/>
+  </metadata>
+
+  <g id="container"/>
+
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="resources/interpolation-test-common.js"/>
+  <script><![CDATA[
+      'use strict';
+
+      // Distinct number of path segments
+      test_no_interpolation({
+        property: 'd',
+        from: 'path("M 0 0 H 1 H 2")',
+        to: 'path("M 0 0 H 3")'
+      });
+
+      test_no_interpolation({
+        property: 'd',
+        from: 'path("M 1 2 L 3 4 Z")',
+        to: "none"
+      });
+
+      // Distinct segment types
+      test_no_interpolation({
+        property: 'd',
+        from: 'path("M 10 0 H 11")',
+        to: 'path("M 20 0 V 2")'
+      });
+
+      test_no_interpolation({
+        property: 'd',
+        from: 'path("M 1 2 L 4 6 Z")',
+        to: 'path("M 1 2 H 4 V 6")'
+      });
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/path/property/d-interpolation-relative-absolute.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/path/property/d-interpolation-relative-absolute.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
+    <h:meta name="assert" content="d can interpolate between absolute and relative paths."/>
+  </metadata>
+
+  <g id="container"/>
+
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="resources/interpolation-test-common.js"/>
+  <script><![CDATA[
+      'use strict';
+
+      // Mix relative and non-relative
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")',
+        to: 'path("M 0 0 L 100 100 m 0 100 l 100 0 z l 300 100 z")'
+      }, [
+        {at: -1, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 0 -100 Z")'},
+        {at: 0, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+        {at: 0.125, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 225 125 Z")'},
+        {at: 0.875, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 375 275 Z")'},
+        {at: 1, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 400 300 Z")'},
+        {at: 2, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 600 500 Z")'},
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")',
+        to: 'path("M 0 0 L 100 100 m 0 100 l 100 0 z l 100 -100 z")'
+      }, [
+        {at: -1, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+        {at: 0, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+        {at: 0.125, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+        {at: 0.875, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+        {at: 1, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+        {at: 2, expect: 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 200 100 Z")'},
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 10 20 l 40 50 z l 40 60 z m 60 70 l 90 60 z t 70 130")',
+        to: 'path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")'
+      }, [
+        {at: -1, expect: 'path("M -190 -180 L -70 -50 Z L 10 40 Z M 30 50 L 120 70 Z T 60 220")'},
+        {at: 0, expect: 'path("M 10 20 L 50 70 Z L 50 80 Z M 70 90 L 160 150 Z T 140 220")'},
+        {at: 0.125, expect: 'path("M 35 45 L 65 85 Z L 55 85 Z M 75 95 L 165 160 Z T 150 220")'},
+        {at: 0.875, expect: 'path("M 185 195 L 155 175 Z L 85 115 Z M 105 125 L 195 220 Z T 210 220")'},
+        {at: 1, expect: 'path("M 210 220 L 170 190 Z L 90 120 Z M 110 130 L 200 230 Z T 220 220")'},
+        {at: 2, expect: 'path("M 410 420 L 290 310 Z L 130 160 Z M 150 170 L 240 310 Z T 300 220")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 10 20 c 40 50 30 60 80 70 c 120 130 170 140 110 160")',
+        to: 'path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")'
+      }, [
+        {at: -1, expect: 'path("M -110 -60 C -30 -10 -40 0 -30 10 C 130 140 180 150 80 170")'},
+        {at: 0, expect: 'path("M 10 20 C 50 70 40 80 90 90 C 210 220 260 230 200 250")'},
+        {at: 0.125, expect: 'path("M 25 30 C 60 80 50 90 105 100 C 220 230 270 240 215 260")'},
+        {at: 0.875, expect: 'path("M 115 90 C 120 140 110 150 195 160 C 280 290 330 300 305 320")'},
+        {at: 1, expect: 'path("M 130 100 C 130 150 120 160 210 170 C 290 300 340 310 320 330")'},
+        {at: 2, expect: 'path("M 250 180 C 210 230 200 240 330 250 C 370 380 420 390 440 410")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 10 20 q 30 60 40 50 q 110 80 90 80")',
+        to: 'path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")'
+      }, [
+        {at: -1, expect: 'path("M -110 -60 Q -40 0 -30 -10 Q 120 150 100 110")'},
+        {at: 0, expect: 'path("M 10 20 Q 40 80 50 70 Q 160 150 140 150")'},
+        {at: 0.125, expect: 'path("M 25 30 Q 50 90 60 80 Q 165 150 145 155")'},
+        {at: 0.875, expect: 'path("M 115 90 Q 110 150 120 140 Q 195 150 175 185")'},
+        {at: 1, expect: 'path("M 130 100 Q 120 160 130 150 Q 200 150 180 190")'},
+        {at: 2, expect: 'path("M 250 180 Q 200 240 210 230 Q 240 150 220 230")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 10 20 s 30 60 40 50 s 110 60 90 70")',
+        to: 'path("M 130 140 S 120 160 130 150 S 200 170 140 180")'
+      }, [
+        {at: -1, expect: 'path("M -110 -100 S -40 0 -30 -10 S 120 90 140 100")'},
+        {at: 0, expect: 'path("M 10 20 S 40 80 50 70 S 160 130 140 140")'},
+        {at: 0.125, expect: 'path("M 25 35 S 50 90 60 80 S 165 135 140 145")'},
+        {at: 0.875, expect: 'path("M 115 125 S 110 150 120 140 S 195 165 140 175")'},
+        {at: 1, expect: 'path("M 130 140 S 120 160 130 150 S 200 170 140 180")'},
+        {at: 2, expect: 'path("M 250 260 S 200 240 210 230 S 240 210 140 220")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")',
+        to: 'path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")'
+      }, [
+        {at: -1, expect: 'path("M -110 -100 H -40 V 0 H -30 V -10 L 120 90 Z")'},
+        {at: 0, expect: 'path("M 10 20 H 40 V 80 H 50 V 70 L 160 130 Z")'},
+        {at: 0.125, expect: 'path("M 25 35 H 50 V 90 H 60 V 80 L 165 135 Z")'},
+        {at: 0.875, expect: 'path("M 115 125 H 110 V 150 H 120 V 140 L 195 165 Z")'},
+        {at: 1, expect: 'path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")'},
+        {at: 2, expect: 'path("M 250 260 H 200 V 240 H 210 V 230 L 240 210 Z")'}
+      ]);
+
+      // At progress 0.125/0.875, arc flags in path() should consider
+      // non-zero interpolated values as one to match <path> behaviour.
+      // https://w3c.github.io/svgwg/specs/paths/#PathElement
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")',
+        to: 'path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")'
+      }, [
+        {at: -1, expect: 'path("M 2 28 A -30 -60 -10 1 0 10 30 A 70 80 -10 1 1 310 160")'},
+        {at: 0, expect: 'path("M 10 20 A 10 20 30 1 0 50 70 A 110 120 30 1 1 190 120")'},
+        {at: 0.125, expect: 'path("M 11 19 A 15 30 35 1 1 55 75 A 115 125 35 1 1 175 115")'},
+        {at: 0.875, expect: 'path("M 17 13 A 45 90 65 1 1 85 105 A 145 155 65 1 1 85 85")'},
+        {at: 1, expect: 'path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")'},
+        {at: 2, expect: 'path("M 26 4 A 90 180 110 0 1 130 150 A 190 200 110 0 1 -50 40")'}
+      ]);
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/path/property/d-interpolation-single.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/path/property/d-interpolation-single.svg
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
+    <h:meta name="assert" content="Each path command interpolates."/>
+  </metadata>
+
+  <g id="container"/>
+
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <h:script src="resources/interpolation-test-common.js"/>
+  <script><![CDATA[
+      'use strict';
+
+      // Exercise each segment type
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 20 70")',
+        to: 'path("M 100 30")'
+      }, [
+        {at: -1, expect: 'path("M -60 110")'},
+        {at: 0, expect: 'path("M 20 70")'},
+        {at: 0.125, expect: 'path("M 30 65")'},
+        {at: 0.875, expect: 'path("M 90 35")'},
+        {at: 1, expect: 'path("M 100 30")'},
+        {at: 2, expect: 'path("M 180 -10")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 20 70")',
+        to: 'path("m 100 30")'
+      }, [
+        {at: -1, expect: 'path("M -60 110")'},
+        {at: 0, expect: 'path("M 20 70")'},
+        {at: 0.125, expect: 'path("M 30 65")'},
+        {at: 0.875, expect: 'path("M 90 35")'},
+        {at: 1, expect: 'path("M 100 30")'},
+        {at: 2, expect: 'path("M 180 -10")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 100 200 L 120 270")',
+        to: 'path("m 100 200 L 200 230")'
+      }, [
+        {at: -1, expect: 'path("M 100 200 L 40 310")'},
+        {at: 0, expect: 'path("M 100 200 L 120 270")'},
+        {at: 0.125, expect: 'path("M 100 200 L 130 265")'},
+        {at: 0.875, expect: 'path("M 100 200 L 190 235")'},
+        {at: 1, expect: 'path("M 100 200 L 200 230")'},
+        {at: 2, expect: 'path("M 100 200 L 280 190")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 100 200 l 20 70")',
+        to: 'path("m 100 200 l 100 30")'
+      }, [
+        {at: -1, expect: 'path("M 100 200 L 40 310")'},
+        {at: 0, expect: 'path("M 100 200 L 120 270")'},
+        {at: 0.125, expect: 'path("M 100 200 L 130 265")'},
+        {at: 0.875, expect: 'path("M 100 200 L 190 235")'},
+        {at: 1, expect: 'path("M 100 200 L 200 230")'},
+        {at: 2, expect: 'path("M 100 200 L 280 190")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 20 10 C 32 42 52 62 120 2200")',
+        to: 'path("M 20 10 C 40 50 60 70 200 3000")',
+      }, [
+        {at: -1, expect: 'path("M 20 10 C 24 34 44 54 40 1400")'},
+        {at: 0, expect: 'path("M 20 10 C 32 42 52 62 120 2200")'},
+        {at: 0.125, expect: 'path("M 20 10 C 33 43 53 63 130 2300")'},
+        {at: 0.875, expect: 'path("M 20 10 C 39 49 59 69 190 2900")'},
+        {at: 1, expect: 'path("M 20 10 C 40 50 60 70 200 3000")'},
+        {at: 2, expect: 'path("M 20 10 C 48 58 68 78 280 3800")'}
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 20 10 c 12 32 32 52 100 2190")',
+        to: 'path("m 20 10 c 20 40 40 60 180 2990")'
+      }, [
+        {at: -1, expect: 'path("M 20 10 C 24 34 44 54 40 1400")'},
+        {at: 0, expect: 'path("M 20 10 C 32 42 52 62 120 2200")'},
+        {at: 0.125, expect: 'path("M 20 10 C 33 43 53 63 130 2300")'},
+        {at: 0.875, expect: 'path("M 20 10 C 39 49 59 69 190 2900")'},
+        {at: 1, expect: 'path("M 20 10 C 40 50 60 70 200 3000")'},
+        {at: 2, expect: 'path("M 20 10 C 48 58 68 78 280 3800")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 20 10 Q 32 42 120 2200")',
+        to: 'path("M 20 10 Q 40 50 200 3000")'
+      }, [
+        {at: -1, expect: 'path("M 20 10 Q 24 34 40 1400")'},
+        {at: 0, expect: 'path("M 20 10 Q 32 42 120 2200")'},
+        {at: 0.125, expect: 'path("M 20 10 Q 33 43 130 2300")'},
+        {at: 0.875, expect: 'path("M 20 10 Q 39 49 190 2900")'},
+        {at: 1, expect: 'path("M 20 10 Q 40 50 200 3000")'},
+        {at: 2, expect: 'path("M 20 10 Q 48 58 280 3800")'}
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 20 10 q 12 32 100 2190")',
+        to: 'path("m 20 10 q 20 40 180 2990")'
+      }, [
+        {at: -1, expect: 'path("M 20 10 Q 24 34 40 1400")'},
+        {at: 0, expect: 'path("M 20 10 Q 32 42 120 2200")'},
+        {at: 0.125, expect: 'path("M 20 10 Q 33 43 130 2300")'},
+        {at: 0.875, expect: 'path("M 20 10 Q 39 49 190 2900")'},
+        {at: 1, expect: 'path("M 20 10 Q 40 50 200 3000")'},
+        {at: 2, expect: 'path("M 20 10 Q 48 58 280 3800")'}
+      ]);
+
+      // At progress 0.125/0.875, arc flags in path() should consider
+      // non-zero interpolated values as one to match <path> behaviour.
+      // https://w3c.github.io/svgwg/specs/paths/#PathElement
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 100 400 A 10 20 30 1 0 140 450")',
+        to: 'path("M 300 200 A 50 60 70 0 1 380 290")'
+      }, [
+        {at: -1, expect: 'path("M -100 600 A -30 -20 -10 1 0 -100 610")'},
+        {at: 0, expect: 'path("M 100 400 A 10 20 30 1 0 140 450")'},
+        {at: 0.125, expect: 'path("M 125 375 A 15 25 35 1 1 170 430")'},
+        {at: 0.875, expect: 'path("M 275 225 A 45 55 65 1 1 350 310")'},
+        {at: 1, expect: 'path("M 300 200 A 50 60 70 0 1 380 290")'},
+        {at: 2, expect: 'path("M 500 0 A 90 100 110 0 1 620 130")'}
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 100 400 a 10 20 30 1 0 40 50")',
+        to: 'path("m 300 200 a 50 60 70 0 1 80 90")'
+      }, [
+        {at: -1, expect: 'path("M -100 600 A -30 -20 -10 1 0 -100 610")'},
+        {at: 0, expect: 'path("M 100 400 A 10 20 30 1 0 140 450")'},
+        {at: 0.125, expect: 'path("M 125 375 A 15 25 35 1 1 170 430")'},
+        {at: 0.875, expect: 'path("M 275 225 A 45 55 65 1 1 350 310")'},
+        {at: 1, expect: 'path("M 300 200 A 50 60 70 0 1 380 290")'},
+        {at: 2, expect: 'path("M 500 0 A 90 100 110 0 1 620 130")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 50 60 H 70")',
+        to: 'path("M 10 140 H 270")'
+      }, [
+        {at: -1, expect: 'path("M 90 -20 H -130")'},
+        {at: 0, expect: 'path("M 50 60 H 70")'},
+        {at: 0.125, expect: 'path("M 45 70 H 95")'},
+        {at: 0.875, expect: 'path("M 15 130 H 245")'},
+        {at: 1, expect: 'path("M 10 140 H 270")'},
+        {at: 2, expect: 'path("M -30 220 H 470")'}
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 50 60 h 20")',
+        to: 'path("m 10 140 h 260")'
+      }, [
+        {at: -1, expect: 'path("M 90 -20 H -130")'},
+        {at: 0, expect: 'path("M 50 60 H 70")'},
+        {at: 0.125, expect: 'path("M 45 70 H 95")'},
+        {at: 0.875, expect: 'path("M 15 130 H 245")'},
+        {at: 1, expect: 'path("M 10 140 H 270")'},
+        {at: 2, expect: 'path("M -30 220 H 470")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 50 60 V 70")',
+        to: 'path("M 10 140 V 270")'
+      }, [
+        {at: -1, expect: 'path("M 90 -20 V -130")'},
+        {at: 0, expect: 'path("M 50 60 V 70")'},
+        {at: 0.125, expect: 'path("M 45 70 V 95")'},
+        {at: 0.875, expect: 'path("M 15 130 V 245")'},
+        {at: 1, expect: 'path("M 10 140 V 270")'},
+        {at: 2, expect: 'path("M -30 220 V 470")'}
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 50 60 v 10")',
+        to: 'path("m 10 140 v 130")'
+      }, [
+        {at: -1, expect: 'path("M 90 -20 V -130")'},
+        {at: 0, expect: 'path("M 50 60 V 70")'},
+        {at: 0.125, expect: 'path("M 45 70 V 95")'},
+        {at: 0.875, expect: 'path("M 15 130 V 245")'},
+        {at: 1, expect: 'path("M 10 140 V 270")'},
+        {at: 2, expect: 'path("M -30 220 V 470")'}
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 12 34 S 45 67 89 123")',
+        to: 'path("M 20 26 S 61 51 113 99")'
+      }, [
+        {at: -1, expect: 'path("M 4 42 S 29 83 65 147")'},
+        {at: 0, expect: 'path("M 12 34 S 45 67 89 123")'},
+        {at: 0.125, expect: 'path("M 13 33 S 47 65 92 120")'},
+        {at: 0.875, expect: 'path("M 19 27 S 59 53 110 102")'},
+        {at: 1, expect: 'path("M 20 26 S 61 51 113 99")'},
+        {at: 2, expect: 'path("M 28 18 S 77 35 137 75")'},
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 12 34 s 33 33 77 89")',
+        to: 'path("m 20 26 s 41 25 93 73")'
+      }, [
+        {at: -1, expect: 'path("M 4 42 S 29 83 65 147")'},
+        {at: 0, expect: 'path("M 12 34 S 45 67 89 123")'},
+        {at: 0.125, expect: 'path("M 13 33 S 47 65 92 120")'},
+        {at: 0.875, expect: 'path("M 19 27 S 59 53 110 102")'},
+        {at: 1, expect: 'path("M 20 26 S 61 51 113 99")'},
+        {at: 2, expect: 'path("M 28 18 S 77 35 137 75")'},
+      ]);
+
+      test_interpolation({
+        property: 'd',
+        from: 'path("M 12 34 T 45 67")',
+        to: 'path("M 20 26 T 61 51")'
+      }, [
+        {at: -1, expect: 'path("M 4 42 T 29 83")'},
+        {at: 0, expect: 'path("M 12 34 T 45 67")'},
+        {at: 0.125, expect: 'path("M 13 33 T 47 65")'},
+        {at: 0.875, expect: 'path("M 19 27 T 59 53")'},
+        {at: 1, expect: 'path("M 20 26 T 61 51")'},
+        {at: 2, expect: 'path("M 28 18 T 77 35")'},
+      ]);
+      test_interpolation({
+        property: 'd',
+        from: 'path("m 12 34 t 33 33")',
+        to: 'path("m 20 26 t 41 25")'
+      }, [
+        {at: -1, expect: 'path("M 4 42 T 29 83")'},
+        {at: 0, expect: 'path("M 12 34 T 45 67")'},
+        {at: 0.125, expect: 'path("M 13 33 T 47 65")'},
+        {at: 0.875, expect: 'path("M 19 27 T 59 53")'},
+        {at: 1, expect: 'path("M 20 26 T 61 51")'},
+        {at: 2, expect: 'path("M 28 18 T 77 35")'},
+      ]);
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/path/property/getComputedStyle.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/path/property/getComputedStyle.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty"/>
+    <h:meta name="assert" content="d is a property"/>
+  </metadata>
+  <style>
+    .p3 {
+      d: path('M 10 3 H 30');
+    }
+    .g5 {
+      d: path('m 10 5 h 40');
+    }
+    .p6 {
+      d: inherit;
+    }
+  </style>
+  <g id="g0">
+    <path id="p1"></path>
+    <path id="p2" d="M 10 2 H 20"></path>
+    <path id="p3" class="p3"></path>
+    <path id="p4" style="d: path('M 10 4 H 40')"></path>
+  </g>
+  <g id="g5" class="g5">
+    <path id="p6" class="p6"></path>
+    <path id="p7"></path>
+  </g>
+  <h:script src="../../../resources/testharness.js"/>
+  <h:script src="../../../resources/testharnessreport.js"/>
+  <script><![CDATA[
+  function test_computed_value_of_d(id, expected) {
+    test(function() {
+      let target = document.getElementById(id);
+      assert_equals(getComputedStyle(target).d, expected);
+    }, `d property of ${id} should be ${expected}.`);
+  }
+
+  test_computed_value_of_d('g0', 'none');
+  test_computed_value_of_d('p1', 'none');
+  test_computed_value_of_d('p2', 'path("M 10 2 H 20")');
+  test_computed_value_of_d('p3', 'path("M 10 3 H 30")');
+  test_computed_value_of_d('p4', 'path("M 10 4 H 40")');
+  test_computed_value_of_d('g5', 'path("M 10 5 H 50")');
+  test_computed_value_of_d('p6', 'path("M 10 5 H 50")');
+  test_computed_value_of_d('p7', 'none');
+  ]]></script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/svg/path/property/resources/interpolation-test-common.js
+++ b/Tests/LibWeb/Text/input/wpt-import/svg/path/property/resources/interpolation-test-common.js
@@ -1,0 +1,71 @@
+'use strict';
+function test_interpolation(settings, expectations) {
+
+  test(function(){
+    assert_true(CSS.supports(settings.property, settings.from), 'Value "' + settings.from + '" is supported by ' + settings.property);
+    assert_true(CSS.supports(settings.property, settings.to), 'Value "' + settings.to + '" is supported by ' + settings.property);
+  }, '"' + settings.from + '" and "' + settings.to + '" are valid ' + settings.property + ' values');
+
+  const container = document.getElementById('container');
+  for (let i = 0; i < expectations.length; ++i) {
+    const progress = expectations[i].at;
+    const expectation = expectations[i].expect;
+    const animationId = 'anim' + i;
+    const targetId = 'target' + i;
+    const referenceId = 'reference' + i;
+
+    test(function(){
+      assert_true(CSS.supports(settings.property, expectation), 'Value "' + expectation + '" is supported by ' + settings.property);
+
+      const target = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      target.id = targetId;
+      container.appendChild(target);
+
+      const reference = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      reference.id = referenceId;
+      container.appendChild(reference);
+
+      assert_equals(getComputedStyle(target)[settings.property], getComputedStyle(reference)[settings.property]);
+
+      // Create an animation of length 2s that starts at -1s so the current time of 0s is
+      // exactly halfway through the animation. A cubic bezier timing function is used that
+      // evaluates to |progress| at the current time (halfway through the animation).
+
+      // Cubic bezier evaluates to |progress| at 50%.
+      const y = (8 * progress - 1) / 6;
+      const timing_function = 'cubic-bezier(0, ' + y + ', 1, ' + y + ')';
+
+      const stylesheet = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+      stylesheet.textContent =
+        '#' + targetId + ' {\n' +
+        '  animation: 2s ' + timing_function + ' -1s paused ' + animationId + ';\n' +
+        '}\n' +
+        '@keyframes ' + animationId + ' {\n' +
+        '  0% { ' + settings.property + ': ' + settings.from + '; }\n' +
+        '  100% { ' + settings.property + ': ' + settings.to + '; }\n' +
+        '}\n' +
+        '#' + referenceId + ' {\n' +
+        '  ' + settings.property + ': ' + expectation + ';\n' +
+        '}\n';
+      container.appendChild(stylesheet);
+
+      assert_equals(getComputedStyle(target)[settings.property], getComputedStyle(reference)[settings.property]);
+      assert_equals(getComputedStyle(target)[settings.property], expectation);
+
+      container.removeChild(target);
+      container.removeChild(reference);
+      container.removeChild(stylesheet);
+    }, 'Animation between "' + settings.from + '" and "' + settings.to + '" at progress ' + progress);
+  }
+}
+
+function test_no_interpolation(settings) {
+  const expectFrom = [-1, 0, 0.125].map(function (progress) {
+    return {at: progress, expect: settings.from};
+  });
+  const expectTo = [0.875, 1, 2].map(function (progress) {
+    return {at: progress, expect: settings.to};
+  });
+
+  test_interpolation(settings, expectFrom.concat(expectTo));
+}


### PR DESCRIPTION
Previously we directly used the attribute value for a `<path>` element's path.

This PR implements the `d` CSS property and instead uses the cascaded value (including the attribute value as a presentational hint).