### PR TITLE
LibWeb: Persist a response's end time across failed TAO checks

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -820,9 +820,10 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
                 return;
 
             // 2. Set timingInfo’s end time to the relative high resolution time given unsafeEndTime and global.
-            // Spec Issue: Using relative time here is incorrect, as end time is converted to relative time by Resource Timing,
-            //             causing it to take a relative time of an already relative time, effectively make it always a negative
-            //             value approximately the value of the time origin.
+            // FIXME: Spec issue: Using relative time here is incorrect, as end time is converted to relative time by
+            //        Resource Timing, causing it to take a relative time of an already relative time, effectively make
+            //        it always a negative value approximately the value of the time origin.
+            //        https://github.com/whatwg/fetch/issues/1812
             timing_info->set_end_time(unsafe_end_time);
 
             // 3. Let cacheState be response’s cache state.

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchTimingInfo.cpp
@@ -34,6 +34,17 @@ GC::Ref<FetchTimingInfo> create_opaque_timing_info(JS::VM& vm, FetchTimingInfo c
     auto new_timing_info = FetchTimingInfo::create(vm);
     new_timing_info->set_start_time(timing_info.start_time());
     new_timing_info->set_post_redirect_start_time(timing_info.start_time());
+
+    // FIXME: Spec issue: We invoke this factory due to a failed Timing-Allow-Origin check. In such cases, responseEnd
+    //        is not one the fields listed for protection:
+    //        https://w3c.github.io/resource-timing/#sec-cross-origin-resources
+    //
+    //        If we do not copy the end time here, startTime will be non-zero and responseEnd will be zero, resulting in
+    //        a negative duration. This is an observable difference from other engines.
+    //
+    //        https://github.com/whatwg/fetch/issues/1945
+    new_timing_info->set_end_time(timing_info.end_time());
+
     return new_timing_info;
 }
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -62,6 +62,9 @@ Text/input/wpt-import/html/interaction/focus/processing-model/preventScroll.html
 ; This test needs to taint a canvas with a cross-origin image.
 Text/input/HTML/canvas-toDataURL-toBlob-origin-clean.html
 
+; Tests cross-origin Resource Timing.
+Text/input/Fetch/cross-origin-resource-timing-duration.html
+
 ; Navigation has entries and events disabled for opaque origins, so this crash only reproduces over HTTP.
 Crash/DOM/document-open-navigation-api.html
 

--- a/Tests/LibWeb/Text/expected/Fetch/cross-origin-resource-timing-duration.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/cross-origin-resource-timing-duration.txt
@@ -1,0 +1,6 @@
+Resource is cross-origin: true
+Resource timing entry found: true
+responseEnd follows startTime: true
+duration is non-negative: true
+requestStart is masked: true
+responseStart is masked: true

--- a/Tests/LibWeb/Text/input/Fetch/cross-origin-resource-timing-duration.html
+++ b/Tests/LibWeb/Text/input/Fetch/cross-origin-resource-timing-duration.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const scriptUrl = new URL(
+            await server.createEcho("GET", "/cross-origin-resource-timing-duration.js", {
+                status: 200,
+                headers: {
+                    "Cache-Control": "no-store",
+                    "Content-Type": "text/javascript",
+                },
+                body: "",
+            })
+        );
+        scriptUrl.hostname = uniqueLocalhostHostname("resource-timing-duration");
+
+        const script = document.createElement("script");
+        script.src = scriptUrl.href;
+        await new Promise((resolve, reject) => {
+            script.onload = resolve;
+            script.onerror = reject;
+            document.head.appendChild(script);
+        });
+
+        let entry;
+        for (let attempt = 0; attempt < 50; ++attempt) {
+            entry = performance.getEntriesByName(scriptUrl.href, "resource").at(-1);
+            if (entry) break;
+            await timeout(10);
+        }
+
+        println(`Resource is cross-origin: ${scriptUrl.origin !== location.origin}`);
+        println(`Resource timing entry found: ${entry !== undefined}`);
+        if (!entry) return;
+
+        println(`responseEnd follows startTime: ${entry.responseEnd >= entry.startTime}`);
+        println(`duration is non-negative: ${entry.duration >= 0}`);
+        println(`requestStart is masked: ${entry.requestStart === 0}`);
+        println(`responseStart is masked: ${entry.responseStart === 0}`);
+    });
+</script>


### PR DESCRIPTION
The end time is not a field listed for protection against failed Timing-Allow-Origin checks. If we set it to zero, we will have an end time that is less than the object's start time, resulting in a negative duration.

This was seen on Strava's login form, where I am getting "An unexpected error occurred". The issue is we get rejected due to some reCAPTCHA scoring. This was one obvious observable difference between us and Firefox, but does not fix the issue. 