### PR TITLE
LibWeb: Remove per-element computed style overrides

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -915,6 +915,7 @@ void StyleComputer::collect_animations_into(DOM::AbstractElement abstract_elemen
 void StyleComputer::collect_animations_into(DOM::AbstractElement abstract_element, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>> effects, ComputedProperties& computed_properties) const
 {
     collect_animation_effects_into(abstract_element, effects, computed_properties, nullptr);
+    adjust_animated_element_style_if_needed(computed_properties, abstract_element);
 }
 
 void StyleComputer::collect_animation_effects_into(DOM::AbstractElement abstract_element, ReadonlySpan<GC::Ref<Animations::KeyframeEffect>> effects, ComputedProperties& computed_properties, ComputedProperties::Builder* builder) const
@@ -2995,27 +2996,40 @@ static ComputedValuesFFI::FfiBoxTypeTransformationInput make_box_type_transforma
     };
 }
 
-static void apply_box_type_transformation(ComputedProperties::Builder& builder, ComputedValuesFFI::FfiDisplay const& display_before, ComputedValuesFFI::FfiBoxTypeTransformation const& transformation)
-{
-    builder.set_display_before_box_type_transformation(display_from_ffi_display(display_before));
-    if (transformation.set_float_none)
-        builder.set_property(PropertyID::Float, KeywordStyleValue::create(Keyword::None));
-    if (transformation.changed_display)
-        builder.set_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(transformation.display)));
-}
-
-static ComputedValuesFFI::FfiInputLineHeightMetrics input_line_height_metrics(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element, bool should_measure)
+template<typename Style>
+static ComputedValuesFFI::FfiInputLineHeightMetrics input_line_height_metrics(Style& style, DOM::AbstractElement abstract_element, bool should_measure)
 {
     ComputedValuesFFI::FfiInputLineHeightMetrics line_height_metrics {};
     if (should_measure) {
-        line_height_metrics.current_line_height = builder.line_height(abstract_element.element().document().font_computer()).to_double();
-        line_height_metrics.minimum_line_height = ComputedProperties::normal_line_height(builder.first_available_computed_font(abstract_element.element().document().font_computer())->pixel_metrics()).to_double();
+        line_height_metrics.current_line_height = style.line_height(abstract_element.element().document().font_computer()).to_double();
+        line_height_metrics.minimum_line_height = ComputedProperties::normal_line_height(style.first_available_computed_font(abstract_element.element().document().font_computer())->pixel_metrics()).to_double();
     }
     return line_height_metrics;
 }
 
+template<typename Style, typename SetProperty>
+static void apply_element_style_adjustments(Style& style, DOM::AbstractElement abstract_element, ComputedValuesFFI::FfiElementStyleAdjustments const& adjustments, SetProperty set_property)
+{
+    if (adjustments.box_type.set_float_none)
+        set_property(PropertyID::Float, KeywordStyleValue::create(Keyword::None));
+    if (adjustments.box_type.changed_display)
+        set_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(adjustments.box_type.display)));
+
+    auto const& element_style = adjustments.element_style;
+    if (element_style.changed_display)
+        set_property(PropertyID::Display, DisplayStyleValue::create(display_from_ffi_display(element_style.display)));
+    if (element_style.set_position_static)
+        set_property(PropertyID::Position, KeywordStyleValue::create(Keyword::Static));
+    if (element_style.changed_text_align)
+        set_property(PropertyID::TextAlign, KeywordStyleValue::create(static_cast<Keyword>(element_style.text_align)));
+
+    auto line_height_metrics = input_line_height_metrics(style, abstract_element, element_style.check_input_line_height);
+    if (element_style.set_line_height_normal || (element_style.check_input_line_height && line_height_metrics.current_line_height < line_height_metrics.minimum_line_height))
+        set_property(PropertyID::LineHeight, KeywordStyleValue::create(Keyword::Normal));
+}
+
 // https://drafts.csswg.org/css-display/#transformations
