### PR TITLE
LibWeb+LibWebView: Finalize same-document navigations in UI 

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3121,24 +3121,14 @@ void LocalNavigable::navigate_to_a_fragment(URL::URL const& url, HistoryHandling
     // 16. Let traversable be navigable's traversable navigable.
     auto traversable = traversable_navigable();
 
-    // AD-HOC: Browser engines commit same-document navigations synchronously when no traversal state is active. Keep
-    //         the spec's queued synchronous-navigation steps as the fallback for reentrant traversal work and child
-    //         navigables whose nested history is not ready yet.
     // 17. Append the following session history synchronous navigation steps involving navigable to traversable:
-    if (!traversable->try_to_synchronously_commit_same_document_navigation(*this, history_entry, entry_to_replace)) {
-        traversable->append_session_history_synchronous_navigation_steps(*this, GC::create_function(heap(), [this, traversable, history_entry, entry_to_replace, navigation_id, history_handling, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
-            // 1. Finalize a same-document navigation given traversable, navigable, historyEntry, entryToReplace,
-            //    historyHandling, and userInvolvement.
-            finalize_a_same_document_navigation(*traversable, *this, history_entry, entry_to_replace, history_handling, user_involvement,
-                GC::create_function(heap(), [signal](HistoryStepResult) {
-                    signal->resolve({});
-                }));
+    // 1. Finalize a same-document navigation given traversable, navigable, historyEntry, entryToReplace,
+    //    historyHandling, and userInvolvement.
+    traversable->finalize_same_document_navigation(*this, history_entry, entry_to_replace, history_handling, user_involvement);
 
-            // FIXME: 2. Invoke WebDriver BiDi fragment navigated with navigable and a new WebDriver BiDi
-            //            navigation status whose id is navigationId, url is url, and status is "complete".
-            (void)navigation_id;
-        }));
-    }
+    // FIXME: Invoke WebDriver BiDi fragment navigated with navigable and a new WebDriver BiDi navigation status whose
+    //        id is navigationId, url is url, and status is "complete".
+    (void)navigation_id;
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#evaluate-a-javascript:-url
@@ -3719,21 +3709,12 @@ void perform_url_and_history_update_steps(DOM::Document& document, URL::URL new_
     // 12. Let traversable be navigable's traversable navigable.
     auto traversable = navigable->traversable_navigable();
 
-    // AD-HOC: Browser engines commit same-document navigations synchronously when no traversal state is active. Keep
-    //         the spec's queued synchronous-navigation steps as the fallback for reentrant traversal work and child
-    //         navigables whose nested history is not ready yet.
     // 13. Append the following session history synchronous navigation steps involving navigable to traversable:
-    if (!traversable->try_to_synchronously_commit_same_document_navigation(*navigable, new_entry, entry_to_replace)) {
-        traversable->append_session_history_synchronous_navigation_steps(*navigable, GC::create_function(document.realm().heap(), [traversable, navigable, new_entry, entry_to_replace, history_handling](NonnullRefPtr<Core::Promise<Empty>> signal) {
-            // 1. Finalize a same-document navigation given traversable, navigable, newEntry, entryToReplace,
-            //    historyHandling, and "none".
-            finalize_a_same_document_navigation(*traversable, *navigable, new_entry, entry_to_replace, history_handling, UserNavigationInvolvement::None,
-                GC::create_function(traversable->heap(), [signal](HistoryStepResult) {
-                    signal->resolve({});
-                }));
-            // 2. FIXME: Invoke WebDriver BiDi history updated with navigable.
-        }));
-    }
+    // 1. Finalize a same-document navigation given traversable, navigable, newEntry, entryToReplace,
+    //    historyHandling, and "none".
+    traversable->finalize_same_document_navigation(*navigable, new_entry, entry_to_replace, history_handling, UserNavigationInvolvement::None);
+
+    // FIXME: Invoke WebDriver BiDi history updated with navigable.
 }
 
 void LocalNavigable::scroll_offset_did_change()

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1318,6 +1318,12 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
                 auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*page, opener, target_name);
                 page->set_top_level_traversable(traversable);
                 traversable->set_window_handle(Utf16String::from_ascii_without_validation(window_handle.bytes()));
+
+                auto initial_history_entry = traversable->active_session_history_entry();
+                VERIFY(initial_history_entry);
+                page->client().page_did_create_top_level_traversable(
+                    traversable->id(),
+                    create_session_history_entry_descriptor(*initial_history_entry));
                 return traversable;
             };
             auto create_new_traversable = GC::create_function(heap(), move(create_new_traversable_closure));

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1260,6 +1260,12 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
     //    agent's configuration and abilities — it is determined by the rules given for the first applicable option
     //    from the following list:
     if (!chosen) {
+        auto request_new_web_view = [&] {
+            TokenizedFeature::Map empty_window_features;
+            auto hints = WebViewHints::from_tokenised_features(window_features.has_value() ? *window_features : empty_window_features, traversable_navigable()->page());
+            return traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints, no_opener);
+        };
+
         // --> If currentNavigable's active window does not have transient activation and the user agent has been configured to
         //     not show popups (i.e., the user agent has a "popup blocker" enabled)
         if (active_window() && !active_window()->has_transient_activation() && traversable_navigable()->page().should_block_pop_ups()) {
@@ -1274,7 +1280,7 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
         }
 
         // --> If the user agent has been configured such that in this instance it will create a new top-level traversable
