### PR TITLE
LibWeb: Declare each style groups in `Properties.json`

### DIFF
--- a/Documentation/CSSGeneratedFiles.md
+++ b/Documentation/CSSGeneratedFiles.md
@@ -35,6 +35,7 @@ Each property will have some set of these fields on it:
 | `positional-value-list-shorthand`   | No       | `false`    | Boolean. Whether this property is a "positional value list shorthand". See below.                           | `bool property_is_positional_value_list_shorthand(PropertyID)`                                                                                                                                                                                              |
 | `quirks`                            | No       | `[]`       | Array of strings. Some properties have special behavior in "quirks mode", which are listed here. See below. | `bool property_has_quirk(PropertyID, Quirk)`                                                                                                                                                                                                                |
 | `requires-computation`              | Yes      |            | String. When a property's value needs to be run through the computation process. See below.                 | `bool property_requires_computation_with_inherited_value(PropertyID)`<br/>`bool property_requires_computation_with_initial_value(PropertyID)`<br/>`bool property_requires_computation_with_cascaded_value(PropertyID)`                                      |
+| `style-group`                       | Yes      |            | String or array of strings. Which style group stores the longhand's computed value. See below.              | `u32 style_group_dependency_mask(PropertyID)`<br/>`ReadonlySpan<PropertyID> longhands_in_style_group(StyleGroupIndex)`                                                                                                                                      |
 | `valid-identifiers`                 | No       | `[]`       | Array of strings. Which keywords the property accepts. See below.                                           | `bool property_accepts_keyword(PropertyID, Keyword)`<br/>`Optional<Keyword> resolve_legacy_value_alias(PropertyID, Keyword)`                                                                                                                                |
 | `valid-types`                       | No       | `[]`       | Array of strings. Which value types the property accepts. See below.                                        | `bool property_accepts_type(PropertyID, ValueType)`                                                                                                                                                                                                         |
 | `needs-layout-for-getcomputedstyle` | No       | `false`    | Boolean. Whether this property requires up-to-date layout before it could be queried by getComputedStyle()  | `bool property_needs_layout_for_getcomputedstyle(PropertyID)`                                                                                                                                                                                               |
@@ -120,6 +121,16 @@ required.
 | `non-inherited-value` | Only run the computation process if the specified value was determined based on the initial or cascaded value |
 | `cascaded-value`      | Only run the computation process if the specified value was determined based on a cascaded value              |
 | `never`               | Always skip the computation process                                                                           |
+
+### `style-group`
+
+`ComputedValues` stores computed values in groups of related properties, which elements share with each other wherever
+possible. When two styles use the same group payload, every property in that group is known to be equal, which saves 
+memory and allows style diffing to skip work.
+
+Each longhand names the group that stores its value, Shorthands and aliases take their values from their longhands, so 
+they must not declare a group. If producing a property's computed style value also reads from other groups, you should 
+list all of the relevant groups.
 
 ### `valid-identifiers`
 

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -455,6 +455,7 @@ static void register_style_group_field_descriptors()
 
     Vector<FfiGroupFieldDescriptor> descriptors;
     auto add = [&](size_t group_index, PropertyID property, u32 offset, u8 kind, u16 keyword, Array<u8, number_of_keywords> const* keyword_table, double required_px = 0) {
+        VERIFY((style_group_dependency_mask(property) & (1u << group_index)) != 0);
         descriptors.append({
             .group_index = static_cast<u32>(group_index),
             .property_id = static_cast<u16>(to_underlying(property)),
@@ -673,6 +674,21 @@ static void register_style_group_field_descriptors()
              PropertyID::BackgroundOrigin, PropertyID::BackgroundPositionX, PropertyID::BackgroundPositionY,
              PropertyID::BackgroundRepeat, PropertyID::BackgroundSize, PropertyID::BackgroundBlendMode })
         add(background, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
+
+    u32 generically_built_group_mask = 0;
+    Array<bool, number_of_longhand_properties> longhand_has_descriptor {};
+    for (auto const& descriptor : descriptors) {
+        generically_built_group_mask |= 1u << descriptor.group_index;
+        longhand_has_descriptor[descriptor.property_id - to_underlying(first_longhand_property_id)] = true;
+    }
+
+    for (auto i = to_underlying(first_longhand_property_id); i <= to_underlying(last_longhand_property_id); ++i) {
+        auto property_id = static_cast<PropertyID>(i);
+        if (property_is_logical_alias(property_id))
+            continue;
+        if ((style_group_dependency_mask(property_id) & generically_built_group_mask) != 0)
+            VERIFY(longhand_has_descriptor[i - to_underlying(first_longhand_property_id)]);
+    }
 
     rust_style_group_register_field_descriptors(descriptors.data(), descriptors.size());
 }

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -454,6 +454,7 @@ static void register_style_group_field_descriptors()
 
     Vector<FfiGroupFieldDescriptor> descriptors;
     auto add = [&](size_t group_index, PropertyID property, u32 offset, u8 kind, u16 keyword, Array<u8, number_of_keywords> const* keyword_table, double required_px = 0) {
+        VERIFY((style_group_dependency_mask(property) & (1u << group_index)) != 0);
         descriptors.append({
             .group_index = static_cast<u32>(group_index),
             .property_id = static_cast<u16>(to_underlying(property)),
@@ -672,6 +673,21 @@ static void register_style_group_field_descriptors()
              PropertyID::BackgroundOrigin, PropertyID::BackgroundPositionX, PropertyID::BackgroundPositionY,
              PropertyID::BackgroundRepeat, PropertyID::BackgroundSize, PropertyID::BackgroundBlendMode })
         add(background, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
+
+    u32 generically_built_group_mask = 0;
+    Array<bool, number_of_longhand_properties> longhand_has_descriptor {};
+    for (auto const& descriptor : descriptors) {
+        generically_built_group_mask |= 1u << descriptor.group_index;
+        longhand_has_descriptor[descriptor.property_id - to_underlying(first_longhand_property_id)] = true;
+    }
+
+    for (auto i = to_underlying(first_longhand_property_id); i <= to_underlying(last_longhand_property_id); ++i) {
+        auto property_id = static_cast<PropertyID>(i);
+        if (property_is_logical_alias(property_id))
+            continue;
+        if ((style_group_dependency_mask(property_id) & generically_built_group_mask) != 0)
+            VERIFY(longhand_has_descriptor[i - to_underlying(first_longhand_property_id)]);
+    }
 
     rust_style_group_register_field_descriptors(descriptors.data(), descriptors.size());
 }

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/NeverDestroyed.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/GridTrackPlacement.h>
@@ -126,28 +127,6 @@ static Array<u8, number_of_keywords> const& keyword_code_table()
     return table;
 }
 
-// The properties feeding the text reset group's descriptors, in registration
-// order.
-static constexpr Array text_reset_group_properties {
-    PropertyID::TextDecorationLine,
-    PropertyID::TextDecorationThickness,
-    PropertyID::TextDecorationStyle,
-    PropertyID::TextDecorationColor,
-    PropertyID::WhiteSpaceTrim,
-};
-
-// The properties feeding the effects group's descriptors, in registration
-// order.
-static constexpr Array effects_group_properties {
-    PropertyID::Opacity,
-    PropertyID::Filter,
-    PropertyID::BackdropFilter,
-    PropertyID::MixBlendMode,
-    PropertyID::Isolation,
-    PropertyID::BoxShadow,
-    PropertyID::Clip,
-};
-
 // The appearance keyword mapping with the compatibility keywords excluded:
 // they normalize to auto for the appearance field but stay raw for
 // computed_appearance, so their pages take the C++ population path.
@@ -175,43 +154,6 @@ static Optional<Appearance> appearance_without_compat_from_keyword(Keyword keywo
     }
 }
 
-// The properties feeding the misc reset group's descriptors, in registration
-// order; Appearance appears twice, once per derived field.
-static constexpr Array misc_reset_group_properties {
-    PropertyID::ScrollMarginTop,
-    PropertyID::ScrollMarginRight,
-    PropertyID::ScrollMarginBottom,
-    PropertyID::ScrollMarginLeft,
-    PropertyID::ScrollPaddingTop,
-    PropertyID::ScrollPaddingRight,
-    PropertyID::ScrollPaddingBottom,
-    PropertyID::ScrollPaddingLeft,
-    PropertyID::OverflowClipMarginTop,
-    PropertyID::OverflowClipMarginRight,
-    PropertyID::OverflowClipMarginBottom,
-    PropertyID::OverflowClipMarginLeft,
-    PropertyID::ColumnSpan,
-    PropertyID::Appearance,
-    PropertyID::Appearance,
-    PropertyID::OutlineStyle,
-    PropertyID::ObjectFit,
-    PropertyID::ColumnHeight,
-    PropertyID::OutlineColor,
-    PropertyID::OutlineOffset,
-    PropertyID::OutlineWidth,
-    PropertyID::UserSelect,
-    PropertyID::ObjectPosition,
-    PropertyID::ViewTransitionName,
-    PropertyID::TouchAction,
-    PropertyID::ScrollBehavior,
-    PropertyID::ScrollbarGutter,
-    PropertyID::ScrollbarWidth,
-    PropertyID::ShapeImageThreshold,
-    PropertyID::ShapeMargin,
-    PropertyID::ShapeOutside,
-    PropertyID::WillChange,
-};
-
 // overflow-wrap has no generated keyword converter; the mapping matches the
 // switch in create().
 static Optional<OverflowWrap> overflow_wrap_from_keyword(Keyword keyword)
@@ -228,222 +170,14 @@ static Optional<OverflowWrap> overflow_wrap_from_keyword(Keyword keyword)
     }
 }
 
-// The properties feeding the inherited text group's descriptors, in
-// registration order; the doubled properties feed two fields each.
-static constexpr Array inherited_text_group_properties {
-    PropertyID::Color,
-    PropertyID::Color,
-    PropertyID::WebkitTextFillColor,
-    PropertyID::WebkitTextFillColor,
-    PropertyID::TextShadow,
-    PropertyID::TextAlign,
-    PropertyID::TextJustify,
-    PropertyID::TextTransform,
-    PropertyID::TextWrapMode,
-    PropertyID::TextWrapStyle,
-    PropertyID::TextDecorationSkipInk,
-    PropertyID::TextUnderlinePosition,
-    PropertyID::TextUnderlineOffset,
-    PropertyID::TextIndent,
-    PropertyID::TabSize,
-    PropertyID::WhiteSpaceCollapse,
-    PropertyID::WordBreak,
-    PropertyID::OverflowWrap,
-    PropertyID::WordSpacing,
-    PropertyID::WordSpacing,
-    PropertyID::LetterSpacing,
-    PropertyID::LetterSpacing,
-    PropertyID::Orphans,
-    PropertyID::Widows,
-};
+static NeverDestroyed<Array<Vector<PropertyID>, to_underlying(StyleGroupIndex::Count)>> s_style_group_gather_properties;
+static bool s_style_group_gather_properties_populated { false };
 
