### PR TITLE
LibWeb+LibWebView+WebContent: Fire the “paste” event for UI-driven pastes

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4533,6 +4533,13 @@ void LocalNavigable::paste(Utf16View text)
     m_event_handler.perform_paste_action(data_store);
 }
 
+void LocalNavigable::paste_from_clipboard()
+{
+    // Run the whole paste action: It retrieves the system clipboard's contents from the UI process itself, which
+    // preserves every supported clipboard representation — where a bare-text handover would keep only the text.
+    (void)m_event_handler.perform_paste_action();
+}
+
 void LocalNavigable::undo()
 {
     auto document = active_document();

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/BrowsingContextGroup.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/DragDataStore.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
@@ -4516,7 +4517,20 @@ void LocalNavigable::paste(Utf16View text)
     if (!document)
         return;
 
-    m_event_handler.handle_paste(text, {});
+    // The UI process hands off the text to paste: The system clipboard's text for chrome-initiated paste or the primary
+    // selection's text for middle-click paste. Run the paste action with that as the content to paste — so the paste
+    // clipboard event fires, and canceling suppresses the insertion (as for a paste initiated with keyboard shortcut).
+    // INTEROP: For middle-click paste, Gecko and Blink also fire the paste event — with the event's clipboard data
+    //          reading from the primary selection.
+    auto data_store = DragDataStore::create();
+    data_store->add_item({
+        .kind = DragDataStoreItem::Kind::Text,
+        .type_string = "text/plain"_utf16_fly_string,
+        .data = Utf16String::from_utf16(text),
+        .file_data = {},
+        .file_name = {},
+    });
+    m_event_handler.perform_paste_action(data_store);
 }
 
 void LocalNavigable::undo()

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/BrowsingContextGroup.h>
 #include <LibWeb/HTML/DocumentState.h>
+#include <LibWeb/HTML/DragDataStore.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/HTMLBRElement.h>
 #include <LibWeb/HTML/HTMLIFrameElement.h>
@@ -4510,7 +4511,20 @@ void LocalNavigable::paste(Utf16View text)
     if (!document)
         return;
 
-    m_event_handler.handle_paste(text, {});
+    // The UI process hands off the text to paste: The system clipboard's text for chrome-initiated paste or the primary
+    // selection's text for middle-click paste. Run the paste action with that as the content to paste — so the paste
+    // clipboard event fires, and canceling suppresses the insertion (as for a paste initiated with keyboard shortcut).
+    // INTEROP: For middle-click paste, Gecko and Blink also fire the paste event — with the event's clipboard data
+    //          reading from the primary selection.
+    auto data_store = DragDataStore::create();
+    data_store->add_item({
+        .kind = DragDataStoreItem::Kind::Text,
+        .type_string = "text/plain"_utf16_fly_string,
+        .data = Utf16String::from_utf16(text),
+        .file_data = {},
+        .file_name = {},
+    });
+    m_event_handler.perform_paste_action(data_store);
 }
 
 void LocalNavigable::undo()

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -4527,6 +4527,13 @@ void LocalNavigable::paste(Utf16View text)
     m_event_handler.perform_paste_action(data_store);
 }
 
+void LocalNavigable::paste_from_clipboard()
+{
+    // Run the whole paste action: It retrieves the system clipboard's contents from the UI process itself, which
+    // preserves every supported clipboard representation — where a bare-text handover would keep only the text.
+    (void)m_event_handler.perform_paste_action();
+}
+
 void LocalNavigable::undo()
 {
     auto document = active_document();

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -259,6 +259,7 @@ public:
     Utf16String cut_selected_text() const;
     void select_all();
     void paste(Utf16View);
+    void paste_from_clipboard();
     void undo();
     void redo();
     void set_marked_text_from_input_method(Utf16View text);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -346,6 +346,11 @@ void Internals::paste(HTML::HTMLElement& target, Utf16String const& text)
     page.focused_navigable().paste(text);
 }
 
+void Internals::paste_from_clipboard()
+{
+    page().focused_navigable().paste_from_clipboard();
+}
+
 void Internals::commit_text()
 {
     page().handle_keydown(UIEvents::Key_Return, 0, 0x0d, false, true);

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -367,6 +367,11 @@ void Internals::paste(HTML::HTMLElement& target, Utf16String const& text)
     page.focused_navigable().paste(text);
 }
 
