### PR TITLE
LibWebView: Guess http, not https, for loopback and localhost URLs

### DIFF
--- a/Libraries/LibURL/Host.cpp
+++ b/Libraries/LibURL/Host.cpp
@@ -157,6 +157,30 @@ bool Host::is_empty_host() const
     return m_value.has<String>() && m_value.get<String>().is_empty();
 }
 
+// AD-HOC: This isn't a standalone spec concept; instead, it's the host-focused portion of steps 4 and 5 of
+//         https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy — shared here so LibWeb's Secure
+//         Contexts implementation and other components can identify hosts guaranteed to name the loopback interface.
+bool Host::is_loopback_or_localhost() const
+{
+    // If origin's host matches one of the CIDR notations 127.0.0.0/8 or ::1/128 [RFC4632], return "Potentially Trustworthy".
+    // NOTE: For hosts produced by the URL parser, to_u32() is the URL spec's IPv4 number — with the first octet in the
+    //       most-significant byte.
+    if (auto const* ipv4_address = m_value.get_pointer<IPv4Address>())
+        return (ipv4_address->to_u32() & 0xff000000) == 0x7f000000;
+
+    if (auto const* ipv6_address = m_value.get_pointer<IPv6Address>())
+        return *ipv6_address == IPv6Address::loopback();
+
+    // If the user agent conforms to the name resolution rules in [let-localhost-be-localhost] and one of the following is true:
+    // - origin's host is "localhost" or "localhost."
+    // - origin's host ends with ".localhost" or ".localhost."
+    // then return "Potentially Trustworthy".
+    auto const& domain_or_opaque_host = m_value.get<String>();
+    return domain_or_opaque_host.is_one_of("localhost"sv, "localhost."sv)
+        || domain_or_opaque_host.ends_with_bytes(".localhost"sv)
+        || domain_or_opaque_host.ends_with_bytes(".localhost."sv);
+}
+
 // https://url.spec.whatwg.org/#concept-host-serializer
 String Host::serialize() const
 {

--- a/Libraries/LibURL/Host.h
+++ b/Libraries/LibURL/Host.h
@@ -26,6 +26,7 @@ public:
 
     bool is_domain() const;
     bool is_empty_host() const;
+    bool is_loopback_or_localhost() const;
 
     template<typename T>
     bool has() const { return m_value.template has<T>(); }

--- a/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
+++ b/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/IPv4Address.h>
-#include <AK/IPv6Address.h>
 #include <LibURL/InternalURLs.h>
 #include <LibURL/Origin.h>
 #include <LibURL/URL.h>
@@ -33,28 +31,13 @@ Trustworthiness is_origin_potentially_trustworthy(URL::Origin const& origin)
         return Trustworthiness::PotentiallyTrustworthy;
 
     // 4. If origin’s host matches one of the CIDR notations 127.0.0.0/8 or ::1/128 [RFC4632], return "Potentially Trustworthy".
-    if (origin.host().has<IPv4Address>()) {
-        if ((origin.host().get<IPv4Address>().to_u32() & 0xff000000) == 0x7f000000)
-            return Trustworthiness::PotentiallyTrustworthy;
-    } else if (origin.host().has<IPv6Address>()) {
-        auto ipv6_address = origin.host().get<IPv6Address>();
-        if (ipv6_address == IPv6Address::loopback())
-            return Trustworthiness::PotentiallyTrustworthy;
-    }
-
     // 5. If the user agent conforms to the name resolution rules in [let-localhost-be-localhost] and one of the following is true:
     // - origin’s host is "localhost" or "localhost."
     // - origin’s host ends with ".localhost" or ".localhost."
     // then return "Potentially Trustworthy".
     // Note: See § 5.2 localhost for details on the requirements here.
-    if (origin.host().has<String>()) {
-        auto const& host = origin.host().get<String>();
-        if (host.is_one_of("localhost"sv, "localhost.")
-            || host.ends_with_bytes(".localhost"sv)
-            || host.ends_with_bytes(".localhost."sv)) {
-            return Trustworthiness::PotentiallyTrustworthy;
-        }
-    }
+    if (origin.host().is_loopback_or_localhost())
+        return Trustworthiness::PotentiallyTrustworthy;
 
     // 6. If origin’s scheme is "file", return "Potentially Trustworthy".
     // AD-HOC: Our resource:// is basically an alias to file://

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -58,17 +58,30 @@ static bool has_valid_explicit_port(StringView input)
 // AD-HOC: When guessing the scheme for schemeless input, we prefer "https" — except for hosts that can't generally
 //         obtain publicly-trusted TLS certs, and whose traffic never leaves the machine: loopback addresses and
 //         localhost names (which the Secure Contexts spec treats as "potentially trustworthy", even over plain http),
-//         as well as the unspecified addresses 0.0.0.0 and [::] (which reach loopback in practice). Gecko and Blink
-//         likewise exempt all of those hosts from their HTTPS-upgrade machinery.
+//         as well as the unspecified addresses 0.0.0.0 and [::] (which reach loopback in practice), and private-use and
+//         link-local addresses. Gecko and Blink likewise exempt all of those hosts from their HTTPS-upgrade machinery.
 static bool should_guess_http_scheme_for_host(URL::Host const& host)
 {
     if (host.is_loopback_or_localhost())
         return true;
 
-    if (host.has<IPv4Address>() && host.get<IPv4Address>().to_u32() == 0)
-        return true;
-    if (host.has<IPv6Address>() && host.get<IPv6Address>().is_zero())
-        return true;
+    // NOTE: For hosts produced by the URL parser, to_u32() is the URL spec's IPv4 number — with the first octet in the
+    //       most-significant byte.
+    if (host.has<IPv4Address>()) {
+        u32 const value = host.get<IPv4Address>().to_u32();
+        return (value >> 24) == 0x00    // 0.0.0.0/8: "this network" (RFC 791).
+            || (value >> 24) == 0x0a    // 10.0.0.0/8: private use (RFC 1918).
+            || (value >> 20) == 0xac1   // 172.16.0.0/12: private use (RFC 1918).
+            || (value >> 16) == 0xc0a8  // 192.168.0.0/16: private use (RFC 1918).
+            || (value >> 16) == 0xa9fe; // 169.254.0.0/16: link-local (RFC 3927).
+    }
+
+    if (host.has<IPv6Address>()) {
+        auto const& address = host.get<IPv6Address>();
+        return address.is_zero()                // [::]: the unspecified address.
+            || (address[0] & 0xfe00) == 0xfc00  // fc00::/7: unique local (RFC 4193).
+            || (address[0] & 0xffc0) == 0xfe80; // fe80::/10: link-local (RFC 4291).
+    }
 
     return false;
 }

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/IPv4Address.h>
+#include <AK/IPv6Address.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibFileSystem/FileSystem.h>
@@ -53,6 +55,24 @@ static bool has_valid_explicit_port(StringView input)
     return url.has_value() && url->scheme() == "https"sv;
 }
 