-void StyleComputer::transform_box_type_if_needed(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element) const
+void StyleComputer::adjust_element_style_if_needed(ComputedProperties::Builder& builder, DOM::AbstractElement abstract_element) const
 {
     auto& style = builder.style();
     auto input = make_box_type_transformation_input(
@@ -3023,8 +3037,48 @@ void StyleComputer::transform_box_type_if_needed(ComputedProperties::Builder& bu
         style.display(),
         style.property(PropertyID::Position).to_keyword(),
         style.property(PropertyID::Float).to_keyword());
-    auto transformation = ComputedValuesFFI::rust_transform_box_type(&input);
-    apply_box_type_transformation(builder, input.display, transformation);
+    auto adjustments = ComputedValuesFFI::rust_adjust_element_style(
+        &input, to_underlying(style.property(PropertyID::TextAlign).to_keyword()));
+
+    auto set_adjusted_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> value) {
+        // Animated values are stored separately from the builder's base values, so post-compute
+        // adjustments must replace the sampled value as well.
+        if (style.has_animated_property(property_id)) {
+            auto is_result_of_transition = style.is_animated_property_result_of_transition(property_id)
+                ? AnimatedPropertyResultOfTransition::Yes
+                : AnimatedPropertyResultOfTransition::No;
+            auto inherited = style.is_animated_property_inherited(property_id)
+                ? ComputedProperties::Inherited::Yes
+                : ComputedProperties::Inherited::No;
+            style.set_animated_property(Badge<StyleComputer> {}, property_id, value, is_result_of_transition, inherited);
+        }
+        builder.set_property(property_id, move(value));
+    };
+
+    builder.set_display_before_box_type_transformation(display_from_ffi_display(input.display));
+    apply_element_style_adjustments(builder, abstract_element, adjustments, set_adjusted_property);
+}
+
+void StyleComputer::adjust_animated_element_style_if_needed(ComputedProperties& style, DOM::AbstractElement abstract_element) const
+{
+    auto input = make_box_type_transformation_input(
+        abstract_element,
+        style.display(),
+        style.property(PropertyID::Position).to_keyword(),
+        style.property(PropertyID::Float).to_keyword());
+    auto adjustments = ComputedValuesFFI::rust_adjust_element_style(
+        &input, to_underlying(style.property(PropertyID::TextAlign).to_keyword()));
+
+    auto set_adjusted_property = [&](PropertyID property_id, NonnullRefPtr<StyleValue const> value) {
+        auto is_result_of_transition = style.has_animated_property(property_id) && style.is_animated_property_result_of_transition(property_id)
+            ? AnimatedPropertyResultOfTransition::Yes
+            : AnimatedPropertyResultOfTransition::No;
+        auto inherited = style.has_animated_property(property_id) && style.is_animated_property_inherited(property_id)
+            ? ComputedProperties::Inherited::Yes
+            : ComputedProperties::Inherited::No;
+        style.set_animated_property(Badge<StyleComputer> {}, property_id, move(value), is_result_of_transition, inherited);
+    };
+    apply_element_style_adjustments(style, abstract_element, adjustments, set_adjusted_property);
 }
 
 NonnullRefPtr<ComputedValues const> StyleComputer::create_document_style() const
@@ -3215,7 +3269,7 @@ RefPtr<ComputedProperties> StyleComputer::compute_style_impl(DOM::AbstractElemen
         VERIFY(inherited_pseudo_element_style);
         auto builder = ComputedProperties::create_builder_with_base_values_from(*inherited_pseudo_element_style);
 
-        abstract_element.element().adjust_computed_style(builder);
+        adjust_element_style_if_needed(builder, abstract_element);
         return ComputedProperties::create(move(builder));
     }
 
