### PR TITLE
LibWeb: Publish root baselines as formatting context run output

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -193,6 +193,7 @@ pub(crate) struct BlockFormattingContext<'pass> {
     bands: RefCell<Vec<FloatBand>>,
     lowest_left_margin_edge: Cell<CssPixels>,
     lowest_right_margin_edge: Cell<CssPixels>,
+    derived_baselines_of_root_box: Cell<DerivedBaselines>,
 }
 
 impl<'pass> BlockFormattingContext<'pass> {
@@ -209,6 +210,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             bands: RefCell::new(vec![FloatBand::default()]),
             lowest_left_margin_edge: Cell::new(CssPixels::default()),
             lowest_right_margin_edge: Cell::new(CssPixels::default()),
+            derived_baselines_of_root_box: Cell::new(DerivedBaselines::default()),
         }
     }
 
@@ -297,7 +299,24 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
-        crate::layout::compute_and_store_baselines(self.state, &self.callbacks, node, false);
+        let baselines = crate::layout::derive_baselines(self.state, &self.callbacks, node, false);
+        if node == self.root {
+            self.record_derived_baselines_of_root_box(baselines);
+        } else {
+            crate::layout::store_derived_baselines(self.used(node), baselines);
+        }
+    }
+
+    pub(crate) fn root_box(&self) -> Node {
+        self.root
+    }
+
+    pub(crate) fn record_derived_baselines_of_root_box(&self, baselines: DerivedBaselines) {
+        self.derived_baselines_of_root_box.set(baselines);
+    }
+
+    pub(crate) fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
+        self.derived_baselines_of_root_box.get()
     }
 
     fn compute_inset(&self, node: Node, containing_block_size: LogicalSize) {

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -178,6 +178,7 @@ struct FlexFormattingContext<'pass> {
     flex_container_state: &'pass UsedValues,
     flex_lines: Vec<FlexLine>,
     flex_items: Vec<FlexItem<'pass>>,
+    derived_baselines_of_root_box: DerivedBaselines,
     flex_direction: u8,
     available_space_for_items: Option<AxisAgnosticAvailableSpace>,
     available_space: Option<AvailableSpace>,
@@ -198,6 +199,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             flex_container_state,
             flex_lines: Vec::new(),
             flex_items: Vec::new(),
+            derived_baselines_of_root_box: DerivedBaselines::default(),
             flex_direction,
             available_space_for_items: None,
             available_space: None,
@@ -3117,7 +3119,8 @@ impl<'pass> FlexFormattingContext<'pass> {
                 };
                 crate::layout::place_child(self.state, &self.callbacks, item.box_, offset);
             }
-            crate::layout::compute_and_store_baselines(self.state, &self.callbacks, self.flex_container, true);
+            self.derived_baselines_of_root_box =
+                crate::layout::derive_baselines(self.state, &self.callbacks, self.flex_container, true);
         }
 
         if self.should_collect_devtools_layout_data {
@@ -3143,6 +3146,10 @@ impl<'pass> FlexFormattingContext<'pass> {
             }
             child = next;
         }
+    }
+
+    fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
+        self.derived_baselines_of_root_box
     }
 
     fn automatic_content_inline_size(&self) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -553,18 +553,39 @@ pub(crate) fn box_baseline(
     used.margin_box_block_size(collapsed)
 }
 