+// AD-HOC: When guessing the scheme for schemeless input, we prefer "https" — except for hosts that can't generally
+//         obtain publicly-trusted TLS certs, and whose traffic never leaves the machine: loopback addresses and
+//         localhost names (which the Secure Contexts spec treats as "potentially trustworthy", even over plain http),
+//         as well as the unspecified addresses 0.0.0.0 and [::] (which reach loopback in practice). Gecko and Blink
+//         likewise exempt all of those hosts from their HTTPS-upgrade machinery.
+static bool should_guess_http_scheme_for_host(URL::Host const& host)
+{
+    if (host.is_loopback_or_localhost())
+        return true;
+
+    if (host.has<IPv4Address>() && host.get<IPv4Address>().to_u32() == 0)
+        return true;
+    if (host.has<IPv6Address>() && host.get<IPv6Address>().is_zero())
+        return true;
+
+    return false;
+}
+
 ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tld)
 {
     location = location.trim_whitespace();
@@ -66,6 +86,7 @@ ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tl
 
     bool https_scheme_was_guessed = false;
     bool input_has_explicit_port = false;
+    ByteString schemeless_location;
 
     auto url = URL::create_with_url_or_path(location);
     // These known schemes do not use an authority, so recognize them before
@@ -79,6 +100,7 @@ ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tl
     } else if (has_known_external_scheme) {
         return { UserInputClassification::ExternalURL, move(url) };
     } else if (has_valid_explicit_port(location)) {
+        schemeless_location = location;
         url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
         if (!url.has_value())
             return {};
@@ -88,7 +110,15 @@ ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tl
     } else if (url.has_value()) {
         return { UserInputClassification::ExternalURL, move(url) };
     } else {
-        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
+        schemeless_location = location;
+
+        // AD-HOC: A bare IPv6 address can't be a URL host until it's wrapped in square brackets. Wrap it here, so that
+        //         e.g., "::1" becomes a navigation — instead of falling through to a search. Chromium's omnibox
+        //         likewise classifies bare IPv6 addresses as navigations.
+        if (auto ipv6_address = IPv6Address::from_string(location); ipv6_address.has_value())
+            schemeless_location = ByteString::formatted("[{}]", MUST(ipv6_address->to_string()));
+
+        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", schemeless_location));
         if (!url.has_value())
             return {};
 
@@ -106,17 +136,25 @@ ClassifiedUserInput classify_user_input(StringView location, AppendTLD append_tl
 
         // https://datatracker.ietf.org/doc/html/rfc2606
         static constexpr Array RESERVED_TLDS { ".test"sv, ".example"sv, ".invalid"sv, ".localhost"sv };
-        if (any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); }))
-            return { UserInputClassification::InternalURL, move(url) };
+        bool has_reserved_tld = any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); });
 
-        auto public_suffix = URL::PublicSuffixData::find_matching_public_suffix(domain, URL::PublicSuffixData::IncludeStarRule::No);
-        if (!public_suffix.has_value() || *public_suffix == domain) {
-            if (append_tld == AppendTLD::Yes)
-                url->set_host(MUST(String::formatted("{}.com", domain)));
-            else if (https_scheme_was_guessed && domain != "localhost"sv && !input_has_explicit_port)
-                return {};
+        if (!has_reserved_tld) {
+            auto public_suffix = URL::PublicSuffixData::find_matching_public_suffix(domain, URL::PublicSuffixData::IncludeStarRule::No);
+            if (!public_suffix.has_value() || *public_suffix == domain) {
+                if (append_tld == AppendTLD::Yes)
+                    url->set_host(MUST(String::formatted("{}.com", domain)));
+                else if (https_scheme_was_guessed && !host->is_loopback_or_localhost() && !input_has_explicit_port)
+                    return {};
+            }
         }
     }
+
+    // AD-HOC: We guessed "https" above without knowing the host. Now that the host is known, guess "http" instead where
+    //         https can't reasonably work. Reparsing the input keeps intact a port that's default for one scheme but
+    //         not the other. An AppendTLD::Yes rewrite above never produces a host for which this branch is taken — so,
+    //         the rewrite can't be lost by reparsing.
+    if (https_scheme_was_guessed && url->host().has_value() && should_guess_http_scheme_for_host(*url->host()))
+        url = URL::create_with_url_or_path(ByteString::formatted("http://{}", schemeless_location));
 
     return { UserInputClassification::InternalURL, move(url) };
 }

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AllOf.h>
 #include <AK/CharacterTypes.h>
 #include <AK/IPv4Address.h>
 #include <AK/IPv6Address.h>
@@ -51,6 +52,42 @@ static bool should_guess_http_scheme_for_host(URL::Host const& host)
     return false;
 }
 
+// FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.
+static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
+
+// Schemes that sanitize_url() recognizes as schemes even though navigating to them is unsupported (input with one of
+// these schemes becomes a search). Recognizing them keeps is_likely_host_with_port() below from reinterpreting input
+// like "tel:911" or "javascript:0" as a hostname followed by a port number.
+static constexpr Array RECOGNIZED_UNSUPPORTED_SCHEMES { "ftp"sv, "javascript"sv, "mailto"sv, "tel"sv, "ws"sv, "wss"sv };
+
+static bool is_recognized_scheme(StringView scheme)
+{
+    return any_of(SUPPORTED_SCHEMES, [&](StringView supported_scheme) { return supported_scheme == scheme; })
+        || any_of(RECOGNIZED_UNSUPPORTED_SCHEMES, [&](StringView unsupported_scheme) { return unsupported_scheme == scheme; });
+}
+
+// AD-HOC: A dotted hostname followed by a port (e.g. "example.org:8000") is also a syntactically valid URL scheme — so
+//         the URL parser accepts it as one, and schemeless host-with-port input would then fall through to a search.
+//         So, when the parsed scheme isn’t a scheme we know — and everything between the first colon and its first '/',
+//         '?', or '#' (or its end) is one or more ASCII digits — treat it as a host with a port instead. Chromium's
+//         url_fixer and Firefox's URIFixup likewise decline to treat an unknown scheme as a scheme when a port-like
+//         number follows the colon. Port range checking is left to the URL parser: For "example.org:99999", etc., the
+//         "https://" retry below fails to parse, and the input becomes a search — just as in Chromium and Firefox.
+static bool is_likely_host_with_port(URL::URL const& url, StringView location)
+{
+    if (is_recognized_scheme(url.scheme()))
+        return false;
+
+    auto first_colon_index = location.find(':');
+    if (!first_colon_index.has_value())
+        return false;
+
+    auto after_colon = location.substring_view(*first_colon_index + 1);
+    auto port_length = after_colon.find_any_of("/?#"sv).value_or(after_colon.length());
+    auto port = after_colon.substring_view(0, port_length);
+    return !port.is_empty() && all_of(port, is_ascii_digit);
+}
+
 Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
 {
     auto search_url_or_error = [&]() -> Optional<URL::URL> {
@@ -74,7 +111,7 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
 
     auto url = URL::create_with_url_or_path(location);
 
-    if (!url.has_value() || url->scheme() == "localhost"sv) {
+    if (!url.has_value() || is_likely_host_with_port(*url, location)) {
         schemeless_location = location;
 
         // AD-HOC: A bare IPv6 address can't be a URL host until it's wrapped in square brackets. Wrap it here, so that
@@ -90,8 +127,6 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
         https_scheme_was_guessed = true;
     }
 
-    // FIXME: Add support for other schemes, e.g. "mailto:". Firefox and Chrome open mailto: locations.
-    static constexpr Array SUPPORTED_SCHEMES { "about"sv, "data"sv, "file"sv, "http"sv, "https"sv, "resource"sv };
     if (!any_of(SUPPORTED_SCHEMES, [&](StringView const& scheme) { return scheme == url->scheme(); }))
         return search_url_or_error();
 

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -23,17 +23,30 @@ namespace WebView {
 // AD-HOC: When guessing the scheme for schemeless input, we prefer "https" — except for hosts that can't generally
 //         obtain publicly-trusted TLS certs, and whose traffic never leaves the machine: loopback addresses and
 //         localhost names (which the Secure Contexts spec treats as "potentially trustworthy", even over plain http),
-//         as well as the unspecified addresses 0.0.0.0 and [::] (which reach loopback in practice). Gecko and Blink
-//         likewise exempt all of those hosts from their HTTPS-upgrade machinery.
+//         as well as the unspecified addresses 0.0.0.0 and [::] (which reach loopback in practice), and private-use and
+//         link-local addresses. Gecko and Blink likewise exempt all of those hosts from their HTTPS-upgrade machinery.
 static bool should_guess_http_scheme_for_host(URL::Host const& host)
 {
     if (host.is_loopback_or_localhost())
         return true;
 
-    if (host.has<IPv4Address>() && host.get<IPv4Address>().to_u32() == 0)
-        return true;
-    if (host.has<IPv6Address>() && host.get<IPv6Address>().is_zero())
-        return true;
+    // NOTE: For hosts produced by the URL parser, to_u32() is the URL spec's IPv4 number — with the first octet in the
+    //       most-significant byte.
+    if (host.has<IPv4Address>()) {
+        u32 const value = host.get<IPv4Address>().to_u32();
+        return (value >> 24) == 0x00    // 0.0.0.0/8: "this network" (RFC 791).
+            || (value >> 24) == 0x0a    // 10.0.0.0/8: private use (RFC 1918).
+            || (value >> 20) == 0xac1   // 172.16.0.0/12: private use (RFC 1918).
+            || (value >> 16) == 0xc0a8  // 192.168.0.0/16: private use (RFC 1918).
+            || (value >> 16) == 0xa9fe; // 169.254.0.0/16: link-local (RFC 3927).
+    }
+
+    if (host.has<IPv6Address>()) {
+        auto const& address = host.get<IPv6Address>();
+        return address.is_zero()                // [::]: the unspecified address.
+            || (address[0] & 0xfe00) == 0xfc00  // fc00::/7: unique local (RFC 4193).
+            || (address[0] & 0xffc0) == 0xfe80; // fe80::/10: link-local (RFC 4291).
+    }
 
     return false;
 }

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/IPv4Address.h>
+#include <AK/IPv6Address.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibFileSystem/FileSystem.h>
@@ -17,6 +19,24 @@
 #include <LibWebView/URL.h>
 
 namespace WebView {
+
+// AD-HOC: When guessing the scheme for schemeless input, we prefer "https" — except for hosts that can't generally
+//         obtain publicly-trusted TLS certs, and whose traffic never leaves the machine: loopback addresses and
+//         localhost names (which the Secure Contexts spec treats as "potentially trustworthy", even over plain http),
+//         as well as the unspecified addresses 0.0.0.0 and [::] (which reach loopback in practice). Gecko and Blink
+//         likewise exempt all of those hosts from their HTTPS-upgrade machinery.
+static bool should_guess_http_scheme_for_host(URL::Host const& host)
+{
+    if (host.is_loopback_or_localhost())
+        return true;
+
+    if (host.has<IPv4Address>() && host.get<IPv4Address>().to_u32() == 0)
+        return true;
+    if (host.has<IPv6Address>() && host.get<IPv6Address>().is_zero())
+        return true;
+
+    return false;
+}
 
 Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> const& search_engine, AppendTLD append_tld)
 {
@@ -37,11 +57,20 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
     }
 
     bool https_scheme_was_guessed = false;
+    ByteString schemeless_location;
 
     auto url = URL::create_with_url_or_path(location);
 
     if (!url.has_value() || url->scheme() == "localhost"sv) {
-        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", location));
+        schemeless_location = location;
+
+        // AD-HOC: A bare IPv6 address can't be a URL host until it's wrapped in square brackets. Wrap it here, so that
+        //         e.g., "::1" becomes a navigation — instead of falling through to a search. Chromium's omnibox
+        //         likewise classifies bare IPv6 addresses as navigations.
+        if (auto ipv6_address = IPv6Address::from_string(location); ipv6_address.has_value())
+            schemeless_location = ByteString::formatted("[{}]", MUST(ipv6_address->to_string()));
+
+        url = URL::create_with_url_or_path(ByteString::formatted("https://{}", schemeless_location));
         if (!url.has_value())
             return search_url_or_error();
 
@@ -61,17 +90,25 @@ Optional<URL::URL> sanitize_url(StringView location, Optional<SearchEngine> cons
 
         // https://datatracker.ietf.org/doc/html/rfc2606
         static constexpr Array RESERVED_TLDS { ".test"sv, ".example"sv, ".invalid"sv, ".localhost"sv };
-        if (any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); }))
-            return url;
+        bool has_reserved_tld = any_of(RESERVED_TLDS, [&](StringView const& tld) { return domain.byte_count() > tld.length() && domain.ends_with_bytes(tld); });
 
-        auto public_suffix = URL::PublicSuffixData::find_matching_public_suffix(domain, URL::PublicSuffixData::IncludeStarRule::No);
-        if (!public_suffix.has_value() || *public_suffix == domain) {
-            if (append_tld == AppendTLD::Yes)
-                url->set_host(MUST(String::formatted("{}.com", domain)));
-            else if (https_scheme_was_guessed && domain != "localhost"sv)
-                return search_url_or_error();
+        if (!has_reserved_tld) {
+            auto public_suffix = URL::PublicSuffixData::find_matching_public_suffix(domain, URL::PublicSuffixData::IncludeStarRule::No);
+            if (!public_suffix.has_value() || *public_suffix == domain) {
+                if (append_tld == AppendTLD::Yes)
+                    url->set_host(MUST(String::formatted("{}.com", domain)));
+                else if (https_scheme_was_guessed && !host->is_loopback_or_localhost())
+                    return search_url_or_error();
+            }
         }
     }
+
+    // AD-HOC: We guessed "https" above without knowing the host. Now that the host is known, guess "http" instead where
+    //         https can't reasonably work. Reparsing the input keeps intact a port that's default for one scheme but
+    //         not the other. An AppendTLD::Yes rewrite above never produces a host for which this branch is taken — so,
+    //         the rewrite can't be lost by reparsing.
+    if (https_scheme_was_guessed && url->host().has_value() && should_guess_http_scheme_for_host(*url->host()))
+        url = URL::create_with_url_or_path(ByteString::formatted("http://{}", schemeless_location));
 
     return url;
 }

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -744,3 +744,32 @@ TEST_CASE(authority_state_lots_of_at_symbols)
     auto horror_url = MUST(String::formatted("ws::{}", many_at_symbols));
     EXPECT(!URL::Parser::basic_parse(horror_url).has_value());
 }
+
+TEST_CASE(host_is_loopback_or_localhost)
+{
+    auto host_of = [](StringView input) {
+        auto url = URL::Parser::basic_parse(input);
+        VERIFY(url.has_value());
+        VERIFY(url->host().has_value());
+        return url->host().value();
+    };
+
+    EXPECT(host_of("http://localhost"sv).is_loopback_or_localhost());
+    EXPECT(host_of("http://localhost."sv).is_loopback_or_localhost());
+    EXPECT(host_of("http://foo.localhost"sv).is_loopback_or_localhost());
+    EXPECT(host_of("http://foo.localhost."sv).is_loopback_or_localhost());
+    EXPECT(host_of("http://127.0.0.1"sv).is_loopback_or_localhost());
+    EXPECT(host_of("http://127.255.255.255"sv).is_loopback_or_localhost());
+    EXPECT(host_of("http://[::1]"sv).is_loopback_or_localhost());
+
+    EXPECT(!host_of("http://localhost4"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://localhost6"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://localhost.example"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://126.255.255.255"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://128.0.0.1"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://[::2]"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://[::ffff:127.0.0.1]"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://[fe80::1]"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://example.com"sv).is_loopback_or_localhost());
+    EXPECT(!host_of("http://0.0.0.0"sv).is_loopback_or_localhost());
+}

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -268,6 +268,23 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("http://[::1]:8000/"sv, "[::1]:8000"sv);
     expect_url_equals_sanitized_url("http://0.0.0.0:8000/"sv, "0.0.0.0:8000"sv); // The unspecified address reaches loopback in practice.
 
+    // Private-use and link-local addresses also get the http guess. Like loopback hosts, they can't obtain publicly-
+    // trusted TLS certs.
+    expect_url_equals_sanitized_url("http://192.168.0.42:8000/"sv, "192.168.0.42:8000"sv);
+    expect_url_equals_sanitized_url("http://10.0.0.5:3000/"sv, "10.0.0.5:3000"sv);
+    expect_url_equals_sanitized_url("http://172.16.0.1/"sv, "172.16.0.1"sv);
+    expect_url_equals_sanitized_url("http://172.31.255.254/"sv, "172.31.255.254"sv);
+    expect_url_equals_sanitized_url("http://169.254.1.1/"sv, "169.254.1.1"sv);
+    expect_url_equals_sanitized_url("http://[fe80::1]/"sv, "[fe80::1]"sv);
+    expect_url_equals_sanitized_url("http://[fd00::1]:8080/"sv, "[fd00::1]:8080"sv);
+
+    // Addresses just outside those ranges keep the https guess.
+    expect_url_equals_sanitized_url("https://172.32.0.1/"sv, "172.32.0.1"sv);
+    expect_url_equals_sanitized_url("https://11.0.0.1/"sv, "11.0.0.1"sv);
+    expect_url_equals_sanitized_url("https://100.64.0.1/"sv, "100.64.0.1"sv); // Shared space (CGNAT) is not local.
+    expect_url_equals_sanitized_url("https://8.8.8.8/"sv, "8.8.8.8"sv);
+    expect_url_equals_sanitized_url("https://[2001:db8::1]/"sv, "[2001:db8::1]"sv);
+
     // An explicitly typed scheme is never rewritten.
     expect_url_equals_sanitized_url("https://localhost:8000/"sv, "https://localhost:8000"sv);
     expect_url_equals_sanitized_url("https://127.0.0.1/"sv, "https://127.0.0.1"sv);

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -247,7 +247,7 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://example.test/path"sv, "example.test/path"sv); // Reserved TLDs.
     expect_url_equals_sanitized_url("https://example.example/path"sv, "example.example/path"sv);
     expect_url_equals_sanitized_url("https://example.invalid/path"sv, "example.invalid/path"sv);
-    expect_url_equals_sanitized_url("https://example.localhost/path"sv, "example.localhost/path"sv);
+    expect_url_equals_sanitized_url("http://example.localhost/path"sv, "example.localhost/path"sv); // .localhost names get the http guess below.
 
     expect_search_url_equals_sanitized_url("example.def"sv); // Invalid domain but no scheme: search (Like Firefox or Chrome).
 
@@ -255,15 +255,40 @@ TEST_CASE(location_to_search_or_url)
     // Respect the user if the url has a valid scheme but not a public suffix (.def is not a recognized TLD).
     expect_url_equals_sanitized_url("https://example.def/"sv, "https://example.def"sv);
 
-    expect_url_equals_sanitized_url("https://localhost/"sv, "localhost"sv); // Respect localhost.
-    expect_url_equals_sanitized_url("https://localhost:8000/"sv, "localhost:8000"sv);
-    expect_url_equals_sanitized_url("https://localhost/hello"sv, "localhost/hello"sv);
-    expect_url_equals_sanitized_url("https://localhost/hello.world"sv, "localhost/hello.world"sv);
-    expect_url_equals_sanitized_url("https://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);
+    // Respect localhost, and guess http (not https) for it: loopback and localhost hosts can't generally obtain
+    // publicly-trusted TLS cert — and their traffic never leaves the machine.
+    expect_url_equals_sanitized_url("http://localhost/"sv, "localhost"sv);
+    expect_url_equals_sanitized_url("http://localhost:8000/"sv, "localhost:8000"sv);
+    expect_url_equals_sanitized_url("http://localhost/hello"sv, "localhost/hello"sv);
+    expect_url_equals_sanitized_url("http://localhost/hello.world"sv, "localhost/hello.world"sv);
+    expect_url_equals_sanitized_url("http://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);
+    expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv);
+    expect_url_equals_sanitized_url("http://127.0.0.1:8000/"sv, "127.0.0.1:8000"sv);
+    expect_url_equals_sanitized_url("http://[::1]/"sv, "::1"sv); // A bare IPv6 address gets bracketed.
+    expect_url_equals_sanitized_url("http://[::1]:8000/"sv, "[::1]:8000"sv);
+    expect_url_equals_sanitized_url("http://0.0.0.0:8000/"sv, "0.0.0.0:8000"sv); // The unspecified address reaches loopback in practice.
+
+    // An explicitly typed scheme is never rewritten.
+    expect_url_equals_sanitized_url("https://localhost:8000/"sv, "https://localhost:8000"sv);
+    expect_url_equals_sanitized_url("https://127.0.0.1/"sv, "https://127.0.0.1"sv);
+
+    // Reparsing with the http guess keeps a port that's default for https only, and drops a port that's default for http.
+    expect_url_equals_sanitized_url("http://localhost:443/"sv, "localhost:443"sv);
+    expect_url_equals_sanitized_url("http://localhost/"sv, "localhost:80"sv);
+
+    // Without brackets, ":8000" parses as part of the IPv6 address, not as a port.
+    expect_url_equals_sanitized_url("https://[::1:8000]/"sv, "::1:8000"sv);
+
+    // Single-label hostnames other than "localhost" still search – like in other browsers — even if the system resolver
+    // might know them (e.g., from the hosts file).
+    expect_search_url_equals_sanitized_url("localhost4"sv);
+    expect_search_url_equals_sanitized_url("localhost6"sv);
 
     expect_url_equals_sanitized_url("https://example.com/"sv, "example"sv, WebView::AppendTLD::Yes); // User holds down the Ctrl key.
     expect_url_equals_sanitized_url("https://example.def.com/"sv, "example.def"sv, WebView::AppendTLD::Yes);
     expect_url_equals_sanitized_url("https://com.com/"sv, "com"sv, WebView::AppendTLD::Yes);
+    expect_url_equals_sanitized_url("https://localhost.com/"sv, "localhost"sv, WebView::AppendTLD::Yes); // localhost.com is a public site.
+    expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv, WebView::AppendTLD::Yes);      // No TLD is appended to an IP address.
     expect_url_equals_sanitized_url("https://example.com/index.html"sv, "example/index.html"sv, WebView::AppendTLD::Yes);
 
     expect_search_url_equals_sanitized_url("whatever:example.com"sv);
@@ -280,7 +305,7 @@ TEST_CASE(classify_user_input)
     using enum WebView::UserInputClassification;
 
     expect_user_input_classification("example.org"sv, InternalURL, "https://example.org/"sv);
-    expect_user_input_classification("localhost:8080"sv, InternalURL, "https://localhost:8080/"sv);
+    expect_user_input_classification("localhost:8080"sv, InternalURL, "http://localhost:8080/"sv);
     expect_user_input_classification("example.com:8080"sv, InternalURL, "https://example.com:8080/"sv);
     expect_user_input_classification("host:8080/path?query#fragment"sv, InternalURL, "https://host:8080/path?query#fragment"sv);
     expect_user_input_classification("1.2:45"sv, InternalURL, "https://1.0.0.2:45/"sv);
@@ -306,6 +331,7 @@ TEST_CASE(location_looks_like_url)
     expect_location_looks_like_url("example.org"sv);
     expect_location_looks_like_url("example.com"sv);
     expect_location_looks_like_url("localhost"sv);
+    expect_location_looks_like_url("::1"sv);
     expect_location_looks_like_url("https://example.def"sv);
     expect_location_looks_like_url("site:example.com"sv);
     expect_location_looks_like_url("mailto:hello@example.com"sv);
@@ -325,7 +351,7 @@ TEST_CASE(context_menu_url_text)
 {
     expect_context_menu_text_url("ladybird.org"sv, "https://ladybird.org/"sv);
     expect_context_menu_text_url("www.ladybird.org/path?x=1"sv, "https://www.ladybird.org/path?x=1"sv);
-    expect_context_menu_text_url("localhost:8000"sv, "https://localhost:8000/"sv);
+    expect_context_menu_text_url("localhost:8000"sv, "http://localhost:8000/"sv);
     expect_context_menu_text_url("https://ladybird.org"sv, "https://ladybird.org/"sv);
 
     expect_context_menu_text_not_url("ladybird"sv);

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -238,7 +238,7 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://example.test/path"sv, "example.test/path"sv); // Reserved TLDs.
     expect_url_equals_sanitized_url("https://example.example/path"sv, "example.example/path"sv);
     expect_url_equals_sanitized_url("https://example.invalid/path"sv, "example.invalid/path"sv);
-    expect_url_equals_sanitized_url("https://example.localhost/path"sv, "example.localhost/path"sv);
+    expect_url_equals_sanitized_url("http://example.localhost/path"sv, "example.localhost/path"sv); // .localhost names get the http guess below.
 
     expect_search_url_equals_sanitized_url("example.def"sv); // Invalid domain but no scheme: search (Like Firefox or Chrome).
 
@@ -246,15 +246,40 @@ TEST_CASE(location_to_search_or_url)
     // Respect the user if the url has a valid scheme but not a public suffix (.def is not a recognized TLD).
     expect_url_equals_sanitized_url("https://example.def/"sv, "https://example.def"sv);
 
-    expect_url_equals_sanitized_url("https://localhost/"sv, "localhost"sv); // Respect localhost.
-    expect_url_equals_sanitized_url("https://localhost:8000/"sv, "localhost:8000"sv);
-    expect_url_equals_sanitized_url("https://localhost/hello"sv, "localhost/hello"sv);
-    expect_url_equals_sanitized_url("https://localhost/hello.world"sv, "localhost/hello.world"sv);
-    expect_url_equals_sanitized_url("https://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);
+    // Respect localhost, and guess http (not https) for it: loopback and localhost hosts can't generally obtain
+    // publicly-trusted TLS cert — and their traffic never leaves the machine.
+    expect_url_equals_sanitized_url("http://localhost/"sv, "localhost"sv);
+    expect_url_equals_sanitized_url("http://localhost:8000/"sv, "localhost:8000"sv);
+    expect_url_equals_sanitized_url("http://localhost/hello"sv, "localhost/hello"sv);
+    expect_url_equals_sanitized_url("http://localhost/hello.world"sv, "localhost/hello.world"sv);
+    expect_url_equals_sanitized_url("http://localhost/hello.world?query=123"sv, "localhost/hello.world?query=123"sv);
+    expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv);
+    expect_url_equals_sanitized_url("http://127.0.0.1:8000/"sv, "127.0.0.1:8000"sv);
+    expect_url_equals_sanitized_url("http://[::1]/"sv, "::1"sv); // A bare IPv6 address gets bracketed.
+    expect_url_equals_sanitized_url("http://[::1]:8000/"sv, "[::1]:8000"sv);
+    expect_url_equals_sanitized_url("http://0.0.0.0:8000/"sv, "0.0.0.0:8000"sv); // The unspecified address reaches loopback in practice.
+
+    // An explicitly typed scheme is never rewritten.
+    expect_url_equals_sanitized_url("https://localhost:8000/"sv, "https://localhost:8000"sv);
+    expect_url_equals_sanitized_url("https://127.0.0.1/"sv, "https://127.0.0.1"sv);
+
+    // Reparsing with the http guess keeps a port that's default for https only, and drops a port that's default for http.
+    expect_url_equals_sanitized_url("http://localhost:443/"sv, "localhost:443"sv);
+    expect_url_equals_sanitized_url("http://localhost/"sv, "localhost:80"sv);
+
+    // Without brackets, ":8000" parses as part of the IPv6 address, not as a port.
+    expect_url_equals_sanitized_url("https://[::1:8000]/"sv, "::1:8000"sv);
+
+    // Single-label hostnames other than "localhost" still search – like in other browsers — even if the system resolver
+    // might know them (e.g., from the hosts file).
+    expect_search_url_equals_sanitized_url("localhost4"sv);
+    expect_search_url_equals_sanitized_url("localhost6"sv);
 
     expect_url_equals_sanitized_url("https://example.com/"sv, "example"sv, WebView::AppendTLD::Yes); // User holds down the Ctrl key.
     expect_url_equals_sanitized_url("https://example.def.com/"sv, "example.def"sv, WebView::AppendTLD::Yes);
     expect_url_equals_sanitized_url("https://com.com/"sv, "com"sv, WebView::AppendTLD::Yes);
+    expect_url_equals_sanitized_url("https://localhost.com/"sv, "localhost"sv, WebView::AppendTLD::Yes); // localhost.com is a public site.
+    expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv, WebView::AppendTLD::Yes);      // No TLD is appended to an IP address.
     expect_url_equals_sanitized_url("https://example.com/index.html"sv, "example/index.html"sv, WebView::AppendTLD::Yes);
 
     expect_search_url_equals_sanitized_url("whatever:example.com"sv);     // Invalid scheme.
@@ -268,6 +293,7 @@ TEST_CASE(location_looks_like_url)
     expect_location_looks_like_url("example.org"sv);
     expect_location_looks_like_url("example.com"sv);
     expect_location_looks_like_url("localhost"sv);
+    expect_location_looks_like_url("::1"sv);
     expect_location_looks_like_url("https://example.def"sv);
 
     expect_location_does_not_look_like_url("hello"sv);
@@ -282,7 +308,7 @@ TEST_CASE(context_menu_url_text)
 {
     expect_context_menu_text_url("ladybird.org"sv, "https://ladybird.org/"sv);
     expect_context_menu_text_url("www.ladybird.org/path?x=1"sv, "https://www.ladybird.org/path?x=1"sv);
-    expect_context_menu_text_url("localhost:8000"sv, "https://localhost:8000/"sv);
+    expect_context_menu_text_url("localhost:8000"sv, "http://localhost:8000/"sv);
     expect_context_menu_text_url("https://ladybird.org"sv, "https://ladybird.org/"sv);
 
     expect_context_menu_text_not_url("ladybird"sv);

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -41,10 +41,10 @@ static void expect_url_equals_sanitized_url(StringView test_url, StringView url,
     EXPECT_EQ(sanitized_url->to_string(), test_url);
 }
 
-static void expect_search_url_equals_sanitized_url(StringView url)
+static void expect_search_url_equals_sanitized_url(StringView url, WebView::AppendTLD append_tld = WebView::AppendTLD::No)
 {
     auto search_url = s_test_engine.format_search_query_for_navigation(url);
-    auto sanitized_url = WebView::sanitize_url(url, s_test_engine);
+    auto sanitized_url = WebView::sanitize_url(url, s_test_engine, append_tld);
 
     EXPECT(sanitized_url.has_value());
     EXPECT_EQ(sanitized_url->to_string(), search_url);
@@ -239,6 +239,7 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://example.example/path"sv, "example.example/path"sv);
     expect_url_equals_sanitized_url("https://example.invalid/path"sv, "example.invalid/path"sv);
     expect_url_equals_sanitized_url("http://example.localhost/path"sv, "example.localhost/path"sv); // .localhost names get the http guess below.
+    expect_url_equals_sanitized_url("http://foo.localhost/"sv, "foo.localhost"sv);
 
     expect_search_url_equals_sanitized_url("example.def"sv); // Invalid domain but no scheme: search (Like Firefox or Chrome).
 
@@ -287,6 +288,29 @@ TEST_CASE(location_to_search_or_url)
     // Without brackets, ":8000" parses as part of the IPv6 address, not as a port.
     expect_url_equals_sanitized_url("https://[::1:8000]/"sv, "::1:8000"sv);
 
+    // A dotted hostname:port is also a syntactically-valid scheme. Schemeless host-with-port input gets reinterpreted
+    // as a hostname:port — instead of being treated as a URL with an unknown scheme, and falling through to a search.
+    expect_url_equals_sanitized_url("http://foo.localhost:8000/"sv, "foo.localhost:8000"sv);
+    expect_url_equals_sanitized_url("http://a.b.localhost:8000/"sv, "a.b.localhost:8000"sv);
+    expect_url_equals_sanitized_url("https://example.test:8000/"sv, "example.test:8000"sv);
+    expect_url_equals_sanitized_url("https://example.org:8000/"sv, "example.org:8000"sv);
+    expect_url_equals_sanitized_url("https://example.org:8000/path"sv, "example.org:8000/path"sv);
+    expect_url_equals_sanitized_url("https://example.org:8000/?q=1"sv, "example.org:8000?q=1"sv);
+    expect_url_equals_sanitized_url("https://example.org:8000/#frag"sv, "example.org:8000#frag"sv);
+    expect_url_equals_sanitized_url("https://example.org/"sv, "example.org:443"sv); // 443 is the default port for the https guess.
+
+    // The URL parser rejects the "https://" retry for an out-of-range port, so the input becomes a search.
+    expect_search_url_equals_sanitized_url("example.org:99999"sv);
+    // Only one or more digits (up to the end of the input, or up to '/', '?', or '#') make a port.
+    expect_search_url_equals_sanitized_url("example.org:"sv);
+    expect_search_url_equals_sanitized_url("localhost:"sv); // Searches in Firefox too.
+    expect_search_url_equals_sanitized_url("example.org:blah"sv);
+    expect_search_url_equals_sanitized_url("example.org:8000:9000"sv);
+    // A host with a port still goes through the usual host checks: unrecognized TLDs and single-label hostnames other
+    // than "localhost" search.
+    expect_search_url_equals_sanitized_url("example.def:8000"sv);
+    expect_search_url_equals_sanitized_url("foo:8000"sv);
+
     // Single-label hostnames other than "localhost" still search – like in other browsers — even if the system resolver
     // might know them (e.g., from the hosts file).
     expect_search_url_equals_sanitized_url("localhost4"sv);
@@ -298,9 +322,18 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("https://localhost.com/"sv, "localhost"sv, WebView::AppendTLD::Yes); // localhost.com is a public site.
     expect_url_equals_sanitized_url("http://127.0.0.1/"sv, "127.0.0.1"sv, WebView::AppendTLD::Yes);      // No TLD is appended to an IP address.
     expect_url_equals_sanitized_url("https://example.com/index.html"sv, "example/index.html"sv, WebView::AppendTLD::Yes);
+    expect_url_equals_sanitized_url("https://example.com:8000/"sv, "example:8000"sv, WebView::AppendTLD::Yes);
 
     expect_search_url_equals_sanitized_url("whatever:example.com"sv);     // Invalid scheme.
     expect_search_url_equals_sanitized_url("mailto:hello@example.com"sv); // For now, unsupported scheme.
+    expect_search_url_equals_sanitized_url("javascript:alert(1)"sv);      // Unsupported scheme.
+    expect_search_url_equals_sanitized_url("tel:+15551234567"sv);         // Unsupported scheme.
+    expect_search_url_equals_sanitized_url("foo:bar"sv);                  // Unknown scheme, and no port number after the colon.
+    // Recognized schemes never get reinterpreted as a hostname and port — not even with a digits-only remainder, and
+    // not even when Ctrl+Enter appends a TLD.
+    expect_search_url_equals_sanitized_url("javascript:0"sv);
+    expect_search_url_equals_sanitized_url("tel:911"sv);
+    expect_search_url_equals_sanitized_url("tel:911"sv, WebView::AppendTLD::Yes);
     // FIXME: Add support for opening mailto: scheme (below). Firefox opens mailto: locations
     // expect_url_equals_sanitized_url("mailto:hello@example.com"sv, "mailto:hello@example.com"sv);
 }
@@ -326,6 +359,7 @@ TEST_CASE(context_menu_url_text)
     expect_context_menu_text_url("ladybird.org"sv, "https://ladybird.org/"sv);
     expect_context_menu_text_url("www.ladybird.org/path?x=1"sv, "https://www.ladybird.org/path?x=1"sv);
     expect_context_menu_text_url("localhost:8000"sv, "http://localhost:8000/"sv);
+    expect_context_menu_text_url("example.org:8000"sv, "https://example.org:8000/"sv);
     expect_context_menu_text_url("https://ladybird.org"sv, "https://ladybird.org/"sv);
 
     expect_context_menu_text_not_url("ladybird"sv);

--- a/Tests/LibWebView/TestWebViewURL.cpp
+++ b/Tests/LibWebView/TestWebViewURL.cpp
@@ -259,6 +259,23 @@ TEST_CASE(location_to_search_or_url)
     expect_url_equals_sanitized_url("http://[::1]:8000/"sv, "[::1]:8000"sv);
     expect_url_equals_sanitized_url("http://0.0.0.0:8000/"sv, "0.0.0.0:8000"sv); // The unspecified address reaches loopback in practice.
 
+    // Private-use and link-local addresses also get the http guess. Like loopback hosts, they can't obtain publicly-
+    // trusted TLS certs.
+    expect_url_equals_sanitized_url("http://192.168.0.42:8000/"sv, "192.168.0.42:8000"sv);
+    expect_url_equals_sanitized_url("http://10.0.0.5:3000/"sv, "10.0.0.5:3000"sv);
+    expect_url_equals_sanitized_url("http://172.16.0.1/"sv, "172.16.0.1"sv);
+    expect_url_equals_sanitized_url("http://172.31.255.254/"sv, "172.31.255.254"sv);
+    expect_url_equals_sanitized_url("http://169.254.1.1/"sv, "169.254.1.1"sv);
+    expect_url_equals_sanitized_url("http://[fe80::1]/"sv, "[fe80::1]"sv);
+    expect_url_equals_sanitized_url("http://[fd00::1]:8080/"sv, "[fd00::1]:8080"sv);
+
+    // Addresses just outside those ranges keep the https guess.
+    expect_url_equals_sanitized_url("https://172.32.0.1/"sv, "172.32.0.1"sv);
+    expect_url_equals_sanitized_url("https://11.0.0.1/"sv, "11.0.0.1"sv);
+    expect_url_equals_sanitized_url("https://100.64.0.1/"sv, "100.64.0.1"sv); // Shared space (CGNAT) is not local.
+    expect_url_equals_sanitized_url("https://8.8.8.8/"sv, "8.8.8.8"sv);
+    expect_url_equals_sanitized_url("https://[2001:db8::1]/"sv, "[2001:db8::1]"sv);
+
     // An explicitly typed scheme is never rewritten.
     expect_url_equals_sanitized_url("https://localhost:8000/"sv, "https://localhost:8000"sv);
     expect_url_equals_sanitized_url("https://127.0.0.1/"sv, "https://127.0.0.1"sv);


### PR DESCRIPTION
**Problem:** Typing a schemeless loopback address into the URL bar navigated to an https URL; e.g., `127.0.0.1:8000` to `https://127.0.0.1:8000/`. So the connection failed after a TLS ClientHello. Typing a bare IPv6 one like `::1` wasn’t treated as a URL at all; it was sent to the search engine.

**Cause:** `sanitize_url` prepends “`https://`” to any schemeless input before it knows what the host is — and nothing downstream ever reconsidered that, without any HTTPS upgrade/fallback machinery in the network stack. Bare IPv6 additionally failed to parse as a host since it’s not wrapped in square brackets, and a hardcoded `domain != localhost` check meant only that exact name escaped search-engine fallback for single-label hosts.

**Fix:** After parsing the guessed URL, reparse it with “`http`” when the host is a loopback address or localhost name (per the Secure-Contexts predicate now shared through `URL::Host::is_loopback_or_localhost()`), or the unspecified `0.0.0.0`/`[::]` — which reaches loopback in practice. Such hosts can’t obtain publicly-trusted TLS certs, and their traffic never leaves the machine. (For comparison: Gecko exempts those from HTTPS-Only mode (`nsHTTPSOnlyUtils::LoopbackOrLocalException`), and Blink from HTTPS-Upgrades (`net::IsLocalhost`). And Chromium’s omnibox supports typed navigation to `0.0.0.0`.) Bare IPv6 addresses are now wrapped in brackets so they navigate, matching Chromium. An explicitly-typed scheme is never rewritten. Single-label names other than localhost (e.g. `localhost4`) still go to the search engine — matching both Firefox and Chromium. Fixes #8344. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10977. 

The branch includes a separate commit to extend support to the additional LAN addresses the #10977 issue reporter asked for — separate so if we decide we don’t want to do it, we can easily/separately just drop that entire commit.