-// The properties feeding the inherited UI group's descriptors, in
-// registration order; the doubled properties feed two fields each.
-static constexpr Array inherited_ui_group_properties {
-    PropertyID::CaretColor,
-    PropertyID::CaretColor,
-    PropertyID::AccentColor,
-    PropertyID::AccentColor,
-    PropertyID::Cursor,
-    PropertyID::PointerEvents,
-    PropertyID::ScrollbarColor,
-    PropertyID::ColorScheme,
-    PropertyID::ColorScheme,
-};
-
-// The properties feeding the transform group's descriptors, in registration
-// order.
-static constexpr Array transform_group_properties {
-    PropertyID::Transform,
-    PropertyID::TransformBox,
-    PropertyID::TransformOrigin,
-    PropertyID::TransformStyle,
-    PropertyID::BackfaceVisibility,
-    PropertyID::Rotate,
-    PropertyID::Translate,
-    PropertyID::Scale,
-    PropertyID::Perspective,
-    PropertyID::PerspectiveOrigin,
-};
-
-// The properties feeding the mask group's descriptors, in registration
-// order.
-static constexpr Array mask_group_properties {
-    PropertyID::MaskImage,
-    PropertyID::MaskType,
-    PropertyID::ClipPath,
-    PropertyID::MaskMode,
-    PropertyID::MaskRepeat,
-    PropertyID::MaskPosition,
-    PropertyID::MaskClip,
-    PropertyID::MaskOrigin,
-    PropertyID::MaskSize,
-    PropertyID::MaskComposite,
-};
-
-// The properties feeding the grid group's descriptors, in registration
-// order. Every field registers as an initial-value constraint until the
-// core learns the grid representations.
-static constexpr Array grid_group_properties {
-    PropertyID::GridAutoColumns,
-    PropertyID::GridAutoRows,
-    PropertyID::GridTemplateColumns,
-    PropertyID::GridTemplateRows,
-    PropertyID::GridColumnEnd,
-    PropertyID::GridColumnStart,
-    PropertyID::GridRowEnd,
-    PropertyID::GridRowStart,
-    PropertyID::GridTemplateAreas,
-};
-
-// The properties feeding the animation group's descriptors, in registration
-// order. Every field registers as an initial-value constraint: elements
-// without animations, timelines or transitions adopt a shared payload.
-static constexpr Array animation_group_properties {
-    PropertyID::AnimationName,
-    PropertyID::AnimationComposition,
-    PropertyID::AnimationDelay,
-    PropertyID::AnimationDirection,
-    PropertyID::AnimationDuration,
-    PropertyID::AnimationFillMode,
-    PropertyID::AnimationIterationCount,
-    PropertyID::AnimationPlayState,
-    PropertyID::AnimationTimeline,
-    PropertyID::AnimationTimingFunction,
-    PropertyID::ScrollTimelineName,
-    PropertyID::ScrollTimelineAxis,
-    PropertyID::TimelineScope,
-    PropertyID::ViewTimelineName,
-    PropertyID::ViewTimelineAxis,
-    PropertyID::ViewTimelineInset,
-    PropertyID::TransitionProperty,
-    PropertyID::TransitionDuration,
-    PropertyID::TransitionTimingFunction,
-    PropertyID::TransitionDelay,
-    PropertyID::TransitionBehavior,
-};
-
-// The properties feeding the inherited SVG group's descriptors, in
-// registration order.
-static constexpr Array inherited_svg_group_properties {
-    PropertyID::Fill,
-    PropertyID::Stroke,
-    PropertyID::FillRule,
-    PropertyID::ClipRule,
-    PropertyID::FillOpacity,
-    PropertyID::StrokeOpacity,
-    PropertyID::StrokeLinecap,
-    PropertyID::StrokeLinejoin,
-    PropertyID::StrokeDasharray,
-    PropertyID::StrokeDashoffset,
-    PropertyID::StrokeMiterlimit,
-    PropertyID::StrokeWidth,
-    PropertyID::ColorInterpolation,
-    PropertyID::ColorInterpolationFilters,
-    PropertyID::PaintOrder,
-    PropertyID::TextAnchor,
-    PropertyID::DominantBaseline,
-};
-
-// The properties feeding the inherited list group's descriptors, in
-// registration order.
-static constexpr Array inherited_list_group_properties {
-    PropertyID::ListStyleType,
-    PropertyID::ListStylePosition,
-    PropertyID::ListStyleImage,
-    PropertyID::Quotes,
-};
-
-// The properties feeding the content and anchor groups' descriptors, in
-// registration order. Everything registers as constraints: both groups adopt
-// shared payloads unless their properties are actually used.
-static constexpr Array content_group_properties {
-    PropertyID::Content,
-    PropertyID::CounterIncrement,
-    PropertyID::CounterReset,
-    PropertyID::CounterSet,
-};
-
-static constexpr Array anchor_group_properties {
-    PropertyID::AnchorName,
-    PropertyID::AnchorScope,
-    PropertyID::PositionAnchor,
-    PropertyID::PositionArea,
-    PropertyID::PositionTryFallbacks,
-    PropertyID::PositionTryOrder,
-    PropertyID::PositionVisibility,
-};
-
-// The properties feeding the border group's descriptors, in registration
-// order; each side's color feeds both the resolved color and the retained
-// shell.
-static constexpr Array border_group_properties {
-    PropertyID::BorderLeftColor,
-    PropertyID::BorderLeftColor,
-    PropertyID::BorderLeftStyle,
-    PropertyID::BorderLeftWidth,
-    PropertyID::BorderTopColor,
-    PropertyID::BorderTopColor,
-    PropertyID::BorderTopStyle,
-    PropertyID::BorderTopWidth,
-    PropertyID::BorderRightColor,
-    PropertyID::BorderRightColor,
-    PropertyID::BorderRightStyle,
-    PropertyID::BorderRightWidth,
-    PropertyID::BorderBottomColor,
-    PropertyID::BorderBottomColor,
-    PropertyID::BorderBottomStyle,
-    PropertyID::BorderBottomWidth,
-    PropertyID::BorderBottomLeftRadius,
-    PropertyID::BorderBottomRightRadius,
-    PropertyID::BorderTopLeftRadius,
-    PropertyID::BorderTopRightRadius,
-    PropertyID::CornerBottomLeftShape,
-    PropertyID::CornerBottomRightShape,
-    PropertyID::CornerTopLeftShape,
-    PropertyID::CornerTopRightShape,
-    PropertyID::BorderImageSource,
-    PropertyID::BorderImageOutset,
-    PropertyID::BorderImageRepeat,
-    PropertyID::BorderImageSlice,
-    PropertyID::BorderImageWidth,
-};
-
-// The properties feeding the background group's descriptors, in registration
-// order; the color feeds both the resolved color and the retained shell.
-static constexpr Array background_group_properties {
-    PropertyID::BackgroundColor,
-    PropertyID::BackgroundColor,
-    PropertyID::BackgroundImage,
-    PropertyID::BackgroundClip,
-    PropertyID::BackgroundAttachment,
-    PropertyID::BackgroundOrigin,
-    PropertyID::BackgroundPositionX,
-    PropertyID::BackgroundPositionY,
-    PropertyID::BackgroundRepeat,
-    PropertyID::BackgroundSize,
-    PropertyID::BackgroundBlendMode,
-};
+static ReadonlySpan<PropertyID> style_group_gather_properties(StyleGroupIndex group_index)
+{
+    VERIFY(s_style_group_gather_properties_populated);
+    return (*s_style_group_gather_properties)[to_underlying(group_index)];
+}
 
 static void register_style_group_field_descriptors()
 {
@@ -581,11 +315,11 @@ static void register_style_group_field_descriptors()
     add(mask, PropertyID::MaskComposite, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
 
     constexpr auto grid = to_underlying(StyleGroupIndex::GridValues);
-    for (auto property : grid_group_properties)
+    for (auto property : longhands_in_style_group(StyleGroupIndex::GridValues))
         add(grid, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
 
     constexpr auto animation = to_underlying(StyleGroupIndex::AnimationValues);
-    for (auto property : animation_group_properties)
+    for (auto property : longhands_in_style_group(StyleGroupIndex::AnimationValues))
         add(animation, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
 
     using InheritedSVG = ComputedValues::InheritedSVGValues;
@@ -669,18 +403,21 @@ static void register_style_group_field_descriptors()
     constexpr auto background = to_underlying(StyleGroupIndex::BackgroundValues);
     add(background, PropertyID::BackgroundColor, offsetof(Background, background_color), GROUP_FIELD_COLOR, 0, nullptr);
     add(background, PropertyID::BackgroundColor, offsetof(Background, background_color_style_value), GROUP_FIELD_RETAINED_DATA, 0, nullptr);
-    for (auto property : { PropertyID::BackgroundImage, PropertyID::BackgroundClip, PropertyID::BackgroundAttachment,
-             PropertyID::BackgroundOrigin, PropertyID::BackgroundPositionX, PropertyID::BackgroundPositionY,
-             PropertyID::BackgroundRepeat, PropertyID::BackgroundSize, PropertyID::BackgroundBlendMode })
+    for (auto property : longhands_in_style_group(StyleGroupIndex::BackgroundValues)) {
+        if (property == PropertyID::BackgroundColor)
+            continue;
         add(background, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
+    }
 
     u32 generically_built_group_mask = 0;
     Array<bool, number_of_longhand_properties> longhand_has_descriptor {};
     for (auto const& descriptor : descriptors) {
         generically_built_group_mask |= 1u << descriptor.group_index;
         longhand_has_descriptor[descriptor.property_id - to_underlying(first_longhand_property_id)] = true;
+        (*s_style_group_gather_properties)[descriptor.group_index].append(static_cast<PropertyID>(descriptor.property_id));
     }
 
+    s_style_group_gather_properties_populated = true;
     for (auto i = to_underlying(first_longhand_property_id); i <= to_underlying(last_longhand_property_id); ++i) {
         auto property_id = static_cast<PropertyID>(i);
         if (property_is_logical_alias(property_id))
@@ -1205,15 +942,15 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (inherited_table_adopted)
         computed_values.adopt_inherited_table_group(const_cast<void*>(inherited_table_payload));
 
-    auto gather_group_values = [&]<size_t N>(Array<PropertyID, N> const& properties, Array<ComputedValuesFFI::FfiGroupValueEntry, N>& entries) {
-        for (size_t i = 0; i < N; ++i) {
-            auto const& value = computed_style.property(properties[i]);
-            entries[i] = { value.rust_style_value_data(), 0, false, 0, false };
-        }
+    auto gather_group_values = [&](ReadonlySpan<PropertyID> properties) {
+        Vector<ComputedValuesFFI::FfiGroupValueEntry, 40> entries;
+        entries.ensure_capacity(properties.size());
+        for (auto property : properties)
+            entries.unchecked_append({ computed_style.property(property).rust_style_value_data(), 0, false, 0, false });
+        return entries;
     };
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, content_group_properties.size()> content_group_values;
-    gather_group_values(content_group_properties, content_group_values);
+    auto content_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::ContentValues));
     auto* content_payload = ComputedValuesFFI::rust_build_style_group(
         ContentValues::style_group_index,
         content_group_values.data(),
@@ -1223,8 +960,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (content_adopted)
         computed_values.adopt_content_group(const_cast<void*>(content_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, anchor_group_properties.size()> anchor_group_values;
-    gather_group_values(anchor_group_properties, anchor_group_values);
+    auto anchor_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::AnchorValues));
     auto* anchor_payload = ComputedValuesFFI::rust_build_style_group(
         AnchorValues::style_group_index,
         anchor_group_values.data(),
@@ -1355,8 +1091,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         inherit_parent ? static_cast<void const*>(inherit_parent->m_noninherited.sizing.operator->()) : nullptr);
     computed_values.adopt_sizing_group(const_cast<void*>(sizing_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, grid_group_properties.size()> grid_group_values;
-    gather_group_values(grid_group_properties, grid_group_values);
+    auto grid_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::GridValues));
     auto* grid_payload = ComputedValuesFFI::rust_build_style_group(
         GridValues::style_group_index,
         grid_group_values.data(),
@@ -1366,8 +1101,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (grid_adopted)
         computed_values.adopt_grid_group(const_cast<void*>(grid_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, mask_group_properties.size()> mask_group_values;
-    gather_group_values(mask_group_properties, mask_group_values);
+    auto mask_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::MaskValues));
     auto* mask_payload = ComputedValuesFFI::rust_build_style_group(
         MaskValues::style_group_index,
         mask_group_values.data(),
@@ -1377,8 +1111,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (mask_adopted)
         computed_values.adopt_mask_group(const_cast<void*>(mask_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, transform_group_properties.size()> transform_group_values;
-    gather_group_values(transform_group_properties, transform_group_values);
+    auto transform_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::TransformValues));
     auto* transform_payload = ComputedValuesFFI::rust_build_style_group(
         TransformValues::style_group_index,
         transform_group_values.data(),
@@ -1388,8 +1121,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (transform_adopted)
         computed_values.adopt_transform_group(const_cast<void*>(transform_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, effects_group_properties.size()> effects_group_values;
-    gather_group_values(effects_group_properties, effects_group_values);
+    auto effects_group_properties = style_group_gather_properties(StyleGroupIndex::EffectsValues);
+    auto effects_group_values = gather_group_values(effects_group_properties);
     for (size_t i = 0; i < effects_group_properties.size(); ++i) {
         if (effects_group_properties[i] == PropertyID::Opacity) {
             effects_group_values[i].resolved_number = computed_style.opacity();
@@ -1478,8 +1211,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     computed_values.set_line_height(computed_style.line_height_data(), computed_style.line_height(document.font_computer()));
     computed_values.set_font_variant_emoji(computed_style.font_variant_emoji());
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, animation_group_properties.size()> animation_group_values;
-    gather_group_values(animation_group_properties, animation_group_values);
+    auto animation_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::AnimationValues));
     auto* animation_payload = ComputedValuesFFI::rust_build_style_group(
         AnimationValues::style_group_index,
         animation_group_values.data(),
@@ -1592,8 +1324,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     //     own color, which reaches the shared resolution context only further down.
     auto own_color_resolution_context = color_resolution_context;
     own_color_resolution_context.current_color = color;
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_text_group_properties.size()> inherited_text_group_values;
-    gather_group_values(inherited_text_group_properties, inherited_text_group_values);
+    auto inherited_text_group_properties = style_group_gather_properties(StyleGroupIndex::InheritedTextValues);
+    auto inherited_text_group_values = gather_group_values(inherited_text_group_properties);
     for (size_t i = 0; i < inherited_text_group_properties.size(); ++i) {
         auto gather_property_id = inherited_text_group_properties[i];
         if (gather_property_id == PropertyID::Color) {
@@ -1606,8 +1338,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
             }
         }
     }
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_ui_group_properties.size()> inherited_ui_group_values;
-    gather_group_values(inherited_ui_group_properties, inherited_ui_group_values);
+    auto inherited_ui_group_properties = style_group_gather_properties(StyleGroupIndex::InheritedUIValues);
+    auto inherited_ui_group_values = gather_group_values(inherited_ui_group_properties);
     for (size_t i = 0; i < inherited_ui_group_properties.size(); ++i) {
         auto ui_property_id = inherited_ui_group_properties[i];
         if (ui_property_id == PropertyID::CaretColor) {
@@ -1622,8 +1354,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         }
     }
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_list_group_properties.size()> inherited_list_group_values;
-    gather_group_values(inherited_list_group_properties, inherited_list_group_values);
+    auto inherited_list_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::InheritedListValues));
     auto* inherited_list_payload = ComputedValuesFFI::rust_build_style_group(
         InheritedListValues::style_group_index,
         inherited_list_group_values.data(),
@@ -1633,8 +1364,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (inherited_list_adopted)
         computed_values.adopt_inherited_list_group(const_cast<void*>(inherited_list_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_svg_group_properties.size()> inherited_svg_group_values;
-    gather_group_values(inherited_svg_group_properties, inherited_svg_group_values);
+    auto inherited_svg_group_properties = style_group_gather_properties(StyleGroupIndex::InheritedSVGValues);
+    auto inherited_svg_group_values = gather_group_values(inherited_svg_group_properties);
     for (size_t i = 0; i < inherited_svg_group_properties.size(); ++i) {
         auto svg_property_id = inherited_svg_group_properties[i];
         if (svg_property_id == PropertyID::FillOpacity) {
@@ -1674,8 +1405,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     VERIFY(svg_reset_payload);
     computed_values.adopt_svg_reset_group(const_cast<void*>(svg_reset_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, border_group_properties.size()> border_group_values;
-    gather_group_values(border_group_properties, border_group_values);
+    auto border_group_properties = style_group_gather_properties(StyleGroupIndex::BorderValues);
+    auto border_group_values = gather_group_values(border_group_properties);
     for (size_t i = 0; i < border_group_properties.size(); ++i) {
         auto border_property_id = border_group_properties[i];
         switch (border_property_id) {
@@ -1697,8 +1428,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
             break;
         }
     }
-    Array<ComputedValuesFFI::FfiGroupValueEntry, background_group_properties.size()> background_group_values;
-    gather_group_values(background_group_properties, background_group_values);
+    auto background_group_properties = style_group_gather_properties(StyleGroupIndex::BackgroundValues);
+    auto background_group_values = gather_group_values(background_group_properties);
     for (size_t i = 0; i < background_group_properties.size(); ++i) {
         if (background_group_properties[i] == PropertyID::BackgroundColor) {
             background_group_values[i].resolved_color = computed_style.color(PropertyID::BackgroundColor, own_color_resolution_context).value();
@@ -1759,8 +1490,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
 
     // NB: The text reset group builds only after the element's color lands in the
     //     resolution context above, since text-decoration-color may be currentcolor.
-    Array<ComputedValuesFFI::FfiGroupValueEntry, text_reset_group_properties.size()> text_reset_group_values;
-    gather_group_values(text_reset_group_properties, text_reset_group_values);
+    auto text_reset_group_properties = style_group_gather_properties(StyleGroupIndex::TextResetValues);
+    auto text_reset_group_values = gather_group_values(text_reset_group_properties);
     for (size_t i = 0; i < text_reset_group_properties.size(); ++i) {
         if (text_reset_group_properties[i] == PropertyID::TextDecorationColor) {
             text_reset_group_values[i].resolved_color = computed_style.color(PropertyID::TextDecorationColor, color_resolution_context).value();
@@ -1776,8 +1507,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (text_reset_adopted)
         computed_values.adopt_text_reset_group(const_cast<void*>(text_reset_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, misc_reset_group_properties.size()> misc_reset_group_values;
-    gather_group_values(misc_reset_group_properties, misc_reset_group_values);
+    auto misc_reset_group_properties = style_group_gather_properties(StyleGroupIndex::MiscResetValues);
+    auto misc_reset_group_values = gather_group_values(misc_reset_group_properties);
     for (size_t i = 0; i < misc_reset_group_properties.size(); ++i) {
         if (misc_reset_group_properties[i] == PropertyID::OutlineColor) {
             if (auto const& outline_color = computed_style.property(PropertyID::OutlineColor); outline_color.has_color()) {

--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/AnyOf.h>
+#include <AK/NeverDestroyed.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/GridTrackPlacement.h>
@@ -127,28 +128,6 @@ static Array<u8, number_of_keywords> const& keyword_code_table()
     return table;
 }
 
-// The properties feeding the text reset group's descriptors, in registration
-// order.
-static constexpr Array text_reset_group_properties {
-    PropertyID::TextDecorationLine,
-    PropertyID::TextDecorationThickness,
-    PropertyID::TextDecorationStyle,
-    PropertyID::TextDecorationColor,
-    PropertyID::WhiteSpaceTrim,
-};
-
-// The properties feeding the effects group's descriptors, in registration
-// order.
-static constexpr Array effects_group_properties {
-    PropertyID::Opacity,
-    PropertyID::Filter,
-    PropertyID::BackdropFilter,
-    PropertyID::MixBlendMode,
-    PropertyID::Isolation,
-    PropertyID::BoxShadow,
-    PropertyID::Clip,
-};
-
 // The appearance keyword mapping with the compatibility keywords excluded:
 // they normalize to auto for the appearance field but stay raw for
 // computed_appearance, so their pages take the C++ population path.
@@ -176,43 +155,6 @@ static Optional<Appearance> appearance_without_compat_from_keyword(Keyword keywo
     }
 }
 
-// The properties feeding the misc reset group's descriptors, in registration
-// order; Appearance appears twice, once per derived field.
-static constexpr Array misc_reset_group_properties {
-    PropertyID::ScrollMarginTop,
-    PropertyID::ScrollMarginRight,
-    PropertyID::ScrollMarginBottom,
-    PropertyID::ScrollMarginLeft,
-    PropertyID::ScrollPaddingTop,
-    PropertyID::ScrollPaddingRight,
-    PropertyID::ScrollPaddingBottom,
-    PropertyID::ScrollPaddingLeft,
-    PropertyID::OverflowClipMarginTop,
-    PropertyID::OverflowClipMarginRight,
-    PropertyID::OverflowClipMarginBottom,
-    PropertyID::OverflowClipMarginLeft,
-    PropertyID::ColumnSpan,
-    PropertyID::Appearance,
-    PropertyID::Appearance,
-    PropertyID::OutlineStyle,
-    PropertyID::ObjectFit,
-    PropertyID::ColumnHeight,
-    PropertyID::OutlineColor,
-    PropertyID::OutlineOffset,
-    PropertyID::OutlineWidth,
-    PropertyID::UserSelect,
-    PropertyID::ObjectPosition,
-    PropertyID::ViewTransitionName,
-    PropertyID::TouchAction,
-    PropertyID::ScrollBehavior,
-    PropertyID::ScrollbarGutter,
-    PropertyID::ScrollbarWidth,
-    PropertyID::ShapeImageThreshold,
-    PropertyID::ShapeMargin,
-    PropertyID::ShapeOutside,
-    PropertyID::WillChange,
-};
-
 // overflow-wrap has no generated keyword converter; the mapping matches the
 // switch in create().
 static Optional<OverflowWrap> overflow_wrap_from_keyword(Keyword keyword)
@@ -229,222 +171,14 @@ static Optional<OverflowWrap> overflow_wrap_from_keyword(Keyword keyword)
     }
 }
 
-// The properties feeding the inherited text group's descriptors, in
-// registration order; the doubled properties feed two fields each.
-static constexpr Array inherited_text_group_properties {
-    PropertyID::Color,
-    PropertyID::Color,
-    PropertyID::WebkitTextFillColor,
-    PropertyID::WebkitTextFillColor,
-    PropertyID::TextShadow,
-    PropertyID::TextAlign,
-    PropertyID::TextJustify,
-    PropertyID::TextTransform,
-    PropertyID::TextWrapMode,
-    PropertyID::TextWrapStyle,
-    PropertyID::TextDecorationSkipInk,
-    PropertyID::TextUnderlinePosition,
-    PropertyID::TextUnderlineOffset,
-    PropertyID::TextIndent,
-    PropertyID::TabSize,
-    PropertyID::WhiteSpaceCollapse,
-    PropertyID::WordBreak,
-    PropertyID::OverflowWrap,
-    PropertyID::WordSpacing,
-    PropertyID::WordSpacing,
-    PropertyID::LetterSpacing,
-    PropertyID::LetterSpacing,
-    PropertyID::Orphans,
-    PropertyID::Widows,
-};
+static NeverDestroyed<Array<Vector<PropertyID>, to_underlying(StyleGroupIndex::Count)>> s_style_group_gather_properties;
+static bool s_style_group_gather_properties_populated { false };
 
-// The properties feeding the inherited UI group's descriptors, in
-// registration order; the doubled properties feed two fields each.
-static constexpr Array inherited_ui_group_properties {
-    PropertyID::CaretColor,
-    PropertyID::CaretColor,
-    PropertyID::AccentColor,
-    PropertyID::AccentColor,
-    PropertyID::Cursor,
-    PropertyID::PointerEvents,
-    PropertyID::ScrollbarColor,
-    PropertyID::ColorScheme,
-    PropertyID::ColorScheme,
-};
-
-// The properties feeding the transform group's descriptors, in registration
-// order.
-static constexpr Array transform_group_properties {
-    PropertyID::Transform,
-    PropertyID::TransformBox,
-    PropertyID::TransformOrigin,
-    PropertyID::TransformStyle,
-    PropertyID::BackfaceVisibility,
-    PropertyID::Rotate,
-    PropertyID::Translate,
-    PropertyID::Scale,
-    PropertyID::Perspective,
-    PropertyID::PerspectiveOrigin,
-};
-
-// The properties feeding the mask group's descriptors, in registration
-// order.
-static constexpr Array mask_group_properties {
-    PropertyID::MaskImage,
-    PropertyID::MaskType,
-    PropertyID::ClipPath,
-    PropertyID::MaskMode,
-    PropertyID::MaskRepeat,
-    PropertyID::MaskPosition,
-    PropertyID::MaskClip,
-    PropertyID::MaskOrigin,
-    PropertyID::MaskSize,
-    PropertyID::MaskComposite,
-};
-
-// The properties feeding the grid group's descriptors, in registration
-// order. Every field registers as an initial-value constraint until the
-// core learns the grid representations.
-static constexpr Array grid_group_properties {
-    PropertyID::GridAutoColumns,
-    PropertyID::GridAutoRows,
-    PropertyID::GridTemplateColumns,
-    PropertyID::GridTemplateRows,
-    PropertyID::GridColumnEnd,
-    PropertyID::GridColumnStart,
-    PropertyID::GridRowEnd,
-    PropertyID::GridRowStart,
-    PropertyID::GridTemplateAreas,
-};
-
-// The properties feeding the animation group's descriptors, in registration
-// order. Every field registers as an initial-value constraint: elements
-// without animations, timelines or transitions adopt a shared payload.
-static constexpr Array animation_group_properties {
-    PropertyID::AnimationName,
-    PropertyID::AnimationComposition,
-    PropertyID::AnimationDelay,
-    PropertyID::AnimationDirection,
-    PropertyID::AnimationDuration,
-    PropertyID::AnimationFillMode,
-    PropertyID::AnimationIterationCount,
-    PropertyID::AnimationPlayState,
-    PropertyID::AnimationTimeline,
-    PropertyID::AnimationTimingFunction,
-    PropertyID::ScrollTimelineName,
-    PropertyID::ScrollTimelineAxis,
-    PropertyID::TimelineScope,
-    PropertyID::ViewTimelineName,
-    PropertyID::ViewTimelineAxis,
-    PropertyID::ViewTimelineInset,
-    PropertyID::TransitionProperty,
-    PropertyID::TransitionDuration,
-    PropertyID::TransitionTimingFunction,
-    PropertyID::TransitionDelay,
-    PropertyID::TransitionBehavior,
-};
-
-// The properties feeding the inherited SVG group's descriptors, in
-// registration order.
-static constexpr Array inherited_svg_group_properties {
-    PropertyID::Fill,
-    PropertyID::Stroke,
-    PropertyID::FillRule,
-    PropertyID::ClipRule,
-    PropertyID::FillOpacity,
-    PropertyID::StrokeOpacity,
-    PropertyID::StrokeLinecap,
-    PropertyID::StrokeLinejoin,
-    PropertyID::StrokeDasharray,
-    PropertyID::StrokeDashoffset,
-    PropertyID::StrokeMiterlimit,
-    PropertyID::StrokeWidth,
-    PropertyID::ColorInterpolation,
-    PropertyID::ColorInterpolationFilters,
-    PropertyID::PaintOrder,
-    PropertyID::TextAnchor,
-    PropertyID::DominantBaseline,
-};
-
-// The properties feeding the inherited list group's descriptors, in
-// registration order.
-static constexpr Array inherited_list_group_properties {
-    PropertyID::ListStyleType,
-    PropertyID::ListStylePosition,
-    PropertyID::ListStyleImage,
-    PropertyID::Quotes,
-};
-
-// The properties feeding the content and anchor groups' descriptors, in
-// registration order. Everything registers as constraints: both groups adopt
-// shared payloads unless their properties are actually used.
-static constexpr Array content_group_properties {
-    PropertyID::Content,
-    PropertyID::CounterIncrement,
-    PropertyID::CounterReset,
-    PropertyID::CounterSet,
-};
-
-static constexpr Array anchor_group_properties {
-    PropertyID::AnchorName,
-    PropertyID::AnchorScope,
-    PropertyID::PositionAnchor,
-    PropertyID::PositionArea,
-    PropertyID::PositionTryFallbacks,
-    PropertyID::PositionTryOrder,
-    PropertyID::PositionVisibility,
-};
-
-// The properties feeding the border group's descriptors, in registration
-// order; each side's color feeds both the resolved color and the retained
-// shell.
-static constexpr Array border_group_properties {
-    PropertyID::BorderLeftColor,
-    PropertyID::BorderLeftColor,
-    PropertyID::BorderLeftStyle,
-    PropertyID::BorderLeftWidth,
-    PropertyID::BorderTopColor,
-    PropertyID::BorderTopColor,
-    PropertyID::BorderTopStyle,
-    PropertyID::BorderTopWidth,
-    PropertyID::BorderRightColor,
-    PropertyID::BorderRightColor,
-    PropertyID::BorderRightStyle,
-    PropertyID::BorderRightWidth,
-    PropertyID::BorderBottomColor,
-    PropertyID::BorderBottomColor,
-    PropertyID::BorderBottomStyle,
-    PropertyID::BorderBottomWidth,
-    PropertyID::BorderBottomLeftRadius,
-    PropertyID::BorderBottomRightRadius,
-    PropertyID::BorderTopLeftRadius,
-    PropertyID::BorderTopRightRadius,
-    PropertyID::CornerBottomLeftShape,
-    PropertyID::CornerBottomRightShape,
-    PropertyID::CornerTopLeftShape,
-    PropertyID::CornerTopRightShape,
-    PropertyID::BorderImageSource,
-    PropertyID::BorderImageOutset,
-    PropertyID::BorderImageRepeat,
-    PropertyID::BorderImageSlice,
-    PropertyID::BorderImageWidth,
-};
-
-// The properties feeding the background group's descriptors, in registration
-// order; the color feeds both the resolved color and the retained shell.
-static constexpr Array background_group_properties {
-    PropertyID::BackgroundColor,
-    PropertyID::BackgroundColor,
-    PropertyID::BackgroundImage,
-    PropertyID::BackgroundClip,
-    PropertyID::BackgroundAttachment,
-    PropertyID::BackgroundOrigin,
-    PropertyID::BackgroundPositionX,
-    PropertyID::BackgroundPositionY,
-    PropertyID::BackgroundRepeat,
-    PropertyID::BackgroundSize,
-    PropertyID::BackgroundBlendMode,
-};
+static ReadonlySpan<PropertyID> style_group_gather_properties(StyleGroupIndex group_index)
+{
+    VERIFY(s_style_group_gather_properties_populated);
+    return (*s_style_group_gather_properties)[to_underlying(group_index)];
+}
 
 static void register_style_group_field_descriptors()
 {
@@ -582,11 +316,11 @@ static void register_style_group_field_descriptors()
     add(mask, PropertyID::MaskComposite, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
 
     constexpr auto grid = to_underlying(StyleGroupIndex::GridValues);
-    for (auto property : grid_group_properties)
+    for (auto property : longhands_in_style_group(StyleGroupIndex::GridValues))
         add(grid, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
 
     constexpr auto animation = to_underlying(StyleGroupIndex::AnimationValues);
-    for (auto property : animation_group_properties)
+    for (auto property : longhands_in_style_group(StyleGroupIndex::AnimationValues))
         add(animation, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
 
     using InheritedSVG = ComputedValues::InheritedSVGValues;
@@ -670,18 +404,21 @@ static void register_style_group_field_descriptors()
     constexpr auto background = to_underlying(StyleGroupIndex::BackgroundValues);
     add(background, PropertyID::BackgroundColor, offsetof(Background, background_color), GROUP_FIELD_COLOR, 0, nullptr);
     add(background, PropertyID::BackgroundColor, offsetof(Background, background_color_style_value), GROUP_FIELD_RETAINED_DATA, 0, nullptr);
-    for (auto property : { PropertyID::BackgroundImage, PropertyID::BackgroundClip, PropertyID::BackgroundAttachment,
-             PropertyID::BackgroundOrigin, PropertyID::BackgroundPositionX, PropertyID::BackgroundPositionY,
-             PropertyID::BackgroundRepeat, PropertyID::BackgroundSize, PropertyID::BackgroundBlendMode })
+    for (auto property : longhands_in_style_group(StyleGroupIndex::BackgroundValues)) {
+        if (property == PropertyID::BackgroundColor)
+            continue;
         add(background, property, 0, GROUP_FIELD_REQUIRE_INITIAL_VALUE, 0, nullptr);
+    }
 
     u32 generically_built_group_mask = 0;
     Array<bool, number_of_longhand_properties> longhand_has_descriptor {};
     for (auto const& descriptor : descriptors) {
         generically_built_group_mask |= 1u << descriptor.group_index;
         longhand_has_descriptor[descriptor.property_id - to_underlying(first_longhand_property_id)] = true;
+        (*s_style_group_gather_properties)[descriptor.group_index].append(static_cast<PropertyID>(descriptor.property_id));
     }
 
+    s_style_group_gather_properties_populated = true;
     for (auto i = to_underlying(first_longhand_property_id); i <= to_underlying(last_longhand_property_id); ++i) {
         auto property_id = static_cast<PropertyID>(i);
         if (property_is_logical_alias(property_id))
@@ -1257,15 +994,15 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (inherited_table_adopted)
         computed_values.adopt_inherited_table_group(const_cast<void*>(inherited_table_payload));
 
-    auto gather_group_values = [&]<size_t N>(Array<PropertyID, N> const& properties, Array<ComputedValuesFFI::FfiGroupValueEntry, N>& entries) {
-        for (size_t i = 0; i < N; ++i) {
-            auto const& value = computed_style.property(properties[i]);
-            entries[i] = { value.rust_style_value_data(), 0, false, 0, false };
-        }
+    auto gather_group_values = [&](ReadonlySpan<PropertyID> properties) {
+        Vector<ComputedValuesFFI::FfiGroupValueEntry, 40> entries;
+        entries.ensure_capacity(properties.size());
+        for (auto property : properties)
+            entries.unchecked_append({ computed_style.property(property).rust_style_value_data(), 0, false, 0, false });
+        return entries;
     };
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, content_group_properties.size()> content_group_values;
-    gather_group_values(content_group_properties, content_group_values);
+    auto content_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::ContentValues));
     auto* content_payload = ComputedValuesFFI::rust_build_style_group(
         ContentValues::style_group_index,
         content_group_values.data(),
@@ -1275,8 +1012,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (content_adopted)
         computed_values.adopt_content_group(const_cast<void*>(content_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, anchor_group_properties.size()> anchor_group_values;
-    gather_group_values(anchor_group_properties, anchor_group_values);
+    auto anchor_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::AnchorValues));
     auto* anchor_payload = ComputedValuesFFI::rust_build_style_group(
         AnchorValues::style_group_index,
         anchor_group_values.data(),
@@ -1407,8 +1143,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         inherit_parent ? static_cast<void const*>(inherit_parent->m_noninherited.sizing.operator->()) : nullptr);
     computed_values.adopt_sizing_group(const_cast<void*>(sizing_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, grid_group_properties.size()> grid_group_values;
-    gather_group_values(grid_group_properties, grid_group_values);
+    auto grid_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::GridValues));
     auto* grid_payload = ComputedValuesFFI::rust_build_style_group(
         GridValues::style_group_index,
         grid_group_values.data(),
@@ -1418,8 +1153,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (grid_adopted)
         computed_values.adopt_grid_group(const_cast<void*>(grid_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, mask_group_properties.size()> mask_group_values;
-    gather_group_values(mask_group_properties, mask_group_values);
+    auto mask_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::MaskValues));
     auto* mask_payload = ComputedValuesFFI::rust_build_style_group(
         MaskValues::style_group_index,
         mask_group_values.data(),
@@ -1429,8 +1163,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (mask_adopted)
         computed_values.adopt_mask_group(const_cast<void*>(mask_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, transform_group_properties.size()> transform_group_values;
-    gather_group_values(transform_group_properties, transform_group_values);
+    auto transform_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::TransformValues));
     auto* transform_payload = ComputedValuesFFI::rust_build_style_group(
         TransformValues::style_group_index,
         transform_group_values.data(),
@@ -1440,8 +1173,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (transform_adopted)
         computed_values.adopt_transform_group(const_cast<void*>(transform_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, effects_group_properties.size()> effects_group_values;
-    gather_group_values(effects_group_properties, effects_group_values);
+    auto effects_group_properties = style_group_gather_properties(StyleGroupIndex::EffectsValues);
+    auto effects_group_values = gather_group_values(effects_group_properties);
     for (size_t i = 0; i < effects_group_properties.size(); ++i) {
         if (effects_group_properties[i] == PropertyID::Opacity) {
             effects_group_values[i].resolved_number = computed_style.opacity();
@@ -1530,8 +1263,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     computed_values.set_line_height(computed_style.line_height_data(), computed_style.line_height(document.font_computer()));
     computed_values.set_font_variant_emoji(computed_style.font_variant_emoji());
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, animation_group_properties.size()> animation_group_values;
-    gather_group_values(animation_group_properties, animation_group_values);
+    auto animation_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::AnimationValues));
     auto* animation_payload = ComputedValuesFFI::rust_build_style_group(
         AnimationValues::style_group_index,
         animation_group_values.data(),
@@ -1644,8 +1376,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     //     own color, which reaches the shared resolution context only further down.
     auto own_color_resolution_context = color_resolution_context;
     own_color_resolution_context.current_color = color;
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_text_group_properties.size()> inherited_text_group_values;
-    gather_group_values(inherited_text_group_properties, inherited_text_group_values);
+    auto inherited_text_group_properties = style_group_gather_properties(StyleGroupIndex::InheritedTextValues);
+    auto inherited_text_group_values = gather_group_values(inherited_text_group_properties);
     for (size_t i = 0; i < inherited_text_group_properties.size(); ++i) {
         auto gather_property_id = inherited_text_group_properties[i];
         if (gather_property_id == PropertyID::Color) {
@@ -1658,8 +1390,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
             }
         }
     }
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_ui_group_properties.size()> inherited_ui_group_values;
-    gather_group_values(inherited_ui_group_properties, inherited_ui_group_values);
+    auto inherited_ui_group_properties = style_group_gather_properties(StyleGroupIndex::InheritedUIValues);
+    auto inherited_ui_group_values = gather_group_values(inherited_ui_group_properties);
     for (size_t i = 0; i < inherited_ui_group_properties.size(); ++i) {
         auto ui_property_id = inherited_ui_group_properties[i];
         if (ui_property_id == PropertyID::CaretColor) {
@@ -1674,8 +1406,7 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
         }
     }
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_list_group_properties.size()> inherited_list_group_values;
-    gather_group_values(inherited_list_group_properties, inherited_list_group_values);
+    auto inherited_list_group_values = gather_group_values(style_group_gather_properties(StyleGroupIndex::InheritedListValues));
     auto* inherited_list_payload = ComputedValuesFFI::rust_build_style_group(
         InheritedListValues::style_group_index,
         inherited_list_group_values.data(),
@@ -1685,8 +1416,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (inherited_list_adopted)
         computed_values.adopt_inherited_list_group(const_cast<void*>(inherited_list_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, inherited_svg_group_properties.size()> inherited_svg_group_values;
-    gather_group_values(inherited_svg_group_properties, inherited_svg_group_values);
+    auto inherited_svg_group_properties = style_group_gather_properties(StyleGroupIndex::InheritedSVGValues);
+    auto inherited_svg_group_values = gather_group_values(inherited_svg_group_properties);
     for (size_t i = 0; i < inherited_svg_group_properties.size(); ++i) {
         auto svg_property_id = inherited_svg_group_properties[i];
         if (svg_property_id == PropertyID::FillOpacity) {
@@ -1726,8 +1457,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     VERIFY(svg_reset_payload);
     computed_values.adopt_svg_reset_group(const_cast<void*>(svg_reset_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, border_group_properties.size()> border_group_values;
-    gather_group_values(border_group_properties, border_group_values);
+    auto border_group_properties = style_group_gather_properties(StyleGroupIndex::BorderValues);
+    auto border_group_values = gather_group_values(border_group_properties);
     for (size_t i = 0; i < border_group_properties.size(); ++i) {
         auto border_property_id = border_group_properties[i];
         switch (border_property_id) {
@@ -1749,8 +1480,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
             break;
         }
     }
-    Array<ComputedValuesFFI::FfiGroupValueEntry, background_group_properties.size()> background_group_values;
-    gather_group_values(background_group_properties, background_group_values);
+    auto background_group_properties = style_group_gather_properties(StyleGroupIndex::BackgroundValues);
+    auto background_group_values = gather_group_values(background_group_properties);
     for (size_t i = 0; i < background_group_properties.size(); ++i) {
         if (background_group_properties[i] == PropertyID::BackgroundColor) {
             background_group_values[i].resolved_color = computed_style.color(PropertyID::BackgroundColor, own_color_resolution_context).value();
@@ -1811,8 +1542,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
 
     // NB: The text reset group builds only after the element's color lands in the
     //     resolution context above, since text-decoration-color may be currentcolor.
-    Array<ComputedValuesFFI::FfiGroupValueEntry, text_reset_group_properties.size()> text_reset_group_values;
-    gather_group_values(text_reset_group_properties, text_reset_group_values);
+    auto text_reset_group_properties = style_group_gather_properties(StyleGroupIndex::TextResetValues);
+    auto text_reset_group_values = gather_group_values(text_reset_group_properties);
     for (size_t i = 0; i < text_reset_group_properties.size(); ++i) {
         if (text_reset_group_properties[i] == PropertyID::TextDecorationColor) {
             text_reset_group_values[i].resolved_color = computed_style.color(PropertyID::TextDecorationColor, color_resolution_context).value();
@@ -1828,8 +1559,8 @@ NonnullRefPtr<ComputedValues const> ComputedValues::create(ComputedProperties co
     if (text_reset_adopted)
         computed_values.adopt_text_reset_group(const_cast<void*>(text_reset_payload));
 
-    Array<ComputedValuesFFI::FfiGroupValueEntry, misc_reset_group_properties.size()> misc_reset_group_values;
-    gather_group_values(misc_reset_group_properties, misc_reset_group_values);
+    auto misc_reset_group_properties = style_group_gather_properties(StyleGroupIndex::MiscResetValues);
+    auto misc_reset_group_values = gather_group_values(misc_reset_group_properties);
     for (size_t i = 0; i < misc_reset_group_properties.size(); ++i) {
         if (misc_reset_group_properties[i] == PropertyID::OutlineColor) {
             if (auto const& outline_color = computed_style.property(PropertyID::OutlineColor); outline_color.has_color()) {

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -153,6 +153,7 @@
     "initial": "currentColor",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "color"
     ]
@@ -190,6 +191,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui",
     "valid-types": [
       "color"
     ],
@@ -202,6 +204,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "align-content"
     ]
@@ -211,6 +214,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "align-items"
     ]
@@ -220,6 +224,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "align-self"
     ]
@@ -236,6 +241,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident"
     ],
@@ -249,6 +255,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident"
     ],
@@ -279,6 +286,7 @@
     "inherited": false,
     "initial": "replace",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "animation-composition"
     ],
@@ -291,6 +299,7 @@
     "initial": "0s",
     "requires-computation": "cascaded-value",
     "multiplicity": "coordinating-list",
+    "style-group": "animation",
     "valid-types": [
       "time [-∞,∞]"
     ]
@@ -302,6 +311,7 @@
     "initial": "normal",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "normal",
       "reverse",
@@ -317,6 +327,7 @@
     "multiplicity": "coordinating-list",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "time [0,∞]"
     ],
@@ -331,6 +342,7 @@
     "initial": "none",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "none",
       "forwards",
@@ -345,6 +357,7 @@
     "initial": "1",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "number [0,∞]"
     ],
@@ -359,6 +372,7 @@
     "initial": "none",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "string",
       "custom-ident ![none]"
@@ -374,6 +388,7 @@
     "initial": "running",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "running",
       "paused"
@@ -385,6 +400,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "dashed-ident",
       "scroll-function",
@@ -403,6 +419,7 @@
     "initial": "ease",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "easing-function",
       "easing-keyword"
@@ -413,6 +430,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "appearance"
     ]
@@ -423,6 +441,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "ratio"
     ],
@@ -441,6 +460,7 @@
     "__comment": "FIXME: List `filter-value-list` as a valid-type once it's generically supported.",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": [ "effects", "inherited-text" ],
     "valid-identifiers": [
       "none"
     ]
@@ -452,6 +472,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "transform",
     "valid-types": [
       "backface-visibility"
     ]
@@ -479,6 +500,7 @@
     "initial": "scroll",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "background-attachment"
     ]
@@ -490,6 +512,7 @@
     "initial": "normal",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "mix-blend-mode"
     ]
@@ -502,6 +525,7 @@
     "multiplicity": "coordinating-list",
     "__comment": "FIXME: Support `border-area`",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "background-box"
     ]
@@ -513,6 +537,7 @@
     "initial": "transparent",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "background",
     "valid-types": [
       "color"
     ],
@@ -527,6 +552,7 @@
     "initial": "none",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "background",
     "valid-types": [
       "image"
     ],
@@ -542,6 +568,7 @@
     "multiplicity": "coordinating-list",
     "__comment": "FIXME: This shouldn't allow `text`",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "background-box"
     ]
@@ -570,6 +597,7 @@
     "initial": "0%",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -588,6 +616,7 @@
     "initial": "0%",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -607,6 +636,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "repetition"
     ],
@@ -623,6 +653,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -776,6 +807,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -790,6 +822,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -803,6 +836,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -814,6 +848,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -823,6 +858,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -838,6 +874,7 @@
     "inherited": true,
     "initial": "separate",
     "requires-computation": "never",
+    "style-group": "inherited-table",
     "valid-types": [
       "border-collapse"
     ]
@@ -890,6 +927,7 @@
     "initial": "0",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]"
@@ -902,6 +940,7 @@
     "initial": "stretch",
     "max-values": 2,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "border-image-repeat"
     ]
@@ -912,6 +951,7 @@
     "inherited": false,
     "initial": "100%",
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-identifiers": [
       "fill"
     ],
@@ -927,6 +967,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "image"
     ],
@@ -941,6 +982,7 @@
     "initial": "1",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]",
@@ -1070,6 +1112,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -1082,6 +1125,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -1091,6 +1135,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -1130,6 +1175,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -1142,6 +1188,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -1151,6 +1198,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -1167,6 +1215,7 @@
     "initial": "0",
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-table",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -1216,6 +1265,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -1230,6 +1280,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -1243,6 +1294,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -1254,6 +1306,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -1263,6 +1316,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -1294,6 +1348,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -1316,6 +1371,7 @@
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
     "multiplicity": "list",
+    "style-group": "effects",
     "valid-identifiers": [
       "none"
     ]
@@ -1325,6 +1381,7 @@
     "inherited": false,
     "initial": "content-box",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "box-sizing"
     ]
@@ -1334,6 +1391,7 @@
     "inherited": true,
     "initial": "top",
     "requires-computation": "never",
+    "style-group": "inherited-table",
     "valid-types": [
       "caption-side"
     ]
@@ -1345,6 +1403,7 @@
     "initial": "auto",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui",
     "valid-identifiers": [
       "auto"
     ],
@@ -1357,6 +1416,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "clear"
     ]
@@ -1368,6 +1428,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "effects",
     "valid-identifiers": [
       "auto"
     ],
@@ -1385,6 +1446,7 @@
     "affects-stacking-context": true,
     "inherited": false,
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-identifiers": [
       "none"
     ],
@@ -1401,6 +1463,7 @@
     "inherited": true,
     "initial": "nonzero",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "fill-rule"
     ]
@@ -1412,6 +1475,7 @@
     "initial": "canvastext",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "color"
     ],
@@ -1425,6 +1489,7 @@
     "inherited": true,
     "initial": "srgb",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "color-interpolation"
     ]
@@ -1435,6 +1500,7 @@
     "inherited": true,
     "initial": "linearrgb",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "color-interpolation"
     ]
@@ -1445,6 +1511,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "inherited-ui",
     "valid-types": [
       "custom-ident ![normal,light,dark,only]"
     ],
@@ -1459,6 +1526,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "integer [1,∞]"
     ],
@@ -1471,6 +1539,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -1485,6 +1554,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -1497,6 +1567,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "column-span"
     ]
@@ -1506,6 +1577,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -1528,6 +1600,7 @@
     "initial": "none",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "contain"
     ]
@@ -1546,6 +1619,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "custom-ident ![none,and,not,or]"
     ],
@@ -1559,6 +1633,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-identifiers": [
       "normal",
       "size",
@@ -1572,6 +1647,7 @@
     "initial": "normal",
     "__comment": "FIXME: This accepts a whole lot of other types and identifiers!",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "counter",
       "image",
@@ -1591,6 +1667,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "content-visibility"
     ]
@@ -1622,6 +1699,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1631,6 +1709,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1732,6 +1811,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1741,6 +1821,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1762,6 +1843,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "custom-ident ![none]",
       "integer [-∞,∞]"
@@ -1776,6 +1858,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "custom-ident ![none]",
       "integer [-∞,∞]"
@@ -1790,6 +1873,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "custom-ident ![none]",
       "integer [-∞,∞]"
@@ -1804,6 +1888,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui",
     "valid-types": [
       "url",
       "cursor-predefined",
@@ -1816,6 +1901,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -1831,6 +1917,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -1844,13 +1931,15 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "none",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "svg-reset"
   },
   "direction": {
     "animation-type": "none",
     "inherited": true,
     "initial": "ltr",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "direction"
     ]
@@ -1861,6 +1950,7 @@
     "initial": "inline",
     "requires-computation": "never",
     "max-values": 3,
+    "style-group": "box",
     "valid-identifiers": [
       "list-item"
     ],
@@ -1877,6 +1967,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "baseline-metric"
     ],
@@ -1889,6 +1980,7 @@
     "inherited": true,
     "initial": "show",
     "requires-computation": "never",
+    "style-group": "inherited-table",
     "valid-types": [
       "empty-cells"
     ]
@@ -1899,6 +1991,7 @@
     "inherited": true,
     "initial": "black",
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "paint"
     ]
@@ -1909,6 +2002,7 @@
     "inherited": true,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "opacity-value"
     ]
@@ -1919,6 +2013,7 @@
     "inherited": true,
     "initial": "nonzero",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "fill-rule"
     ]
@@ -1934,6 +2029,7 @@
     "__comment": "FIXME: List `filter-value-list` as a valid-type once it's generically supported.",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": [ "effects", "inherited-text" ],
     "valid-identifiers": [
       "none"
     ]
@@ -1954,6 +2050,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -1972,6 +2069,7 @@
     "inherited": false,
     "initial": "row",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "flex-direction"
     ]
@@ -1988,6 +2086,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "number [0,∞]"
     ]
@@ -1997,6 +2096,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "number [0,∞]"
     ]
@@ -2006,6 +2106,7 @@
     "inherited": false,
     "initial": "nowrap",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "flex-wrap"
     ]
@@ -2015,6 +2116,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "float"
     ]
@@ -2025,6 +2127,7 @@
     "inherited": false,
     "initial": "black",
     "requires-computation": "non-inherited-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "color"
     ]
@@ -2035,6 +2138,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "opacity-value"
     ]
@@ -2063,6 +2167,7 @@
     "initial": "serif",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "custom-ident",
       "string"
@@ -2074,6 +2179,7 @@
     "initial": "normal",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "integer [0,∞]",
       "opentype-tag"
@@ -2089,6 +2195,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-kerning"
     ]
@@ -2098,6 +2205,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "string"
     ],