-pub(crate) fn compute_and_store_baselines(
+/// First and last baseline sets derived for one box, relative to its content
+/// box. A formatting context derives its own root box's baselines during its
+/// run and records them on the instance; run_formatting_context, the side
+/// that ran the context, stores them into the root's used values. Interior
+/// boxes keep the derive-and-store shortcut.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct DerivedBaselines {
+    pub(crate) first: Option<CssPixels>,
+    pub(crate) last: Option<CssPixels>,
+}
+
+// NOTE: A box can be baselined more than once (e.g. table cells are laid out
+//       twice), so both presence bits are re-assigned on every store. The
+//       payload cells are left untouched for an absent baseline so that
+//       resetting the presence bits does not perturb payloads observed by the
+//       existing derivation flow.
+pub(crate) fn store_derived_baselines(used: &UsedValues, baselines: DerivedBaselines) {
+    used.has_first_baseline.set(baselines.first.is_some());
+    if let Some(value) = baselines.first {
+        used.first_baseline.set(value);
+    }
+    used.has_last_baseline.set(baselines.last.is_some());
+    if let Some(value) = baselines.last {
+        used.last_baseline.set(value);
+    }
+}
+
+pub(crate) fn derive_baselines(
     state: &LayoutState,
     callbacks: &FfiLayoutFcCallbacks,
     box_: Node,
     inhibits_floating: bool,
-) {
-    let used_pointer = state.used_values(callbacks, box_);
-    // NOTE: This may run more than once for the same UsedValues (e.g. table cells are laid out twice),
-    //       so reset both baselines before deriving them anew.
-    used_pointer.has_first_baseline.set(false);
-    used_pointer.has_last_baseline.set(false);
-
+) -> DerivedBaselines {
     let facts = state.node_facts(callbacks, box_);
     let slot_index = callbacks.slot_index(box_);
     let line_count = state.line_data(slot_index).map_or(0, |data| data.line_boxes.len());
@@ -614,15 +635,14 @@ pub(crate) fn compute_and_store_baselines(
             last_line_index -= 1;
         }
         let last_baseline = baseline_for_line_box(last_line_index, BaselineSet::Last);
-        used_pointer.has_first_baseline.set(true);
-        used_pointer.first_baseline.set(first_baseline);
-        used_pointer.has_last_baseline.set(true);
-        used_pointer.last_baseline.set(last_baseline);
-        return;
+        return DerivedBaselines {
+            first: Some(first_baseline),
+            last: Some(last_baseline),
+        };
     }
 
     if callbacks.first_child(box_).is_invalid() || facts.children_are_inline() {
-        return;
+        return DerivedBaselines::default();
     }
 
     // Derive baselines from the first/last in-flow child that has a baseline set of its own.
@@ -669,15 +689,9 @@ pub(crate) fn compute_and_store_baselines(
         }
         None
     };
-    let first_baseline = baseline_from_children(BaselineSet::First);
-    let last_baseline = baseline_from_children(BaselineSet::Last);
-    if let Some(value) = first_baseline {
-        used_pointer.has_first_baseline.set(true);
-        used_pointer.first_baseline.set(value);
-    }
-    if let Some(value) = last_baseline {
-        used_pointer.has_last_baseline.set(true);
-        used_pointer.last_baseline.set(value);
+    DerivedBaselines {
+        first: baseline_from_children(BaselineSet::First),
+        last: baseline_from_children(BaselineSet::Last),
     }
 }
 
@@ -1457,11 +1471,19 @@ fn run_formatting_context<'pass>(
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
                 };
