### PR TITLE
LibWeb: Flatten 3D transforms at `transform-style: flat` boundaries

### DIFF
--- a/Libraries/LibGfx/Matrix4x4.h
+++ b/Libraries/LibGfx/Matrix4x4.h
@@ -108,6 +108,32 @@ Gfx::AffineTransform extract_2d_affine_transform(Matrix4x4<T> const& m)
     return Gfx::AffineTransform(m[0, 0], m[1, 0], m[0, 1], m[1, 1], m[0, 3], m[1, 3]);
 }
 
+template<typename T>
+constexpr static Matrix4x4<T> flattened(Matrix4x4<T> const& m)
+{
+    Matrix4x4<T> result = m;
+    result[0, 2] = 0;
+    result[1, 2] = 0;
+    result[3, 2] = 0;
+    result[2, 0] = 0;
+    result[2, 1] = 0;
+    result[2, 2] = 1;
+    result[2, 3] = 0;
+    // Normalizing a uniform positive w scale into the other components makes the result a true two-dimensional
+    // affine matrix. A non-positive m44 is preserved, since it marks content behind the eye plane.
+    if (result[3, 0] == 0 && result[3, 1] == 0 && result[3, 3] != 1 && result[3, 3] > 0) {
+        T scale = 1 / result[3, 3];
+        result[0, 0] *= scale;
+        result[0, 1] *= scale;
+        result[1, 0] *= scale;
+        result[1, 1] *= scale;
+        result[0, 3] *= scale;
+        result[1, 3] *= scale;
+        result[3, 3] = 1;
+    }
+    return result;
+}
+
 typedef Matrix4x4<float> FloatMatrix4x4;
 typedef Matrix4x4<double> DoubleMatrix4x4;
 

--- a/Libraries/LibGfx/Matrix4x4.h
+++ b/Libraries/LibGfx/Matrix4x4.h
@@ -109,6 +109,14 @@ Gfx::AffineTransform extract_2d_affine_transform(Matrix4x4<T> const& m)
 }
 
 template<typename T>