@@ -2110,6 +2218,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-optical-sizing"
     ]
@@ -2119,6 +2228,7 @@
     "inherited": true,
     "initial": "medium",
     "requires-computation": "non-inherited-value",
+    "style-group": "font",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]",
@@ -2141,6 +2251,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "font-style"
     ]
@@ -2165,6 +2276,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal"
     ],
@@ -2177,6 +2289,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-variant-caps"
     ]
@@ -2186,6 +2299,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal"
     ],
@@ -2198,6 +2312,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-variant-emoji"
     ]
@@ -2207,6 +2322,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal",
       "none"
@@ -2220,6 +2336,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal"
     ],
@@ -2232,6 +2349,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-variant-position"
     ]
@@ -2242,6 +2360,7 @@
     "initial": "normal",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "number [-∞,∞]",
       "opentype-tag"
@@ -2256,6 +2375,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "font",
     "valid-types": [
       "number [1,1000]"
     ],
@@ -2272,6 +2392,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "font",
     "valid-types": [
       "percentage [0,∞]",
       "font-width"
@@ -2333,6 +2454,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2347,13 +2469,15 @@
     "animation-type": "discrete",
     "inherited": false,
     "initial": "row",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "box"
   },
   "grid-auto-rows": {
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2382,6 +2506,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2397,6 +2522,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2425,6 +2551,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2440,6 +2567,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2470,6 +2598,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "grid",
     "valid-identifiers": [
       "none"
     ],
@@ -2483,6 +2612,7 @@
     "initial": "none",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2500,6 +2630,7 @@
     "initial": "none",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2516,6 +2647,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -2538,6 +2670,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "image-rendering"
     ]