+void Internals::paste_from_clipboard()
+{
+    page().focused_navigable().paste_from_clipboard();
+}
+
 void Internals::commit_text()
 {
     page().handle_keydown(UIEvents::Key_Return, 0, 0x0d, false, true);

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -65,6 +65,7 @@ public:
     void send_text(HTML::HTMLElement&, Utf16String const&, WebIDL::UnsignedShort modifiers);
     void send_key(HTML::HTMLElement&, Utf16String const&, WebIDL::UnsignedShort modifiers);
     void paste(HTML::HTMLElement& target, Utf16String const& text);
+    void paste_from_clipboard();
     void commit_text();
 
     // Low-level mouse primitives

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -52,6 +52,7 @@ public:
     void send_text(HTML::HTMLElement&, Utf16String const&, WebIDL::UnsignedShort modifiers);
     void send_key(HTML::HTMLElement&, Utf16String const&, WebIDL::UnsignedShort modifiers);
     void paste(HTML::HTMLElement& target, Utf16String const& text);
+    void paste_from_clipboard();
     void commit_text();
 
     // Low-level mouse primitives

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -34,6 +34,7 @@ interface Internals {
     undefined sendText(HTMLElement target, Utf16DOMString text, optional unsigned short modifiers = 0);
     undefined sendKey(HTMLElement target, Utf16DOMString keyName, optional unsigned short modifiers = 0);
     undefined paste(HTMLElement target, Utf16DOMString text);
+    undefined pasteFromClipboard();
     undefined commitText();
 
     // Low-level mouse primitives

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -31,6 +31,7 @@ interface Internals {
     undefined sendText(HTMLElement target, Utf16DOMString text, optional unsigned short modifiers = 0);
     undefined sendKey(HTMLElement target, Utf16DOMString keyName, optional unsigned short modifiers = 0);
     undefined paste(HTMLElement target, Utf16DOMString text);
+    undefined pasteFromClipboard();
     undefined commitText();
 
     // Low-level mouse primitives

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1693,8 +1693,8 @@ EventResult EventHandler::perform_paste_action()
     if (!document || !document->is_fully_active())
         return EventResult::Dropped;
 
-    // NB: The system clipboard lives in the UI process, so retrieve its contents first and fire the paste event once
-    //     they arrive.
+    // NB: The system clipboard lives in the UI process. So, retrieve its contents first — and run the rest of the paste
+    //     action once the contents arrive.
     document->page().request_clipboard_entries(GC::create_function(document->heap(), [document = GC::Ref { *document }](Vector<Clipboard::SystemClipboardItem> items) {
         auto data_store = HTML::DragDataStore::create();
         if (!items.is_empty()) {
@@ -1717,35 +1717,51 @@ EventResult EventHandler::perform_paste_action()
                 });
             }
         }
-        data_store->set_mode(HTML::DragDataStore::Mode::ReadOnly);
-        auto data_transfer = HTML::DataTransfer::create(data_store);
-
-        // 2. Fire a clipboard event named paste.
-        bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::paste, data_transfer);
-        data_store->set_mode(HTML::DragDataStore::Mode::Protected);
-
-        // 3. If the event was not canceled, then: if there is a selection or cursor in an editable context where
-        //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
-        if (event_was_not_canceled) {
-            Optional<Utf16View> html;
-            Utf16View plain_text;
-            for (auto const& item : data_store->item_list()) {
-                if (item.kind != HTML::DragDataStoreItem::Kind::Text)
-                    continue;
-                if (item.type_string == u"text/html"sv)
-                    html = item.data;
-                else if (item.type_string == u"text/plain"sv)
-                    plain_text = item.data;
-            }
-            if (auto navigable = document->navigable(); html.has_value() || !plain_text.is_empty())
-                navigable->event_handler().handle_paste(plain_text, html);
-        }
+        if (auto navigable = document->navigable())
+            navigable->event_handler().perform_paste_action(data_store);
     }));
 
     return EventResult::Handled;
 }
 
