### PR TITLE
LibWeb: Advance the SVG current text position across text runs

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -70,6 +70,7 @@
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGMaskElement.h>
 #include <LibWeb/SVG/SVGSVGElement.h>
+#include <LibWeb/SVG/SVGTextElement.h>
 
 namespace Web::Layout {
 
@@ -408,28 +409,77 @@ static Utf16String rendered_svg_text_contents(SVG::SVGTextContentElement const& 
     return builder.to_string().trim_ascii_whitespace();
 }
 
+// The advance of the text run rendered by the given box; that is, of its direct child text content.
+static float svg_text_run_advance(SVGTextBox const& text_box)
+{
+    // FIXME: Use per-code-point fonts.
+    return text_box.first_available_font().width(text_box.dom_node().text_contents());
+}
+
+// https://svgwg.org/svg2-draft/text.html#TermTextChunk
+// Each new absolute positioning adjustment (due to an 'x' or 'y' attribute, or forced line break) creates a new text chunk.
+// https://svgwg.org/svg2-draft/text.html#TextElementXAttribute
+// NB: The initial value of 'x' and 'y' is "0 for 'text'; (none) for 'tspan'". So, a <text> element always positions its
+//     first character absolutely, and so always starts a chunk.
+static bool svg_text_box_starts_text_chunk(SVGTextBox const& text_box)
+{
+    if (is<SVG::SVGTextElement>(text_box.dom_node()))
+        return true;
+    auto text_positioning = text_box.dom_node().text_positioning();
+    return !text_positioning.x.is_empty() || !text_positioning.y.is_empty();
+}
+
+struct SvgTextChunkMeasurement {
+    float advance { 0 };
+    CSS::TextAnchor anchor { CSS::TextAnchor::Start };
+};
+
+// Measures the total advance of the text chunk that starts at the given box, and determines the 'text-anchor' value
+// that applies to the chunk. The chunk extends in document order through the subtree of the containing <text> element
+// until the next box that starts a chunk of its own.
+static SvgTextChunkMeasurement measure_svg_text_chunk(SVGTextBox const& chunk_start_box)
+{
+    auto const* subtree_root = &chunk_start_box;
+    for (auto const* ancestor = chunk_start_box.parent(); ancestor && is<SVGTextBox>(*ancestor); ancestor = ancestor->parent())
+        subtree_root = static_cast<SVGTextBox const*>(ancestor);
+
+    SvgTextChunkMeasurement measurement;
+    bool found_chunk_start = false;
+    bool found_first_rendered_text = false;
+    subtree_root->for_each_in_inclusive_subtree([&](Node const& node) {
+        // AD-HOC: Text on a path is laid out independently; see compute_path_for_svg_text_path().
+        if (is<SVGTextPathBox>(node))
+            return TraversalDecision::SkipChildrenAndContinue;
+        auto const* text_box = as_if<SVGTextBox>(node);
+        if (!text_box)
+            return TraversalDecision::Continue;
+        if (text_box == &chunk_start_box)
+            found_chunk_start = true;
+        else if (found_chunk_start && svg_text_box_starts_text_chunk(*text_box))
+            return TraversalDecision::Break;
+        if (found_chunk_start && !text_box->dom_node().text_contents().is_empty()) {
+            if (!found_first_rendered_text) {
+                // https://svgwg.org/svg2-draft/text.html#TextLayoutAlgorithm
+                // Adjust shift based on the value of 'text-anchor' and 'direction' of the element the character at index i.
+                // FIXME: Take text direction into account.
+                measurement.anchor = text_box->computed_values().text_anchor();
+                found_first_rendered_text = true;
+            }
+            measurement.advance += svg_text_run_advance(*text_box);
+        }
+        return TraversalDecision::Continue;
+    });
+    return measurement;
+}
+
 static Gfx::Path compute_path_for_svg_text(SVGTextBox const& text_box, Gfx::FloatPoint current_text_position)
 {
     auto& text_element = text_box.dom_node();
     // FIXME: Use per-code-point fonts.
     auto& font = text_box.first_available_font();
     auto text_contents = text_element.text_contents();
-    auto text_width = font.width(text_contents);
+
     auto text_offset = current_text_position;
-
-    switch (text_element.text_anchor().value_or(SVG::TextAnchor::Start)) {
-    case SVG::TextAnchor::Start:
-        break;
-    case SVG::TextAnchor::Middle:
-        text_offset.translate_by(-text_width / 2, 0);
-        break;
-    case SVG::TextAnchor::End:
-        text_offset.translate_by(-text_width, 0);
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-
     auto baseline_metric = resolve_dominant_baseline_metric(text_box.computed_values());
     text_offset.translate_by(0, dominant_baseline_offset(baseline_metric, font.pixel_metrics()));
 
@@ -487,9 +537,48 @@ static RustFFI::FfiSvgPathResult compute_svg_path(NodeWithStyle const& node, Rus
     if (auto const* geometry_box = as_if<SVGGeometryBox>(graphics_box)) {
         path = const_cast<SVGGeometryBox&>(*geometry_box).dom_node().get_path(viewport_size);
     } else if (auto const* text_box = as_if<SVGTextBox>(graphics_box)) {
-        auto text_positioning = text_box->dom_node().text_positioning();
-        text_positioning.apply_to_text_position(viewport_size, text_position, 0u);
+        auto const& text_element = text_box->dom_node();
+        // https://svgwg.org/svg2-draft/text.html#TextElementXAttribute
+        // the starting X (Y) coordinate for rendering the glyphs corresponding to the given character is the X (Y) coordinate
+        // of the resulting current text position from the most recently rendered glyph for the current 'text' element.
+        // NB: The initial value of 'x' and 'y' is "0 for 'text'; (none) for 'tspan'": a <text> element starts at (0, 0)
+        //     regardless of the current text position, while a <tspan> without 'x'/'y' continues at the current text position.
+        if (is<SVG::SVGTextElement>(text_element))
+            text_position = {};
+        text_element.text_positioning().apply_to_text_position(viewport_size, text_position, 0u);
+        if (svg_text_box_starts_text_chunk(*text_box)) {
+            // https://svgwg.org/svg2-draft/text.html#TextAnchoringProperties
+            // The 'text-anchor' property is applied to each individual text chunk within a given 'text' element.
+            // AD-HOC: The spec applies 'text-anchor' as a shift of the chunk's rendered glyphs after layout; shifting
+            //         the chunk's starting position up front by the chunk's total advance is equivalent for horizontal
+            //         text — since every run in the chunk is laid out sequentially from this position.
+            auto chunk = measure_svg_text_chunk(*text_box);
+            switch (chunk.anchor) {
+            case CSS::TextAnchor::Start:
+                // The rendered characters are aligned such that the start of the resulting rendered text is at the
+                // initial current text position."
+                break;
+            case CSS::TextAnchor::Middle:
+                // The rendered characters are shifted such that the geometric middle of the resulting rendered text
+                // (determined from the initial and final current text position before applying the 'text-anchor'
+                // property) is at the initial current text position.
+                text_position.translate_by(-chunk.advance / 2, 0);
+                break;
+            case CSS::TextAnchor::End:
+                // The rendered characters are shifted such that the end of the resulting rendered text (final current
+                // text position before applying the 'text-anchor' property) is at the initial current text position."
+                text_position.translate_by(-chunk.advance, 0);
+                break;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        }
         path = compute_path_for_svg_text(*text_box, text_position);
+        // https://svgwg.org/svg2-draft/text.html#TextLayoutIntroduction
+        // After each glyph is placed, the current text position is advanced by the glyph's advance value (typically the
+        // width for horizontal text or height for vertical text).
+        // FIXME: Take writing mode and text direction into account.
+        text_position.translate_by(svg_text_run_advance(*text_box), 0);
     } else if (auto const* text_path_box = as_if<SVGTextPathBox>(graphics_box)) {
         path = compute_path_for_svg_text_path(*text_path_box, viewport_size);
     }
@@ -505,7 +594,7 @@ static RustFFI::FfiSvgPathResult compute_svg_path(NodeWithStyle const& node, Rus
             .width = bounding_box.width(),
             .height = bounding_box.height(),
         },
-        .text_position_for_children = {
+        .text_position_after = {
             .x = text_position.x(),
             .y = text_position.y(),
         },

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -99,7 +99,7 @@ pub struct FfiSvgPathRequest {
 pub struct FfiSvgPathResult {
     pub path_handle: *mut c_void,
     pub bounding_box: FfiFloatRect,
-    pub text_position_for_children: FfiFloatPoint,
+    pub text_position_after: FfiFloatPoint,
 }
 
 pub(crate) const PRESERVE_ASPECT_RATIO_NONE: u8 = 0;
@@ -933,7 +933,8 @@ impl<'pass> SvgFormattingContext<'pass> {
         assert!(!result.path_handle.is_null());
 
         if self.node_kind(graphics_box) == NodeKind::SVGTextBox {
-            self.current_text_position = result.text_position_for_children;
+            // Descendant and following text elements continue from the text position after this element's own text run.
+            self.current_text_position = result.text_position_after;
             // <text> and <tspan> elements can contain more text elements.
             let mut child = self.first_child(graphics_box);
             while !child.is_invalid() {
@@ -945,10 +946,6 @@ impl<'pass> SvgFormattingContext<'pass> {
             }
         }
 
-        self.current_text_position = FfiFloatPoint {
-            x: result.bounding_box.x + result.bounding_box.width,
-            y: result.bounding_box.y + result.bounding_box.height,
-        };
         let mut transformed_bounding_box =
             float_rect_to_css_pixels(to_css_pixels_transform.map_rect(result.bounding_box));
         // Stroke increases the path's size by stroke_width/2 per side.

--- a/Tests/LibWeb/Layout/expected/svg/svg-text-positioning.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-text-positioning.txt
@@ -11,10 +11,10 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
           SVGTextBox <tspan> at [48.796875,23.140625] [0+0+0 44.46875 0+0+0] [0+0+0 22.125 0+0+0] children: inline
             TextNode <#text> (not painted)
           TextNode <#text> (not painted)
-          SVGTextBox <tspan> at [114.390625,48.9375] [0+0+0 45.765625 0+0+0] [0+0+0 20.53125 0+0+0] children: inline
+          SVGTextBox <tspan> at [116.640625,47.6875] [0+0+0 45.765625 0+0+0] [0+0+0 20.53125 0+0+0] children: inline
             TextNode <#text> (not painted)
           TextNode <#text> (not painted)
-          SVGTextBox <tspan> at [191.28125,84.15625] [0+0+0 45.09375 0+0+0] [0+0+0 20.53125 0+0+0] children: inline
+          SVGTextBox <tspan> at [195.03125,82.6875] [0+0+0 45.09375 0+0+0] [0+0+0 20.53125 0+0+0] children: inline
             TextNode <#text> (not painted)
           TextNode <#text> (not painted)
         TextNode <#text> (not painted)
@@ -27,8 +27,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         SVGPathPaintable (SVGGeometryBox<rect>) [8,8 300x120]
         SVGPathPaintable (SVGTextBox<text>) [8,8 0x0]
           SVGPathPaintable (SVGTextBox<tspan>) [48.796875,23.140625 44.46875x22.125]
-          SVGPathPaintable (SVGTextBox<tspan>) [114.390625,48.9375 45.765625x20.53125]
-          SVGPathPaintable (SVGTextBox<tspan>) [191.28125,84.15625 45.09375x20.53125]
+          SVGPathPaintable (SVGTextBox<tspan>) [116.640625,47.6875 45.765625x20.53125]
+          SVGPathPaintable (SVGTextBox<tspan>) [195.03125,82.6875 45.09375x20.53125]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
  SC for BlockContainer<HTML> [0,0 800x136] (z-index: auto)

--- a/Tests/LibWeb/Ref/expected/svg-tspan-current-text-position-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-tspan-current-text-position-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+</style>
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" font-family="Ahem" font-size="20">
+    <text x="20" y="30">XXXX</text>
+    <text x="160" y="70">XXXX</text>
+    <text x="120" y="110">XXXX</text>
+    <text x="20" y="150">X</text>
+    <text x="60" y="150">X</text>
+    <text x="80" y="160">X</text>
+    <text x="180" y="190">XX</text>
+    <text x="180" y="220">XX</text>
+    <text x="20" y="270">X</text>
+    <text x="40" y="270" font-size="40">X</text>
+    <text x="80" y="270">X</text>
+    <text x="200" y="270">XXXX</text>
+</svg>

--- a/Tests/LibWeb/Ref/input/svg-tspan-current-text-position.html
+++ b/Tests/LibWeb/Ref/input/svg-tspan-current-text-position.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-tspan-current-text-position-ref.html">
+<style>
+@font-face {
+    font-family: Ahem;
+    src: url("../data/fonts/Ahem.ttf");
+}
+</style>
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" font-family="Ahem" font-size="20">
+    <!-- A tspan without x/y continues at the current text position. -->
+    <text x="20" y="30"><tspan>X</tspan><tspan>X</tspan><tspan>X</tspan><tspan>X</tspan></text>
+    <!-- text-anchor applies to the whole text chunk, not to each tspan. -->
+    <text x="200" y="70" text-anchor="middle"><tspan>X</tspan><tspan>X</tspan><tspan>X</tspan><tspan>X</tspan></text>
+    <text x="200" y="110" text-anchor="end"><tspan>X</tspan><tspan>X</tspan><tspan>X</tspan><tspan>X</tspan></text>
+    <!-- dx/dy shift the current text position without starting a new chunk. -->
+    <text x="20" y="150"><tspan>X</tspan><tspan dx="20">X</tspan><tspan dy="10">X</tspan></text>
+    <!-- A tspan with an absolute position starts a new, separately anchored chunk. -->
+    <text x="200" y="190" text-anchor="middle"><tspan>XX</tspan><tspan x="200" y="220">XX</tspan></text>
+    <!-- Each run contributes the advance of its own font. -->
+    <text x="20" y="270"><tspan>X</tspan><tspan font-size="40">X</tspan><tspan>X</tspan></text>
+    <!-- Direct child text of the text element advances the position for tspans. -->
+    <text x="200" y="270">XX<tspan>XX</tspan></text>
+</svg>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/cssom-getBoundingClientRect-003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/cssom-getBoundingClientRect-003.txt
@@ -2,6 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	{Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Element
-Fail	{Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Range
+2 Pass
+Pass	{Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Element
+Pass	{Element,Range}.prototype.getBoundingClientRect on SVG <tspan>, Range


### PR DESCRIPTION
**Problem:** All `<tspan>` elements without explicit positions rendered on top of each other, at the position where their parent `<text>` element starts.

**Cause:** SVG text layout never advanced the current text position by the advance of each rendered text run. The position handed to a text box’s children was the position before any of the box’s own glyphs got placed. And between sibling boxes, the position was clobbered with the bottom-right corner of the previous box’s ink bounding box. That differs from the glyph advance, and is wrong in y — since the pen must stay on the baseline. In addition, `text-anchor` was applied separately to every box’s own text run. So, anchoring a `<text>` whose content is split across `<tspan>`s shifted each run individually, instead of the whole text chunk.

**Fix:** Track the current text position as the spec defines it: each text run advances the position by its own advance; a `<tspan>` without `x`/`y` continues at the current position; and a `<text>` element always starts at its own absolute position — since `x` and `y` default to 0 for `<text>`. Apply `text-anchor` per text chunk: When a box starts a chunk (every `<text>`, and any `<tspan>` with an absolute position), measure the total advance of all runs in the chunk, and shift the chunk’s starting position once — instead of shifting every run separately. Fixes https://github.com/LadybirdBrowser/ladybird/issues/10625.
