### PR TITLE
LibWeb: Implement the `backface-visibility` property

### DIFF
--- a/Libraries/LibGfx/Matrix.h
+++ b/Libraries/LibGfx/Matrix.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Optional.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
 #include <initializer_list>
@@ -201,9 +202,12 @@ public:
         return result;
     }
 
-    [[nodiscard]] constexpr Matrix inverse() const
+    [[nodiscard]] constexpr Optional<Matrix> inverse() const
     {
-        return adjugate() / determinant();
+        auto const determinant = this->determinant();
+        if (determinant == static_cast<T>(0))
+            return {};
+        return adjugate() / determinant;
     }
 
     [[nodiscard]] constexpr Matrix transpose() const

--- a/Libraries/LibGfx/Matrix4x4.h
+++ b/Libraries/LibGfx/Matrix4x4.h
@@ -60,6 +60,15 @@ constexpr static Matrix4x4<T> scale_matrix(Vector3<T> const& s)
 }
 
 template<typename T>
+constexpr static bool is_back_face_visible(Matrix4x4<T> const& m)
+{
+    auto determinant = m.determinant();
+    if (determinant == 0)
+        return false;
+    return m.first_minor(2, 2) / determinant < 0;
+}
+
+template<typename T>
 constexpr static Matrix4x4<T> perspective_matrix(T distance)
 {
     return Matrix4x4<T>(

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -376,6 +376,8 @@ RefPtr<StyleValue const> ComputedValues::computed_style_value(PropertyID propert
             { KeywordStyleValue::create(Keyword::Auto), move(ratio) },
             StyleValueList::Separator::Space);
     }
+    case PropertyID::BackfaceVisibility:
+        return KeywordStyleValue::create(to_keyword(backface_visibility()));
     case PropertyID::BackgroundColor:
         return color_style_value(background_color());
     case PropertyID::BackgroundAttachment: {
@@ -2840,6 +2842,12 @@ TransformStyle ComputedProperties::transform_style() const
 {
     auto const& value = property(PropertyID::TransformStyle);
     return keyword_to_transform_style(value.to_keyword()).release_value();
+}
+
+BackfaceVisibility ComputedProperties::backface_visibility() const
+{
+    auto const& value = property(PropertyID::BackfaceVisibility);
+    return keyword_to_backface_visibility(value.to_keyword()).release_value();
 }
 
 Color ComputedProperties::accent_color(ColorResolutionContext const& color_resolution_context) const

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -292,6 +292,7 @@ public:
     TransformBox transform_box() const;
     TransformOrigin transform_origin() const;
     TransformStyle transform_style() const;
+    BackfaceVisibility backface_visibility() const;
     RefPtr<TransformationStyleValue const> rotate() const;
     RefPtr<TransformationStyleValue const> translate() const;
     RefPtr<TransformationStyleValue const> scale() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -278,6 +278,7 @@ static constexpr Array transform_group_properties {
     PropertyID::TransformBox,
     PropertyID::TransformOrigin,
     PropertyID::TransformStyle,
+    PropertyID::BackfaceVisibility,
     PropertyID::Rotate,
     PropertyID::Translate,
     PropertyID::Scale,
@@ -558,6 +559,7 @@ static void register_style_group_field_descriptors()
     add(transform, PropertyID::TransformBox, offsetof(Transform, transform_box), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_transform_box>());
     add(transform, PropertyID::TransformOrigin, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
     add(transform, PropertyID::TransformStyle, offsetof(Transform, transform_style), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_transform_style>());
+    add(transform, PropertyID::BackfaceVisibility, offsetof(Transform, backface_visibility), GROUP_FIELD_ENUM_KEYWORD, 0, &keyword_code_table<keyword_to_backface_visibility>());
     add(transform, PropertyID::Rotate, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
     add(transform, PropertyID::Translate, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
     add(transform, PropertyID::Scale, 0, GROUP_FIELD_REQUIRE_KEYWORD, to_underlying(Keyword::None), nullptr);
@@ -2273,6 +2275,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         computed_values.set_transform_origin(computed_style.transform_origin());
     if (!transform_adopted)
         computed_values.set_transform_style(computed_style.transform_style());
+    if (!transform_adopted)
+        computed_values.set_backface_visibility(computed_style.backface_visibility());
     if (!transform_adopted)
         computed_values.set_perspective(computed_style.perspective());
     if (!transform_adopted)

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -449,6 +449,7 @@ public:
     static QuotesData quotes() { return QuotesData { .type = QuotesData::Type::Auto }; }
     static TransformBox transform_box() { return TransformBox::ViewBox; }
     static TransformStyle transform_style() { return TransformStyle::Flat; }
+    static BackfaceVisibility backface_visibility() { return BackfaceVisibility::Visible; }
     static Direction direction() { return Direction::Ltr; }
     static Optional<BaselineMetric> dominant_baseline() { return {}; }
     static WritingMode writing_mode() { return WritingMode::HorizontalTb; }
@@ -1478,6 +1479,7 @@ public:
     TransformBox const& transform_box() const { return m_noninherited.transform->transform_box; }
     TransformOrigin const& transform_origin() const { return m_noninherited.transform->transform_origin; }
     TransformStyle const& transform_style() const { return m_noninherited.transform->transform_style; }
+    BackfaceVisibility const& backface_visibility() const { return m_noninherited.transform->backface_visibility; }
     RefPtr<TransformationStyleValue const> const& rotate() const { return m_noninherited.transform->rotate; }
     RefPtr<TransformationStyleValue const> const& translate() const { return m_noninherited.transform->translate; }
     RefPtr<TransformationStyleValue const> const& scale() const { return m_noninherited.transform->scale; }
@@ -1858,6 +1860,7 @@ public:
         TransformBox transform_box { InitialValues::transform_box() };
         TransformOrigin transform_origin {};
         TransformStyle transform_style { InitialValues::transform_style() };
+        BackfaceVisibility backface_visibility { InitialValues::backface_visibility() };
         RefPtr<TransformationStyleValue const> rotate;
         RefPtr<TransformationStyleValue const> translate;
         RefPtr<TransformationStyleValue const> scale;
@@ -3117,6 +3120,12 @@ public:
         if (m_values.m_noninherited.transform->transform_style == value)
             return;
         m_values.m_noninherited.transform.access().transform_style = value;
+    }
+    void set_backface_visibility(BackfaceVisibility value)
+    {
+        if (m_values.m_noninherited.transform->backface_visibility == value)
+            return;
+        m_values.m_noninherited.transform.access().backface_visibility = value;
     }
     void set_translate(RefPtr<TransformationStyleValue const> value)
     {

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -116,6 +116,10 @@
     "x",
     "y"
   ],
+  "backface-visibility": [
+    "visible",
+    "hidden"
+  ],
   "background-attachment": [
     "fixed",
     "local",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -444,6 +444,15 @@
       "none"
     ]
   },
+  "backface-visibility": {
+    "animation-type": "discrete",
+    "inherited": false,
+    "initial": "visible",
+    "requires-computation": "never",
+    "valid-types": [
+      "backface-visibility"
+    ]
+  },
   "background": {
     "affects-layout": false,
     "initial": "transparent",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -445,6 +445,7 @@
     ]
   },
   "backface-visibility": {
+    "affects-accumulated-visual-contexts": true,
     "affects-stacking-context": true,
     "animation-type": "discrete",
     "inherited": false,
@@ -4630,6 +4631,7 @@
     "percentages-resolve-to": "length"
   },
   "transform-style": {
+    "affects-accumulated-visual-contexts": true,
     "animation-type": "discrete",
     "inherited": false,
     "initial": "flat",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -445,6 +445,7 @@
     ]
   },
   "backface-visibility": {
+    "affects-stacking-context": true,
     "animation-type": "discrete",
     "inherited": false,
     "initial": "visible",

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -53,6 +53,8 @@ static Optional<bool> typed_value_creates_stacking_context(PropertyID property_i
         return values.perspective().has_value();
     case PropertyID::TransformStyle:
         return values.transform_style() != TransformStyle::Flat;
+    case PropertyID::BackfaceVisibility:
+        return values.backface_visibility() == BackfaceVisibility::Hidden;
     default:
         return {};
     }
@@ -99,6 +101,8 @@ static bool is_stacking_context_creating_value(CSS::PropertyID property_id, Styl
     case CSS::PropertyID::Perspective:
     case CSS::PropertyID::TransformStyle:
         return value->to_keyword() != CSS::Keyword::None && value->to_keyword() != CSS::Keyword::Flat;
+    case CSS::PropertyID::BackfaceVisibility:
+        return value->to_keyword() == CSS::Keyword::Hidden;
     default:
         // For properties we haven't optimized (contain, container-type, will-change, all),
         // assume any value creates stacking context to be safe
@@ -126,6 +130,8 @@ static bool is_containing_block_establishing_value(CSS::PropertyID property_id, 
         return value->to_keyword() != CSS::Keyword::None;
     case CSS::PropertyID::TransformStyle:
         return value->to_keyword() == CSS::Keyword::Preserve3d;
+    case CSS::PropertyID::BackfaceVisibility:
+        return value->to_keyword() == CSS::Keyword::Hidden;
     case CSS::PropertyID::Filter:
     case CSS::PropertyID::BackdropFilter:
         if (value->is_keyword())
@@ -162,8 +168,8 @@ static bool is_containing_block_establishing_value(CSS::PropertyID property_id, 
             return AK::first_is_one_of(*property,
                 CSS::PropertyID::Transform, CSS::PropertyID::Translate, CSS::PropertyID::Rotate,
                 CSS::PropertyID::Scale, CSS::PropertyID::Perspective, CSS::PropertyID::TransformStyle,
-                CSS::PropertyID::Filter, CSS::PropertyID::BackdropFilter, CSS::PropertyID::Contain,
-                CSS::PropertyID::Position);
+                CSS::PropertyID::BackfaceVisibility, CSS::PropertyID::Filter, CSS::PropertyID::BackdropFilter,
+                CSS::PropertyID::Contain, CSS::PropertyID::Position);
         };
         if (value->to_keyword() == CSS::Keyword::Auto)
             return false;

--- a/Libraries/LibWeb/Geometry/DOMMatrix.cpp
+++ b/Libraries/LibWeb/Geometry/DOMMatrix.cpp
@@ -587,14 +587,12 @@ GC::Ref<DOMMatrix> DOMMatrix::skew_y_self(double sy)
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-invertself
 GC::Ref<DOMMatrix> DOMMatrix::invert_self()
 {
-    bool is_invertible = m_matrix.is_invertible();
-
     // 1. Invert the current matrix.
-    if (is_invertible)
-        m_matrix = m_matrix.inverse();
-
-    // 2. If the current matrix is not invertible set all attributes to NaN and set is 2D to false.
-    if (!is_invertible) {
+    auto inverse = m_matrix.inverse();
+    if (inverse.has_value()) {
+        m_matrix = inverse.release_value();
+    } else {
+        // 2. If the current matrix is not invertible set all attributes to NaN and set is 2D to false.
         for (u8 i = 0; i < 4; i++) {
             for (u8 j = 0; j < 4; j++)
                 m_matrix[j, i] = NAN;

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -241,6 +241,13 @@ static bool computed_values_establish_fixed_positioning_containing_block(NodeWit
     if ((computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)) && node_is_transformable())
         return true;
 
+    // https://drafts.csswg.org/css-transforms-2/#backface-visibility-property
+    // A computed value of hidden for backface-visibility on a transformable element that participates in a 3D
+    // rendering context establishes both a stacking context and a containing block for all descendants.
+    if ((computed_values.backface_visibility() == CSS::BackfaceVisibility::Hidden || will_change_property(CSS::PropertyID::BackfaceVisibility))
+        && node_is_transformable() && node.participates_in_a_3d_rendering_context())
+        return true;
+
     // https://drafts.csswg.org/css-view-transitions-1/#snapshot-containing-block-concept
     // FIXME: The snapshot containing block is considered to be an absolute positioning containing block and a fixed
     //        positioning containing block for ::view-transition and its descendants.
@@ -591,6 +598,13 @@ bool NodeWithStyle::establishes_stacking_context() const
     if (is_transformable() && (computed_values.transform_style() == CSS::TransformStyle::Preserve3d || will_change_property(CSS::PropertyID::TransformStyle)))
         return true;
 
+    // https://drafts.csswg.org/css-transforms-2/#backface-visibility-property
+    // A computed value of hidden for backface-visibility on a transformable element that participates in a 3D
+    // rendering context establishes both a stacking context and a containing block for all descendants.
+    if ((computed_values.backface_visibility() == CSS::BackfaceVisibility::Hidden || will_change_property(CSS::PropertyID::BackfaceVisibility))
+        && is_transformable() && participates_in_a_3d_rendering_context())
+        return true;
+
     return computed_values.opacity() < 1.0f || will_change_property(CSS::PropertyID::Opacity);
 }
 
@@ -937,6 +951,22 @@ bool NodeWithStyle::is_transformable() const
     }
 
     return false;
+}
+
+bool NodeWithStyle::establishes_or_extends_a_3d_rendering_context() const
+{
+    // FIXME: Use the used value of 'transform-style', which is 'flat' when grouping property values apply.
+    return is_transformable() && computed_values().transform_style() == CSS::TransformStyle::Preserve3d;
+}
+
+// https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
+bool NodeWithStyle::participates_in_a_3d_rendering_context() const
+{
+    // An element participates in a 3D rendering context if its parent establishes or extends a 3D rendering context.
+    auto const* ancestor = parent();
+    while (ancestor && ancestor->is_anonymous())
+        ancestor = ancestor->parent();
+    return ancestor && ancestor->establishes_or_extends_a_3d_rendering_context();
 }
 
 NonnullRefPtr<NodeWithStyle> NodeWithStyle::create_anonymous_wrapper() const

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -373,6 +373,8 @@ public:
     bool is_inline_table() const;
     bool has_replaced_element_table_display_adjustment() const;
     bool is_transformable() const;
+    bool establishes_or_extends_a_3d_rendering_context() const;
+    bool participates_in_a_3d_rendering_context() const;
 
     bool is_floating() const;
     bool is_positioned() const;

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <AK/Atomic.h>
 #include <AK/HashTable.h>
 #include <AK/StringBuilder.h>
@@ -384,6 +385,9 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         NearestScrollNodeIndices normal_nearest_scroll_nodes;
         NearestScrollNodeIndices absolute_position_nearest_scroll_nodes;
         NearestScrollNodeIndices fixed_position_nearest_scroll_nodes;
+        VisualContextIndex normal_plane_root;
+        VisualContextIndex absolute_position_plane_root;
+        VisualContextIndex fixed_position_plane_root;
     };
 
     auto build_paintable_box = [&](Paintable& paintable_box, DescendantVisualContexts inherited_contexts, bool may_be_root_element) -> DescendantVisualContexts {
@@ -499,6 +503,30 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             paintable_box.set_has_non_invertible_css_transform(false);
         }
 
+        // https://drafts.csswg.org/css-transforms-2/#backface-visibility-property
+        // NB: Whether the element's backface is visible depends on its accumulated 3D transformation matrix, which
+        //     is only known at replay time once scroll offsets have been applied. The node recorded below marks the
+        //     content to skip and stores the plane root from which that matrix is accumulated. The plane root bounds
+        //     the accumulation to the element's 3D rendering context.
+        // AD-HOC: The spec determines visibility from the sign of m33 in the accumulated matrix. That is wrong for
+        //         matrices with a perspective component, so we test the z-component of the transformed plane normal
+        //         instead. See: https://github.com/w3c/csswg-drafts/issues/917.
+        auto inherited_plane_root = [&] {
+            if (paintable_box.is_fixed_position())
+                return inherited_contexts.fixed_position_plane_root;
+            if (paintable_box.is_absolutely_positioned())
+                return inherited_contexts.absolute_position_plane_root;
+            return inherited_contexts.normal_plane_root;
+        }();
+        if (computed_values.backface_visibility() == CSS::BackfaceVisibility::Hidden && layout_node.is_transformable())
+            own_state = append_node(own_state, BackfaceVisibilityData { inherited_plane_root });
+
+        // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
+        // An element whose used value for transform-style is preserve-3d extends its 3D rendering context, so its
+        // descendants accumulate through this element's transform; any other element starts a new plane below its
+        // own transform.
+        auto plane_root_for_descendants = layout_node.establishes_or_extends_a_3d_rendering_context() ? inherited_plane_root : own_state;
+
         if (computed_values.clip().is_rect()) {
             if (auto css_clip = compute_css_clip_data(paintable_box, computed_values, converter); css_clip.has_value())
                 append_to_own_and_positioned_descendant_contexts(css_clip.value());
@@ -589,13 +617,17 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         paintable_box.set_visual_context_node_range(first_visual_context_node_index, visual_context_tree.nodes().size());
         auto absolute_position_nearest_scroll_nodes = inherited_contexts.absolute_position_nearest_scroll_nodes;
         auto fixed_position_nearest_scroll_nodes = inherited_contexts.fixed_position_nearest_scroll_nodes;
+        auto absolute_position_plane_root = inherited_contexts.absolute_position_plane_root;
+        auto fixed_position_plane_root = inherited_contexts.fixed_position_plane_root;
         if (positioning_containing_blocks.absolute) {
             state_for_absolute_position_descendants = state_for_descendants;
             absolute_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
+            absolute_position_plane_root = plane_root_for_descendants;
         }
         if (positioning_containing_blocks.fixed) {
             state_for_fixed_position_descendants = state_for_descendants;
             fixed_position_nearest_scroll_nodes = nearest_scroll_nodes_for_descendants;
+            fixed_position_plane_root = plane_root_for_descendants;
         }
 
         return DescendantVisualContexts {
@@ -605,6 +637,9 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             nearest_scroll_nodes_for_descendants,
             absolute_position_nearest_scroll_nodes,
             fixed_position_nearest_scroll_nodes,
+            plane_root_for_descendants,
+            absolute_position_plane_root,
+            fixed_position_plane_root,
         };
     };
 
@@ -616,6 +651,9 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         viewport_nearest_scroll_nodes,
         viewport_nearest_scroll_nodes,
         viewport_nearest_scroll_nodes,
+        viewport_state_for_descendants,
+        viewport_state_for_descendants,
+        visual_viewport_context_index,
     };
 
     struct PendingPaintable {
@@ -829,10 +867,48 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
 {
     auto chain = build_ancestor_chain(index);
 
+    // The backface test needs forward matrices, but this walk only applies inverses. When the chain contains
+    // backface markers, we accumulate the forward matrices as we walk, from the root down, so a marker can look up
+    // the matrix at its plane root by depth.
+    bool chain_has_backface_marker = any_of(chain, [&](size_t chain_index) {
+        return m_nodes[chain_index].data.has<BackfaceVisibilityData>();
+    });
+    Vector<Gfx::FloatMatrix4x4, 8> accumulated_matrices;
+    if (chain_has_backface_marker)
+        accumulated_matrices.ensure_capacity(chain.size());
+
     auto point = screen_point;
     for (size_t i = chain.size(); i > 0; --i) {
         auto node_index = VisualContextIndex { chain[i - 1] };
         auto const& node = m_nodes[node_index.value()];
+
+        if (chain_has_backface_marker) {
+            auto local_matrix = node.data.visit(
+                [&](TransformData const& transform) {
+                    return transform.matrix_including_origin();
+                },
+                [&](PerspectiveData const& perspective) {
+                    return perspective.matrix;
+                },
+                [&](ScrollData const&) {
+                    auto offset = scroll_state.device_offset_for_index(node_index);
+                    return Gfx::translation_matrix(Vector3 { offset.x(), offset.y(), 0.f });
+                },
+                [&](ScrollCompensation const& compensation) {
+                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
+                    return Gfx::translation_matrix(Vector3 { -offset.x(), -offset.y(), 0.f });
+                },
+                [&](AnchorScrollShift const& shift) {
+                    auto offset = shift.masked_offset(scroll_state);
+                    return Gfx::translation_matrix(Vector3 { offset.x(), offset.y(), 0.f });
+                },
+                [&](BackfaceVisibilityData const&) { return Gfx::FloatMatrix4x4::identity(); },
+                [&](ClipData const&) { return Gfx::FloatMatrix4x4::identity(); },
+                [&](ClipPathData const&) { return Gfx::FloatMatrix4x4::identity(); },
+                [&](EffectsData const&) { return Gfx::FloatMatrix4x4::identity(); },
+                [&](MaskData const&) { return Gfx::FloatMatrix4x4::identity(); });
+            accumulated_matrices.unchecked_append(i == chain.size() ? local_matrix : accumulated_matrices.last() * local_matrix);
+        }
 
         auto result = node.data.visit(
             [&](PerspectiveData const& perspective) -> Optional<Gfx::FloatPoint> {
@@ -841,6 +917,13 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
                 if (!inverse.has_value())
                     return {};
                 point = inverse->map(point);
+                return point;
+            },
+            [&](BackfaceVisibilityData const& backface) -> Optional<Gfx::FloatPoint> {
+                auto plane_root_depth = m_nodes[backface.plane_root_index.value()].depth;
+                VERIFY(chain[chain.size() - 1 - plane_root_depth] == backface.plane_root_index.value());
+                if (should_cull_back_face(accumulated_matrices.last(), accumulated_matrices[plane_root_depth]))
+                    return {};
                 return point;
             },
             [&](ScrollData const&) -> Optional<Gfx::FloatPoint> {
@@ -957,6 +1040,7 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
                 [&](AnchorScrollShift const& shift) {
                     rect.translate_by(shift.masked_offset(scroll_state));
                 },
+                [&](BackfaceVisibilityData const&) {},
                 [&](ClipData const&) { /* clips don't affect rect coordinates */ },
                 [&](ClipPathData const&) { /* clip paths don't affect rect coordinates */ },
                 [&](EffectsData const&) { /* effects don't affect rect coordinates */ },
@@ -967,6 +1051,21 @@ Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualCo
     }
 
     return rect;
+}
+
+Gfx::FloatMatrix4x4 TransformData::matrix_including_origin() const
+{
+    auto origin_translation = Gfx::translation_matrix(Gfx::Vector3<float> { origin.x(), origin.y(), 0 });
+    auto inverse_origin_translation = Gfx::translation_matrix(Gfx::Vector3<float> { -origin.x(), -origin.y(), 0 });
+    return origin_translation * matrix * inverse_origin_translation;
+}
+
+bool should_cull_back_face(Gfx::FloatMatrix4x4 const& accumulated_matrix, Gfx::FloatMatrix4x4 const& plane_root_matrix)
+{
+    auto inverse_plane_root_matrix = plane_root_matrix.inverse();
+    if (!inverse_plane_root_matrix.has_value())
+        return false;
+    return Gfx::is_back_face_visible(*inverse_plane_root_matrix * accumulated_matrix);
 }
 
 Gfx::FloatPoint AnchorScrollShift::masked_offset(ScrollStateSnapshot const& scroll_state) const
@@ -985,6 +1084,9 @@ void AccumulatedVisualContextTree::dump(VisualContextIndex index, StringBuilder&
     node.data.visit(
         [&](PerspectiveData const&) {
             builder.append("perspective"sv);
+        },
+        [&](BackfaceVisibilityData const& backface) {
+            builder.appendff("backface-hidden plane_root={}", backface.plane_root_index.value());
         },
         [&](ScrollData const& scroll) {
             builder.append("scroll"sv);
@@ -1122,6 +1224,21 @@ ErrorOr<Web::Painting::PerspectiveData> decode(Decoder& decoder)
 {
     return Web::Painting::PerspectiveData {
         .matrix = TRY(decoder.decode<Gfx::FloatMatrix4x4>()),
+    };
+}
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::Painting::BackfaceVisibilityData const& data)
+{
+    TRY(encoder.encode(data.plane_root_index));
+    return {};
+}
+
+template<>
+ErrorOr<Web::Painting::BackfaceVisibilityData> decode(Decoder& decoder)
+{
+    return Web::Painting::BackfaceVisibilityData {
+        .plane_root_index = TRY(decoder.decode<Web::Painting::VisualContextIndex>()),
     };
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -59,11 +59,19 @@ struct ClipData {
 struct TransformData {
     Gfx::FloatMatrix4x4 matrix;
     Gfx::FloatPoint origin;
+
+    Gfx::FloatMatrix4x4 matrix_including_origin() const;
 };
 
 struct PerspectiveData {
     Gfx::FloatMatrix4x4 matrix;
 };
+
+struct BackfaceVisibilityData {
+    VisualContextIndex plane_root_index;
+};
+
+bool should_cull_back_face(Gfx::FloatMatrix4x4 const& accumulated_matrix, Gfx::FloatMatrix4x4 const& plane_root_matrix);
 
 struct ClipPathData {
     Gfx::Path path;
@@ -113,7 +121,7 @@ struct AnchorScrollShift {
     Gfx::FloatPoint masked_offset(ScrollStateSnapshot const&) const;
 };
 
-using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, ClipPathData, EffectsData, ScrollCompensation, AnchorScrollShift, MaskData>;
+using VisualContextData = Variant<ScrollData, ClipData, TransformData, PerspectiveData, BackfaceVisibilityData, ClipPathData, EffectsData, ScrollCompensation, AnchorScrollShift, MaskData>;
 
 Optional<TransformData> compute_transform(Paintable const&, CSS::ComputedValues const&, double pixel_ratio);
 
@@ -217,6 +225,11 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::PerspectiveData const&);
 template<>
 WEB_API ErrorOr<Web::Painting::PerspectiveData> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::BackfaceVisibilityData const&);
+template<>
+WEB_API ErrorOr<Web::Painting::BackfaceVisibilityData> decode(Decoder&);
 
 template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::Painting::ClipPathData const&);

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -194,6 +194,9 @@ void DisplayListPlayer::execute_impl(
     nearest_spatial_node.ensure_capacity(nodes.size());
     nearest_frame_node.clear_with_capacity();
     nearest_frame_node.ensure_capacity(nodes.size());
+    auto& backface_culled = palette_storage.backface_culled;
+    backface_culled.clear_with_capacity();
+    backface_culled.ensure_capacity(nodes.size());
     auto const replay_base_matrix = canvas_matrix();
     for (size_t i = 0; i < nodes.size(); ++i) {
         auto const& node = nodes[i];
@@ -202,6 +205,7 @@ void DisplayListPlayer::execute_impl(
             transform_palette.unchecked_append(parent_matrix * local_matrix);
             nearest_spatial_node.unchecked_append(VisualContextIndex { i });
             nearest_frame_node.unchecked_append(i == 0 ? VISUAL_VIEWPORT_NODE_INDEX : nearest_frame_node[node.parent_index.value()]);
+            backface_culled.unchecked_append(i == 0 ? false : backface_culled[node.parent_index.value()]);
         };
         auto append_spatial_translation = [&](Gfx::IntPoint offset) {
             // Whole device pixels, so scrolled content never lands on subpixel positions.
@@ -212,16 +216,25 @@ void DisplayListPlayer::execute_impl(
             transform_palette.unchecked_append(transform_palette[node.parent_index.value()]);
             nearest_spatial_node.unchecked_append(nearest_spatial_node[node.parent_index.value()]);
             nearest_frame_node.unchecked_append(VisualContextIndex { i });
+            backface_culled.unchecked_append(backface_culled[node.parent_index.value()]);
         };
         node.data.visit(
             [&](TransformData const& transform) {
-                auto matrix = Gfx::translation_matrix(Vector3<float>(transform.origin.x(), transform.origin.y(), 0));
-                matrix = matrix * transform.matrix;
-                matrix = matrix * Gfx::translation_matrix(Vector3<float>(-transform.origin.x(), -transform.origin.y(), 0));
-                append_spatial(matrix);
+                append_spatial(transform.matrix_including_origin());
             },
             [&](PerspectiveData const& perspective) {
                 append_spatial(perspective.matrix);
+            },
+            [&](BackfaceVisibilityData const& backface) {
+                transform_palette.unchecked_append(transform_palette[node.parent_index.value()]);
+                nearest_spatial_node.unchecked_append(nearest_spatial_node[node.parent_index.value()]);
+                nearest_frame_node.unchecked_append(nearest_frame_node[node.parent_index.value()]);
+                bool culled = backface_culled[node.parent_index.value()];
+                if (!culled) {
+                    auto const& plane_root_matrix = transform_palette[backface.plane_root_index.value()];
+                    culled = should_cull_back_face(transform_palette.last(), plane_root_matrix);
+                }
+                backface_culled.unchecked_append(culled);
             },
             [&](ScrollData const&) {
                 append_spatial_translation(scroll_state.device_offset_for_index(VisualContextIndex { i }).to_type<int>());
@@ -387,6 +400,9 @@ void DisplayListPlayer::execute_impl(
 
     DisplayList::for_each_command_header(commands, [&](DisplayListCommandHeader const& header, ReadonlyBytes payload) {
         if (display_list_command_is_compositor_metadata(header.type))
+            return;
+
+        if (backface_culled[header.context_index.value()])
             return;
 
         auto bounding_rect = header.has_bounding_rect

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -87,6 +87,7 @@ private:
         Vector<Gfx::FloatMatrix4x4> to_root_matrices;
         Vector<VisualContextIndex> nearest_spatial_nodes;
         Vector<VisualContextIndex> nearest_frame_nodes;
+        Vector<bool> backface_culled;
     };
     ReplayPaletteStorage m_replay_palette_storage;
 };

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -129,6 +129,10 @@ static bool visual_context_data_is_equal(VisualContextIndex a_index, VisualConte
             auto const* other = b.get_pointer<PerspectiveData>();
             return other && matrices_are_equal(data.matrix, other->matrix);
         },
+        [&](BackfaceVisibilityData const& data) {
+            auto const* other = b.get_pointer<BackfaceVisibilityData>();
+            return other && data.plane_root_index == other->plane_root_index;
+        },
         [&](ClipPathData const& data) {
             auto const* other = b.get_pointer<ClipPathData>();
             return other

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-001.ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-001.ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@google.com">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<meta name="assert" content="backface-visibility should have no effect when no transforms are present">
+<style>
+.box {
+    border: 1px solid black;
+    width: 200px;
+    height: 200px;
+}
+</style>
+<div class="box">
+    This text should be visible
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-002-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-002-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden self-transform</title>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+
+<p>The test passes if there is a green rectangle and no red.</p>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div style="backface-visibility:hidden"></div>
+<div style="background: green"></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-003-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+
+<p>The test passes if there is a green rectangle and no red.</p>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div style="background: green"></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-006-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-006-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden scrolling contents if backface-invisible</title>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-animated-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/backface-visibility-hidden-animated-ref.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+  <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">
+  <style>
+    #flip {
+      height: 100px;
+      width: 100px;
+      transform: rotateY(180deg);
+      transform-style: preserve-3d;
+    }
+
+    #back {
+      background: lightblue;
+      transform: rotateY(180deg);
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 200px;
+      height: 200px;
+      backface-visibility: hidden;
+    }
+
+    #posabs {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      background: yellow;
+    }
+  </style>
+  <div id="flip">
+    <div id="back">
+      <i id="posabs">Text</i>
+    </div>
+  </div>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/offset-change-inline-backface-visibility-hidden-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/offset-change-inline-backface-visibility-hidden-ref.html
@@ -1,0 +1,5 @@
+<!doctype HTML>
+<link rel="stylesheet" href="../../../../data/fonts/ahem.css">
+<div id="container" style="font-family: ahem; margin-left: 100px; width: 100px; background: green">
+  X
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/reference/backface-visibility-hidden-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/reference/backface-visibility-hidden-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Transforms Reference File</title>
+    <link rel="author" title="Jian Zhang" href="mailto:jian.andy.zhang@gmail.com">
+    <style type="text/css">
+        .greenSquare {
+            position: absolute;
+            top: 50px;
+            left: 50px;
+            width: 100px;
+            height: 100px;
+            background: green;
+            z-index: 2;
+        }
+
+        .card {
+            transform-style: preserve-3d;
+        }
+
+        .container {
+            width: 200px;
+            height: 200px;
+            perspective: 1000;
+            transform: rotateY(45deg);
+        }
+
+    </style>
+</head>
+<body>
+    <p>The test passes if there is a green retangle and no red.</p>
+    <div class="container">
+        <div class="card">
+            <div class="greenSquare face"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/size-change-under-backface-visibility-hidden-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/size-change-under-backface-visibility-hidden-ref.html
@@ -1,0 +1,9 @@
+<!doctype HTML>
+<title>CSS Test</title>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org" />
+Passes if it shows a green 200x200 square.
+<div style="will-change: transform; width: 300px; height: 0px">
+  <div style="width: 1px; height: 1px; backface-visibility: hidden;">
+    <div id=target style="width: 200px; height: 200px; position: relative; background: green; left: 10px;"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/subpixel-perspective-backface-hidden-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/subpixel-perspective-backface-hidden-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<div style="padding: 0.4px 0.6px">
+  <div style="width: 100px; height: 100px; border: 1px solid black"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-001.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@google.com">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-001.ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-2">
+<meta name="assert" content="backface-visibility should have no effect when no transforms are present">
+<style>
+.box {
+    border: 1px solid black;
+    width: 200px;
+    height: 200px;
+    backface-visibility: hidden;
+}
+</style>
+<div class="box">
+    This text should be visible
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-001.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Transforms Test: transform property with backface visibility = hidden</title>
+    <link rel="author" title="Jian Zhang" href="mailto:jian.andy.zhang@gmail.com">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/reference/backface-visibility-hidden-ref.html">
+    <meta name="fuzzy" content="maxDifference=0-100;totalPixels=0-300">
+    <meta name="assert" content="When the value of backface visibility property is 'hidden', the back side of a transformed element is invisible when facing the viewer.">
+    <style type="text/css">
+        .greenSquare {
+            position: absolute;
+            top: 50px;
+            left: 50px;
+            width: 100px;
+            height: 100px;
+            background: green;
+            z-index: 2;
+        }
+
+        .redSquare {
+            position: absolute;
+            top: 50px;
+            left: 50px;
+            width: 100px;
+            height: 100px;
+            background: red;
+            z-index: 1;
+            transform: rotateY(180deg);
+        }
+
+        .face {
+            backface-visibility: hidden;
+        }
+
+        .card {
+            transform-style: preserve-3d;
+        }
+
+        .container {
+            width: 200px;
+            height: 200px;
+            perspective: 1000px;
+            transform: rotateY(45deg);
+        }
+
+    </style>
+</head>
+<body>
+    <p>The test passes if there is a green retangle and no red.</p>
+    <div class="container">
+        <div class="card">
+            <div class="redSquare face"></div>
+            <div class="greenSquare face"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-002.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden self-transform</title>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-002-ref.html">
+
+<p>The test passes if there is a green rectangle and no red.</p>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+  }
+  .target {
+    transform: rotateY(180deg);
+  }
+</style>
+<div class=target style="backface-visibility: hidden; background: red"></div>
+<div class=target style="background: green"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-003.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden creates containing block and stacking context when participating in a 3D rendering context</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-003-ref.html">
+
+<p>The test passes if there is a green rectangle and no red.</p>
+<style>
+.outer {
+  transform-style: preserve-3d;
+  width: 100px;
+  height: 100px;
+  background-color: red;
+}
+
+.inner {
+  backface-visibility: hidden;
+}
+
+.positioned {
+  position: absolute;
+  top: -100px;
+  z-index: -1;
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+
+.sibling {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+}
+
+</style>
+
+<div class="outer">
+  <div class="sibling"></div>
+  <div class="inner">
+    <div class="positioned"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-004.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden creates containing block and stacking context when participating in a 3D rendering context</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-003-ref.html">
+
+<p>The test passes if there is a green rectangle and no red.</p>
+<style>
+.outer {
+  transform-style: preserve-3d;
+  transform: rotateX(180deg);
+  width: 100px;
+  height: 100px;
+}
+
+.card {
+  width: 100px;
+  height: 100px;
+  position: absolute;
+  backface-visibility: hidden;
+}
+
+.front {
+  background-color: red;
+}
+
+.back {
+  background-color: green;
+  transform: rotateX(180deg);
+}
+
+.inner {
+  position: fixed;
+  width: 100px;
+  height: 100px;
+  background-color: red;
+}
+
+</style>
+
+<div class="outer">
+  <div class="card back"></div>
+  <div class="card front">
+    <div class="inner"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-005.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden creates containing block and stacking context when transformed</title>
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-003-ref.html">
+
+<p>The test passes if there is a green rectangle and no red.</p>
+<style>
+.background {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+
+.flipper {
+  backface-visibility:hidden;
+  transform: rotateY(180deg);
+  width: 100px;
+  top: -100px;
+  margin-top: -100px;
+}
+
+.scroll {
+  overflow-y: scroll;
+  width: 100px;
+  height: 100px;
+}
+
+.inner {
+  height: 900px;
+  background: red;
+}
+
+</style>
+
+<div class="background"></div>
+<div class="flipper">
+  <div class="scroll">
+    <div class="inner">
+    </div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-006.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>backface visibility: hidden scrolling contents if backface-invisible</title>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-006-ref.html">
+<div style="transform: rotateY(180deg); backface-visibility: hidden; overflow: scroll; height: 300px;">
+  <p style="display: inline-block; height: 300px">
+    This text should be invisible
+  </p>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-animated-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-animated-001.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html class=reftest-wait>
+  <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+  <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-animated-ref.html">
+  <style>
+    @keyframes show-backface {
+      0% { transform: rotateY(60deg); }
+      0.01% { transform: rotateY(180deg); }
+      100% { transform: rotateY(180deg); }
+    }
+
+    .flip {
+      animation: 10s linear 0s infinite forwards show-backface;
+      height: 100px;
+      width: 100px;
+      transform: rotateY(60deg);
+      transform-style: preserve-3d;
+    }
+
+    #back {
+      background: lightblue;
+      transform: rotateY(180deg);
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 200px;
+      height: 200px;
+      backface-visibility: hidden;
+    }
+
+    #posabs {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      background: yellow;
+    }
+  </style>
+  <div id="flip">
+    <div id="back">
+      <i id="posabs">Text</i>
+    </div>
+  </div>
+  <script>
+    onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
+      flip.classList.add("flip");
+      requestAnimationFrame(() => requestAnimationFrame(() =>
+          document.documentElement.classList.remove("reftest-wait")));
+    }));
+  </script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-animated-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-animated-002.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html class=reftest-wait>
+  <link rel="author" title="Xianzhu Wang" href="mailto:wangxianzhu@chromium.org">
+  <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/backface-visibility-hidden-animated-ref.html">
+  <style>
+    @keyframes show-backface {
+      0% { transform: rotateY(60deg); }
+      0.01% { transform: rotateY(180deg); }
+      100% { transform: rotateY(180deg); }
+    }
+
+    .flip {
+      animation: 10s linear 0s infinite forwards show-backface;
+      height: 100px;
+      width: 100px;
+      transform: rotateY(60deg);
+      transform-style: preserve-3d;
+    }
+
+    #back {
+      background: lightblue;
+      transform: rotateY(180deg);
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 200px;
+      height: 200px;
+      backface-visibility: hidden;
+    }
+
+    #posabs {
+      position: absolute;
+      /* This is the only difference from backface-visibility-hidden-animated-001.html. */
+      will-change: transform;
+      bottom: 0;
+      right: 0;
+      background: yellow;
+    }
+  </style>
+  <div id="flip">
+    <div id="back">
+      <i id="posabs">Text</i>
+    </div>
+  </div>
+  <script>
+    onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
+      flip.classList.add("flip");
+      requestAnimationFrame(() => requestAnimationFrame(() =>
+          document.documentElement.classList.remove("reftest-wait")));
+    }));
+  </script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-child-translate.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-child-translate.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#backface-visibility-property">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="background: green; width: 100px">
+  <div style="transform: rotateY(180deg); backface-visibility: hidden">
+    <div style="background: red; transform: translateX(20px); height: 100px"></div>
+  </div>
+</div>
+

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-child-will-change-transform.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-hidden-child-will-change-transform.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#backface-visibility-property">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/../reference/ref-filled-green-100px-square.xht">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="background: green; width: 100px">
+  <div style="transform: rotateY(180deg); backface-visibility: hidden">
+    <div style="background: red; will-change: transform; height: 100px"></div>
+  </div>
+</div>
+

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-with-sibling-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/backface-visibility-with-sibling-001.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<title>backface-visibility test</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#3d-transform-rendering">
+<link rel="match" href="../../../../expected/wpt-import//common/blank.html">
+<meta name="assert" content="The backface-visibility property still works correctly when there is an element outside the 3-D rendering context that is, in tree order, in between the element with backface-visibility and the root of the 3-D Rendering Context">
+
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#outer {
+  transform-style: preserve-3d;
+  transform: rotateX(120deg);
+  position: relative;
+}
+
+#outer > div {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+#grandchild {
+  transform: translateZ(1px);
+}
+
+#child2 {
+  transform-style: preserve-3d;
+  transform: translateX(0);
+  backface-visibility: hidden;
+  background: red;
+}
+
+</style>
+
+<div id="outer">
+  <div id="child1"><div id="grandchild"></div></div>
+  <div id="child2"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/offset-change-inline-backface-visibility-hidden.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/offset-change-inline-backface-visibility-hidden.html
@@ -1,0 +1,23 @@
+<!doctype HTML>
+<html class="reftest-wait">
+<title>CSS Test: Repaint after moving an inline element with backface-visibility:hidden</title>
+<link rel="author" title="Xianzhu Wang" href="mailto:wangxianzhu@chromium.org" />
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">
+<link rel="help" href="https://crbug.com/455884493">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/offset-change-inline-backface-visibility-hidden-ref.html">
+<link rel="stylesheet" href="../../../../data/fonts/ahem.css">
+<script src="../../common/reftest-wait.js"></script>
+<div id="container">
+  <div style="width: 100px; background: green; font-family: ahem">
+    <span style="backface-visibility: hidden">X</span>
+  </div>
+</div>
+<script>
+  onload = function() {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      container.style.marginLeft = '100px';
+      takeScreenshot();
+    }));
+  };
+</script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/size-change-under-backface-visibility-hidden.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/size-change-under-backface-visibility-hidden.html
@@ -1,0 +1,22 @@
+<!doctype HTML>
+<html class="reftest-wait">
+  <title>CSS Test: Test for re-paint after resizing an element underneath a backface-visibility hidden element</title>
+  <link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org" />
+  <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/size-change-under-backface-visibility-hidden-ref.html">
+  <script src="../../common/reftest-wait.js"></script>
+  Passes if it shows a green 200x200 square.
+  <div style="will-change: transform; width: 300px; height: 0px">
+    <div style="width: 1px; height: 1px; backface-visibility: hidden;">
+      <div id=target style="width: 200px; height: 0px; position: relative; background: green; left: 10px;"></div>
+    </div>
+  </div>
+  <script>
+    onload = function() {
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        target.style.height = '200px';
+        takeScreenshot();
+      }));
+    };
+  </script>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/subpixel-perspective-backface-hidden.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/subpixel-perspective-backface-hidden.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link ref="help" href="https://drafts.csswg.org/css-transforms-2/#perspective-property">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/subpixel-perspective-backface-hidden-ref.html">
+<meta name="assert" content="Subpixel-positioned contents should be rendered the same regardless of perspective and backface-visibility:hidden">
+<div style="padding: 0.4px 0.6px">
+  <div style="perspective: 1000px; backface-visibility: hidden">
+    <div style="width: 100px; height: 100px;
+                backface-visibility: hidden;border: 1px solid black">
+    </div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-001.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Simple Backface-Visibility, rotatex(180deg)</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content='This tests that a very simple case of
+    backface-visibility causes the element to disappear: rotateX(180deg) is
+    specified on the same element that has backface-visibility: hidden.'>
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+    <style>div { height: 100px; width: 100px }</style>
+  </head>
+  <body>
+    <div style="background:lime">
+      <div style="background:red;transform:rotatex(180deg);
+        backface-visibility:hidden">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-002.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Backface-Visibility With Transformed Parent
+    and Child in Different Rendering Contexts</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content="This tests that if an element has
+    'backface-visibility: hidden' and is rotated 180deg, so it would normally
+    disappear, it doesn't reappear just because its parent also has a 180deg
+    rotation.  The rotations don't cancel, since the parent doesn't have
+    'transform-style: preserve-3d' and is in a different rendering context.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="height:100px;width:100px;background:lime;
+      transform:rotatex(180deg)">
+      <div style="height:100px;width:100px;background:red;
+        transform:rotatex(180deg);backface-visibility:hidden">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Simple Backface-Visibility, rotatex(180deg) on Table</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content='This is identical to
+    transform3d-backface-visibility-001.html, except that display: table is
+    specified too.  This is motivated by a real-world UA bug:
+    <https://bugzilla.mozilla.org/show_bug.cgi?id=724750>.'>
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="height:100px;width:100px;background:lime">
+      <div style="height:100px;width:100px;background:red;
+        transform:rotatex(180deg);backface-visibility:hidden;display:table">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-004.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Backface-Visibility With Transformed Parent
+    in Same Rendering Context, Split Transform</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content="This tests that if a parent and child are in
+    the same 3D rendering context, and a 60deg rotation on the parent combines
+    with a 60deg rotation on the child to make a 120deg rotation, the child
+    will disappear if 'backface-visibility: hidden' is specified, just like if
+    the 120deg rotation were specified on the child to start with.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="height:100px;width:100px;background:lime">
+      <div style="transform:rotatex(60deg);transform-style:preserve-3d">
+        <div style="height:100px;width:100px;background:red;
+          transform:rotatex(60deg);backface-visibility:hidden">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-005.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Backface-Visibility With Transformed Parent
+    in Different Rendering Context</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content="This tests that if an element is not
+    transformed, but its parent is rotated 180deg in a different rendering
+    context, the child's 'backface-visibility: hidden' does not make it
+    disappear.  Only transforms that affect the child itself are relevant to
+    'backface-visibility'.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+    <style>div { width: 100px; height: 100px }</style>
+  </head>
+  <body>
+    <div style="transform: rotateX(180deg); background: red">
+      <div style="backface-visibility: hidden; background: lime">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-006.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Backface-Visibility With Transformed Parent
+    in Same Rendering Context</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content="This is the same as
+    transform3d-backface-visibility-005.html, except that the parent has
+    'transform-style: preserve-3d'.  Thus the child is affected by the parent's
+    transform and should not be visible.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+    <style>div { width: 100px; height: 100px }</style>
+  </head>
+  <body>
+    <div style="transform: rotateX(180deg); transform-style: preserve-3d;
+      background: lime">
+      <div style="backface-visibility: hidden; background: red">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-007.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Simple Backface-Visibility, scalez(-1)</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#propdef-backface-visibility">
+    <meta name="assert" content="This is the same as
+    transform3d-backface-visibility-001.html, except it uses scalez(-1) instead
+    of rotatex(180deg).  scalez(-1) has no visible effect when applied by
+    itself to a box, since the box's Z-coordinates are all 0, but it still
+    causes it to be affected by 'backface-visibility'.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+    <style>div { height: 100px; width: 100px }</style>
+  </head>
+  <body>
+    <div style="background: lime">
+      <div style="background: red; backface-visibility: hidden;
+        transform: scalez(-1)">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-008.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-backface-visibility-008.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Transforms Test: backface-visibility - visible</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="reviewer" title="Zhiqiang Zhang" href="mailto:zhiqiang.zhang@intel.com"> <!-- 2015-05-22 -->
+<link rel="help" href="http://www.w3.org/TR/css-transforms-2/#backface-visibility-property">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="When 'backface-visiblity' is set to visible,
+                             the back side of a transformed element is visible.">
+<style>
+  div {
+    height: 100px;
+    width: 100px;
+  }
+
+  body > div {
+    background: red;
+  }
+
+  div > div {
+    background: green;
+    backface-visibility: visible;
+    transform: rotateY(180deg);
+  }
+</style>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div>
+    <div></div>
+  </div>
+</body>
+

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-has-indexed-property-getter.txt
@@ -97,6 +97,7 @@ All properties associated with getComputedStyle(document.body):
     "appearance",
     "aspect-ratio",
     "backdrop-filter",