-        else if (true) { // FIXME: When is this the case?
+        else if (auto new_web_view = request_new_web_view(); new_web_view.page) {
             // 1. Consume user activation of currentNavigable's active window.
             active_window()->consume_user_activation();
 
@@ -1308,10 +1314,7 @@ LocalNavigable::ChosenNavigable LocalNavigable::choose_a_navigable(Utf16View nam
             if (!name.equals_ignoring_ascii_case(u"_blank"sv))
                 target_name = Utf16String::from_utf16(name);
 
-            auto create_new_traversable_closure = [this, no_opener, target_name, activate_tab, window_features](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalNavigable> {
-                TokenizedFeature::Map empty_window_features;
-                auto hints = WebViewHints::from_tokenised_features(window_features.has_value() ? *window_features : empty_window_features, traversable_navigable()->page());
-                auto [page, window_handle] = traversable_navigable()->page().client().page_did_request_new_web_view(activate_tab, hints, no_opener);
+            auto create_new_traversable_closure = [page = new_web_view.page, window_handle = move(new_web_view.window_handle), target_name](GC::Ptr<BrowsingContext> opener) -> GC::Ref<LocalNavigable> {
                 auto traversable = LocalTraversableNavigable::create_a_new_top_level_traversable(*page, opener, target_name);
                 page->set_top_level_traversable(traversable);
                 traversable->set_window_handle(Utf16String::from_ascii_without_validation(window_handle.bytes()));

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/Window.h>
@@ -60,6 +61,8 @@ void LocalTraversableNavigable::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_storage_shed);
     visitor.visit(m_apply_history_step_state);
     visitor.visit(m_paused_apply_history_step_state);
+    for (auto& pending_navigation : m_pending_same_document_navigations)
+        visitor.visit(pending_navigation.value.target_navigable);
 }
 
 static OrderedHashTable<LocalTraversableNavigable*>& user_agent_top_level_traversable_set()
@@ -1731,8 +1734,13 @@ int LocalTraversableNavigable::claim_next_session_history_step()
     for (auto claimed : m_outstanding_claimed_session_history_steps)
         step = max(step, claimed);
     ++step;
-    m_outstanding_claimed_session_history_steps.append(step);
+    claim_session_history_step(step);
     return step;
+}
+
+void LocalTraversableNavigable::claim_session_history_step(int step)
+{
+    m_outstanding_claimed_session_history_steps.append(step);
 }
 
 void LocalTraversableNavigable::retire_claimed_session_history_step(int step)
@@ -2428,127 +2436,182 @@ void LocalTraversableNavigable::apply_the_push_or_replace_history_step(int step,
     apply_the_history_step(step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
 }
 
-static void report_finalized_same_document_navigation_to_ui_process(LocalTraversableNavigable& traversable, LocalNavigable const& target_navigable, SessionHistoryEntry const& target_entry, RefPtr<SessionHistoryEntry> const& entry_to_replace)
+static void reconcile_same_document_navigation_with_local_session_history(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, int entry_step)
 {
-    Optional<Utf16String> entry_to_replace_navigation_api_key;
-    if (entry_to_replace)
-        entry_to_replace_navigation_api_key = entry_to_replace->navigation_api_key();
-
-    traversable.page().client().page_did_finalize_same_document_navigation(
-        target_navigable.id(),
-        create_session_history_entry_descriptor(target_entry),
-        entry_to_replace_navigation_api_key);
-}
-
-static Optional<int> update_session_history_entries_for_same_document_navigation(LocalTraversableNavigable& traversable, GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace)
-{
-    // NB: This is the entry-list portion of the "finalize a same-document navigation" algorithm. Keep the synchronous
-    //     commit path and the queued fallback sharing it so the two paths cannot drift.
-
-    // 2. If targetNavigable's active session history entry is not targetEntry, then return.
-    // FIXME: This is a workaround for a spec issue where the early return loses replace entries.
-    //        Revisit when https://github.com/whatwg/html/issues/10232 is resolved.
-    if (target_navigable->active_session_history_entry() != target_entry) {
-        if (entry_to_replace) {
-            auto& target_entries = target_navigable->get_session_history_entries();
-            if (auto it = target_entries.find(*entry_to_replace); it != target_entries.end()) {
-                target_entry->set_step(entry_to_replace->step());
-                *it = target_entry;
-                report_finalized_same_document_navigation_to_ui_process(traversable, target_navigable, target_entry, entry_to_replace);
-            }
-        }
-        return {};
-    }
-
-    // 3. Let targetStep be null.
-    Optional<int> target_step;
-
-    // 4. Let targetEntries be the result of getting session history entries for targetNavigable.
+    // AD-HOC: The UI process does not yet coordinate applying history steps, so WebContent keeps its local entry list
+    //         usable while finalization crosses IPC. This reconciliation can be removed once the UI process owns that
+    //         coordination.
     auto& target_entries = target_navigable->get_session_history_entries();
 
-    // 5. If entryToReplace is null, then:
-    // FIXME: Checking containment of entryToReplace should not be needed.
-    //        For more details see https://github.com/whatwg/html/issues/10232#issuecomment-2037543137
-    if (!entry_to_replace || !target_entries.contains_slow(NonnullRefPtr { *entry_to_replace })) {
-        // 1. Clear the forward session history of traversable.
-        traversable.clear_the_forward_session_history();
-
-        // 2. Set targetStep to traversable's current session history step + 1.
-        // AD-HOC: Claim the step instead — so a step claimed by an apply-history-step run still in flight can't be
-        //         handed out twice. See https://github.com/whatwg/html/issues/12576.
-        target_step = traversable.claim_next_session_history_step();
-
-        // 3. Set targetEntry's step to targetStep.
-        target_entry->set_step(*target_step);
-
-        // 4. Append targetEntry to targetEntries.
-        target_entries.append(target_entry);
-        report_finalized_same_document_navigation_to_ui_process(traversable, target_navigable, target_entry, nullptr);
-    } else {
-        // 1. Replace entryToReplace with targetEntry in targetEntries.
-        *(target_entries.find(*entry_to_replace)) = target_entry;
-
-        // 2. Set targetEntry's step to entryToReplace's step.
-        target_entry->set_step(entry_to_replace->step());
-
-        // 3. Set targetStep to traversable's current session history step.
-        target_step = traversable.current_session_history_step();
-        report_finalized_same_document_navigation_to_ui_process(traversable, target_navigable, target_entry, entry_to_replace);
+    if (target_entries.contains_slow(target_entry)) {
+        target_entry->set_step(entry_step);
+        return;
     }
 
-    return target_step;
+    auto entry_to_replace_iterator = entry_to_replace ? target_entries.find(*entry_to_replace) : target_entries.end();
+    if (entry_to_replace_iterator == target_entries.end()) {
+        target_entry->set_step(entry_step);
+        target_entries.append(target_entry);
+    } else {
+        *entry_to_replace_iterator = target_entry;
+        target_entry->set_step(entry_step);
+    }
 }
 
-bool LocalTraversableNavigable::try_to_synchronously_commit_same_document_navigation(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace)
+void LocalTraversableNavigable::finalize_same_document_navigation(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement)
 {
-    if (m_apply_history_step_state || m_paused_apply_history_step_state)
-        return false;
-
     if (target_navigable->has_been_destroyed())
-        return true;
+        return;
 
-    if (!target_navigable->has_session_history_entry_and_ready_for_navigation())
-        return false;
-
-    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
-    auto target_step = update_session_history_entries_for_same_document_navigation(*this, target_navigable, target_entry, entry_to_replace);
-    if (!target_step.has_value())
-        return true;
-
-    target_navigable->set_current_session_history_entry(target_entry);
-    m_current_session_history_step = get_the_used_step(*target_step);
-
-    // AD-HOC: A synchronous commit applies its step in this same task, so it has no asynchronous window in which
-    //         another run could observe the claim. Retire it immediately. Unlike the queued apply-history-step path,
-    //         nothing else will. Leaving it outstanding would let claimed steps accumulate without bound — and push
-    //         later step numbers ever higher. (A replacement reuses the current step and claimed nothing, so retiring
-    //         it is a no-op.) See https://github.com/whatwg/html/issues/12576.
-    retire_claimed_session_history_step(*target_step);
-
-    // NB: The queued apply-history-step path clears the ongoing navigation when the history step finishes. The
-    //     synchronous fast path has already committed the same-document navigation and the Navigation API entry update
-    //     owns settling its promises/events, so do the same cleanup without reporting an abort to the Navigation API.
-    if (!synchronous_same_document_navigation_must_preserve_ongoing_navigation(*target_navigable))
-        target_navigable->set_ongoing_navigation({}, LocalNavigable::NavigationAPIAbortBehavior::Preserve);
-
-    auto history_object_length_and_index = get_the_history_object_length_and_index(m_current_session_history_step);
-    if (auto active_document = this->active_document()) {
-        for (auto const& navigable : active_document->inclusive_descendant_navigables()) {
-            if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()->is_fully_active())
-                continue;
-
-            auto document = navigable->active_document();
-            document->history()->m_index = history_object_length_and_index.script_history_index;
-            document->history()->m_length = history_object_length_and_index.script_history_length;
-        }
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-traversal-parallel-queue-sync-nav-steps
+    // AD-HOC: Browser engines commit same-document navigations synchronously when no traversal state is active. Keep
+    //         the spec's queued synchronous-navigation steps as the fallback for reentrant traversal work and child
+    //         navigables whose nested history is not ready yet.
+    if (m_apply_history_step_state || m_paused_apply_history_step_state || !target_navigable->has_session_history_entry_and_ready_for_navigation()) {
+        append_session_history_synchronous_navigation_steps(target_navigable, GC::create_function(heap(), [this, target_navigable, target_entry, entry_to_replace, history_handling, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
+            if (target_navigable->has_been_destroyed()) {
+                signal->resolve({});
+                return;
+            }
+            begin_same_document_navigation_finalization(target_navigable, target_entry, entry_to_replace, history_handling, user_involvement, signal);
+        }));
+        return;
     }
 
-    save_persisted_state_to_active_session_history_entry();
-    page().client().page_did_set_current_session_history_step(m_current_session_history_step);
+    begin_same_document_navigation_finalization(target_navigable, target_entry, entry_to_replace, history_handling, user_involvement, nullptr);
+}
 
-    VERIFY(session_history_entries().size() > 0);
-    page().client().page_did_change_url(current_session_history_entry()->url());
-    return true;
+void LocalTraversableNavigable::set_history_object_length_and_index(HistoryObjectLengthAndIndex history_object_length_and_index)
+{
+    auto active_document = this->active_document();
+    if (!active_document)
+        return;
+
+    for (auto const& navigable : active_document->inclusive_descendant_navigables()) {
+        if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()->is_fully_active())
+            continue;
+
+        auto document = navigable->active_document();
+        document->history()->m_index = history_object_length_and_index.script_history_index;
+        document->history()->m_length = history_object_length_and_index.script_history_length;
+    }
+}
+
+void LocalTraversableNavigable::begin_same_document_navigation_finalization(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, RefPtr<Core::Promise<Empty>> signal)
+{
+    auto is_queued = signal != nullptr;
+    auto provisional_target_step = current_session_history_step();
+    Optional<int> provisional_claimed_step;
+    if (!entry_to_replace) {
+        clear_the_forward_session_history();
+
+        // AD-HOC: Claim the step instead — so a step claimed by an apply-history-step run still in flight can't be
+        //         handed out twice. See https://github.com/whatwg/html/issues/12576.
+        provisional_target_step = claim_next_session_history_step();
+        if (is_queued)
+            provisional_claimed_step = provisional_target_step;
+    }
+    reconcile_same_document_navigation_with_local_session_history(target_navigable, target_entry, entry_to_replace, provisional_target_step);
+
+    auto pending_navigation = PendingSameDocumentNavigation {
+        .target_navigable = target_navigable,
+        .target_entry = target_entry,
+        .entry_to_replace = entry_to_replace,
+        .history_handling = history_handling,
+        .user_involvement = user_involvement,
+        .provisional_claimed_step = provisional_claimed_step,
+        .signal = move(signal),
+    };
+
+    if (!is_queued) {
+        target_navigable->set_current_session_history_entry(target_entry);
+        m_current_session_history_step = get_the_used_step(provisional_target_step);
+
+        // AD-HOC: A synchronous commit applies its step in this same task, so it has no asynchronous window in which
+        //         another run could observe the claim. Retire it immediately. Unlike the queued apply-history-step path,
+        //         nothing else will. Leaving it outstanding would let claimed steps accumulate without bound — and push
+        //         later step numbers ever higher. (A replacement reuses the current step and claimed nothing, so retiring
+        //         it is a no-op.) See https://github.com/whatwg/html/issues/12576.
+        retire_claimed_session_history_step(provisional_target_step);
+
+        auto must_preserve_ongoing_navigation = synchronous_same_document_navigation_must_preserve_ongoing_navigation(*target_navigable);
+        if (!must_preserve_ongoing_navigation)
+            m_committed_apply_history_step_generation = ++m_apply_history_step_generation_counter;
+
+        // NB: The queued apply-history-step path clears the ongoing navigation when the history step finishes. The
+        //     synchronous fast path has already committed the same-document navigation and the Navigation API entry
+        //     update owns settling its promises/events, so do the same cleanup without reporting an abort to the
+        //     Navigation API.
+        if (!must_preserve_ongoing_navigation)
+            target_navigable->set_ongoing_navigation({}, LocalNavigable::NavigationAPIAbortBehavior::Preserve);
+
+        auto history_object_length_and_index = get_the_history_object_length_and_index(m_current_session_history_step);
+        set_history_object_length_and_index(history_object_length_and_index);
+
+        save_persisted_state_to_active_session_history_entry();
+        page().client().page_did_change_url(current_session_history_entry()->url());
+    }
+
+    auto operation_id = m_next_same_document_navigation_operation_id++;
+    m_pending_same_document_navigations.set(operation_id, move(pending_navigation));
+
+    page().client().page_did_request_finalize_same_document_navigation(
+        operation_id,
+        target_navigable->id(),
+        create_same_document_navigation_entry(target_entry),
+        entry_to_replace != nullptr,
+        history_handling,
+        user_involvement);
+}
+
+void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex history_object_length_and_index)
+{
+    auto pending_navigation = m_pending_same_document_navigations.take(operation_id);
+    VERIFY(pending_navigation.has_value());
+
+    auto is_newest_pending_navigation = m_pending_same_document_navigations.is_empty();
+
+    auto complete = [&] {
+        if (pending_navigation->provisional_claimed_step.has_value())
+            retire_claimed_session_history_step(*pending_navigation->provisional_claimed_step);
+        if (pending_navigation->signal)
+            pending_navigation->signal->resolve({});
+    };
+
+    if (!committed || pending_navigation->target_navigable->has_been_destroyed()) {
+        complete();
+        return;
+    }
+
+    reconcile_same_document_navigation_with_local_session_history(pending_navigation->target_navigable, pending_navigation->target_entry, pending_navigation->entry_to_replace, entry_step);
+
+    if (is_newest_pending_navigation)
+        set_history_object_length_and_index(history_object_length_and_index);
+
+    if (pending_navigation->target_navigable->active_session_history_entry() != pending_navigation->target_entry) {
+        complete();
+        return;
+    }
+
+    if (pending_navigation->signal) {
+        // The UI process assigns the canonical step, which need not be the step claimed locally. Move the claim onto it
+        // so that applying the history step below retires exactly what is outstanding.
+        if (pending_navigation->provisional_claimed_step.has_value() && *pending_navigation->provisional_claimed_step != target_step) {
+            retire_claimed_session_history_step(*pending_navigation->provisional_claimed_step);
+            claim_session_history_step(target_step);
+        }
+
+        auto signal = pending_navigation->signal;
+        apply_the_push_or_replace_history_step(target_step, pending_navigation->history_handling, pending_navigation->user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {},
+            GC::create_function(heap(), [signal](HistoryStepResult) {
+                signal->resolve({});
+            }));
+        return;
+    }
+
+    pending_navigation->target_navigable->set_current_session_history_entry(pending_navigation->target_entry);
+    if (is_newest_pending_navigation)
+        m_current_session_history_step = target_step;
 }
 
 void LocalTraversableNavigable::apply_the_traverse_history_step(int step, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<LocalNavigable> initiator_to_check, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
@@ -2644,27 +2707,6 @@ void LocalTraversableNavigable::destroy_top_level_traversable()
     //        However, without this, we can keep stale destroyed traversables around.
     set_has_been_destroyed();
     remove_from_all_local_navigables();
-}
-
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
-void finalize_a_same_document_navigation(GC::Ref<LocalTraversableNavigable> traversable, GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, GC::Ref<OnApplyHistoryStepComplete> on_complete)
-{
-    // NOTE: This is not in the spec but we should not navigate destroyed navigable.
-    if (target_navigable->has_been_destroyed()) {
-        on_complete->function()(HistoryStepResult::Applied);
-        return;
-    }
-
-    // FIXME: 1. Assert: this is running on traversable's session history traversal queue.
-
-    auto target_step = update_session_history_entries_for_same_document_navigation(*traversable, target_navigable, target_entry, entry_to_replace);
-    if (!target_step.has_value()) {
-        on_complete->function()(HistoryStepResult::Applied);
-        return;
-    }
-
-    // 6. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
-    traversable->apply_the_push_or_replace_history_step(*target_step, history_handling, user_involvement, LocalTraversableNavigable::SynchronousNavigation::Yes, nullptr, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#system-visibility-state

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -53,6 +53,7 @@ public:
     // steps in flight at once. So, computing a new step from the current step alone can hand out a step number that an
     // existing entry already holds. A claim is retired when the run that applies it completes.
     [[nodiscard]] int claim_next_session_history_step();
+    void claim_session_history_step(int step);
     void retire_claimed_session_history_step(int step);
     Vector<NonnullRefPtr<SessionHistoryEntry>>& session_history_entries() { return m_session_history_entries; }
     Vector<NonnullRefPtr<SessionHistoryEntry>> const& session_history_entries() const { return m_session_history_entries; }
@@ -120,7 +121,8 @@ public:
     void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete);
     void update_nonchanging_navigable_history_step_state(GC::Ref<LocalNavigable>, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
 
-    [[nodiscard]] bool try_to_synchronously_commit_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace);
+    void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
+    void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
     void apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
     void update_for_navigable_creation_or_destruction(GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
@@ -271,6 +273,20 @@ private:
     GC::Ptr<ApplyHistoryStepState> m_paused_apply_history_step_state;
     GC::Ptr<ApplyHistoryStepState> m_apply_history_step_state;
 
+    struct PendingSameDocumentNavigation {
+        GC::Ref<LocalNavigable> target_navigable;
+        NonnullRefPtr<SessionHistoryEntry> target_entry;
+        RefPtr<SessionHistoryEntry> entry_to_replace;
+        HistoryHandlingBehavior history_handling;
+        UserNavigationInvolvement user_involvement;
+        Optional<int> provisional_claimed_step;
+        RefPtr<Core::Promise<Empty>> signal;
+    };
+    void begin_same_document_navigation_finalization(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement, RefPtr<Core::Promise<Empty>> signal);
+    void set_history_object_length_and_index(HistoryObjectLengthAndIndex);
+    u64 m_next_same_document_navigation_operation_id { 1 };
+    HashMap<u64, PendingSameDocumentNavigation> m_pending_same_document_navigations;
+
     // https://html.spec.whatwg.org/multipage/document-sequences.html#system-visibility-state
     VisibilityState m_system_visibility_state { VisibilityState::Hidden };
 
@@ -302,7 +318,6 @@ struct BrowsingContextAndDocument {
 };
 
 BrowsingContextAndDocument create_a_new_top_level_browsing_context_and_document(GC::Ref<Page> page);
-void finalize_a_same_document_navigation(GC::Ref<LocalTraversableNavigable> traversable, GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement, GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
 template<>
 inline bool LocalNavigable::fast_is<LocalTraversableNavigable>() const { return is_traversable(); }

--- a/Libraries/LibWeb/HTML/SameDocumentNavigationEntry.h
+++ b/Libraries/LibWeb/HTML/SameDocumentNavigationEntry.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/HTML/SessionHistoryEntry.h>
+
+namespace Web::HTML {
+
+struct SameDocumentNavigationEntry {
+    URL::URL url;
+    CrossProcessId document_state_id;
+    StorageSerializationRecord classic_history_api_state;
+    StorageSerializationRecord navigation_api_state;
+    Utf16String navigation_api_key;
+    Utf16String navigation_api_id;
+    ScrollRestorationMode scroll_restoration_mode { ScrollRestorationMode::Auto };
+    SessionHistoryEntryScrollPositionData scroll_position_data;
+};
+
+WEB_API SameDocumentNavigationEntry create_same_document_navigation_entry(SessionHistoryEntry const&);
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::HTML::SameDocumentNavigationEntry const&);
+
+template<>
+WEB_API ErrorOr<Web::HTML::SameDocumentNavigationEntry> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
+++ b/Libraries/LibWeb/HTML/SessionHistoryEntry.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 
@@ -90,6 +91,22 @@ SessionHistoryEntryDescriptor create_session_history_entry_descriptor(SessionHis
         .step = static_cast<i32>(*entry_step),
         .url = entry.url(),
         .document_state = move(document_state_descriptor),
+        .classic_history_api_state = entry.classic_history_api_state(),
+        .navigation_api_state = entry.navigation_api_state(),
+        .navigation_api_key = entry.navigation_api_key(),
+        .navigation_api_id = entry.navigation_api_id(),
+        .scroll_restoration_mode = entry.scroll_restoration_mode(),
+        .scroll_position_data = entry.scroll_position_data(),
+    };
+}
+
+SameDocumentNavigationEntry create_same_document_navigation_entry(SessionHistoryEntry const& entry)
+{
+    auto document_state = entry.document_state();
+    VERIFY(document_state);
+    return {
+        .url = entry.url(),
+        .document_state_id = document_state->cross_process_id(),
         .classic_history_api_state = entry.classic_history_api_state(),
         .navigation_api_state = entry.navigation_api_state(),
         .navigation_api_key = entry.navigation_api_key(),
@@ -310,6 +327,35 @@ ErrorOr<Web::HTML::SessionHistoryEntryDescriptor> IPC::decode(Decoder& decoder)
         .navigation_api_id = move(navigation_api_id),
         .scroll_restoration_mode = scroll_restoration_mode,
         .scroll_position_data = move(scroll_position_data),
+    };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::HTML::SameDocumentNavigationEntry const& entry)
+{
+    TRY(encoder.encode(entry.url));
+    TRY(encoder.encode(entry.document_state_id));
+    TRY(encoder.encode(entry.classic_history_api_state));
+    TRY(encoder.encode(entry.navigation_api_state));
+    TRY(encoder.encode(entry.navigation_api_key));
+    TRY(encoder.encode(entry.navigation_api_id));
+    TRY(encoder.encode(entry.scroll_restoration_mode));
+    TRY(encoder.encode(entry.scroll_position_data));
+    return {};
+}
+
+template<>
+ErrorOr<Web::HTML::SameDocumentNavigationEntry> IPC::decode(Decoder& decoder)
+{
+    return Web::HTML::SameDocumentNavigationEntry {
+        .url = TRY(decoder.decode<URL::URL>()),
+        .document_state_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .classic_history_api_state = TRY(decoder.decode<Web::HTML::StorageSerializationRecord>()),
+        .navigation_api_state = TRY(decoder.decode<Web::HTML::StorageSerializationRecord>()),
+        .navigation_api_key = TRY(decoder.decode<Utf16String>()),
+        .navigation_api_id = TRY(decoder.decode<Utf16String>()),
+        .scroll_restoration_mode = TRY(decoder.decode<Web::HTML::ScrollRestorationMode>()),
+        .scroll_position_data = TRY(decoder.decode<Web::HTML::SessionHistoryEntryScrollPositionData>()),
     };
 }
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -612,6 +612,7 @@ public:
     virtual NewWebViewResult page_did_request_new_web_view(HTML::ActivateTab, HTML::WebViewHints, HTML::TokenizedFeature::NoOpener) { return {}; }
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
+    virtual void page_did_create_top_level_traversable([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryDescriptor const& initial_history_entry) { }
     virtual void page_did_update_session_history_entry_navigation_api_state([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] HTML::StorageSerializationRecord const& navigation_api_state) { }
     virtual void page_did_update_session_history_entry_scroll_restoration_mode([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] HTML::ScrollRestorationMode scroll_restoration_mode) { }
     virtual void page_did_update_session_history_entry_scroll_position_data([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] HTML::SessionHistoryEntryScrollPositionData const& scroll_position_data) { }

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -50,13 +50,16 @@
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
+#include <LibWeb/HTML/UserNavigationInvolvement.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentForward.h>
 #include <LibWeb/IndexedDB/TransactionChanges.h>
@@ -620,7 +623,7 @@ public:
     virtual void page_did_set_session_history_entry_document_state_reload_pending([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] Utf16String const& navigation_api_key, [[maybe_unused]] bool reload_pending) { }
     virtual void page_did_append_nested_history([[maybe_unused]] HTML::CrossProcessId parent_navigable_id, [[maybe_unused]] HTML::SessionHistoryNestedHistoryDescriptor const& nested_history) { }
     virtual void page_did_remove_nested_history([[maybe_unused]] HTML::CrossProcessId parent_navigable_id, [[maybe_unused]] HTML::CrossProcessId child_navigable_id) { }
-    virtual void page_did_finalize_same_document_navigation([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryDescriptor const& target_entry, [[maybe_unused]] Optional<Utf16String> const& entry_to_replace_navigation_api_key) { }
+    virtual void page_did_request_finalize_same_document_navigation([[maybe_unused]] u64 operation_id, [[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SameDocumentNavigationEntry const& target_entry, [[maybe_unused]] bool replaces_current_entry, [[maybe_unused]] HTML::HistoryHandlingBehavior history_handling, [[maybe_unused]] HTML::UserNavigationInvolvement user_involvement) { }
     virtual void page_did_finalize_cross_document_navigation([[maybe_unused]] HTML::CrossProcessId navigable_id, [[maybe_unused]] HTML::SessionHistoryEntryDescriptor const& history_entry, [[maybe_unused]] Optional<Utf16String> const& entry_to_replace_navigation_api_key) { }
     virtual void page_did_set_current_session_history_step([[maybe_unused]] int current_session_history_step) { }
     virtual String page_did_request_ui_process_session_history_for_testing() { return "{}"_string; }

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -244,6 +244,12 @@ WebContentSessionHistoryUpdateDecision CanonicalTraversable::did_receive_web_con
     };
 }
 
+void CanonicalTraversable::did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry)
+{
+    m_session_history.initialize_with_initial_history_entry(move(initial_history_entry));
+    m_current_web_content_session_history_matches_mirror = true;
+}
+
 Optional<Web::HTML::CrossProcessId> CanonicalTraversable::nested_history_id_for(CanonicalNavigable const& navigable) const
 {
     if (&navigable == this)

--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -343,17 +343,20 @@ bool CanonicalTraversable::remove_nested_history(CanonicalNavigable const& paren
     return m_session_history.remove_nested_history(parent_navigable, child_navigable_id);
 }
 
-bool CanonicalTraversable::finalize_same_document_navigation(CanonicalNavigable const& navigable, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key)
+Optional<TraversableSessionHistory::SameDocumentNavigationFinalization> CanonicalTraversable::request_to_finalize_same_document_navigation(CanonicalNavigable const& navigable, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement)
 {
     VERIFY(&navigable.top_level_traversable() == this);
 
     if (m_pending_web_content_session_history_seed.ignore_updates_until_seed)
-        return false;
+        return {};
 
-    auto did_finalize = m_session_history.finalize_same_document_navigation(nested_history_id_for(navigable), move(target_entry), move(entry_to_replace_navigation_api_key));
-    if (did_finalize)
-        m_current_web_content_session_history_matches_mirror = false;
-    return did_finalize;
+    auto finalization = m_session_history.finalize_same_document_navigation(navigable, move(target_entry), replaces_current_entry, history_handling, user_involvement);
+
+    // WebContent has already committed this navigation locally, so a request the canonical history could not apply
+    // leaves the two out of sync until the mirror is reconciled.
+    m_current_web_content_session_history_matches_mirror = finalization.has_value() && m_session_history.web_content_history_matches_mirror();
+
+    return finalization;
 }
 
 bool CanonicalTraversable::finalize_cross_document_navigation(CanonicalNavigable const& navigable, Web::HTML::SessionHistoryEntryDescriptor history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key)

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -235,6 +235,7 @@ public:
     void prepare_for_reload();
     void prepare_to_seed_web_content_session_history_from_ui_process();
     WebContentSessionHistoryUpdateDecision did_receive_web_content_session_history_update_for_testing(Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index, URL::URL const& current_url);
+    void did_create_top_level_traversable(Web::HTML::SessionHistoryEntryDescriptor initial_history_entry);
     bool update_session_history_entry_navigation_api_state(CanonicalNavigable const&, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state);
     bool update_session_history_entry_scroll_restoration_mode(CanonicalNavigable const&, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode);
     bool update_session_history_entry_scroll_position_data(CanonicalNavigable const&, Utf16String const& navigation_api_key, Web::HTML::SessionHistoryEntryScrollPositionData scroll_position_data);

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -243,7 +243,7 @@ public:
     bool set_session_history_entry_document_state_reload_pending(CanonicalNavigable const&, Utf16String const& navigation_api_key, bool reload_pending);
     bool append_nested_history(CanonicalNavigable const& parent_navigable, Web::HTML::SessionHistoryNestedHistoryDescriptor nested_history);
     bool remove_nested_history(CanonicalNavigable const& parent_navigable, Web::HTML::CrossProcessId child_navigable_id);
-    bool finalize_same_document_navigation(CanonicalNavigable const&, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key);
+    Optional<TraversableSessionHistory::SameDocumentNavigationFinalization> request_to_finalize_same_document_navigation(CanonicalNavigable const&, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior, Web::HTML::UserNavigationInvolvement);
     bool finalize_cross_document_navigation(CanonicalNavigable const&, Web::HTML::SessionHistoryEntryDescriptor history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key);
     bool did_set_current_session_history_step(i32 current_session_history_step);
     Optional<i32> navigation_api_traversal_target(CanonicalNavigable const&, Utf16String const& navigation_api_key) const;

--- a/Libraries/LibWebView/SessionHistory.cpp
+++ b/Libraries/LibWebView/SessionHistory.cpp
@@ -434,6 +434,17 @@ void TraversableSessionHistory::clear()
     forget_web_content_state();
 }
 
+void TraversableSessionHistory::initialize_with_initial_history_entry(Entry initial_history_entry)
+{
+    m_entries.append(move(initial_history_entry));
+    m_used_steps.append(0);
+    m_current_used_step_index = 0;
+    m_web_content_known_entries = m_entries;
+    m_web_content_known_used_steps = m_used_steps;
+    m_web_content_current_step = 0;
+    m_web_content_uses_ui_step_coordinates = true;
+}
+
 void TraversableSessionHistory::replace_current_entry_url(URL::URL url, Web::HTML::CrossProcessId document_state_id)
 {
     if (!m_current_used_step_index.has_value()) {

--- a/Libraries/LibWebView/SessionHistory.cpp
+++ b/Libraries/LibWebView/SessionHistory.cpp
@@ -750,19 +750,6 @@ static bool update_session_history_entries_for_navigable(Vector<TraversableSessi
     return update_nested_session_history_entries_for_navigable(entries, *nested_history_id, update_entries);
 }
 
-static Web::HTML::SessionHistoryDocumentStateDescriptor const* find_session_history_document_state(Vector<TraversableSessionHistory::Entry> const& entries, Web::HTML::CrossProcessId document_state_id)
-{
-    for (auto const& entry : entries) {
-        if (entry.document_state.id == document_state_id)
-            return &entry.document_state;
-        for (auto const& nested_history : entry.document_state.nested_histories) {
-            if (auto const* document_state = find_session_history_document_state(nested_history.entries, document_state_id))
-                return document_state;
-        }
-    }
-    return nullptr;
-}
-
 static bool append_or_replace_session_history_entry(Vector<TraversableSessionHistory::Entry>& entries, TraversableSessionHistory::Entry const& entry, Optional<Utf16String> const& entry_to_replace_navigation_api_key)
 {
     if (!entry_to_replace_navigation_api_key.has_value()) {
@@ -782,43 +769,119 @@ static bool append_or_replace_session_history_entry(Vector<TraversableSessionHis
     return true;
 }
 
-bool TraversableSessionHistory::finalize_same_document_navigation(Optional<Web::HTML::CrossProcessId> nested_history_id, Entry target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key)
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
+Optional<TraversableSessionHistory::SameDocumentNavigationFinalization> TraversableSessionHistory::finalize_same_document_navigation(CanonicalNavigable const& target_navigable, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement)
 {
+    // 1. Assert: this is running on traversable's session history traversal queue.
+    // NB: WebContent still owns the traversal queue, and only sends this request once the synchronous navigation steps
+    //     are allowed to run.
     if (!m_current_used_step_index.has_value())
-        return false;
+        return {};
 
     auto current_step = m_used_steps[*m_current_used_step_index];
-    auto const* document_state = find_session_history_document_state(m_entries, target_entry.document_state.id);
-    if (!document_state)
-        return false;
+    auto nested_history_id = target_navigable.is_top_level_traversable() ? Optional<Web::HTML::CrossProcessId> {} : target_navigable.id();
 
-    auto canonical_target_entry = target_entry;
-    canonical_target_entry.document_state = *document_state;
+    auto* target_entries = nested_history_id.has_value() ? nested_session_history_entries_for_navigable(m_entries, *nested_history_id) : &m_entries;
+    if (!target_entries)
+        return {};
 
-    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
-    if (!entry_to_replace_navigation_api_key.has_value()) {
+    // 2. If targetNavigable's active session history entry is not targetEntry, then return.
+    // NB: WebContent describes the navigation as an intent — append, or replace whichever entry is current here — so the
+    //     canonical current entry stands in for the entry identity check.
+    auto* current_entry = target_history_entry(*target_entries, current_step);
+    if (!current_entry)
+        return {};
+
+    // A same-document navigation only applies to the document it was reported for. Ignore the request if a
+    // cross-document navigation committed before it completed.
+    if (current_entry->document_state.id != target_entry.document_state_id)
+        return {};
+
+    auto canonical_target_entry = Entry {
+        .step = current_entry->step,
+        .url = move(target_entry.url),
+        .document_state = current_entry->document_state,
+        .classic_history_api_state = move(target_entry.classic_history_api_state),
+        .navigation_api_state = move(target_entry.navigation_api_state),
+        .navigation_api_key = move(target_entry.navigation_api_key),
+        .navigation_api_id = move(target_entry.navigation_api_id),
+        .scroll_restoration_mode = target_entry.scroll_restoration_mode,
+        .scroll_position_data = move(target_entry.scroll_position_data),
+    };
+
+    // 3. Let targetStep be null.
+    i32 target_step = 0;
+
+    // 4. Let targetEntries be the result of getting session history entries for targetNavigable.
+    Optional<Utf16String> entry_to_replace_navigation_api_key;
+    auto can_update_web_content_entries = !m_web_content_known_entries.is_empty()
+        && m_web_content_uses_ui_step_coordinates
+        && m_web_content_current_step == current_step;
+    if (!can_update_web_content_entries)
+        forget_web_content_state();
+
+    // 5. If entryToReplace is null:
+    if (!replaces_current_entry) {
+        // 1. Clear the forward session history of traversable.
         clear_forward_session_history_entries(m_entries, current_step);
-        clear_forward_session_history_entries(m_web_content_known_entries, m_web_content_current_step.value_or(current_step));
-        canonical_target_entry.step = current_step + 1;
+        if (can_update_web_content_entries)
+            clear_forward_session_history_entries(m_web_content_known_entries, current_step);
+
+        // 2. Set targetStep to traversable's current session history step + 1.
+        target_step = current_step + 1;
+
+        // 3. Set targetEntry's step to targetStep.
+        canonical_target_entry.step = target_step;
+
+        // 4. Append targetEntry to targetEntries.
+    }
+    // Otherwise:
+    else {
+        // 1. Replace entryToReplace with targetEntry in targetEntries.
+        entry_to_replace_navigation_api_key = current_entry->navigation_api_key;
+
+        // 2. Set targetEntry's step to entryToReplace's step.
+        // NB: Seeded from the current entry above.
+
+        // 3. Set targetStep to traversable's current session history step.
+        target_step = current_step;
     }
 
     auto did_update = update_session_history_entries_for_navigable(m_entries, nested_history_id, [&](auto& entries) {
         return append_or_replace_session_history_entry(entries, canonical_target_entry, entry_to_replace_navigation_api_key);
     });
     if (!did_update)
-        return false;
+        return {};
 
-    if (!m_web_content_known_entries.is_empty()) {
-        update_session_history_entries_for_navigable(m_web_content_known_entries, nested_history_id, [&](auto& entries) {
+    auto did_update_web_content_entries = false;
+    if (can_update_web_content_entries) {
+        did_update_web_content_entries = update_session_history_entries_for_navigable(m_web_content_known_entries, nested_history_id, [&](auto& entries) {
             return append_or_replace_session_history_entry(entries, canonical_target_entry, entry_to_replace_navigation_api_key);
         });
     }
 
     m_used_steps = get_all_used_history_steps(m_entries);
-    m_current_used_step_index = m_used_steps.find_first_index(current_step);
+    m_current_used_step_index = m_used_steps.find_first_index(target_step);
     VERIFY(m_current_used_step_index.has_value());
-    m_web_content_known_used_steps = get_all_used_history_steps(m_web_content_known_entries);
-    return true;
+    if (did_update_web_content_entries) {
+        m_web_content_known_used_steps = get_all_used_history_steps(m_web_content_known_entries);
+        m_web_content_current_step = target_step;
+    } else {
+        forget_web_content_state();
+    }
+
+    // 6. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
+    // AD-HOC: WebContent still applies history steps, and does so with historyHandling and userInvolvement once it
+    //         receives this result.
+    (void)history_handling;
+    (void)user_involvement;
+
+    return SameDocumentNavigationFinalization {
+        .entry_step = canonical_target_entry.step,
+        .target_step = target_step,
+        .script_history_length = m_used_steps.size(),
+        .script_history_index = *m_current_used_step_index,
+    };
 }
 
 bool TraversableSessionHistory::finalize_cross_document_navigation(Optional<Web::HTML::CrossProcessId> nested_history_id, Entry history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key)

--- a/Libraries/LibWebView/SessionHistory.h
+++ b/Libraries/LibWebView/SessionHistory.h
@@ -9,7 +9,10 @@
 #include <AK/Function.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
+#include <LibWeb/HTML/UserNavigationInvolvement.h>
 #include <LibWebView/Export.h>
 #include <LibWebView/Forward.h>
 
@@ -31,6 +34,13 @@ public:
         Entry const* target_top_level_entry { nullptr };
         bool target_step_is_top_level_entry { false };
         bool changes_top_level_entry { false };
+    };
+
+    struct SameDocumentNavigationFinalization {
+        i32 entry_step { 0 };
+        i32 target_step { 0 };
+        u64 script_history_length { 0 };
+        u64 script_history_index { 0 };
     };
 
     enum class UpdateResult {
@@ -66,7 +76,7 @@ public:
     bool update_document_state(Optional<Web::HTML::CrossProcessId> nested_history_id, Utf16String const& navigation_api_key, Function<void(Web::HTML::SessionHistoryDocumentStateDescriptor&)> const& update_document_state);
     bool append_nested_history(CanonicalNavigable const& parent_navigable, Web::HTML::SessionHistoryNestedHistoryDescriptor);
     bool remove_nested_history(CanonicalNavigable const& parent_navigable, Web::HTML::CrossProcessId child_navigable_id);
-    bool finalize_same_document_navigation(Optional<Web::HTML::CrossProcessId> nested_history_id, Entry target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key);
+    Optional<SameDocumentNavigationFinalization> finalize_same_document_navigation(CanonicalNavigable const&, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior, Web::HTML::UserNavigationInvolvement);
     bool finalize_cross_document_navigation(Optional<Web::HTML::CrossProcessId> nested_history_id, Entry history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key);
     UpdateResult update_from_web_content(Vector<Entry> entries, Vector<i32> used_steps, size_t current_used_step_index);
     [[nodiscard]] bool did_seed_web_content_from_ui_process(Vector<Entry> entries, Vector<i32> used_steps, size_t current_used_step_index);

--- a/Libraries/LibWebView/SessionHistory.h
+++ b/Libraries/LibWebView/SessionHistory.h
@@ -55,6 +55,7 @@ public:
     Optional<size_t> current_top_level_entry_index() const;
 
     void clear();
+    void initialize_with_initial_history_entry(Entry initial_history_entry);
     void navigate(URL::URL, Web::HTML::CrossProcessId document_state_id);
     void navigate(URL::URL, Web::HTML::CrossProcessId document_state_id, Web::HTML::DocumentResource);
     void replace_current_entry_url(URL::URL, Web::HTML::CrossProcessId document_state_id);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1367,6 +1367,12 @@ void ViewImplementation::did_create_top_level_traversable(Badge<WebContentClient
     dump_session_history("created-top-level-traversable"sv);
 }
 
+void ViewImplementation::did_finalize_same_document_navigation(Badge<WebContentClient>)
+{
+    update_navigation_action_state();
+    dump_session_history("finalized-same-document-navigation"sv);
+}
+
 void ViewImplementation::did_set_current_session_history_step(Badge<WebContentClient>, i32 current_session_history_step)
 {
     if (!m_top_level_traversable.did_set_current_session_history_step(current_session_history_step))

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1360,6 +1360,13 @@ void ViewImplementation::apply_web_content_session_history_update(WebContentSess
     update_navigation_action_state();
 }
 
+void ViewImplementation::did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry)
+{
+    m_top_level_traversable.did_create_top_level_traversable(move(initial_history_entry));
+    update_navigation_action_state();
+    dump_session_history("created-top-level-traversable"sv);
+}
+
 void ViewImplementation::did_set_current_session_history_step(Badge<WebContentClient>, i32 current_session_history_step)
 {
     if (!m_top_level_traversable.did_set_current_session_history_step(current_session_history_step))

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -278,6 +278,7 @@ public:
     void did_change_screen_wake_lock_state(Badge<WebContentClient>, Web::ScreenWakeLockState);
     Web::ScreenWakeLockState screen_wake_lock_state() const { return m_screen_wake_lock_state; }
 
+    void did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry);
     void did_set_current_session_history_step(Badge<WebContentClient>, i32 current_session_history_step);
     void did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_set_top_level_session_history(Badge<WebContentClient>, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -279,6 +279,7 @@ public:
     Web::ScreenWakeLockState screen_wake_lock_state() const { return m_screen_wake_lock_state; }
 
     void did_create_top_level_traversable(Badge<WebContentClient>, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry);
+    void did_finalize_same_document_navigation(Badge<WebContentClient>);
     void did_set_current_session_history_step(Badge<WebContentClient>, i32 current_session_history_step);
     void did_update_session_history_for_testing(Badge<WebContentClient>, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32>, size_t current_used_step_index);
     void did_set_top_level_session_history(Badge<WebContentClient>, bool accepted, Vector<Web::HTML::SessionHistoryEntryDescriptor>, Vector<i32> used_steps, size_t current_used_step_index);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1476,10 +1476,14 @@ Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_r
             handle = view->on_new_web_view(activate_tab, hints, new_page_id);
     }
 
-    if (!view_for_page_id(new_page_id).has_value())
-        return { {}, move(handle) };
+    auto view = view_for_page_id(new_page_id);
+    if (!view.has_value())
+        return { {}, {}, move(handle) };
 
-    return { new_page_id, move(handle) };
+    auto root_navigable_id = Application::the().allocate_ui_process_cross_process_id();
+    view->traversable().set_id(root_navigable_id);
+
+    return { new_page_id, root_navigable_id, move(handle) };
 }
 
 void WebContentClient::did_request_activate_tab(u64 page_id)
@@ -1895,6 +1899,18 @@ void WebContentClient::did_change_screen_wake_lock_state(u64 page_id, Web::Scree
 {
     if (auto view = view_for_page_id(page_id); view.has_value())
         view->did_change_screen_wake_lock_state({}, wake_lock_state);
+}
+
+void WebContentClient::did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry)
+{
+    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
+    if (!navigable.has_value() || !navigable->is_top_level_traversable())
+        return;
+
+    auto view = ViewImplementation::find_view_for_traversable(navigable->top_level_traversable());
+    if (!view.has_value())
+        return;
+    view->did_create_top_level_traversable({}, move(initial_history_entry));
 }
 
 void WebContentClient::did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state)

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1476,6 +1476,9 @@ Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_r
             handle = view->on_new_web_view(activate_tab, hints, new_page_id);
     }
 
+    if (!view_for_page_id(new_page_id).has_value())
+        return { {}, move(handle) };
+
     return { new_page_id, move(handle) };
 }
 

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -1969,12 +1969,30 @@ void WebContentClient::did_remove_nested_history(u64 page_id, Web::HTML::CrossPr
     parent_navigable->top_level_traversable().remove_nested_history(*parent_navigable, child_navigable_id);
 }
 
-void WebContentClient::did_finalize_same_document_navigation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key)
+void WebContentClient::did_request_finalize_same_document_navigation(u64 page_id, u64 operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement)
 {
-    auto navigable = hosted_navigable_for_page(page_id, navigable_id);
-    if (!navigable.has_value())
+    Optional<TraversableSessionHistory::SameDocumentNavigationFinalization> finalization;
+    if (auto navigable = hosted_navigable_for_page(page_id, navigable_id); navigable.has_value()) {
+        finalization = navigable->top_level_traversable().request_to_finalize_same_document_navigation(
+            *navigable, move(target_entry), replaces_current_entry, history_handling, user_involvement);
+    }
+
+    if (!finalization.has_value()) {
+        async_complete_finalize_same_document_navigation(page_id, operation_id, false, 0, 0, 0, 0);
         return;
-    navigable->top_level_traversable().finalize_same_document_navigation(*navigable, move(target_entry), move(entry_to_replace_navigation_api_key));
+    }
+
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_finalize_same_document_navigation({});
+
+    async_complete_finalize_same_document_navigation(
+        page_id,
+        operation_id,
+        true,
+        finalization->entry_step,
+        finalization->target_step,
+        finalization->script_history_length,
+        finalization->script_history_index);
 }
 
 void WebContentClient::did_finalize_cross_document_navigation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -258,6 +258,7 @@ private:
     virtual void did_update_primary_selection(u64 page_id, String) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_change_screen_wake_lock_state(u64 page_id, Web::ScreenWakeLockState) override;
+    virtual void did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry) override;
     virtual void did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state) override;
     virtual void did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;
     virtual void did_update_session_history_entry_scroll_position_data(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::SessionHistoryEntryScrollPositionData scroll_position_data) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -32,10 +32,13 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/FileFilter.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
+#include <LibWeb/HTML/UserNavigationInvolvement.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/HTML/WorkerAgentTypes.h>
@@ -266,7 +269,7 @@ private:
     virtual void did_set_session_history_entry_document_state_reload_pending(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, bool reload_pending) override;
     virtual void did_append_nested_history(u64 page_id, Web::HTML::CrossProcessId parent_navigable_id, Web::HTML::SessionHistoryNestedHistoryDescriptor nested_history) override;
     virtual void did_remove_nested_history(u64 page_id, Web::HTML::CrossProcessId parent_navigable_id, Web::HTML::CrossProcessId child_navigable_id) override;
-    virtual void did_finalize_same_document_navigation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key) override;
+    virtual void did_request_finalize_same_document_navigation(u64 page_id, u64 operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement) override;
     virtual void did_finalize_cross_document_navigation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key) override;
     virtual void did_set_current_session_history_step(u64 page_id, i32 current_session_history_step) override;
     virtual Messages::WebContentClient::DidRequestUiProcessSessionHistoryForTestingResponse did_request_ui_process_session_history_for_testing(u64 page_id) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -344,6 +344,12 @@ void ConnectionFromClient::resolve_session_history_traversal_target(u64 page_id,
         page->did_resolve_session_history_traversal_target(request_id, target_step);
 }
 
+void ConnectionFromClient::complete_finalize_same_document_navigation(u64 page_id, u64 operation_id, bool committed, i32 entry_step, i32 target_step, u64 script_history_length, u64 script_history_index)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->did_complete_finalize_same_document_navigation(operation_id, committed, entry_step, target_step, script_history_length, script_history_index);
+}
+
 void ConnectionFromClient::traverse_the_history_to_step(u64 page_id, i32 step)
 {
     auto page = this->page(page_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -100,6 +100,7 @@ private:
     virtual void set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::CrossProcessId frame_id, Optional<Web::Compositor::CompositorContextId>) override;
     virtual void resolve_session_history_traversal_target(u64 page_id, u64 request_id, Optional<i32> target_step) override;
+    virtual void complete_finalize_same_document_navigation(u64 page_id, u64 operation_id, bool committed, i32 entry_step, i32 target_step, u64 script_history_length, u64 script_history_index) override;
     virtual void traverse_the_history_to_step(u64 page_id, i32 step) override;
     virtual void check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) override;
     virtual void set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor>, size_t current_top_level_entry_index, bool allow_reconstructing_current_entry) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1156,7 +1156,10 @@ PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML
         Core::Process::terminate_immediately(0);
     }
 
-    auto& new_client = m_owner.create_page(response->new_page_id());
+    if (!response->new_page_id().has_value())
+        return {};
+
+    auto& new_client = m_owner.create_page(*response->new_page_id());
     return { &new_client.page(), response->take_handle() };
 }
 

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1158,8 +1158,9 @@ PageClient::NewWebViewResult PageClient::page_did_request_new_web_view(Web::HTML
 
     if (!response->new_page_id().has_value())
         return {};
+    VERIFY(response->root_navigable_id().has_value());
 
-    auto& new_client = m_owner.create_page(*response->new_page_id());
+    auto& new_client = m_owner.create_page(*response->new_page_id(), *response->root_navigable_id());
     return { &new_client.page(), response->take_handle() };
 }
 
@@ -1181,6 +1182,11 @@ void PageClient::page_did_close_top_level_traversable()
     // NOTE: This only removes the strong reference the PageHost has for this PageClient.
     //       It will be GC'd 'later'.
     m_owner.remove_page({}, m_id);
+}
+
+void PageClient::page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry)
+{
+    client().async_did_create_top_level_traversable(m_id, navigable_id, initial_history_entry);
 }
 
 void PageClient::page_did_change_needs_beforeunload_check(bool needs_beforeunload_check)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1234,9 +1234,17 @@ void PageClient::page_did_remove_nested_history(Web::HTML::CrossProcessId parent
     client().async_did_remove_nested_history(m_id, parent_navigable_id, child_navigable_id);
 }
 