@@ -3780,17 +3834,13 @@ NonnullRefPtr<ComputedProperties> StyleComputer::compute_properties(DOM::Abstrac
 
     // Run automatic box type transformations again after animations have been applied.
     if (animation_values_applied)
-        transform_box_type_if_needed(builder, abstract_element);
+        adjust_element_style_if_needed(builder, abstract_element);
 
     // Apply any property-specific computed value logic
     if (animation_values_applied)
         resolve_effective_overflow_values(builder);
     if (animation_values_applied || parent_text_align_input_is_animated)
         compute_text_align(builder, abstract_element);
-
-    // Let the element adjust computed style
-    if (animation_values_applied && !abstract_element.pseudo_element().has_value())
-        abstract_element.element().adjust_computed_style(builder);
 
     bool parent_style_in_display_none_subtree = false;
     if (auto parent = abstract_element.element_to_inherit_style_from(); parent.has_value()) {

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -200,7 +200,8 @@ private:
     void compute_custom_properties(ComputedProperties&, DOM::AbstractElement) const;
     void start_needed_transitions(ComputedValues const& old_style, ComputedProperties::Builder& new_style, DOM::AbstractElement) const;
     void resolve_effective_overflow_values(ComputedProperties::Builder&) const;
-    void transform_box_type_if_needed(ComputedProperties::Builder&, DOM::AbstractElement) const;
+    void adjust_element_style_if_needed(ComputedProperties::Builder&, DOM::AbstractElement) const;
+    void adjust_animated_element_style_if_needed(ComputedProperties&, DOM::AbstractElement) const;
 
     [[nodiscard]] CSSPixelRect viewport_rect() const { return m_viewport_rect; }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -385,7 +385,6 @@ public:
     [[nodiscard]] CSSPixelRect bounding_client_rect_assuming_layout_clean() const;
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>);
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) { }
 
     virtual void did_receive_focus() { }
     virtual void did_lose_focus() { }

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -28,15 +28,6 @@ void HTMLAudioElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-void HTMLAudioElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    Base::adjust_computed_style(style);
-
-    // https://html.spec.whatwg.org/multipage/rendering.html#embedded-content-rendering-rules
-    if (!has_attribute(AttributeNames::controls))
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 RefPtr<Layout::Node> HTMLAudioElement::create_layout_node(NonnullRefPtr<CSS::ComputedValues const> style)
 {
     return make_ref_counted<Layout::AudioBox>(document(), *this, style);

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -17,8 +17,6 @@ class HTMLAudioElement final : public HTMLMediaElement {
 public:
     virtual ~HTMLAudioElement() override;
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder& style) override;
-
     Layout::AudioBox* layout_node();
     Layout::AudioBox const* layout_node() const;
 

--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -108,14 +108,4 @@ bool HTMLBRElement::represents_empty_line() const
     return true;
 }
 
-void HTMLBRElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-    else if (!style.display().is_none())
-        // AD-HOC: Prevent other display values from applying, so that we always create a BreakNode
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)));
-}
-
 }

--- a/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -20,8 +20,6 @@ public:
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>) override;
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     // Whether this <br> renders an empty line, i.e. nothing else renders between the start of its line and the <br>
     // itself. Such a <br> hosts a caret position on its parent, at its child index.
     bool represents_empty_line() const;

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -31,23 +31,6 @@ void HTMLButtonElement::initialize(JS::Realm& realm)
     Base::initialize(realm);
 }
 
-void HTMLButtonElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
-    // If the computed value of 'display' is 'inline-grid', 'grid', 'inline-flex', 'flex', 'none', or 'contents', then behave as the computed value.
-    auto display = style.display();
-    if (display.is_flex_inside() || display.is_grid_inside() || display.is_none() || display.is_contents()) {
-        // No-op
-    } else if (display.is_inline_outside()) {
-        // Otherwise, if the computed value of 'display' is a value such that the outer display type is 'inline', then behave as 'inline-block'.
-        // AD-HOC: See https://github.com/whatwg/html/issues/11857
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
-    } else {
-        // Otherwise, behave as 'flow-root'.
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::FlowRoot)));
-    }
-}
-
 HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
 {
     auto value = get_attribute_value_view(HTML::AttributeNames::type);

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -29,8 +29,6 @@ public:
     virtual ~HTMLButtonElement() override;
 
     virtual void initialize(JS::Realm&) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     enum class TypeAttributeState {
 #define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(_, state) state,
         ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTES

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -249,13 +249,6 @@ RefPtr<Layout::Node> HTMLCanvasElement::create_layout_node(NonnullRefPtr<CSS::Co
     return make_ref_counted<Layout::CanvasBox>(document(), *this, style);
 }
 
-void HTMLCanvasElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 JS::ThrowCompletionOr<HTMLCanvasElement::HasOrCreatedContext> HTMLCanvasElement::create_2d_context(JS::Value options)
 {
     if (!m_context.has<Empty>())

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -82,8 +82,6 @@ private:
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     template<typename ContextType>
     JS::ThrowCompletionOr<HasOrCreatedContext> create_webgl_context(JS::Value options);
     WebGL::WebGLRenderingContextBase* webgl_context() const;

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1199,15 +1199,6 @@ void HTMLElement::set_popover(Optional<Utf16String> value)
         remove_attribute(HTML::AttributeNames::popover);
 }
 
-void HTMLElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (local_name() == HTML::TagNames::wbr) {
-        if (style.display().is_contents())
-            style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-    }
-}
-
 // https://html.spec.whatwg.org/multipage/popover.html#check-popover-validity
 // https://whatpr.org/html/9457/popover.html#check-popover-validity
 WebIDL::ExceptionOr<bool> HTMLElement::check_popover_validity(ExpectedToBeShowing expected_to_be_showing, ThrowExceptions throw_exceptions, GC::Ptr<DOM::Document> expected_document, IgnoreDomState ignore_dom_state)

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -202,8 +202,6 @@ protected:
 
     [[nodiscard]] Utf16String get_the_text_steps();
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
 private:
     virtual bool is_html_element() const final { return true; }
 

--- a/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLEmbedElement.cpp
@@ -79,11 +79,4 @@ void HTMLEmbedElement::apply_presentational_hints(Vector<CSS::StyleProperty>& pr
     });
 }
 
