### PR TITLE
LibWeb+LibHTTP+RequestServer: Revalidate page URLs on reload

### DIFF
--- a/Libraries/LibHTTP/Cache/Utilities.cpp
+++ b/Libraries/LibHTTP/Cache/Utilities.cpp
@@ -506,10 +506,16 @@ CacheLifetimeStatus cache_lifetime_status(HeaderList const& request_headers, Hea
 
         // https://httpwg.org/specs/rfc9111.html#cache-request-directive.max-age
         // The max-age request directive indicates that the client prefers a response whose age is less than or equal to
-        // the specified number of seconds.
+        // the specified number of seconds. Unless the max-stale request directive is also present, the client doesn't
+        // wish to receive a stale response.
+        //
+        // NB: This doesn't preclude validating the stored response: per Section 4, a stored response may also be reused
+        //     if it's "successfully validated (see Section 4.3)". Clients send "Cache-Control: max-age=0" to request
+        //     exactly that. Notably, Fetch attaches it to requests whose cache mode is "no-cache" — which is how a
+        //     browser reload forces revalidation of the document.
         if (auto max_age = extract_cache_control_duration_directive(*request_cache_control, "max-age"sv); max_age.has_value()) {
             if (*max_age <= current_age)
-                return CacheLifetimeStatus::Expired;
+                return revalidation_status(CacheLifetimeStatus::MustRevalidate);
         }
 
         // https://httpwg.org/specs/rfc9111.html#cache-request-directive.min-fresh

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -1978,8 +1978,17 @@ static void create_navigation_params_by_fetching(
     }
 
     // 7. If entry's document state's reload pending is true, then set request's reload-navigation flag.
-    if (reload_pending)
+    if (reload_pending) {
         request->set_reload_navigation(true);
+
+        // AD-HOC: The specs don't define HTTP cache behavior for reloads. But every major engine forces at least re-
+        //         validation of the reloaded document rather than serving it straight from cache. Use the "no-cache"
+        //         cache mode, which per Fetch "creates a conditional request if there is a response in the HTTP cache
+        //         and a normal request otherwise. It then updates the HTTP cache with the response." This matches
+        //         Chromium (FetchCacheMode::kValidateCache) and Firefox (nsIRequest::VALIDATE_ALWAYS); WebKit goes
+        //         further, and bypasses the cache entirely (ReloadIgnoringCacheData).
+        request->set_cache_mode(HTTP::CacheMode::NoCache);
+    }
 
     // 8. Otherwise, if entry's document state's ever populated is true, then set request's history-navigation flag.
     else if (ever_populated)

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1231,6 +1231,12 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
                 potentially_target_specific_source_snapshot_params = navigable->active_document()->snapshot_source_snapshot_params();
 
             // 5. Set targetEntry's document state's reload pending to false.
+            // AD-HOC: Snapshot "reload pending" before clearing it. Population in step 7 must still observe it: "create
+            //         navigation params by fetching" reads it to set the request's reload-navigation flag and cache
+            //         mode. The specified order clears the flag before population can read it — which would leave a
+            //         reload indistinguishable from a plain history navigation.
+            //         See https://github.com/whatwg/html/issues/12760.
+            auto input_reload_pending = target_entry->document_state()->reload_pending();
             target_entry->document_state()->set_reload_pending(false);
             page().client().page_did_set_session_history_entry_document_state_reload_pending(
                 navigable->id(), target_entry->navigation_api_key(), false);
@@ -1256,12 +1262,12 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
             //    targetSnapshotParams, userInvolvement, with allowPOST set to allowPOST and completionSteps set to
             //    queue a global task on the navigation and traversal task source given navigable's active window to
             //    run afterDocumentPopulated.
-            Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [input_url = move(input_url), input_document_resource = move(input_document_resource), input_request_referrer = move(input_request_referrer), input_request_referrer_policy, input_initiator_origin = move(input_initiator_origin), input_origin = move(input_origin), input_history_policy_container = move(input_history_policy_container), input_about_base_url = move(input_about_base_url), input_navigable_target_name = move(input_navigable_target_name), input_ever_populated, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated, user_involvement = job.user_involvement] {
+            Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [input_url = move(input_url), input_document_resource = move(input_document_resource), input_request_referrer = move(input_request_referrer), input_request_referrer_policy, input_initiator_origin = move(input_initiator_origin), input_origin = move(input_origin), input_history_policy_container = move(input_history_policy_container), input_about_base_url = move(input_about_base_url), input_navigable_target_name = move(input_navigable_target_name), input_reload_pending, input_ever_populated, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated, user_involvement = job.user_involvement] {
                 navigable->populate_session_history_entry_document(
                     move(input_url), move(input_document_resource), move(input_request_referrer),
                     input_request_referrer_policy, move(input_initiator_origin), {}, move(input_origin),
                     input_history_policy_container, move(input_about_base_url), move(input_navigable_target_name),
-                    false, input_ever_populated,
+                    input_reload_pending, input_ever_populated,
                     *potentially_target_specific_source_snapshot_params, target_snapshot_params,
                     user_involvement, {}, LocalNavigable::NullOrError {},
                     ContentSecurityPolicy::Directives::Directive::NavigationType::Other, allow_POST,

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -534,7 +534,7 @@ void Request::notify_fetch_complete(Badge<ConnectionFromClient>, int result_code
     }
 
     if (is_revalidation_request()) {
-        if (acquire_status_code() == 304) {
+        if (result_code == CURLE_OK && acquire_status_code() == 304) {
             if (m_type == RequestType::BackgroundRevalidation && m_disk_cache->mode() == HTTP::DiskCache::Mode::Testing)
                 m_response_headers->set({ HTTP::TEST_CACHE_REVALIDATION_STATUS_HEADER, "fresh"sv });
 
@@ -546,7 +546,12 @@ void Request::notify_fetch_complete(Badge<ConnectionFromClient>, int result_code
         if (revalidation_failed().is_error())
             return;
 
-        transfer_headers_to_client_if_needed();
+        // Only forward the response to the client if the network request actually produced one. If the request failed
+        // at the transport level (e.g. connection refused), there's no response; fall through so the request completes
+        // with a network error — exactly like a non-revalidation request whose connection failed. Otherwise, the client
+        // would receive an empty response with HTTP status 0 — and then wait forever for a body that will never arrive.
+        if (result_code == CURLE_OK)
+            transfer_headers_to_client_if_needed();
     }
 
     m_curl_result_code = result_code;

--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -145,6 +145,8 @@ class WPTContext:
 
 
 class TestHTTPServer(socketserver.ThreadingTCPServer):
+    request_queue_size = socket.SOMAXCONN
+
     scheme: str
     router: SimpleNamespace
     wpt: WPTContext

--- a/Tests/LibWeb/Text/expected/Cache/reload-revalidates-document.txt
+++ b/Tests/LibWeb/Text/expected/Cache/reload-revalidates-document.txt
@@ -1,0 +1,1 @@
+PASS: the reloaded document was revalidated with the server

--- a/Tests/LibWeb/Text/input/Cache/reload-revalidates-document.html
+++ b/Tests/LibWeb/Text/input/Cache/reload-revalidates-document.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<iframe id="testFrame"></iframe>
+<script>
+    // RequestServer custom headers.
+    const TEST_CACHE_ENABLED_HEADER = "X-Ladybird-Enable-Disk-Cache";
+
+    const server = httpTestServer();
+
+    // The echo path keys both the server-side recording of the most-recent request headers and the disk cache entry.
+    // Give each run its own path, so parallel runner clones of this test don't overwrite each other's recording.
+    const token = crypto.randomUUID();
+
+    // A page served with an explicit freshness lifetime and Last-Modified validator. Reloading this must revalidate it
+    // with the server even though the cached response is still fresh; the reload must not be served straight from cache.
+    const DOCUMENT_PATH = `/reload-revalidates-document-${token}`;
+    const DOCUMENT_BODY =
+        "<!DOCTYPE html><script>window.onmessage = () => { location.reload(); };<\/script>reload test document";
+
+    async function registerDocumentEcho() {
+        await server.createEcho("OPTIONS", DOCUMENT_PATH, {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Headers": TEST_CACHE_ENABLED_HEADER,
+                "Access-Control-Allow-Methods": "GET",
+                "Access-Control-Allow-Origin": location.origin,
+            },
+        });
+
+        return server.createEcho("GET", DOCUMENT_PATH, {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": location.origin,
+                "Cache-Control": "max-age=999",
+                "Content-Type": "text/html",
+                "Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+            },
+            body: DOCUMENT_BODY,
+        });
+    }
+
+    function waitForFrameLoad(frame) {
+        return new Promise(resolve => {
+            frame.addEventListener("load", resolve, { once: true });
+        });
+    }
+
+    async function recordedRequestHeaderNames(url) {
+        const recordedRequestHeadersURL = url.replace("/echo/", "/recorded-request-headers/echo/");
+        const response = await fetch(recordedRequestHeadersURL);
+        const headers = await response.json();
+        return Object.keys(headers).map(name => name.toLowerCase());
+    }
+
+    asyncTest(async done => {
+        const url = await registerDocumentEcho();
+
+        // Prime the disk cache with the document. In test mode, the disk cache only stores responses to requests
+        // carrying the cache-enablement header, and a header cannot be attached to a navigation request. The disk
+        // cache is consulted for navigation requests — regardless of that header.
+        const primingResponse = await fetch(url, {
+            headers: { [TEST_CACHE_ENABLED_HEADER]: "1" },
+            mode: "cors",
+        });
+        await primingResponse.text();
+
+        const frame = document.getElementById("testFrame");
+
+        // Navigate the iframe to the now-cached document.
+        const initialLoad = waitForFrameLoad(frame);
+        frame.src = url;
+        await initialLoad;
+
+        // Reload the iframe from within itself — so this works regardless of whether the test page and the echo server
+        // are same-origin.
+        const reloadLoad = waitForFrameLoad(frame);
+        frame.contentWindow.postMessage("reload", "*");
+        await reloadLoad;
+
+        // The server records the request headers of the most-recent request at the echo path. If the reload never
+        // contacted the server, the request headers are still those of the priming fetch.
+        const headerNames = await recordedRequestHeaderNames(url);
+
+        if (headerNames.includes("if-modified-since")) {
+            println("PASS: the reloaded document was revalidated with the server");
+        } else if (headerNames.includes(TEST_CACHE_ENABLED_HEADER.toLowerCase())) {
+            println("FAIL: the reload was served from cache without contacting the server");
+        } else {
+            println("FAIL: the reload contacted the server without a conditional request");
+        }
+
+        done();
+    });
+</script>


### PR DESCRIPTION
**Problem:** Reloading a URL for a page in the HTTP cache always renders the cached response — without contacting the server at all. Even if the server’s down, a reload keeps rendering the page as if the server were still up. And even a browser restart doesn’t change anything.

**Cause:** Nothing in the navigation path set a cache mode on the request. So, a reload was fetched with the default mode, and was served straight from a fresh cache entry — exactly like a plain navigation. And a few other related problems contributed to the unexpected behavior.

**Fix:** Set no-cache cache mode on the request when the entry’s “reload pending” is true — matching what Blink and Gecko do. (WebKit goes further and bypasses the cache entirely.) Snapshot “reload pending” before the history step clears it — so population can observe it. For a request max-age directive that disqualifies cache reuse, make it revalidate the stored response when it has a validator — rather than deleting it. Complete transport-failed revalidations with a network error — exactly like a non-revalidation request whose connection failed. So, a reload from a dead server renders the connection-error page. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10976. Part of the cause here is a spec bug: https://github.com/whatwg/html/issues/12760.
