### PR TITLE
LibWeb: Move list marker layout into the list item's owning context

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1374,11 +1374,26 @@ impl<'pass> BlockFormattingContext<'pass> {
         ((marker_line_height - marker_block_size) / 2).max(CssPixels::default())
     }
 
+    fn create_marker_used_values(&self, list_item: Node, marker: Node) {
+        let list_item_used = self.used(list_item);
+        let marker_constraints = ContainingBlockConstraints {
+            percentage_basis_inline_size: list_item_used
+                .has_definite_inline_size()
+                .then(|| list_item_used.content_inline_size.get()),
+            percentage_basis_block_size: list_item_used
+                .has_definite_block_size()
+                .then(|| list_item_used.content_block_size.get()),
+            ..ContainingBlockConstraints::default()
+        };
+        self.create_used_values(marker, marker_constraints);
+    }
+
     fn layout_list_item_marker(
         &self,
         run: &FormattingContextRun<'pass>,
         list_item: Node,
         inline_space_used_before_list_item_elements_formatted: SpaceUsedByFloats,
+        list_item_first_baseline: Option<CssPixels>,
     ) {
         let marker = self.facts(list_item).list_item_marker();
         if marker.is_invalid() {
@@ -1390,95 +1405,90 @@ impl<'pass> BlockFormattingContext<'pass> {
         if marker_facts.marker_list_style_position() == list_style_position::INSIDE {
             return;
         }
+        if self.layout_mode == LayoutMode::IntrinsicSizing {
+            return;
+        }
+        // Animations can make `float` or `position` apply to ::marker.
+        if marker_facts.is_floating() || marker_facts.is_absolutely_positioned() {
+            return;
+        }
+        self.create_marker_used_values(list_item, marker);
         let marker_style = self.style(marker);
-
-        if self.layout_mode != LayoutMode::IntrinsicSizing {
-            let marker_is_symbolic = marker_facts.marker_is_symbolic();
-            if marker_is_symbolic {
-                self.dimension_list_item_marker(marker);
-            } else {
-                // FIXME: The max-content measurement and the inside layout each shape the marker text;
-                //        a single max-content-constrained run could provide both.
-                let marker_constraints = ContainingBlockConstraints {
-                    percentage_basis_inline_size: Some(self.used(list_item).content_inline_size.get()),
-                    ..ContainingBlockConstraints::default()
-                };
-                let max_content_inline_size = self
-                    .sizing()
-                    .calculate_max_content_inline_size(marker, marker_constraints);
-                let marker_used = self.used_mut(marker);
-                marker_used.set_content_inline_size(max_content_inline_size);
-                marker_used.has_definite_inline_size.set(true);
-                let inner_available_space = crate::layout::AvailableSpace {
-                    inline_size: crate::layout::AvailableSize::definite(max_content_inline_size),
-                    block_size: crate::layout::AvailableSize::Indefinite,
-                };
-                match crate::layout::layout_inside_child(
-                    run,
-                    None,
-                    None,
-                    marker,
-                    self.layout_mode,
-                    LayoutInput {
-                        available_space: inner_available_space,
-                        containing_block_constraints: marker_constraints,
-                        content_box_position_in_bfc_root: None,
-                        sizing: RootSizingDirectives {
-                            adopt_automatic_content_block_size: true,
-                            ..RootSizingDirectives::default()
-                        },
-                        participation: ParticipationInParentFormattingContext::Item,
+        let marker_is_symbolic = marker_facts.marker_is_symbolic();
+        if marker_is_symbolic {
+            self.dimension_list_item_marker(marker);
+        } else {
+            let marker_constraints = ContainingBlockConstraints {
+                percentage_basis_inline_size: Some(self.used(list_item).content_inline_size.get()),
+                ..ContainingBlockConstraints::default()
+            };
+            let max_content_inline_size = self
+                .sizing()
+                .calculate_max_content_inline_size(marker, marker_constraints);
+            let marker_used = self.used_mut(marker);
+            marker_used.set_content_inline_size(max_content_inline_size);
+            marker_used.has_definite_inline_size.set(true);
+            let inner_available_space = crate::layout::AvailableSpace {
+                inline_size: crate::layout::AvailableSize::definite(max_content_inline_size),
+                block_size: crate::layout::AvailableSize::Indefinite,
+            };
+            match crate::layout::layout_inside_child(
+                run,
+                None,
+                None,
+                marker,
+                self.layout_mode,
+                LayoutInput {
+                    available_space: inner_available_space,
+                    containing_block_constraints: marker_constraints,
+                    content_box_position_in_bfc_root: None,
+                    sizing: RootSizingDirectives {
+                        adopt_automatic_content_block_size: true,
+                        ..RootSizingDirectives::default()
                     },
-                    true,
-                ) {
-                    crate::layout::ChildLayoutOutcome::Created(child_layout) => {
-                        self.used_mut(marker)
-                            .set_content_block_size(child_layout.automatic_content_block_size);
-                    }
-                    crate::layout::ChildLayoutOutcome::Skipped => {}
-                    crate::layout::ChildLayoutOutcome::ReenterCurrent => {
-                        unreachable!("marker inside layout did not establish a formatting context")
-                    }
+                    participation: ParticipationInParentFormattingContext::Item,
+                },
+                true,
+            ) {
+                crate::layout::ChildLayoutOutcome::Created(child_layout) => {
+                    self.used_mut(marker)
+                        .set_content_block_size(child_layout.automatic_content_block_size);
+                }
+                crate::layout::ChildLayoutOutcome::Skipped => {}
+                crate::layout::ChildLayoutOutcome::ReenterCurrent => {
+                    unreachable!("marker inside layout did not establish a formatting context")
                 }
             }
-
-            let marker_distance = self.distance_between_marker_and_list_item(marker);
-            let marker_used = self.used(marker);
-            let marker_block_size = marker_used.content_block_size.get();
-            let marker_inline_size = marker_used.content_inline_size.get();
-            let list_item_style = self.style(list_item);
-            let list_item_used = self.used(list_item);
-            let marker_inline_offset = if list_item_style.direction() == direction::LTR {
-                inline_space_used_before_list_item_elements_formatted.left - marker_distance - marker_inline_size
-            } else {
-                list_item_used.content_inline_size.get()
-                    - (inline_space_used_before_list_item_elements_formatted.right - marker_distance)
-            };
-            let marker_block_offset = if !marker_is_symbolic
-                && list_item_used.has_first_baseline.get()
-                && marker_used.has_first_baseline.get()
-            {
-                list_item_used.first_baseline.get() - marker_used.first_baseline.get()
-            } else {
-                round_css_pixels(Self::marker_centered_block_offset(marker_style.line_height(), marker_block_size))
-            };
-
-            // Animations can make `float` or `position` apply to ::marker.
-            if !marker_facts.is_floating() && !marker_facts.is_absolutely_positioned() {
-                self.place_child(
-                    marker,
-                    FfiCssPixelPoint {
-                        x: round_css_pixels(marker_inline_offset),
-                        y: marker_block_offset,
-                    },
-                );
-            }
         }
 
-        if marker_style.line_height() > self.used(list_item).content_block_size.get() {
-            self.used_mut(list_item)
-                .set_content_block_size(marker_style.line_height());
-        }
+        let marker_distance = self.distance_between_marker_and_list_item(marker);
+        let marker_used = self.used(marker);
+        let marker_block_size = marker_used.content_block_size.get();
+        let marker_inline_size = marker_used.content_inline_size.get();
+        let list_item_style = self.style(list_item);
+        let list_item_used = self.used(list_item);
+        let marker_inline_offset = if list_item_style.direction() == direction::LTR {
+            inline_space_used_before_list_item_elements_formatted.left - marker_distance - marker_inline_size
+        } else {
+            list_item_used.content_inline_size.get()
+                - (inline_space_used_before_list_item_elements_formatted.right - marker_distance)
+        };
+        let marker_block_offset = if !marker_is_symbolic
+            && let Some(list_item_first_baseline) = list_item_first_baseline
+            && marker_used.has_first_baseline.get()
+        {
+            list_item_first_baseline - marker_used.first_baseline.get()
+        } else {
+            round_css_pixels(Self::marker_centered_block_offset(marker_style.line_height(), marker_block_size))
+        };
+
+        self.place_child(
+            marker,
+            FfiCssPixelPoint {
+                x: round_css_pixels(marker_inline_offset),
+                y: marker_block_offset,
+            },
+        );
     }
 
     fn layout_inside(
@@ -1549,9 +1559,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             return;
         }
 
-        // NOTE: ListItemMarkerBoxes are placed by their corresponding ListItemBox, and their used
-        //       values were created together with its own.
-        if facts.is_list_item_marker_box() {
+        if facts.is_list_item_marker_box() && !facts.is_floating() {
             return;
         }
 
@@ -1789,6 +1797,7 @@ impl<'pass> BlockFormattingContext<'pass> {
                     table_box_content_block_offset_in_wrapper: is_table_formatting_context
                         .then_some(content_block_offset),
                     float_avoidance_inline_size,
+                    outer_float_intrusion_before_list_item_children: inline_space_used_before_children_formatted,
                     ..RootSizingDirectives::default()
                 },
                 participation: ParticipationInParentFormattingContext::BlockLevel,
@@ -1867,8 +1876,18 @@ impl<'pass> BlockFormattingContext<'pass> {
         }
 
         // Now that our children are formatted we place the ListItemBox with the left space we remembered.
-        if is_list_item_box {
-            self.layout_list_item_marker(run, node, inline_space_used_before_children_formatted);
+        if is_list_item_box && !has_independent_formatting_context {
+            let list_item_used = self.used(node);
+            let list_item_first_baseline = list_item_used
+                .has_first_baseline
+                .get()
+                .then(|| list_item_used.first_baseline.get());
+            self.layout_list_item_marker(
+                run,
+                node,
+                inline_space_used_before_children_formatted,
+                list_item_first_baseline,
+            );
         }
 
         if let Some(position) = pending_position {
@@ -2225,6 +2244,15 @@ impl<'pass> BlockFormattingContext<'pass> {
             // have been derived from (a scroll container child exports its bottom margin edge), so re-derive them.
             self.compute_and_store_baselines(self.root);
         }
+
+        if root_facts.is_list_item_box() {
+            self.layout_list_item_marker(
+                run,
+                self.root,
+                input.sizing.outer_float_intrusion_before_list_item_children,
+                self.derived_baselines_of_root_box().first,
+            );
+        }
     }
 
     pub(crate) fn place_floats_after_run(&self) {
@@ -2579,6 +2607,27 @@ impl<'pass> BlockFormattingContext<'pass> {
         constraints: ContainingBlockConstraints,
         automatic_content_block_size_of_completed_run: Option<CssPixels>,
     ) -> CssPixels {
+        let automatic_content_block_size = self.automatic_block_size_for_block_level_element_disregarding_marker(
+            node,
+            available_space,
+            constraints,
+            automatic_content_block_size_of_completed_run,
+        );
+        floor_list_item_automatic_block_size_by_marker_line_height(
+            self.state,
+            self.callbacks,
+            node,
+            automatic_content_block_size,
+        )
+    }
+
+    fn automatic_block_size_for_block_level_element_disregarding_marker(
+        &self,
+        node: Node,
+        available_space: AvailableSpace,
+        constraints: ContainingBlockConstraints,
+        automatic_content_block_size_of_completed_run: Option<CssPixels>,
+    ) -> CssPixels {
         let facts = self.facts(node);
         let style = self.style(node);
         if facts.creates_block_formatting_context()
@@ -2624,17 +2673,12 @@ impl<'pass> BlockFormattingContext<'pass> {
         // 2. the bottom edge of the bottom (possibly collapsed) margin of its last in-flow child, if the child's bottom margin does not collapse with the element's bottom margin
         // 3. the bottom border edge of the last in-flow child whose top margin doesn't collapse with the element's bottom margin
         if !facts.children_are_inline() {
-            let mut marker_line_block_size = CssPixels::default();
             for child in self.children(node).into_iter().rev() {
                 let child_facts = self.facts(child);
                 if child_facts.is_absolutely_positioned() || child_facts.is_floating() {
                     continue;
                 }
-                // NOTE: Markers are not in-flow, but for list items that contain only floats (or are otherwise empty),
-                //       the marker's line-height determines the list item's block size. This ensures proper stacking of
-                //       list items and alignment with their floated content.
                 if child_facts.is_list_item_marker_box() {
-                    marker_line_block_size = self.style(child).line_height();
                     continue;
                 }
                 if self.margins_collapse_through(child) {
@@ -2654,10 +2698,6 @@ impl<'pass> BlockFormattingContext<'pass> {
                     + child_used.border_box_bottom(false)
                     + margin_bottom)
                     .max(CssPixels::default());
-            }
-            // If no in-flow children were found but there's a marker, use the marker's line-height.
-            if marker_line_block_size > CssPixels::default() {
-                return marker_line_block_size;
             }
         }
 
@@ -2889,6 +2929,9 @@ pub(crate) fn automatic_block_size_for_bfc_root(
         };
         for child in flow_children {
             let child_facts = state.node_facts(&callbacks, child);
+            if child_facts.is_list_item_marker_box() {
+                continue;
+            }
             if child_facts.is_box() && !child_facts.is_absolutely_positioned() && !child_facts.is_floating() {
                 let child_used = state.try_used_values(&callbacks, child);
                 // Children that have not been laid out yet contribute nothing to the automatic block size.
@@ -2911,5 +2954,27 @@ pub(crate) fn automatic_block_size_for_bfc_root(
         bottom = Some(bottom.map_or(lowest, |value| value.max(lowest)));
     }
     let _ = used;
-    bottom.unwrap_or_default().max(CssPixels::default())
+    floor_list_item_automatic_block_size_by_marker_line_height(
+        state,
+        callbacks,
+        root,
+        bottom.unwrap_or_default().max(CssPixels::default()),
+    )
+}
+
+pub(crate) fn floor_list_item_automatic_block_size_by_marker_line_height(
+    state: &LayoutState,
+    callbacks: FfiLayoutFcCallbacks,
+    node: Node,
+    automatic_content_block_size: CssPixels,
+) -> CssPixels {
+    let facts = state.node_facts(&callbacks, node);
+    if !facts.is_list_item_box() {
+        return automatic_content_block_size;
+    }
+    let marker = facts.list_item_marker();
+    if marker.is_invalid() {
+        return automatic_content_block_size;
+    }
+    automatic_content_block_size.max(state.style_facts(&callbacks, marker).line_height())
 }

--- a/Libraries/LibWeb/Rust/src/layout/geometry.rs
+++ b/Libraries/LibWeb/Rust/src/layout/geometry.rs
@@ -124,6 +124,7 @@ pub(crate) struct RootSizingDirectives {
     pub(crate) table_box_content_block_offset_in_wrapper: Option<CssPixels>,
     pub(crate) adopt_automatic_content_block_size: bool,
     pub(crate) float_avoidance_inline_size: Option<CssPixels>,
+    pub(crate) outer_float_intrusion_before_list_item_children: SpaceUsedByFloats,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -905,9 +905,7 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
                 }
                 ItemType::FloatingElement => {
                     line_builder.commit_pending_margin_before_float();
-                    if !self.facts(item.node).is_list_item_marker_box() {
-                        self.create_used_values(item.node, self.input.containing_block_constraints);
-                    }
+                    self.create_used_values(item.node, self.input.containing_block_constraints);
                     self.clear_floating_boxes(item.node);
                     line_builder.set_unbreakable_run_inline_size_interrupted_by_float(
                         iterator.next_non_whitespace_sequence_inline_size(self),

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -185,13 +185,7 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
             self.visited_fragmented_inlines.push(node);
         }
         let constraints = self.context().input.containing_block_constraints;
-        let used = if self.context().facts(node).is_list_item_marker_box() {
-            self.context()
-                .try_used_pointer(node)
-                .expect("list marker must have precreated used values")
-        } else {
-            self.context().create_used_values(node, constraints)
-        };
+        let used = self.context().create_used_values(node, constraints);
         let style = self.context().style(node);
         let basis = constraints.inline_basis();
         used.margin_top.set(style.margin_top().to_px(basis));
@@ -552,7 +546,7 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
             return Some(Item::new(ItemType::BlockLevelBox, node));
         }
 
-        let used = if facts.is_list_item_marker_box() || self.box_model_node_stack.last().copied() == Some(node) {
+        let used = if self.box_model_node_stack.last().copied() == Some(node) {
             self.context()
                 .try_used_pointer(node)
                 .expect("inline box must have precreated used values")

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -1031,28 +1031,7 @@ impl LayoutState {
         used.content_inline_size.set(content_inline_size.unwrap_or_default());
         used.content_block_size.set(content_block_size.unwrap_or_default());
 
-        let used = self.used_values.allocate(slot_index, used);
-
-        let list_item_marker = facts.is_list_item_box().then(|| facts.list_item_marker());
-        if let Some(list_item_marker) = list_item_marker.filter(|marker| !marker.is_invalid()) {
-            let marker_slot_index = callbacks.slot_index(list_item_marker);
-            if self.used_values.get(marker_slot_index).is_none() {
-                // List markers inherit only bases that were already definite
-                // when their list item entry was created.
-                let marker_constraints = ContainingBlockConstraints {
-                    percentage_basis_inline_size: used
-                        .has_definite_inline_size()
-                        .then_some(used.content_inline_size.get()),
-                    percentage_basis_block_size: used
-                        .has_definite_block_size()
-                        .then_some(used.content_block_size.get()),
-                    ..ContainingBlockConstraints::default()
-                };
-                self.create_used_values(callbacks, list_item_marker, marker_constraints);
-            }
-        }
-
-        used
+        self.used_values.allocate(slot_index, used)
     }
 
     pub(crate) fn populate_from_paintable(

--- a/Tests/LibWeb/Layout/expected/block-in-inline-in-floated-fieldset.txt
+++ b/Tests/LibWeb/Layout/expected/block-in-inline-in-floated-fieldset.txt
@@ -4,7 +4,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
       BlockContainer <ul> at [48,16] [0+0+40 744 0+0+0] [16+0+0 0 0+0+16] children: inline
         TextNode <#text> (not painted)
         ListItemBox <li> at [728.265625,16] floating [0+0+0 63.734375 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
-          ListItemMarkerBox <(anonymous)> at [728.265625,16] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+          ListItemMarkerBox <(anonymous)> at [714.265625,21] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
           BlockContainer <(anonymous)> at [728.265625,16] [0+0+0 63.734375 0+0+0] [0+0+0 0 0+0+0] children: inline
             TextNode <#text> (not painted)
           BlockContainer <form> at [728.265625,16] [0+0+0 63.734375 0+0+0] [0+0+0 24 0+0+0] children: inline
@@ -37,7 +37,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,16 784x0]
       PaintableWithLines (BlockContainer<UL>) [8,16 784x0]
         PaintableWithLines (ListItemBox<LI>) [728.265625,16 63.734375x24]
-          MarkerPaintable (ListItemMarkerBox(anonymous)) [728.265625,16 0x0]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [714.265625,21 6x6]
           PaintableWithLines (BlockContainer(anonymous)) [728.265625,16 63.734375x0]
           PaintableWithLines (BlockContainer<FORM>) [728.265625,16 63.734375x24]
             FieldSetPaintable (FieldSetBox<FIELDSET>) [728.265625,16 63.734375x24]

--- a/Tests/LibWeb/Layout/expected/list-item-specified-height-not-floored-by-marker.txt
+++ b/Tests/LibWeb/Layout/expected/list-item-specified-height-not-floored-by-marker.txt
@@ -1,0 +1,55 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 42 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 42 0+0+0] children: not-inline
+      BlockContainer <ul> at [100,0] [0+0+100 700 0+0+0] [0+0+0 42 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [100,0] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li.h5> at [100,0] [0+0+0 700 0+0+0] [0+0+0 5 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 43, rect: [100,0 354.390625x16] baseline: 12.796875
+              "specified height wins over the marker floor"
+          ListItemMarkerBox <(anonymous)> at [86,5] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,5] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li.mh5> at [100,5] [0+0+0 700 0+0+0] [0+0+0 5 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 40, rect: [100,5 342.203125x16] baseline: 12.796875
+              "max-height clamps below the marker floor"
+          ListItemMarkerBox <(anonymous)> at [86,10] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,10] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [100,10] [0+0+0 700 0+0+0] [0+0+0 16 0+0+0] children: not-inline
+          ListItemMarkerBox <(anonymous)> at [86,15] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+        BlockContainer <(anonymous)> at [100,26] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [100,26] [0+0+0 700 0+0+0] [0+0+0 16 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 21, rect: [100,26 172.828125x16] baseline: 12.796875
+              "automatic height item"
+          ListItemMarkerBox <(anonymous)> at [86,31] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,42] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,42] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x42]
+      PaintableWithLines (BlockContainer<UL>) [0,0 800x42]
+        PaintableWithLines (BlockContainer(anonymous)) [100,0 700x0]
+        PaintableWithLines (ListItemBox<LI>.h5) [100,0 700x5]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,5 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,5 700x0]
+        PaintableWithLines (ListItemBox<LI>.mh5) [100,5 700x5]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,10 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,10 700x0]
+        PaintableWithLines (ListItemBox<LI>) [100,10 700x16]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,15 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,26 700x0]
+        PaintableWithLines (ListItemBox<LI>) [100,26 700x16]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,31 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,42 700x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,42 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x42] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/list-marker-in-abspos-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-in-abspos-list-item.txt
@@ -1,0 +1,36 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+      BlockContainer <ul> at [100,0] [0+0+100 700 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [100,0] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [100,0] [0+0+0 700 0+0+0] [0+0+0 24 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [100,4 54.421875x16] baseline: 12.796875
+              "in flow"
+          ListItemMarkerBox <(anonymous)> at [86,9] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,24] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+          ListItemBox <li.abs> at [300,100] positioned [0+0+0 169.15625 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 21, rect: [300,104 169.15625x16] baseline: 12.796875
+                "absolutely positioned"
+            ListItemMarkerBox <(anonymous)> at [286,109] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,24] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x24]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x24]
+      PaintableWithLines (BlockContainer<UL>) [0,0 800x24]
+        PaintableWithLines (BlockContainer(anonymous)) [100,0 700x0]
+        PaintableWithLines (ListItemBox<LI>) [100,0 700x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,9 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,24 700x0]
+          PaintableWithLines (ListItemBox<LI>.abs) [300,100 169.15625x24]
+            MarkerPaintable (ListItemMarkerBox(anonymous)) [286,109 6x6]
+      PaintableWithLines (BlockContainer(anonymous)) [0,24 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x24] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/list-marker-in-flex-item-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-in-flex-item-list-item.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] children: not-inline
+      Box <ul> at [100,0] flex-container(row) [0+0+100 700 0+0+0] [0+0+0 24 0+0+0] [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [100,0] flex-item [0+0+0 28.6875 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [100,4 28.6875x16] baseline: 12.796875
+              "one"
+          ListItemMarkerBox <(anonymous)> at [86,9] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [168.6875,0] flex-item [0+0+0 28.4375 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [168.6875,4 28.4375x16] baseline: 12.796875
+              "two"
+          ListItemMarkerBox <(anonymous)> at [154.6875,9] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,24] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x24]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x24]
+      Paintable (Box<UL>) [0,0 800x24]
+        PaintableWithLines (ListItemBox<LI>) [100,0 28.6875x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,9 6x6]
+        PaintableWithLines (ListItemBox<LI>) [168.6875,0 28.4375x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [154.6875,9 6x6]
+      PaintableWithLines (BlockContainer(anonymous)) [0,24 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x24] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/list-marker-in-floating-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-in-floating-list-item.txt
@@ -1,0 +1,32 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 24 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+      BlockContainer <ul> at [100,0] [0+0+100 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        ListItemBox <li.left> at [100,0] floating [0+0+0 80.828125 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [100,4 80.828125x16] baseline: 12.796875
+              "floats left"
+          ListItemMarkerBox <(anonymous)> at [86,9] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+        ListItemBox <li.right> at [708.3125,0] floating [0+0+0 91.6875 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 12, rect: [708.3125,4 91.6875x16] baseline: 12.796875
+              "floats right"
+          ListItemMarkerBox <(anonymous)> at [694.3125,9] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x24]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x0]
+      PaintableWithLines (BlockContainer<UL>) [0,0 800x0]
+        PaintableWithLines (ListItemBox<LI>.left) [100,0 80.828125x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,9 6x6]
+        PaintableWithLines (ListItemBox<LI>.right) [708.3125,0 91.6875x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [694.3125,9 6x6]
+      PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x24] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/list-marker-in-flow-root-and-overflow-hidden-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-in-flow-root-and-overflow-hidden-list-item.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 64 0+0+0] children: not-inline
+      BlockContainer <ul> at [100,0] [0+0+100 700 0+0+0] [0+0+0 64 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [100,0] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li.flow-root> at [100,0] [0+0+0 700 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 19, rect: [100,4 148.484375x16] baseline: 12.796875
+              "flow-root list item"
+          ListItemMarkerBox <(anonymous)> at [86,9] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,24] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li.clipped> at [100,24] [0+0+0 700 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 25, rect: [100,28 197.609375x16] baseline: 12.796875
+              "overflow hidden list item"
+          ListItemMarkerBox <(anonymous)> at [86,33] [0+0+0 6 0+0+0] [0+0+0 6 0+0+0] [BFC] children: not-inline
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,64] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,64] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x64]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x64]
+      PaintableWithLines (BlockContainer<UL>) [0,0 800x64]
+        PaintableWithLines (BlockContainer(anonymous)) [100,0 700x0]
+        PaintableWithLines (ListItemBox<LI>.flow-root) [100,0 700x24]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,9 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,24 700x0]
+        PaintableWithLines (ListItemBox<LI>.clipped) [100,24 700x40]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [86,33 6x6]
+        PaintableWithLines (BlockContainer(anonymous)) [100,64 700x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,64 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x64] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/list-marker-text-baseline-in-flow-root-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-text-baseline-in-flow-root-list-item.txt
@@ -1,0 +1,44 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+      BlockContainer <ol> at [100,0] [0+0+100 700 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+        BlockContainer <(anonymous)> at [100,0] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li> at [100,0] [0+0+0 700 0+0+0] [0+0+0 24 0+0+0] children: inline
+          frag 0 from TextNode start: 0, length: 19, rect: [100,4 160.6875x16] baseline: 12.796875
+              "plain numbered item"
+          ListItemMarkerBox <(anonymous)> at [81,0] [0+0+0 18.6875 0+0+0] [0+0+0 24 0+0+0] [BFC] children: inline
+            frag 0 from GeneratedTextNode start: 0, length: 3, rect: [81,4 18.6875x16] baseline: 12.796875
+                "1. "
+            GeneratedTextNode <(anonymous)> (not painted)
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,24] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+        ListItemBox <li.flow-root> at [100,24] [0+0+0 700 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 23, rect: [100,30 298.09375x24] baseline: 19.1875
+              "flow-root numbered item"
+          ListItemMarkerBox <(anonymous)> at [68,24] [0+0+0 31.734375 0+0+0] [0+0+0 36 0+0+0] [BFC] children: inline
+            frag 0 from GeneratedTextNode start: 0, length: 3, rect: [68,30 31.734375x24] baseline: 19.1875
+                "2. "
+            GeneratedTextNode <(anonymous)> (not painted)
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> at [100,60] [0+0+0 700 0+0+0] [0+0+0 0 0+0+0] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [0,60] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x60]
+    PaintableWithLines (BlockContainer<BODY>) [0,0 800x60]
+      PaintableWithLines (BlockContainer<OL>) [0,0 800x60]
+        PaintableWithLines (BlockContainer(anonymous)) [100,0 700x0]
+        PaintableWithLines (ListItemBox<LI>) [100,0 700x24]
+          PaintableWithLines (ListItemMarkerBox(anonymous)) [81,0 18.6875x24]
+        PaintableWithLines (BlockContainer(anonymous)) [100,24 700x0]
+        PaintableWithLines (ListItemBox<LI>.flow-root) [100,24 700x36]
+          PaintableWithLines (ListItemMarkerBox(anonymous)) [68,24 31.734375x36]
+        PaintableWithLines (BlockContainer(anonymous)) [100,60 700x0]
+      PaintableWithLines (BlockContainer(anonymous)) [0,60 800x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x60] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/list-item-specified-height-not-floored-by-marker.html
+++ b/Tests/LibWeb/Layout/input/list-item-specified-height-not-floored-by-marker.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 16px/1 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+    }
+
+    li.h5 {
+        height: 5px;
+    }
+
+    li.mh5 {
+        max-height: 5px;
+    }
+</style>
+<ul>
+    <li class="h5">specified height wins over the marker floor</li>
+    <li class="mh5">max-height clamps below the marker floor</li>
+    <li></li>
+    <li>automatic height item</li>
+</ul>

--- a/Tests/LibWeb/Layout/input/list-marker-in-abspos-list-item.html
+++ b/Tests/LibWeb/Layout/input/list-marker-in-abspos-list-item.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 16px/1.5 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+    }
+
+    li.abs {
+        position: absolute;
+        left: 300px;
+        top: 100px;
+    }
+</style>
+<ul>
+    <li>in flow</li>
+    <li class="abs">absolutely positioned</li>
+</ul>

--- a/Tests/LibWeb/Layout/input/list-marker-in-flex-item-list-item.html
+++ b/Tests/LibWeb/Layout/input/list-marker-in-flex-item-list-item.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 16px/1.5 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+        display: flex;
+        gap: 40px;
+    }
+</style>
+<ul>
+    <li>one</li>
+    <li>two</li>
+</ul>

--- a/Tests/LibWeb/Layout/input/list-marker-in-floating-list-item.html
+++ b/Tests/LibWeb/Layout/input/list-marker-in-floating-list-item.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 16px/1.5 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+    }
+
+    li.left {
+        float: left;
+    }
+
+    li.right {
+        float: right;
+    }
+</style>
+<ul>
+    <li class="left">floats left</li>
+    <li class="right">floats right</li>
+</ul>

--- a/Tests/LibWeb/Layout/input/list-marker-in-flow-root-and-overflow-hidden-list-item.html
+++ b/Tests/LibWeb/Layout/input/list-marker-in-flow-root-and-overflow-hidden-list-item.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 16px/1.5 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+    }
+
+    li.flow-root {
+        display: flow-root list-item;
+    }
+
+    li.clipped {
+        overflow: hidden;
+        height: 40px;
+    }
+</style>
+<ul>
+    <li class="flow-root">flow-root list item</li>
+    <li class="clipped">overflow hidden list item</li>
+</ul>

--- a/Tests/LibWeb/Layout/input/list-marker-text-baseline-in-flow-root-list-item.html
+++ b/Tests/LibWeb/Layout/input/list-marker-text-baseline-in-flow-root-list-item.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 16px/1.5 monospace;
+    }
+
+    ol {
+        margin: 0;
+        padding-left: 100px;
+    }
+
+    li.flow-root {
+        display: flow-root list-item;
+        font-size: 24px;
+    }
+</style>
+<ol>
+    <li>plain numbered item</li>
+    <li class="flow-root">flow-root numbered item</li>
+</ol>