@@ -2641,6 +2774,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "effects",
     "valid-types": [
       "isolation"
     ]
@@ -2650,6 +2784,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "justify-content"
     ]
@@ -2659,6 +2794,7 @@
     "inherited": false,
     "initial": "legacy",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "justify-items"
     ]
@@ -2668,6 +2804,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "justify-self"
     ]
@@ -2677,6 +2814,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -2697,6 +2835,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2715,6 +2854,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]",
@@ -2739,6 +2879,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-list",
     "valid-types": [
       "image"
     ],
@@ -2751,6 +2892,7 @@
     "inherited": true,
     "initial": "outside",
     "requires-computation": "never",
+    "style-group": "inherited-list",
     "valid-types": [
       "list-style-position"
     ]
@@ -2760,6 +2902,7 @@
     "inherited": true,
     "initial": "disc",
     "requires-computation": "never",
+    "style-group": "inherited-list",
     "valid-types": [
       "counter-style",
       "string"
@@ -2826,6 +2969,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2875,6 +3019,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2893,6 +3038,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2911,6 +3057,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2946,6 +3093,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "coord-box"
     ],
@@ -2960,6 +3108,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "compositing-operator"
     ],
@@ -2973,6 +3122,7 @@
     "affects-stacking-context": true,
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-types": [
       "image",
       "url"
