### PR TITLE
LibWeb: Resolve relative positions during the Rust layout commit

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -8,7 +8,6 @@
 #include <AK/Atomic.h>
 #include <AK/Debug.h>
 #include <AK/GenericShorthands.h>
-#include <AK/HashMap.h>
 #include <AK/Math.h>
 #include <AK/NeverDestroyed.h>
 #include <AK/NumericLimits.h>
@@ -656,34 +655,7 @@ struct LayoutRustBridge::LineCommitContext {
     Vector<Painting::InlineBoxPiece> pieces;
 };
 
-struct InlineAncestorChainRelativeOffset {
-    CSSPixelPoint offset;
-    bool found_fragmented_inline_node { false };
-};
-
 static CSS::BorderData from_ffi_border_data(RustFFI::FfiBorderData const&);
-
-// Accumulates relative position insets from a chain of inline-flow ancestors, starting at first_ancestor
-// and walking up until stop_at or the first ancestor that is not inline-flow.
-static InlineAncestorChainRelativeOffset accumulated_relative_insets_from_inline_ancestor_chain(Node const* first_ancestor, Node const* stop_at)
-{
-    InlineAncestorChainRelativeOffset result;
-    for (auto const* ancestor = first_ancestor; ancestor && ancestor != stop_at; ancestor = ancestor->parent()) {
-        if (!is<Layout::NodeWithStyleAndBoxModelMetrics>(*ancestor))
-            break;
-        auto const& ancestor_with_style = static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(*ancestor);
-        if (!ancestor_with_style.display().is_inline_outside() || !ancestor_with_style.display().is_flow_inside())
-            break;
-        result.found_fragmented_inline_node |= ancestor->is_fragmented_inline();
-        if (ancestor_with_style.computed_values().position() == CSS::Positioning::Relative) {
-            VERIFY(ancestor->paintable());
-            auto const& ancestor_paintable_box = *ancestor->paintable();
-            auto const& inset = ancestor_paintable_box.box_model().inset;
-            result.offset.translate_by(inset.left, inset.top);
-        }
-    }
-    return result;
-}
 
 static Painting::Paintable::BorderDataWithElementKind from_ffi_border_data_with_element_kind(RustFFI::FfiBorderDataWithElementKind const& border)
 {
@@ -777,7 +749,13 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
             };
             paintable.set_content_size(
                 CSSPixels::from_raw(metrics.content_inline_size),
-                CSSPixels::from_raw(metrics.content_block_size)); },
+                CSSPixels::from_raw(metrics.content_block_size));
+            paintable.set_offset({
+                CSSPixels::from_raw(metrics.content_offset.x),
+                CSSPixels::from_raw(metrics.content_offset.y),
+            });
+            if (metrics.has_containing_line_box_index)
+                paintable.set_containing_line_box_index(metrics.containing_line_box_index); },
         .set_override_borders = [](void*, void* paintable_pointer, RustFFI::FfiBordersData borders) { static_cast<Painting::Paintable*>(paintable_pointer)->set_override_borders_data({
                                                                                                           .top = from_ffi_border_data_with_element_kind(borders.top),
                                                                                                           .right = from_ffi_border_data_with_element_kind(borders.right),
@@ -911,39 +889,6 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
             auto& paintable = *static_cast<Painting::Paintable*>(paintable_pointer);
             paintable.set_used_values_for_grid_template_columns(CSS::GridTrackSizeListStyleValue::create(build_used_grid_track_list(*columns)));
             paintable.set_used_values_for_grid_template_rows(CSS::GridTrackSizeListStyleValue::create(build_used_grid_track_list(*rows))); },
-        .set_offset = [](void*, void* node_pointer, void* paintable_pointer, RustFFI::FfiCommittedOffset committed) {
-            auto& node = *static_cast<Node*>(node_pointer);
-            auto& paintable = *static_cast<Painting::Paintable*>(paintable_pointer);
-            CSSPixelPoint offset {
-                CSSPixels::from_raw(committed.offset.x),
-                CSSPixels::from_raw(committed.offset.y),
-            };
-            // Used values materialized from a previous layout's paintable keep that paintable's
-            // offset, which already includes any relative position inset. Offsets of fragmented
-            // inlines are not meaningful; their geometry is assigned from pieces once relative
-            // positions are resolved.
-            if (node.is_box() && !node.is_fragmented_inline() && !committed.materialized_from_paintable) {
-                if (committed.has_containing_line_box_fragment) {
-                    // We know that `node` is an atomic inline because `containing_line_box_fragment` refers to the
-                    // line box fragment in the parent block container that contains it. The fragment has the final
-                    // offset for the atomic inline, but line box post-processing may remove fragments after the
-                    // coordinate was recorded, in which case the content offset stands.
-                    if (committed.line_fragment_lookup != RustFFI::FfiLineFragmentLookup::NotFound) {
-                        paintable.set_containing_line_box_index(committed.containing_line_box_index);
-                        if (committed.line_fragment_lookup == RustFFI::FfiLineFragmentLookup::Found) {
-                            offset = {
-                                CSSPixels::from_raw(committed.line_fragment_offset.x),
-                                CSSPixels::from_raw(committed.line_fragment_offset.y),
-                            };
-                        }
-                    }
-                }
-
-                if (is<NodeWithStyleAndBoxModelMetrics>(node)
-                    && static_cast<NodeWithStyleAndBoxModelMetrics const&>(node).computed_values().position() == CSS::Positioning::Relative)
-                    offset.translate_by(CSSPixels::from_raw(committed.inset_left), CSSPixels::from_raw(committed.inset_top));
-            }
-            paintable.set_offset(offset); },
         .finish_node = [](void*, void* node_pointer, void* paintable_pointer, void* parent_paintable_pointer, void* insert_before_paintable_pointer) {
             auto& node = *static_cast<Node*>(node_pointer);
             auto* paintable = static_cast<Painting::Paintable*>(paintable_pointer);
@@ -975,52 +920,7 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
                 .paintable = paintable,
                 .paintable_for_children = paintable_for_children,
             }; },
-        .resolve_relative_positions = [](void* context, void* node_pointer) {
-            auto& bridge = *static_cast<LayoutRustBridge*>(context);
-            auto& node = *static_cast<NodeWithStyle*>(node_pointer);
-
-            // Nodes outside the committed subtree (materialized containing blocks) keep their
-            // already-resolved offsets.
-            VERIFY(bridge.m_commit_root);
-            if (!bridge.m_commit_root->is_inclusive_ancestor_of(node))
-                return;
-
-            if (auto const* box = as_if<Box>(node); box && box->is_in_flow() && box->display().is_block_outside()) {
-                auto accumulated = accumulated_relative_insets_from_inline_ancestor_chain(box->parent(), box->containing_block());
-                if (accumulated.found_fragmented_inline_node) {
-                    if (auto paintable = node.paintable())
-                        paintable->set_offset(paintable->offset().translated(accumulated.offset));
-                }
-            }
-
-            auto* paintable_with_lines = as_if<Painting::PaintableWithLines>(node.paintable().ptr());
-            if (!paintable_with_lines)
-                return;
-
-            for (auto& fragment : paintable_with_lines->fragments()) {
-                auto accumulated = accumulated_relative_insets_from_inline_ancestor_chain(fragment.layout_node().parent(), nullptr);
-                if (!accumulated.offset.is_zero())
-                    fragment.set_offset(fragment.offset().translated(accumulated.offset));
-            }
-
-            HashMap<Layout::Node const*, CSSPixelPoint> accumulated_offset_per_node;
-            for (auto& piece : paintable_with_lines->inline_box_pieces()) {
-                auto const* piece_node = piece.node.ptr();
-                if (!piece_node)
-                    continue;
-                // The chain starts at the piece's own node: a relative inline box shifts its own pieces.
-                auto offset = accumulated_offset_per_node.ensure(piece_node, [&] {
-                    return accumulated_relative_insets_from_inline_ancestor_chain(piece_node, nullptr).offset;
-                });
-                if (!offset.is_zero())
-                    piece.border_box_rect.translate_by(offset);
-            }
-
-            // Piece rects are final only now that this block's relative positions are resolved;
-            // cross-block writes in this pass only touch box offsets, which piece geometry
-            // assignment never reads.
-            if (!paintable_with_lines->inline_box_pieces().is_empty())
-                paintable_with_lines->assign_inline_box_geometry(); },
+        .assign_inline_box_geometry = [](void*, void* paintable_pointer) { as<Painting::PaintableWithLines>(*static_cast<Painting::Paintable*>(paintable_pointer)).assign_inline_box_geometry(); },
     };
 }
 