-void HTMLEmbedElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 }

--- a/Libraries/LibWeb/HTML/HTMLEmbedElement.h
+++ b/Libraries/LibWeb/HTML/HTMLEmbedElement.h
@@ -24,7 +24,6 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -82,13 +82,6 @@ i32 HTMLFrameElement::default_tab_index_value() const
     return 0;
 }
 
-void HTMLFrameElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 // https://html.spec.whatwg.org/multipage/obsolete.html#process-the-frame-attributes
 void HTMLFrameElement::process_the_frame_attributes(InitialInsertion initial_insertion)
 {

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.h
@@ -29,8 +29,6 @@ private:
     virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
     virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     void process_the_frame_attributes(InitialInsertion = InitialInsertion::No);
 };
 

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -23,13 +23,6 @@ HTMLFrameSetElement::HTMLFrameSetElement(DOM::Document& document, DOM::Qualified
 
 HTMLFrameSetElement::~HTMLFrameSetElement() = default;
 
-void HTMLFrameSetElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 void HTMLFrameSetElement::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLFrameSetElement);

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -26,8 +26,6 @@ private:
 
     virtual bool is_html_frameset_element() const override { return true; }
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     virtual void initialize(JS::Realm&) override;
     virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
 

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -47,13 +47,6 @@ RefPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS::Co
     return make_ref_counted<Layout::NavigableContainerViewport>(document(), *this, style);
 }
 
-void HTMLIFrameElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 void HTMLIFrameElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -24,8 +24,6 @@ public:
     virtual ~HTMLIFrameElement() override;
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     // ^EventTarget
     virtual bool is_focusable() const override
     {

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -349,13 +349,6 @@ void HTMLImageElement::update_alt_text_shadow_tree()
     m_alt_text_node->set_data(alt_text);
 }
 
-void HTMLImageElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-width
 WebIDL::UnsignedLong HTMLImageElement::width() const
 {

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -135,8 +135,6 @@ private:
     virtual bool supports_dimension_attributes() const override { return true; }
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     virtual void did_set_viewport_rect(CSSPixelRect const&) override;
 
     void handle_failed_fetch();

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -182,33 +182,6 @@ RefPtr<Layout::Node> HTMLInputElement::create_layout_node(NonnullRefPtr<CSS::Com
     }
 }
 
