### PR TITLE
Keep layout formatting contexts out of each other's used values

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1239,7 +1239,9 @@ impl AbsposEngine<'_> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BlockSizePass {
     BeforeInsideLayout,
-    AfterInsideLayout,
+    AfterInsideLayout {
+        automatic_content_block_size_of_inside_layout: Option<CssPixels>,
+    },
 }
 
 impl AbsposEngine<'_> {
@@ -1276,10 +1278,13 @@ impl AbsposEngine<'_> {
         pass: BlockSizePass,
     ) -> AutoPx {
         if self.facts(node).creates_block_formatting_context() {
-            if pass == BlockSizePass::BeforeInsideLayout {
+            let BlockSizePass::AfterInsideLayout {
+                automatic_content_block_size_of_inside_layout,
+            } = pass
+            else {
                 return None;
-            }
-            return Some(automatic_block_size_for_bfc_root(self.state, self.callbacks, node));
+            };
+            return Some(automatic_content_block_size_of_inside_layout.unwrap_or_default());
         }
         let inner = self
             .used(node)
@@ -1704,7 +1709,12 @@ impl<'pass> AbsposEngine<'pass> {
             .make_button_content_box_definite(node, LayoutMode::Normal, available_space, constraints, None);
     }
 
-    pub(crate) fn finalize_out_of_flow_root_after_inside_layout(&self, node: Node, inputs: AbsposLayoutInputs) {
+    pub(crate) fn finalize_out_of_flow_root_after_inside_layout(
+        &self,
+        node: Node,
+        inputs: AbsposLayoutInputs,
+        automatic_content_block_size_of_inside_layout: Option<CssPixels>,
+    ) {
         let (available_space, constraints) = out_of_flow_root_space(inputs);
         let containing_block_size = LogicalSize {
             inline_size: available_space.inline_size.to_px_or_zero(),
@@ -1717,7 +1727,9 @@ impl<'pass> AbsposEngine<'pass> {
                 available_space,
                 constraints,
                 inputs.static_position_rect,
-                BlockSizePass::AfterInsideLayout,
+                BlockSizePass::AfterInsideLayout {
+                    automatic_content_block_size_of_inside_layout,
+                },
             );
         }
 

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -791,6 +791,7 @@ impl<'pass> BlockFormattingContext<'pass> {
                     self.used(node)
                         .available_inner_space_or_constraints_from(available_space),
                     constraints,
+                    None,
                 )
             },
         );
@@ -2568,6 +2569,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         node: Node,
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
+        automatic_content_block_size_of_completed_run: Option<CssPixels>,
     ) -> CssPixels {
         let facts = self.facts(node);
         let style = self.style(node);
@@ -2576,7 +2578,14 @@ impl<'pass> BlockFormattingContext<'pass> {
             || style.display().is_grid_inside()
             || style.display().is_table_inside()
         {
-            return independent_root_automatic_block_size(self.state, &self.callbacks, node, available_space, constraints);
+            return independent_root_automatic_block_size(
+                self.state,
+                &self.callbacks,
+                node,
+                available_space,
+                constraints,
+                automatic_content_block_size_of_completed_run,
+            );
         }
 
         // https://www.w3.org/TR/CSS22/visudet.html#normal-block

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -180,12 +180,6 @@ struct FloatPlacement {
     offset_from_edge: CssPixels,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) struct CaptionLayoutResult {
-    pub(crate) margin_box_block_size: CssPixels,
-    pub(crate) pending_table_block_offset: CssPixels,
-}
-
 // https://www.w3.org/TR/css-display/#block-formatting-context
 pub(crate) struct BlockFormattingContext<'pass> {
     state: &'pass LayoutState,
@@ -847,8 +841,8 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn intrusions_for_band_into_rect(&self, band: FloatBand, rect_in_root: BlockCssPixelRect) -> SpaceUsedByFloats {
-        // Deliberately read the root inline size at query time. It can still be stale
-        // while intrinsic sizing is in progress.
+        // Deliberately read the root inline size at query time. It can be stale while
+        // intrinsic sizing of this context's own root is in progress.
         let root_content_inline_size = self.used(self.root).content_inline_size.get();
         SpaceUsedByFloats {
             left: if band.left_intrusion == CssPixels::default() {
@@ -1638,17 +1632,11 @@ impl<'pass> BlockFormattingContext<'pass> {
 
         let is_table_formatting_context = independent_type == Some(FfiFormattingContextType::Table);
         let mut pending_position = None;
-        let mut table_box_content_offset_in_wrapper = None;
         if box_is_positioned_by_fieldset_layout {
             self.pending_legend_flow_position.set(Some(LogicalOffset {
                 inline_offset: content_inline_offset,
                 block_offset: content_block_offset,
             }));
-        } else if is_table_formatting_context {
-            table_box_content_offset_in_wrapper = Some(LogicalOffset {
-                inline_offset: content_inline_offset,
-                block_offset: content_block_offset,
-            });
         } else if !box_opens_top_margin_group {
             pending_position = Some(FfiCssPixelPoint {
                 x: content_inline_offset,
@@ -1719,29 +1707,14 @@ impl<'pass> BlockFormattingContext<'pass> {
                     } else {
                         None
                     },
-                    table_box_content_offset_in_wrapper,
+                    table_box_content_block_offset_in_wrapper: is_table_formatting_context
+                        .then_some(content_block_offset),
                     float_avoidance_inline_size,
                     ..RootSizingDirectives::default()
                 },
                 participation: ParticipationInParentFormattingContext::BlockLevel,
             };
-            let child_layout = self.layout_inside(run, node, inside_layout_input, true);
-            if let Some(stashed_offset) = table_box_content_offset_in_wrapper {
-                let block_offset = child_layout
-                    .as_ref()
-                    .and_then(|child_layout| child_layout.table_block_offset_in_wrapper)
-                    .unwrap_or(stashed_offset.block_offset);
-                pending_position = Some(FfiCssPixelPoint {
-                    x: stashed_offset.inline_offset,
-                    y: block_offset,
-                });
-            }
-            if container_facts.is_table_wrapper() && style.display().is_table_inside() {
-                let used = self.used_mut(node);
-                used.margin_left.set(used.margin_left.get().max(CssPixels::default()));
-                used.margin_right.set(used.margin_right.get().max(CssPixels::default()));
-            }
-            child_layout
+            self.layout_inside(run, node, inside_layout_input, true)
         } else {
             // This box participates in the current block container's flow.
             let space_available_for_children = if facts.is_anonymous() {
@@ -1865,18 +1838,12 @@ impl<'pass> BlockFormattingContext<'pass> {
         available_space_for_children: AvailableSpace,
     ) {
         assert!(!self.facts(block_container).children_are_inline());
+        debug_assert!(
+            !self.facts(block_container).is_table_wrapper(),
+            "table wrappers are laid out by layout_table_wrapper_children"
+        );
         let available_space = available_space_for_children;
-        // The table wrapper is invisible to percentage resolution: percentages on the table root
-        // resolve against the wrapper's containing block, so the wrapper's own constraints pass
-        // through to the table box unchanged.
-        let child_input = if self.facts(block_container).is_table_wrapper() {
-            LayoutInput {
-                available_space: available_space_for_children,
-                ..input
-            }
-        } else {
-            self.child_layout_input(block_container, input, available_space_for_children)
-        };
+        let child_input = self.child_layout_input(block_container, input, available_space_for_children);
         let mut bottom_of_lowest_margin_box = CssPixels::default();
         let saved = self
             .block_offset_of_current_block_container
@@ -1891,7 +1858,52 @@ impl<'pass> BlockFormattingContext<'pass> {
             );
         }
         self.block_offset_of_current_block_container.set(saved);
+        self.finish_block_level_children_layout(block_container, input, available_space, bottom_of_lowest_margin_box);
+    }
 
+    // Per https://www.w3.org/TR/CSS22/tables.html#model, caption boxes are block-level boxes laid
+    // out inside the table wrapper box together with the table box itself. Captions remain tree
+    // children of the table box, but they participate in the wrapper's block formatting context:
+    // top captions first, then the table box, then bottom captions, each flowing like any other
+    // block-level child.
+    fn layout_table_wrapper_children(
+        &self,
+        run: &FormattingContextRun<'pass>,
+        input: LayoutInput,
+        available_space_for_children: AvailableSpace,
+    ) {
+        let wrapper = self.root;
+        // The table wrapper is invisible to percentage resolution: percentages on the table root
+        // resolve against the wrapper's containing block, so the wrapper's own constraints pass
+        // through to the table box unchanged.
+        let table_box_input = LayoutInput {
+            available_space: available_space_for_children,
+            ..input
+        };
+        let caption_input = self.child_layout_input(wrapper, input, available_space_for_children);
+        let mut bottom_of_lowest_margin_box = CssPixels::default();
+        let saved = self
+            .block_offset_of_current_block_container
+            .replace(Some(CssPixels::default()));
+        for child in table_wrapper_flow_children(self.state, self.callbacks, wrapper) {
+            let child_input = if self.style(child).display().is_table_inside() {
+                table_box_input
+            } else {
+                caption_input
+            };
+            self.layout_block_level_box(run, child, wrapper, &mut bottom_of_lowest_margin_box, child_input);
+        }
+        self.block_offset_of_current_block_container.set(saved);
+        self.finish_block_level_children_layout(wrapper, input, available_space_for_children, bottom_of_lowest_margin_box);
+    }
+
+    fn finish_block_level_children_layout(
+        &self,
+        block_container: Node,
+        input: LayoutInput,
+        available_space: AvailableSpace,
+        bottom_of_lowest_margin_box: CssPixels,
+    ) {
         if self.layout_mode == LayoutMode::IntrinsicSizing && !self.used(block_container).has_definite_inline_size() {
             let mut inline_size = self.greatest_child_inline_size_including_floats(block_container);
             let style = self.style(block_container);
@@ -2100,7 +2112,9 @@ impl<'pass> BlockFormattingContext<'pass> {
             self.layout_fieldset_with_rendered_legend(run, self.root, root_input);
             return;
         }
-        if root_facts.children_are_inline() {
+        if root_facts.is_table_wrapper() {
+            self.layout_table_wrapper_children(run, root_input, available_space);
+        } else if root_facts.children_are_inline() {
             self.layout_inline_children(run, self.root, root_input, available_space);
         } else {
             self.layout_block_level_children(run, self.root, root_input, available_space);
@@ -2114,7 +2128,12 @@ impl<'pass> BlockFormattingContext<'pass> {
         // Assign collapsed margin left after children layout of formatting context to the last child box
         let collapsed_margin = self.margin_state.borrow().current_collapsed_margin();
         if collapsed_margin != CssPixels::default() {
-            for child in self.children(self.root).into_iter().rev() {
+            let flow_children_bottom_up = if root_facts.is_table_wrapper() {
+                table_wrapper_flow_children(self.state, self.callbacks, self.root)
+            } else {
+                self.children(self.root)
+            };
+            for child in flow_children_bottom_up.into_iter().rev() {
                 let facts = self.facts(child);
                 if facts.is_absolutely_positioned() || facts.is_floating() {
                     continue;
@@ -2158,94 +2177,6 @@ impl<'pass> BlockFormattingContext<'pass> {
                     y: content_block_offset,
                 },
             );
-        }
-    }
-
-    pub(crate) fn layout_table_caption(
-        &self,
-        run: &FormattingContextRun<'pass>,
-        table_box: Node,
-        caption: Node,
-        phase: CaptionPhase,
-        available_space: AvailableSpace,
-        constraints: ContainingBlockConstraints,
-    ) -> CaptionLayoutResult {
-        let mut caption_was_placed = false;
-        if formatting_context_type_created_by_box(self.facts(caption)).is_some() {
-            let mut inner_available_space = available_space;
-            let is_block_context =
-                formatting_context_type_created_by_box(self.facts(caption)) == Some(FfiFormattingContextType::Block);
-            let mut caption_offset = LogicalOffset::default();
-            if is_block_context {
-                let available_inline_size = available_space.inline_size.to_px_or_zero();
-                self.resolve_vertical_box_model_metrics(caption, available_inline_size);
-                self.compute_inline_size(caption, available_space, constraints, FfiCssPixelPoint::default());
-                inner_available_space = self
-                    .used(caption)
-                    .available_inner_space_or_constraints_from(available_space);
-                caption_offset.inline_offset = self.used(caption).border_box_left(false);
-                if phase == CaptionPhase::Bottom {
-                    caption_offset.block_offset = self.used(table_box).margin_box_block_size(false)
-                        + self.used(caption).margin_top.get()
-                        + self.used(caption).border_box_top(false);
-                }
-            }
-
-            let child_layout = self.layout_inside(
-                run,
-                caption,
-                LayoutInput {
-                    available_space: inner_available_space,
-                    containing_block_constraints: constraints,
-                    content_box_position_in_bfc_root: None,
-                    sizing: RootSizingDirectives::default(),
-                    participation: ParticipationInParentFormattingContext::Item,
-                },
-                true,
-            );
-            if is_block_context
-                && let Some(child_layout) = child_layout.as_ref()
-            {
-                if self
-                    .sizing()
-                    .should_treat_block_size_as_auto(caption, available_space, constraints)
-                {
-                    let content_block_size = if self.style(caption).has_size_containment() {
-                        CssPixels::default()
-                    } else {
-                        child_layout.automatic_content_block_size
-                    };
-                    self.used_mut(caption).set_content_block_size(content_block_size);
-                }
-                self.place_child(
-                    caption,
-                    FfiCssPixelPoint {
-                        x: caption_offset.inline_offset,
-                        y: caption_offset.block_offset,
-                    },
-                );
-                caption_was_placed = true;
-            }
-        }
-
-        if phase == CaptionPhase::Bottom && !caption_was_placed {
-            self.place_child(
-                caption,
-                FfiCssPixelPoint {
-                    x: self.used(caption).border_box_left(false),
-                    y: self.used(table_box).margin_box_block_size(false)
-                        + self.used(caption).margin_top.get()
-                        + self.used(caption).border_box_top(false),
-                },
-            );
-        }
-        CaptionLayoutResult {
-            margin_box_block_size: self.used(caption).margin_box_block_size(false),
-            pending_table_block_offset: if phase == CaptionPhase::Top {
-                self.used(caption).content_block_size.get() + self.used(caption).margin_box_bottom(false)
-            } else {
-                CssPixels::default()
-            },
         }
     }
 
@@ -2797,6 +2728,44 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 }
 
+fn table_box_of_wrapper(state: &LayoutState, callbacks: FfiLayoutFcCallbacks, wrapper: Node) -> Node {
+    let mut child = callbacks.first_child(wrapper);
+    while !child.is_invalid() {
+        if state.node_facts(&callbacks, child).is_box()
+            && state.style_facts(&callbacks, child).display().is_table_inside()
+        {
+            return child;
+        }
+        child = callbacks.next_sibling(child);
+    }
+    unreachable!("a table wrapper contains its table box")
+}
+
+// Flow-ordered children of a table wrapper's block formatting context: top captions in document
+// order, then the table box, then bottom captions in document order. Captions are tree children
+// of the table box; absolutely positioned captions are out of flow and are registered by
+// register_table_abspos_descendants instead.
+pub(crate) fn table_wrapper_flow_children(state: &LayoutState, callbacks: FfiLayoutFcCallbacks, wrapper: Node) -> Vec<Node> {
+    let table_box = table_box_of_wrapper(state, callbacks, wrapper);
+    let mut flow_children = Vec::new();
+    let mut bottom_captions = Vec::new();
+    let mut child = callbacks.first_child(table_box);
+    while !child.is_invalid() {
+        let facts = state.node_facts(&callbacks, child);
+        if facts.is_box() && facts.is_table_caption() && !facts.is_absolutely_positioned() {
+            if state.style_facts(&callbacks, child).caption_side() == caption_side::TOP {
+                flow_children.push(child);
+            } else {
+                bottom_captions.push(child);
+            }
+        }
+        child = callbacks.next_sibling(child);
+    }
+    flow_children.push(table_box);
+    flow_children.extend(bottom_captions);
+    flow_children
+}
+
 // https://www.w3.org/TR/CSS22/visudet.html#root-height
 pub(crate) fn automatic_block_size_for_bfc_root(
     state: &LayoutState,
@@ -2804,6 +2773,11 @@ pub(crate) fn automatic_block_size_for_bfc_root(
     root: Node,
 ) -> CssPixels {
     let facts = state.node_facts(&callbacks, root);
+    // https://drafts.csswg.org/css-contain-2/#containment-size
+    // A size-contained box is sized as if it had no contents.
+    if facts.node_has_size_containment() {
+        return CssPixels::default();
+    }
     let used = state.used_values(&callbacks, root);
     let mut bottom = None;
     if facts.children_are_inline() {
@@ -2823,8 +2797,20 @@ pub(crate) fn automatic_block_size_for_bfc_root(
         // the top margin-edge of the topmost block-level child box
         // and the bottom margin-edge of the bottommost block-level child box.
         // NOTE: The top margin edge of the topmost block-level child box is the same as the top content edge of the root box.
-        let mut child = callbacks.first_child(root);
-        while !child.is_invalid() {
+        let flow_children = if facts.is_table_wrapper() {
+            // Captions flow in the wrapper's formatting context while remaining tree children of
+            // the table box, so the wrapper considers its flow children instead of tree children.
+            table_wrapper_flow_children(state, callbacks, root)
+        } else {
+            let mut children = Vec::new();
+            let mut child = callbacks.first_child(root);
+            while !child.is_invalid() {
+                children.push(child);
+                child = callbacks.next_sibling(child);
+            }
+            children
+        };
+        for child in flow_children {
             let child_facts = state.node_facts(&callbacks, child);
             if child_facts.is_box() && !child_facts.is_absolutely_positioned() && !child_facts.is_floating() {
                 let child_used = state.try_used_values(&callbacks, child);
@@ -2836,7 +2822,6 @@ pub(crate) fn automatic_block_size_for_bfc_root(
                     bottom = Some(bottom.map_or(child_bottom, |value: CssPixels| value.max(child_bottom)));
                 }
             }
-            child = callbacks.next_sibling(child);
         }
     }
     // In addition, if the element has any floating descendants

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -724,7 +724,6 @@ pub struct FfiBordersData {
 pub(crate) struct ChildLayoutResult {
     pub automatic_content_inline_size: CssPixels,
     pub automatic_content_block_size: CssPixels,
-    pub table_block_offset_in_wrapper: Option<CssPixels>,
 }
 
 pub(crate) enum ChildLayoutOutcome {
@@ -1454,7 +1453,6 @@ fn run_formatting_context<'pass>(
                 let result = ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
-                    table_block_offset_in_wrapper: None,
                 };
                 context.place_floats_after_run();
                 result
@@ -1464,7 +1462,6 @@ fn run_formatting_context<'pass>(
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
-                    table_block_offset_in_wrapper: None,
                 }
             }
             FormattingContextImplementation::Grid(context) => {
@@ -1472,18 +1469,13 @@ fn run_formatting_context<'pass>(
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
-                    table_block_offset_in_wrapper: None,
                 }
             }
             FormattingContextImplementation::Table(context) => {
-                context.run(run, parent_block, body_input);
+                context.run(run, body_input);
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size,
-                    table_block_offset_in_wrapper: body_input
-                        .sizing
-                        .table_box_content_offset_in_wrapper
-                        .map(|_| context.pending_table_offset.block_offset),
                 }
             }
             FormattingContextImplementation::Svg(context) => {

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -1238,10 +1238,11 @@ pub(crate) fn independent_root_automatic_block_size(
     node: Node,
     available_inner_space: AvailableSpace,
     constraints: ContainingBlockConstraints,
+    automatic_content_block_size_of_completed_run: Option<CssPixels>,
 ) -> CssPixels {
     let facts = state.node_facts(callbacks, node);
     if facts.creates_block_formatting_context() {
-        return automatic_block_size_for_bfc_root(state, *callbacks, node);
+        return automatic_content_block_size_of_completed_run.unwrap_or_default();
     }
     let style = state.style_facts(callbacks, node);
     if style.display().is_flex_inside() || style.display().is_grid_inside() || style.display().is_table_inside() {
@@ -1396,7 +1397,7 @@ fn size_skipped_independent_root(
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
             let engine = AbsposEngine::new(run.state, run.callbacks);
             engine.dimension_out_of_flow_root(child, abspos_inputs);
-            engine.finalize_out_of_flow_root_after_inside_layout(child, abspos_inputs);
+            engine.finalize_out_of_flow_root_after_inside_layout(child, abspos_inputs, None);
         }
         ParticipationInParentFormattingContext::AtomicInline | ParticipationInParentFormattingContext::Item | ParticipationInParentFormattingContext::Root => {}
     }
@@ -1509,11 +1510,23 @@ fn run_formatting_context<'pass>(
             );
         }
         ParticipationInParentFormattingContext::AtomicInline => {
-            finalize_atomic_root_block_size(run, &input, cached_atomic_block_size, parent_block);
+            let automatic_content_block_size_of_completed_body_run = cached_atomic_block_size
+                .is_none()
+                .then_some(result.automatic_content_block_size);
+            finalize_atomic_root_block_size(
+                run,
+                &input,
+                cached_atomic_block_size,
+                automatic_content_block_size_of_completed_body_run,
+                parent_block,
+            );
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::new(run.state, run.callbacks)
-                .finalize_out_of_flow_root_after_inside_layout(run.box_, abspos_inputs);
+            AbsposEngine::new(run.state, run.callbacks).finalize_out_of_flow_root_after_inside_layout(
+                run.box_,
+                abspos_inputs,
+                Some(result.automatic_content_block_size),
+            );
         }
         ParticipationInParentFormattingContext::Item => {
             if input.sizing.adopt_automatic_content_block_size {
@@ -1557,7 +1570,8 @@ fn run_formatting_context<'pass>(
 fn finalize_atomic_root_block_size(
     run: &FormattingContextRun,
     input: &LayoutInput,
-    cached_block_size: Option<CssPixels>,
+    cached_intrinsic_measurement_block_size: Option<CssPixels>,
+    automatic_content_block_size_of_completed_body_run: Option<CssPixels>,
     parent_block: Option<&BlockFormattingContext>,
 ) {
     let node = run.box_;
@@ -1568,24 +1582,34 @@ fn finalize_atomic_root_block_size(
         return;
     }
     if sizing.should_treat_block_size_as_auto(node, available_space, constraints) {
-        sizing.resolve_used_block_size_if_treated_as_auto(node, available_space, constraints, cached_block_size, || {
-            let available_inner_space = run
-                .state
-                .used_values(&run.callbacks, node)
-                .available_inner_space_or_constraints_from(available_space);
-            match parent_block {
-                Some(parent) => {
-                    parent.compute_automatic_block_size_for_block_level_element(node, available_inner_space, constraints)
+        sizing.resolve_used_block_size_if_treated_as_auto(
+            node,
+            available_space,
+            constraints,
+            cached_intrinsic_measurement_block_size,
+            || {
+                let available_inner_space = run
+                    .state
+                    .used_values(&run.callbacks, node)
+                    .available_inner_space_or_constraints_from(available_space);
+                match parent_block {
+                    Some(parent) => parent.compute_automatic_block_size_for_block_level_element(
+                        node,
+                        available_inner_space,
+                        constraints,
+                        automatic_content_block_size_of_completed_body_run,
+                    ),
+                    None => independent_root_automatic_block_size(
+                        run.state,
+                        &run.callbacks,
+                        node,
+                        available_inner_space,
+                        constraints,
+                        automatic_content_block_size_of_completed_body_run,
+                    ),
                 }
-                None => independent_root_automatic_block_size(
-                    run.state,
-                    &run.callbacks,
-                    node,
-                    available_inner_space,
-                    constraints,
-                ),
-            }
-        });
+            },
+        );
     } else {
         sizing.resolve_used_block_size_if_not_treated_as_auto(node, available_space, constraints);
     }

--- a/Libraries/LibWeb/Rust/src/layout/geometry.rs
+++ b/Libraries/LibWeb/Rust/src/layout/geometry.rs
@@ -118,7 +118,10 @@ pub(crate) struct RootSizingDirectives {
     pub(crate) forced_content_inline_size: Option<CssPixels>,
     pub(crate) forced_content_block_size: Option<CssPixels>,
     pub(crate) forced_min_border_box_block_size: Option<CssPixels>,
-    pub(crate) table_box_content_offset_in_wrapper: Option<LogicalOffset>,
+    // Input-only: the wrapper's BFC tells the table formatting context where the table box's
+    // content box sits in the wrapper, so rows and row groups (whose containing block is the
+    // wrapper) can be placed in wrapper coordinates.
+    pub(crate) table_box_content_block_offset_in_wrapper: Option<CssPixels>,
     pub(crate) adopt_automatic_content_block_size: bool,
     pub(crate) float_avoidance_inline_size: Option<CssPixels>,
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -657,7 +657,7 @@ impl<'pass> NodeFacts<'pass> {
         crate::layout::node_has_auto_content_box_size(self.data())
     }
 
-    fn node_has_size_containment(&self) -> bool {
+    pub(crate) fn node_has_size_containment(&self) -> bool {
         let display = self.display();
         if display.is_table_inside() || display.is_internal_table() {
             return false;

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -69,6 +69,5 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
     ChildLayoutResult {
         automatic_content_inline_size: content_inline_size,
         automatic_content_block_size: wrapper_layout.automatic_content_block_size,
-        table_block_offset_in_wrapper: None,
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1148,6 +1148,7 @@ impl<'pass> SizingContext<'pass> {
                     self.used(node)
                         .available_inner_space_or_constraints_from(inline_definite_space),
                     constraints,
+                    None,
                 )
             });
         }

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -742,13 +742,6 @@ pub(crate) fn calculate_table_grid<T: TableTree>(tree: &T, table: Node) -> Table
 const BORDER_COLLAPSE_SEPARATE: u8 = 0;
 const TABLE_LAYOUT_FIXED: u8 = 1;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u8)]
-pub(crate) enum CaptionPhase {
-    Top,
-    Bottom,
-}
-
 pub(crate) trait TableTree {
     fn first_child(&self, node: Node) -> Node;
     fn next_sibling(&self, node: Node) -> Node;
@@ -784,7 +777,7 @@ struct TableFormattingContext<'pass> {
     available_space: AvailableSpace,
     table_block_size: CssPixels,
     automatic_content_block_size: CssPixels,
-    pending_table_offset: crate::layout::LogicalOffset,
+    table_box_content_block_offset_in_wrapper: CssPixels,
     min_border_box_block_size_from_flex_item: Option<CssPixels>,
     needs_fixed_mode_row_measurement: bool,
     cells: Vec<TableCell>,
@@ -842,7 +835,7 @@ impl<'pass> TableFormattingContext<'pass> {
             available_space: AvailableSpace::default(),
             table_block_size: CssPixels::default(),
             automatic_content_block_size: CssPixels::default(),
-            pending_table_offset: crate::layout::LogicalOffset::default(),
+            table_box_content_block_offset_in_wrapper: CssPixels::default(),
             min_border_box_block_size_from_flex_item: None,
             needs_fixed_mode_row_measurement: false,
             cells: Vec::new(),
@@ -1051,9 +1044,6 @@ impl<'pass> TableFormattingContext<'pass> {
         }
         for cell in &self.cells {
             self.create_used_values(cell.box_, self.participant_constraints);
-        }
-        for caption in self.matching_children(self.table_box, |facts| facts.is_table_caption()) {
-            self.create_used_values(caption, self.participant_constraints);
         }
     }
 
@@ -1908,7 +1898,6 @@ impl<'pass> TableFormattingContext<'pass> {
     fn layout_inside_cell(
         &mut self,
         run: &FormattingContextRun<'pass>,
-        parent: Option<&BlockFormattingContext<'pass>>,
         cell: TableCell,
         input: AvailableSpace,
         adopt_automatic_content_block_size: bool,
@@ -1926,7 +1915,7 @@ impl<'pass> TableFormattingContext<'pass> {
         if let crate::layout::ChildLayoutOutcome::ReenterCurrent =
             crate::layout::layout_inside_child(run, None, None, cell.box_, self.layout_mode, layout_input, false)
         {
-            self.run(run, parent, layout_input);
+            self.run(run, layout_input);
         }
     }
 
@@ -2007,7 +1996,7 @@ impl<'pass> TableFormattingContext<'pass> {
         })
     }
 
-    fn compute_table_block_size(&mut self, run: &FormattingContextRun<'pass>, parent: Option<&BlockFormattingContext<'pass>>) {
+    fn compute_table_block_size(&mut self, run: &FormattingContextRun<'pass>) {
         // First pass of row block-size calculation:
         for row_index in 0..self.rows.len() {
             if self.rows[row_index].is_collapsed {
@@ -2073,7 +2062,7 @@ impl<'pass> TableFormattingContext<'pass> {
                     measured_baseline = Some(measured.first_baseline);
                 }
             } else {
-                self.layout_inside_cell(run, parent, cell, inner, true);
+                self.layout_inside_cell(run, cell, inner, true);
             }
             if self.needs_fixed_mode_row_measurement {
                 let min_size = style.min_height().to_px(participant_block_basis);
@@ -2186,7 +2175,7 @@ impl<'pass> TableFormattingContext<'pass> {
             let inner = used.available_inner_space_or_constraints_from(self.available_space);
             // The first pass only measured this cell in a throwaway state; this is its one and
             // only inside layout in the committing state.
-            self.layout_inside_cell(run, parent, cell, inner, false);
+            self.layout_inside_cell(run, cell, inner, false);
             let baseline = self.box_baseline(cell.box_);
             self.cells[cell_index].baseline = baseline;
             if !self.rows[cell.row_index].is_collapsed {
@@ -2258,7 +2247,7 @@ impl<'pass> TableFormattingContext<'pass> {
         let block_spacing = self.border_spacing_block();
         let inline_spacing = self.border_spacing_inline();
         let inline_offset = table_used.border_left.get() + table_used.padding_left.get() + inline_spacing;
-        let mut row_block_offset = self.pending_table_offset.block_offset + block_spacing;
+        let mut row_block_offset = self.table_box_content_block_offset_in_wrapper + block_spacing;
         for row_index in 0..self.rows.len() {
             let row = &self.rows[row_index];
             let inline_size = self
@@ -2279,7 +2268,7 @@ impl<'pass> TableFormattingContext<'pass> {
             }
         }
 
-        let mut group_block_offset = self.pending_table_offset.block_offset + block_spacing;
+        let mut group_block_offset = self.table_box_content_block_offset_in_wrapper + block_spacing;
         for group in self.matching_children(self.table_box, |facts| {
             facts.is_table_row_group() || facts.is_table_header_group() || facts.is_table_footer_group()
         }) {
@@ -2306,7 +2295,8 @@ impl<'pass> TableFormattingContext<'pass> {
                 };
         }
         let padding_top = table_used.padding_top.get();
-        let total = row_block_offset.max(group_block_offset) - self.pending_table_offset.block_offset - padding_top;
+        let total =
+            row_block_offset.max(group_block_offset) - self.table_box_content_block_offset_in_wrapper - padding_top;
         self.table_block_size = self.table_block_size.max(total);
     }
 
@@ -2425,61 +2415,15 @@ impl<'pass> TableFormattingContext<'pass> {
         }
     }
 
-    fn run_caption_layout(
-        &mut self,
-        run: &FormattingContextRun<'pass>,
-        parent: Option<&BlockFormattingContext<'pass>>,
-        phase: CaptionPhase,
-        available: AvailableSpace,
-    ) -> CssPixels {
-        let mut total = CssPixels::default();
-        for caption in self.matching_children(self.table_box, |facts| facts.is_table_caption()) {
-            if self.style_facts(caption).caption_side() != phase as u8 {
-                continue;
-            }
-            // Captions live inside the table wrapper, so their quirks percentage height basis derives
-            // from the wrapper, not from anything the table box inherited.
-            // The caption boxes are principal block-level boxes that retain their own content, padding, margin, and border areas,
-            // and are rendered as normal block boxes inside the table wrapper box, as described in https://www.w3.org/TR/CSS22/tables.html#model
-            let result = if let Some(parent) = parent {
-                parent.layout_table_caption(
-                    run,
-                    self.table_box,
-                    caption,
-                    phase,
-                    available,
-                    self.participant_constraints,
-                )
-            } else {
-                // Measurement-only table contexts may have no parent handle.
-                // Use the same BFC algorithms without attaching a persistent
-                // formatting-context instance.
-                BlockFormattingContext::new(self.state, self.table_box, self.layout_mode, self.callbacks)
-                    .layout_table_caption(
-                        run,
-                        self.table_box,
-                        caption,
-                        phase,
-                        available,
-                        self.participant_constraints,
-                    )
-            };
-            if phase == CaptionPhase::Top {
-                self.pending_table_offset.block_offset = result.pending_table_block_offset;
-            }
-            total += result.margin_box_block_size;
-        }
-        total
-    }
-
     fn compute_and_store_baselines(&self, node: Node) {
         crate::layout::compute_and_store_baselines(self.state, &self.callbacks, node, false);
     }
 
-    fn run(&mut self, run: &FormattingContextRun<'pass>, parent: Option<&BlockFormattingContext<'pass>>, input: LayoutInput) {
+    fn run(&mut self, run: &FormattingContextRun<'pass>, input: LayoutInput) {
         self.available_space = input.available_space;
         self.min_border_box_block_size_from_flex_item = input.sizing.forced_min_border_box_block_size;
-        self.pending_table_offset = input.sizing.table_box_content_offset_in_wrapper.unwrap_or_default();
+        self.table_box_content_block_offset_in_wrapper =
+            input.sizing.table_box_content_block_offset_in_wrapper.unwrap_or_default();
         self.run_until_inline_size_calculation(input, false);
         if matches!(
             self.available_space.inline_size,
@@ -2492,12 +2436,6 @@ impl<'pass> TableFormattingContext<'pass> {
         }
 
         let table_used = self.used_values(self.table_box);
-        let table_border_inline = table_used.border_box_inline_size(false);
-        let caption_available = AvailableSpace {
-            inline_size: AvailableSize::definite(table_border_inline.min(max_dimension_value())),
-            block_size: self.available_space.block_size,
-        };
-        let mut captions = self.run_caption_layout(run, parent, CaptionPhase::Top, caption_available);
         // The total inline-axis border spacing is defined for each table:
         // - For tables laid out in separated-borders mode containing at least one column, the inline-axis component of the computed value of the border-spacing property times one plus the number of columns in the table
         // - Otherwise, 0
@@ -2511,16 +2449,11 @@ impl<'pass> TableFormattingContext<'pass> {
         let fixed = self.use_fixed_mode_layout();
         // Distribute the inline size of the table among columns.
         distribute_inline_size(&mut self.columns, assignable, fixed);
-        self.compute_table_block_size(run, parent);
+        self.compute_table_block_size(run);
         self.distribute_block_size_to_rows();
         self.position_row_boxes();
         self.position_cell_boxes();
         table_used.set_content_block_size(self.table_block_size);
-        captions += self.run_caption_layout(run, parent, CaptionPhase::Bottom, caption_available);
-        // Table captions are positioned between the table margins and its borders (outside the grid box borders) as described in
-        // https://www.w3.org/TR/css-tables-3/#bounding-box-assignment
-        // A visual representation of this model can be found at https://www.w3.org/TR/css-tables-3/images/table_container.png
-        table_used.margin_bottom.set(table_used.margin_bottom.get() + captions);
         // Derive baselines for the table internals bottom-up (rows, then row groups, then the table box)
         // now that all offsets are final, so the table exports its baseline to outside consumers
         // (e.g. an inline-table participating in a line box).

--- a/Tests/LibWeb/Layout/expected/bfc-root-auto-height-uses-child-run-result-abspos-flow-root-floats.txt
+++ b/Tests/LibWeb/Layout/expected/bfc-root-auto-height-uses-child-run-result-abspos-flow-root-floats.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <div> at [1,1] positioned [0+1+0 50 0+1+0] [0+1+0 60 0+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [1,1] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          BlockContainer <div> at [1,1] floating [0+0+0 30 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [1,1] [0+0+0 50 0+0+0] [0+0+0 10 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [1,11] [0+0+0 50 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 52x62]
+        PaintableWithLines (BlockContainer(anonymous)) [1,1 50x0]
+          PaintableWithLines (BlockContainer<DIV>) [1,1 30x60]
+        PaintableWithLines (BlockContainer<DIV>) [1,1 50x10]
+        PaintableWithLines (BlockContainer(anonymous)) [1,11 50x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x0] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/bfc-root-auto-height-uses-child-run-result-inline-block-float-past-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/bfc-root-auto-height-uses-child-run-result-inline-block-float-past-bottom.txt
@@ -1,0 +1,25 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 102 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 102 0+0+0] children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [1,1 40x100] baseline: 102
+      BlockContainer <div> at [1,1] inline-block [0+1+0 40 0+1+0] [0+1+0 100 0+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [1,1] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          BlockContainer <div> at [1,1] floating [0+0+0 10 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [1,1] [0+0+0 40 0+0+0] [0+0+0 20 0+0+35] children: not-inline
+        BlockContainer <(anonymous)> at [1,56] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x102]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x102]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 42x102]
+        PaintableWithLines (BlockContainer(anonymous)) [1,1 40x0]
+          PaintableWithLines (BlockContainer<DIV>) [1,1 10x100]
+        PaintableWithLines (BlockContainer<DIV>) [1,1 40x20]
+        PaintableWithLines (BlockContainer(anonymous)) [1,56 40x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x102] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/bfc-root-auto-height-uses-child-run-result-inline-block-margin-below-last-child.txt
+++ b/Tests/LibWeb/Layout/expected/bfc-root-auto-height-uses-child-run-result-inline-block-margin-below-last-child.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 52 0+0+0] children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [1,1 40x50] baseline: 52
+      BlockContainer <div> at [1,1] inline-block [0+1+0 40 0+1+0] [0+1+0 50 0+1+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [1,1] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div> at [1,1] [0+0+0 40 0+0+0] [0+0+0 20 0+0+30] children: not-inline
+        BlockContainer <(anonymous)> at [1,51] [0+0+0 40 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x52]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x52]
+      PaintableWithLines (BlockContainer<DIV>) [0,0 42x52]
+        PaintableWithLines (BlockContainer(anonymous)) [1,1 40x0]
+        PaintableWithLines (BlockContainer<DIV>) [1,1 40x20]
+        PaintableWithLines (BlockContainer(anonymous)) [1,51 40x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x52] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/flex/table-flex-item-stretch.txt
+++ b/Tests/LibWeb/Layout/expected/flex/table-flex-item-stretch.txt
@@ -21,14 +21,14 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         TableWrapper <(anonymous)> at [8,108] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
-          Box <div.table> at [8,128] table-box [0+0+0 20 0+0+0] [0+0+0 60 0+0+20] [TFC] children: not-inline
+          Box <div.table> at [8,128] table-box [0+0+0 20 0+0+0] [0+0+0 80 0+0+0] [TFC] children: not-inline
             BlockContainer <div.caption> at [8,108] [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
-            Box <(anonymous)> at [8,128] table-row [0+0+0 20 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+            Box <(anonymous)> at [8,128] table-row [0+0+0 20 0+0+0] [0+0+0 80 0+0+0] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <div.cell> at [8,148] table-cell [0+0+0 20 0+0+0] [0+0+20 20 20+0+0] [BFC] children: inline
-                frag 0 from BlockContainer start: 0, length: 0, rect: [8,148 20x20] baseline: 20
-                BlockContainer <span.content> at [8,148] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+              BlockContainer <div.cell> at [8,158] table-cell [0+0+0 20 0+0+0] [0+0+30 20 30+0+0] [BFC] children: inline
+                frag 0 from BlockContainer start: 0, length: 0, rect: [8,158 20x20] baseline: 20
+                BlockContainer <span.content> at [8,158] inline-block [0+0+0 20 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)
         BlockContainer <div.sizer> at [28,108] flex-item [0+0+0 20 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
@@ -50,11 +50,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]
       Paintable (Box<DIV>.flex) [8,108 784x100]
         PaintableWithLines (TableWrapper(anonymous)) [8,108 20x100]
-          Paintable (Box<DIV>.table) [8,128 20x60]
+          Paintable (Box<DIV>.table) [8,128 20x80]
             PaintableWithLines (BlockContainer<DIV>.caption) [8,108 20x20]
-            Paintable (Box(anonymous)) [8,128 20x60]
-              PaintableWithLines (BlockContainer<DIV>.cell) [8,128 20x60]
-                PaintableWithLines (BlockContainer<SPAN>.content) [8,148 20x20]
+            Paintable (Box(anonymous)) [8,128 20x80]
+              PaintableWithLines (BlockContainer<DIV>.cell) [8,128 20x80]
+                PaintableWithLines (BlockContainer<SPAN>.content) [8,158 20x20]
         PaintableWithLines (BlockContainer<DIV>.sizer) [28,108 20x100]
       PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
 

--- a/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
@@ -1,41 +1,41 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 188 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 156 0+0+16] children: not-inline
-      TableWrapper <(anonymous)> at [48,16] [40+0+0 106 0+0+638] [16+0+0 156 0+0+16] [BFC] children: not-inline
-        Box <figure> at [50,66] table-box [0+2+0 102 0+2+0] [0+2+0 52 0+2+52] [TFC] children: not-inline
-          Box <(anonymous)> at [50,66] table-row [0+0+0 102 0+0+0] [0+0+0 52 0+0+0] children: not-inline
-            BlockContainer <(anonymous)> at [50,66] table-cell [0+0+0 102 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
-              BlockContainer <(anonymous)> at [50,66] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 140 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 108 0+0+16] children: not-inline
+      TableWrapper <(anonymous)> at [48,16] [40+0+0 106 0+0+638] [16+0+0 108 0+0+16] [BFC] children: not-inline
+        Box <figure> at [50,70] table-box [0+2+0 102 0+2+0] [0+2+0 52 0+2+0] [TFC] children: not-inline
+          Box <(anonymous)> at [50,70] table-row [0+0+0 102 0+0+0] [0+0+0 52 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> at [50,70] table-cell [0+0+0 102 0+0+0] [0+0+0 52 0+0+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [50,70] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <div.table-content> at [51,67] [0+1+0 100 0+1+0] [0+1+0 50 0+1+0] children: not-inline
-              BlockContainer <(anonymous)> at [50,118] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
+              BlockContainer <div.table-content> at [51,71] [0+1+0 100 0+1+0] [0+1+0 50 0+1+0] children: not-inline
+              BlockContainer <(anonymous)> at [50,122] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
                 TextNode <#text> (not painted)
-          BlockContainer <figcaption> at [50,16] [0+2+0 102 0+2+0] [0+2+0 48 0+2+0] [BFC] children: not-inline
-            BlockContainer <(anonymous)> at [50,16] [0+0+0 102 0+0+0] [0+0+0 16 0+0+0] children: inline
-              frag 0 from TextNode start: 9, length: 12, rect: [50,16 100.609375x16] baseline: 12.796875
+          BlockContainer <figcaption> at [50,18] [0+2+0 102 0+2+0] [0+2+0 48 0+2+0] [BFC] children: not-inline
+            BlockContainer <(anonymous)> at [50,18] [0+0+0 102 0+0+0] [0+0+0 16 0+0+0] children: inline
+              frag 0 from TextNode start: 9, length: 12, rect: [50,18 100.609375x16] baseline: 12.796875
                   "Caption text"
               TextNode <#text> (not painted)
-            BlockContainer <div.caption-content> at [51,33] [0+1+0 100 0+1+0] [0+1+0 30 0+1+0] children: not-inline
-            BlockContainer <(anonymous)> at [50,64] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
+            BlockContainer <div.caption-content> at [51,35] [0+1+0 100 0+1+0] [0+1+0 30 0+1+0] children: not-inline
+            BlockContainer <(anonymous)> at [50,66] [0+0+0 102 0+0+0] [0+0+0 0 0+0+0] children: inline
               TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,188] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,140] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x188]
-    PaintableWithLines (BlockContainer<BODY>) [8,16 784x156]
-      PaintableWithLines (TableWrapper(anonymous)) [48,16 106x156]
-        Paintable (Box<FIGURE>) [48,64 106x56]
-          Paintable (Box(anonymous)) [50,66 102x52]
-            PaintableWithLines (BlockContainer(anonymous)) [50,66 102x52]
-              PaintableWithLines (BlockContainer(anonymous)) [50,66 102x0]
-              PaintableWithLines (BlockContainer<DIV>.table-content) [50,66 102x52]
-              PaintableWithLines (BlockContainer(anonymous)) [50,118 102x0]
-          PaintableWithLines (BlockContainer<FIGCAPTION>) [48,14 106x52]
-            PaintableWithLines (BlockContainer(anonymous)) [50,16 102x16]
-            PaintableWithLines (BlockContainer<DIV>.caption-content) [50,32 102x32]
-            PaintableWithLines (BlockContainer(anonymous)) [50,64 102x0]
-      PaintableWithLines (BlockContainer(anonymous)) [8,188 784x0]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x140]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x108]
+      PaintableWithLines (TableWrapper(anonymous)) [48,16 106x108]
+        Paintable (Box<FIGURE>) [48,68 106x56]
+          Paintable (Box(anonymous)) [50,70 102x52]
+            PaintableWithLines (BlockContainer(anonymous)) [50,70 102x52]
+              PaintableWithLines (BlockContainer(anonymous)) [50,70 102x0]
+              PaintableWithLines (BlockContainer<DIV>.table-content) [50,70 102x52]
+              PaintableWithLines (BlockContainer(anonymous)) [50,122 102x0]
+          PaintableWithLines (BlockContainer<FIGCAPTION>) [48,16 106x52]
+            PaintableWithLines (BlockContainer(anonymous)) [50,18 102x16]
+            PaintableWithLines (BlockContainer<DIV>.caption-content) [50,34 102x32]
+            PaintableWithLines (BlockContainer(anonymous)) [50,66 102x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,140 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x188] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x140] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -1,13 +1,13 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 112 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 96 0+0+8] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 96 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 2 0+0+782] [0+0+0 2 0+0+0] [BFC] children: not-inline
         Box <table#empty-table> at [8,8] table-box [0+0+0 2 0+0+0] [0+0+0 2 0+0+0] [TFC] children: not-inline
       BlockContainer <(anonymous)> at [8,10] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)
-      TableWrapper <(anonymous)> at [8,10] [0+0+0 99.171875 0+0+684.828125] [0+0+0 94 0+0+0] [BFC] children: not-inline
-        Box <table#full-table> at [8,26] table-box [0+0+0 99.171875 0+0+0] [0+0+0 62 0+0+16] [TFC] children: not-inline
+      TableWrapper <(anonymous)> at [8,10] [0+0+0 99.171875 0+0+684.828125] [0+0+0 78 0+0+0] [BFC] children: not-inline
+        Box <table#full-table> at [8,26] table-box [0+0+0 99.171875 0+0+0] [0+0+0 62 0+0+0] [TFC] children: not-inline
           BlockContainer <caption> at [8,10] [0+0+0 99.171875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 9, rect: [16.21875,10 82.734375x16] baseline: 12.796875
                 "A Caption"
@@ -36,16 +36,16 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                 frag 0 from TextNode start: 0, length: 11, rect: [11,69 93.171875x16] baseline: 12.796875
                     "Footer Cell"
                 TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,104] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,88] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x112]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x96]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x96]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x80]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 2x2]
         Paintable (Box<TABLE>#empty-table) [8,8 2x2]
       PaintableWithLines (BlockContainer(anonymous)) [8,10 784x0]
-      PaintableWithLines (TableWrapper(anonymous)) [8,10 99.171875x94]
+      PaintableWithLines (TableWrapper(anonymous)) [8,10 99.171875x78]
         Paintable (Box<TABLE>#full-table) [8,26 99.171875x62]
           PaintableWithLines (BlockContainer<CAPTION>) [8,10 99.171875x16]
           Paintable (Box<THEAD>) [10,28 95.171875x18]
@@ -57,7 +57,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           Paintable (Box<TFOOT>) [10,68 95.171875x18]
             Paintable (Box<TR>) [10,68 95.171875x18]
               PaintableWithLines (BlockContainer<TD>) [10,68 95.171875x18]
-      PaintableWithLines (BlockContainer(anonymous)) [8,104 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,88 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x112] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x96] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -4,7 +4,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       TextNode <#text> (not painted)
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 78 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 99.171875 0+0+684.828125] [0+0+0 78 0+0+0] [BFC] children: not-inline
-        Box <table#full-table> at [8,8] table-box [0+0+0 99.171875 0+0+0] [0+0+0 62 0+0+16] [TFC] children: not-inline
+        Box <table#full-table> at [8,8] table-box [0+0+0 99.171875 0+0+0] [0+0+0 62 0+0+0] [TFC] children: not-inline
           BlockContainer <caption> at [8,70] [0+0+0 99.171875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 9, rect: [16.21875,70 82.734375x16] baseline: 12.796875
                 "A Caption"

--- a/Tests/LibWeb/Layout/expected/table/caption-constrained-to-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/caption-constrained-to-table-width.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 186 0+0+0] [BFC] children: not-inline
     BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 170 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [8,8] [0+0+0 104 0+0+680] [0+0+0 170 0+0+0] [BFC] children: not-inline
-        Box <div.table> at [10,10] table-box [0+2+0 100 0+2+0] [0+2+0 100 0+2+66] [TFC] children: not-inline
+        Box <div.table> at [10,10] table-box [0+2+0 100 0+2+0] [0+2+0 100 0+2+0] [TFC] children: not-inline
           Box <(anonymous)> at [10,10] table-row [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] children: not-inline
             BlockContainer <(anonymous)> at [10,10] table-cell [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
               BlockContainer <(anonymous)> at [10,10] [0+0+0 100 0+0+0] [0+0+0 0 0+0+0] children: inline

--- a/Tests/LibWeb/Layout/expected/table/caption-specified-width-with-float.txt
+++ b/Tests/LibWeb/Layout/expected/table/caption-specified-width-with-float.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 110 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 86 0+0+8] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 92 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 68 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 32 0+0+16] children: inline
         frag 0 from TextNode start: 1, length: 96, rect: [8,16 771.90625x16] baseline: 12.796875
             "The words floated and inline should be legible below, with inline appearing just to the right of"
@@ -9,8 +9,8 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
         TextNode <#text> (not painted)
       BlockContainer <(anonymous)> at [8,64] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
-      TableWrapper <(anonymous)> at [8,64] [0+0+0 200 0+0+584] [0+0+0 38 0+0+0] [BFC] children: not-inline
-        Box <table> at [8,82] table-box [0+0+0 200 0+0+0] [0+0+0 2 0+0+18] [TFC] children: not-inline
+      TableWrapper <(anonymous)> at [8,64] [0+0+0 200 0+0+584] [0+0+0 20 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,82] table-box [0+0+0 200 0+0+0] [0+0+0 2 0+0+0] [TFC] children: not-inline
           BlockContainer <caption> at [8,64] [0+0+0 200 0+0+0] [0+0+0 18 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 9, length: 6, rect: [63.8125,64 41.296875x16] baseline: 12.796875
                 "inline"
@@ -20,19 +20,19 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
                   "floated"
               TextNode <#text> (not painted)
             TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,102] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,84] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x110]
-    PaintableWithLines (BlockContainer<BODY>) [8,16 784x86]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x92]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x68]
       PaintableWithLines (BlockContainer<P>) [8,16 784x32]
       PaintableWithLines (BlockContainer(anonymous)) [8,64 784x0]
-      PaintableWithLines (TableWrapper(anonymous)) [8,64 200x38]
+      PaintableWithLines (TableWrapper(anonymous)) [8,64 200x20]
         Paintable (Box<TABLE>) [8,82 200x2]
           PaintableWithLines (BlockContainer<CAPTION>) [8,64 200x18]
             PaintableWithLines (BlockContainer<DIV>) [8,64 55.8125x18]
-      PaintableWithLines (BlockContainer(anonymous)) [8,102 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,84 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x110] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x92] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -1,10 +1,10 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 150 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 120 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 134 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 63.046875 0+0+720.953125] [0+0+0 134 0+0+0] [BFC] children: not-inline
-        Box <table#full-table> at [10,40] table-box [0+2+0 59.046875 0+2+0] [0+2+0 68 0+2+32] [TFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 104 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 63.046875 0+0+720.953125] [0+0+0 104 0+0+0] [BFC] children: not-inline
+        Box <table#full-table> at [10,42] table-box [0+2+0 59.046875 0+2+0] [0+2+0 68 0+2+0] [TFC] children: not-inline
           BlockContainer <caption> at [8,8] [0+0+0 63.046875 0+0+0] [0+0+0 32 0+0+0] [BFC] children: inline
             frag 0 from TextNode start: 5, length: 6, rect: [12.5,8 54.03125x16] baseline: 12.796875
                 "A long"
@@ -13,69 +13,69 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <thead> at [12,42] table-header-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            Box <tr> at [12,42] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <td> at [14,44] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [14,44 20.609375x16] baseline: 12.796875
+          Box <thead> at [12,44] table-header-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            Box <tr> at [12,44] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <td> at [14,46] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [14,46 20.609375x16] baseline: 12.796875
                     "A1"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [41.25,44] table-cell [0+1+1 23.796875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [41.25,44 23.078125x16] baseline: 12.796875
+              BlockContainer <td> at [41.25,46] table-cell [0+1+1 23.796875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,46 23.078125x16] baseline: 12.796875
                     "A2"
                 TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <tbody> at [12,64] table-row-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            Box <tr> at [12,64] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <td> at [14,66] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [14,66 15.6875x16] baseline: 12.796875
+          Box <tbody> at [12,66] table-row-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            Box <tr> at [12,66] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <td> at [14,68] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [14,68 15.6875x16] baseline: 12.796875
                     "B1"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [41.25,66] table-cell [0+1+1 23.796875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [41.25,66 18.15625x16] baseline: 12.796875
+              BlockContainer <td> at [41.25,68] table-cell [0+1+1 23.796875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,68 18.15625x16] baseline: 12.796875
                     "B2"
                 TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <tfoot> at [12,86] table-footer-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-            Box <tr> at [12,86] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
-              BlockContainer <td> at [14,88] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [14,88 18.890625x16] baseline: 12.796875
+          Box <tfoot> at [12,88] table-footer-group [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+            Box <tr> at [12,88] table-row [0+0+0 55.046875 0+0+0] [0+0+0 20 0+0+0] children: not-inline
+              BlockContainer <td> at [14,90] table-cell [0+1+1 21.25 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [14,90 18.890625x16] baseline: 12.796875
                     "F1"
                 TextNode <#text> (not painted)
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <td> at [41.25,88] table-cell [0+1+1 23.796875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [41.25,88 21.359375x16] baseline: 12.796875
+              BlockContainer <td> at [41.25,90] table-cell [0+1+1 23.796875 1+1+0] [0+1+1 16 1+1+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 2, rect: [41.25,90 21.359375x16] baseline: 12.796875
                     "F2"
                 TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,142] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,112] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x150]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x120]
     PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x134]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 63.046875x134]
-        Paintable (Box<TABLE>#full-table) [8,38 63.046875x72]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x104]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 63.046875x104]
+        Paintable (Box<TABLE>#full-table) [8,40 63.046875x72]
           PaintableWithLines (BlockContainer<CAPTION>) [8,8 63.046875x32]
-          Paintable (Box<THEAD>) [12,42 55.046875x20]
-            Paintable (Box<TR>) [12,42 55.046875x20]
-              PaintableWithLines (BlockContainer<TD>) [12,42 25.25x20]
-              PaintableWithLines (BlockContainer<TD>) [39.25,42 27.796875x20]
-          Paintable (Box<TBODY>) [12,64 55.046875x20]
-            Paintable (Box<TR>) [12,64 55.046875x20]
-              PaintableWithLines (BlockContainer<TD>) [12,64 25.25x20]
-              PaintableWithLines (BlockContainer<TD>) [39.25,64 27.796875x20]
-          Paintable (Box<TFOOT>) [12,86 55.046875x20]
-            Paintable (Box<TR>) [12,86 55.046875x20]
-              PaintableWithLines (BlockContainer<TD>) [12,86 25.25x20]
-              PaintableWithLines (BlockContainer<TD>) [39.25,86 27.796875x20]
-      PaintableWithLines (BlockContainer(anonymous)) [8,142 784x0]
+          Paintable (Box<THEAD>) [12,44 55.046875x20]
+            Paintable (Box<TR>) [12,44 55.046875x20]
+              PaintableWithLines (BlockContainer<TD>) [12,44 25.25x20]
+              PaintableWithLines (BlockContainer<TD>) [39.25,44 27.796875x20]
+          Paintable (Box<TBODY>) [12,66 55.046875x20]
+            Paintable (Box<TR>) [12,66 55.046875x20]
+              PaintableWithLines (BlockContainer<TD>) [12,66 25.25x20]
+              PaintableWithLines (BlockContainer<TD>) [39.25,66 27.796875x20]
+          Paintable (Box<TFOOT>) [12,88 55.046875x20]
+            Paintable (Box<TR>) [12,88 55.046875x20]
+              PaintableWithLines (BlockContainer<TD>) [12,88 25.25x20]
+              PaintableWithLines (BlockContainer<TD>) [39.25,88 27.796875x20]
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x150] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x120] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/table-caption-inline-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-caption-inline-width.txt
@@ -1,35 +1,35 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 77 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 61 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 208 0+0+576] [0+0+0 61 0+0+0] [BFC] children: not-inline
-        Box <table> at [9,29] table-box [0+1+0 206 0+1+0] [0+1+0 17 0+1+22] [TFC] children: not-inline
-          BlockContainer <caption> at [15,8] [0+1+6 194 6+1+0] [0+1+0 20 0+1+0] [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 10, rect: [62,8 100x10] baseline: 8
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 57 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 41 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 208 0+0+576] [0+0+0 41 0+0+0] [BFC] children: not-inline
+        Box <table> at [9,31] table-box [0+1+0 206 0+1+0] [0+1+0 17 0+1+0] [TFC] children: not-inline
+          BlockContainer <caption> at [15,9] [0+1+6 194 6+1+0] [0+1+0 20 0+1+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 10, rect: [62,9 100x10] baseline: 8
                 "AAAAAAAAAA"
-            frag 1 from TextNode start: 11, length: 14, rect: [42,18 140x10] baseline: 8
+            frag 1 from TextNode start: 11, length: 14, rect: [42,19 140x10] baseline: 8
                 "BBBBBBBBB CCCC"
             TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <tbody> at [11,31] table-row-group [0+0+0 202 0+0+0] [0+0+0 13 0+0+0] children: not-inline
-            Box <tr> at [11,31] table-row [0+0+0 202 0+0+0] [0+0+0 13 0+0+0] children: not-inline
-              BlockContainer <td> at [12,32] table-cell [0+0+1 200 1+0+0] [0+0+1 11 1+0+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [12,31 10x10] baseline: 8
+          Box <tbody> at [11,33] table-row-group [0+0+0 202 0+0+0] [0+0+0 13 0+0+0] children: not-inline
+            Box <tr> at [11,33] table-row [0+0+0 202 0+0+0] [0+0+0 13 0+0+0] children: not-inline
+              BlockContainer <td> at [12,34] table-cell [0+0+1 200 1+0+0] [0+0+1 11 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [12,33 10x10] baseline: 8
                     "x"
                 TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,69] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,49] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x77]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x61]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 208x61]
-        Paintable (Box<TABLE>) [8,28 208x19]
-          PaintableWithLines (BlockContainer<CAPTION>) [8,7 208x22]
-          Paintable (Box<TBODY>) [11,31 202x13]
-            Paintable (Box<TR>) [11,31 202x13]
-              PaintableWithLines (BlockContainer<TD>) [11,31 202x13]
-      PaintableWithLines (BlockContainer(anonymous)) [8,69 784x0]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x57]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x41]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 208x41]
+        Paintable (Box<TABLE>) [8,30 208x19]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,8 208x22]
+          Paintable (Box<TBODY>) [11,33 202x13]
+            Paintable (Box<TR>) [11,33 202x13]
+              PaintableWithLines (BlockContainer<TD>) [11,33 202x13]
+      PaintableWithLines (BlockContainer(anonymous)) [8,49 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x77] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x57] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -1,30 +1,30 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 84 0+0+8] children: not-inline
-      TableWrapper <(anonymous)> at [8,8] [0+0+0 80.46875 0+0+703.53125] [0+0+0 84 0+0+0] [BFC] children: not-inline
-        Box <table> at [8,34] table-box [0+0+0 80.46875 0+0+0] [0+0+0 22 0+0+36] [TFC] children: not-inline
-          BlockContainer <caption> at [18,8] [0+0+10 60.46875 10+0+0] [0+0+10 16 10+0+0] [BFC] children: inline
-            frag 0 from TextNode start: 5, length: 7, rect: [18,8 60.46875x16] baseline: 12.796875
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 74 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 58 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 80.46875 0+0+703.53125] [0+0+0 58 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,44] table-box [0+0+0 80.46875 0+0+0] [0+0+0 22 0+0+0] [TFC] children: not-inline
+          BlockContainer <caption> at [18,18] [0+0+10 60.46875 10+0+0] [0+0+10 16 10+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 5, length: 7, rect: [18,18 60.46875x16] baseline: 12.796875
                 "Caption"
             TextNode <#text> (not painted)
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text> (not painted)
-          Box <tbody> at [10,36] table-row-group [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-            Box <tr> at [10,36] table-row [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
-              BlockContainer <td> at [11,37] table-cell [0+0+1 74.46875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,37 27.5x16] baseline: 12.796875
+          Box <tbody> at [10,46] table-row-group [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+            Box <tr> at [10,46] table-row [0+0+0 76.46875 0+0+0] [0+0+0 18 0+0+0] children: not-inline
+              BlockContainer <td> at [11,47] table-cell [0+0+1 74.46875 1+0+0] [0+0+1 16 1+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [11,47 27.5x16] baseline: 12.796875
                     "Cell"
                 TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x100]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x84]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 80.46875x84]
-        Paintable (Box<TABLE>) [8,34 80.46875x22]
-          PaintableWithLines (BlockContainer<CAPTION>) [8,-2 80.46875x36]
-          Paintable (Box<TBODY>) [10,36 76.46875x18]
-            Paintable (Box<TR>) [10,36 76.46875x18]
-              PaintableWithLines (BlockContainer<TD>) [10,36 76.46875x18]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x74]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x58]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 80.46875x58]
+        Paintable (Box<TABLE>) [8,44 80.46875x22]
+          PaintableWithLines (BlockContainer<CAPTION>) [8,8 80.46875x36]
+          Paintable (Box<TBODY>) [10,46 76.46875x18]
+            Paintable (Box<TR>) [10,46 76.46875x18]
+              PaintableWithLines (BlockContainer<TD>) [10,46 76.46875x18]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x100] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x74] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/bfc-root-auto-height-uses-child-run-result-abspos-flow-root-floats.html
+++ b/Tests/LibWeb/Layout/input/bfc-root-auto-height-uses-child-run-result-abspos-flow-root-floats.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+    * { margin: 0; padding: 0; }
+</style>
+<div style="position: absolute; display: flow-root; border: 1px solid blue;">
+    <div style="float: left; width: 30px; height: 60px; background: yellow;"></div>
+    <div style="height: 10px; width: 50px; background: red;"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/bfc-root-auto-height-uses-child-run-result-inline-block-float-past-bottom.html
+++ b/Tests/LibWeb/Layout/input/bfc-root-auto-height-uses-child-run-result-inline-block-float-past-bottom.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+    * { margin: 0; padding: 0; }
+</style>
+<div style="display: inline-block; border: 1px solid black;">
+    <div style="float: left; height: 100px; width: 10px; background: teal;"></div>
+    <div style="height: 20px; width: 40px; margin-bottom: 35px; background: silver;"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/bfc-root-auto-height-uses-child-run-result-inline-block-margin-below-last-child.html
+++ b/Tests/LibWeb/Layout/input/bfc-root-auto-height-uses-child-run-result-inline-block-margin-below-last-child.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+    * { margin: 0; padding: 0; }
+</style>
+<div style="display: inline-block; border: 1px solid black;">
+    <div style="height: 20px; width: 40px; margin-bottom: 30px; background: silver;"></div>
+</div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/container-units-auto.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-conditional/container-queries/container-units-auto.txt
@@ -2,5 +2,5 @@ Harness status: OK
 
 Found 1 tests
 
