### PR TITLE
LibWeb: Implement some missing IDL interface members

### DIFF
--- a/Libraries/LibWeb/CSS/TransitionEvent.cpp
+++ b/Libraries/LibWeb/CSS/TransitionEvent.cpp
@@ -7,6 +7,7 @@
 #include "TransitionEvent.h"
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/TransitionEvent.h>
+#include <LibWeb/CSS/CSSTransition.h>
 
 namespace Web::CSS {
 
@@ -29,6 +30,7 @@ TransitionEvent::TransitionEvent(JS::Realm& realm, Utf16FlyString const& type, B
     , m_property_name(event_init.property_name)
     , m_elapsed_time(event_init.elapsed_time)
     , m_pseudo_element(event_init.pseudo_element)
+    , m_animation(event_init.animation)
 {
 }
 
@@ -38,6 +40,12 @@ void TransitionEvent::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(TransitionEvent);
     Base::initialize(realm);
+}
+
+void TransitionEvent::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_animation);
 }
 
 }

--- a/Libraries/LibWeb/CSS/TransitionEvent.h
+++ b/Libraries/LibWeb/CSS/TransitionEvent.h
@@ -25,6 +25,9 @@ public:
     Utf16String const& property_name() const { return m_property_name; }
     double elapsed_time() const { return m_elapsed_time; }
     Utf16String const& pseudo_element() const { return m_pseudo_element; }
+    GC::Ptr<CSSTransition> animation() const { return m_animation; }
+
+    virtual void visit_edges(Cell::Visitor&) override;
 
 private:
     TransitionEvent(JS::Realm&, Utf16FlyString const& event_name, Bindings::TransitionEventInit const& event_init);
@@ -34,6 +37,7 @@ private:
     Utf16String m_property_name {};
     double m_elapsed_time {};
     Utf16String m_pseudo_element {};
+    GC::Ptr<CSSTransition> m_animation;
 };
 
 }

--- a/Libraries/LibWeb/CSS/TransitionEvent.idl
+++ b/Libraries/LibWeb/CSS/TransitionEvent.idl
@@ -1,16 +1,19 @@
-// https://drafts.csswg.org/css-transitions/#transitionevent
+// https://drafts.csswg.org/css-transitions-2/#interface-transitionevent-idl
 [Exposed=Window]
 interface TransitionEvent : Event {
     constructor([Utf16FlyString] Utf16CSSOMString type, optional TransitionEventInit transitionEventInitDict = {});
     readonly attribute Utf16CSSOMString propertyName;
     readonly attribute double elapsedTime;
     readonly attribute Utf16CSSOMString pseudoElement;
+    readonly attribute CSSTransition? animation;
 };
 
+// https://drafts.csswg.org/css-transitions-2/#interface-transitionevent-idl
 dictionary TransitionEventInit : EventInit {
     Utf16CSSOMString propertyName = "";
     double elapsedTime = 0.0;
     Utf16CSSOMString pseudoElement = "";
+    CSSTransition? animation = null;
 };
 
 // https://drafts.csswg.org/css-transitions/#interface-globaleventhandlers-idl

--- a/Libraries/LibWeb/CSS/TransitionEvent.idl
+++ b/Libraries/LibWeb/CSS/TransitionEvent.idl
@@ -12,3 +12,11 @@ dictionary TransitionEventInit : EventInit {
     double elapsedTime = 0.0;
     Utf16CSSOMString pseudoElement = "";
 };
+
+// https://drafts.csswg.org/css-transitions/#interface-globaleventhandlers-idl
+partial interface mixin GlobalEventHandlers {
+    attribute EventHandler ontransitionrun;
+    attribute EventHandler ontransitionstart;
+    attribute EventHandler ontransitionend;
+    attribute EventHandler ontransitioncancel;
+};

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3909,6 +3909,7 @@ void Document::dispatch_events_for_transition(GC::Ref<CSS::CSSTransition> transi
             pseudo_element.has_value()) {
             event_init.pseudo_element = pseudo_element.release_value();
         }
+        event_init.animation = transition;
 
         auto timeline = transition->timeline();
 

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -125,8 +125,9 @@ interface Document : Node {
     [LegacyLenientThis] attribute EventHandler onreadystatechange;
     attribute EventHandler onvisibilitychange;
 
-    // https://drafts.csswg.org/css-view-transitions-1/#additions-to-document-api
+    // https://drafts.csswg.org/css-view-transitions-2/#additions-to-document-api
     [Experimental] ViewTransition startViewTransition(optional ViewTransitionUpdateCallback updateCallback);
+    [Experimental] readonly attribute ViewTransition? activeViewTransition;
 
     // https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceDocumentExtensions
     readonly attribute SVGSVGElement? rootElement;

--- a/Libraries/LibWeb/DOM/StyleElementBase.cpp
+++ b/Libraries/LibWeb/DOM/StyleElementBase.cpp
@@ -306,6 +306,33 @@ CSS::CSSStyleSheet const* StyleElementBase::sheet() const
     return m_associated_css_style_sheet;
 }
 
