### PR TITLE
LibWeb: Guard MSE against media elements with no playback manager

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -167,11 +167,7 @@ public:
 
     void set_duration(Badge<MediaSourceExtensions::MediaSource>, double duration) { set_duration(duration); }
 
-    Media::PlaybackManager& playback_manager()
-    {
-        VERIFY(m_playback_manager);
-        return *m_playback_manager;
-    }
+    Media::PlaybackManager* playback_manager() { return m_playback_manager.ptr(); }
 
     void create_controls();
     void destroy_controls();

--- a/Libraries/LibWeb/MediaSourceExtensions/MediaSource.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/MediaSource.cpp
@@ -332,8 +332,15 @@ void MediaSource::run_duration_change_algorithm(double new_duration)
     // FIXME: Mirror to the Window when workers are supported.
     //        Update the media element's duration to new duration.
     //        Run the HTMLMediaElement duration change algorithm.
-    media_element_assigned_to()->set_duration({}, new_duration);
-    media_element_assigned_to()->playback_manager().set_duration(AK::Duration::from_seconds_f64(new_duration));
+    // AD-HOC: Skip duration-mirroring to the reset element. When the media-element load AO resets the element, it
+    //         removes only tasks on the media-element event task source. A buffer-append AO task queued before that
+    //         still runs afterwards — against an element with no playback manager. Detaching the MediaSource wouldn't
+    //         cancel it either: The detach steps close the MediaSource, but don't abort the buffer-append AO.
+    auto media_element = media_element_assigned_to();
+    if (!media_element || !media_element->playback_manager())
+        return;
+    media_element->set_duration({}, new_duration);
+    media_element->playback_manager()->set_duration(AK::Duration::from_seconds_f64(new_duration));
 }
 
 // https://w3c.github.io/media-source/#dom-mediasource-istypesupported

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -275,11 +275,18 @@ WebIDL::ExceptionOr<void> SourceBuffer::set_mode(Bindings::AppendMode mode)
 }
 
 // https://w3c.github.io/media-source/#sourcebuffer-prepare-append
-WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK::Duration current_time)
+WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size)
 {
     // FIXME: Support MediaSourceExtensions in workers.
-    if (!m_media_source->media_element_assigned_to())
+    auto media_element = m_media_source->media_element_assigned_to();
+    if (!media_element)
         return WebIDL::InvalidStateError::create(realm(), "Unsupported in workers"_utf16);
+
+    // AD-HOC: Detaching the MediaSource would remove this SourceBuffer from the sourceBuffers attribute — making step 1
+    //         below throw. We don't implement detaching yet — so throw the same exception here. The current time is
+    //         read below rather than passed in: As a call argument, it would dereference a null playback manager.
+    if (!media_element->playback_manager())
+        return WebIDL::InvalidStateError::create(realm(), "Media element has been reset"_utf16);
 
     // 1. If the SourceBuffer has been removed from the sourceBuffers attribute of the parent media source then throw an
     //    InvalidStateError exception and abort these steps.
@@ -318,7 +325,7 @@ WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK:
     }
 
     // 6. Run the coded frame eviction algorithm.
-    m_processor->run_coded_frame_eviction(new_data_size, current_time);
+    m_processor->run_coded_frame_eviction(new_data_size, media_element->playback_manager()->current_time());
 
     // 7. If the [[buffer full flag]] equals true, then throw a QuotaExceededError exception and abort these steps.
     if (m_processor->is_buffer_full())
