### PR TITLE
LibWeb: Switch apply-the-history-step state over to navigable id

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -625,6 +625,15 @@ HashTable<GC::RawRef<LocalNavigable>>& all_local_navigables()
     return *set;
 }
 
+GC::Ptr<LocalNavigable> local_navigable_with_id(CrossProcessId id)
+{
+    for (auto& navigable : all_local_navigables()) {
+        if (navigable->id() == id)
+            return navigable;
+    }
+    return nullptr;
+}
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-session-history-entries
 static Vector<NonnullRefPtr<SessionHistoryEntry>>* get_session_history_entries_if_present(LocalTraversableNavigable& traversable, LocalNavigable const& navigable)
 {

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -501,6 +501,7 @@ private:
 };
 
 WEB_API HashTable<GC::RawRef<LocalNavigable>>& all_local_navigables();
+WEB_API GC::Ptr<LocalNavigable> local_navigable_with_id(CrossProcessId);
 
 Vector<NonnullRefPtr<SessionHistoryEntry>>* append_nested_history_for_child_navigable(
     LocalNavigable& parent_navigable, LocalNavigable& child_navigable, SessionHistoryEntry& history_entry);

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -874,11 +874,7 @@ private:
         visitor.visit(m_expected_ongoing_navigation_navigable);
         visitor.visit(m_on_complete);
         visitor.visit(m_timeout);
-        visitor.visit(m_changing_navigables);
-        visitor.visit(m_non_changing_navigables);
         visitor.visit(m_continuations);
-        for (auto& navigable : m_navigables_that_must_wait_before_handling_sync_navigation)
-            visitor.visit(navigable);
     }
 
     void try_advance()
@@ -930,15 +926,15 @@ private:
     GC::Ptr<OnApplyHistoryStepComplete> m_on_complete;
     GC::Ref<Platform::Timer> m_timeout;
 
-    Vector<GC::Ref<LocalNavigable>> m_changing_navigables;
-    Vector<GC::Ref<LocalNavigable>> m_non_changing_navigables;
+    Vector<CrossProcessId> m_changing_navigables;
+    Vector<CrossProcessId> m_non_changing_navigables;
 
     size_t m_completed_change_jobs { 0 };
     Vector<GC::Ref<ChangingNavigableContinuationState>> m_continuations;
     size_t m_continuation_index { 0 };
 
     RefPtr<Core::Promise<Empty>> m_pending_sync_nav_promise;
-    HashTable<GC::Ref<LocalNavigable>> m_navigables_that_must_wait_before_handling_sync_navigation;
+    HashTable<CrossProcessId> m_navigables_that_must_wait_before_handling_sync_navigation;
 
     size_t m_completed_non_changing_jobs { 0 };
 };
@@ -958,8 +954,8 @@ void ApplyHistoryStepState::start()
 
     // 7. Let nonchangingNavigablesThatStillNeedUpdates be the result of getting all navigables that only need history object length/index update given traversable and targetStep.
     auto non_changing_navigables = m_traversable->get_all_local_navigables_that_only_need_history_object_length_index_update(m_target_step);
-    for (auto& nav : non_changing_navigables)
-        m_non_changing_navigables.append(*nav);
+    for (auto& navigable : non_changing_navigables)
+        m_non_changing_navigables.append(navigable->id());
 
     // 8. For each navigable of changingNavigables:
     auto changing_navigables = m_traversable->get_all_local_navigables_whose_current_session_history_entry_will_change_or_reload(m_target_step);
@@ -1013,16 +1009,18 @@ void ApplyHistoryStepState::start()
         // 3. Set navigable's ongoing navigation to "traversal".
         navigable->set_ongoing_navigation(HTML::LocalNavigable::Traversal::Tag, m_navigation_api_abort_behavior);
 
-        m_changing_navigables.append(*navigable);
+        m_changing_navigables.append(navigable->id());
     }
 
     // 12. For each navigable of changingNavigables, queue a global task on the navigation and traversal task source.