@@ -1124,9 +1024,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
     static_assert(to_underlying(SVG::PreserveAspectRatio::MeetOrSlice::Slice) == 1);
     static_assert(to_underlying(SVG::SVGUnits::ObjectBoundingBox) == 0);
     static_assert(to_underlying(SVG::SVGUnits::UserSpaceOnUse) == 1);
-    static_assert(to_underlying(RustFFI::FfiLineFragmentLookup::NotFound) == 0);
-    static_assert(to_underlying(RustFFI::FfiLineFragmentLookup::LineOnly) == 1);
-    static_assert(to_underlying(RustFFI::FfiLineFragmentLookup::Found) == 2);
     static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Invalid) == 0);
     static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Top) == 1);
     static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Right) == 2);

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1377,6 +1377,22 @@ pub(crate) fn push_line_data(
     let Some(mut data) = state.line_data_mut_if_present(slot_index) else {
         return false;
     };
+    // Fragments and pieces are stored at their static positions; the relative
+    // insets contributed by inline-flow ancestor chains are applied here, at
+    // emission, so the stored line data never depends on ancestor geometry.
+    let mut accumulated_relative_offset_by_chain_start = HashMap::<Node, (CssPixels, CssPixels)>::new();
+    let mut accumulated_relative_offset_from = |first_ancestor: Node| -> (CssPixels, CssPixels) {
+        *accumulated_relative_offset_by_chain_start
+            .entry(first_ancestor)
+            .or_insert_with(|| {
+                let chain = state.accumulated_relative_insets_from_inline_ancestor_chain(
+                    callbacks,
+                    first_ancestor,
+                    NodeSlotId::INVALID,
+                );
+                (chain.offset_x, chain.offset_y)
+            })
+    };
     for line in &mut data.line_boxes {
         let committed_fragment_count = line
             .fragments
@@ -1398,6 +1414,8 @@ pub(crate) fn push_line_data(
                 continue;
             }
             let (x, y) = fragment.offset();
+            let (relative_dx, relative_dy) = accumulated_relative_offset_from(callbacks.parent(fragment.layout_node));
+            let (x, y) = (x + relative_dx, y + relative_dy);
             let (width, height) = fragment.size();
             let glyphs = fragment
                 .glyphs
@@ -1440,6 +1458,9 @@ pub(crate) fn push_line_data(
         }
     }
     for piece in &data.inline_box_pieces {
+        // The chain starts at the piece's own node: a relative inline box
+        // shifts its own pieces.
+        let (relative_dx, relative_dy) = accumulated_relative_offset_from(piece.node);
         // SAFETY: The sink copies the POD piece synchronously.
         unsafe {
             (sink.emit_inline_box_piece)(
@@ -1449,8 +1470,8 @@ pub(crate) fn push_line_data(
                     first_fragment_index: piece.first_fragment_index,
                     fragment_count: piece.fragment_count,
                     border_box_rect: FfiCssPixelRect {
-                        x: piece.border_box_rect.x,
-                        y: piece.border_box_rect.y,
+                        x: piece.border_box_rect.x + relative_dx,
+                        y: piece.border_box_rect.y + relative_dy,
                         width: piece.border_box_rect.width,
                         height: piece.border_box_rect.height,
                     },

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -160,6 +160,7 @@ pub struct FfiTableCellCoordinates {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct FfiCommittedBoxMetrics {
+    pub content_offset: crate::layout::FfiCssPixelPoint,
     pub content_inline_size: crate::layout::CssPixels,
     pub content_block_size: crate::layout::CssPixels,
     pub margin_left: crate::layout::CssPixels,
@@ -178,28 +179,23 @@ pub struct FfiCommittedBoxMetrics {
     pub inset_right: crate::layout::CssPixels,
     pub inset_top: crate::layout::CssPixels,
     pub inset_bottom: crate::layout::CssPixels,
-}
-
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(C)]
-pub struct FfiCommittedOffset {
-    pub offset: crate::layout::FfiCssPixelPoint,
-    pub inset_left: crate::layout::CssPixels,
-    pub inset_top: crate::layout::CssPixels,
-    pub materialized_from_paintable: bool,
-    pub has_containing_line_box_fragment: bool,
     pub containing_line_box_index: usize,
-    pub line_fragment_lookup: FfiLineFragmentLookup,
-    pub line_fragment_offset: crate::layout::FfiCssPixelPoint,
+    pub has_containing_line_box_index: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(u8)]
-pub enum FfiLineFragmentLookup {
+pub(crate) enum LineFragmentLookup {
     #[default]
-    NotFound = 0,
-    LineOnly = 1,
-    Found = 2,
+    NotFound,
+    LineOnly,
+    Found,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct InlineAncestorChainRelativeOffset {
+    pub(crate) offset_x: crate::layout::CssPixels,
+    pub(crate) offset_y: crate::layout::CssPixels,
+    pub(crate) found_fragmented_inline_node: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -263,10 +259,9 @@ pub struct FfiCommitSink {
     pub set_flex_layout_data: unsafe extern "C" fn(*mut c_void, *mut c_void, *const FfiFlexLayoutData),
     pub set_used_grid_tracks:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *const FfiUsedGridTrackList, *const FfiUsedGridTrackList),
-    pub set_offset: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, FfiCommittedOffset),
     pub finish_node:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut c_void, *mut c_void) -> FfiCommitNodeResult,
-    pub resolve_relative_positions: unsafe extern "C" fn(*mut c_void, *mut c_void),
+    pub assign_inline_box_geometry: unsafe extern "C" fn(*mut c_void, *mut c_void),
 }
 
 pub(crate) type ReleaseRetainedLayoutHandle = unsafe extern "C" fn(*mut c_void, *mut c_void);
@@ -396,6 +391,15 @@ impl<'pass> NodeFacts<'pass> {
     pub(crate) fn is_absolutely_positioned(&self) -> bool {
         self.computed_values_view_if_styled()
             .is_some_and(|style| style.is_absolutely_positioned())
+    }
+
+    pub(crate) fn is_relatively_positioned(&self) -> bool {
+        self.computed_values_view_if_styled()
+            .is_some_and(|style| style.position() == crate::css::css_enums::positioning::RELATIVE)
+    }
+
+    pub(crate) fn is_in_flow(&self) -> bool {
+        !crate::layout::node_is_out_of_flow(self.data(), self.computed_values_view_if_styled())
     }
 
     pub(crate) fn is_inline(&self) -> bool {
@@ -1411,13 +1415,93 @@ impl LayoutState {
             .pop_front()
     }
 
+    /// Accumulates relative-position insets from a chain of inline-flow
+    /// ancestors, starting at first_ancestor and walking up until stop_at or
+    /// the first ancestor that is not inline-flow.
+    pub(crate) fn accumulated_relative_insets_from_inline_ancestor_chain(
+        &self,
+        callbacks: &FfiLayoutFcCallbacks,
+        first_ancestor: Node,
+        stop_at: Node,
+    ) -> InlineAncestorChainRelativeOffset {
+        let mut result = InlineAncestorChainRelativeOffset::default();
+        let mut ancestor = first_ancestor;
+        while !ancestor.is_invalid() && ancestor != stop_at {
+            let facts = self.node_facts(callbacks, ancestor);
+            if !facts.has_box_model_metrics() {
+                break;
+            }
+            let display = facts.display();
+            if !display.is_inline_outside() || !display.is_flow_inside() {
+                break;
+            }
+            result.found_fragmented_inline_node |= facts.is_fragmented_inline();
+            if facts.is_relatively_positioned() {
+                // An inline that never went through inline layout this pass has
+                // no used values; its committed box model is zeroed, so it
+                // contributes no inset.
+                if let Some(used) = self.try_used_values(callbacks, ancestor) {
+                    result.offset_x += used.inset_left.get();
+                    result.offset_y += used.inset_top.get();
+                }
+            }
+            ancestor = callbacks.parent(ancestor);
+        }
+        result
+    }
+
+    /// Composes the offset the paintable receives: the containing line box
+    /// fragment override for atomic inlines, the box's own relative-position
+    /// inset, and the relative insets accumulated from a fragmented inline
+    /// ancestor chain (block-in-inline). Offsets materialized from a previous
+    /// layout's paintable already include all of these. Also returns the line
+    /// box index to record for atomic inlines whose containing line survived
+    /// line post-processing.
+    fn committed_content_offset(
+        &self,
+        callbacks: &FfiLayoutFcCallbacks,
+        node: Node,
+        used: &UsedValues,
+    ) -> (crate::layout::FfiCssPixelPoint, Option<usize>) {
+        let mut offset = used.content_offset.get();
+        let mut containing_line_box_index = None;
+        if !used.materialized_from_paintable.get() {
+            let facts = self.node_facts(callbacks, node);
+            if facts.is_box() && !facts.is_fragmented_inline() {
+                let (lookup, line_fragment_offset) = self.line_fragment_lookup(callbacks, used);
+                if lookup != LineFragmentLookup::NotFound {
+                    containing_line_box_index = Some(used.containing_line_box_fragment.get().line_box_index);
+                }
+                if lookup == LineFragmentLookup::Found {
+                    offset = line_fragment_offset;
+                }
+                if facts.is_relatively_positioned() {
+                    offset.x += used.inset_left.get();
+                    offset.y += used.inset_top.get();
+                }
+                if facts.is_in_flow() && facts.display().is_block_outside() {
+                    let chain = self.accumulated_relative_insets_from_inline_ancestor_chain(
+                        callbacks,
+                        callbacks.parent(node),
+                        callbacks.containing_block(node),
+                    );
+                    if chain.found_fragmented_inline_node {
+                        offset.x += chain.offset_x;
+                        offset.y += chain.offset_y;
+                    }
+                }
+            }
+        }
+        (offset, containing_line_box_index)
+    }
+
     fn line_fragment_lookup(
         &self,
         callbacks: &FfiLayoutFcCallbacks,
         used: &UsedValues,
-    ) -> (FfiLineFragmentLookup, crate::layout::FfiCssPixelPoint) {
+    ) -> (LineFragmentLookup, crate::layout::FfiCssPixelPoint) {
         if !used.has_containing_line_box_fragment.get() {
-            return (FfiLineFragmentLookup::NotFound, crate::layout::FfiCssPixelPoint::default());
+            return (LineFragmentLookup::NotFound, crate::layout::FfiCssPixelPoint::default());
         }
         // SAFETY: Commit traverses the still-live C++ layout tree
         // synchronously with the pass callback table.
@@ -1425,17 +1509,17 @@ impl LayoutState {
         assert!(!containing_block.is_invalid());
         let slot_index = callbacks.slot_index(containing_block);
         let Some(data) = self.line_data(slot_index) else {
-            return (FfiLineFragmentLookup::NotFound, crate::layout::FfiCssPixelPoint::default());
+            return (LineFragmentLookup::NotFound, crate::layout::FfiCssPixelPoint::default());
         };
         let coordinate = used.containing_line_box_fragment.get();
         let Some(line) = data.line_boxes.get(coordinate.line_box_index) else {
-            return (FfiLineFragmentLookup::NotFound, crate::layout::FfiCssPixelPoint::default());
+            return (LineFragmentLookup::NotFound, crate::layout::FfiCssPixelPoint::default());
         };
         let Some(fragment) = line.fragments.get(coordinate.fragment_index) else {
-            return (FfiLineFragmentLookup::LineOnly, crate::layout::FfiCssPixelPoint::default());
+            return (LineFragmentLookup::LineOnly, crate::layout::FfiCssPixelPoint::default());
         };
         let (x, y) = fragment.offset();
-        (FfiLineFragmentLookup::Found, crate::layout::FfiCssPixelPoint { x, y })
+        (LineFragmentLookup::Found, crate::layout::FfiCssPixelPoint { x, y })
     }
 
     fn commit_subtree(
@@ -1459,9 +1543,11 @@ impl LayoutState {
         let node_shell = callbacks.shell(node);
         let paintable = unsafe { (sink.prepare_node)(sink.context, node_shell, used.is_some()) };
 
+        let mut has_pending_inline_box_geometry = false;
         if let Some(used) = used
             && !paintable.is_null()
         {
+            let (content_offset, containing_line_box_index) = self.committed_content_offset(callbacks, node, used);
             // SAFETY: Every callback below copies its plain-data argument or
             // consumes one retained handle synchronously.
             unsafe {
@@ -1469,6 +1555,7 @@ impl LayoutState {
                     sink.context,
                     paintable,
                     FfiCommittedBoxMetrics {
+                        content_offset,
                         content_inline_size: used.content_inline_size.get(),
                         content_block_size: used.content_block_size.get(),
                         margin_left: used.margin_left.get(),
@@ -1487,21 +1574,11 @@ impl LayoutState {
                         inset_right: used.inset_right.get(),
                         inset_top: used.inset_top.get(),
                         inset_bottom: used.inset_bottom.get(),
+                        containing_line_box_index: containing_line_box_index.unwrap_or(0),
+                        has_containing_line_box_index: containing_line_box_index.is_some(),
                     },
                 );
             }
-
-            let (line_fragment_lookup, line_fragment_offset) = self.line_fragment_lookup(callbacks, used);
-            let committed_offset = FfiCommittedOffset {
-                offset: used.content_offset.get(),
-                inset_left: used.inset_left.get(),
-                inset_top: used.inset_top.get(),
-                materialized_from_paintable: used.materialized_from_paintable.get(),
-                has_containing_line_box_fragment: used.has_containing_line_box_fragment.get(),
-                containing_line_box_index: used.containing_line_box_fragment.get().line_box_index,
-                line_fragment_lookup,
-                line_fragment_offset,
-            };
 
             let (override_borders, table_cell_coordinates) =
                 self.used_values_rare_data(slot_index).map_or((None, None), |rare| {
@@ -1532,6 +1609,9 @@ impl LayoutState {
                     unsafe {
                         (sink.finish_line_data)(sink.context);
                     }
+                    has_pending_inline_box_geometry = self
+                        .line_data(slot_index)
+                        .is_some_and(|data| !data.inline_box_pieces.is_empty());
                 }
             }
 
@@ -1578,9 +1658,6 @@ impl LayoutState {
                     });
                 }
             }
-            unsafe {
-                (sink.set_offset)(sink.context, node_shell, paintable, committed_offset);
-            }
         }
 
         // SAFETY: Wiring uses only live layout and paintable pointers for this
@@ -1602,24 +1679,13 @@ impl LayoutState {
             self.commit_subtree(child, result.paintable_for_children, null_mut(), callbacks, sink);
             child = next;
         }
-    }
 
-    pub(crate) fn commit_at(
-        &self,
-        root: Node,
-        parent_paintable: *mut c_void,
-        insert_before_paintable: *mut c_void,
-        callbacks: &FfiLayoutFcCallbacks,
-        sink: &FfiCommitSink,
-    ) {
-        self.commit_subtree(root, parent_paintable, insert_before_paintable, callbacks, sink);
-
-        // Relative inline ancestor offsets require the complete paint tree.
-        // Keep the pass paintable-only on the C++ side, but preserve the used
-        // values store's original page/slot iteration order.
-        self.used_values.for_each(|used| unsafe {
-            (sink.resolve_relative_positions)(sink.context, callbacks.shell(used.node));
-        });
+        if has_pending_inline_box_geometry {
+            // Inline box geometry unites this block's piece rects with the box
+            // models of its descendant inline paintables, which exist only now
+            // that the whole subtree has committed.
+            unsafe { (sink.assign_inline_box_geometry)(sink.context, paintable) };
+        }
     }
 
     pub(crate) fn commit_replacing(
@@ -1633,7 +1699,7 @@ impl LayoutState {
         // returns borrowed insertion pointers that stay live until
         // finish_commit().
         let position = unsafe { (sink.begin_commit)(sink.context, callbacks.shell(root), paintable_to_replace) };
-        self.commit_at(
+        self.commit_subtree(
             root,
             position.parent_paintable,
             position.insert_before_paintable,

--- a/Tests/LibWeb/Text/expected/svg-relayout-inside-relative-fragmented-inline.txt
+++ b/Tests/LibWeb/Text/expected/svg-relayout-inside-relative-fragmented-inline.txt
@@ -1,0 +1,3 @@
+stable after first relayout: true
+stable after second relayout: true
+partial-layouts=2 full-layouts=0

--- a/Tests/LibWeb/Text/input/svg-relayout-inside-relative-fragmented-inline.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-inside-relative-fragmented-inline.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    body { margin: 0; }
+    #relative_inline {
+        position: relative;
+        top: 20px;
+        left: 30px;
+    }
+    svg { display: block; }
+</style>
+<span id="relative_inline">before
+    <svg id="target" width="120" height="100" viewBox="0 0 120 100">
+        <rect id="r" width="60" height="40" fill="rgb(200, 0, 0)"/>
+    </svg>
+after</span>
+<script>
+    // An in-flow block-level SVG root inside a position:relative fragmented inline is a
+    // partial relayout boundary whose offset is frozen at the previous layout's value.
+    // That frozen offset already includes the inline ancestor chain's relative inset, so
+    // the commit must not accumulate the chain again or the box drifts further on every
+    // subtree relayout.
+    test(() => {
+        document.body.offsetHeight;
+        const before = document.getElementById("target").getBoundingClientRect();
+
+        const partialBefore = internals.partialLayoutCount();
+        const fullBefore = internals.fullLayoutCount();
+
+        document.getElementById("r").setAttribute("width", "80");
+        document.body.offsetHeight;
+        const afterFirstRelayout = document.getElementById("target").getBoundingClientRect();
+
+        document.getElementById("r").setAttribute("width", "100");
+        document.body.offsetHeight;
+        const afterSecondRelayout = document.getElementById("target").getBoundingClientRect();
+
+        const partialDelta = internals.partialLayoutCount() - partialBefore;
+        const fullDelta = internals.fullLayoutCount() - fullBefore;
+
+        println(`stable after first relayout: ${before.x === afterFirstRelayout.x && before.y === afterFirstRelayout.y}`);
+        println(`stable after second relayout: ${before.x === afterSecondRelayout.x && before.y === afterSecondRelayout.y}`);
+        println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
+    });
+</script>


### PR DESCRIPTION
The commit sink's resolve_relative_positions callback re-walked every used-values slot after the paint tree was built, accumulating the relative insets of inline-flow ancestor chains by reading them back from paintable box models. That data dependency was an artifact of the retired C++ engine: descendant paintables receive their box models only after the block holding their fragments commits, which forced the walk to wait for the complete paint tree. The insets are copies of the pass state's used.inset_* values, so the accumulation can instead run against Rust pass state at emission time, where commit order does not matter.

The chain walk now lives in LayoutState and its results are applied where geometry is emitted: fragment offsets and inline box piece rects are translated in push_line_data (memoized per chain-start node), and the block-in-inline shift joins the line-fragment override and the box's own relative inset in committed_content_offset.

Skipping the offset composition for used values materialized from a previous paintable fixes a double shift: a partial relayout rooted at an in-flow SVG inside a position:relative fragmented inline re-applied the ancestor chain to an echoed offset that already included it, drifting the box further on every relayout.