-void HTMLInputElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    if (type_state() == TypeAttributeState::Hidden || type_state() == TypeAttributeState::SubmitButton || type_state() == TypeAttributeState::Button || type_state() == TypeAttributeState::ResetButton || type_state() == TypeAttributeState::ImageButton || type_state() == TypeAttributeState::Checkbox || type_state() == TypeAttributeState::RadioButton)
-        return;
-
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-
-    // AD-HOC: We rewrite `display: inline` to `display: inline-block`.
-    //         This is required for the internal shadow tree to work correctly in layout.
-    if (style.display().is_inline_outside() && style.display().is_flow_inside())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
-
-    // https://drafts.csswg.org/css-ui-4/#input-rules
-    // * The content is vertically centered
-    // NB: Blink, WebKit, and Gecko clamp single-line input text to the font's normal line height. This prevents a
-    //     smaller author-specified line height from clipping glyph ink inside the vertically centered editor.
-    if (is_single_line()) {
-        auto current_line_height = style.line_height(document().font_computer()).to_double();
-        auto minimum_line_height = CSS::ComputedProperties::normal_line_height(style.first_available_computed_font(document().font_computer())->pixel_metrics()).to_double();
-
-        if (current_line_height < minimum_line_height)
-            style.set_property(CSS::PropertyID::LineHeight, CSS::KeywordStyleValue::create(CSS::Keyword::Normal));
-    }
-}
-
 void HTMLInputElement::set_checked(bool checked)
 {
     // The dirty checkedness flag must be initially set to false when the element is created,

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -66,7 +66,6 @@ public:
     virtual ~HTMLInputElement() override;
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
     virtual void set_being_activated(bool) override;
 
     enum class TypeAttributeState {

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -204,18 +204,6 @@ void HTMLMediaElement::finalize()
     document().page().unregister_media_element({}, unique_id());
 }
 
-void HTMLMediaElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-
-    // AD-HOC: We rewrite `display: inline` to `display: inline-block`.
-    //         This is required for the internal shadow tree to work correctly in layout.
-    if (style.display().is_inline_outside() && style.display().is_flow_inside())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
-}
-
 // https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task
 void HTMLMediaElement::queue_a_media_element_task(Function<void(HTMLMediaElement&)> steps)
 {

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -54,8 +54,6 @@ public:
         return meets_focusable_area_rendering_requirements();
     }
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder& style) override;
-
     // NOTE: The function is wrapped in a GC::HeapFunction immediately.
     void queue_a_media_element_task(Function<void(HTMLMediaElement&)>);
 

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -170,13 +170,6 @@ void HTMLMeterElement::inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLMeterElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 void HTMLMeterElement::create_shadow_tree_if_needed()
 {
     if (shadow_root())

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.h
@@ -36,8 +36,6 @@ public:
     // ^HTMLElement
     virtual void inserted() override;
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -222,13 +222,6 @@ RefPtr<Layout::Node> HTMLObjectElement::create_layout_node(NonnullRefPtr<CSS::Co
     return nullptr;
 }
 
-void HTMLObjectElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 bool HTMLObjectElement::has_ancestor_media_element_or_object_element_not_showing_fallback_content() const
 {
     for (auto const* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -65,8 +65,6 @@ private:
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::ComputedValues const>) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     bool has_ancestor_media_element_or_object_element_not_showing_fallback_content() const;
 
     void queue_element_task_to_run_object_representation_steps();

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -95,13 +95,6 @@ void HTMLProgressElement::inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLProgressElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-}
-
 void HTMLProgressElement::create_shadow_tree_if_needed()
 {
     if (shadow_root())

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -30,8 +30,6 @@ public:
     // ^HTMLElement
     virtual void inserted() override;
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -79,21 +79,6 @@ void HTMLSelectElement::visit_edges(Cell::Visitor& visitor)
     }
 }
 
-void HTMLSelectElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-
-    // AD-HOC: We rewrite `display: inline` to `display: inline-block`.
-    //         This is required for the internal shadow tree to work correctly in layout.
-    if (style.display().is_inline_outside() && style.display().is_flow_inside())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
-
-    // AD-HOC: Enforce normal line-height for select elements. This matches the behavior of other engines.
-    style.set_property(CSS::PropertyID::LineHeight, CSS::KeywordStyleValue::create(CSS::Keyword::Normal));
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#concept-select-size
 u32 HTMLSelectElement::display_size() const
 {

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -31,8 +31,6 @@ public:
 
     virtual bool is_html_select_element() const final { return true; }
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     WebIDL::UnsignedLong size() const;
     void set_size(WebIDL::UnsignedLong);
 

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -49,17 +49,6 @@ void HTMLTableElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_t_bodies);
 }
 