+constexpr static bool is_2d_affine_transform(Matrix4x4<T> const& m)
+{
+    return m[0, 2] == 0 && m[1, 2] == 0
+        && m[2, 0] == 0 && m[2, 1] == 0 && m[2, 2] == 1 && m[2, 3] == 0
+        && m[3, 0] == 0 && m[3, 1] == 0 && m[3, 2] == 0 && m[3, 3] == 1;
+}
+
+template<typename T>
 constexpr static Matrix4x4<T> flattened(Matrix4x4<T> const& m)
 {
     Matrix4x4<T> result = m;

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/GridTrackPlacement.h>
@@ -878,6 +879,57 @@ bool ComputedValues::adopt_identical_group_payloads(ComputedValues const& previo
     LIBWEB_ADOPT_STYLE_GROUP(m_noninherited.svg_reset)
 #undef LIBWEB_ADOPT_STYLE_GROUP
     return all_shared;
+}
+
+// https://drafts.csswg.org/css-transforms-2/#grouping-property-values
+bool ComputedValues::has_transform_style_grouping_property() const
+{
+    // The following CSS property values require the user agent to create a flattened representation of the
+    // descendant elements before they can be applied, and therefore force the element to have a used style of
+    // flat for preserve-3d.
+    // NB: The contain bullet requires layout context and is checked by NodeWithStyle::used_transform_style().
+
+    // overflow: any value other than visible or clip.
+    if (!first_is_one_of(overflow_x(), Overflow::Visible, Overflow::Clip)
+        || !first_is_one_of(overflow_y(), Overflow::Visible, Overflow::Clip))
+        return true;
+
+    // opacity: any value less than 1.
+    if (opacity() < 1)
+        return true;
+
+    // filter: any value other than none.
+    if (filter().has_filters())
+        return true;
+
+    // clip: any value other than auto.
+    if (!clip().is_auto())
+        return true;
+
+    // clip-path: any value other than none.
+    if (clip_path().has_value())
+        return true;
+
+    // isolation: used value of isolate.
+    if (isolation() == Isolation::Isolate)
+        return true;
+
+    // mask-image: any value other than none.
+    if (mask().has_value() || any_of(mask_layers(), [](auto const& layer) { return layer.background_image != nullptr; }))
+        return true;
+
+    // FIXME: mask-border-source: any value other than none.
+
+    // mix-blend-mode: any value other than normal.
+    if (mix_blend_mode() != MixBlendMode::Normal)
+        return true;
+
+    // AD-HOC: backdrop-filter is missing from the specification's list, but it buffers descendants the same way
+    //         filter does, and other engines treat it as a grouping property.
+    if (backdrop_filter().has_filters())
+        return true;
+
+    return false;
 }
 
 void const* ComputedValues::style_group_payload(StyleGroupIndex group) const

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1062,6 +1062,8 @@ public:
     // group ends up sharing its payload with `previous`.
     bool adopt_identical_group_payloads(ComputedValues const& previous) const;
 
+    bool has_transform_style_grouping_property() const;
+
     // Returns the Rust-owned payload for direct read-only layout access. The
     // pointer is borrowed from this immutable ComputedValues instance.
     void const* style_group_payload(StyleGroupIndex) const;

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -431,6 +431,7 @@
     ]
   },
   "backdrop-filter": {
+    "affects-accumulated-visual-contexts": true,
     "affects-layout": false,
     "affects-stacking-context": true,
     "animation-type": "custom",

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -273,6 +273,7 @@ static bool accumulated_visual_context_change_requires_repaint(CSS::PropertyID p
         return true;
 
     switch (property_id) {
+    case CSS::PropertyID::BackdropFilter:
     case CSS::PropertyID::BackgroundAttachment:
     case CSS::PropertyID::Clip:
     case CSS::PropertyID::ClipPath:
@@ -398,6 +399,16 @@ RequiredInvalidationAfterStyleChange compute_property_invalidation(CSS::Property
 
     if (is_containing_block_establishing_value(property_id, old_value) != is_containing_block_establishing_value(property_id, new_value))
         invalidation.changes_containing_block_establishment = true;
+
+    // A grouping property value forces a used transform-style of flat, which changes whether descendants with
+    // backface-visibility: hidden participate in a 3D rendering context and establish containing blocks.
+    // Containing block pointers are only recomputed by a layout pass.
+    if (old_computed_values && new_computed_values
+        && new_computed_values->transform_style() == CSS::TransformStyle::Preserve3d
+        && old_computed_values->has_transform_style_grouping_property() != new_computed_values->has_transform_style_grouping_property()) {
+        invalidation.changes_containing_block_establishment = true;
+        invalidation.ensure_at_least(InvalidationLevel::Relayout);
+    }
 
     bool needs_repaint = true;
     if (CSS::property_affects_accumulated_visual_contexts(property_id)) {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -953,10 +953,27 @@ bool NodeWithStyle::is_transformable() const
     return false;
 }
 
+// https://drafts.csswg.org/css-transforms-2/#grouping-property-values
+CSS::TransformStyle NodeWithStyle::used_transform_style() const
+{
+    auto const& computed_values = this->computed_values();
+    if (computed_values.transform_style() == CSS::TransformStyle::Flat)
+        return CSS::TransformStyle::Flat;
+
+    if (computed_values.has_transform_style_grouping_property())
+        return CSS::TransformStyle::Flat;
+
+    // contain: paint and any other property/value combination that causes paint containment.
+    // FIXME: has_paint_containment() does not cover content-visibility: hidden, which also causes paint containment.
+    if (has_paint_containment())
+        return CSS::TransformStyle::Flat;
+
+    return CSS::TransformStyle::Preserve3d;
+}
+
 bool NodeWithStyle::establishes_or_extends_a_3d_rendering_context() const
 {
-    // FIXME: Use the used value of 'transform-style', which is 'flat' when grouping property values apply.
-    return is_transformable() && computed_values().transform_style() == CSS::TransformStyle::Preserve3d;
+    return is_transformable() && used_transform_style() == CSS::TransformStyle::Preserve3d;
 }
 
 // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -373,6 +373,7 @@ public:
     bool is_inline_table() const;
     bool has_replaced_element_table_display_adjustment() const;
     bool is_transformable() const;
+    CSS::TransformStyle used_transform_style() const;
     bool establishes_or_extends_a_3d_rendering_context() const;
     bool participates_in_a_3d_rendering_context() const;
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -982,8 +982,10 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
     bool chain_has_backface_marker = any_of(chain, [&](size_t chain_index) {
         return m_nodes[chain_index].data.has<BackfaceVisibilityData>();
     });
+    bool chain_has_3d_transform = chain_contains_3d_transform(index);
+    bool needs_accumulated_matrices = chain_has_backface_marker || chain_has_3d_transform;
     Vector<Gfx::FloatMatrix4x4, 8> accumulated_matrices;
-    if (chain_has_backface_marker)
+    if (needs_accumulated_matrices)
         accumulated_matrices.ensure_capacity(chain.size());
 
     auto point = screen_point;
@@ -991,7 +993,7 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
         auto node_index = VisualContextIndex { chain[i - 1] };
         auto const& node = m_nodes[node_index.value()];
 
-        if (chain_has_backface_marker) {
+        if (needs_accumulated_matrices) {
             auto local = local_spatial_matrix(node, node_index, scroll_state);
             if (i == chain.size()) {
                 accumulated_matrices.unchecked_append(local.matrix);
@@ -999,6 +1001,19 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
                 auto const& parent_matrix = accumulated_matrices.last();
                 accumulated_matrices.unchecked_append((local.flattens_inherited_transform ? Gfx::flattened(parent_matrix) : parent_matrix) * local.matrix);
             }
+        }
+
+        if (chain_has_3d_transform
+            && (node.data.has<TransformData>() || node.data.has<PerspectiveData>() || node.data.has<ScrollData>()
+                || node.data.has<ScrollCompensation>() || node.data.has<AnchorScrollShift>())) {
+            auto inverse = Gfx::flattened(accumulated_matrices.last()).inverse();
+            if (!inverse.has_value())
+                return {};
+            auto mapped = *inverse * Gfx::FloatVector4 { screen_point.x(), screen_point.y(), 0, 1 };
+            if (mapped.w() < minimum_projection_w)
+                return {};
+            point = { mapped.x() / mapped.w(), mapped.y() / mapped.w() };
+            continue;
         }
 
         auto result = node.data.visit(

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -388,6 +388,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         VisualContextIndex normal_plane_root;
         VisualContextIndex absolute_position_plane_root;
         VisualContextIndex fixed_position_plane_root;
+        bool flattens_inherited_transform { false };
     };
 
     auto build_paintable_box = [&](Paintable& paintable_box, DescendantVisualContexts inherited_contexts, bool may_be_root_element) -> DescendantVisualContexts {
@@ -492,10 +493,15 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         if (auto effects = compute_effects_data(paintable_box, computed_values, pixel_ratio); effects.has_value())
             append_to_own_and_positioned_descendant_contexts(effects.value());
 
+        auto flattens_inherited_transform = inherited_contexts.flattens_inherited_transform;
+
+        bool appended_transform_node = false;
         if (computed_values_have_transform(computed_values)) {
             if (auto transform_data = compute_transform(paintable_box, computed_values, pixel_ratio); transform_data.has_value()) {
+                transform_data->flattens_inherited_transform = flattens_inherited_transform;
                 paintable_box.set_has_non_invertible_css_transform(!transform_data->matrix.is_invertible());
                 own_state = append_node(own_state, *transform_data);
+                appended_transform_node = true;
             } else {
                 paintable_box.set_has_non_invertible_css_transform(false);
             }
@@ -518,14 +524,26 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
                 return inherited_contexts.absolute_position_plane_root;
             return inherited_contexts.normal_plane_root;
         }();
-        if (computed_values.backface_visibility() == CSS::BackfaceVisibility::Hidden && layout_node.is_transformable())
-            own_state = append_node(own_state, BackfaceVisibilityData { inherited_plane_root });
+        bool appended_backface_marker = false;
+        if (computed_values.backface_visibility() == CSS::BackfaceVisibility::Hidden && layout_node.is_transformable()) {
+            own_state = append_node(own_state, BackfaceVisibilityData { inherited_plane_root, !appended_transform_node && flattens_inherited_transform });
+            appended_backface_marker = true;
+        }
 
         // https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts
-        // An element whose used value for transform-style is preserve-3d extends its 3D rendering context, so its
-        // descendants accumulate through this element's transform; any other element starts a new plane below its
-        // own transform.
-        auto plane_root_for_descendants = layout_node.establishes_or_extends_a_3d_rendering_context() ? inherited_plane_root : own_state;
+        // An element participates in a 3D rendering context if its parent establishes or extends a 3D rendering
+        // context. The position of each element in that three-dimensional space is determined by accumulating the
+        // transformation matrices up from the given element to the element that establishes the 3D rendering context.
+        // NB: Children of an element that neither establishes nor extends a 3D rendering context start a new plane
+        //     below the element's own transform. Anonymous boxes carry no element style and are invisible to 3D
+        //     rendering contexts, so they pass the inherited plane through unchanged. Pseudo-element boxes carry
+        //     their own style and participate normally. An inherited flatten is only materialized by an appended
+        //     node, so an element that appends none keeps it pending for its descendants.
+        auto establishes_or_extends_3d_rendering_context = layout_node.establishes_or_extends_a_3d_rendering_context();
+        bool invisible_to_3d_rendering_contexts = layout_node.is_anonymous() && !layout_node.is_generated_for_pseudo_element();
+        auto plane_root_for_descendants = establishes_or_extends_3d_rendering_context || invisible_to_3d_rendering_contexts ? inherited_plane_root : own_state;
+        bool inherited_flatten_still_pending = flattens_inherited_transform && !appended_transform_node && !appended_backface_marker;
+        auto descendants_flatten_inherited_transform = invisible_to_3d_rendering_contexts ? flattens_inherited_transform : (!establishes_or_extends_3d_rendering_context || inherited_flatten_still_pending);
 
         if (computed_values.clip().is_rect()) {
             if (auto css_clip = compute_css_clip_data(paintable_box, computed_values, converter); css_clip.has_value())
@@ -591,8 +609,11 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         VisualContextIndex state_for_descendants = own_state;
 
         if (computed_values.perspective().has_value()) {
-            if (auto perspective_data = compute_perspective_data(paintable_box, computed_values, scale); perspective_data.has_value())
+            if (auto perspective_data = compute_perspective_data(paintable_box, computed_values, scale); perspective_data.has_value()) {
+                perspective_data->flattens_inherited_transform = descendants_flatten_inherited_transform;
+                descendants_flatten_inherited_transform = false;
                 state_for_descendants = append_node(state_for_descendants, *perspective_data);
+            }
         }
 
         auto may_have_clip = computed_values.overflow_x() != CSS::Overflow::Visible
@@ -640,6 +661,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
             plane_root_for_descendants,
             absolute_position_plane_root,
             fixed_position_plane_root,
+            descendants_flatten_inherited_transform,
         };
     };
 
@@ -654,6 +676,7 @@ AccumulatedVisualContextTree build_accumulated_visual_context_tree(ViewportPaint
         viewport_state_for_descendants,
         viewport_state_for_descendants,
         visual_viewport_context_index,
+        true,
     };
 
     struct PendingPaintable {
@@ -763,6 +786,7 @@ bool update_accumulated_visual_context_values(ViewportPaintable& viewport_painta
         if (auto* transform_data = node.data.get_pointer<TransformData>()) {
             if (!transform.has_value())
                 return false;
+            transform->flattens_inherited_transform = transform_data->flattens_inherited_transform;
             *transform_data = *transform;
             found_transform = true;
         } else if (auto* effects_data = node.data.get_pointer<EffectsData>()) {
@@ -773,6 +797,7 @@ bool update_accumulated_visual_context_values(ViewportPaintable& viewport_painta
         } else if (auto* perspective_data = node.data.get_pointer<PerspectiveData>()) {
             if (!perspective.has_value())
                 return false;
+            perspective->flattens_inherited_transform = perspective_data->flattens_inherited_transform;
             *perspective_data = *perspective;
             found_perspective = true;
         }
@@ -863,6 +888,39 @@ Vector<size_t, 8> AccumulatedVisualContextTree::build_ancestor_chain(VisualConte
     return chain;
 }
 
+struct LocalSpatialMatrix {
+    Gfx::FloatMatrix4x4 matrix;
+    bool flattens_inherited_transform { false };
+};
+
+static LocalSpatialMatrix local_spatial_matrix(AccumulatedVisualContextNode const& node, VisualContextIndex node_index, ScrollStateSnapshot const& scroll_state)
+{
+    return node.data.visit(
+        [&](TransformData const& transform) {
+            return LocalSpatialMatrix { transform.matrix_including_origin(), transform.flattens_inherited_transform };
+        },
+        [&](PerspectiveData const& perspective) {
+            return LocalSpatialMatrix { perspective.matrix, perspective.flattens_inherited_transform };
+        },
+        [&](ScrollData const&) {
+            auto offset = scroll_state.device_offset_for_index(node_index);
+            return LocalSpatialMatrix { Gfx::translation_matrix(Vector3 { offset.x(), offset.y(), 0.f }) };
+        },
+        [&](ScrollCompensation const& compensation) {
+            auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
+            return LocalSpatialMatrix { Gfx::translation_matrix(Vector3 { -offset.x(), -offset.y(), 0.f }) };
+        },
+        [&](AnchorScrollShift const& shift) {
+            auto offset = shift.masked_offset(scroll_state);
+            return LocalSpatialMatrix { Gfx::translation_matrix(Vector3 { offset.x(), offset.y(), 0.f }) };
+        },
+        [&](BackfaceVisibilityData const& backface) { return LocalSpatialMatrix { Gfx::FloatMatrix4x4::identity(), backface.flattens_inherited_transform }; },
+        [&](ClipData const&) { return LocalSpatialMatrix { Gfx::FloatMatrix4x4::identity() }; },
+        [&](ClipPathData const&) { return LocalSpatialMatrix { Gfx::FloatMatrix4x4::identity() }; },
+        [&](EffectsData const&) { return LocalSpatialMatrix { Gfx::FloatMatrix4x4::identity() }; },
+        [&](MaskData const&) { return LocalSpatialMatrix { Gfx::FloatMatrix4x4::identity() }; });
+}
+
 Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_test(VisualContextIndex index, Gfx::FloatPoint screen_point, ScrollStateSnapshot const& scroll_state, ClipBehavior clip_behavior) const
 {
     auto chain = build_ancestor_chain(index);
@@ -883,31 +941,13 @@ Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_
         auto const& node = m_nodes[node_index.value()];
 
         if (chain_has_backface_marker) {
-            auto local_matrix = node.data.visit(
-                [&](TransformData const& transform) {
-                    return transform.matrix_including_origin();
-                },
-                [&](PerspectiveData const& perspective) {
-                    return perspective.matrix;
-                },
-                [&](ScrollData const&) {
-                    auto offset = scroll_state.device_offset_for_index(node_index);
-                    return Gfx::translation_matrix(Vector3 { offset.x(), offset.y(), 0.f });
-                },
-                [&](ScrollCompensation const& compensation) {
-                    auto offset = scroll_state.device_offset_for_index(compensation.scroll_node_index);
-                    return Gfx::translation_matrix(Vector3 { -offset.x(), -offset.y(), 0.f });
-                },
-                [&](AnchorScrollShift const& shift) {
-                    auto offset = shift.masked_offset(scroll_state);
-                    return Gfx::translation_matrix(Vector3 { offset.x(), offset.y(), 0.f });
-                },
-                [&](BackfaceVisibilityData const&) { return Gfx::FloatMatrix4x4::identity(); },
-                [&](ClipData const&) { return Gfx::FloatMatrix4x4::identity(); },
-                [&](ClipPathData const&) { return Gfx::FloatMatrix4x4::identity(); },
-                [&](EffectsData const&) { return Gfx::FloatMatrix4x4::identity(); },
-                [&](MaskData const&) { return Gfx::FloatMatrix4x4::identity(); });
-            accumulated_matrices.unchecked_append(i == chain.size() ? local_matrix : accumulated_matrices.last() * local_matrix);
+            auto local = local_spatial_matrix(node, node_index, scroll_state);
+            if (i == chain.size()) {
+                accumulated_matrices.unchecked_append(local.matrix);
+            } else {
+                auto const& parent_matrix = accumulated_matrices.last();
+                accumulated_matrices.unchecked_append((local.flattens_inherited_transform ? Gfx::flattened(parent_matrix) : parent_matrix) * local.matrix);
+            }
         }
 
         auto result = node.data.visit(
@@ -1062,7 +1102,7 @@ Gfx::FloatMatrix4x4 TransformData::matrix_including_origin() const
 
 bool should_cull_back_face(Gfx::FloatMatrix4x4 const& accumulated_matrix, Gfx::FloatMatrix4x4 const& plane_root_matrix)
 {
-    auto inverse_plane_root_matrix = plane_root_matrix.inverse();
+    auto inverse_plane_root_matrix = Gfx::flattened(plane_root_matrix).inverse();
     if (!inverse_plane_root_matrix.has_value())
         return false;
     return Gfx::is_back_face_visible(*inverse_plane_root_matrix * accumulated_matrix);
@@ -1200,6 +1240,7 @@ ErrorOr<void> encode(Encoder& encoder, Web::Painting::TransformData const& data)
 {
     TRY(encoder.encode(data.matrix));
     TRY(encoder.encode(data.origin));
+    TRY(encoder.encode(data.flattens_inherited_transform));
     return {};
 }
 
@@ -1209,6 +1250,7 @@ ErrorOr<Web::Painting::TransformData> decode(Decoder& decoder)
     return Web::Painting::TransformData {
         .matrix = TRY(decoder.decode<Gfx::FloatMatrix4x4>()),
         .origin = TRY(decoder.decode<Gfx::FloatPoint>()),
+        .flattens_inherited_transform = TRY(decoder.decode<bool>()),
     };
 }
 
@@ -1216,6 +1258,7 @@ template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::PerspectiveData const& data)
 {
     TRY(encoder.encode(data.matrix));
+    TRY(encoder.encode(data.flattens_inherited_transform));
     return {};
 }
 
@@ -1224,6 +1267,7 @@ ErrorOr<Web::Painting::PerspectiveData> decode(Decoder& decoder)
 {
     return Web::Painting::PerspectiveData {
         .matrix = TRY(decoder.decode<Gfx::FloatMatrix4x4>()),
+        .flattens_inherited_transform = TRY(decoder.decode<bool>()),
     };
 }
 
@@ -1231,6 +1275,7 @@ template<>
 ErrorOr<void> encode(Encoder& encoder, Web::Painting::BackfaceVisibilityData const& data)
 {
     TRY(encoder.encode(data.plane_root_index));
+    TRY(encoder.encode(data.flattens_inherited_transform));
     return {};
 }
 
@@ -1239,6 +1284,7 @@ ErrorOr<Web::Painting::BackfaceVisibilityData> decode(Decoder& decoder)
 {
     return Web::Painting::BackfaceVisibilityData {
         .plane_root_index = TRY(decoder.decode<Web::Painting::VisualContextIndex>()),
+        .flattens_inherited_transform = TRY(decoder.decode<bool>()),
     };
 }
 

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.cpp
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AllOf.h>
 #include <AK/AnyOf.h>
+#include <AK/Array.h>
 #include <AK/Atomic.h>
 #include <AK/HashTable.h>
 #include <AK/StringBuilder.h>
@@ -921,6 +923,55 @@ static LocalSpatialMatrix local_spatial_matrix(AccumulatedVisualContextNode cons
         [&](MaskData const&) { return LocalSpatialMatrix { Gfx::FloatMatrix4x4::identity() }; });
 }
 
+bool AccumulatedVisualContextTree::chain_contains_3d_transform(VisualContextIndex index) const
+{
+    for (size_t i = index.value();; i = m_nodes[i].parent_index.value()) {
+        auto const& node = m_nodes[i];
+        if (auto const* transform = node.data.get_pointer<TransformData>()) {
+            if (!Gfx::is_2d_affine_transform(transform->matrix))
+                return true;
+        } else if (node.data.has<PerspectiveData>()) {
+            return true;
+        }
+        if (i == VISUAL_VIEWPORT_NODE_INDEX.value())
+            break;
+    }
+    return false;
+}
+
+// Homogeneous coordinates this close to the eye plane have no meaningful projection.
+static constexpr float minimum_projection_w = 0.0001f;
+
+static Gfx::FloatRect map_rect_through_matrix(Gfx::FloatMatrix4x4 const& matrix, Gfx::FloatRect const& rect)
+{
+    auto map_corner = [&](Gfx::FloatPoint point) {
+        return matrix * Gfx::FloatVector4 { point.x(), point.y(), 0, 1 };
+    };
+    Array<Gfx::FloatVector4, 4> mapped_corners {
+        map_corner(rect.top_left()),
+        map_corner(rect.top_right()),
+        map_corner(rect.bottom_left()),
+        map_corner(rect.bottom_right()),
+    };
+    bool all_corners_behind_eye_plane = all_of(mapped_corners, [](auto const& corner) { return corner.w() <= 0; });
+    // A rect entirely behind the eye plane divides through its negative homogeneous coordinates, matching the
+    // geometry other engines report. A rect that crosses the eye plane projects without bound, so the corners
+    // behind it are clamped to keep the result conservatively covering the rendered region.
+    auto project_corner = [&](Gfx::FloatVector4 const& corner) -> Gfx::FloatPoint {
+        auto w = all_corners_behind_eye_plane ? min(corner.w(), -minimum_projection_w) : max(corner.w(), minimum_projection_w);
+        return { corner.x() / w, corner.y() / w };
+    };
+    auto top_left = project_corner(mapped_corners[0]);
+    auto top_right = project_corner(mapped_corners[1]);
+    auto bottom_left = project_corner(mapped_corners[2]);
+    auto bottom_right = project_corner(mapped_corners[3]);
+    auto left = min(min(top_left.x(), top_right.x()), min(bottom_left.x(), bottom_right.x()));
+    auto right = max(max(top_left.x(), top_right.x()), max(bottom_left.x(), bottom_right.x()));
+    auto top = min(min(top_left.y(), top_right.y()), min(bottom_left.y(), bottom_right.y()));
+    auto bottom = max(max(top_left.y(), top_right.y()), max(bottom_left.y(), bottom_right.y()));
+    return { left, top, right - left, bottom - top };
+}
+
 Optional<Gfx::FloatPoint> AccumulatedVisualContextTree::transform_point_for_hit_test(VisualContextIndex index, Gfx::FloatPoint screen_point, ScrollStateSnapshot const& scroll_state, ClipBehavior clip_behavior) const
 {
     auto chain = build_ancestor_chain(index);
@@ -1028,6 +1079,32 @@ Gfx::FloatPoint AccumulatedVisualContextTree::inverse_transform_point(VisualCont
 {
     auto chain = build_ancestor_chain(index);
 
+    // This walk deliberately skips translation-only nodes. Callers resolve offsets and scroll positions
+    // themselves. The per-node inverses below are only exact for chains of 2D transforms, so a chain containing a
+    // 3D transform inverts the flattened accumulated matrix, mapping the screen point onto the plane the content
+    // was rendered into.
+    if (chain_contains_3d_transform(index)) {
+        auto matrix = Gfx::FloatMatrix4x4::identity();
+        for (size_t i = chain.size(); i > 0; --i) {
+            auto const& node = m_nodes[chain[i - 1]];
+            node.data.visit(
+                [&](TransformData const& transform) {
+                    matrix = (transform.flattens_inherited_transform ? Gfx::flattened(matrix) : matrix) * transform.matrix_including_origin();
+                },
+                [&](PerspectiveData const& perspective) {
+                    matrix = (perspective.flattens_inherited_transform ? Gfx::flattened(matrix) : matrix) * perspective.matrix;
+                },
+                [&](auto const&) {});
+        }
+        auto inverse = Gfx::flattened(matrix).inverse();
+        if (!inverse.has_value())
+            return screen_point;
+        auto mapped = *inverse * Gfx::FloatVector4 { screen_point.x(), screen_point.y(), 0, 1 };
+        if (mapped.w() < minimum_projection_w)
+            return screen_point;
+        return { mapped.x() / mapped.w(), mapped.y() / mapped.w() };
+    }
+
     auto point = screen_point;
     for (size_t i = chain.size(); i > 0; --i) {
         auto const& node = m_nodes[chain[i - 1]];
@@ -1056,6 +1133,20 @@ Gfx::FloatPoint AccumulatedVisualContextTree::inverse_transform_point(VisualCont
 
 Gfx::FloatRect AccumulatedVisualContextTree::transform_rect_to_viewport(VisualContextIndex index, Gfx::FloatRect const& source_rect, ScrollStateSnapshot const& scroll_state, IncludeVisualViewportTransform include_visual_viewport_transform) const
 {
+    // A chain with three-dimensional transforms cannot be applied one two-dimensional projection at a time.
+    if (chain_contains_3d_transform(index)) {
+        auto chain = build_ancestor_chain(index);
+        auto matrix = Gfx::FloatMatrix4x4::identity();
+        for (size_t i = chain.size(); i > 0; --i) {
+            auto node_index = VisualContextIndex { chain[i - 1] };
+            if (node_index == VISUAL_VIEWPORT_NODE_INDEX && include_visual_viewport_transform == IncludeVisualViewportTransform::No)
+                continue;
+            auto local = local_spatial_matrix(m_nodes[node_index.value()], node_index, scroll_state);
+            matrix = (local.flattens_inherited_transform ? Gfx::flattened(matrix) : matrix) * local.matrix;
+        }
+        return map_rect_through_matrix(matrix, source_rect);
+    }
+
     auto rect = source_rect;
     for (size_t i = index.value();; i = m_nodes[i].parent_index.value()) {
         auto const& node = m_nodes[i];

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -59,16 +59,19 @@ struct ClipData {
 struct TransformData {
     Gfx::FloatMatrix4x4 matrix;
     Gfx::FloatPoint origin;
+    bool flattens_inherited_transform { false };
 
     Gfx::FloatMatrix4x4 matrix_including_origin() const;
 };
 
 struct PerspectiveData {
     Gfx::FloatMatrix4x4 matrix;
+    bool flattens_inherited_transform { false };
 };
 
 struct BackfaceVisibilityData {
     VisualContextIndex plane_root_index;
+    bool flattens_inherited_transform { false };
 };
 
 bool should_cull_back_face(Gfx::FloatMatrix4x4 const& accumulated_matrix, Gfx::FloatMatrix4x4 const& plane_root_matrix);

--- a/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
+++ b/Libraries/LibWeb/Painting/AccumulatedVisualContext.h
@@ -195,6 +195,7 @@ private:
     }
 
     Vector<size_t, 8> build_ancestor_chain(VisualContextIndex index) const;
+    bool chain_contains_3d_transform(VisualContextIndex index) const;
 
     u64 m_version { 0 };
     Vector<AccumulatedVisualContextNode> m_nodes;

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -200,9 +200,9 @@ void DisplayListPlayer::execute_impl(
     auto const replay_base_matrix = canvas_matrix();
     for (size_t i = 0; i < nodes.size(); ++i) {
         auto const& node = nodes[i];
-        auto append_spatial = [&](Gfx::FloatMatrix4x4 const& local_matrix) {
+        auto append_spatial = [&](Gfx::FloatMatrix4x4 const& local_matrix, bool flattens_inherited_transform = false) {
             auto const& parent_matrix = i == 0 ? replay_base_matrix : transform_palette[node.parent_index.value()];
-            transform_palette.unchecked_append(parent_matrix * local_matrix);
+            transform_palette.unchecked_append((flattens_inherited_transform ? Gfx::flattened(parent_matrix) : parent_matrix) * local_matrix);
             nearest_spatial_node.unchecked_append(VisualContextIndex { i });
             nearest_frame_node.unchecked_append(i == 0 ? VISUAL_VIEWPORT_NODE_INDEX : nearest_frame_node[node.parent_index.value()]);
             backface_culled.unchecked_append(i == 0 ? false : backface_culled[node.parent_index.value()]);
@@ -220,13 +220,17 @@ void DisplayListPlayer::execute_impl(
         };
         node.data.visit(
             [&](TransformData const& transform) {
-                append_spatial(transform.matrix_including_origin());
+                append_spatial(transform.matrix_including_origin(), transform.flattens_inherited_transform);
             },
             [&](PerspectiveData const& perspective) {
-                append_spatial(perspective.matrix);
+                append_spatial(perspective.matrix, perspective.flattens_inherited_transform);
             },
             [&](BackfaceVisibilityData const& backface) {
-                transform_palette.unchecked_append(transform_palette[node.parent_index.value()]);
+                // The flattened entry only feeds the backface test and descendant accumulation. Drawing under the
+                // marker keeps using the parent entry via nearest_spatial_node, since the element's own content
+                // belongs to its parent's plane.
+                auto const& parent_matrix = transform_palette[node.parent_index.value()];
+                transform_palette.unchecked_append(backface.flattens_inherited_transform ? Gfx::flattened(parent_matrix) : parent_matrix);
                 nearest_spatial_node.unchecked_append(nearest_spatial_node[node.parent_index.value()]);
                 nearest_frame_node.unchecked_append(nearest_frame_node[node.parent_index.value()]);
                 bool culled = backface_culled[node.parent_index.value()];

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -123,15 +123,18 @@ static bool visual_context_data_is_equal(VisualContextIndex a_index, VisualConte
         },
         [&](TransformData const& data) {
             auto const* other = b.get_pointer<TransformData>();
-            return other && matrices_are_equal(data.matrix, other->matrix) && data.origin == other->origin;
+            return other && matrices_are_equal(data.matrix, other->matrix) && data.origin == other->origin
+                && data.flattens_inherited_transform == other->flattens_inherited_transform;
         },
         [&](PerspectiveData const& data) {
             auto const* other = b.get_pointer<PerspectiveData>();
-            return other && matrices_are_equal(data.matrix, other->matrix);
+            return other && matrices_are_equal(data.matrix, other->matrix)
+                && data.flattens_inherited_transform == other->flattens_inherited_transform;
         },
         [&](BackfaceVisibilityData const& data) {
             auto const* other = b.get_pointer<BackfaceVisibilityData>();
-            return other && data.plane_root_index == other->plane_root_index;
+            return other && data.plane_root_index == other->plane_root_index
+                && data.flattens_inherited_transform == other->flattens_inherited_transform;
         },
         [&](ClipPathData const& data) {
             auto const* other = b.get_pointer<ClipPathData>();

--- a/Libraries/LibWeb/Painting/DisplayListDamage.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListDamage.cpp
@@ -251,6 +251,12 @@ Optional<Gfx::IntRect> compute_display_list_damage(
             return;
         }
         auto transformed_rect = visual_context_tree.transform_rect_to_viewport(command.header.context_index, command.header.bounding_rect.to_type<float>(), scroll_state);
+        // Eye-plane clamping in the projection can produce coordinates beyond integer range, and converting
+        // such a float to int is undefined.
+        constexpr float damage_coordinate_limit = 16777216.0f;
+        transformed_rect.intersect({ -damage_coordinate_limit, -damage_coordinate_limit, 2 * damage_coordinate_limit, 2 * damage_coordinate_limit });
+        if (transformed_rect.is_empty())
+            return;
         auto command_damage = Gfx::enclosing_int_rect(transformed_rect);
         if (damage_rect.has_value())
             damage_rect->unite(command_damage);

--- a/Tests/LibWeb/Ref/expected/css/preserve-3d-transformless-flatten-boundary-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/preserve-3d-transformless-flatten-boundary-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+.box {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<div class="box" style="transform: rotateY(60deg)">
+    <div class="box">
+        <div class="box" style="transform: rotateY(-60deg); background: teal"></div>
+    </div>
+</div>
+<div class="box" style="transform: rotateY(60deg)">
+    <div class="box" style="perspective: 10000px">
+        <div class="box" style="transform: rotateY(-60deg); background: navy"></div>
+    </div>
+</div>

--- a/Tests/LibWeb/Ref/expected/css/transform-behind-eye-plane-not-painted-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/transform-behind-eye-plane-not-painted-ref.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-blank-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform-blank-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+  </head>
+  <body>
+    <p>Nothing should appear except this sentence.</p>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform3d-perspective-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform3d-perspective-001-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+  </head>
+  <body>
+    <div style="perspective: 1000px; perspective-origin: 50px 50px">
+      <div style="height: 100px; width: 100px; background: lime;
+        transform: rotatex(45deg) scaley(1.41421356); transform-origin: top">
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform3d-preserve3d-013-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-transforms/transform3d-preserve3d-013-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <!-- sqrt(2) == 0.70710678; 200/sqrt(2) == 141.421356.
+    'transform' is needed on the outer div so the scrollbars are shrunk
+    appropriately. -->
+  </head>
+  <body>
+    <div style="overflow: scroll; transform: scaley(0.70710678);
+      transform-origin: top">
+      <div style="height: 200px">
+        <div style="height: 141.421356px; width: 100px; background: lime">
+        </div>
+    </div></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/css/preserve-3d-transformless-flatten-boundary.html
+++ b/Tests/LibWeb/Ref/input/css/preserve-3d-transformless-flatten-boundary.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/preserve-3d-transformless-flatten-boundary-ref.html" />
+<style>
+.box {
+    width: 100px;
+    height: 100px;
+}
+</style>
+<div class="box" style="transform: rotateY(60deg)">
+    <div class="box" style="transform-style: preserve-3d">
+        <div class="box" style="transform: rotateY(-60deg); background: teal"></div>
+    </div>
+</div>
+<div class="box" style="transform: rotateY(60deg)">
+    <div class="box" style="transform-style: preserve-3d; perspective: 10000px">
+        <div class="box" style="transform: rotateY(-60deg); background: navy"></div>
+    </div>
+</div>

--- a/Tests/LibWeb/Ref/input/css/transform-behind-eye-plane-not-painted.html
+++ b/Tests/LibWeb/Ref/input/css/transform-behind-eye-plane-not-painted.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<link rel="match" href="../../expected/css/transform-behind-eye-plane-not-painted-ref.html" />
+<style>
+#container {
+    perspective: 100px;
+    width: 100px;
+    height: 100px;
+}
+#parent {
+    transform: translateZ(200px);
+    width: 100px;
+    height: 100px;
+    background: blue;
+}
+#child {
+    transform: translateX(1px);
+    width: 100px;
+    height: 100px;
+    background: red;
+}
+</style>
+<div id="container">
+    <div id="parent">
+        <div id="child"></div>
+    </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/3d-rendering-context-and-inline.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/3d-rendering-context-and-inline.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<title>CSS Test (Transforms): 3D Rendering Context following DOM Tree (inlines)</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts">
+<meta name="assert" content="Blocks inside of inlines participate in 3D Rendering Contexts based on their parent, not their containing block.">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-blank-ref.html">
+
+<style>
+
+.outer {
+  display: block;
+  width: 100px;
+  height: 100px;
+  transform-style: preserve-3d;
+  transform: rotateX(90deg);
+}
+
+.middle {
+  display: inline;
+}
+
+.inner {
+  display: block;
+  width: 100px;
+  height: 100px;
+  transform: rotateX(-90deg);
+  background: red;
+}
+
+</style>
+
+<p>Nothing should appear except this sentence.</p>
+
+<div class="outer">
+  <div class="middle">
+    <div class="inner"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-children-only-abspos.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-children-only-abspos.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): perspective applies only to DOM children (position: absolute)</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#perspective">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#propdef-perspective">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/918">
+<meta name="assert" content="The perspective property influences an element's children.">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/reference/green.html">
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#outer {
+  position: relative;
+  background: red;
+  perspective: 100px;
+}
+
+#middle {
+}
+
+#inner {
+  transform: translateZ(-100px);
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: green;
+}
+
+</style>
+
+<p>Pass if there is NO red below:</p>
+
+<div id="outer">
+  <div id="middle">
+    <div id="inner"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-children-only-fixpos.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-children-only-fixpos.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): perspective applies only to DOM children (position: absolute)</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#perspective">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#propdef-perspective">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/918">
+<meta name="assert" content="The perspective property influences an element's children.">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/reference/green.html">
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#outer {
+  transform: scale(1);
+  position: relative;
+  background: red;
+  perspective: 100px;
+}
+
+#middle {
+}
+
+#inner {
+  transform: translateZ(-100px);
+  position: fixed;
+  top: 0;
+  left: 0;
+  background: green;
+}
+
+</style>
+
+<p>Pass if there is NO red below:</p>
+
+<div id="outer">
+  <div id="middle">
+    <div id="inner"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-children-only-inline.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/perspective-children-only-inline.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset=UTF-8>
+<title>CSS Test (Transforms): perspective applies only to DOM children (position: absolute)</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Google" href="http://www.google.com/">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#perspective">
+<link rel="help" href="https://www.w3.org/TR/css-transforms-2/#propdef-perspective">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/918">
+<meta name="assert" content="The perspective property influences an element's children.">
+<link rel="match" href="../../../../expected/wpt-import/css/css-transforms/reference/green.html">
+<style>
+
+div {
+  width: 100px;
+  height: 100px;
+}
+
+#outer {
+  background: red;
+  perspective: 100px;
+}
+
+#middle {
+  display: inline;
+}
+
+#inner {
+  transform: translateZ(-100px);
+  background: green;
+}
+
+</style>
+
+<p>Pass if there is NO red below:</p>
+
+<div id="outer">
+  <div id="middle">
+    <div id="inner"></div>
+  </div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform-table-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform-table-006.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Table Without Preserve-3D 1</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This has preserve-3d applied to the outer
+    wrapper of a table, but not the inner wrapper containing its contents.
+    Therefore, the contents should be rotated 90 degrees and vanish, and the
+    90-degree rotation on the outer wrapper shouldn't restore them.  An
+    implementation that incorrectly propagated preserve-3d to table descendants
+    might cause the text to appear, but mirrored.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-blank-ref.html">
+    <style>
+      body > div {
+        transform: rotateX(90deg);
+        transform-style: preserve-3d;
+      }
+      td > div {
+        transform: rotateX(90deg);
+      }
+    </style>
+  </head>
+  <body>
+    <p>Nothing should appear except this sentence.</p>
+    <div>
+      <table>
+        <tr>
+          <td>
+            <div>Some text</div>
+          </td>
+        </tr>
+      </table>
+    </body>
+  </html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-002.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Inherited Perspective</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">
+    <meta name="assert" content="This tests that 'perspective: inherit' works
+    the same as specifying that perspective to start with.">
+    <meta name="fuzzy" content="maxDifference=0-2;totalPixels=0-215">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform3d-perspective-001-ref.html">
+    <link rel="mismatch" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="perspective: 1000px">
+      <div style="perspective: inherit; perspective-origin: 50px 50px">
+        <div style="height: 100px; width: 100px; background: lime;
+          transform: rotatex(45deg) scaley(1.41421356); transform-origin: top">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Perspective on Grandparent</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">
+    <meta name="assert" content="This tests that 'perspective' affects only the
+    element's children, not its grandchildren.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="perspective: 1000px">
+      <div>
+        <div style="height: 100px; width: 100px; background: lime;
+          transform: rotatex(45deg) scaley(1.41421356); transform-origin: top">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-004.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): 'perspective: 1000px' on Grandparent and
+    'perspective: none' on Parent</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">
+    <meta name="assert" content="This tests that 'perspective: none' actually
+    results in no perspective being applied to children, even if the
+    grandparent has perspective.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="perspective: 1000px">
+      <div style="perspective: none">
+        <div style="height: 100px; width: 100px; background: lime;
+          transform: rotatex(45deg) scaley(1.41421356); transform-origin: top">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-perspective-005.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): 'perspective: 1000px' on Grandparent and
+    'perspective: 0px' on Parent</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="author" title="L. David Baron" href="https://dbaron.org/">
+    <link rel="author" title="Google" href="http://www.google.com/">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#perspective-property">
+    <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/413">
+    <meta name="assert" content="This tests that 'perspective: 0px' behaves the
+    same as perspective: 1px.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="perspective: 1000px">
+      <div style="perspective: 0px; perspective-origin: 50px bottom">
+        <div style="height: 50px; width: 50px; background: lime;
+          transform: translate3d(25px, 25px, 0.5px)">
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-006.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Two rotatex(), No Preserve-3D</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="rotatex(45deg) or rotatex(-45deg), by itself,
+    should both just scale down the element by a factor of sqrt(2) (and perhaps
+    shift it, depending on 'transform-origin').  Without 'transform-style:
+    preserve-3d', the rotations on parent and child shouldn't cancel, so its
+    height should be halved with no other effect.">
+    <meta name="fuzzy" content="maxDifference=0-55;totalPixels=0-299">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="transform: rotatex(45deg); transform-origin: top">
+      <div style="transform: rotatex(-45deg); transform-origin: top;
+        height: 200px; width: 100px; background: lime">
+    </div></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-007.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Two rotatey(), No Preserve-3D</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This is identical to
+    transform3d-preserve3d-006.html, except with rotatey() instead of
+    rotatex().">
+    <meta name="fuzzy" content="maxDifference=0-55; totalPixels=0-200">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="transform: rotatey(45deg); transform-origin: left">
+      <div style="transform: rotatey(-45deg); transform-origin: left;
+        height: 100px; width: 200px; background: lime">
+    </div></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-008.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-008.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Preserve-3D with 'overflow: hidden'</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This is identical to
+    transform3d-preserve3d-006.html, except that it has 'transform-style:
+    preserve-3d; overflow: hidden' specified on the parent element.
+    'transform-style: preserve-3d' would normally make the result different,
+    but 'overflow: hidden' overrides its effect and causes it to work the same
+    as 'transform-style: flat'.">
+    <meta name="fuzzy" content="maxDifference=0-55;totalPixels=0-299">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="transform: rotatex(45deg); transform-origin: top;
+      transform-style: preserve-3d; overflow: hidden">
+      <div style="transform: rotatex(-45deg); transform-origin: top;
+        height: 200px; width: 100px; background: lime">
+    </div></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-009.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-009.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Preserve-3D with 'overflow: auto'</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This is identical to
+    transform3d-preserve3d-008.html, except with 'overflow: auto' instead of
+    'hidden'.">
+    <meta name="fuzzy" content="maxDifference=0-55;totalPixels=0-299">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-lime-square-ref.html">
+  </head>
+  <body>
+    <div style="transform: rotatex(45deg); transform-origin: top;
+      transform-style: preserve-3d; overflow: auto">
+      <div style="transform: rotatex(-45deg); transform-origin: top;
+        height: 200px; width: 100px; background: lime">
+    </div></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-012.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-012.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): 90-Degree Rotations Without Preserve-3D</title>
+    <link rel="author" title="Matt Woodrow" href="mailto:mwoodrow@mozilla.com">
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This tests that two 90-degree rotations with
+    the default 'transform-style: flat' do not add together to form a
+    180-degree rotation.  Instead, the first causes the contents to vanish and
+    the second does not restore them.">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform-blank-ref.html">
+  </head>
+  <body>
+    <p>Nothing should appear except this sentence.</p>
+    <div style="transform: rotatex(90deg);">
+      <div style="transform: rotatex(90deg); width: 100px; height: 100px;">
+        Test Text
+      </div>
+    </div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-013.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-transforms/transform3d-preserve3d-013.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>CSS Test (Transforms): Preserve-3D with 'overflow: scroll'</title>
+    <link rel="author" title="Aryeh Gregor" href="mailto:ayg@aryeh.name">
+    <link rel="help" href="http://www.w3.org/TR/css-transforms-2/#transform-style-property">
+    <meta name="assert" content="This is identical to
+    transform3d-preserve3d-008.html, except with 'overflow: scroll' instead of
+    'hidden'.  (Note that the ref is nontrivial, because the scrollbar has to
+    be scaled appropriately.)">
+    <link rel="match" href="../../../../expected/wpt-import/css/css-transforms/transform3d-preserve3d-013-ref.html">
+    <meta name=fuzzy content="maxDifference=0-120;totalPixels=0-3422">
+  </head>
+  <body>
+    <div style="transform: rotatex(45deg); transform-origin: top;
+      transform-style: preserve-3d; overflow: scroll">
+      <div style="transform: rotatex(-45deg); transform-origin: top;
+        height: 200px; width: 100px; background: lime">
+    </div></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/expected/css/preserve-3d-grouping-property-change-containing-block.txt
+++ b/Tests/LibWeb/Text/expected/css/preserve-3d-grouping-property-change-containing-block.txt
@@ -1,0 +1,2 @@
+PASS
+PASS

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/3d-point-mapping-3.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/3d-point-mapping-3.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Point mapping through 3D transform hierarchies, hittesting card)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/3d-point-mapping.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/3d-point-mapping.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 12 tests
+
+12 Pass
+Pass	Point mapping through 3D transforms, hittesting box1)
+Pass	Point mapping through 3D transforms, hittesting box2)
+Pass	Point mapping through 3D transforms, hittesting box5)
+Pass	Point mapping through 3D transforms, hittesting box6)
+Pass	Point mapping through 3D transforms, hittesting box7)
+Pass	Point mapping through 3D transforms, hittesting box8)
+Pass	Point mapping through 3D transforms, hittesting box9)
+Pass	Point mapping through 3D transforms, hittesting box10)
+Pass	Point mapping through 3D transforms, hittesting box11)
+Pass	Point mapping through 3D transforms, hittesting box12)
+Pass	Point mapping through 3D transforms, hittesting box13)
+Pass	Point mapping through 3D transforms, hittesting box14)

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/3d-rendering-context-behavior.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/3d-rendering-context-behavior.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 12 tests
+
+12 Pass
+Pass	Direct DOM parent is root of rendering context (normal flow)
+Pass	Direct DOM parent is root of rendering context (absolute)
+Pass	Direct DOM parent is root of rendering context (fixed)
+Pass	Intermediate DOM nodes cause rendering context to end (normal flow)
+Pass	Intermediate DOM nodes cause rendering context to end (absolute)
+Pass	Intermediate DOM nodes cause rendering context to end (fixed)
+Pass	Perspective applies to direct DOM normal-flow children
+Pass	Perspective applies to direct DOM abs-pos children
+Pass	Perspective applies to direct DOM fixed-pos children
+Pass	Perspective does not apply to DOM normal-flow grandchildren
+Pass	Perspective does not apply to DOM abs-pos grandchildren
+Pass	Perspective does not apply to DOM fixed-pos grandchildren

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/preserve-3d-flat-grouping-properties.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transforms/preserve-3d-flat-grouping-properties.txt
@@ -1,0 +1,15 @@
+Harness status: OK
+
+Found 10 tests
+
+10 Pass
+Pass	Preserve-3d element not flattened
+Pass	Preserve-3d element flattened due to opacity
+Pass	Preserve-3d element flattened due to overflow clip
+Pass	Preserve-3d element flattened due to filter
+Pass	Preserve-3d element flattened due to backdrop-filter
+Pass	Preserve-3d element flattened due to mix-blend-mode
+Pass	Preserve-3d element flattened due to clip CSS
+Pass	Preserve-3d element flattened due to clip-path
+Pass	Preserve-3d element flattened due to isolation
+Pass	Preserve-3d element flattened due to mask