+// https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled
+bool StyleElementBase::disabled()
+{
+    // 1. If this does not have an associated CSS style sheet, return false.
+    if (!sheet())
+        return false;
+
+    // 2. If this's associated CSS style sheet's disabled flag is set, return true.
+    if (sheet()->disabled())
+        return true;
+
+    // 3. Return false.
+    return false;
+}
+
+// https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled
+void StyleElementBase::set_disabled(bool disabled)
+{
+    // 1. If this does not have an associated CSS style sheet, return.
+    if (!sheet())
+        return;
+
+    // 2. If the given value is true, set this's associated CSS style sheet's disabled flag.
+    //    Otherwise, unset this's associated CSS style sheet's disabled flag.
+    sheet()->set_disabled(disabled);
+}
+
 void StyleElementBase::visit_style_element_edges(JS::Cell::Visitor& visitor)
 {
     visitor.visit(m_associated_css_style_sheet);

--- a/Libraries/LibWeb/DOM/StyleElementBase.h
+++ b/Libraries/LibWeb/DOM/StyleElementBase.h
@@ -33,6 +33,9 @@ public:
     CSS::CSSStyleSheet* sheet();
     CSS::CSSStyleSheet const* sheet() const;
 
+    bool disabled();
+    void set_disabled(bool disabled);
+
     [[nodiscard]] GC::Ptr<CSS::StyleSheetList> style_sheet_list() { return m_style_sheet_list; }
     [[nodiscard]] GC::Ptr<CSS::StyleSheetList const> style_sheet_list() const { return m_style_sheet_list; }
 

--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -249,6 +249,10 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onsuspend, "onsuspend")                                             \
     __ENUMERATE_HTML_ATTRIBUTE(ontimeupdate, "ontimeupdate")                                       \
     __ENUMERATE_HTML_ATTRIBUTE(ontoggle, "ontoggle")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(ontransitioncancel, "ontransitioncancel")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(ontransitionend, "ontransitionend")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(ontransitionrun, "ontransitionrun")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(ontransitionstart, "ontransitionstart")                             \
     __ENUMERATE_HTML_ATTRIBUTE(onunhandledrejection, "onunhandledrejection")                       \
     __ENUMERATE_HTML_ATTRIBUTE(onunload, "onunload")                                               \
     __ENUMERATE_HTML_ATTRIBUTE(onvolumechange, "onvolumechange")                                   \

--- a/Libraries/LibWeb/HTML/GlobalEventHandlers.h
+++ b/Libraries/LibWeb/HTML/GlobalEventHandlers.h
@@ -99,6 +99,10 @@
     E(onsuspend, HTML::EventNames::suspend)                                   \
     E(ontimeupdate, HTML::EventNames::timeupdate)                             \
     E(ontoggle, HTML::EventNames::toggle)                                     \
+    E(ontransitioncancel, HTML::EventNames::transitioncancel)                 \
+    E(ontransitionend, HTML::EventNames::transitionend)                       \
+    E(ontransitionrun, HTML::EventNames::transitionrun)                       \
+    E(ontransitionstart, HTML::EventNames::transitionstart)                   \
     E(onvolumechange, HTML::EventNames::volumechange)                         \
     E(onwaiting, HTML::EventNames::waiting)                                   \
     E(onwebkitanimationend, HTML::EventNames::webkitAnimationEnd)             \

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -63,33 +63,6 @@ void HTMLStyleElement::attribute_changed(Utf16FlyString const& name, Optional<Ut
     style_element_attribute_changed(name, value);
 }
 
-// https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled
-bool HTMLStyleElement::disabled()
-{
-    // 1. If this does not have an associated CSS style sheet, return false.
-    if (!sheet())
-        return false;
-
-    // 2. If this's associated CSS style sheet's disabled flag is set, return true.
-    if (sheet()->disabled())
-        return true;
-
-    // 3. Return false.
-    return false;
-}
-
-// https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled
-void HTMLStyleElement::set_disabled(bool disabled)
-{
-    // 1. If this does not have an associated CSS style sheet, return.
-    if (!sheet())
-        return;
-
-    // 2. If the given value is true, set this's associated CSS style sheet's disabled flag.
-    //    Otherwise, unset this's associated CSS style sheet's disabled flag.
-    sheet()->set_disabled(disabled);
-}
-
 // https://html.spec.whatwg.org/multipage/semantics.html#contributes-a-script-blocking-style-sheet
 bool HTMLStyleElement::contributes_a_script_blocking_style_sheet() const
 {

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -26,9 +26,6 @@ public:
     virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
 
-    bool disabled();
-    void set_disabled(bool disabled);
-
     virtual bool contributes_a_script_blocking_style_sheet() const final;
 
 private:

--- a/Libraries/LibWeb/HTML/PopStateEvent.cpp
+++ b/Libraries/LibWeb/HTML/PopStateEvent.cpp
@@ -27,6 +27,7 @@ GC::Ref<PopStateEvent> PopStateEvent::construct_impl(JS::Realm& realm, Utf16FlyS
 PopStateEvent::PopStateEvent(JS::Realm& realm, Utf16FlyString const& event_name, Bindings::PopStateEventInit const& event_init)
     : DOM::Event(realm, event_name, event_init)
     , m_state(event_init.state)
+    , m_has_ua_visual_transition(event_init.has_ua_visual_transition)
 {
 }
 

--- a/Libraries/LibWeb/HTML/PopStateEvent.h
+++ b/Libraries/LibWeb/HTML/PopStateEvent.h
@@ -20,6 +20,7 @@ public:
     [[nodiscard]] static GC::Ref<PopStateEvent> construct_impl(JS::Realm&, Utf16FlyString const& event_name, Bindings::PopStateEventInit const&);
 
     JS::Value const& state() const { return m_state; }
+    bool has_ua_visual_transition() const { return m_has_ua_visual_transition; }
 
 private:
     PopStateEvent(JS::Realm&, Utf16FlyString const& event_name, Bindings::PopStateEventInit const& event_init);
@@ -28,6 +29,7 @@ private:
     virtual void visit_edges(JS::Cell::Visitor& visitor) override;
 
     JS::Value m_state { JS::js_null() };
+    bool m_has_ua_visual_transition { false };
 };
 
 }