@@ -331,7 +338,7 @@ WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK:
 WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(WebIDL::BufferSource data)
 {
     // 1. Run the prepare append algorithm.
-    TRY(prepare_append(data.byte_length(), m_media_source->media_element_assigned_to()->playback_manager().current_time()));
+    TRY(prepare_append(data.byte_length()));
 
     // 2. Add data to the end of the [[input buffer]].
     if (auto array_buffer = data.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !data.is_out_of_bounds()) {
@@ -502,6 +509,15 @@ void SourceBuffer::on_first_initialization_segment_processed(InitializationSegme
 {
     auto& realm = this->realm();
 
+    // AD-HOC: Return early instead of touching the reset element. See MediaSource::run_duration_change_algorithm. This
+    //         is the same queued-task case as that. This algorithm can run after the media-element load algorithm reset
+    //         the element — and detaching still wouldn't prevent that.
+    {
+        auto media_element = m_media_source->media_element_assigned_to();
+        if (!media_element || !media_element->playback_manager())
+            return;
+    }
+
     // 4. Let active track flag equal false.
     bool active_track_flag = false;
 
@@ -568,7 +584,7 @@ void SourceBuffer::on_first_initialization_segment_processed(InitializationSegme
             // 8. Add the track description for this track to the track buffer.
             // NB: Track buffers and their demuxers are created by the processor. Here we pass the
             //     demuxer to the PlaybackManager so the decoder thread can read coded frames from it.
-            m_media_source->media_element_assigned_to()->playback_manager().add_media_source(audio_track_info.demuxer);
+            m_media_source->media_element_assigned_to()->playback_manager()->add_media_source(audio_track_info.demuxer);
         }
 
         // 3. For each video track in the initialization segment, run following steps:
@@ -629,7 +645,7 @@ void SourceBuffer::on_first_initialization_segment_processed(InitializationSegme
             // 8. Add the track description for this track to the track buffer.
             // NB: Track buffers and their demuxers are created by the processor. Here we pass the
             //     demuxer to the PlaybackManager so the decoder thread can read coded frames from it.
-            m_media_source->media_element_assigned_to()->playback_manager().add_media_source(video_track_info.demuxer);
+            m_media_source->media_element_assigned_to()->playback_manager()->add_media_source(video_track_info.demuxer);
         }
 
         // 4. For each text track in the initialization segment, run following steps:

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
@@ -71,7 +71,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    WebIDL::ExceptionOr<void> prepare_append(size_t new_data_size, AK::Duration current_time);
+    WebIDL::ExceptionOr<void> prepare_append(size_t new_data_size);
     void run_buffer_append_algorithm();
     void run_append_error_algorithm();
     void on_first_initialization_segment_processed(InitializationSegmentData const&);

--- a/Tests/LibWeb/Crash/HTML/media-element-load-with-pending-source-buffer-append.html
+++ b/Tests/LibWeb/Crash/HTML/media-element-load-with-pending-source-buffer-append.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<video id="video"></video>
+<script>
+    // Resetting the media element with load() while a SourceBuffer append is still queued removes the element's
+    // playback manager. The queued segment parser loop, and any later appendBuffer() call, must handle the missing
+    // playback manager — instead of crashing. See #10202.
+    const video = document.getElementById("video");
+    const mediaSource = new MediaSource();
+    video.src = URL.createObjectURL(mediaSource);
+
+    mediaSource.addEventListener("sourceopen", async () => {
+        const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+
+        const response = await fetch("../../Assets/two-video-tracks.webm");
+        const data = new Uint8Array(await response.arrayBuffer());
+
+        sourceBuffer.addEventListener("updateend", () => {
+            // Appending to a SourceBuffer whose media element has been reset must throw instead of crashing.
+            try {
+                sourceBuffer.appendBuffer(data.slice(0, 632));
+            } catch (e) {
+                // InvalidStateError is expected.
+            }
+            document.documentElement.classList.remove("test-wait");
+        }, { once: true });
+
+        // Append the init segment, which is every byte before the first Cluster element (632 bytes for this file). This
+        // queues a task to run the buffer append algorithm.
+        sourceBuffer.appendBuffer(data.slice(0, 632));
+
+        // Reset the media element while the buffer append algorithm is still queued.
+        video.load();
+    });
+</script>
+</html>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -11,6 +11,7 @@ Text/input/wpt-import/workers/Worker_ErrorEvent_type.htm
 Text/input/Worker/XHttpRequest-responseXML-unavailable-in-worker.html
 
 ; fetching a file only works from an HTTP server.
+Crash/HTML/media-element-load-with-pending-source-buffer-append.html
 Crash/HTML/video-track-switch-during-seek.html
 Text/input/WebAudio/BaseAudioContext-decodeAudioData.html
 Text/input/HTML/media-source-buffered.html


### PR DESCRIPTION
**Problem:** Crash when resetting a media element while MSE appends are pending — e.g., by hovering YouTube video cards so that preview players get created and torn down rapidly.

**Cause:** The media-element load algorithm resets the element and removes its playback manager. It should also detach the attached MediaSource — but we don’t yet implement detaching. So, the MediaSource stays open and assigned to the reset element. MediaSource and SourceBuffer called the element’s playback_manager() accessor, which asserted that a playback manager exists — in four places reachable after such a reset. Detaching wouldn’t sufficiently fix this. A buffer-append algorithm task queued before the reset still runs afterwards, because the load algorithm only removes tasks on the media-element event task source — and the detach steps close the MediaSource but don’t abort the buffer-append algorithm.

**Fix:** Make playback_manager() return a nullable pointer, matching the nullable member it exposes, and make the callers degrade gracefully when the element has no playback manager. The duration-change algorithm skips mirroring the duration, the prepare-append one throws InvalidStateError, and the initialization-segment-received algorithm returns early. (Once we implement detaching, the prepare-append check would become redundant. But the two queued-task guards wouldn’t. However, they could then be consolidated into a single early-out in the buffer-append algorithm.)

Fixes https://github.com/LadybirdBrowser/ladybird/issues/10202