-void HTMLTableElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    Base::adjust_computed_style(style);
-
-    // Tables must not inherit -libweb-* values for text-align.
-    // FIXME: Find the spec for this.
-    auto text_align = style.style().text_align();
-    if (text_align == CSS::TextAlign::LibwebLeft || text_align == CSS::TextAlign::LibwebCenter || text_align == CSS::TextAlign::LibwebRight)
-        style.set_property(CSS::PropertyID::TextAlign, CSS::KeywordStyleValue::create(CSS::Keyword::Start));
-}
-
 static unsigned parse_border(Utf16View value)
 {
     return parse_non_negative_integer(value).value_or(0);

--- a/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -61,8 +61,6 @@ private:
     virtual bool is_presentational_hint(Utf16FlyString const&) const override;
     virtual void apply_presentational_hints(Vector<CSS::StyleProperty>&) const override;
     virtual void attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_) override;
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     GC::Ptr<DOM::HTMLCollection> mutable m_rows;
     GC::Ptr<DOM::HTMLCollection> mutable m_t_bodies;
     Optional<u32> m_cellpadding;

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -41,18 +41,6 @@ HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, DOM::Qualified
 
 HTMLTextAreaElement::~HTMLTextAreaElement() = default;
 
-void HTMLTextAreaElement::adjust_computed_style(CSS::ComputedProperties::Builder& style)
-{
-    // https://drafts.csswg.org/css-display-3/#unbox
-    if (style.display().is_contents())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
-
-    // AD-HOC: We rewrite `display: inline` to `display: inline-block`.
-    //         This is required for the internal shadow tree to work correctly in layout.
-    if (style.display().is_inline_outside() && style.display().is_flow_inside())
-        style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::InlineBlock)));
-}
-
 void HTMLTextAreaElement::initialize(JS::Realm& realm)
 {
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLTextAreaElement);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -33,8 +33,6 @@ class WEB_API HTMLTextAreaElement final
 public:
     virtual ~HTMLTextAreaElement() override;
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     Utf16FlyString type() const
     {
         return "textarea"_utf16_fly_string;

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -3000,15 +3000,15 @@ pub unsafe extern "C" fn rust_drive_property_computation(
         let float_before = computed_float.expect("float must be computed by the longhand driver");
         box_type_input.float_value = float_before;
         box_type_input.position = computed_position.expect("position must be computed by the longhand driver");
-        let transformation = transform_box_type(&box_type_input);
+        let text_align = computed_text_align.expect("text-align must be computed by the longhand driver");
+        let adjustments = compute_element_style_adjustments(&box_type_input, text_align);
+        let transformation = adjustments.box_type;
+        let element_adjustment = adjustments.element_style;
         let display_after_box_type_transformation = if transformation.changed_display {
             transformation.display
         } else {
             display_before
         };
-        let text_align = computed_text_align.expect("text-align must be computed by the longhand driver");
-        let element_adjustment =
-            adjust_element_style(&box_type_input, display_after_box_type_transformation, text_align);
         if transformation.set_float_none {
             clear_longhand_bit(important_words, prop::FLOAT);
             clear_longhand_bit(inherited_words, prop::FLOAT);
@@ -3290,6 +3290,15 @@ pub struct FfiElementStyleAdjustment {
     pub text_align: u16,
 }
 
+/// The automatic box type transformation and element-specific adjustment,
+/// sequenced as they are in the normal property computation path.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FfiElementStyleAdjustments {
+    pub box_type: FfiBoxTypeTransformation,
+    pub element_style: FfiElementStyleAdjustment,
+}
+
 #[repr(C)]
 pub struct FfiInputLineHeightMetrics {
     pub current_line_height: f64,
@@ -3361,6 +3370,23 @@ fn adjust_element_style(
         set_position_static: input.force_position_static,
         changed_text_align: new_text_align != text_align,
         text_align: new_text_align,
+    }
+}
+
+fn compute_element_style_adjustments(
+    input: &FfiBoxTypeTransformationInput,
+    text_align: u16,
+) -> FfiElementStyleAdjustments {
+    let box_type = transform_box_type(input);
+    let display = if box_type.changed_display {
+        box_type.display
+    } else {
+        input.display
+    };
+    let element_style = adjust_element_style(input, display, text_align);
+    FfiElementStyleAdjustments {
+        box_type,
+        element_style,
     }
 }
 
@@ -3485,11 +3511,12 @@ fn transform_box_type(input: &FfiBoxTypeTransformationInput) -> FfiBoxTypeTransf
 /// # Safety
 /// `input` must be a valid pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn rust_transform_box_type(
+pub unsafe extern "C" fn rust_adjust_element_style(
     input: *const FfiBoxTypeTransformationInput,
-) -> FfiBoxTypeTransformation {
+    text_align: u16,
+) -> FfiElementStyleAdjustments {
     crate::css::ffi_stats::bump(crate::css::ffi_stats::FfiOp::NestedPropertyComputeEntry);
-    abort_on_panic(|| transform_box_type(unsafe { &*input }))
+    abort_on_panic(|| compute_element_style_adjustments(unsafe { &*input }, text_align))
 }
 
 /// Result of resolving the effective overflow pair: each axis' possibly
@@ -3843,6 +3870,19 @@ mod tests {
                 minimum_line_height: 16.0,
             }
         ));
