### PR TITLE
WebContent: Flush pending WebDriver messages before the process exits

### DIFF
--- a/Libraries/LibIPC/Connection.cpp
+++ b/Libraries/LibIPC/Connection.cpp
@@ -134,9 +134,7 @@ OwnPtr<IPC::Message> ConnectionBase::wait_for_specific_endpoint_message_impl(u32
     VERIFY(m_owner_thread_id.is_current_thread());
     bool peer_disconnected_during_wait = false;
 
-    for (;;) {
-        // Double check we don't already have the event waiting for us.
-        // Otherwise we might end up blocked for a while for no reason.
+    auto take_matching_message = [&]() -> OwnPtr<IPC::Message> {
         for (size_t i = 0; i < m_unprocessed_messages.size(); ++i) {
             auto& message = m_unprocessed_messages[i];
             if (message->endpoint_magic() != endpoint_magic)
@@ -144,6 +142,14 @@ OwnPtr<IPC::Message> ConnectionBase::wait_for_specific_endpoint_message_impl(u32
             if (message->message_id() == message_id)
                 return m_unprocessed_messages.take(i);
         }
+        return {};
+    };
+
+    for (;;) {
+        // Double check we don't already have the event waiting for us.
+        // Otherwise we might end up blocked for a while for no reason.
+        if (auto message = take_matching_message())
+            return message;
 
         if (!is_open())
             break;
@@ -153,6 +159,14 @@ OwnPtr<IPC::Message> ConnectionBase::wait_for_specific_endpoint_message_impl(u32
             peer_disconnected_during_wait = true;
             break;
         }
+    }
+
+    // The EOF-reporting drain can deliver the awaited response in the same batch. A peer replying then exiting produces
+    // that. Take the response instead of failing; the drain-scheduled deferred handle_messages/shutdown still run after-
+    // wards. So, other messages from that final batch are dispatched in order before the connection close is acted on.
+    if (peer_disconnected_during_wait) {
+        if (auto message = take_matching_message())
+            return message;
     }
 
     dbgln("Failed to receive message_id: {}", message_id);

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -176,6 +176,7 @@ Optional<PageClient const&> ConnectionFromClient::page(u64 index, SourceLocation
 
 void ConnectionFromClient::close_server()
 {
+    m_page_host->close_webdriver_connections_after_sending_pending_messages();
     shutdown();
 }
 

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -265,6 +265,12 @@ void PageClient::notify_webdriver_of_window_replacement()
         m_webdriver->page_did_start_window_replacement({}, page().top_level_traversable()->window_handle().to_utf8());
 }
 
+void PageClient::close_webdriver_connection_after_sending_pending_messages()
+{
+    if (m_webdriver)
+        m_webdriver->transport().close_after_sending_all_pending_messages();
+}
+
 void PageClient::request_new_process_for_child_frame_navigation(Web::HTML::CrossProcessId frame_id, URL::URL const& url, Web::HTML::DocumentResource document_resource, Web::Bindings::NavigationHistoryBehavior history_handling, Optional<Web::HTML::NavigationSourceSnapshot> const& source_snapshot)
 {
     client().async_did_request_new_process_for_child_frame_navigation(m_id, frame_id, url, move(document_resource), history_handling, source_snapshot);

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -55,6 +55,7 @@ public:
 
     ErrorOr<void> connect_to_webdriver(ByteString const& webdriver_endpoint);
     void notify_webdriver_of_window_replacement();
+    void close_webdriver_connection_after_sending_pending_messages();
     ErrorOr<void> connect_to_web_ui(IPC::TransportHandle);
 
     virtual Queue<Web::QueuedInputEvent>& input_event_queue() override;

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -55,6 +55,12 @@ void PageHost::remove_page(Badge<PageClient>, u64 page_id)
     m_pages.remove(page_id);
 }
 
+void PageHost::close_webdriver_connections_after_sending_pending_messages()
+{
+    for (auto& page : m_pages)
+        page.value->close_webdriver_connection_after_sending_pending_messages();
+}
+
 Optional<PageClient&> PageHost::page(u64 page_id)
 {
     return m_pages.get(page_id).map([](auto& value) -> PageClient& {

--- a/Services/WebContent/PageHost.h
+++ b/Services/WebContent/PageHost.h
@@ -40,6 +40,7 @@ public:
     Optional<PageClient&> page(u64 page_id);
     PageClient& create_page(u64 page_id, Optional<Web::HTML::CrossProcessId> pending_root_navigable_id = {});
     void remove_page(Badge<PageClient>, u64 page_id);
+    void close_webdriver_connections_after_sending_pending_messages();
     Web::HTML::CrossProcessId allocate_cross_process_id();
     Web::HTML::CrossProcessId allocate_navigable_id();
 


### PR DESCRIPTION
**Problem:** `TestWebDriverSessionHistory` timeouts on the x86_64 Release GNU CI job in the cross-process no-content navigation-restore subtest. The harness waits 30s for the restored `/a` document — which never loads.

https://github.com/LadybirdBrowser/ladybird/actions/runs/30988508142
https://github.com/LadybirdBrowser/ladybird/actions/runs/30999552155
https://github.com/LadybirdBrowser/ladybird/actions/runs/31042505962
https://github.com/LadybirdBrowser/ladybird/actions/runs/31082213133

**Cause:** When a cross-site navigation replaces a WebContent process, the UI tells the outgoing process to notify WebDriver of the window replacement, then immediately tells it to close. Both are async IPC messages: the notify only enqueues on the send queue for the IO thread to write, while `close_server()` exits the process via `terminate_immediately()`. Under load, the process exits before the IO thread flushes, so WebDriver never receives the replacement notice. It sees only the socket EOF, treats the window as closed, and tears the session down — SIGTERM-ing the UI mid-restore, so the restored `/a` document never loads.

**Fix:** Before WebContent exits in `close_server()`, flush each page’s WebDriver transport with `close_after_sending_all_pending_messages()`, so the pending-replacement notice reaches WebDriver ahead of the EOF. The flush runs in `close_server()` rather than `die()` because `die()` can run during construction, before the page host is initialized.

The first commit in the branch here is a separate-but-related ordering bug found incidentally on the way: A sync IPC wait could report `Failed to receive message_id: N` even though the peer had sent the response — when the peer replied and then exited so that the response and the socket EOF were read in the same drain. `wait_for_specific_endpoint_message_impl()` broke out of its loop on EOF without rescanning the unprocessed messages the drain had just appended. It now rescans once — before reporting failure.