@@ -2988,6 +3138,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "masking-mode"
     ],
@@ -2999,6 +3150,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "coord-box"
     ],
@@ -3011,6 +3163,7 @@
     "initial": "0% 0%",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-types": [
       "position"
     ],
@@ -3024,6 +3177,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "repetition"
     ],
@@ -3040,6 +3194,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3058,6 +3213,7 @@
     "affects-layout": false,
     "multiplicity": "single",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "mask-type"
     ],
@@ -3070,6 +3226,7 @@
     "needs-layout-node-for-resolved-value": true,
     "__comment": "FIXME: `add(<integer>)` is also valid but we can't represent that here yet.",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "integer [-∞,∞]"
     ],
@@ -3082,6 +3239,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "math-shift"
     ]
@@ -3091,6 +3249,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "math-style"
     ]
@@ -3107,6 +3266,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3134,6 +3294,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3161,6 +3322,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3188,6 +3350,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3210,6 +3373,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "effects",
     "valid-types": [
       "mix-blend-mode"
     ]
@@ -3220,6 +3384,7 @@
     "inherited": false,
     "initial": "fill",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "object-fit"
     ]
@@ -3231,6 +3396,7 @@
     "inherited": false,
     "initial": "50% 50%",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "position"
     ],
@@ -3244,6 +3410,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "effects",
     "valid-types": [
       "opacity-value"
     ]
@@ -3253,6 +3420,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "integer [-∞,∞]"
     ]
@@ -3262,6 +3430,7 @@
     "inherited": true,
     "initial": "2",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "integer [1,∞]"
     ],
@@ -3284,6 +3453,7 @@
     "initial": "currentColor",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "color"
     ]
@@ -3294,6 +3464,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3304,6 +3475,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "outline-style"
     ]
@@ -3314,6 +3486,7 @@
     "inherited": false,
     "initial": "medium",
     "requires-computation": "non-inherited-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -3377,6 +3550,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3408,6 +3582,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3417,6 +3592,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3426,6 +3602,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3442,6 +3619,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "anywhere",
       "break-word",
@@ -3453,6 +3631,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "overflow"
     ],
@@ -3465,6 +3644,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "overflow"
     ],
@@ -3524,6 +3704,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3566,6 +3747,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3581,6 +3763,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3596,6 +3779,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3611,6 +3795,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-identifiers": [
       "normal"
     ],
@@ -3624,6 +3809,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-identifiers": [
       "none"
     ],
@@ -3638,6 +3824,7 @@
     "inherited": false,
     "initial": "50% 50%",
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "position"
     ],
@@ -3670,6 +3857,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-ui",
     "valid-types": [
       "pointer-events"
     ]
@@ -3679,6 +3867,7 @@
     "inherited": false,
     "initial": "static",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "positioning"
     ]
@@ -3688,6 +3877,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident"
     ],
@@ -3703,6 +3893,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "anchor",
     "valid-types": [
       "position-area"
     ],
@@ -3715,6 +3906,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident",
       "try-tactic"
@@ -3728,6 +3920,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "try-order"
     ],
@@ -3740,6 +3933,7 @@
     "inherited": false,
     "initial": "anchors-visible",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-identifiers": [
       "always",
       "anchors-valid",
@@ -3753,6 +3947,7 @@
     "initial": "auto",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "inherited-list",
     "valid-types": [
       "string"
     ],
@@ -3767,6 +3962,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3782,6 +3978,7 @@
     "affects-layout": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "resize"
     ]
