### PR TITLE
LibMedia: Prevent compilation failure if audio backend is undefined

### DIFF
--- a/Libraries/LibMedia/Audio/PlaybackStream.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStream.cpp
@@ -8,7 +8,7 @@
 
 namespace Audio {
 
-NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStream::create_platform_or_null(OutputState initial_output_state, u32 target_latency_ms, AudioDataRequestCallback platform_data_request_callback, AudioDataRequestCallback fallback_data_request_callback)
+NonnullRefPtr<PlaybackStream::CreatePromise> PlaybackStream::create_platform_or_null(OutputState initial_output_state, u32 target_latency_ms, [[maybe_unused]] AudioDataRequestCallback platform_data_request_callback, AudioDataRequestCallback fallback_data_request_callback)
 {
     auto promise = PlaybackStream::CreatePromise::construct();
 


### PR DESCRIPTION
When `LIBMEDIA_AUDIO_BACKEND` was undefined, the `platform_data_request_callback` parameter was never used.

Fixes #10972.