+    "backface-visibility",
     "background-attachment",
     "background-blend-mode",
     "background-clip",

--- a/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleProperties-all-supported-properties-and-default-values.txt
@@ -215,6 +215,8 @@ All supported properties and their default values exposed from CSSStylePropertie
 'aspect-ratio': 'auto'
 'backdropFilter': 'none'
 'backdrop-filter': 'none'
+'backfaceVisibility': 'visible'
+'backface-visibility': 'visible'
 'background': 'none'
 'backgroundAttachment': 'scroll'
 'background-attachment': 'scroll'

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -95,6 +95,7 @@ animation-timing-function: ease
 appearance: none
 aspect-ratio: auto
 backdrop-filter: none
+backface-visibility: visible
 background-attachment: scroll
 background-blend-mode: normal
 background-clip: border-box
@@ -105,7 +106,7 @@ background-position-x: 0%
 background-position-y: 0%
 background-repeat: repeat
 background-size: auto
-block-size: 1391px
+block-size: 1404px
 border-block-end-color: rgb(0, 0, 0)
 border-block-end-style: none
 border-block-end-width: 0px
@@ -193,7 +194,7 @@ grid-row-start: auto
 grid-template-areas: none
 grid-template-columns: none
 grid-template-rows: none
-height: 2535px
+height: 2548px
 inline-size: 784px
 inset-block-end: auto
 inset-block-start: auto

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-cascade/all-prop-revert-layer.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 308 tests
+Found 309 tests
 