@@ -3791,6 +3988,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -3813,13 +4011,15 @@
     "affects-layout": false,
     "affects-scrollable-overflow": true,
     "affects-stacking-context": true,
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "transform"
   },
   "row-gap": {
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "normal",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3835,6 +4035,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3853,6 +4054,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3873,7 +4075,8 @@
     "affects-layout": false,
     "affects-scrollable-overflow": true,
     "affects-stacking-context": true,
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "transform"
   },
   "scroll-behavior": {
     "initial": "auto",
@@ -3881,6 +4084,7 @@
     "affects-layout": false,
     "animation-type": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-identifiers": [
       "auto",
       "smooth"
@@ -3927,6 +4131,7 @@
     "initial": "0",
     "inherited": false,
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3959,6 +4164,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3968,6 +4174,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3977,6 +4184,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -4032,6 +4240,7 @@
     "initial": "auto",
     "inherited": false,
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4074,6 +4283,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4088,6 +4298,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4102,6 +4313,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4126,6 +4338,7 @@
     "inherited": false,
     "initial": "block",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "axis"
     ],
@@ -4137,6 +4350,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "none"
     ],
@@ -4150,7 +4364,8 @@
     "animation-type": "by-computed-value",
     "inherited": true,
     "initial": "auto",
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui"
   },
   "scrollbar-gutter": {
     "affects-layout": false,
@@ -4158,7 +4373,8 @@
     "__comment": "This property should affect layout per-spec, but ladybird always uses overlay scrollbars so it doesn't in practice.",
     "inherited": false,
     "initial": "auto",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "misc-reset"
   },
   "scrollbar-width": {
     "affects-layout": false,
@@ -4166,6 +4382,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "scrollbar-width"
     ],
@@ -4181,6 +4398,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "opacity-value"
     ]
@@ -4190,6 +4408,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4201,7 +4420,8 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "none",
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "misc-reset"
   },
   "shape-rendering": {
     "affects-layout": true,
@@ -4209,6 +4429,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "svg-reset",
     "valid-types": [
       "shape-rendering"
     ]
@@ -4219,6 +4440,7 @@
     "inherited": false,
     "initial": "black",
     "requires-computation": "non-inherited-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "color"
     ]
@@ -4229,6 +4451,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "opacity-value"
     ]
@@ -4239,6 +4462,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "paint"
     ]
@@ -4249,7 +4473,8 @@
     "initial": "none",
     "affects-layout": false,
     "percentages-resolve-to": "length",
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg"
   },
   "stroke-dashoffset": {
     "affects-layout": false,
@@ -4257,6 +4482,7 @@
     "inherited": true,
     "initial": "0px",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]",
@@ -4270,6 +4496,7 @@
     "inherited": true,
     "initial": "butt",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "stroke-linecap"
     ]
@@ -4280,6 +4507,7 @@
     "inherited": true,
     "initial": "miter",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "stroke-linejoin"
     ]
@@ -4290,6 +4518,7 @@
     "inherited": true,
     "initial": "4",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "number [0,∞]"
     ]
@@ -4300,6 +4529,7 @@
     "inherited": true,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "opacity-value"
     ]
@@ -4310,6 +4540,7 @@
     "inherited": true,
     "initial": "1px",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]",
@@ -4322,6 +4553,7 @@
     "inherited": true,
     "initial": "8",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]"
@@ -4332,6 +4564,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "table-layout"
     ]
@@ -4341,6 +4574,7 @@
     "inherited": true,
     "initial": "start",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-align"
     ]
@@ -4350,6 +4584,7 @@
     "inherited": true,
     "initial": "start",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "text-anchor"
     ]
@@ -4371,6 +4606,7 @@
     "initial": "currentcolor",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "text-reset",
     "valid-types": [
       "color"
     ]
@@ -4382,6 +4618,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "text-reset",
     "valid-types": [
       "text-decoration-line"
     ]
@@ -4392,6 +4629,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-decoration-skip-ink"
     ]
@@ -4402,6 +4640,7 @@
     "inherited": false,
     "initial": "solid",
     "requires-computation": "never",
+    "style-group": "text-reset",
     "valid-types": [
       "text-decoration-style"
     ]
@@ -4412,6 +4651,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "text-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4427,6 +4667,7 @@
     "inherited": true,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4445,6 +4686,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-justify"
     ],
@@ -4458,6 +4700,7 @@
     "inherited": false,
     "initial": "clip",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "text-overflow"
     ]
@@ -4468,6 +4711,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "text-rendering"
     ]
@@ -4479,6 +4723,7 @@
     "initial": "none",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "none"
     ]
@@ -4489,6 +4734,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-transform"
     ]
@@ -4498,6 +4744,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "auto"
     ],
@@ -4512,6 +4759,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-underline-position-horizontal",
       "text-underline-position-vertical"
@@ -4529,6 +4777,7 @@
     "inherited": true,
     "initial": "wrap",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-wrap-mode"
     ]
@@ -4538,6 +4787,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-wrap-style"
     ]
@@ -4547,13 +4797,15 @@
     "animation-type": "none",
     "inherited": false,
     "initial": "none",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "animation"
   },
   "top": {
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -4575,6 +4827,7 @@
     "initial": "auto",
     "max-values": 3,
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "touch-action"
     ]
@@ -4590,6 +4843,7 @@
     "needs-layout-node-for-resolved-value": true,
     "percentages-resolve-to": "length",
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "transform-list"
     ],
@@ -4605,6 +4859,7 @@
     "affects-layout": false,
     "affects-scrollable-overflow": true,
     "requires-computation": "never",
+    "style-group": "transform",
     "valid-types": [
       "transform-box"
     ]
@@ -4618,6 +4873,7 @@
     "initial": "50% 50%",
     "max-values": 3,
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4637,6 +4893,7 @@
     "inherited": false,
     "initial": "flat",
     "requires-computation": "never",
+    "style-group": "transform",
     "valid-identifiers": [
       "flat",
       "preserve-3d"
@@ -4661,6 +4918,7 @@
     "initial": "normal",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "transition-behavior"
     ]
@@ -4672,6 +4930,7 @@
     "initial": "0s",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "time [-∞,∞]"
     ]
@@ -4683,6 +4942,7 @@
     "initial": "0s",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "time [0,∞]"
     ]
@@ -4694,6 +4954,7 @@
     "initial": "all",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "custom-ident ![none]"
     ],
@@ -4708,6 +4969,7 @@
     "initial": "ease",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "easing-function",
       "easing-keyword"
@@ -4722,6 +4984,7 @@
     "affects-scrollable-overflow": true,
     "affects-stacking-context": true,
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4733,6 +4996,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "unicode-bidi"
     ]
@@ -4743,6 +5007,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "user-select"
     ]
@@ -4753,6 +5018,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "svg-reset",
     "valid-types": [
       "vector-effect"
     ]
@@ -4762,6 +5028,7 @@
     "inherited": false,
     "initial": "baseline",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -4788,6 +5055,7 @@
     "inherited": false,
     "initial": "block",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "axis"
     ],
@@ -4799,6 +5067,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "view-timeline-inset"
     ],
@@ -4811,6 +5080,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "none"
     ],
@@ -4826,6 +5096,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "custom-ident ![auto,none]"
     ],
@@ -4838,6 +5109,7 @@
     "inherited": true,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "visibility"
     ]
@@ -4858,6 +5130,7 @@
     "inherited": true,
     "initial": "collapse",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "white-space-collapse"
     ]
@@ -4867,6 +5140,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "text-reset",
     "valid-identifiers": [
       "none",
       "discard-before",
@@ -4879,6 +5153,7 @@
     "inherited": true,
     "initial": "2",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "integer [1,∞]"
     ],
@@ -4889,6 +5164,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -4913,6 +5189,7 @@
     "initial": "auto",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "custom-ident ![all,auto,contents,none,scroll-position,will-change]"
     ],
@@ -4927,6 +5204,7 @@
     "initial": "normal",
     "inherited": true,
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "normal",
       "keep-all",
@@ -4939,6 +5217,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4959,6 +5238,7 @@
     "inherited": true,
     "initial": "horizontal-tb",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "writing-mode"
     ]
@@ -4969,6 +5249,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4984,6 +5265,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -5000,6 +5282,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "integer [-∞,∞]"
     ],

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -153,6 +153,7 @@
     "initial": "currentColor",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "color"
     ]
@@ -190,6 +191,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui",
     "valid-types": [
       "color"
     ],
@@ -202,6 +204,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "align-content"
     ]
@@ -211,6 +214,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "align-items"
     ]
@@ -220,6 +224,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "align-self"
     ]
@@ -236,6 +241,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident"
     ],
@@ -249,6 +255,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident"
     ],
@@ -279,6 +286,7 @@
     "inherited": false,
     "initial": "replace",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "animation-composition"
     ],
@@ -291,6 +299,7 @@
     "initial": "0s",
     "requires-computation": "cascaded-value",
     "multiplicity": "coordinating-list",
+    "style-group": "animation",
     "valid-types": [
       "time [-∞,∞]"
     ]
@@ -302,6 +311,7 @@
     "initial": "normal",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "normal",
       "reverse",
@@ -317,6 +327,7 @@
     "multiplicity": "coordinating-list",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "time [0,∞]"
     ],
@@ -331,6 +342,7 @@
     "initial": "none",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "none",
       "forwards",
@@ -345,6 +357,7 @@
     "initial": "1",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "number [0,∞]"
     ],
@@ -359,6 +372,7 @@
     "initial": "none",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "string",
       "custom-ident ![none]"
@@ -374,6 +388,7 @@
     "initial": "running",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "running",
       "paused"
@@ -385,6 +400,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "dashed-ident",
       "scroll-function",
@@ -403,6 +419,7 @@
     "initial": "ease",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "easing-function",
       "easing-keyword"
@@ -413,6 +430,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "appearance"
     ]
@@ -423,6 +441,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "ratio"
     ],
@@ -440,6 +459,7 @@
     "__comment": "FIXME: List `filter-value-list` as a valid-type once it's generically supported.",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": [ "effects", "inherited-text" ],
     "valid-identifiers": [
       "none"
     ]
@@ -451,6 +471,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "transform",
     "valid-types": [
       "backface-visibility"
     ]
@@ -478,6 +499,7 @@
     "initial": "scroll",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "background-attachment"
     ]
@@ -489,6 +511,7 @@
     "initial": "normal",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "mix-blend-mode"
     ]
@@ -501,6 +524,7 @@
     "multiplicity": "coordinating-list",
     "__comment": "FIXME: Support `border-area`",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "background-box"
     ]
@@ -512,6 +536,7 @@
     "initial": "transparent",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "background",
     "valid-types": [
       "color"
     ],
@@ -526,6 +551,7 @@
     "initial": "none",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "background",
     "valid-types": [
       "image"
     ],
@@ -541,6 +567,7 @@
     "multiplicity": "coordinating-list",
     "__comment": "FIXME: This shouldn't allow `text`",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "background-box"
     ]
@@ -569,6 +596,7 @@
     "initial": "0%",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -587,6 +615,7 @@
     "initial": "0%",
     "multiplicity": "coordinating-list",
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -606,6 +635,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "repetition"
     ],
@@ -622,6 +652,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "always",
+    "style-group": "background",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -775,6 +806,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -789,6 +821,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -802,6 +835,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -813,6 +847,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -822,6 +857,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -837,6 +873,7 @@
     "inherited": true,
     "initial": "separate",
     "requires-computation": "never",
+    "style-group": "inherited-table",
     "valid-types": [
       "border-collapse"
     ]
@@ -889,6 +926,7 @@
     "initial": "0",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]"
@@ -901,6 +939,7 @@
     "initial": "stretch",
     "max-values": 2,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "border-image-repeat"
     ]
@@ -911,6 +950,7 @@
     "inherited": false,
     "initial": "100%",
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-identifiers": [
       "fill"
     ],
@@ -926,6 +966,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "image"
     ],
@@ -940,6 +981,7 @@
     "initial": "1",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]",
@@ -1069,6 +1111,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -1081,6 +1124,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -1090,6 +1134,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -1129,6 +1174,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -1141,6 +1187,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -1150,6 +1197,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -1166,6 +1214,7 @@
     "initial": "0",
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-table",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -1215,6 +1264,7 @@
     "inherited": false,
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "color"
     ],
@@ -1229,6 +1279,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -1242,6 +1293,7 @@
     "inherited": false,
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -1253,6 +1305,7 @@
     "initial": "none",
     "inherited": false,
     "requires-computation": "never",
+    "style-group": "border",
     "valid-types": [
       "line-style"
     ]
@@ -1262,6 +1315,7 @@
     "initial": "medium",
     "inherited": false,
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -1293,6 +1347,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -1315,6 +1370,7 @@
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
     "multiplicity": "list",
+    "style-group": "effects",
     "valid-identifiers": [
       "none"
     ]
@@ -1324,6 +1380,7 @@
     "inherited": false,
     "initial": "content-box",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "box-sizing"
     ]
@@ -1333,6 +1390,7 @@
     "inherited": true,
     "initial": "top",
     "requires-computation": "never",
+    "style-group": "inherited-table",
     "valid-types": [
       "caption-side"
     ]
@@ -1344,6 +1402,7 @@
     "initial": "auto",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui",
     "valid-identifiers": [
       "auto"
     ],
@@ -1356,6 +1415,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "clear"
     ]
@@ -1367,6 +1427,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "effects",
     "valid-identifiers": [
       "auto"
     ],
@@ -1384,6 +1445,7 @@
     "affects-stacking-context": true,
     "inherited": false,
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-identifiers": [
       "none"
     ],
@@ -1400,6 +1462,7 @@
     "inherited": true,
     "initial": "nonzero",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "fill-rule"
     ]
@@ -1411,6 +1474,7 @@
     "initial": "canvastext",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "color"
     ],
@@ -1424,6 +1488,7 @@
     "inherited": true,
     "initial": "srgb",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "color-interpolation"
     ]
@@ -1434,6 +1499,7 @@
     "inherited": true,
     "initial": "linearrgb",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "color-interpolation"
     ]
@@ -1444,6 +1510,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "inherited-ui",
     "valid-types": [
       "custom-ident ![normal,light,dark,only]"
     ],
@@ -1458,6 +1525,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "integer [1,∞]"
     ],
@@ -1470,6 +1538,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -1484,6 +1553,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -1496,6 +1566,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "column-span"
     ]