-void PageClient::page_did_finalize_same_document_navigation(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& target_entry, Optional<Utf16String> const& entry_to_replace_navigation_api_key)
+void PageClient::page_did_request_finalize_same_document_navigation(u64 operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SameDocumentNavigationEntry const& target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement)
 {
-    client().async_did_finalize_same_document_navigation(m_id, navigable_id, target_entry, entry_to_replace_navigation_api_key);
+    client().async_did_request_finalize_same_document_navigation(m_id, operation_id, navigable_id, target_entry, replaces_current_entry, history_handling, user_involvement);
+}
+
+void PageClient::did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, u64 script_history_length, u64 script_history_index)
+{
+    page().top_level_traversable()->did_complete_finalize_same_document_navigation(operation_id, committed, entry_step, target_step, {
+                                                                                                                                         .script_history_length = script_history_length,
+                                                                                                                                         .script_history_index = script_history_index,
+                                                                                                                                     });
 }
 
 void PageClient::page_did_finalize_cross_document_navigation(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& history_entry, Optional<Utf16String> const& entry_to_replace_navigation_api_key)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -248,6 +248,7 @@ private:
     virtual NewWebViewResult page_did_request_new_web_view(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Web::HTML::TokenizedFeature::NoOpener) override;
     virtual void page_did_request_activate_tab() override;
     virtual void page_did_close_top_level_traversable() override;
