### PR TITLE
LibWeb: Remove `SVGUseElement.{animated}instanceRoot`

### DIFF
--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -401,11 +401,6 @@ GC::Ptr<SVGElement> SVGUseElement::instance_root() const
     return const_cast<DOM::ShadowRoot&>(*shadow_root()).first_child_of_type<SVGElement>();
 }
 
-GC::Ptr<SVGElement> SVGUseElement::animated_instance_root() const
-{
-    return instance_root();
-}
-
 RefPtr<Layout::Node> SVGUseElement::create_layout_node(NonnullRefPtr<CSS::ComputedValues const> style)
 {
     return make_ref_counted<Layout::SVGGraphicsBox>(document(), *this, style);

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -50,7 +50,6 @@ public:
     REFLECT_ANIMATED_LENGTH_ATTRIBUTE(height, Vertical, CSS::NumberStyleValue::create(0));
 
     GC::Ptr<SVGElement> instance_root() const;
-    GC::Ptr<SVGElement> animated_instance_root() const;
 
     virtual Gfx::AffineTransform element_transform() const override;
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.idl
+++ b/Libraries/LibWeb/SVG/SVGUseElement.idl
@@ -1,12 +1,10 @@
-// https://svgwg.org/svg2-draft/struct.html#InterfaceSVGUseElement
+// https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGUseElement
 [Exposed=Window]
 interface SVGUseElement : SVGGraphicsElement {
     [SameObject] readonly attribute SVGAnimatedLength x;
     [SameObject] readonly attribute SVGAnimatedLength y;
     [SameObject] readonly attribute SVGAnimatedLength width;
     [SameObject] readonly attribute SVGAnimatedLength height;
-    [SameObject] readonly attribute SVGElement? instanceRoot;
-    [SameObject] readonly attribute SVGElement? animatedInstanceRoot;
 };
 
 SVGUseElement includes SVGURIReference;

--- a/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg/idlharness.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 1780 tests
 
-1131 Pass
-649 Fail
+1127 Pass
+653 Fail
 Pass	idl_test setup
 Pass	idl_test validation
 Pass	Partial interface Document: original interface defined
@@ -604,8 +604,8 @@ Pass	SVGUseElement interface: attribute x
 Pass	SVGUseElement interface: attribute y
 Pass	SVGUseElement interface: attribute width
 Pass	SVGUseElement interface: attribute height
-Pass	SVGUseElement interface: attribute instanceRoot
-Pass	SVGUseElement interface: attribute animatedInstanceRoot
+Fail	SVGUseElement interface: attribute instanceRoot
+Fail	SVGUseElement interface: attribute animatedInstanceRoot
 Pass	SVGUseElement interface: attribute href
 Pass	SVGUseElement must be primary interface of objects.use
 Pass	Stringification of objects.use
@@ -613,8 +613,8 @@ Pass	SVGUseElement interface: objects.use must inherit property "x" with the pro
 Pass	SVGUseElement interface: objects.use must inherit property "y" with the proper type
 Pass	SVGUseElement interface: objects.use must inherit property "width" with the proper type
 Pass	SVGUseElement interface: objects.use must inherit property "height" with the proper type
-Pass	SVGUseElement interface: objects.use must inherit property "instanceRoot" with the proper type
-Pass	SVGUseElement interface: objects.use must inherit property "animatedInstanceRoot" with the proper type
+Fail	SVGUseElement interface: objects.use must inherit property "instanceRoot" with the proper type
+Fail	SVGUseElement interface: objects.use must inherit property "animatedInstanceRoot" with the proper type
 Pass	SVGUseElement interface: objects.use must inherit property "href" with the proper type
 Pass	SVGGraphicsElement interface: objects.use must inherit property "transform" with the proper type
 Pass	SVGGraphicsElement interface: objects.use must inherit property "getBBox(optional SVGBoundingBoxOptions)" with the proper type

--- a/Tests/LibWeb/Text/input/SVG/use-element-does-not-reclone-on-load.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-does-not-reclone-on-load.html
@@ -13,16 +13,16 @@
 <script>
     const resolvedUseElement = document.getElementById("resolvedUse");
     const forwardUseElement = document.getElementById("forwardUse");
-    const initialResolvedInstanceRoot = resolvedUseElement.instanceRoot;
-    const initialForwardInstanceRoot = forwardUseElement.instanceRoot;
+    const initialResolvedInstanceRoot = internals.getShadowRoot(resolvedUseElement).firstElementChild;
+    const initialForwardInstanceRoot = internals.getShadowRoot(forwardUseElement).firstElementChild;
 
     asyncTest((done) => {
         window.addEventListener("load", () => {
             setTimeout(() => {
                 println(`Had resolved instance root before load: ${!!initialResolvedInstanceRoot}`);
                 println(`Had forward instance root before load: ${!!initialForwardInstanceRoot}`);
-                println(`Kept resolved instance root after load: ${resolvedUseElement.instanceRoot === initialResolvedInstanceRoot}`);
-                println(`Has forward instance root after load: ${!!forwardUseElement.instanceRoot}`);
+                println(`Kept resolved instance root after load: ${internals.getShadowRoot(resolvedUseElement).firstElementChild === initialResolvedInstanceRoot}`);
+                println(`Has forward instance root after load: ${!!internals.getShadowRoot(forwardUseElement).firstElementChild}`);
                 done();
             }, 0);
         }, { once: true });

--- a/Tests/LibWeb/Text/input/SVG/use-element-inserted-together-with-referenced-element.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-inserted-together-with-referenced-element.html
@@ -31,11 +31,11 @@
                 // two elements has its insertion steps run first.
                 let { svg, use } = makeSubtree("targetBeforeUse", "target-first");
                 document.body.appendChild(svg);
-                println(`Referenced element before use: has instance root: ${!!use.instanceRoot}`);
+                println(`Referenced element before use: has instance root: ${!!internals.getShadowRoot(use).firstElementChild}`);
 
                 ({ svg, use } = makeSubtree("useBeforeTarget", "use-first"));
                 document.body.appendChild(svg);
-                println(`Use before referenced element: has instance root: ${!!use.instanceRoot}`);
+                println(`Use before referenced element: has instance root: ${!!internals.getShadowRoot(use).firstElementChild}`);
 
                 done();
             }, 0);

--- a/Tests/LibWeb/Text/input/SVG/use-element-moveBefore-registry.html
+++ b/Tests/LibWeb/Text/input/SVG/use-element-moveBefore-registry.html
@@ -37,7 +37,7 @@
                     host.shadowRoot.moveBefore(use, null);
                     source.setAttribute("fill", "green");
 
-                    println(`Use moved into shadow tree kept old fill: ${use.instanceRoot.getAttribute("fill")}`);
+                    println(`Use moved into shadow tree kept old fill: ${internals.getShadowRoot(use).firstElementChild.getAttribute("fill")}`);
                 }
 
                 {
@@ -50,7 +50,7 @@
                     svg.moveBefore(use, null);
                     source.setAttribute("fill", "green");
 
-                    println(`Use moved into document tree updated fill: ${use.instanceRoot.getAttribute("fill")}`);
+                    println(`Use moved into document tree updated fill: ${internals.getShadowRoot(use).firstElementChild.getAttribute("fill")}`);
                 }
 
                 done();


### PR DESCRIPTION
No other browsers implement this and it was removed from the spec in https://github.com/w3c/svgwg/commit/3279b17

The WPT idlharness test is yet to be updated upstream so there are a couple of failures that will remain until that's done.

Tests relying on `instanceRoot` now instead use `internals.getShadowRoot()` which has the same effect.