--- a/Tests/LibWeb/Ref/expected/overflow-hidden-list-item-clips-outside-marker-ref.html
+++ b/Tests/LibWeb/Ref/expected/overflow-hidden-list-item-clips-outside-marker-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+        font: 20px/1.5 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+        list-style: none;
+    }
+
+    li {
+        overflow: hidden;
+        height: 40px;
+        background: #cfc;
+    }
+</style>
+<ul>
+    <li>the marker must not paint</li>
+</ul>

--- a/Tests/LibWeb/Ref/input/overflow-hidden-list-item-clips-outside-marker.html
+++ b/Tests/LibWeb/Ref/input/overflow-hidden-list-item-clips-outside-marker.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/overflow-hidden-list-item-clips-outside-marker-ref.html">
+<style>
+    body {
+        margin: 0;
+        font: 20px/1.5 monospace;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 100px;
+    }
+
+    li {
+        overflow: hidden;
+        height: 40px;
+        background: #cfc;
+    }
+
+    li::marker {
+        color: red;
+        font-size: 40px;
+    }
+</style>
+<ul>
+    <li>the marker must not paint</li>
+</ul>


### PR DESCRIPTION
Outside markers of list items that establish an independent formatting context were laid out from outside the boundary: the outer block context measured and placed them, create_used_values allocated marker entries recursively together with the list item's, and the list item's content block size was overwritten with the marker line-height after its own run had finished.

Marker layout now runs in the epilogue of the list item's own block formatting context run; the outer context handles only markers of list items that participate in its flow directly. Outer float bands reach the run through a new input-only root sizing directive and the baseline comes from the run's derived baselines. The line-height floor is now part of automatic block size computation, so specified height and max-height win over it, matching other engines.

Marker used values are created at one fixed point per configuration: layout_list_item_marker for in-flow outside markers, the inline-level iterator for markers in inline flow, the float machinery for floating markers, and the abspos engine for absolutely positioned ones. The empty-slot assert in create_used_values catches any second creator.

Markers of absolutely positioned, floating, and flex-item list items were never laid out before and now work; the one rebaseline is such a marker changing from 0x0 to a placed box. New layout tests cover markers in flex-item, abspos, floating, flow-root, and overflow:hidden list items, marker baseline alignment in a flow-root list item, and specified heights winning over the floor; a ref test checks that overflow:hidden on a list item still clips its outside marker like other engines do.