+    }
+
+    #[test]
+    fn element_style_adjustments_follow_box_type_transformation() {
+        let mut input = element_adjustment_input();
+        input.is_button_element = true;
+        input.position = keyword::ABSOLUTE;
+
+        let adjustments = compute_element_style_adjustments(&input, keyword::LEFT);
+        assert!(adjustments.box_type.changed_display);
+        assert!(adjustments.box_type.display.is_block_outside());
+        assert!(adjustments.element_style.changed_display);
+        assert!(adjustments.element_style.display.is_flow_root_inside());
     }
 
     fn test_context() -> FfiLengthResolutionContext {

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -337,29 +337,6 @@ void SVGElement::remove_from_use_element_that_reference_this()
     }
 }
 
-void SVGElement::adjust_computed_style(CSS::ComputedProperties::Builder& computed_properties)
-{
-    Base::adjust_computed_style(computed_properties);
-
-    // An <svg> element that is not in SVG layout participates in CSS box layout
-    // and may be positioned. That includes the outermost <svg>, and <svg>
-    // elements in HTML content inside <foreignObject>.
-    if (is<SVGSVGElement>(*this)) {
-        for (auto ancestor = parent_element(); ancestor; ancestor = ancestor->parent_element()) {
-            if (is<SVGForeignObjectElement>(*ancestor))
-                return;
-            if (is<SVGSVGElement>(*ancestor))
-                break;
-        }
-        if (!owner_svg_element())
-            return;
-    }
-
-    // SVG elements in SVG layout use SVG's coordinate system and must be forced
-    // to position: static.
-    computed_properties.set_property(CSS::PropertyID::Position, CSS::KeywordStyleValue::create(CSS::Keyword::Static));
-}
-
 // https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__classNames
 GC::Ref<SVGAnimatedString> SVGElement::class_name()
 {

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -59,8 +59,6 @@ protected:
     virtual void children_changed(ChildrenChangedMetadata const&) override;
     virtual void inserted() override;
     virtual void removed_from(IsSubtreeRoot, Node* old_ancestor, Node& old_root) override;
-    MUST_UPCALL virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
     void update_use_elements_that_reference_this();
     void remove_from_use_element_that_reference_this();
     void mark_resource_box_referencing_elements_for_layout_tree_update();

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -35,16 +35,6 @@ void SVGSymbolElement::visit_edges(Cell::Visitor& visitor)
     SVGFitToViewBox::visit_edges(visitor);
 }
 