--- a/Libraries/LibWeb/HTML/PopStateEvent.idl
+++ b/Libraries/LibWeb/HTML/PopStateEvent.idl
@@ -4,10 +4,10 @@ interface PopStateEvent : Event {
     constructor([Utf16FlyString] Utf16DOMString type, optional PopStateEventInit eventInitDict = {});
 
     readonly attribute any state;
-    [FIXME] readonly attribute boolean hasUAVisualTransition;
+    readonly attribute boolean hasUAVisualTransition;
 };
 
 dictionary PopStateEventInit : EventInit {
     any state = null;
-  // FIXME: boolean hasUAVisualTransition = false;
+    boolean hasUAVisualTransition = false;
 };

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/FragmentIdentifier.h>
 #include <LibWeb/SVG/SVGAnimatedRect.h>
+#include <LibWeb/SVG/SVGNumber.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
 #include <LibWeb/SVG/SVGViewElement.h>
 #include <LibWeb/Selection/Selection.h>
@@ -223,6 +224,12 @@ void SVGSVGElement::deselect_all() const
     // This is equivalent to calling document.getSelection().removeAllRanges() on the document that this ‘svg’ element is in.
     if (auto selection = document().get_selection())
         selection->remove_all_ranges();
+}
+
+// https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGNumber
+GC::Ref<SVGNumber> SVGSVGElement::create_svg_number() const
+{
+    return SVGNumber::create(realm(), 0, SVGNumber::ReadOnly::No);
 }
 
 GC::Ref<SVGLength> SVGSVGElement::create_svg_length() const

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -65,6 +65,7 @@ public:
 
     void deselect_all() const;
 
+    GC::Ref<SVGNumber> create_svg_number() const;
     GC::Ref<SVGLength> create_svg_length() const;
     GC::Ref<Geometry::DOMPoint> create_svg_point() const;
     GC::Ref<Geometry::DOMMatrix> create_svg_matrix() const;