+    virtual void page_did_create_top_level_traversable(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& initial_history_entry) override;
     virtual void page_did_change_needs_beforeunload_check(bool needs_beforeunload_check) override;
     virtual void page_did_update_session_history_entry_navigation_api_state(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, Web::HTML::StorageSerializationRecord const& navigation_api_state) override;
     virtual void page_did_update_session_history_entry_scroll_restoration_mode(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -18,6 +18,7 @@
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/Scripting/ScriptRegistry.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
 #include <LibWeb/Page/Page.h>
@@ -85,6 +86,7 @@ public:
         bool will_change_top_level_entry { false };
     };
     void did_resolve_session_history_traversal_target(u64 request_id, Optional<i32> target_step);
+    void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, u64 script_history_length, u64 script_history_index);
     void request_webdriver_history_traversal(int delta, Function<void(WebDriverHistoryTraversalResult)>);
     void did_complete_webdriver_history_traversal(u64 request_id, bool accepted, bool will_replace_web_content_process, bool will_change_top_level_entry);
     Web::WebDriver::Response request_webdriver_load_url_from_ui(URL::URL const&);
@@ -257,7 +259,7 @@ private:
     virtual void page_did_set_session_history_entry_document_state_reload_pending(Web::HTML::CrossProcessId navigable_id, Utf16String const& navigation_api_key, bool reload_pending) override;
     virtual void page_did_append_nested_history(Web::HTML::CrossProcessId parent_navigable_id, Web::HTML::SessionHistoryNestedHistoryDescriptor const& nested_history) override;
     virtual void page_did_remove_nested_history(Web::HTML::CrossProcessId parent_navigable_id, Web::HTML::CrossProcessId child_navigable_id) override;