-void SVGSymbolElement::adjust_computed_style(CSS::ComputedProperties::Builder& computed_properties)
-{
-    Base::adjust_computed_style(computed_properties);
-
-    if (is_direct_child_of_use_shadow_tree()) {
-        // The generated instance of a ‘symbol’ that is the direct referenced element of a ‘use’ element must always have a computed value of inline for the display property.
-        computed_properties.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::Inline)));
-    }
-}
-
 void SVGSymbolElement::attribute_changed(Utf16FlyString const& name, Optional<Utf16String> const& old_value, Optional<Utf16String> const& value, Optional<Utf16FlyString> const& namespace_)
 {
     Base::attribute_changed(name, old_value, value, namespace_);

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -19,8 +19,6 @@ class SVGSymbolElement final : public SVGGraphicsElement
 public:
     virtual ~SVGSymbolElement() override = default;
 
-    virtual void adjust_computed_style(CSS::ComputedProperties::Builder&) override;
-
 private:
     virtual bool is_svg_symbol_element() const final { return true; }
 

--- a/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
+++ b/Tests/LibWeb/Text/expected/css/animated-post-compute-adjustments.txt
@@ -8,3 +8,8 @@ inherited overflow-x: scroll
 adjusted overflow-y: auto
 inherited display: block
 inherited position: absolute
+input line-height: normal
+select line-height: normal
+svg position: static
+table text-align: start
+file selector display: inline-block

--- a/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
+++ b/Tests/LibWeb/Text/input/css/animated-post-compute-adjustments.html
@@ -11,6 +11,16 @@
 <div id="inherited-position-parent" style="position: static">
     <div id="inherited-position-child" style="display: inline; position: inherit"></div>
 </div>
+<input id="adjusted-input" style="line-height: 1px">
+<select id="adjusted-select" style="line-height: 1px"></select>
+<svg><g id="adjusted-svg" style="position: absolute"></g></svg>
+<table id="adjusted-table" align="center"></table>
+<input id="file-input" type="file">
+<style>
+    #file-input::file-selector-button {
+        display: inline;
+    }
+</style>
 <script>
     promiseTest(async () => {
         const overflowAnimation = overflow.animate(
@@ -74,5 +84,44 @@
         const inheritedPositionStyle = getComputedStyle(inheritedPositionChild);
         println(`inherited display: ${inheritedPositionStyle.display}`);
         println(`inherited position: ${inheritedPositionStyle.position}`);
+
+        const adjustedInput = document.getElementById("adjusted-input");
+        const inputAnimation = adjustedInput.animate(
+            [{ lineHeight: "1px" }, { lineHeight: "1px" }],
+            { duration: 1000, fill: "forwards" });
+        inputAnimation.pause();
+        inputAnimation.currentTime = 500;
+        await inputAnimation.ready;
+        println(`input line-height: ${getComputedStyle(adjustedInput).lineHeight}`);
+
+        const adjustedSelect = document.getElementById("adjusted-select");
+        const selectAnimation = adjustedSelect.animate(
+            [{ lineHeight: "1px" }, { lineHeight: "1px" }],
+            { duration: 1000, fill: "forwards" });
+        selectAnimation.pause();
+        selectAnimation.currentTime = 500;
+        await selectAnimation.ready;
+        println(`select line-height: ${getComputedStyle(adjustedSelect).lineHeight}`);
+
+        const adjustedSvg = document.getElementById("adjusted-svg");
+        const svgAnimation = adjustedSvg.animate(
+            [{ position: "absolute" }, { position: "absolute" }],
+            { duration: 1000, fill: "forwards" });
+        svgAnimation.pause();
+        svgAnimation.currentTime = 500;
+        await svgAnimation.ready;
+        println(`svg position: ${getComputedStyle(adjustedSvg).position}`);
+
+        const adjustedTable = document.getElementById("adjusted-table");
+        const tableAnimation = adjustedTable.animate(
+            [{ opacity: "1" }, { opacity: "1" }],
+            { duration: 1000, fill: "forwards" });
+        tableAnimation.pause();
+        tableAnimation.currentTime = 500;
+        await tableAnimation.ready;
+        println(`table text-align: ${getComputedStyle(adjustedTable).textAlign}`);
+
+        const fileInput = document.getElementById("file-input");
+        println(`file selector display: ${getComputedStyle(fileInput, "::file-selector-button").display}`);
     });
 </script>


### PR DESCRIPTION
Element-specific computed style adjustments existed in the Rust style computation core and a virtual method on Element. The latter was still required for element-backed shadow pseudo-elements and animation style updates, so the two implementations could silently diverge over time.

Expose a combined box transformation and element adjustment through the Rust FFI and use it for the remaining side paths and per-frame animation samples. Remove the Element virtual and its 20 HTML and SVG overrides. Adjusted animation samples preserve input and select line heights, SVG positioning, and table alignment throughout animated style updates.