-304 Pass
+305 Pass
 4 Fail
 Pass	accent-color
 Pass	border-collapse
@@ -96,6 +96,7 @@ Pass	animation-timing-function
 Pass	appearance
 Pass	aspect-ratio
 Pass	backdrop-filter
+Pass	backface-visibility
 Pass	background-attachment
 Pass	background-blend-mode
 Pass	background-clip

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/inline-with-filter-and-hidden-backface.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/inline-with-filter-and-hidden-backface.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Hit test

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/backface-visibility-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/backface-visibility-computed.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	Property backface-visibility value 'visible'
+Pass	Property backface-visibility value 'hidden'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/backface-visibility-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/backface-visibility-invalid.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	e.style['backface-visibility'] = "auto" should not set the property value
+Pass	e.style['backface-visibility'] = "visible hidden" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/backface-visibility-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/parsing/backface-visibility-valid.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	e.style['backface-visibility'] = "visible" should set the property value
+Pass	e.style['backface-visibility'] = "hidden" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/preserve3d-backface-hit-test-1.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/preserve3d-backface-hit-test-1.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Hit test back face hidden preserve3d, hittesting

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/inline-with-filter-and-hidden-backface.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/inline-with-filter-and-hidden-backface.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mailto:mstensho@chromium.org">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1321302">
+<span id="elm" style="filter:blur(1px); backface-visibility:hidden;">x</span>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  test(()=> {
+    assert_equals(elm, document.elementFromPoint(10, 10));
+  }, "Hit test");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/parsing/backface-visibility-computed.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/parsing/backface-visibility-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: getComputedStyle().backfaceVisibility</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<meta name="assert" content="backface-visibility computed value is as specified.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("backface-visibility", "visible");
+test_computed_value("backface-visibility", "hidden");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/parsing/backface-visibility-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/parsing/backface-visibility-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: parsing backface-visibility with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<meta name="assert" content="backface-visibility supports only the grammar 'visible | hidden'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("backface-visibility", "auto");
+test_invalid_value("backface-visibility", "visible hidden");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/parsing/backface-visibility-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/parsing/backface-visibility-valid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transform Module Level 2: parsing backface-visibility with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<meta name="assert" content="backface-visibility supports the full grammar 'visible | hidden'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("backface-visibility", "visible");
+test_valid_value("backface-visibility", "hidden");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/preserve3d-backface-hit-test-1.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/preserve3d-backface-hit-test-1.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<title>Hit test back face hidden preserve3d</title>
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#backface-visibility-property">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  .container {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    perspective: 600px;
+    width: 200px;
+    height: 200px;
+  }
+
+  .rotatetoback {
+    width: 100%;
+    height: 100%;
+    transform-style: preserve-3d;
+    transform: rotateY(-180deg);
+  }
+
+  .hideback {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+  }
+
+  .rotatetofront {
+    transform: rotateY(180deg);
+  }
+</style>
+
+<body>
+
+<div class="container">
+  <div class="rotatetoback" >
+    <div id="target" class="hideback rotatetofront" style="background: blue">
+    </div>
+    <div class="hideback" style="background: green;">
+    </div>
+  </div>
+</div>
+
+</body>
+
+<script>
+
+  test(t => {
+    const expectedElemId = "target";
+    const expectedElem = document.getElementById(expectedElemId);
+    const x = 150;
+    const y = 150;
+    const hitElem = document.elementFromPoint(x, y);
+    assert_equals(hitElem, expectedElem,
+      `point (${x}, ${y}) is inside element ${expectedElemId}`);
+  }, `${document.title}, hittesting`);
+
+</script>
+
+</html>