-    for (auto& navigable : m_changing_navigables) {
+    for (auto navigable_id : m_changing_navigables) {
+        auto navigable = local_navigable_with_id(navigable_id);
+        VERIFY(navigable);
         auto target_entry = navigable->current_session_history_entry();
         VERIFY(target_entry);
         m_traversable->run_changing_navigable_history_step_job(
             {
-                .navigable = navigable,
+                .navigable = *navigable,
                 .target_entry = target_entry.release_nonnull(),
                 .source_snapshot_params = m_source_snapshot_params,
                 .user_involvement = m_user_involvement,
@@ -1350,7 +1348,7 @@ void ApplyHistoryStepState::process_continuations()
         auto history_object_length_and_index = m_traversable->get_the_history_object_length_and_index(m_target_step);
 
         // 8. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
-        m_navigables_that_must_wait_before_handling_sync_navigation.set(*continuation->navigable);
+        m_navigables_that_must_wait_before_handling_sync_navigation.set(continuation->navigable->id());
 
         // 9. Let entriesForNavigationAPI be the result of getting session history entries for the navigation API given navigable and targetStep.
         auto entries_for_navigation_api = m_traversable->get_session_history_entries_for_the_navigation_api(*continuation->navigable, m_target_step);
@@ -1552,9 +1550,14 @@ void ApplyHistoryStepState::enter_waiting_for_non_changing_jobs()
     auto script_history_index = length_and_index.script_history_index;
 
     // 18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
-    for (auto& navigable : m_non_changing_navigables) {
+    for (auto navigable_id : m_non_changing_navigables) {
+        auto navigable = local_navigable_with_id(navigable_id);
+        if (!navigable) {
+            signal_progress();
+            continue;
+        }
         m_traversable->update_nonchanging_navigable_history_step_state(
-            navigable,
+            *navigable,
             {
                 .script_history_length = script_history_length,
                 .script_history_index = script_history_index,
@@ -1730,8 +1733,8 @@ void ApplyHistoryStepState::clear_ongoing_traversal_for_changing_navigable(GC::P
 
 void ApplyHistoryStepState::clear_ongoing_traversals_for_changing_navigables()
 {
-    for (auto& navigable : m_changing_navigables)
-        clear_ongoing_traversal_for_changing_navigable(navigable);
+    for (auto navigable_id : m_changing_navigables)
+        clear_ongoing_traversal_for_changing_navigable(local_navigable_with_id(navigable_id));
 }
 
 int LocalTraversableNavigable::claim_next_session_history_step()

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -332,10 +332,13 @@ static bool synchronous_same_document_navigation_must_preserve_ongoing_navigatio
     return navigable.ongoing_navigation().has<Utf16String>();
 }
 
-static bool expected_ongoing_navigation_was_superseded(GC::Ptr<LocalNavigable> navigable, Optional<Utf16String> const& expected_navigation_id)
+static bool expected_ongoing_navigation_was_superseded(Optional<CrossProcessId> navigable_id, Optional<Utf16String> const& expected_navigation_id)
 {
-    if (!navigable || !expected_navigation_id.has_value())
+    if (!navigable_id.has_value() || !expected_navigation_id.has_value())
         return false;
+    auto navigable = local_navigable_with_id(*navigable_id);
+    if (!navigable)
+        return true;
     if (navigable->has_been_destroyed())
         return true;
     return navigable->ongoing_navigation() != *expected_navigation_id;
@@ -810,7 +813,7 @@ public:
         , m_synchronous_navigation(synchronous_navigation)
         , m_navigation_api_abort_behavior(navigation_api_abort_behavior)
         , m_pending_document(pending_document)
-        , m_expected_ongoing_navigation_navigable(expected_ongoing_navigation_navigable)
+        , m_expected_ongoing_navigation_navigable_id(expected_ongoing_navigation_navigable ? Optional<CrossProcessId> { expected_ongoing_navigation_navigable->id() } : OptionalNone {})
         , m_expected_ongoing_navigation_id(move(expected_ongoing_navigation_id))
         , m_on_complete(on_complete)
         , m_timeout(Platform::Timer::create_single_shot(heap(), TIMEOUT_MS, GC::create_function(heap(), [this] {
@@ -871,7 +874,6 @@ private:
         visitor.visit(m_traversable);
         visitor.visit(m_source_snapshot_params);
         visitor.visit(m_pending_document);
-        visitor.visit(m_expected_ongoing_navigation_navigable);
         visitor.visit(m_on_complete);
         visitor.visit(m_timeout);
         visitor.visit(m_continuations);
@@ -921,7 +923,7 @@ private:
     LocalTraversableNavigable::SynchronousNavigation m_synchronous_navigation;
     LocalNavigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
     GC::Ptr<DOM::Document> m_pending_document;
-    GC::Ptr<LocalNavigable> m_expected_ongoing_navigation_navigable;
+    Optional<CrossProcessId> m_expected_ongoing_navigation_navigable_id;
     Optional<Utf16String> m_expected_ongoing_navigation_id;
     GC::Ptr<OnApplyHistoryStepComplete> m_on_complete;
     GC::Ref<Platform::Timer> m_timeout;
@@ -943,7 +945,7 @@ GC_DEFINE_ALLOCATOR(ApplyHistoryStepState);
 
 void ApplyHistoryStepState::start()
 {
-    if (expected_ongoing_navigation_was_superseded(m_expected_ongoing_navigation_navigable, m_expected_ongoing_navigation_id)) {
+    if (expected_ongoing_navigation_was_superseded(m_expected_ongoing_navigation_navigable_id, m_expected_ongoing_navigation_id)) {
         // NB: A cross-document navigation can be superseded after its document has populated but before its queued
         //     history-step application runs. The navigate algorithm's earlier navigation ID check caught the same
         //     condition before appending these steps; this re-check keeps a stale finalization from claiming
@@ -1020,7 +1022,7 @@ void ApplyHistoryStepState::start()
         VERIFY(target_entry);
         m_traversable->run_changing_navigable_history_step_job(
             {
-                .navigable = *navigable,
+                .navigable_id = navigable_id,
                 .target_entry = target_entry.release_nonnull(),
                 .source_snapshot_params = m_source_snapshot_params,
                 .user_involvement = m_user_involvement,
@@ -1029,14 +1031,14 @@ void ApplyHistoryStepState::start()
                 .navigation_api_abort_behavior = m_navigation_api_abort_behavior,
                 .pending_document = m_pending_document,
             },
-            GC::create_function(heap(), [this, navigable](LocalTraversableNavigable::ChangingNavigableHistoryStepJobResult result) {
+            GC::create_function(heap(), [this, navigable_id](LocalTraversableNavigable::ChangingNavigableHistoryStepJobResult result) {
                 switch (result.disposition) {
                 case LocalTraversableNavigable::ChangingNavigableHistoryStepJobDisposition::Ready:
                     VERIFY(result.continuation);
                     did_receive_continuation(*result.continuation);
                     break;
                 case LocalTraversableNavigable::ChangingNavigableHistoryStepJobDisposition::Skipped:
-                    complete_change_job_without_applying(navigable);
+                    complete_change_job_without_applying(local_navigable_with_id(navigable_id));
                     break;
                 case LocalTraversableNavigable::ChangingNavigableHistoryStepJobDisposition::Stale:
                     finish_without_applying();
@@ -1050,7 +1052,11 @@ void ApplyHistoryStepState::start()
 
 void LocalTraversableNavigable::run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob job, GC::Ref<OnChangingNavigableHistoryStepJobComplete> on_complete)
 {
-    auto navigable = job.navigable;
+    auto navigable = local_navigable_with_id(job.navigable_id);
+    if (!navigable) {
+        on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
+        return;
+    }
 
     // AD-HOC: If the navigable has been destroyed, or has no active window, skip it.
     //         Complete the job here rather than relying on the queued task, because Document::destroy() removes tasks
@@ -1059,9 +1065,7 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
         return;
     }
-    queue_apply_history_step_task(navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), on_complete] {
-        auto navigable = job.navigable;
-
+    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), navigable, on_complete] {
         // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
         if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()) {
             on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
@@ -1551,13 +1555,8 @@ void ApplyHistoryStepState::enter_waiting_for_non_changing_jobs()
 
     // 18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
     for (auto navigable_id : m_non_changing_navigables) {
-        auto navigable = local_navigable_with_id(navigable_id);
-        if (!navigable) {
-            signal_progress();
-            continue;
-        }
         m_traversable->update_nonchanging_navigable_history_step_state(
-            *navigable,
+            navigable_id,
             {
                 .script_history_length = script_history_length,
                 .script_history_index = script_history_index,
@@ -1570,11 +1569,13 @@ void ApplyHistoryStepState::enter_waiting_for_non_changing_jobs()
     try_advance();
 }
 
-void LocalTraversableNavigable::update_nonchanging_navigable_history_step_state(GC::Ref<LocalNavigable> navigable, HistoryObjectLengthAndIndex history_object_length_and_index, GC::Ref<GC::Function<void()>> on_complete)
+void LocalTraversableNavigable::update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex history_object_length_and_index, GC::Ref<GC::Function<void()>> on_complete)
 {
+    auto navigable = local_navigable_with_id(navigable_id);
+
     // AD-HOC: This check is not in the spec but we should not continue navigation if navigable has been destroyed,
     //         or if there's no active window.
-    if (navigable->has_been_destroyed() || !navigable->active_window()) {
+    if (!navigable || navigable->has_been_destroyed() || !navigable->active_window()) {
         on_complete->function()();
         return;
     }
@@ -1584,7 +1585,7 @@ void LocalTraversableNavigable::update_nonchanging_navigable_history_step_state(
     //         In the async state machine, documents can become non-fully-active between
     //         queue time and execution, causing the task to be permanently stuck.
     //         A null-document task is always runnable; we check validity inside.
-    queue_a_task(Task::Source::NavigationAndTraversal, nullptr, nullptr, GC::create_function(heap(), [navigable, history_object_length_and_index, on_complete] {
+    queue_a_task(Task::Source::NavigationAndTraversal, nullptr, nullptr, GC::create_function(heap(), [navigable = GC::Ref { *navigable }, history_object_length_and_index, on_complete] {
         if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()->is_fully_active()) {
             on_complete->function()();
             return;
@@ -1866,7 +1867,7 @@ void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
     Optional<Utf16String> expected_ongoing_navigation_id,
     GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
-    if (expected_ongoing_navigation_was_superseded(expected_ongoing_navigation_navigable, expected_ongoing_navigation_id)) {
+    if (expected_ongoing_navigation_was_superseded(expected_ongoing_navigation_navigable ? Optional<CrossProcessId> { expected_ongoing_navigation_navigable->id() } : OptionalNone {}, expected_ongoing_navigation_id)) {
         on_complete->function()(HistoryStepResult::Applied);
         return;
     }

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -89,7 +89,7 @@ public:
     };
 
     struct ChangingNavigableHistoryStepJob {
-        GC::Ref<LocalNavigable> navigable;
+        CrossProcessId navigable_id;
         NonnullRefPtr<SessionHistoryEntry> target_entry;
         GC::Ptr<SourceSnapshotParams> source_snapshot_params;
         UserNavigationInvolvement user_involvement;
@@ -119,7 +119,7 @@ public:
         UserNavigationInvolvement user_involvement;
     };
     void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete);
-    void update_nonchanging_navigable_history_step_state(GC::Ref<LocalNavigable>, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
+    void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);

--- a/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.cpp
+++ b/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.cpp
@@ -72,14 +72,14 @@ void SessionHistoryTraversalQueue::schedule_processing()
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigations-jump-queue
-GC::Ptr<SessionHistoryTraversalQueueEntry> SessionHistoryTraversalQueue::first_synchronous_navigation_steps_with_target_navigable_not_contained_in(HashTable<GC::Ref<LocalNavigable>> const& set)
+GC::Ptr<SessionHistoryTraversalQueueEntry> SessionHistoryTraversalQueue::first_synchronous_navigation_steps_with_target_navigable_not_contained_in(HashTable<CrossProcessId> const& set)
 {
     auto index = m_queue.find_first_index_if([&set](auto const& entry) -> bool {
         auto target_navigable = entry->target_navigable();
         if (target_navigable == nullptr)
             return false;
 
-        if (set.contains(*target_navigable))
+        if (set.contains(target_navigable->id()))
             return false;
 
         // A newly created child navigable is not yet discoverable through get_session_history_entries()

--- a/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
+++ b/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashTable.h>
 #include <AK/Vector.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Promise.h>
@@ -16,6 +17,7 @@
 #include <LibJS/Heap/Cell.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/CrossProcessId.h>
 
 namespace Web::HTML {
 
@@ -56,7 +58,7 @@ public:
     void append_sync(GC::Ref<SessionHistoryTraversalSteps> steps, GC::Ptr<LocalNavigable> target_navigable);
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigations-jump-queue
-    GC::Ptr<SessionHistoryTraversalQueueEntry> first_synchronous_navigation_steps_with_target_navigable_not_contained_in(HashTable<GC::Ref<LocalNavigable>> const&);
+    GC::Ptr<SessionHistoryTraversalQueueEntry> first_synchronous_navigation_steps_with_target_navigable_not_contained_in(HashTable<CrossProcessId> const&);
 
 private:
     virtual void visit_edges(Cell::Visitor&) override;


### PR DESCRIPTION
Store navigable ids instead of pointers in the sets and jobs that apply-the-history-step passes between its phases, and only resolve a navigable where the work runs.

This is prep work for driving this from the UI process.