-EventResult EventHandler::handle_paste(Utf16View plain_text, Optional<Utf16View> html)
+// https://w3c.github.io/clipboard-apis/#the-paste-action
+// This is the paste action from the point where the content to paste is already in hand, either because async retrieval
+// of the system clipboard's contents above finished, or because the paste arrived through LocalNavigable::paste() —
+// which the UI process hands the content to paste directly.
+EventResult EventHandler::perform_paste_action(NonnullRefPtr<HTML::DragDataStore> const& data_store)
+{
+    auto document = m_navigable->active_document();
+    if (!document || !document->is_fully_active())
+        return EventResult::Dropped;
+
+    data_store->set_mode(HTML::DragDataStore::Mode::ReadOnly);
+    auto data_transfer = HTML::DataTransfer::create(data_store);
+
+    // 2. Fire a clipboard event named paste.
+    bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::paste, data_transfer);
+    data_store->set_mode(HTML::DragDataStore::Mode::Protected);
+
+    // 3. If the event was not canceled, then: if there is a selection or cursor in an editable context where
+    //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
+    if (event_was_not_canceled) {
+        Optional<Utf16View> html;
+        Utf16View plain_text;
+        for (auto const& item : data_store->item_list()) {
+            if (item.kind != HTML::DragDataStoreItem::Kind::Text)
+                continue;
+            if (item.type_string == u"text/html"sv)
+                html = item.data;
+            else if (item.type_string == u"text/plain"sv)
+                plain_text = item.data;
+        }
+        if (html.has_value() || !plain_text.is_empty())
+            return insert_pasted_content(plain_text, html);
+    }
+
+    return EventResult::Handled;
+}
+
+EventResult EventHandler::insert_pasted_content(Utf16View plain_text, Optional<Utf16View> html)
 {
     auto active_document = m_navigable->active_document();
     if (!active_document)

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1743,6 +1743,7 @@ EventResult EventHandler::perform_paste_action(NonnullRefPtr<HTML::DragDataStore
 
     // 3. If the event was not canceled, then: if there is a selection or cursor in an editable context where
     //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
+    auto result = EventResult::Handled;
     if (event_was_not_canceled) {
         Optional<Utf16View> html;
         Utf16View plain_text;
@@ -1755,10 +1756,16 @@ EventResult EventHandler::perform_paste_action(NonnullRefPtr<HTML::DragDataStore
                 plain_text = item.data;
         }
         if (html.has_value() || !plain_text.is_empty())
-            return insert_pasted_content(plain_text, html);
+            result = insert_pasted_content(plain_text, html);
     }
 
-    return EventResult::Handled;
+    // The trigger starting a paste can finish before the paste action does — so any input-method state pushed to the UI
+    // when the trigger finishes carries the state from before the paste. Notify the client here — where every paste
+    // completes — so it can push fresh state. This also covers a canceled paste event — since the page's paste handler
+    // may itself have edited the document.
+    document->page().client().page_did_complete_paste_action();
+
+    return result;
 }
 
 EventResult EventHandler::insert_pasted_content(Utf16View plain_text, Optional<Utf16View> html)

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1693,8 +1693,8 @@ EventResult EventHandler::perform_paste_action()
     if (!document || !document->is_fully_active())
         return EventResult::Dropped;
 
-    // NB: The system clipboard lives in the UI process, so retrieve its contents first and fire the paste event once
-    //     they arrive.
+    // NB: The system clipboard lives in the UI process. So, retrieve its contents first — and run the rest of the paste
+    //     action once the contents arrive.
     document->page().request_clipboard_entries(GC::create_function(document->heap(), [document = GC::Ref { *document }](Vector<Clipboard::SystemClipboardItem> items) {
         auto data_store = HTML::DragDataStore::create();
         if (!items.is_empty()) {
@@ -1717,35 +1717,51 @@ EventResult EventHandler::perform_paste_action()
                 });
             }
         }
-        data_store->set_mode(HTML::DragDataStore::Mode::ReadOnly);
-        auto data_transfer = HTML::DataTransfer::create(document->realm(), data_store);
-
-        // 2. Fire a clipboard event named paste.
-        bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::paste, data_transfer);
-        data_store->set_mode(HTML::DragDataStore::Mode::Protected);
-
-        // 3. If the event was not canceled, then: if there is a selection or cursor in an editable context where
-        //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
-        if (event_was_not_canceled) {
-            Optional<Utf16View> html;
-            Utf16View plain_text;
-            for (auto const& item : data_store->item_list()) {
-                if (item.kind != HTML::DragDataStoreItem::Kind::Text)
-                    continue;
-                if (item.type_string == u"text/html"sv)
-                    html = item.data;
-                else if (item.type_string == u"text/plain"sv)
-                    plain_text = item.data;
-            }
-            if (auto navigable = document->navigable(); html.has_value() || !plain_text.is_empty())
-                navigable->event_handler().handle_paste(plain_text, html);
-        }
+        if (auto navigable = document->navigable())
+            navigable->event_handler().perform_paste_action(data_store);
     }));
 
     return EventResult::Handled;
 }
 