### PR DESCRIPTION
A transformable element with a `backface-visibility` of `hidden` records a marker node in the AVC tree, which stores the element's plane root. This is where accumulation of the element's 3D transformation matrix begins. It sits just below the transform of the nearest flattening ancestor. A flattening ancestor is one whose `transform-style` is `flat`. Such an ancestor flattens its descendants into its own plane and starts a new 3D rendering context. Ancestors with `preserve-3d` extend the element's plane, so accumulation continues through their transforms.

During display list replay, content under a marker is skipped while the transform accumulated from the plane root to the marker is back facing. Hit testing rejects points the same way. Evaluating at replay time keeps the decision correct when scroll offsets change the accumulated matrix under a perspective.

The spec expects visibility to be determined by inspecting m33 of the accumulated matrix. We deviate from this because m33 gives the wrong answer for matrices with a perspective component. Replay instead transforms the plane normal and tests the sign of its z-component. Relevant spec issue: https://github.com/w3c/csswg-drafts/issues/917.

NB: Currently 3D transforms aren't flattened (see: #8006), but the backface visibility calculation can be made independently of this.

---

A good example of backface-visibility in action from https://www.hankgreen.com/fourbythree/, which uses 3D rotating card animations:

Before (card backfaces visible):
<img width="1046" height="638" alt="image" src="https://github.com/user-attachments/assets/555161dd-2f4b-4f8e-a18b-220f1efdb522" />

After (card backfaces hidden):
<img width="1046" height="638" alt="image" src="https://github.com/user-attachments/assets/0a1ebc28-3384-48f3-95fb-80900d21fc35" />