@@ -1505,6 +1576,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -1527,6 +1599,7 @@
     "initial": "none",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "contain"
     ]
@@ -1545,6 +1618,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "custom-ident ![none,and,not,or]"
     ],
@@ -1558,6 +1632,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-identifiers": [
       "normal",
       "size",
@@ -1571,6 +1646,7 @@
     "initial": "normal",
     "__comment": "FIXME: This accepts a whole lot of other types and identifiers!",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "counter",
       "image",
@@ -1590,6 +1666,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "content-visibility"
     ]
@@ -1621,6 +1698,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1630,6 +1708,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1731,6 +1810,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1740,6 +1820,7 @@
     "inherited": false,
     "initial": "round",
     "requires-computation": "non-inherited-value",
+    "style-group": "border",
     "valid-types": [
       "corner-shape"
     ]
@@ -1761,6 +1842,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "custom-ident ![none]",
       "integer [-∞,∞]"
@@ -1775,6 +1857,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "custom-ident ![none]",
       "integer [-∞,∞]"
@@ -1789,6 +1872,7 @@
     "initial": "none",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "content",
     "valid-types": [
       "custom-ident ![none]",
       "integer [-∞,∞]"
@@ -1803,6 +1887,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui",
     "valid-types": [
       "url",
       "cursor-predefined",
@@ -1815,6 +1900,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -1830,6 +1916,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -1843,13 +1930,15 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "none",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "svg-reset"
   },
   "direction": {
     "animation-type": "none",
     "inherited": true,
     "initial": "ltr",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "direction"
     ]
@@ -1860,6 +1949,7 @@
     "initial": "inline",
     "requires-computation": "never",
     "max-values": 3,
+    "style-group": "box",
     "valid-identifiers": [
       "list-item"
     ],
@@ -1876,6 +1966,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "baseline-metric"
     ],
@@ -1888,6 +1979,7 @@
     "inherited": true,
     "initial": "show",
     "requires-computation": "never",
+    "style-group": "inherited-table",
     "valid-types": [
       "empty-cells"
     ]
@@ -1898,6 +1990,7 @@
     "inherited": true,
     "initial": "black",
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "paint"
     ]
@@ -1908,6 +2001,7 @@
     "inherited": true,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "opacity-value"
     ]
@@ -1918,6 +2012,7 @@
     "inherited": true,
     "initial": "nonzero",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "fill-rule"
     ]
@@ -1933,6 +2028,7 @@
     "__comment": "FIXME: List `filter-value-list` as a valid-type once it's generically supported.",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": [ "effects", "inherited-text" ],
     "valid-identifiers": [
       "none"
     ]
@@ -1953,6 +2049,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -1971,6 +2068,7 @@
     "inherited": false,
     "initial": "row",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "flex-direction"
     ]
@@ -1987,6 +2085,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "number [0,∞]"
     ]
@@ -1996,6 +2095,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "number [0,∞]"
     ]
@@ -2005,6 +2105,7 @@
     "inherited": false,
     "initial": "nowrap",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "flex-wrap"
     ]
@@ -2014,6 +2115,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "float"
     ]
@@ -2024,6 +2126,7 @@
     "inherited": false,
     "initial": "black",
     "requires-computation": "non-inherited-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "color"
     ]
@@ -2034,6 +2137,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "opacity-value"
     ]
@@ -2062,6 +2166,7 @@
     "initial": "serif",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "custom-ident",
       "string"
@@ -2073,6 +2178,7 @@
     "initial": "normal",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "integer [0,∞]",
       "opentype-tag"
@@ -2088,6 +2194,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-kerning"
     ]
@@ -2097,6 +2204,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "string"
     ],
@@ -2109,6 +2217,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-optical-sizing"
     ]
@@ -2118,6 +2227,7 @@
     "inherited": true,
     "initial": "medium",
     "requires-computation": "non-inherited-value",
+    "style-group": "font",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]",
@@ -2140,6 +2250,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "font-style"
     ]
@@ -2164,6 +2275,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal"
     ],
@@ -2176,6 +2288,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-variant-caps"
     ]
@@ -2185,6 +2298,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal"
     ],
@@ -2197,6 +2311,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-variant-emoji"
     ]
@@ -2206,6 +2321,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal",
       "none"
@@ -2219,6 +2335,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-identifiers": [
       "normal"
     ],
@@ -2231,6 +2348,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "font-variant-position"
     ]
@@ -2241,6 +2359,7 @@
     "initial": "normal",
     "multiplicity": "list",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "number [-∞,∞]",
       "opentype-tag"
@@ -2255,6 +2374,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "font",
     "valid-types": [
       "number [1,1000]"
     ],
@@ -2271,6 +2391,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "font",
     "valid-types": [
       "percentage [0,∞]",
       "font-width"
@@ -2332,6 +2453,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2346,13 +2468,15 @@
     "animation-type": "discrete",
     "inherited": false,
     "initial": "row",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "box"
   },
   "grid-auto-rows": {
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2381,6 +2505,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2396,6 +2521,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2424,6 +2550,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2439,6 +2566,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2469,6 +2597,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "grid",
     "valid-identifiers": [
       "none"
     ],
@@ -2482,6 +2611,7 @@
     "initial": "none",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2499,6 +2629,7 @@
     "initial": "none",
     "max-values": 4,
     "requires-computation": "cascaded-value",
+    "style-group": "grid",
     "valid-identifiers": [
       "auto"
     ],
@@ -2515,6 +2646,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -2537,6 +2669,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "image-rendering"
     ]
@@ -2640,6 +2773,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "effects",
     "valid-types": [
       "isolation"
     ]
@@ -2649,6 +2783,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "justify-content"
     ]
@@ -2658,6 +2793,7 @@
     "inherited": false,
     "initial": "legacy",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "justify-items"
     ]
@@ -2667,6 +2803,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "alignment",
     "valid-types": [
       "justify-self"
     ]
@@ -2676,6 +2813,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -2696,6 +2834,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2714,6 +2853,7 @@
     "initial": "normal",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]",
@@ -2738,6 +2878,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-list",
     "valid-types": [
       "image"
     ],
@@ -2750,6 +2891,7 @@
     "inherited": true,
     "initial": "outside",
     "requires-computation": "never",
+    "style-group": "inherited-list",
     "valid-types": [
       "list-style-position"
     ]
@@ -2759,6 +2901,7 @@
     "inherited": true,
     "initial": "disc",
     "requires-computation": "never",
+    "style-group": "inherited-list",
     "valid-types": [
       "counter-style",
       "string"
@@ -2825,6 +2968,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2874,6 +3018,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2892,6 +3037,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2910,6 +3056,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -2945,6 +3092,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "coord-box"
     ],
@@ -2959,6 +3107,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "compositing-operator"
     ],
@@ -2972,6 +3121,7 @@
     "affects-stacking-context": true,
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-types": [
       "image",
       "url"
@@ -2987,6 +3137,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "masking-mode"
     ],
@@ -2998,6 +3149,7 @@
     "affects-layout": false,
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "coord-box"
     ],
@@ -3010,6 +3162,7 @@
     "initial": "0% 0%",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-types": [
       "position"
     ],
@@ -3023,6 +3176,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "repetition"
     ],
@@ -3039,6 +3193,7 @@
     "multiplicity": "coordinating-list",
     "max-values": 2,
     "requires-computation": "cascaded-value",
+    "style-group": "mask",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3057,6 +3212,7 @@
     "affects-layout": false,
     "multiplicity": "single",
     "requires-computation": "never",
+    "style-group": "mask",
     "valid-types": [
       "mask-type"
     ],
@@ -3069,6 +3225,7 @@
     "needs-layout-node-for-resolved-value": true,
     "__comment": "FIXME: `add(<integer>)` is also valid but we can't represent that here yet.",
     "requires-computation": "cascaded-value",
+    "style-group": "font",
     "valid-types": [
       "integer [-∞,∞]"
     ],
@@ -3081,6 +3238,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "math-shift"
     ]
@@ -3090,6 +3248,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "math-style"
     ]
@@ -3106,6 +3265,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3133,6 +3293,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3160,6 +3321,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3187,6 +3349,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -3209,6 +3372,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "effects",
     "valid-types": [
       "mix-blend-mode"
     ]
@@ -3219,6 +3383,7 @@
     "inherited": false,
     "initial": "fill",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "object-fit"
     ]
@@ -3230,6 +3395,7 @@
     "inherited": false,
     "initial": "50% 50%",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "position"
     ],
@@ -3243,6 +3409,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "effects",
     "valid-types": [
       "opacity-value"
     ]
@@ -3252,6 +3419,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "integer [-∞,∞]"
     ]
@@ -3261,6 +3429,7 @@
     "inherited": true,
     "initial": "2",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "integer [1,∞]"
     ],
@@ -3283,6 +3452,7 @@
     "initial": "currentColor",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "color"
     ]
@@ -3293,6 +3463,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3303,6 +3474,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "outline-style"
     ]
@@ -3313,6 +3485,7 @@
     "inherited": false,
     "initial": "medium",
     "requires-computation": "non-inherited-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "line-width"
@@ -3376,6 +3549,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3407,6 +3581,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3416,6 +3591,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3425,6 +3601,7 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "0px",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]"
     ],
@@ -3441,6 +3618,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "anywhere",
       "break-word",
@@ -3452,6 +3630,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "overflow"
     ],
@@ -3464,6 +3643,7 @@
     "inherited": false,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "overflow"
     ],
@@ -3523,6 +3703,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3565,6 +3746,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3580,6 +3762,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3595,6 +3778,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3610,6 +3794,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-identifiers": [
       "normal"
     ],
@@ -3623,6 +3808,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-identifiers": [
       "none"
     ],
@@ -3637,6 +3823,7 @@
     "inherited": false,
     "initial": "50% 50%",
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "position"
     ],
@@ -3669,6 +3856,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-ui",
     "valid-types": [
       "pointer-events"
     ]
@@ -3678,6 +3866,7 @@
     "inherited": false,
     "initial": "static",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "positioning"
     ]
@@ -3687,6 +3876,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident"
     ],
@@ -3702,6 +3892,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "anchor",
     "valid-types": [
       "position-area"
     ],
@@ -3714,6 +3905,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "dashed-ident",
       "try-tactic"
@@ -3727,6 +3919,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-types": [
       "try-order"
     ],
@@ -3739,6 +3932,7 @@
     "inherited": false,
     "initial": "anchors-visible",
     "requires-computation": "never",
+    "style-group": "anchor",
     "valid-identifiers": [
       "always",
       "anchors-valid",
@@ -3752,6 +3946,7 @@
     "initial": "auto",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "inherited-list",
     "valid-types": [
       "string"
     ],
@@ -3766,6 +3961,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3781,6 +3977,7 @@
     "affects-layout": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "resize"
     ]
@@ -3790,6 +3987,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -3812,13 +4010,15 @@
     "affects-layout": false,
     "affects-scrollable-overflow": true,
     "affects-stacking-context": true,
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "transform"
   },
   "row-gap": {
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "normal",
     "requires-computation": "cascaded-value",
+    "style-group": "alignment",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3834,6 +4034,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3852,6 +4053,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -3872,7 +4074,8 @@
     "affects-layout": false,
     "affects-scrollable-overflow": true,
     "affects-stacking-context": true,
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "transform"
   },
   "scroll-behavior": {
     "initial": "auto",
@@ -3880,6 +4083,7 @@
     "affects-layout": false,
     "animation-type": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-identifiers": [
       "auto",
       "smooth"
@@ -3926,6 +4130,7 @@
     "initial": "0",
     "inherited": false,
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3958,6 +4163,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3967,6 +4173,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -3976,6 +4183,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [-∞,∞]"
     ]
@@ -4031,6 +4239,7 @@
     "initial": "auto",
     "inherited": false,
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4073,6 +4282,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4087,6 +4297,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4101,6 +4312,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4125,6 +4337,7 @@
     "inherited": false,
     "initial": "block",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "axis"
     ],
@@ -4136,6 +4349,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "none"
     ],
@@ -4149,7 +4363,8 @@
     "animation-type": "by-computed-value",
     "inherited": true,
     "initial": "auto",
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "inherited-ui"
   },
   "scrollbar-gutter": {
     "affects-layout": false,
@@ -4157,7 +4372,8 @@
     "__comment": "This property should affect layout per-spec, but ladybird always uses overlay scrollbars so it doesn't in practice.",
     "inherited": false,
     "initial": "auto",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "misc-reset"
   },
   "scrollbar-width": {
     "affects-layout": false,
@@ -4165,6 +4381,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "scrollbar-width"
     ],
@@ -4180,6 +4397,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "opacity-value"
     ]
@@ -4189,6 +4407,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "misc-reset",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
@@ -4200,7 +4419,8 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "none",
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "misc-reset"
   },
   "shape-rendering": {
     "affects-layout": true,
@@ -4208,6 +4428,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "svg-reset",
     "valid-types": [
       "shape-rendering"
     ]
@@ -4218,6 +4439,7 @@
     "inherited": false,
     "initial": "black",
     "requires-computation": "non-inherited-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "color"
     ]
@@ -4228,6 +4450,7 @@
     "inherited": false,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "opacity-value"
     ]
@@ -4238,6 +4461,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "paint"
     ]
@@ -4248,7 +4472,8 @@
     "initial": "none",
     "affects-layout": false,
     "percentages-resolve-to": "length",
-    "requires-computation": "cascaded-value"
+    "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg"
   },
   "stroke-dashoffset": {
     "affects-layout": false,
@@ -4256,6 +4481,7 @@
     "inherited": true,
     "initial": "0px",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]",
@@ -4269,6 +4495,7 @@
     "inherited": true,
     "initial": "butt",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "stroke-linecap"
     ]
@@ -4279,6 +4506,7 @@
     "inherited": true,
     "initial": "miter",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "stroke-linejoin"
     ]
@@ -4289,6 +4517,7 @@
     "inherited": true,
     "initial": "4",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "number [0,∞]"
     ]