--- a/Libraries/LibWeb/SVG/SVGSVGElement.idl
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.idl
@@ -16,7 +16,7 @@ interface SVGSVGElement : SVGGraphicsElement {
 
     undefined deselectAll();
 
-    // FIXME: [NewObject] SVGNumber createSVGNumber();
+    [NewObject] SVGNumber createSVGNumber();
     [NewObject] SVGLength createSVGLength();
     [FIXME, NewObject] SVGAngle createSVGAngle();
     [NewObject] DOMPoint createSVGPoint();

--- a/Libraries/LibWeb/SVG/SVGStyleElement.idl
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.idl
@@ -3,7 +3,8 @@
 interface SVGStyleElement : SVGElement {
     [Reflect] attribute Utf16DOMString media;
     [Reflect] attribute Utf16DOMString title;
-    
+    attribute boolean disabled;
+
     // obsolete members
     [Reflect] attribute Utf16DOMString type;
 };

--- a/Libraries/LibWeb/UIEvents/InputEvent.cpp
+++ b/Libraries/LibWeb/UIEvents/InputEvent.cpp
@@ -26,7 +26,7 @@ GC::Ref<InputEvent> InputEvent::create_from_platform_event(JS::Realm& realm, Utf
 
 WebIDL::ExceptionOr<GC::Ref<InputEvent>> InputEvent::construct_impl(JS::Realm& realm, Utf16FlyString const& event_name, Bindings::InputEventInit const& event_init)
 {
-    return realm.create<InputEvent>(realm, event_name, event_init);
+    return realm.create<InputEvent>(realm, event_name, event_init, event_init.target_ranges);
 }
 
 InputEvent::InputEvent(JS::Realm& realm, Utf16FlyString const& event_name, Bindings::InputEventInit const& event_init, Vector<GC::Ref<DOM::StaticRange>> const& target_ranges)

--- a/Libraries/LibWeb/UIEvents/InputEvent.cpp
+++ b/Libraries/LibWeb/UIEvents/InputEvent.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/InputEvent.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/HTML/DataTransfer.h>
 #include <LibWeb/UIEvents/InputEvent.h>
 
 namespace Web::UIEvents {
@@ -33,6 +34,7 @@ InputEvent::InputEvent(JS::Realm& realm, Utf16FlyString const& event_name, Bindi
     , m_data(event_init.data)
     , m_is_composing(event_init.is_composing)
     , m_input_type(event_init.input_type)
+    , m_data_transfer(event_init.data_transfer)
     , m_target_ranges(target_ranges)
 {
 }
@@ -48,6 +50,7 @@ void InputEvent::initialize(JS::Realm& realm)
 void InputEvent::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_data_transfer);
     visitor.visit(m_target_ranges);
 }
 

--- a/Libraries/LibWeb/UIEvents/InputEvent.h
+++ b/Libraries/LibWeb/UIEvents/InputEvent.h
@@ -30,6 +30,8 @@ public:
     // https://w3c.github.io/uievents/#dom-inputevent-inputtype
     Utf16FlyString input_type() const { return m_input_type; }
 
+    GC::Ptr<HTML::DataTransfer> data_transfer() const { return m_data_transfer; }
+
     ReadonlySpan<GC::Ref<DOM::StaticRange>> get_target_ranges() const;
 
 private:
@@ -41,6 +43,7 @@ private:
     Optional<Utf16String> m_data;
     bool m_is_composing;
     Utf16FlyString m_input_type;
+    GC::Ptr<HTML::DataTransfer> m_data_transfer;
     Vector<GC::Ref<DOM::StaticRange>> m_target_ranges;
 };
 

--- a/Libraries/LibWeb/UIEvents/InputEvent.idl
+++ b/Libraries/LibWeb/UIEvents/InputEvent.idl
@@ -6,6 +6,8 @@ interface InputEvent : UIEvent {
     readonly attribute boolean isComposing;
     readonly attribute Utf16DOMString inputType;
 
+    // https://w3c.github.io/input-events/#interface-InputEvent
+    readonly attribute DataTransfer? dataTransfer;
     sequence<StaticRange> getTargetRanges();
 };
 
@@ -14,4 +16,7 @@ dictionary InputEventInit : UIEventInit {
     Utf16DOMString? data = null;
     boolean isComposing = false;
     [Utf16FlyString] Utf16DOMString inputType = "";
+
+    // https://w3c.github.io/input-events/#interface-InputEvent
+    DataTransfer? dataTransfer = null;
 };

--- a/Libraries/LibWeb/UIEvents/InputEvent.idl
+++ b/Libraries/LibWeb/UIEvents/InputEvent.idl
@@ -19,4 +19,5 @@ dictionary InputEventInit : UIEventInit {
 
     // https://w3c.github.io/input-events/#interface-InputEvent
     DataTransfer? dataTransfer = null;
+    sequence<StaticRange> targetRanges = [];
 };

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -138,6 +138,7 @@ Text/input/wpt-import/css/css-animations/idlharness.html
 Text/input/wpt-import/css/css-conditional/idlharness.html
 Text/input/wpt-import/css/css-counter-styles/idlharness.html
 Text/input/wpt-import/css/css-fonts/idlharness.html
+Text/input/wpt-import/css/css-transitions/idlharness.html
 Text/input/wpt-import/css/css-typed-om/idlharness.html
 Text/input/wpt-import/css/cssom-view/idlharness.html
 Text/input/wpt-import/gamepad/idlharness.window.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -143,6 +143,7 @@ Text/input/wpt-import/css/css-typed-om/idlharness.html
 Text/input/wpt-import/css/cssom-view/idlharness.html
 Text/input/wpt-import/gamepad/idlharness.window.html
 Text/input/wpt-import/geolocation/idlharness.https.window.html
+Text/input/wpt-import/input-events/idlharness.window.html
 Text/input/wpt-import/notifications/idlharness.https.any.html
 Text/input/wpt-import/permissions/idlharness.any.html
 Text/input/wpt-import/permissions/idlharness.any.worker.html

--- a/Tests/LibWeb/Text/expected/SVG/svg-create-svg-number.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-create-svg-number.txt
@@ -1,0 +1,4 @@
+is an SVGNumber: true
+initial value: 0
+value after assignment: 12.5
+returns a new object each call: true

--- a/Tests/LibWeb/Text/expected/SVG/svg-style-element-disabled.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-style-element-disabled.txt
@@ -1,0 +1,6 @@
+disabled: false
+fill: rgb(0, 128, 0)
+disabled after disabling: true
+fill after disabling: rgb(0, 0, 0)
+disabled after enabling: false
+fill after enabling: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/expected/UIEvents/InputEvent-construction-target-ranges.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/InputEvent-construction-target-ranges.txt
@@ -1,0 +1,6 @@
+range count: 1
+start container is the text node: true
+start offset: 1
+end offset: 3
+collapsed: false
+range count without targetRanges: 0

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/events-008.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/events-008.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	transitionrun event has animation property and its value is the corresponding CSSTransition object
+Pass	transitionstart event has animation property and its value is the corresponding CSSTransition object
+Pass	transitionend event has animation property and its value is the corresponding CSSTransition object

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/idlharness.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/idlharness.txt
@@ -1,0 +1,69 @@
+Harness status: OK
+
+Found 64 tests
+
+64 Pass
+Pass	idl_test setup
+Pass	idl_test validation
+Pass	Partial interface mixin GlobalEventHandlers: original interface mixin defined
+Pass	Partial interface mixin GlobalEventHandlers: member names are unique
+Pass	Partial interface Document: member names are unique
+Pass	Partial interface Element: member names are unique
+Pass	Partial interface Document[2]: member names are unique
+Pass	Partial interface Window: member names are unique
+Pass	Document includes GlobalEventHandlers: member names are unique
+Pass	HTMLElement includes GlobalEventHandlers: member names are unique
+Pass	HTMLElement includes ElementContentEditable: member names are unique
+Pass	HTMLElement includes HTMLOrSVGElement: member names are unique
+Pass	Window includes GlobalEventHandlers: member names are unique
+Pass	Window includes WindowEventHandlers: member names are unique
+Pass	Window includes WindowOrWorkerGlobalScope: member names are unique
+Pass	Window includes AnimationFrameProvider: member names are unique
+Pass	Window includes WindowSessionStorage: member names are unique
+Pass	Window includes WindowLocalStorage: member names are unique
+Pass	Document includes NonElementParentNode: member names are unique
+Pass	Document includes DocumentOrShadowRoot: member names are unique
+Pass	Document includes ParentNode: member names are unique
+Pass	Element includes ParentNode: member names are unique
+Pass	Element includes NonDocumentTypeChildNode: member names are unique
+Pass	Element includes ChildNode: member names are unique
+Pass	Element includes Slottable: member names are unique
+Pass	Document includes XPathEvaluatorBase: member names are unique
+Pass	TransitionEvent interface: existence and properties of interface object
+Pass	TransitionEvent interface object length
+Pass	TransitionEvent interface object name
+Pass	TransitionEvent interface: existence and properties of interface prototype object
+Pass	TransitionEvent interface: existence and properties of interface prototype object's "constructor" property
+Pass	TransitionEvent interface: existence and properties of interface prototype object's @@unscopables property
+Pass	TransitionEvent interface: attribute propertyName
+Pass	TransitionEvent interface: attribute elapsedTime
+Pass	TransitionEvent interface: attribute pseudoElement
+Pass	TransitionEvent must be primary interface of new TransitionEvent("transitionend")
+Pass	Stringification of new TransitionEvent("transitionend")
+Pass	TransitionEvent interface: new TransitionEvent("transitionend") must inherit property "propertyName" with the proper type
+Pass	TransitionEvent interface: new TransitionEvent("transitionend") must inherit property "elapsedTime" with the proper type
+Pass	TransitionEvent interface: new TransitionEvent("transitionend") must inherit property "pseudoElement" with the proper type
+Pass	HTMLElement interface: attribute ontransitionrun
+Pass	HTMLElement interface: attribute ontransitionstart
+Pass	HTMLElement interface: attribute ontransitionend
+Pass	HTMLElement interface: attribute ontransitioncancel
+Pass	HTMLElement interface: document must inherit property "ontransitionrun" with the proper type
+Pass	HTMLElement interface: document must inherit property "ontransitionstart" with the proper type
+Pass	HTMLElement interface: document must inherit property "ontransitionend" with the proper type
+Pass	HTMLElement interface: document must inherit property "ontransitioncancel" with the proper type
+Pass	Window interface: attribute ontransitionrun
+Pass	Window interface: attribute ontransitionstart
+Pass	Window interface: attribute ontransitionend
+Pass	Window interface: attribute ontransitioncancel
+Pass	Window interface: window must inherit property "ontransitionrun" with the proper type
+Pass	Window interface: window must inherit property "ontransitionstart" with the proper type
+Pass	Window interface: window must inherit property "ontransitionend" with the proper type
+Pass	Window interface: window must inherit property "ontransitioncancel" with the proper type
+Pass	Document interface: attribute ontransitionrun
+Pass	Document interface: attribute ontransitionstart
+Pass	Document interface: attribute ontransitionend
+Pass	Document interface: attribute ontransitioncancel
+Pass	Document interface: document must inherit property "ontransitionrun" with the proper type
+Pass	Document interface: document must inherit property "ontransitionstart" with the proper type
+Pass	Document interface: document must inherit property "ontransitionend" with the proper type
+Pass	Document interface: document must inherit property "ontransitioncancel" with the proper type

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/transitionevent-interface.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/transitionevent-interface.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 41 tests
+Found 42 tests
 
-41 Pass
+42 Pass
 Pass	the event is an instance of TransitionEvent
 Pass	the event inherts from Event
 Pass	Missing type argument
@@ -44,3 +44,4 @@ Pass	elapsedTime cannot be set to 'sample'
 Pass	elapsedTime cannot be set to [0.5, 1.0]
 Pass	elapsedTime cannot be set to an object
 Pass	TransitionEventInit properties set value
+Pass	TransitionEventInit animation property sets value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-view-transitions/document-active-view-transition.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-view-transitions/document-active-view-transition.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	document.activeViewTransition returns the active transition

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/history-traversal/PopStateEvent.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/history-traversal/PopStateEvent.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	PopStateEvent constructor called as normal function
+Pass	initPopStateEvent
+Pass	Initial value of PopStateEvent.state must be null
+Pass	Initial value of PopStateEvent.hasUAVisualTransition must be false
+Pass	Dispatching a synthetic PopStateEvent

--- a/Tests/LibWeb/Text/expected/wpt-import/input-events/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/input-events/idlharness.window.txt
@@ -1,0 +1,18 @@
+Harness status: OK
+
+Found 13 tests
+
+13 Pass
+Pass	idl_test setup
+Pass	idl_test validation
+Pass	Partial interface InputEvent: original interface defined
+Pass	Partial interface InputEvent: member names are unique
+Pass	Partial dictionary InputEventInit: original dictionary defined
+Pass	Partial dictionary InputEventInit: member names are unique
+Pass	Partial interface UIEvent: member names are unique
+Pass	Partial interface UIEvent[2]: member names are unique
+Pass	Partial dictionary UIEventInit: member names are unique
+Pass	InputEvent interface: attribute dataTransfer
+Pass	InputEvent interface: operation getTargetRanges()
+Pass	InputEvent interface: new InputEvent("foo") must inherit property "dataTransfer" with the proper type
+Pass	InputEvent interface: new InputEvent("foo") must inherit property "getTargetRanges()" with the proper type

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 1780 tests
 
-1126 Pass
-654 Fail
+1131 Pass
+649 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Document: original interface defined
@@ -94,9 +94,9 @@ Pass	SVGNumber interface: existence and properties of interface prototype object
 Pass	SVGNumber interface: existence and properties of interface prototype object's "constructor" property
 Pass	SVGNumber interface: existence and properties of interface prototype object's @@unscopables property
 Pass	SVGNumber interface: attribute value
-Fail	SVGNumber must be primary interface of objects.svg.createSVGNumber()
-Fail	Stringification of objects.svg.createSVGNumber()
-Fail	SVGNumber interface: objects.svg.createSVGNumber() must inherit property "value" with the proper type
+Pass	SVGNumber must be primary interface of objects.svg.createSVGNumber()
+Pass	Stringification of objects.svg.createSVGNumber()
+Pass	SVGNumber interface: objects.svg.createSVGNumber() must inherit property "value" with the proper type
 Pass	SVGLength interface: existence and properties of interface object
 Pass	SVGLength interface object length
 Pass	SVGLength interface object name
@@ -417,7 +417,7 @@ Pass	SVGSVGElement interface: operation getEnclosureList(DOMRectReadOnly, SVGEle
 Pass	SVGSVGElement interface: operation checkIntersection(SVGElement, DOMRectReadOnly)
 Pass	SVGSVGElement interface: operation checkEnclosure(SVGElement, DOMRectReadOnly)
 Pass	SVGSVGElement interface: operation deselectAll()
-Fail	SVGSVGElement interface: operation createSVGNumber()
+Pass	SVGSVGElement interface: operation createSVGNumber()
 Pass	SVGSVGElement interface: operation createSVGLength()
 Fail	SVGSVGElement interface: operation createSVGAngle()
 Pass	SVGSVGElement interface: operation createSVGPoint()
@@ -454,7 +454,7 @@ Pass	SVGSVGElement interface: calling checkIntersection(SVGElement, DOMRectReadO
 Pass	SVGSVGElement interface: objects.svg must inherit property "checkEnclosure(SVGElement, DOMRectReadOnly)" with the proper type
 Pass	SVGSVGElement interface: calling checkEnclosure(SVGElement, DOMRectReadOnly) on objects.svg with too few arguments must throw TypeError
 Pass	SVGSVGElement interface: objects.svg must inherit property "deselectAll()" with the proper type
-Fail	SVGSVGElement interface: objects.svg must inherit property "createSVGNumber()" with the proper type
+Pass	SVGSVGElement interface: objects.svg must inherit property "createSVGNumber()" with the proper type
 Pass	SVGSVGElement interface: objects.svg must inherit property "createSVGLength()" with the proper type
 Fail	SVGSVGElement interface: objects.svg must inherit property "createSVGAngle()" with the proper type
 Pass	SVGSVGElement interface: objects.svg must inherit property "createSVGPoint()" with the proper type

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 1780 tests
 
-1124 Pass
-656 Fail
+1126 Pass
+654 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Document: original interface defined
@@ -670,13 +670,13 @@ Pass	SVGStyleElement interface: existence and properties of interface prototype 
 Pass	SVGStyleElement interface: attribute type
 Pass	SVGStyleElement interface: attribute media
 Pass	SVGStyleElement interface: attribute title
-Fail	SVGStyleElement interface: attribute disabled
+Pass	SVGStyleElement interface: attribute disabled
 Pass	SVGStyleElement must be primary interface of objects.style
 Pass	Stringification of objects.style
 Pass	SVGStyleElement interface: objects.style must inherit property "type" with the proper type
 Pass	SVGStyleElement interface: objects.style must inherit property "media" with the proper type
 Pass	SVGStyleElement interface: objects.style must inherit property "title" with the proper type
-Fail	SVGStyleElement interface: objects.style must inherit property "disabled" with the proper type
+Pass	SVGStyleElement interface: objects.style must inherit property "disabled" with the proper type
 Pass	SVGElement interface: objects.style must inherit property "className" with the proper type
 Pass	SVGElement interface: objects.style must inherit property "ownerSVGElement" with the proper type
 Pass	SVGElement interface: objects.style must inherit property "viewportElement" with the proper type

--- a/Tests/LibWeb/Text/input/SVG/svg-create-svg-number.html
+++ b/Tests/LibWeb/Text/input/SVG/svg-create-svg-number.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const svgNamespace = "http://www.w3.org/2000/svg";
+        const svg = document.createElementNS(svgNamespace, "svg");
+        const number = svg.createSVGNumber();
+
+        println(`is an SVGNumber: ${number instanceof SVGNumber}`);
+        println(`initial value: ${number.value}`);
+
+        number.value = 12.5;
+        println(`value after assignment: ${number.value}`);
+
+        println(`returns a new object each call: ${svg.createSVGNumber() !== number}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/SVG/svg-style-element-disabled.html
+++ b/Tests/LibWeb/Text/input/SVG/svg-style-element-disabled.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg>
+    <style>
+        rect { fill: green; }
+    </style>
+    <rect id="target" width="100" height="100"></rect>
+</svg>
+<script>
+    test(() => {
+        const style = document.querySelector("svg style");
+        const target = document.getElementById("target");
+
+        println(`disabled: ${style.disabled}`);
+        println(`fill: ${getComputedStyle(target).fill}`);
+
+        style.disabled = true;
+        println(`disabled after disabling: ${style.disabled}`);
+        println(`fill after disabling: ${getComputedStyle(target).fill}`);
+
+        style.disabled = false;
+        println(`disabled after enabling: ${style.disabled}`);
+        println(`fill after enabling: ${getComputedStyle(target).fill}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/UIEvents/InputEvent-construction-target-ranges.html
+++ b/Tests/LibWeb/Text/input/UIEvents/InputEvent-construction-target-ranges.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<script src="../include.js"></script>
+<div id="host">hello</div>
+<script>
+    test(() => {
+        const host = document.getElementById("host");
+        const range = new StaticRange({
+            startContainer: host.firstChild,
+            startOffset: 1,
+            endContainer: host.firstChild,
+            endOffset: 3,
+        });
+
+        const event = new InputEvent("beforeinput", { targetRanges: [range] });
+        const ranges = event.getTargetRanges();
+
+        println(`range count: ${ranges.length}`);
+        println(`start container is the text node: ${ranges[0].startContainer === host.firstChild}`);
+        println(`start offset: ${ranges[0].startOffset}`);
+        println(`end offset: ${ranges[0].endOffset}`);
+        println(`collapsed: ${ranges[0].collapsed}`);
+
+        const withoutRanges = new InputEvent("beforeinput");
+        println(`range count without targetRanges: ${withoutRanges.getTargetRanges().length}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/events-008.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/events-008.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<meta name="timeout" content="long">
+<title>CSS Transitions Test: TransitionEvent and animation property</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#interface-transitionevent">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  #test {
+    transition-property: opacity;
+    transition-duration: 1s;
+    opacity: 0;
+  }
+</style>
+<div id="test"></div>
+<script>
+  const testDiv = document.getElementById("test");
+  let anim = null; // transitionrun sets the animation.
+
+  getComputedStyle(testDiv).opacity;
+  requestAnimationFrame(() => {
+    testDiv.style.opacity = "1";
+  });
+
+  async_test(function(t) {
+    testDiv.addEventListener("transitionrun", t.step_func(function(evt) {
+      assert_idl_attribute(evt, "animation", "transitionrun has animation property");
+
+      assert_true(evt.animation instanceof window.CSSTransition, "animation property is an instance of CSSTransition");
+      assert_equals(evt.animation.transitionProperty, 'opacity', "animation property has a correct transition property");
+
+      t.done();
+    }), true);
+  }, "transitionrun event has animation property and its value is the corresponding CSSTransition object");
+
+  async_test(function(t) {
+    testDiv.addEventListener("transitionstart", t.step_func(function(evt) {
+      assert_idl_attribute(evt, "animation", "transitionstart has animation property");
+
+      assert_true(evt.animation instanceof window.CSSTransition, "animation property is an instance of CSSTransition");
+      assert_equals(evt.animation.transitionProperty, 'opacity', "animation property has a correct transition property");
+
+      t.done();
+    }), true);
+  }, "transitionstart event has animation property and its value is the corresponding CSSTransition object");
+
+  async_test(function(t) {
+    testDiv.addEventListener("transitionend", t.step_func(function(evt) {
+      assert_idl_attribute(evt, "animation", "transitionend has animation property");
+
+      assert_true(evt.animation instanceof window.CSSTransition, "animation property is an instance of CSSTransition");
+      assert_equals(evt.animation.transitionProperty, 'opacity', "animation property has a correct transition property");
+
+      t.done();
+    }), true);
+  }, "transitionend event has animation property and its value is the corresponding CSSTransition object");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/idlharness.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/idlharness.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>css-transitions IDL tests</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/WebIDLParser.js"></script>
+<script src="../../resources/idlharness.js"></script>
+<script>
+  "use strict";
+
+  idl_test(
+    ['css-transitions'],
+    ['cssom', 'html', 'dom'],
+    idl_array => {
+      idl_array.add_objects({
+        TransitionEvent: ['new TransitionEvent("transitionend")'],
+        // These include GlobalEventHandlers
+        Document: ['document'],
+        HTMLElement: ['document'],
+        Window: ['window'],
+      })
+    }
+  );
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/transitionevent-interface.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/transitionevent-interface.html
@@ -5,7 +5,8 @@
 
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
-<script src="transitionevent-interface.js"></script>
+
+<div id="test"></div>
 
 <script>
 test(function() {
@@ -226,4 +227,17 @@ test(function() {
   assert_equals(event.propertyName, "sample");
   assert_equals(event.elapsedTime, 0.5);
 }, "TransitionEventInit properties set value");
+
+test(function() {
+  var target = document.getElementById('test');
+  target.style.opacity = '0';
+  getComputedStyle(target).opacity;
+  target.style.transition = 'opacity 1s';
+  target.style.opacity = '1';
+  var anim = target.getAnimations()[0];
+
+  var eventInit = {animation: anim};
+  var event = new TransitionEvent("test", eventInit);
+  assert_equals(event.animation, anim);
+}, "TransitionEventInit animation property sets value");
 </script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-view-transitions/document-active-view-transition.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-view-transitions/document-active-view-transition.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>View Transition: document.activeViewTransition attribute</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/#dom-document-activeviewtransition">
+<link rel="author" href="mailto:vmpstr@chromium.org">
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+#target {
+  width: 100px;
+  height: 100px;
+  view-transition-name: target;
+}
+::view-transition-group(*) {
+  animation-duration: 1ms;
+}
+</style>
+
+<div id=target></div>
+
+<script>
+promise_test(async t => {
+  assert_implements(document.startViewTransition, "View Transitions are not supported");
+
+  assert_equals(document.activeViewTransition, null, "activeViewTransition is null initially");
+
+  const transition = document.startViewTransition(() => {});
+  assert_equals(document.activeViewTransition, transition, "activeViewTransition returns the running transition");
+
+  await transition.finished;
+
+  assert_equals(document.activeViewTransition, null, "activeViewTransition is null after transition finishes");
+
+
+  const transition2 = document.startViewTransition(() => {});
+  assert_equals(document.activeViewTransition, transition2, "activeViewTransition returns the running transition (2)");
+
+  transition2.skipTransition();
+
+  assert_equals(document.activeViewTransition, null, "activeViewTransition is null after transition is skipped");
+
+  let [result] = await Promise.allSettled([transition2.ready]);
+  assert_equals(result.status, "rejected", "ready promise should be rejected due to skipTransition call");
+}, "document.activeViewTransition returns the active transition");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Synthetic popstate events</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  assert_throws_js(
+    TypeError,
+    () => PopStateEvent(''),
+    "Calling PopStateEvent constructor without 'new' must throw"
+  );
+}, "PopStateEvent constructor called as normal function");
+
+test(function () {
+  assert_false('initPopStateEvent' in PopStateEvent.prototype,
+               'There should be no PopStateEvent#initPopStateEvent');
+}, 'initPopStateEvent');
+
+test(function () {
+  var popStateEvent = new PopStateEvent("popstate");
+  assert_equals(popStateEvent.state, null, "the PopStateEvent.state");
+}, "Initial value of PopStateEvent.state must be null");
+
+test(function () {
+  var popStateEvent = new PopStateEvent("popstate");
+  assert_false(popStateEvent.hasUAVisualTransition, "the PopStateEvent.hasUAVisualTransition");
+}, "Initial value of PopStateEvent.hasUAVisualTransition must be false");
+
+test(function () {
+  var state = history.state;
+  var data;
+  var hasUAVisualTransition = false;
+  window.addEventListener('popstate', function (e) {
+    data = e.state;
+    hasUAVisualTransition = e.hasUAVisualTransition;
+  });
+  window.dispatchEvent(new PopStateEvent('popstate', {
+    'state': {testdata:true},
+    'hasUAVisualTransition': true
+  }));
+  assert_true(data.testdata,'state data was corrupted');
+  assert_equals(history.state, state, "history.state was NOT set by dispatching the event");
+  assert_true(hasUAVisualTransition, 'hasUAVisualTransition not set correctly');
+}, 'Dispatching a synthetic PopStateEvent');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/input-events/idlharness.window.html
+++ b/Tests/LibWeb/Text/input/wpt-import/input-events/idlharness.window.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/WebIDLParser.js"></script>
+<script src="../resources/idlharness.js"></script>
+<div id=log></div>
+<script src="../input-events/idlharness.window.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/input-events/idlharness.window.js
+++ b/Tests/LibWeb/Text/input/wpt-import/input-events/idlharness.window.js
@@ -1,0 +1,14 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+idl_test(
+  ['input-events'],
+  ['uievents', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      InputEvent: ['new InputEvent("foo")'],
+    });
+  }
+);

--- a/Tests/LibWeb/Text/input/wpt-import/interfaces/css-transitions.idl
+++ b/Tests/LibWeb/Text/input/wpt-import/interfaces/css-transitions.idl
@@ -1,0 +1,25 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into webref
+// (https://github.com/w3c/webref)
+// Source: CSS Transitions Module Level 1 (https://drafts.csswg.org/css-transitions-1/)
+
+[Exposed=Window]
+interface TransitionEvent : Event {
+  constructor(CSSOMString type, optional TransitionEventInit transitionEventInitDict = {});
+  readonly attribute CSSOMString propertyName;
+  readonly attribute double elapsedTime;
+  readonly attribute CSSOMString pseudoElement;
+};
+
+dictionary TransitionEventInit : EventInit {
+  CSSOMString propertyName = "";
+  double elapsedTime = 0.0;
+  CSSOMString pseudoElement = "";
+};
+
+partial interface mixin GlobalEventHandlers {
+  attribute EventHandler ontransitionrun;
+  attribute EventHandler ontransitionstart;
+  attribute EventHandler ontransitionend;
+  attribute EventHandler ontransitioncancel;
+};

--- a/Tests/LibWeb/Text/input/wpt-import/interfaces/input-events.idl
+++ b/Tests/LibWeb/Text/input/wpt-import/interfaces/input-events.idl
@@ -1,0 +1,14 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content was automatically extracted by Reffy into webref
+// (https://github.com/w3c/webref)
+// Source: Input Events Level 2 (https://w3c.github.io/input-events/)
+
+partial interface InputEvent {
+   readonly attribute DataTransfer? dataTransfer;
+   sequence<StaticRange> getTargetRanges();
+};
+
+partial dictionary InputEventInit {
+   DataTransfer? dataTransfer = null;
+   sequence<StaticRange> targetRanges = [];
+};


### PR DESCRIPTION
This PR adds a smattering of APIs, which are supported by every other engine and were easily implementable.

Found by scouring: https://cxbyte.me/are-we-web-yet.html.

See individual commits for details.

NB: A few of the `css-view-transitions` WPTs complained when I tried to import them because they were referencing missing scripts. I've put up a fix for that here (https://github.com/web-platform-tests/wpt/pull/61680). I've stripped the missing scripts from the imports here too.