### PR TITLE
UI/Qt: Send ignored Vulkan window wheel events to the top-level window

### DIFF
--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -1318,6 +1318,10 @@ bool WebContentView::handle_vulkan_window_event(QEvent* event)
         return true;
     case QEvent::Wheel:
         wheelEvent(static_cast<QWheelEvent*>(event));
+        // An ignored event is reserved for a browser shortcut such as Ctrl+wheel zoom. A native window has no widget
+        // ancestors to propagate it through, so send it to the top-level window directly.
+        if (!event->isAccepted())
+            return QCoreApplication::sendEvent(window(), event);
         return true;
     case QEvent::Leave:
         leaveEvent(event);


### PR DESCRIPTION
Previously, Ctrl+wheel over the web content did not zoom the page when the native Vulkan window was active. The Vulkan window was swallowing wheel events without propagating them to the top-level window that implements the shortcut logic. We now send the ignored event to the top-level window directly.

Fixes #10973