-EventResult EventHandler::handle_paste(Utf16View plain_text, Optional<Utf16View> html)
+// https://w3c.github.io/clipboard-apis/#the-paste-action
+// This is the paste action from the point where the content to paste is already in hand, either because async retrieval
+// of the system clipboard's contents above finished, or because the paste arrived through LocalNavigable::paste() —
+// which the UI process hands the content to paste directly.
+EventResult EventHandler::perform_paste_action(NonnullRefPtr<HTML::DragDataStore> const& data_store)
+{
+    auto document = m_navigable->active_document();
+    if (!document || !document->is_fully_active())
+        return EventResult::Dropped;
+
+    data_store->set_mode(HTML::DragDataStore::Mode::ReadOnly);
+    auto data_transfer = HTML::DataTransfer::create(document->realm(), data_store);
+
+    // 2. Fire a clipboard event named paste.
+    bool event_was_not_canceled = fire_clipboard_event(*document, HTML::EventNames::paste, data_transfer);
+    data_store->set_mode(HTML::DragDataStore::Mode::Protected);
+
+    // 3. If the event was not canceled, then: if there is a selection or cursor in an editable context where
+    //    pasting is enabled, insert the most suitable content found on the clipboard, if any, into the context.
+    if (event_was_not_canceled) {
+        Optional<Utf16View> html;
+        Utf16View plain_text;
+        for (auto const& item : data_store->item_list()) {
+            if (item.kind != HTML::DragDataStoreItem::Kind::Text)
+                continue;
+            if (item.type_string == u"text/html"sv)
+                html = item.data;
+            else if (item.type_string == u"text/plain"sv)
+                plain_text = item.data;
+        }
+        if (html.has_value() || !plain_text.is_empty())
+            return insert_pasted_content(plain_text, html);
+    }
+
+    return EventResult::Handled;
+}
+
+EventResult EventHandler::insert_pasted_content(Utf16View plain_text, Optional<Utf16View> html)
 {
     auto active_document = m_navigable->active_document();
     if (!active_document)

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -59,6 +59,7 @@ public:
 
     EventResult handle_drag_and_drop_event(DragEvent::Type, CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);
     EventResult handle_pinch_event(CSSPixelPoint, unsigned modifiers, double scale_delta);
+    [[nodiscard]] EventResult perform_paste_action();
     EventResult perform_paste_action(NonnullRefPtr<HTML::DragDataStore> const&);
     void handle_sdl_input_events();
 
@@ -91,7 +92,6 @@ private:
 
     [[nodiscard]] EventResult perform_copy_action();
     [[nodiscard]] EventResult perform_cut_action();
-    [[nodiscard]] EventResult perform_paste_action();
     EventResult insert_pasted_content(Utf16View plain_text, Optional<Utf16View> html);
 
     EventResult focus_next_element();

--- a/Libraries/LibWeb/Page/EventHandler.h
+++ b/Libraries/LibWeb/Page/EventHandler.h
@@ -59,7 +59,7 @@ public:
 
     EventResult handle_drag_and_drop_event(DragEvent::Type, CSSPixelPoint, CSSPixelPoint screen_position, unsigned button, unsigned buttons, unsigned modifiers, Vector<HTML::SelectedFile> files);
     EventResult handle_pinch_event(CSSPixelPoint, unsigned modifiers, double scale_delta);
-    EventResult handle_paste(Utf16View plain_text, Optional<Utf16View> html);
+    EventResult perform_paste_action(NonnullRefPtr<HTML::DragDataStore> const&);
     void handle_sdl_input_events();
 
     void process_auto_scroll();
@@ -92,6 +92,7 @@ private:
     [[nodiscard]] EventResult perform_copy_action();
     [[nodiscard]] EventResult perform_cut_action();
     [[nodiscard]] EventResult perform_paste_action();
+    EventResult insert_pasted_content(Utf16View plain_text, Optional<Utf16View> html);
 
     EventResult focus_next_element();
     EventResult focus_previous_element();

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -654,6 +654,7 @@ public:
     virtual void page_did_insert_clipboard_item(Clipboard::SystemClipboardItem const&, [[maybe_unused]] StringView presentation_style) { }
     virtual void page_did_request_clipboard_entries([[maybe_unused]] u64 request_id) { }
     virtual void page_did_request_primary_paste() { }
+    virtual void page_did_complete_paste_action() { }
     virtual void page_did_update_primary_selection(Utf16String const&) { }
 
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1812,7 +1812,7 @@ void Application::initialize_actions()
     });
     m_paste_action = Action::create("Paste"sv, ActionID::Paste, [this]() {
         if (auto view = active_web_view(); view.has_value())
-            view->paste_text_from_clipboard();
+            view->paste_from_clipboard();
     });
     m_select_all_action = Action::create("Select All"sv, ActionID::SelectAll, [this]() {
         if (auto view = active_web_view(); view.has_value())

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1796,7 +1796,7 @@ void Application::initialize_actions()
     });
     m_paste_action = Action::create("Paste"sv, ActionID::Paste, [this]() {
         if (auto view = active_web_view(); view.has_value())
-            view->paste_text_from_clipboard();
+            view->paste_from_clipboard();
     });
     m_select_all_action = Action::create("Select All"sv, ActionID::SelectAll, [this]() {
         if (auto view = active_web_view(); view.has_value())

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1231,9 +1231,9 @@ void ViewImplementation::select_dropdown_closed(Optional<u32> const& selected_it
     client().async_select_dropdown_closed(page_id(), selected_item_id);
 }
 
-void ViewImplementation::paste_text_from_clipboard()
+void ViewImplementation::paste_from_clipboard()
 {
-    client().async_paste(page_id(), Application::the().clipboard_text());
+    client().async_paste_from_clipboard(page_id());
 }
 
 void ViewImplementation::set_marked_text_from_input_method(Utf16String const& text)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -249,7 +249,7 @@ public:
     void file_picker_closed(Vector<Web::HTML::SelectedFile> selected_files);
     void select_dropdown_closed(Optional<u32> const& selected_item_id);
 
-    void paste_text_from_clipboard();
+    void paste_from_clipboard();
     void retrieved_clipboard_entries(u64 request_id, ReadonlySpan<Web::Clipboard::SystemClipboardItem>);
 
     // Used by platform input methods to drive marked/preedit-text composition, and to query the on-screen caret

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2229,14 +2229,12 @@ void ConnectionFromClient::paste(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().paste(text);
-    update_input_method_state(page_id);
 }
 
 void ConnectionFromClient::paste_from_clipboard(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().paste_from_clipboard();
-    update_input_method_state(page_id);
 }
 
 void ConnectionFromClient::set_marked_text_from_input_method(u64 page_id, Utf16String text)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2232,6 +2232,13 @@ void ConnectionFromClient::paste(u64 page_id, Utf16String text)
     update_input_method_state(page_id);
 }
 
+void ConnectionFromClient::paste_from_clipboard(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().focused_navigable().paste_from_clipboard();
+    update_input_method_state(page_id);
+}
+
 void ConnectionFromClient::set_marked_text_from_input_method(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2224,6 +2224,13 @@ void ConnectionFromClient::paste(u64 page_id, Utf16String text)
     update_input_method_state(page_id);
 }
 
+void ConnectionFromClient::paste_from_clipboard(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().focused_navigable().paste_from_clipboard();
+    update_input_method_state(page_id);
+}
+
 void ConnectionFromClient::set_marked_text_from_input_method(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -2221,14 +2221,12 @@ void ConnectionFromClient::paste(u64 page_id, Utf16String text)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().paste(text);
-    update_input_method_state(page_id);
 }
 
 void ConnectionFromClient::paste_from_clipboard(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())
         page->page().focused_navigable().paste_from_clipboard();
-    update_input_method_state(page_id);
 }
 
 void ConnectionFromClient::set_marked_text_from_input_method(u64 page_id, Utf16String text)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -221,6 +221,7 @@ private:
     virtual void find_in_page_previous_match(u64 page_id) override;
 
     virtual void paste(u64 page_id, Utf16String text) override;