-1 Fail
-Fail	Resolving cqh against a auto height size container should be 0
+1 Pass
+Pass	Resolving cqh against a auto height size container should be 0


### PR DESCRIPTION
This PR fixes two cross-context ownership violations in layout, where FC reached into used values that belong to a different FC.

1. Parents looked into child context internals to resolve auto block sizes. Resolving a child box's automatic block size re-derived it from outside the child's formatting context: `automatic_block_size_for_bfc_root()` read the child's line data, the used values of every in-flow grandchild, and the child context's float bookkeeping. Every context run already computes this value, so the resolution paths now consume the run's `ChildLayoutResult` through explicit parameters instead, with no copy stored on used values.

2. Caption layout ran inside the table formatting context by borrowing the wrapper's BFC. This inverted ownership — a float-band query inside caption layout read the wrapper's content inline size from within the table context's run — and caption heights were smuggled into the wrapper through the table box's content offset and an inflated used margin-bottom. CSS 2 §17.4 ([Tables in the visual formatting model](https://www.w3.org/TR/CSS22/tables.html#model)) puts captions in the wrapper's block formatting context, not the table's:

> the table generates a principal block container box called the table
> wrapper box that contains the table box itself and any caption boxes (in
> document order). The table wrapper box establishes a block formatting
> context, and the table box establishes a table formatting context.

> The caption boxes are principal block-level boxes that retain their own
> content, padding, margin, and border areas, and are rendered as normal
> block boxes inside the table wrapper box. Whether the caption boxes are
> placed before or after the table box is decided by the 'caption-side'
> property, as described below.

The wrapper's BFC now does exactly that — it lays out top captions, the table box, and bottom captions as ordinary flow children, and the table context handles only the grid. This deletes the table run's aliased `parent_block` parameter and the offset/margin round-trip, and fixes real top-caption bugs (caption box-model edges overhanging above the wrapper, the table's top border overlapping the caption, double-counted wrapper heights, a phantom gap below stretched table flex items); the affected expectations are rebaselined. The caption path's hand-rolled `contain: size` handling is replaced by zeroing the automatic block size of any size-contained BFC root, which also makes the imported `container-units-auto` WPT test pass.