--- a/Tests/LibWeb/Text/input/css/preserve-3d-grouping-property-change-containing-block.html
+++ b/Tests/LibWeb/Text/input/css/preserve-3d-grouping-property-change-containing-block.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div style="position: relative; margin-left: 50px; height: 60px">
+    <div id="dynamicGrouper" style="transform-style: preserve-3d">
+        <div style="backface-visibility: hidden; margin-left: 20px; width: 100px; height: 50px">
+            <div id="dynamicAbs" style="position: absolute; left: 0; top: 0; width: 10px; height: 10px"></div>
+        </div>
+    </div>
+</div>
+<div style="position: relative; margin-left: 50px; height: 60px">
+    <div style="transform-style: preserve-3d; opacity: 0.5">
+        <div style="backface-visibility: hidden; margin-left: 20px; width: 100px; height: 50px">
+            <div id="staticAbs" style="position: absolute; left: 0; top: 0; width: 10px; height: 10px"></div>
+        </div>
+    </div>
+</div>
+<script>
+test(() => {
+    const initialX = dynamicAbs.getBoundingClientRect().x;
+    dynamicGrouper.style.opacity = "0.5";
+    const dynamicX = dynamicAbs.getBoundingClientRect().x;
+    const staticX = staticAbs.getBoundingClientRect().x;
+    println(initialX !== dynamicX ? "PASS" : "FAIL");
+    println(dynamicX === staticX ? "PASS" : "FAIL");
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/3d-point-mapping-3.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/3d-point-mapping-3.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<title>Point mapping through 3D transform hierarchies</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style type="text/css" media="screen">
+  #scene {
+    position: absolute;
+    border: 1px solid black;
+    height: 400px;
+    width: 400px;
+    perspective: 600px;
+    transform-style: preserve-3d;
+  }
+
+  #container {
+    position: absolute;
+    height: 300px;
+    width: 300px;
+    margin: 50px;
+    border: 1px solid blue;
+    transform-style: preserve-3d;
+  }
+
+  #card {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    height: 200px;
+    width: 200px;
+    background-color: #81AA8A;
+    transform-origin: right top;
+    transform: rotateY(45deg);
+  }
+
+  #card:hover {
+    background-color: orange;
+  }
+</style>
+
+<body>
+  <div id="scene">
+    <div id="container">
+      <div id="card"></div>
+    </div>
+  </div>
+</body>
+
+<script>
+  class Point {
+    constructor(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+  };
+  const tests = [{
+      expectedElemId: 'card',
+      // Points inside the 3D-transformed element
+      insidePoints: [
+        new Point(160, 85),   // Top-left
+        new Point(306, 113),  // Top-right
+        new Point(160, 335),  // Bottom-left
+        new Point(307, 307),  // Bottom-right
+      ],
+      // Points outside the 3D-transformed element
+      outsidePoints: [
+        new Point(115, 115),  // Inside top-left when untransformed
+        new Point(115, 300),  // Inside bottom-left when untransformed
+      ]
+    }
+  ];
+
+  tests.forEach(testcase => {
+    test(t => {
+      const expectedElem = document.getElementById(testcase.expectedElemId);
+      // Test points that should hit the element
+      for (const point of testcase.insidePoints) {
+        const hitElem = document.elementFromPoint(point.x, point.y);
+        assert_equals(hitElem, expectedElem,
+          `point (${point.x}, ${point.y}) should be inside element ${testcase.expectedElemId}`);
+      }
+      // Test points that should NOT hit the element
+      for (const point of testcase.outsidePoints) {
+        const hitElem = document.elementFromPoint(point.x, point.y);
+        assert_not_equals(hitElem, expectedElem,
+          `point (${point.x}, ${point.y}) should be outside element ${testcase.expectedElemId}`);
+      }
+    }, `${document.title}, hittesting ${testcase.expectedElemId})`);
+  });
+</script>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/3d-point-mapping.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/3d-point-mapping.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<title>Point mapping through 3D transforms</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style type="text/css" media="screen">
+  body {
+    margin: 0;
+  }
+
+  .test {
+    position: absolute;
+    height: 200px;
+    width: 200px;
+    border: 1px solid black;
+    margin: 20px;
+  }
+
+  .test.one { top: 1px; left: 1px; }
+  .test.two { top: 1px; left: 247px; }
+  .test.three { top: 247px; left: 1px; }
+  .test.four { top: 247px; left: 247px; }
+
+  #box1, #box5, #box8, #box11 {
+    height: 140px;
+    width: 140px;
+    margin: 20px;
+    background-color: #DDD;
+    border: 1px solid black;
+    box-sizing: border-box;
+    perspective: 400px;
+  }
+
+  #box2, #box6, #box9, #box12 {
+    position: relative;
+    height: 100px;
+    width: 100px;
+    padding: 20px;
+    margin: 20px;
+    background-color: #AAA;
+    box-sizing: border-box;
+    transform: translateZ(100px) rotateY(-40deg);
+    border: 1px solid black;
+  }
+
+  #box7, #box10, #box13, #box14 {
+    height: 100px;
+    width: 100px;
+    background-color: blue;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  #box10, #box14 {
+    position: relative;
+  }
+
+  #box13 {
+    padding: 20px;
+    background-color: #C0D69E;
+  }
+
+  [id^="box"]:hover {
+    outline: 3px solid orange;
+  }
+
+</style>
+
+<body>
+
+<div class="test one">
+  <!-- Simple transformed div in perspective -->
+  <div id="box1">
+    <div id="box2">
+    </div>
+  </div>
+</div>
+
+<div class="test two">
+  <!-- Transformed div in perspective with non-layer child -->
+  <div id="box5">
+    <div id="box6">
+      <div id="box7">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="test three">
+  <!-- Transformed div in perspective with layer child -->
+  <div id="box8">
+    <div id="box9">
+      <div id="box10">
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="test four">
+  <!-- Transformed div in perspective with child having layer child -->
+  <div id="box11">
+    <div id="box12">
+      <div id="box13">
+        <div id="box14">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+
+<script>
+  class Point {
+    constructor(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+  };
+  // Each test case defines four test points near the corners of an element.
+  // - Point 1: Top-left
+  // - Point 2: Top-right
+  // - Point 3: Bottom-left
+  // - Point 4: Bottom-right
+  const tests = [{
+      expectedElemId: 'box1',
+      points: [
+        new Point(50, 45),
+        new Point(175, 45),
+        new Point(50, 175),
+        new Point(175, 175),
+      ]
+    },
+    {
+      expectedElemId: 'box2',
+      points: [
+        new Point(75, 55),
+        new Point(166, 41),
+        new Point(70, 167),
+        new Point(165, 183),
+      ]
+    },
+    {
+      expectedElemId: 'box5',
+      points: [
+        new Point(292, 45),
+        new Point(422, 46),
+        new Point(294, 175),
+        new Point(323, 176),
+      ]
+    },
+    {
+      expectedElemId: 'box6',
+      points: [
+        new Point(316, 53),
+        new Point(412, 41),
+        new Point(318, 167),
+        new Point(326, 171),
+      ]
+    },
+    {
+      expectedElemId: 'box7',
+      points: [
+        new Point(336, 77),
+        new Point(438, 74),
+        new Point(338, 192),
+        new Point(439, 213),
+      ]
+    },
+    {
+      expectedElemId: 'box8',
+      points: [
+        new Point(47, 291),
+        new Point(177, 295),
+        new Point(49, 421),
+        new Point(80, 424),
+      ]
+    },
+    {
+      expectedElemId: 'box9',
+      points: [
+        new Point(72, 302),
+        new Point(165, 290),
+        new Point(72, 414),
+        new Point(82, 417),
+      ]
+    },
+    {
+      expectedElemId: 'box10',
+      points: [
+        new Point(91, 326),
+        new Point(194, 318),
+        new Point(88, 445),
+        new Point(195, 469),
+      ]
+    },
+    {
+      expectedElemId: 'box11',
+      points: [
+        new Point(294, 292),
+        new Point(422, 292),
+        new Point(293, 424),
+        new Point(327, 425),
+      ]
+    },
+    {
+      expectedElemId: 'box12',
+      points: [
+        new Point(318, 302),
+        new Point(413, 288),
+        new Point(317, 416),
+        new Point(329, 417),
+      ]
+    },
+    {
+      expectedElemId: 'box13',
+      points: [
+        new Point(335, 325),
+        new Point(440, 319),
+        new Point(336, 444),
+        new Point(349, 448),
+      ]
+    },
+    {
+      expectedElemId: 'box14',
+      points: [
+        new Point(355, 351),
+        new Point(468, 354),
+        new Point(356, 475),
+        new Point(473, 506),
+      ]
+    }
+  ];
+
+  tests.forEach(testcase => {
+    test(t => {
+      const expectedElem = document.getElementById(testcase.expectedElemId);
+      for (const point of testcase.points) {
+        const hitElem = document.elementFromPoint(point.x, point.y);
+        assert_equals(hitElem, expectedElem,
+          `point (${point.x}, ${point.y}) is inside element ${testcase.expectedElemId}`);
+      }
+    }, `${document.title}, hittesting ${testcase.expectedElemId})`);
+  });
+</script>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/3d-rendering-context-behavior.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/3d-rendering-context-behavior.html
@@ -1,0 +1,126 @@
+<!doctype HTML>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+  div {
+    width: 200px;
+    height: 200px;
+  }
+
+  .rotate45 {
+    transform: rotateY(45deg)
+  }
+  .rotateNeg45 {
+    transform: rotateY(-45deg)
+  }
+
+  .parent {
+    transform-style: preserve-3d;
+  }
+
+  .perspective {
+    perspective: 200px;
+  }
+</style>
+
+<div class="parent rotateNeg45">
+  <div id=childOfPreserve3D class="child rotate45"></div>
+</div>
+
+<div class="parent rotateNeg45">
+  <div id=absChildOfPreserve3D class="child rotate45" style="position: absolute"></div>
+</div>
+
+<div class="parent rotateNeg45">
+  <div id=fixedChildOfPreserve3D class="child rotate45" style="position: fixed"></div>
+</div>
+
+<div class="parent rotateNeg45">
+  <div>
+    <div id=childWithIntermediate class="child rotate45"></div>
+  </div>
+</div>
+
+<div class="parent rotateNeg45">
+  <div>
+    <div id=absWithIntermediate class="child rotate45" style="position: absolute"></div>
+  </div>
+</div>
+
+<div class="parent rotateNeg45">
+  <div>
+    <div id=fixedWithIntermediate class="child rotate45" style="position: fixed"></div>
+  </div>
+</div>
+
+<div class="perspective">
+  <div id=childWithPerspectiveParent class="child rotate45"></div>
+  <div id=absWithPerspectiveParent class="child rotate45" style="position: absolute"></div>
+  <div id=fixedWithPerspectiveParent class="child rotate45" style="position: fixed"></div>
+</div>
+
+<div class="perspective">
+  <div>
+    <div id=childWithIntermediateAndPerspectiveParent class="child rotate45"></div>
+    <div id=absWithIntermediateAndPerspectiveParent class="child rotate45" style="position: absolute"></div>
+    <div id=fixedWithIntermediateAndPerspectiveParent class="child rotate45" style="position: fixed"></div>
+  </div>
+</div>
+
+<script>
+  test(function() {
+    assert_equals(childOfPreserve3D.getBoundingClientRect().width, 200);
+  }, "Direct DOM parent is root of rendering context (normal flow)");
+  test(function() {
+    assert_equals(absChildOfPreserve3D.getBoundingClientRect().width, 200);
+  }, "Direct DOM parent is root of rendering context (absolute)");
+  test(function() {
+    assert_equals(fixedChildOfPreserve3D.getBoundingClientRect().width, 200);
+  }, "Direct DOM parent is root of rendering context (fixed)");
+
+  test(function() {
+    assert_equals(childWithIntermediate.getBoundingClientRect().width, 100);
+  }, "Intermediate DOM nodes cause rendering context to end (normal flow)");
+  test(function() {
+    assert_equals(absWithIntermediate.getBoundingClientRect().width, 100);
+  }, "Intermediate DOM nodes cause rendering context to end (absolute)");
+  test(function() {
+    assert_equals(fixedWithIntermediate.getBoundingClientRect().width, 100);
+  }, "Intermediate DOM nodes cause rendering context to end (fixed)");
+
+  test(function() {
+    assert_approx_equals(
+        childWithPerspectiveParent.getBoundingClientRect().width, 161, 1);
+  }, "Perspective applies to direct DOM normal-flow children");
+
+  test(function() {
+    assert_approx_equals(
+        absWithPerspectiveParent.getBoundingClientRect().width, 161, 1);
+  }, "Perspective applies to direct DOM abs-pos children");
+
+  test(function() {
+    assert_approx_equals(
+        fixedWithPerspectiveParent.getBoundingClientRect().width, 161, 1);
+  }, "Perspective applies to direct DOM fixed-pos children");
+
+  test(function() {
+    assert_approx_equals(
+        childWithIntermediateAndPerspectiveParent.getBoundingClientRect().width,
+        141, 1);
+  }, "Perspective does not apply to DOM normal-flow grandchildren");
+
+  test(function() {
+    assert_approx_equals(
+        absWithIntermediateAndPerspectiveParent.getBoundingClientRect().width,
+        141, 1);
+  }, "Perspective does not apply to DOM abs-pos grandchildren");
+
+  test(function() {
+    assert_approx_equals(
+      fixedWithIntermediateAndPerspectiveParent.getBoundingClientRect().width,
+      141, 1);
+  }, "Perspective does not apply to DOM fixed-pos grandchildren");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/preserve-3d-flat-grouping-properties.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transforms/preserve-3d-flat-grouping-properties.html
@@ -1,0 +1,121 @@
+<!doctype HTML>
+<link rel="author" title="Chris Harrelson" href="mailto:chrishtr@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-transforms-2/#grouping-property-values">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style>
+  .testContainer div {
+    /* Note: .testContainer is just here to prevent this rule from squishing
+       the dynamically-generated human-readable divs that show this test's
+       pass/fail results. */
+    width: 200px;
+    height: 200px;
+  }
+  .parent {
+    transform-style: preserve-3d;
+    transform: rotateY(45deg)
+  }
+
+  .child {
+    transform: rotateY(45deg);
+    background: lightblue
+  }
+</style>
+
+<div class=testContainer>
+  <div class=parent>
+    <div id=nonflat class=child></div>
+  </div>
+
+  <div class=parent style="opacity: 0.5">
+    <div id=opacity class=child></div>
+  </div>
+
+  <div class=parent style="overflow: hidden">
+    <div id=overflowClip class=child></div>
+  </div>
+
+  <div class=parent style="filter: invert(0)">
+    <div id=filter class=child></div>
+  </div>
+
+  <div class=parent style="-webkit-backdrop-filter: invert(0); backdrop-filter: invert(0)">
+    <div id=backdropFilter class=child></div>
+  </div>
+
+  <div class=parent style="mix-blend-mode: multiply;">
+    <div id=mixBlendMode class=child></div>
+  </div>
+
+  <div class=parent style="clip: rect(1px, 2px, 3px, 4px); position: absolute">
+    <div id=cssClip class=child></div>
+  </div>
+
+  <div class=parent style="clip-path: circle(40%)">
+    <div id=clipPath class=child></div>
+  </div>
+
+  <div class=parent style="isolation: isolate">
+    <div id=isolation class=child></div>
+  </div>
+
+  <div class=parent style="-webkit-mask:linear-gradient(black,transparent);
+                           mask:linear-gradient(black,transparent)">
+    <div id=mask class=child></div>
+  </div>
+
+  <div id=parentWithGrouping style="transform-style: preserve-3d; overflow: hidden">
+    <div id=absoluteUnderGrouping style="position: absolute">
+    </div>
+  </div>
+
+  <div id=parentWithoutGrouping style="transform-style: preserve-3d">
+    <div id=absoluteNotUnderGrouping style="position: absolute">
+    </div>
+  </div>
+</div>
+
+<script>
+  nonflatWidth = nonflat.getBoundingClientRect().width;
+
+  test(function() {
+    assert_equals(nonflat.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element not flattened");
+
+  test(function() {
+    assert_not_equals(opacity.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to opacity");
+
+  test(function() {
+    assert_not_equals(overflowClip.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to overflow clip");
+
+  test(function() {
+    assert_not_equals(filter.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to filter");
+
+  test(function() {
+    assert_not_equals(backdropFilter.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to backdrop-filter");
+
+  test(function() {
+    assert_not_equals(mixBlendMode.getBoundingClientRect().width), nonflatWidth;
+  }, "Preserve-3d element flattened due to mix-blend-mode");
+
+  test(function() {
+    assert_not_equals(cssClip.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to clip CSS");
+
+  test(function() {
+    assert_not_equals(clipPath.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to clip-path");
+
+  test(function() {
+    assert_not_equals(isolation.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to isolation");
+
+  test(function() {
+    assert_not_equals(mask.getBoundingClientRect().width, nonflatWidth);
+  }, "Preserve-3d element flattened due to mask");
+</script>


### PR DESCRIPTION
Three-dimensional transforms now flatten wherever the parent element has a used `transform-style` of `flat`. Descendants of such an element render into its plane rather than composing with its ancestors in three dimensions. Perspective still applies to child transforms in three dimensions when the element with perspective is itself flattened. Backface culling accumulates from the flattened space of the plane root.

Geometry queries such as `getBoundingClientRect()` and hit testing now produce the correct results for elements inside 3D rendering contexts or under perspective.

Planes in a 3D rendering context may still be painted in the wrong order. I plan to address 3D depth sorting in a subsequent PR. 

Closes: #8006