-    virtual void page_did_finalize_same_document_navigation(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& target_entry, Optional<Utf16String> const& entry_to_replace_navigation_api_key) override;
+    virtual void page_did_request_finalize_same_document_navigation(u64 operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SameDocumentNavigationEntry const& target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement) override;
     virtual void page_did_finalize_cross_document_navigation(Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor const& history_entry, Optional<Utf16String> const& entry_to_replace_navigation_api_key) override;
     virtual void page_did_set_current_session_history_step(int current_session_history_step) override;
     virtual String page_did_request_ui_process_session_history_for_testing() override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -145,7 +145,7 @@ endpoint WebContentClient
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
-    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (Optional<u64> new_page_id, String handle)
+    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (Optional<u64> new_page_id, Optional<Web::HTML::CrossProcessId> root_navigable_id, String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|
@@ -184,6 +184,7 @@ endpoint WebContentClient
     did_request_primary_paste(u64 page_id) =|
     did_update_primary_selection(u64 page_id, String text) =|
 
+    did_create_top_level_traversable(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor initial_history_entry) =|
     did_update_session_history_entry_navigation_api_state(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::StorageSerializationRecord navigation_api_state) =|
     did_update_session_history_entry_scroll_restoration_mode(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::ScrollRestorationMode scroll_restoration_mode) =|
     did_update_session_history_entry_scroll_position_data(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, Web::HTML::SessionHistoryEntryScrollPositionData scroll_position_data) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -145,7 +145,7 @@ endpoint WebContentClient
     did_post_broadcast_channel_message(u64 page_id, Web::HTML::BroadcastChannelMessage message) =|
 
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
-    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (u64 new_page_id, String handle)
+    did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints) => (Optional<u64> new_page_id, String handle)
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_change_needs_beforeunload_check(u64 page_id, bool needs_beforeunload_check) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -26,6 +26,7 @@
 #include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/SessionHistoryEntry.h>
