### PR TITLE
LibWeb: Implement detaching a MediaSource from its media element

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -239,6 +239,7 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_source_element_selector);
     visitor.visit(m_pending_play_promises);
     visitor.visit(m_selected_video_track);
+    visitor.visit(m_attached_media_source);
     m_assigned_media_provider_object.visit(
         [](Empty) {},
         [&visitor](GC::Ref<MediaSourceExtensions::MediaSource> media_source) {
@@ -798,22 +799,24 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
 {
     m_first_data_load_event_since_load_start = true;
 
-    // 1. Abort any already-running instance of the resource selection algorithm for this element.
+    // FIXME: 1. Set this element's is currently stalled to false.
+
+    // 2. Abort any already-running instance of the resource selection algorithm for this element.
     //    NOTE: All deferred subroutines of the resource selection algorithm will be queued under the media element task
-    //          source, or run as part of the fetch. Step 2 will remove any subroutine from the queue. Step 6.2 will stop
+    //          source, or run as part of the fetch. Step 3 will remove any subroutine from the queue. Step 7.2 will stop
     //          any ongoing fetch operation. Therefore, all resource selection algorithms will be cancelled before a new
     //          one begins.
 
-    // 2. Let pending tasks be a list of all tasks from the media element's media element event task source in one of
+    // 3. Let pending tasks be a list of all tasks from the media element's media element event task source in one of
     //    the task queues.
-    // FIXME: 3. For each task in pending tasks that would resolve pending play promises or reject pending play promises,
+    // FIXME: 4. For each task in pending tasks that would resolve pending play promises or reject pending play promises,
     //    immediately resolve or reject those promises in the order the corresponding tasks were queued.
-    // 4. Remove each task in pending tasks from its task queue
+    // 5. Remove each task in pending tasks from its task queue.
     main_thread_event_loop().task_queue().remove_tasks_matching([&](auto& task) {
         return task.source() == media_element_event_task_source();
     });
 
-    // 5. If the media element's networkState is set to NETWORK_LOADING or NETWORK_IDLE, queue a media element task given the media element to
+    // 6. If the media element's networkState is set to NETWORK_LOADING or NETWORK_IDLE, queue a media element task given the media element to
     //    fire an event named abort at the media element.
     if (m_network_state == NetworkState::Loading || m_network_state == NetworkState::Idle) {
         queue_a_media_element_task([](HTMLMediaElement& self) {
@@ -821,7 +824,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
         });
     }
 
-    // 6. If the media element's networkState is not set to NETWORK_EMPTY, then:
+    // 7. If the media element's networkState is not set to NETWORK_EMPTY:
     if (m_network_state != NetworkState::Empty) {
         // 1. Queue a media element task given the media element to fire an event named emptied at the media element.
         queue_a_media_element_task([](HTMLMediaElement& self) {
@@ -831,7 +834,19 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
         // 2. If a fetching process is in progress for the media element, the user agent should stop it.
         cancel_the_fetching_process();
 
-        // FIXME: 3. If the media element's assigned media provider object is a MediaSource object, then detach it.
+        // 3. If the media element's assigned media provider object is a MediaSource object, then detach it.
+        // AD-HOC: We detach the attached MediaSource whether or not it's the assigned media provider object — since a
+        //         MediaSource can also be attached through a blob URL. The MSE spec runs its detaching steps "in any
+        //         case where the media element is going to transition to NETWORK_EMPTY and queue a task to fire an
+        //         event named emptied at the media element" — which covers both ways of attaching one.
+        //         https://w3c.github.io/media-source/#mediasource-detach
+        //         This step is also unusable as written: The srcObject setter sets the new value before invoking this.
+        //         So, the assigned media provider object here is already the incoming one — not the one being replaced.
+        //         https://github.com/whatwg/html/issues/12757
+        if (m_attached_media_source) {
+            m_attached_media_source->detach_from_media_element({});
+            m_attached_media_source = nullptr;
+        }
 
         // 4. Forget the media element's media-resource-specific tracks.
         forget_media_resource_specific_tracks();
@@ -840,7 +855,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
         if (m_ready_state != ReadyState::HaveNothing)
             set_ready_state(ReadyState::HaveNothing);
 
-        // 6. If the paused attribute is false, then:
+        // 6. If the paused attribute is false:
         if (!paused()) {
             // 1. Set the paused attribute to true.
             set_paused(true);
@@ -875,17 +890,17 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
         set_duration(NAN);
     }
 
-    // 7. Set the playbackRate attribute to the value of the defaultPlaybackRate attribute.
+    // 8. Set the playbackRate attribute to the value of the defaultPlaybackRate attribute.
     TRY(set_playback_rate(m_default_playback_rate));
 
-    // 8. Set the error attribute to null and the can autoplay flag to true.
+    // 9. Set the error attribute to null and the can autoplay flag to true.
     m_error = nullptr;
     m_can_autoplay = true;
 
-    // 9. Invoke the media element's resource selection algorithm.
+    // 10. Invoke the media element's resource selection algorithm.
     select_resource();
 
-    // 10. NOTE: Playback of any previously playing media resource for this element stops.
+    // 11. NOTE: Playback of any previously playing media resource for this element stops.
     return {};
 }
 
@@ -1617,6 +1632,7 @@ void HTMLMediaElement::load_local_resource(MediaProviderObject const& media_prov
             //        3. Set [[port to main]] null.
 
             media_source->set_assigned_to_media_element({}, *this);
+            m_attached_media_source = media_source;
             set_up_playback_manager_for_local();
 
             // 4. Set the readyState attribute to "open".

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -320,6 +320,11 @@ private:
     // https://html.spec.whatwg.org/multipage/media.html#assigned-media-provider-object
     MediaProviderObject m_assigned_media_provider_object;
 
+    // https://w3c.github.io/media-source/#mediasource-attach
+    // NB: Unlike the assigned media provider object, this is also set when a MediaSource is attached through a blob
+    //     URL — so that the media element load algorithm can detach it.
+    GC::Ptr<MediaSourceExtensions::MediaSource> m_attached_media_source;
+
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc
     Utf16String m_current_src;
 

--- a/Libraries/LibWeb/MediaSourceExtensions/MediaSource.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/MediaSource.cpp
@@ -99,8 +99,58 @@ void MediaSource::set_assigned_to_media_element(Badge<HTML::HTMLMediaElement>, H
     m_media_element_assigned_to = media_element;
 }
 
-void MediaSource::unassign_from_media_element(Badge<HTML::HTMLMediaElement>)
+// https://w3c.github.io/media-source/#mediasource-detach
+void MediaSource::detach_from_media_element(Badge<HTML::HTMLMediaElement>)
 {
+    // FIXME: 1. If the MediaSource was constructed in a DedicatedWorkerGlobalScope:
+    //               1. Notify the MediaSource using an internal detach message posted to [[port to worker]].
+    //               2. Set [[port to worker]] null.
+    //               3. Set [[channel with worker]] null.
+    //               4. The implicit message handler for this detach notification runs the remainder of these
+    //                  steps in the DedicatedWorkerGlobalScope MediaSource.
+    //           Otherwise, the MediaSource was constructed in a Window:
+    //               Continue the remainder of these steps on the Window MediaSource.
+    // FIXME: 2. Set [[port to main]] null.
+
+    // 3. Set the readyState attribute to "closed".
+    m_ready_state = ReadyState::Closed;
+
+    // FIXME: 4. If this is a ManagedMediaSource, then set streaming attribute to false.
+
+    // 5. Update duration to NaN.
+    m_duration = NAN;
+
+    // AD-HOC: Abort the buffer-append algorithm of every SourceBuffer removed below. The spec steps (copied in below)
+    //         don't say to do that, but other engines implement them by running the removeSourceBuffer() steps on every
+    //         SourceBuffer — and those steps abort the buffer-append algorithm when the updating attribute is true.
+    //         Without this, a buffer-append task queued before detaching would still run afterwards — against a media
+    //         element that the media element load algorithm has reset.
+    //         https://github.com/w3c/media-source/issues/378
+    for (size_t i = 0; i < m_source_buffers->length(); i++)
+        m_source_buffers->item(i)->abort_if_updating({});
+
+    // 6. Remove all the SourceBuffer objects from activeSourceBuffers.
+    m_active_source_buffers->remove_all_buffers({});
+
+    // 7. Queue a task to fire an event named removesourcebuffer at activeSourceBuffers.
+    queue_a_media_source_task(GC::create_function(heap(), [source_buffers = m_active_source_buffers] {
+        source_buffers->dispatch_event(DOM::Event::create(source_buffers->realm(), EventNames::removesourcebuffer));
+    }));
+
+    // 8. Remove all the SourceBuffer objects from sourceBuffers.
+    m_source_buffers->remove_all_buffers({});
+
+    // 9. Queue a task to fire an event named removesourcebuffer at sourceBuffers.
+    queue_a_media_source_task(GC::create_function(heap(), [source_buffers = m_source_buffers] {
+        source_buffers->dispatch_event(DOM::Event::create(source_buffers->realm(), EventNames::removesourcebuffer));
+    }));
+
+    // 10. Queue a task to fire an event named sourceclose at the MediaSource.
+    queue_a_media_source_task(GC::create_function(heap(), [this] {
+        dispatch_event(DOM::Event::create(realm(), EventNames::sourceclose));
+    }));
+
+    // AD-HOC: Sever the media element assignment that was established when this MediaSource was attached.
     m_media_element_assigned_to = nullptr;
 }
 

--- a/Libraries/LibWeb/MediaSourceExtensions/MediaSource.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/MediaSource.h
@@ -35,7 +35,10 @@ public:
     static bool can_construct_in_dedicated_worker(JS::VM&) { return false; }
 
     void set_assigned_to_media_element(Badge<HTML::HTMLMediaElement>, HTML::HTMLMediaElement&);
-    void unassign_from_media_element(Badge<HTML::HTMLMediaElement>);
+
+    // https://w3c.github.io/media-source/#mediasource-detach
+    void detach_from_media_element(Badge<HTML::HTMLMediaElement>);
+
     GC::Ptr<HTML::HTMLMediaElement> media_element_assigned_to() { return m_media_element_assigned_to; }
 
     void set_onsourceopen(GC::Ptr<WebIDL::CallbackType>);

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -275,16 +275,18 @@ WebIDL::ExceptionOr<void> SourceBuffer::set_mode(Bindings::AppendMode mode)
 }
 
 // https://w3c.github.io/media-source/#sourcebuffer-prepare-append
-WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK::Duration current_time)
+WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size)
 {
+    // 1. If the SourceBuffer has been removed from the sourceBuffers attribute of the parent media source then throw an
+    //    InvalidStateError exception and abort these steps.
+    // NB: This covers appending to a SourceBuffer whose parent media source has been detached from its media element —
+    //     since detaching removes all SourceBuffer objects from the sourceBuffers attribute.
+    if (!m_media_source->source_buffers()->contains(*this))
+        return WebIDL::InvalidStateError::create(realm(), "SourceBuffer has been removed"_utf16);
+
     // FIXME: Support MediaSourceExtensions in workers.
     if (!m_media_source->media_element_assigned_to())
         return WebIDL::InvalidStateError::create(realm(), "Unsupported in workers"_utf16);
-
-    // 1. If the SourceBuffer has been removed from the sourceBuffers attribute of the parent media source then throw an
-    //    InvalidStateError exception and abort these steps.
-    if (!m_media_source->source_buffers()->contains(*this))
-        return WebIDL::InvalidStateError::create(realm(), "SourceBuffer has been removed"_utf16);
 
     // 2. If the updating attribute equals true, then throw an InvalidStateError exception and abort these steps.
     if (updating())
@@ -318,7 +320,9 @@ WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK:
     }
 
     // 6. Run the coded frame eviction algorithm.
-    m_processor->run_coded_frame_eviction(new_data_size, current_time);
+    // NB: The current playback position is read here — not passed in by append_buffer(): As a call argument it would be
+    //     evaluated before step 1 could reject a SourceBuffer whose media element has been reset.
+    m_processor->run_coded_frame_eviction(new_data_size, m_media_source->media_element_assigned_to()->playback_manager().current_time());
 
     // 7. If the [[buffer full flag]] equals true, then throw a QuotaExceededError exception and abort these steps.
     if (m_processor->is_buffer_full())
@@ -331,7 +335,7 @@ WebIDL::ExceptionOr<void> SourceBuffer::prepare_append(size_t new_data_size, AK:
 WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(WebIDL::BufferSource data)
 {
     // 1. Run the prepare append algorithm.
-    TRY(prepare_append(data.byte_length(), m_media_source->media_element_assigned_to()->playback_manager().current_time()));
+    TRY(prepare_append(data.byte_length()));
 
     // 2. Add data to the end of the [[input buffer]].
     if (auto array_buffer = data.viewed_array_buffer(); array_buffer && !array_buffer->is_detached() && !data.is_out_of_bounds()) {
@@ -349,11 +353,47 @@ WebIDL::ExceptionOr<void> SourceBuffer::append_buffer(WebIDL::BufferSource data)
     }));
 
     // 5. Asynchronously run the buffer append algorithm.
-    m_media_source->queue_a_media_source_task(GC::create_function(heap(), [this] {
-        run_buffer_append_algorithm();
+    // NB: The queued task captures the current append generation — so a bump by abort_buffer_append_algorithm() before
+    //     the task runs makes the task do nothing; see run_buffer_append_algorithm().
+    m_media_source->queue_a_media_source_task(GC::create_function(heap(), [this, append_generation = m_append_generation] {
+        run_buffer_append_algorithm(append_generation);
     }));
 
     return {};
+}
+
+// https://w3c.github.io/media-source/#sourcebuffer-buffer-append
+void SourceBuffer::abort_buffer_append_algorithm()
+{
+    // NB: Bumping the append generation aborts the buffer-append algorithm: Any queued or in-progress run of the
+    //     algorithm compares the generation it captured at its start against the current one — and stops once they no
+    //     longer match; see run_buffer_append_algorithm() and finish_buffer_append().
+    ++m_append_generation;
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-removesourcebuffer
+void SourceBuffer::abort_if_updating(Badge<MediaSource>)
+{
+    // From the removeSourceBuffer() steps:
+    // 2. If the sourceBuffer.updating attribute equals true, then run the following steps:
+    if (!updating())
+        return;
+
+    // 2.1. Abort the buffer append algorithm if it is running.
+    abort_buffer_append_algorithm();
+
+    // 2.2. Set the sourceBuffer.updating attribute to false.
+    m_processor->set_updating(false);
+
+    // 2.3. Queue a task to fire an event named abort at sourceBuffer.
+    m_media_source->queue_a_media_source_task(GC::create_function(heap(), [this] {
+        dispatch_event(DOM::Event::create(realm(), EventNames::abort));
+    }));
+
+    // 2.4. Queue a task to fire an event named updateend at sourceBuffer.
+    m_media_source->queue_a_media_source_task(GC::create_function(heap(), [this] {
+        dispatch_event(DOM::Event::create(realm(), EventNames::updateend));
+    }));
 }
 
 // https://w3c.github.io/media-source/#dom-sourcebuffer-abort
@@ -374,8 +414,7 @@ WebIDL::ExceptionOr<void> SourceBuffer::abort()
     // 4. If the updating attribute equals true, then run the following steps:
     if (updating()) {
         // 4.1. Abort the buffer append algorithm if it is running.
-        // FIXME: The buffer append algorithm cannot be running in parallel with this code. However, when
-        //        it can, this will need additional work.
+        abort_buffer_append_algorithm();
 
         // 4.2. Set the updating attribute to false.
         m_processor->set_updating(false);
@@ -467,10 +506,17 @@ void SourceBuffer::clear_reached_end_of_stream(Badge<MediaSource>)
 }
 
 // https://w3c.github.io/media-source/#sourcebuffer-buffer-append
-void SourceBuffer::run_buffer_append_algorithm()
+void SourceBuffer::run_buffer_append_algorithm(u64 append_generation)
 {
+    // NB: A generation mismatch means abort_buffer_append_algorithm() aborted this run of the algorithm before its
+    //     queued task ran — through abort(), or through detaching the parent media source from its media element.
+    if (append_generation != m_append_generation)
+        return;
+
     // 1. Run the segment parser loop algorithm.
-    // NB: SourceBufferProcessor's append done callback invokes finish_buffer_append for the rest of this algorithm.
+    // 2. If the segment parser loop algorithm in the previous step was aborted, then abort this algorithm.
+    // NB: The segment-parser loop implements step 2 by invoking the append-done callback — which runs
+    //     finish_buffer_append() for the remaining steps — only when it wasn't aborted.
     m_processor->run_segment_parser_loop();
 }
 
@@ -739,6 +785,9 @@ void SourceBuffer::on_first_initialization_segment_processed(InitializationSegme
 // https://w3c.github.io/media-source/#sourcebuffer-buffer-append
 void SourceBuffer::finish_buffer_append()
 {
+    // NB: The segment-parser loop invokes this synchronously, through the append-done callback — so the generation
+    //     check at the start of run_buffer_append_algorithm() still holds here: The loop's callbacks queue tasks
+    //     rather than running script — so, no script can run abort_buffer_append_algorithm() while the loop runs.
     // 3. Set the updating attribute to false.
     m_processor->set_updating(false);
 

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
@@ -62,6 +62,8 @@ public:
     void set_reached_end_of_stream(Badge<MediaSource>);
     void clear_reached_end_of_stream(Badge<MediaSource>);
 
+    void abort_if_updating(Badge<MediaSource>);
+
 protected:
     SourceBuffer(JS::Realm&, MediaSource&);
 
@@ -71,8 +73,9 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    WebIDL::ExceptionOr<void> prepare_append(size_t new_data_size, AK::Duration current_time);
-    void run_buffer_append_algorithm();
+    WebIDL::ExceptionOr<void> prepare_append(size_t new_data_size);
+    void run_buffer_append_algorithm(u64 append_generation);
+    void abort_buffer_append_algorithm();
     void run_append_error_algorithm();
     void on_first_initialization_segment_processed(InitializationSegmentData const&);
     void update_ready_state_and_duration_after_coded_frame_processing();
@@ -80,6 +83,10 @@ private:
 
     GC::Ref<MediaSource> m_media_source;
     NonnullRefPtr<SourceBufferProcessor> m_processor;
+
+    // NB: The generation of the current buffer-append run — captured by the run when it starts. Bumped by
+    //     abort_buffer_append_algorithm(). A run whose captured generation no longer matches does nothing further.
+    u64 m_append_generation { 0 };
 
     // https://w3c.github.io/media-source/#dom-sourcebuffer-audiotracks
     GC::Ref<HTML::AudioTrackList> m_audio_tracks;

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.cpp
@@ -49,6 +49,11 @@ void SourceBufferList::append(GC::Ref<SourceBuffer> buffer)
     }));
 }
 
+void SourceBufferList::remove_all_buffers(Badge<MediaSource>)
+{
+    m_buffers.clear();
+}
+
 size_t SourceBufferList::length() const
 {
     return m_buffers.size();

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.h
@@ -17,6 +17,7 @@ class SourceBufferList : public DOM::EventTarget {
 
 public:
     void append(GC::Ref<SourceBuffer>);
+    void remove_all_buffers(Badge<MediaSource>);
 
     size_t length() const;
     GC::Ref<SourceBuffer> const& item(u32 index) const;

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferProcessor.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferProcessor.cpp
@@ -221,7 +221,12 @@ void SourceBufferProcessor::run_segment_parser_loop()
             }
 
             // 2. Run the initialization segment received algorithm.
-            initialization_segment_received();
+            // AD-HOC: If the initialization-segment-received algorithm ran the append-error algorithm, abort this.
+            //         Otherwise, this loop would complete normally and invoke the append done callback — and the
+            //         buffer-append algorithm would complete the failed append, firing update and updateend events
+            //         after the error and updateend events queued by the append-error algorithm.
+            if (!initialization_segment_received())
+                return;
 
             // 3. Remove the initialization segment bytes from the beginning of the [[input buffer]].
             drop_consumed_bytes_from_input_buffer();
@@ -315,7 +320,8 @@ void SourceBufferProcessor::reset_parser_state()
 }
 
 // https://w3c.github.io/media-source/#sourcebuffer-init-segment-received
-void SourceBufferProcessor::initialization_segment_received()
+// AD-HOC: Returns false if the append-error algorithm was run — so that the segment parser loop can abort.
+bool SourceBufferProcessor::initialization_segment_received()
 {
     // 1. Update the duration attribute if it currently equals NaN:
     // AD-HOC: Pass off the duration to the callback, and allow it to check for NaN.
@@ -336,7 +342,7 @@ void SourceBufferProcessor::initialization_segment_received()
     //    and abort these steps.
     if (m_parser->video_tracks().is_empty() && m_parser->audio_tracks().is_empty() && m_parser->text_tracks().is_empty()) {
         m_append_error_callback();
-        return;
+        return false;
     }
 
     // 3. If the [[first initialization segment received flag]] is true, then run the following steps:
@@ -402,6 +408,8 @@ void SourceBufferProcessor::initialization_segment_received()
     // NB: Steps 8-9 (updating the element's readyState) are handled by the initialization segment callback invoked
     //     above. Since active track flag is only true if the first initialization segment was being received, this
     //     will only need to happen when that callback is invoked, so we don't need separate one.
+
+    return true;
 }
 
 // https://w3c.github.io/media-source/#sourcebuffer-coded-frame-processing

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferProcessor.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferProcessor.h
@@ -105,7 +105,7 @@ private:
     void unset_all_track_buffer_timestamps();
     void set_need_random_access_point_flag_on_all_track_buffers(bool);
 
-    void initialization_segment_received();
+    [[nodiscard]] bool initialization_segment_received();
     void run_coded_frame_processing(Vector<DemuxedCodedFrame>&);
 
     // https://w3c.github.io/media-source/#dom-sourcebuffer-updating

--- a/Tests/LibWeb/Crash/HTML/media-element-load-with-pending-source-buffer-append.html
+++ b/Tests/LibWeb/Crash/HTML/media-element-load-with-pending-source-buffer-append.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<video id="video"></video>
+<script>
+    // Resetting the media element with load() while a SourceBuffer append task is still queued detaches the MediaSource
+    // and removes the element's playback manager. Detaching must abort the queued buffer append algorithm, and any
+    // later appendBuffer() call must throw — instead of crashing. See #10202.
+    const video = document.getElementById("video");
+    const mediaSource = new MediaSource();
+    video.src = URL.createObjectURL(mediaSource);
+
+    // once: the load() below reattaches the MediaSource (which is closed after detaching), firing sourceopen again.
+    mediaSource.addEventListener("sourceopen", async () => {
+        const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+
+        const response = await fetch("../../Assets/two-video-tracks.webm");
+        const data = new Uint8Array(await response.arrayBuffer());
+
+        sourceBuffer.addEventListener("updateend", () => {
+            // Appending to a SourceBuffer that detaching removed from the parent media source's sourceBuffers
+            // attribute must throw instead of crashing.
+            try {
+                sourceBuffer.appendBuffer(data.slice(0, 632));
+            } catch (e) {
+                // InvalidStateError is expected.
+            }
+            document.documentElement.classList.remove("test-wait");
+        }, { once: true });
+
+        // Append the init segment — which is every byte before the first Cluster element (632 bytes for this file).
+        // This queues a task to run the buffer append algorithm.
+        sourceBuffer.appendBuffer(data.slice(0, 632));
+
+        // Reset the media element while the buffer append algorithm task is still queued.
+        video.load();
+    }, { once: true });
+</script>
+</html>

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -11,6 +11,7 @@ Text/input/wpt-import/workers/Worker_ErrorEvent_type.htm
 Text/input/Worker/XHttpRequest-responseXML-unavailable-in-worker.html
 
 ; fetching a file only works from an HTTP server.
+Crash/HTML/media-element-load-with-pending-source-buffer-append.html
 Crash/HTML/video-track-switch-during-seek.html
 Text/input/WebAudio/BaseAudioContext-decodeAudioData.html
 Text/input/HTML/media-source-buffered.html

--- a/Tests/LibWeb/Text/expected/HTML/media-source-abort.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-abort.txt
@@ -1,0 +1,6 @@
+after appendBuffer(): updating true
+after abort(): updating false
+SourceBuffer updatestart
+SourceBuffer abort
+SourceBuffer updateend
+settled: updating false, buffered 0

--- a/Tests/LibWeb/Text/expected/HTML/media-source-detach.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-detach.txt
@@ -1,0 +1,8 @@
+before load(): readyState open, duration 42, sourceBuffers 1, updating true
+after load(): readyState closed, duration NaN, sourceBuffers 0, updating false
+SourceBuffer updatestart
+SourceBuffer abort
+SourceBuffer updateend
+activeSourceBuffers removesourcebuffer
+sourceBuffers removesourcebuffer
+sourceclose: sourceBuffers 0, activeSourceBuffers 0

--- a/Tests/LibWeb/Text/expected/HTML/media-source-trackless-init-segment.txt
+++ b/Tests/LibWeb/Text/expected/HTML/media-source-trackless-init-segment.txt
@@ -1,0 +1,7 @@
+isTypeSupported: true
+after appendBuffer(): updating true
+SourceBuffer updatestart
+SourceBuffer error
+SourceBuffer updateend
+MediaSource sourceended
+settled: updating false, readyState ended, duration 2, buffered 0

--- a/Tests/LibWeb/Text/input/HTML/media-source-abort.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-abort.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script src="../include.js"></script>
+<script>
+    // SourceBuffer.abort() must abort a pending buffer append:
+    // https://w3c.github.io/media-source/#dom-sourcebuffer-abort
+    // Step 4.1 aborts the buffer append algorithm — so the buffer-append task queued by appendBuffer() must have no
+    // effect when it runs afterwards. Otherwise, it reaches the segment parser loop with the input buffer that step 5
+    // just emptied — completing the append, and firing a second update/updateend pair for an aborted append.
+    asyncTest(done => {
+        const video = document.getElementById("video");
+        const mediaSource = new MediaSource();
+        video.src = URL.createObjectURL(mediaSource);
+
+        mediaSource.addEventListener("sourceopen", () => {
+            const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+
+            for (const eventName of ["updatestart", "update", "abort", "updateend"])
+                sourceBuffer.addEventListener(eventName, () => println(`SourceBuffer ${eventName}`));
+
+            sourceBuffer.appendBuffer(new Uint8Array([0x1a, 0x45, 0xdf, 0xa3]));
+            println(`after appendBuffer(): updating ${sourceBuffer.updating}`);
+
+            sourceBuffer.abort();
+            println(`after abort(): updating ${sourceBuffer.updating}`);
+
+            // Drain the task queue so any surviving buffer-append task gets a chance to run.
+            setTimeout(() => setTimeout(() => {
+                println(`settled: updating ${sourceBuffer.updating}, buffered ${sourceBuffer.buffered.length}`);
+                done();
+            }));
+        }, { once: true });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/media-source-detach.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-detach.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script src="../include.js"></script>
+<script>
+    // Calling load() on a media element with an attached MediaSource must detach the MediaSource:
+    // https://w3c.github.io/media-source/#mediasource-detach
+    // Detaching aborts a pending buffer append, closes the MediaSource, resets its duration, empties both
+    // SourceBuffer lists, and fires removesourcebuffer and sourceclose events.
+    asyncTest(done => {
+        const video = document.getElementById("video");
+        const mediaSource = new MediaSource();
+        video.src = URL.createObjectURL(mediaSource);
+
+        // once: the load() below reattaches the MediaSource (which is closed after detaching), firing sourceopen again.
+        mediaSource.addEventListener("sourceopen", () => {
+            const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+            mediaSource.duration = 42;
+
+            for (const eventName of ["updatestart", "update", "abort", "updateend"])
+                sourceBuffer.addEventListener(eventName, () => println(`SourceBuffer ${eventName}`));
+            mediaSource.activeSourceBuffers.addEventListener("removesourcebuffer", () =>
+                println("activeSourceBuffers removesourcebuffer"));
+            mediaSource.sourceBuffers.addEventListener("removesourcebuffer", () =>
+                println("sourceBuffers removesourcebuffer"));
+            mediaSource.addEventListener("sourceclose", () => {
+                println(`sourceclose: sourceBuffers ${mediaSource.sourceBuffers.length}, ` +
+                    `activeSourceBuffers ${mediaSource.activeSourceBuffers.length}`);
+                // Drain the task queue before finishing — so that any events fired by a surviving buffer append get
+                // recorded. The aborted append must not complete and fire update/updateend after the detach events.
+                setTimeout(() => setTimeout(done));
+            });
+
+            // The appended bytes are never parsed: the load() below aborts the buffer append algorithm before its
+            // queued task runs.
+            sourceBuffer.appendBuffer(new Uint8Array([0x1a, 0x45, 0xdf, 0xa3]));
+            println(`before load(): readyState ${mediaSource.readyState}, duration ${mediaSource.duration}, ` +
+                `sourceBuffers ${mediaSource.sourceBuffers.length}, updating ${sourceBuffer.updating}`);
+
+            video.load();
+            println(`after load(): readyState ${mediaSource.readyState}, duration ${mediaSource.duration}, ` +
+                `sourceBuffers ${mediaSource.sourceBuffers.length}, updating ${sourceBuffer.updating}`);
+        }, { once: true });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/media-source-trackless-init-segment.html
+++ b/Tests/LibWeb/Text/input/HTML/media-source-trackless-init-segment.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<video id="video"></video>
+<script src="../include.js"></script>
+<script>
+    // Appending an initialization segment that has no tracks must fail the append:
+    // https://w3c.github.io/media-source/#sourcebuffer-init-segment-received
+    // Step 2 runs the append-error algorithm — which fires error and updateend, and ends the stream with a decode
+    // error. The segment-parser loop must abort there: The buffer append algorithm must not complete the failed
+    // append and fire an update/updateend pair reporting success after the error/updateend pair reporting failure.
+    asyncTest(done => {
+        const video = document.getElementById("video");
+        const mediaSource = new MediaSource();
+        video.src = URL.createObjectURL(mediaSource);
+
+        // A minimal WebM initialization segment with no tracks: an EBML header, then a Segment element of unknown
+        // size containing a Segment Information element and an empty Tracks element. The parser accepts this — only
+        // a missing Tracks element is a parse error — and reports zero tracks.
+        const tracklessInitSegment = new Uint8Array([
+            0x1a, 0x45, 0xdf, 0xa3, 0x8b, // EBML header, size 11
+            0x42, 0x82, 0x84, 0x77, 0x65, 0x62, 0x6d, // DocType "webm"
+            0x42, 0x87, 0x81, 0x02, // DocTypeVersion 2
+            0x18, 0x53, 0x80, 0x67, 0xff, // Segment, unknown size
+            0x15, 0x49, 0xa9, 0x66, 0x8e, // Info, size 14
+            0x2a, 0xd7, 0xb1, 0x83, 0x0f, 0x42, 0x40, // TimestampScale 1000000
+            0x44, 0x89, 0x84, 0x44, 0xfa, 0x00, 0x00, // Duration 2000.0
+            0x16, 0x54, 0xae, 0x6b, 0x80, // Tracks, size 0
+        ]);
+
+        mediaSource.addEventListener("sourceopen", () => {
+            // Guard against this test silently testing nothing: the appended bytes only reach the WebM parser if
+            // this type is supported.
+            println(`isTypeSupported: ${MediaSource.isTypeSupported('video/webm; codecs="vp9"')}`);
+
+            const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"');
+
+            for (const eventName of ["updatestart", "update", "error", "abort", "updateend"])
+                sourceBuffer.addEventListener(eventName, () => println(`SourceBuffer ${eventName}`));
+            mediaSource.addEventListener("sourceended", () => println("MediaSource sourceended"));
+
+            sourceBuffer.appendBuffer(tracklessInitSegment);
+            println(`after appendBuffer(): updating ${sourceBuffer.updating}`);
+
+            sourceBuffer.addEventListener("updateend", () => {
+                // Drain the task queue before finishing — so that any update/updateend events get recorded if fired by
+                // a buffer append that wrongly kept running after the append error.
+                setTimeout(() => setTimeout(() => {
+                    // duration 2 proves the init segment parsed far enough to reach the no-tracks check: the duration
+                    // change step that precedes it ran. A segment rejected by the parser would fire the same error/
+                    // updateend events, but the duration would still be NaN.
+                    println(`settled: updating ${sourceBuffer.updating}, readyState ${mediaSource.readyState}, ` +
+                        `duration ${mediaSource.duration}, buffered ${sourceBuffer.buffered.length}`);
+                    done();
+                }));
+            }, { once: true });
+        }, { once: true });
+    });
+</script>


### PR DESCRIPTION
**Problem:** Crash when resetting a media element while MSE appends are pending — e.g., by hovering YouTube video cards so that preview players get created and torn down rapidly.

**Cause:** The spec’s media-element load algorithm resets the element and removes its playback manager, and has a step for detaching the attached MediaSource that we didn’t implement. So our MediaSource stayed open and assigned to the reset element, and a buffer-append task queued before the reset still ran afterwards — because the load algorithm only removes tasks on the media-element event task source. Our segment-parser loop then called the element’s `playback_manager` accessor, which assert-fails when it finds the expected-but-removed playback manager doesn’t exist.

**Fix:** Implement detachment at the right per-spec point during the load steps. And because a MediaSource can be attached through a blob URL — not just through `srcObject` — we now make the media element track which MediaSource it’s attached to. The spec’s detaching steps don’t abort a pending buffer append; but WebKit/Blink/Gecko implement the “remove all the SourceBuffer objects” steps by running the `removeSourceBuffer()` steps on every SourceBuffer. Those abort the append when the updating attribute is true. And we do the same: by removing the queued buffer-append task so the append can never run against a detached MediaSource. We cover all other paths by following the existing spec-mandated checks. However, we read the current playback position within the algorithm, instead of passing it in as an argument — because, as an argument, it’d be evaluated before the algorithm’s first step could reject the append. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10202. Related spec bug: https://github.com/w3c/media-source/issues/378.