@@ -4299,6 +4528,7 @@
     "inherited": true,
     "initial": "1",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "opacity-value"
     ]
@@ -4309,6 +4539,7 @@
     "inherited": true,
     "initial": "1px",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-svg",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]",
@@ -4321,6 +4552,7 @@
     "inherited": true,
     "initial": "8",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [0,∞]",
       "number [0,∞]"
@@ -4331,6 +4563,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "table-layout"
     ]
@@ -4340,6 +4573,7 @@
     "inherited": true,
     "initial": "start",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-align"
     ]
@@ -4349,6 +4583,7 @@
     "inherited": true,
     "initial": "start",
     "requires-computation": "never",
+    "style-group": "inherited-svg",
     "valid-types": [
       "text-anchor"
     ]
@@ -4370,6 +4605,7 @@
     "initial": "currentcolor",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "text-reset",
     "valid-types": [
       "color"
     ]
@@ -4381,6 +4617,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "text-reset",
     "valid-types": [
       "text-decoration-line"
     ]
@@ -4391,6 +4628,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-decoration-skip-ink"
     ]
@@ -4401,6 +4639,7 @@
     "inherited": false,
     "initial": "solid",
     "requires-computation": "never",
+    "style-group": "text-reset",
     "valid-types": [
       "text-decoration-style"
     ]
@@ -4411,6 +4650,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "text-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4426,6 +4666,7 @@
     "inherited": true,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4444,6 +4685,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-justify"
     ],
@@ -4457,6 +4699,7 @@
     "inherited": false,
     "initial": "clip",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "text-overflow"
     ]
@@ -4467,6 +4710,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "font",
     "valid-types": [
       "text-rendering"
     ]
@@ -4478,6 +4722,7 @@
     "initial": "none",
     "needs-layout-node-for-resolved-value": true,
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "none"
     ]
@@ -4488,6 +4733,7 @@
     "inherited": true,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-transform"
     ]
@@ -4497,6 +4743,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "auto"
     ],
@@ -4511,6 +4758,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-underline-position-horizontal",
       "text-underline-position-vertical"
@@ -4528,6 +4776,7 @@
     "inherited": true,
     "initial": "wrap",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-wrap-mode"
     ]
@@ -4537,6 +4786,7 @@
     "inherited": true,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "text-wrap-style"
     ]
@@ -4546,13 +4796,15 @@
     "animation-type": "none",
     "inherited": false,
     "initial": "none",
-    "requires-computation": "never"
+    "requires-computation": "never",
+    "style-group": "animation"
   },
   "top": {
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "surround",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -4574,6 +4826,7 @@
     "initial": "auto",
     "max-values": 3,
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "touch-action"
     ]
@@ -4589,6 +4842,7 @@
     "needs-layout-node-for-resolved-value": true,
     "percentages-resolve-to": "length",
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "transform-list"
     ],
@@ -4604,6 +4858,7 @@
     "affects-layout": false,
     "affects-scrollable-overflow": true,
     "requires-computation": "never",
+    "style-group": "transform",
     "valid-types": [
       "transform-box"
     ]
@@ -4617,6 +4872,7 @@
     "initial": "50% 50%",
     "max-values": 3,
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4636,6 +4892,7 @@
     "inherited": false,
     "initial": "flat",
     "requires-computation": "never",
+    "style-group": "transform",
     "valid-identifiers": [
       "flat",
       "preserve-3d"
@@ -4660,6 +4917,7 @@
     "initial": "normal",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "transition-behavior"
     ]
@@ -4671,6 +4929,7 @@
     "initial": "0s",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "time [-∞,∞]"
     ]
@@ -4682,6 +4941,7 @@
     "initial": "0s",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "time [0,∞]"
     ]
@@ -4693,6 +4953,7 @@
     "initial": "all",
     "multiplicity": "coordinating-list",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "custom-ident ![none]"
     ],
@@ -4707,6 +4968,7 @@
     "initial": "ease",
     "multiplicity": "coordinating-list",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "easing-function",
       "easing-keyword"
@@ -4721,6 +4983,7 @@
     "affects-scrollable-overflow": true,
     "affects-stacking-context": true,
     "requires-computation": "cascaded-value",
+    "style-group": "transform",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4732,6 +4995,7 @@
     "inherited": false,
     "initial": "normal",
     "requires-computation": "never",
+    "style-group": "box",
     "valid-types": [
       "unicode-bidi"
     ]
@@ -4742,6 +5006,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "user-select"
     ]
@@ -4752,6 +5017,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "svg-reset",
     "valid-types": [
       "vector-effect"
     ]
@@ -4761,6 +5027,7 @@
     "inherited": false,
     "initial": "baseline",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]",
@@ -4787,6 +5054,7 @@
     "inherited": false,
     "initial": "block",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-types": [
       "axis"
     ],
@@ -4798,6 +5066,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "animation",
     "valid-types": [
       "view-timeline-inset"
     ],
@@ -4810,6 +5079,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "animation",
     "valid-identifiers": [
       "none"
     ],
@@ -4825,6 +5095,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "custom-ident ![auto,none]"
     ],
@@ -4837,6 +5108,7 @@
     "inherited": true,
     "initial": "visible",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "visibility"
     ]
@@ -4857,6 +5129,7 @@
     "inherited": true,
     "initial": "collapse",
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-types": [
       "white-space-collapse"
     ]
@@ -4866,6 +5139,7 @@
     "inherited": false,
     "initial": "none",
     "requires-computation": "never",
+    "style-group": "text-reset",
     "valid-identifiers": [
       "none",
       "discard-before",
@@ -4878,6 +5152,7 @@
     "inherited": true,
     "initial": "2",
     "requires-computation": "cascaded-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "integer [1,∞]"
     ],
@@ -4888,6 +5163,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "sizing",
     "valid-types": [
       "fit-content",
       "length [0,∞]",
@@ -4912,6 +5188,7 @@
     "initial": "auto",
     "multiplicity": "list",
     "requires-computation": "never",
+    "style-group": "misc-reset",
     "valid-types": [
       "custom-ident ![all,auto,contents,none,scroll-position,will-change]"
     ],
@@ -4926,6 +5203,7 @@
     "initial": "normal",
     "inherited": true,
     "requires-computation": "never",
+    "style-group": "inherited-text",
     "valid-identifiers": [
       "normal",
       "keep-all",
@@ -4938,6 +5216,7 @@
     "inherited": true,
     "initial": "normal",
     "requires-computation": "non-inherited-value",
+    "style-group": "inherited-text",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4958,6 +5237,7 @@
     "inherited": true,
     "initial": "horizontal-tb",
     "requires-computation": "never",
+    "style-group": "inherited-box",
     "valid-types": [
       "writing-mode"
     ]
@@ -4968,6 +5248,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4983,6 +5264,7 @@
     "inherited": false,
     "initial": "0",
     "requires-computation": "cascaded-value",
+    "style-group": "svg-reset",
     "valid-types": [
       "length [-∞,∞]",
       "percentage [-∞,∞]"
@@ -4999,6 +5281,7 @@
     "inherited": false,
     "initial": "auto",
     "requires-computation": "cascaded-value",
+    "style-group": "box",
     "valid-types": [
       "integer [-∞,∞]"
     ],

--- a/Meta/Generators/generate_libweb_css_property_id.py
+++ b/Meta/Generators/generate_libweb_css_property_id.py
@@ -26,6 +26,69 @@ def is_legacy_alias(prop: dict) -> bool:
     return "legacy-alias-for" in prop
 
 
+STYLE_GROUP_ENUMERATORS = {
+    "alignment": "AlignmentValues",
+    "anchor": "AnchorValues",
+    "animation": "AnimationValues",
+    "background": "BackgroundValues",
+    "border": "BorderValues",
+    "box": "BoxValues",
+    "content": "ContentValues",
+    "effects": "EffectsValues",
+    "font": "FontValues",
+    "grid": "GridValues",
+    "inherited-box": "InheritedBoxValues",
+    "inherited-list": "InheritedListValues",
+    "inherited-svg": "InheritedSVGValues",
+    "inherited-table": "InheritedTableValues",
+    "inherited-text": "InheritedTextValues",
+    "inherited-ui": "InheritedUIValues",
+    "mask": "MaskValues",
+    "misc-reset": "MiscResetValues",
+    "sizing": "SizingValues",
+    "surround": "SurroundValues",
+    "svg-reset": "SVGResetValues",
+    "text-reset": "TextResetValues",
+    "transform": "TransformValues",
+}
+
+
+def style_groups_of(prop: dict) -> list:
+    groups = prop.get("style-group")
+    if groups is None:
+        return []
+    if isinstance(groups, str):
+        return [groups]
+    return groups
+
+
+def verify_style_groups(properties: dict, logical_property_groups: dict) -> None:
+    for name, value in properties.items():
+        groups = style_groups_of(value)
+        is_physical_longhand = (
+            not is_legacy_alias(value) and "longhands" not in value and "logical-alias-for" not in value
+        )
+        if is_physical_longhand:
+            if not groups:
+                print(f"Longhand property '{name}' is missing its style-group", file=sys.stderr)
+                sys.exit(1)
+            for group in groups:
+                if group not in STYLE_GROUP_ENUMERATORS:
+                    print(f"Property '{name}' has unknown style-group '{group}'", file=sys.stderr)
+                    sys.exit(1)
+        elif groups:
+            print(f"Property '{name}' must not declare a style-group", file=sys.stderr)
+            sys.exit(1)
+
+    # A logical alias inherits the style-group of its group's first physical member, so every
+    # member must agree on it.
+    for group_name, group in logical_property_groups.items():
+        member_groups = {tuple(style_groups_of(properties[member])) for member in group["physical"].values()}
+        if len(member_groups) > 1:
+            print(f"Logical property group '{group_name}' spans multiple style-groups", file=sys.stderr)
+            sys.exit(1)
+
+
 def verify_alphabetical(data: dict, path: str) -> None:
     most_recent_name = ""
     for name in data:
@@ -176,6 +239,7 @@ def write_header_file(out: TextIO, properties: dict, logical_property_groups: di
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/Span.h>
 #include <AK/Traits.h>
 #include <AK/Utf16FlyString.h>
 #include <AK/Utf16View.h>
@@ -187,6 +251,8 @@ def write_header_file(out: TextIO, properties: dict, logical_property_groups: di
 #include <LibWeb/Forward.h>
 
 namespace Web::CSS {{
+
+enum class StyleGroupIndex : size_t;
 
 enum class PropertyID : {property_id_underlying_type} {{
     Custom,
@@ -293,6 +359,8 @@ WEB_API bool property_requires_computation_with_cascaded_value(PropertyID);
 size_t property_maximum_value_count(PropertyID);
 
 bool property_affects_layout(PropertyID);
+u32 style_group_dependency_mask(PropertyID);
+ReadonlySpan<PropertyID> longhands_in_style_group(StyleGroupIndex);
 bool property_affects_stacking_context(PropertyID);
 bool property_affects_accumulated_visual_contexts(PropertyID);
 bool property_affects_scrollable_overflow(PropertyID);
@@ -356,6 +424,7 @@ def write_implementation_file(out: TextIO, properties: dict, logical_property_gr
     out.write("""
 #include <AK/Assertions.h>
 #include <AK/NeverDestroyed.h>
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
@@ -558,6 +627,65 @@ bool property_affects_layout(PropertyID property_id)
         return true;
     default:
         return false;
+    }
+}
+
+u32 style_group_dependency_mask(PropertyID property_id)
+{
+    switch (property_id) {
+""")
+
+    dependency_mask_clusters: dict = {}
+    for name, value in properties.items():
+        if is_legacy_alias(value):
+            continue
+        groups = style_groups_of(value)
+        if not groups:
+            continue
+        if "logical-alias-for" in value and "inherited-box" not in groups:
+            # The mapping context stored in the inherited box group selects the physical
+            # longhand a logical alias follows.
+            groups = groups + ["inherited-box"]
+        expression = " | ".join(
+            f"1u << to_underlying(StyleGroupIndex::{STYLE_GROUP_ENUMERATORS[group]})" for group in groups
+        )
+        dependency_mask_clusters.setdefault(expression, []).append(name)
+
+    for expression, names in dependency_mask_clusters.items():
+        for name in names:
+            out.write(f"    case PropertyID::{title_casify(name)}:\n")
+        out.write(f"        return {expression};\n")
+
+    out.write("""    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+ReadonlySpan<PropertyID> longhands_in_style_group(StyleGroupIndex group)
+{
+    switch (group) {
+""")
+
+    style_group_members: dict = {group: [] for group in STYLE_GROUP_ENUMERATORS}
+    for name, value in properties.items():
+        if is_legacy_alias(value) or "logical-alias-for" in value:
+            continue
+        groups = style_groups_of(value)
+        if groups:
+            style_group_members[groups[0]].append(name)
+
+    for group, enumerator in STYLE_GROUP_ENUMERATORS.items():
+        out.write(f"    case StyleGroupIndex::{enumerator}: {{\n")
+        out.write("        static constexpr Array longhands {\n")
+        for name in style_group_members[group]:
+            out.write(f"            PropertyID::{title_casify(name)},\n")
+        out.write("""        };
+        return longhands.span();
+    }
+""")
+
+    out.write("""    default:
+        VERIFY_NOT_REACHED();
     }
 }
 
@@ -1659,6 +1787,7 @@ def main():
     verify_alphabetical(properties, args.properties_json)
     verify_alphabetical(logical_property_groups, args.groups_json)
     verify_alphabetical(enums, args.enums_json)
+    verify_style_groups(properties, logical_property_groups)
 
     enum_names = list(enums.keys())
 


### PR DESCRIPTION
Declare the group for every physical longhand in `Properties.json` and generate a dependency mask function and a per group longhand list from the declarations. The generator rejects a longhand without a declaration and a shorthand or alias with one. A logical alias derives its mask from the target property's group and the inherited box group that stores the mapping context.

My intention is to use the newly-introduced `style_group_dependency_mask()` function to speed up style diffing in certain cases.