@@ -192,7 +193,7 @@ endpoint WebContentClient
     did_set_session_history_entry_document_state_reload_pending(u64 page_id, Web::HTML::CrossProcessId navigable_id, Utf16String navigation_api_key, bool reload_pending) =|
     did_append_nested_history(u64 page_id, Web::HTML::CrossProcessId parent_navigable_id, Web::HTML::SessionHistoryNestedHistoryDescriptor nested_history) =|
     did_remove_nested_history(u64 page_id, Web::HTML::CrossProcessId parent_navigable_id, Web::HTML::CrossProcessId child_navigable_id) =|
-    did_finalize_same_document_navigation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor target_entry, Optional<Utf16String> entry_to_replace_navigation_api_key) =|
+    did_request_finalize_same_document_navigation(u64 page_id, u64 operation_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SameDocumentNavigationEntry target_entry, bool replaces_current_entry, Web::HTML::HistoryHandlingBehavior history_handling, Web::HTML::UserNavigationInvolvement user_involvement) =|
     did_finalize_cross_document_navigation(u64 page_id, Web::HTML::CrossProcessId navigable_id, Web::HTML::SessionHistoryEntryDescriptor history_entry, Optional<Utf16String> entry_to_replace_navigation_api_key) =|
     did_set_current_session_history_step(u64 page_id, i32 current_session_history_step) =|
     did_request_ui_process_session_history_for_testing(u64 page_id) => (String session_history)

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -72,6 +72,7 @@ endpoint WebContentServer
     set_page_parent_context(u64 page_id, Optional<Web::Compositor::CompositorContextId> parent_context_id) =|
     set_remote_child_frame_compositor_context(u64 page_id, Web::HTML::CrossProcessId frame_id, Optional<Web::Compositor::CompositorContextId> context_id) =|
     resolve_session_history_traversal_target(u64 page_id, u64 request_id, Optional<i32> target_step) =|
+    complete_finalize_same_document_navigation(u64 page_id, u64 operation_id, bool committed, i32 entry_step, i32 target_step, u64 script_history_length, u64 script_history_index) =|
     traverse_the_history_to_step(u64 page_id, i32 step) =|
     check_if_traverse_history_step_is_canceled(u64 page_id, u64 request_id, i32 step) =|
     set_top_level_session_history(u64 page_id, Vector<Web::HTML::SessionHistoryEntryDescriptor> entries,


### PR DESCRIPTION
Resolve same-document navigations against canonical session history
instead of accepting the entry and step chosen by WebContent. This lets
races with history traversal be resolved where the current step is
owned.

Keep the History API's synchronous best-guess length and index while
finalization is pending. Track pending changes so a UI confirmation does
not overwrite newer same-document updates.

This is another step towards moving ownership of session history to
the UI process.