+                store_derived_baselines(
+                    run.state.used_values(&run.callbacks, run.box_),
+                    context.derived_baselines_of_root_box(),
+                );
                 context.place_floats_after_run();
                 result
             }
             FormattingContextImplementation::Flex(context) => {
                 context.run(run, body_input);
+                store_derived_baselines(
+                    run.state.used_values(&run.callbacks, run.box_),
+                    context.derived_baselines_of_root_box(),
+                );
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
@@ -1469,6 +1491,10 @@ fn run_formatting_context<'pass>(
             }
             FormattingContextImplementation::Grid(context) => {
                 context.run(run, body_input);
+                store_derived_baselines(
+                    run.state.used_values(&run.callbacks, run.box_),
+                    context.derived_baselines_of_root_box(),
+                );
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
@@ -1476,6 +1502,10 @@ fn run_formatting_context<'pass>(
             }
             FormattingContextImplementation::Table(context) => {
                 context.run(run, body_input);
+                store_derived_baselines(
+                    run.state.used_values(&run.callbacks, run.box_),
+                    context.derived_baselines_of_root_box(),
+                );
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size,

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -1033,6 +1033,7 @@ impl GridItem<'_> {
 pub(crate) struct GridFormattingContext<'pass> {
     state: &'pass LayoutState,
     grid_container: Node,
+    derived_baselines_of_root_box: DerivedBaselines,
     parent_grid: Option<ParentGridData>,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
@@ -1126,6 +1127,7 @@ impl<'pass> GridFormattingContext<'pass> {
         Self {
             state,
             grid_container,
+            derived_baselines_of_root_box: DerivedBaselines::default(),
             parent_grid: parent_grid.map(|parent| ParentGridData::for_child_container(parent, grid_container)),
             layout_mode,
             callbacks,
@@ -3455,7 +3457,8 @@ impl<'pass> GridFormattingContext<'pass> {
                 area.size.block_size,
             );
         }
-        crate::layout::compute_and_store_baselines(self.state, &self.callbacks, self.grid_container, false);
+        self.derived_baselines_of_root_box =
+            crate::layout::derive_baselines(self.state, &self.callbacks, self.grid_container, false);
     }
 
     fn used_track_list_data(&self, axis: Axis, subgrid: bool) -> OwnedUsedGridTrackList {
@@ -3709,6 +3712,10 @@ impl<'pass> GridFormattingContext<'pass> {
         self.layout_items(run);
         self.save_used_tracks(grid_style);
         self.save_devtools_data(grid_style);
+    }
+
+    pub(crate) fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
+        self.derived_baselines_of_root_box
     }
 
     pub(crate) fn automatic_content_inline_size(&self) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1059,7 +1059,15 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         self.automatic_content_inline_size = self
             .parent
             .greatest_child_inline_size_including_floats(self.containing_block);
-        crate::layout::compute_and_store_baselines(self.state, &self.callbacks, self.containing_block, false);
+        let baselines = crate::layout::derive_baselines(self.state, &self.callbacks, self.containing_block, false);
+        if self.containing_block == self.parent.root_box() {
+            self.parent.record_derived_baselines_of_root_box(baselines);
+        } else {
+            crate::layout::store_derived_baselines(
+                self.state.used_values(&self.callbacks, self.containing_block),
+                baselines,
+            );
+        }
     }
 
     fn compute_inline_box_pieces(&mut self) {

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -783,6 +783,7 @@ struct TableFormattingContext<'pass> {
     cells: Vec<TableCell>,
     columns: Vec<Column>,
     rows: Vec<Row>,
+    derived_baselines_of_root_box: Cell<DerivedBaselines>,
 }
 
 impl TableTree for TableFormattingContext<'_> {
@@ -841,6 +842,7 @@ impl<'pass> TableFormattingContext<'pass> {
             cells: Vec::new(),
             columns: Vec::new(),
             rows: Vec::new(),
+            derived_baselines_of_root_box: Cell::new(DerivedBaselines::default()),
         }
     }
 
@@ -2397,7 +2399,12 @@ impl<'pass> TableFormattingContext<'pass> {
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
-        crate::layout::compute_and_store_baselines(self.state, &self.callbacks, node, false);
+        let baselines = crate::layout::derive_baselines(self.state, &self.callbacks, node, false);
+        if node == self.table_box {
+            self.derived_baselines_of_root_box.set(baselines);
+        } else {
+            crate::layout::store_derived_baselines(self.used_values(node), baselines);
+        }
     }
 
     fn run(&mut self, run: &FormattingContextRun<'pass>, input: LayoutInput) {
@@ -2448,6 +2455,10 @@ impl<'pass> TableFormattingContext<'pass> {
         }
         self.compute_and_store_baselines(self.table_box);
         self.automatic_content_block_size = self.table_block_size;
+    }
+
+    fn derived_baselines_of_root_box(&self) -> DerivedBaselines {
+        self.derived_baselines_of_root_box.get()
     }
 
     fn automatic_content_inline_size(&self) -> CssPixels {


### PR DESCRIPTION
A formatting context's first and last baselines are its own result: deriving them means walking the context's line data and its children's used values, and only the context that owns those boxes can do that without reaching across a context boundary. The code instead derived and published them from wherever a consumer happened to be — the block context at the end of child layout and after collapsed-margin reassignment, the inline context on behalf of its block container, and the flex, grid and table contexts at the end of their runs — writing the four baseline cells straight into the shared used-values store, so the values crossed context boundaries through the store and nothing in the structure said who owned the derivation.

Split the derivation from the store: derive_baselines returns the values, every context derives its own root's baselines during its own run and records them on the instance, and the side that ran the context publishes them into the root's used values in the four context arms of run_formatting_context — the funnel every run passes through: child runs, measurement probes, the root and partial-relayout entries, and the wrapper run the replaced-with-children path delegates — so a cached intrinsic measurement replay, which runs no context, keeps its restored cells untouched. Interior boxes that never cross a boundary keep the derive-and-store shortcut inside their owning context.