+    virtual void paste_from_clipboard(u64 page_id) override;
     virtual void set_marked_text_from_input_method(u64 page_id, Utf16String text) override;
     virtual void commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length) override;
     virtual void unmark_text_from_input_method(u64 page_id) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -220,6 +220,7 @@ private:
     virtual void find_in_page_previous_match(u64 page_id) override;
 
     virtual void paste(u64 page_id, Utf16String text) override;
+    virtual void paste_from_clipboard(u64 page_id) override;
     virtual void set_marked_text_from_input_method(u64 page_id, Utf16String text) override;
     virtual void commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length) override;
     virtual void unmark_text_from_input_method(u64 page_id) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1397,6 +1397,11 @@ void PageClient::page_did_request_primary_paste()
     client().async_did_request_primary_paste(m_id);
 }
 
+void PageClient::page_did_complete_paste_action()
+{
+    client().update_input_method_state(m_id);
+}
+
 void PageClient::page_did_update_primary_selection(Utf16String const& text)
 {
     client().async_did_update_primary_selection(m_id, text.to_utf8());

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -1372,6 +1372,11 @@ void PageClient::page_did_request_primary_paste()
     client().async_did_request_primary_paste(m_id);
 }
 
+void PageClient::page_did_complete_paste_action()
+{
+    client().update_input_method_state(m_id);
+}
+
 void PageClient::page_did_update_primary_selection(Utf16String const& text)
 {
     client().async_did_update_primary_selection(m_id, text.to_utf8());

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -288,6 +288,7 @@ private:
     virtual void page_did_insert_clipboard_item(Web::Clipboard::SystemClipboardItem const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_request_primary_paste() override;
+    virtual void page_did_complete_paste_action() override;
     virtual void page_did_update_primary_selection(Utf16String const&) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual void page_did_change_screen_wake_lock_state(Web::ScreenWakeLockState) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -283,6 +283,7 @@ private:
     virtual void page_did_insert_clipboard_item(Web::Clipboard::SystemClipboardItem const&, StringView presentation_style) override;
     virtual void page_did_request_clipboard_entries(u64 request_id) override;
     virtual void page_did_request_primary_paste() override;
+    virtual void page_did_complete_paste_action() override;
     virtual void page_did_update_primary_selection(Utf16String const&) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual void page_did_change_screen_wake_lock_state(Web::ScreenWakeLockState) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -150,6 +150,7 @@ endpoint WebContentServer
     undo(u64 page_id) =|
     redo(u64 page_id) =|
     paste(u64 page_id, Utf16String text) =|
+    paste_from_clipboard(u64 page_id) =|
     set_marked_text_from_input_method(u64 page_id, Utf16String text) =|
     commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length) =|
     unmark_text_from_input_method(u64 page_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -149,6 +149,7 @@ endpoint WebContentServer
     undo(u64 page_id) =|
     redo(u64 page_id) =|
     paste(u64 page_id, Utf16String text) =|
+    paste_from_clipboard(u64 page_id) =|
     set_marked_text_from_input_method(u64 page_id, Utf16String text) =|
     commit_text_from_input_method(u64 page_id, Utf16String text, i32 replacement_start, i32 replacement_length) =|
     unmark_text_from_input_method(u64 page_id) =|

--- a/Tests/LibWeb/Text/expected/Editing/clipboard-chrome-paste-preserves-flavors.txt
+++ b/Tests/LibWeb/Text/expected/Editing/clipboard-chrome-paste-preserves-flavors.txt
@@ -1,0 +1,3 @@
+text handover types: ["text/plain"]
+clipboard paste: types=["text/plain","text/html"] html="<b>html flavor</b>"
+editor after clipboard paste: <b>html flavor</b>

--- a/Tests/LibWeb/Text/expected/Editing/clipboard-ui-initiated-paste.txt
+++ b/Tests/LibWeb/Text/expected/Editing/clipboard-ui-initiated-paste.txt
@@ -1,0 +1,7 @@
+paste events: paste(bubbles=true cancelable=true composed=true isTrusted=true types=["text/plain"] data="pasted text") beforeinput(inputType=insertFromPaste data="pasted text")
+value after paste: "pasted text"
+canceled paste events: paste(bubbles=true cancelable=true composed=true isTrusted=true types=["text/plain"] data="must not appear")
+value after canceled paste: ""
+verification code fields: 1 2 3 4 5 6
+non-editable paste events: paste(data="nowhere to go")
+values after non-editable paste: "" "not editable"

--- a/Tests/LibWeb/Text/input/Editing/clipboard-chrome-paste-preserves-flavors.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-chrome-paste-preserves-flavors.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="editor" contenteditable="true">seed</div>
+<script>
+    asyncTest(async done => {
+        const modCtrl = (1 << 1) | (1 << 3); // Ctrl and Super, to cover the platform clipboard modifier everywhere.
+        const editor = document.getElementById("editor");
+        const withTimeout = (promise, what) => Promise.race([
+            promise,
+            new Promise((_, reject) => setTimeout(
+                () => reject(new Error(`Timed out after 10000 ms awaiting ${what}`)), 10000)),
+        ]);
+
+        // Seed the system clipboard with both a text/plain and a text/html representation – by canceling a copy event:
+        // A canceled copy writes the event's data to the clipboard instead.
+        editor.focus();
+        getSelection().selectAllChildren(editor);
+        editor.addEventListener("copy", e => {
+            e.preventDefault();
+            e.clipboardData.setData("text/plain", "plain flavor");
+            e.clipboardData.setData("text/html", "<b>html flavor</b>");
+        }, { once: true });
+        internals.sendKey(editor, "C", modCtrl);
+
+        // A paste whose content is handed over as bare text (middle-click primary paste) carries only that text.
+        const textPasteTypes = new Promise(resolve => {
+            editor.addEventListener("paste", e => {
+                e.preventDefault();
+                resolve(JSON.stringify(e.clipboardData.types));
+            }, { once: true });
+        });
+        internals.paste(editor, "bare text");
+        println(`text handover types: ${await textPasteTypes}`);
+
+        // A chrome-initiated paste of the system clipboard (context-menu or menu-bar Paste) runs the whole paste
+        // action — which retrieves the clipboard's contents itself, and so preserves every supported representation.
+        const clipboardPaste = withTimeout(new Promise(resolve => {
+            editor.addEventListener("paste", e => {
+                resolve(`types=${JSON.stringify(e.clipboardData.types)} html=${JSON.stringify(e.clipboardData.getData("text/html"))}`);
+            }, { once: true });
+        }), "the paste event after internals.pasteFromClipboard()");
+        internals.pasteFromClipboard();
+        println(`clipboard paste: ${await clipboardPaste}`);
+        const deadline = performance.now() + 10000;
+        while (editor.innerHTML === "seed") {
+            if (performance.now() > deadline)
+                throw new Error("Timed out after 10000 ms awaiting the clipboard paste insertion");
+            await new Promise(resolve => requestAnimationFrame(resolve));
+        }
+        println(`editor after clipboard paste: ${editor.innerHTML}`);
+        done();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-ui-initiated-paste.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-ui-initiated-paste.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input id="plain">
+<div id="otp">
+    <input maxlength="1"><input maxlength="1"><input maxlength="1"><input maxlength="1"><input maxlength="1"><input maxlength="1">
+</div>
+<div id="inert">not editable</div>
+<script>
+    test(() => {
+        // A paste handed over by the UI process (context-menu paste, middle-click primary paste on platforms that have
+        // a primary selection) must fire the paste clipboard event — exactly like a paste initiated with the keyboard
+        // shortcut. internals.paste() enters through the same LocalNavigable::paste() path as the UI process does.
+        const plain = document.getElementById("plain");
+
+        const log = [];
+        plain.addEventListener("paste", e => {
+            log.push(`paste(bubbles=${e.bubbles} cancelable=${e.cancelable} composed=${e.composed} isTrusted=${e.isTrusted} types=${JSON.stringify(e.clipboardData.types)} data=${JSON.stringify(e.clipboardData.getData("text/plain"))})`);
+        });
+        plain.addEventListener("beforeinput", e => {
+            log.push(`beforeinput(inputType=${e.inputType} data=${JSON.stringify(e.data)})`);
+        });
+
+        internals.paste(plain, "pasted text");
+        println(`paste events: ${log.join(" ")}`);
+        println(`value after paste: ${JSON.stringify(plain.value)}`);
+
+        // Canceling the paste event must suppress the insertion.
+        log.length = 0;
+        plain.value = "";
+        plain.addEventListener("paste", e => e.preventDefault(), { once: true });
+        internals.paste(plain, "must not appear");
+        println(`canceled paste events: ${log.join(" ")}`);
+        println(`value after canceled paste: ${JSON.stringify(plain.value)}`);
+
+        // A verification-code form intercepts the paste event and spreads the pasted code across its six single-
+        // character fields.
+        const fields = [...document.querySelectorAll("#otp input")];
+        fields[0].addEventListener("paste", e => {
+            e.preventDefault();
+            const code = e.clipboardData.getData("text/plain");
+            [...code].slice(0, fields.length).forEach((character, i) => fields[i].value = character);
+        });
+        internals.paste(fields[0], "123456");
+        println(`verification code fields: ${fields.map(field => field.value).join(" ")}`);
+
+        // The paste event fires even when nothing is focused and nothing is editable at the paste target; the
+        // insertion is simply skipped then.
+        document.activeElement.blur();
+        getSelection().removeAllRanges();
+        const inertLog = [];
+        document.addEventListener("paste", e => {
+            inertLog.push(`paste(data=${JSON.stringify(e.clipboardData.getData("text/plain"))})`);
+        }, { once: true });
+        internals.paste(document.getElementById("inert"), "nowhere to go");
+        println(`non-editable paste events: ${inertLog.join(" ")}`);
+        println(`values after non-editable paste: ${JSON.stringify(plain.value)} ${JSON.stringify(document.getElementById("inert").textContent)}`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** Pasting with the context menu’s **Paste** item — or with a middle-click primary paste on platforms having a primary selection — inserted the pasted text without firing the `paste` clipboard event. Pages which react to that event (such as verification-code forms that spread the pasted code across one field per character) never saw those pastes — while the same pastes done with <kbd>Ctrl</kbd>+<kbd>V</kbd> work as expected. Separately, a chrome-initiated paste delivered only the clipboard’s plain text — so, the event’s clipboard data and the inserted content lacked the `text/html` representation that <kbd>Ctrl</kbd>+<kbd>V</kbd> preserves.

**Cause:** Both broken paste paths funnel through one IPC message whose handler calls `LocalNavigable::paste()`, which goes straight to `EventHandler::handle_paste()` — the paste action’s insertion half. The half that builds a `DataTransfer` and fires the `paste` event lived only in `EventHandler::perform_paste_action()`, which only the <kbd>Ctrl</kbd>+<kbd>V</kbd> keyboard path reached. The lost flavors have a separate cause: the **Paste** action read the clipboard’s text in the UI process, and shipped that bare text to WebContent — dropping every other representation before the paste action ran.

**Fix:** Hoist the firing-and-inserting tail of the paste action into an overload of `perform_paste_action()` taking the content to paste as a drag data store — and make `LocalNavigable::paste()` run that whole tail with the text the UI process handed over. Canceling the event now suppresses the insertion on those paths too — matching the spec and the keyboard path. The insertion half is renamed `insert_pasted_content()` and made private — so no future entry point can mistake it for the whole paste action. For the chrome paste, ship no text at all: Instead, send a paste-from-clipboard request, and let WebContent run the same paste action the <kbd>Ctrl</kbd>+<kbd>V</kbd>path runs — retrieving the clipboard from the UI process with all supported representations intact. Fixes https://github.com/LadybirdBrowser/ladybird/issues/11005.

Gecko and Blink likewise fire `paste` for middle-click pastes — with the event’s clipboard data reading from the primary selection ([`EventStateManager::HandleMiddleClickPaste`](https://searchfox.org/mozilla-central/source/dom/events/EventStateManager.cpp), [`ClipboardCommands::ExecutePasteGlobalSelection`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/commands/clipboard_commands.cc)); in Blink, middle-click paste routes into the same `Paste()` routine as Ctrl+V — whose first act is dispatching the event.

This also fixes a latent crash on the <kbd>Ctrl</kbd>+<kbd>V</kbd> path: The completion lambda ran `if (auto navigable = document->navigable(); html.has_value() || !plain_text.is_empty())`, whose condition never tested `navigable` — so a doc detached from its navigable during the clipboard round-trip, with a non-empty clipboard, dereferenced null.

