### PR TITLE
LibWeb: Prepare layout for result-carried fragment trees

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -664,6 +664,7 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRe
 {
     set_flag(RustFFI::NodeFlag::HasStyle, true);
     set_flag(RustFFI::NodeFlag::IsBody, node && node == document.body());
+    set_flag(RustFFI::NodeFlag::HasAnchorNames, !m_computed_values->anchor_names().is_empty());
     publish_style_container_to_node_data();
     synchronize_table_span_data();
 }
@@ -986,6 +987,7 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
 {
     VERIFY(!layout_pass_currently_running());
     m_computed_values = move(computed_values);
+    set_flag(RustFFI::NodeFlag::HasAnchorNames, !m_computed_values->anchor_names().is_empty());
     publish_style_container_to_node_data();
 
     for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -275,14 +275,11 @@ struct AnchorCalcCallbackContext<'pass> {
 
 impl AbsposEngine<'_> {
     fn anchor_lookup(&self, positioned_box: Node, anchor_name: usize) -> Option<Node> {
-        let eligible_anchor_boxes = self.state.used_value_nodes();
-        let eligible_anchor_shells = eligible_anchor_boxes
-            .iter()
-            .map(|&node| self.callbacks.shell(node))
-            .collect::<Vec<_>>();
+        let eligible_anchor_shells = self.state.anchor_candidate_shells();
         // SAFETY: The name handle is retained by either the style snapshot or
-        // the live anchor() shell. The eligible-node slice is borrowed only
-        // for this synchronous lookup.
+        // the live anchor() shell. The registry borrow is held only for this
+        // synchronous lookup, and the callback never re-enters layout code
+        // that could register another candidate.
         let anchor_box = unsafe {
             (self.callbacks.anchor_lookup)(
                 self.callbacks.context,

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1691,7 +1691,13 @@ impl<'pass> AbsposEngine<'pass> {
         self.layout_element(run, node, inputs);
     }
 
-    fn compute_inset(&self, node: Node, containing_block_size: LogicalSize) {
+    fn compute_inset(
+        &self,
+        node: Node,
+        containing_block_size: LogicalSize,
+        formatting_context_root: Node,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
+    ) {
         // Most boxes are neither relatively positioned nor carry anchor()
         // insets. Preserve the old C++ fast path without populating the
         // comprehensive Rust facts caches for those boxes.
@@ -1731,27 +1737,25 @@ impl<'pass> AbsposEngine<'pass> {
             containing_block_size.inline_size,
         );
 
-        let treat_percentage_as_auto = |value: InsetValue<'pass>| -> InsetValue<'pass> {
-            if !value.contains_percentage() {
-                return value;
-            }
-            let mut containing_block = self.callbacks.containing_block(node);
-            while !containing_block.is_invalid() {
-                let facts = self.facts(containing_block);
-                if !facts.is_anonymous() || facts.is_table_cell() {
-                    break;
-                }
-                containing_block = self.callbacks.containing_block(containing_block);
-            }
-            if !containing_block.is_invalid() && !self.used(containing_block).has_definite_block_size() {
+        let treat_block_axis_percentage_insets_as_auto = (style.inset_top().contains_percentage()
+            || style.inset_bottom().contains_percentage())
+            && !crate::layout::resolve_block_axis_percentage_inset_basis_is_definite(
+                self.state,
+                &self.callbacks,
+                self.callbacks.containing_block(node),
+                formatting_context_root,
+                treat_block_axis_percentage_insets_as_auto_beyond_root,
+            );
+        let block_axis_inset_value = |value: InsetValue<'pass>| -> InsetValue<'pass> {
+            if treat_block_axis_percentage_insets_as_auto && value.contains_percentage() {
                 InsetValue::auto_value()
             } else {
                 value
             }
         };
         let (top, bottom) = resolve_opposing(
-            treat_percentage_as_auto(style.inset_top()),
-            treat_percentage_as_auto(style.inset_bottom()),
+            block_axis_inset_value(style.inset_top()),
+            block_axis_inset_value(style.inset_bottom()),
             containing_block_size.block_size,
         );
         let used = self.used_mut(node);
@@ -1784,7 +1788,7 @@ pub(crate) fn run_abspos_layout_pass(
             continue;
         }
         let run =
-            crate::layout::FormattingContextRun::new(state, root, LayoutMode::Normal, callbacks, should_collect_devtools_layout_data);
+            crate::layout::FormattingContextRun::new(state, root, LayoutMode::Normal, callbacks, should_collect_devtools_layout_data, false);
         layout_contained_abspos_children(&run);
     }
     state.set_abspos_layout_pass_is_active(false);
@@ -1800,6 +1804,8 @@ pub(crate) fn compute_inset_native(
     node: Node,
     inline_size: CssPixels,
     block_size: CssPixels,
+    formatting_context_root: Node,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 ) {
     AbsposEngine::new(state, callbacks).compute_inset(
         node,
@@ -1807,5 +1813,7 @@ pub(crate) fn compute_inset_native(
             inline_size,
             block_size,
         },
+        formatting_context_root,
+        treat_block_axis_percentage_insets_as_auto_beyond_root,
     );
 }

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -321,13 +321,15 @@ impl<'pass> BlockFormattingContext<'pass> {
         self.derived_baselines_of_root_box.get()
     }
 
-    fn compute_inset(&self, node: Node, containing_block_size: LogicalSize) {
+    fn compute_inset(&self, run: &FormattingContextRun<'pass>, node: Node, containing_block_size: LogicalSize) {
         crate::layout::compute_inset_native(
             self.state,
             self.callbacks,
             node,
             containing_block_size.inline_size,
             containing_block_size.block_size,
+            self.root,
+            run.treat_block_axis_percentage_insets_as_auto_beyond_root,
         );
     }
 
@@ -1887,6 +1889,7 @@ impl<'pass> BlockFormattingContext<'pass> {
 
         let block_container_used = self.used(block_container);
         self.compute_inset(
+            run,
             node,
             LogicalSize {
                 inline_size: block_container_used.content_inline_size.get(),
@@ -2396,7 +2399,9 @@ impl<'pass> BlockFormattingContext<'pass> {
                 available_space,
                 containing_block_constraints: input.containing_block_constraints,
                 content_box_position_in_bfc_root: input.content_box_position_in_bfc_root,
-                sizing: RootSizingDirectives::default(),
+                sizing: RootSizingDirectives {
+                    ..RootSizingDirectives::default()
+                },
                 participation: ParticipationInParentFormattingContext::Float,
             },
             false,
@@ -2490,6 +2495,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         }
         let block_container_used = self.used(block_container);
         self.compute_inset(
+            run,
             node,
             LogicalSize {
                 inline_size: block_container_used.content_inline_size.get(),

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -2401,6 +2401,8 @@ impl<'pass> FlexFormattingContext<'pass> {
             node,
             container_inline_size,
             container_block_size,
+            self.flex_container,
+            run.treat_block_axis_percentage_insets_as_auto_beyond_root,
         );
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -1023,6 +1023,7 @@ pub(crate) struct FormattingContextRun<'pass> {
     pub(crate) layout_mode: LayoutMode,
     pub(crate) callbacks: FfiLayoutFcCallbacks,
     pub(crate) should_collect_devtools_layout_data: bool,
+    pub(crate) treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 }
 
 impl<'pass> FormattingContextRun<'pass> {
@@ -1032,6 +1033,7 @@ impl<'pass> FormattingContextRun<'pass> {
         layout_mode: LayoutMode,
         callbacks: FfiLayoutFcCallbacks,
         should_collect_devtools_layout_data: bool,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     ) -> Self {
         Self {
             state,
@@ -1039,6 +1041,7 @@ impl<'pass> FormattingContextRun<'pass> {
             layout_mode,
             callbacks,
             should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root,
         }
     }
 }
@@ -1410,7 +1413,14 @@ fn run_formatting_context<'pass>(
     parent_block: Option<&BlockFormattingContext<'pass>>,
 ) -> ChildLayoutResult {
     assert!(!box_.is_invalid());
-    let run = FormattingContextRun::new(state, box_, layout_mode, callbacks, should_collect_devtools_layout_data);
+    let run = FormattingContextRun::new(
+        state,
+        box_,
+        layout_mode,
+        callbacks,
+        should_collect_devtools_layout_data,
+        input.sizing.treat_block_axis_percentage_insets_as_auto_beyond_root,
+    );
     let run = &run;
     let body_input = apply_root_sizing_directives(run, &input, parent_block);
 
@@ -1614,7 +1624,7 @@ pub(crate) fn layout_inside_child<'pass>(
     parent_grid: Option<&GridFormattingContext<'pass>>,
     child: Node,
     layout_mode: LayoutMode,
-    input: LayoutInput,
+    mut input: LayoutInput,
     force_independent_context_run: bool,
 ) -> ChildLayoutOutcome {
     let facts = run.state.node_facts(&run.callbacks, child);
@@ -1657,6 +1667,14 @@ pub(crate) fn layout_inside_child<'pass>(
         }
         return ChildLayoutOutcome::ReenterCurrent;
     };
+    input.sizing.treat_block_axis_percentage_insets_as_auto_beyond_root =
+        treat_block_axis_percentage_insets_as_auto_beyond_anonymous_child_root(
+            run.state,
+            &run.callbacks,
+            child,
+            run.box_,
+            run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+        );
     ChildLayoutOutcome::Created(run_formatting_context(
         run.state,
         child,
@@ -1688,6 +1706,47 @@ fn independent_formatting_context_type(
         "FIXME: An independent formatting context was requested from a Box that does not have a formatting context type. A dummy formatting context will be created instead."
     );
     FfiFormattingContextType::InternalDummy
+}
+
+pub(crate) fn resolve_block_axis_percentage_inset_basis_is_definite(
+    state: &LayoutState,
+    callbacks: &FfiLayoutFcCallbacks,
+    containing_block: Node,
+    formatting_context_root: Node,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
+) -> bool {
+    let mut candidate = containing_block;
+    while !candidate.is_invalid() {
+        let facts = state.node_facts(callbacks, candidate);
+        if !facts.is_anonymous() || facts.is_table_cell() {
+            return state.used_values(callbacks, candidate).has_definite_block_size();
+        }
+        if candidate == formatting_context_root {
+            return !treat_block_axis_percentage_insets_as_auto_beyond_root;
+        }
+        candidate = callbacks.containing_block(candidate);
+    }
+    true
+}
+
+pub(crate) fn treat_block_axis_percentage_insets_as_auto_beyond_anonymous_child_root(
+    state: &LayoutState,
+    callbacks: &FfiLayoutFcCallbacks,
+    child_root: Node,
+    formatting_context_root: Node,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
+) -> bool {
+    let child_root_facts = state.node_facts(callbacks, child_root);
+    if !child_root_facts.is_anonymous() || child_root_facts.is_table_cell() {
+        return false;
+    }
+    !resolve_block_axis_percentage_inset_basis_is_definite(
+        state,
+        callbacks,
+        callbacks.containing_block(child_root),
+        formatting_context_root,
+        treat_block_axis_percentage_insets_as_auto_beyond_root,
+    )
 }
 
 /// # Safety
@@ -1839,7 +1898,7 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         let state_ref = &state;
         let containing_block = callbacks.containing_block(box_);
         assert!(!containing_block.is_invalid());
-        let run = crate::layout::FormattingContextRun::new(state_ref, containing_block, LayoutMode::Normal, callbacks, false);
+        let run = crate::layout::FormattingContextRun::new(state_ref, containing_block, LayoutMode::Normal, callbacks, false, false);
         AbsposEngine::new(state_ref, callbacks).replay(&run, box_);
         run_abspos_layout_pass(state_ref, callbacks, false);
         state.commit_replacing(box_, paintable_to_replace, &callbacks, sink);

--- a/Libraries/LibWeb/Rust/src/layout/geometry.rs
+++ b/Libraries/LibWeb/Rust/src/layout/geometry.rs
@@ -128,6 +128,7 @@ pub(crate) struct RootSizingDirectives {
     pub(crate) adopt_automatic_content_block_size: bool,
     pub(crate) float_avoidance_inline_size: Option<CssPixels>,
     pub(crate) outer_float_intrusion_before_list_item_children: SpaceUsedByFloats,
+    pub(crate) treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3455,6 +3455,8 @@ impl<'pass> GridFormattingContext<'pass> {
                 item.box_,
                 area.size.inline_size,
                 area.size.block_size,
+                self.grid_container,
+                run.treat_block_axis_percentage_insets_as_auto_beyond_root,
             );
         }
         self.derived_baselines_of_root_box =

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -823,6 +823,8 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
             node,
             used.content_inline_size.get(),
             used.content_block_size.get(),
+            self.run.box_,
+            self.run.treat_block_axis_percentage_insets_as_auto_beyond_root,
         );
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1237,9 +1237,17 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         let (pieces, inline_containing_block_rect_candidates) = compute(self);
         self.line_data_mut().inline_box_pieces = pieces;
         for candidate in inline_containing_block_rect_candidates {
+            let relative_inset_chain = self.state.accumulated_relative_insets_from_inline_ancestor_chain(
+                &self.callbacks,
+                candidate.inline_containing_block,
+                self.containing_block,
+            );
+            let mut rect = candidate.rect;
+            rect.x += relative_inset_chain.offset_x;
+            rect.y += relative_inset_chain.offset_y;
             self.state
                 .used_values_rare_data_for_node_mut(&self.callbacks, candidate.inline_containing_block)
-                .inline_containing_block_first_last_rect = Some(candidate.rect);
+                .inline_containing_block_first_last_rect = Some(rect);
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -530,6 +530,10 @@ impl<'pass> NodeFacts<'pass> {
         crate::layout::has_flag(self.data(), NodeFlag::Anonymous)
     }
 
+    pub(crate) fn has_anchor_names(&self) -> bool {
+        crate::layout::has_flag(self.data(), NodeFlag::HasAnchorNames)
+    }
+
     pub(crate) fn can_have_children(&self) -> bool {
         crate::layout::node_can_have_children(self.data())
     }
@@ -814,6 +818,7 @@ pub(crate) struct LayoutState {
     line_data: PagedStore<RefCell<LineData>>,
     used_values_rare_data: PagedStore<RefCell<UsedValuesRareData>>,
     inline_containing_blocks: RefCell<HashSet<Node>>,
+    anchor_candidate_shells: RefCell<Vec<*mut c_void>>,
     purpose: LayoutStatePurpose,
 }
 
@@ -862,6 +867,7 @@ impl LayoutState {
             line_data: PagedStore::default(),
             used_values_rare_data: PagedStore::default(),
             inline_containing_blocks: RefCell::new(HashSet::new()),
+            anchor_candidate_shells: RefCell::new(Vec::new()),
             purpose,
         }
     }
@@ -1038,7 +1044,9 @@ impl LayoutState {
         used.content_inline_size.set(content_inline_size.unwrap_or_default());
         used.content_block_size.set(content_block_size.unwrap_or_default());
 
-        self.used_values.allocate(slot_index, used)
+        let used = self.used_values.allocate(slot_index, used);
+        self.register_anchor_candidate_if_carries_anchor_names(callbacks, node);
+        used
     }
 
     pub(crate) fn populate_from_paintable(
@@ -1093,7 +1101,9 @@ impl LayoutState {
             self.used_values_rare_data_mut(slot_index).svg_viewport_size = Some(geometry.svg_viewport_size);
         }
 
-        Some(self.used_values.allocate(slot_index, used))
+        let used = self.used_values.allocate(slot_index, used);
+        self.register_anchor_candidate_if_carries_anchor_names(callbacks, node);
+        Some(used)
     }
 
     pub(crate) fn note_inline_containing_block(&self, inline_containing_block: Node) {
@@ -1112,10 +1122,15 @@ impl LayoutState {
         self.used_values_rare_data(slot_index)?.inline_containing_block_first_last_rect
     }
 
-    pub(crate) fn used_value_nodes(&self) -> Vec<Node> {
-        let mut nodes = Vec::new();
-        self.used_values.for_each(|used| nodes.push(used.node));
-        nodes
+    fn register_anchor_candidate_if_carries_anchor_names(&self, callbacks: &FfiLayoutFcCallbacks, node: Node) {
+        if !self.node_facts(callbacks, node).has_anchor_names() {
+            return;
+        }
+        self.anchor_candidate_shells.borrow_mut().push(callbacks.shell(node));
+    }
+
+    pub(crate) fn anchor_candidate_shells(&self) -> Ref<'_, Vec<*mut c_void>> {
+        self.anchor_candidate_shells.borrow()
     }
 
     pub(crate) fn set_box_is_grid_item(&self, callbacks: &FfiLayoutFcCallbacks, node: Node, is_grid_item: bool) {

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -143,6 +143,7 @@ pub enum NodeFlag {
     SavedAbsposAlignmentDerivesFromOwnComputedValues = 1 << 21,
     ProducesLineBoxFragmentWhenEmpty = 1 << 22,
     ListMarkerIsInside = 1 << 23,
+    HasAnchorNames = 1 << 24,
 }
 
 #[repr(C)]

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1901,6 +1901,7 @@ impl<'pass> SizingContext<'pass> {
             LayoutMode::IntrinsicSizing,
             *measurement.callbacks(),
             false,
+            false,
         );
         let mut table = TableFormattingContext::new(&table_run);
         let table_available = table_used.available_inner_space_or_constraints_from(available_space);

--- a/Tests/LibWeb/Text/expected/css/abspos-cb-inline-relative-inset-shift.txt
+++ b/Tests/LibWeb/Text/expected/css/abspos-cb-inline-relative-inset-shift.txt
@@ -1,0 +1,3 @@
+plain alignment: 0,0
+shifted alignment: 0,0
+chain alignment: 0,0

--- a/Tests/LibWeb/Text/input/css/abspos-cb-inline-relative-inset-shift.html
+++ b/Tests/LibWeb/Text/input/css/abspos-cb-inline-relative-inset-shift.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body { margin: 0; font: 16px/20px monospace; }
+    .frame { width: 300px; margin: 20px; }
+    .abs { position: absolute; inset: 0; }
+</style>
+<body>
+    <!-- The relative inset of the inline containing block shifts its
+         absolutely positioned children with it, as in Chrome. -->
+    <div class="frame">
+        <span id="plain" style="position: relative;">text<span class="abs" id="unshifted">a</span></span>
+    </div>
+    <div class="frame">
+        <span id="offset" style="position: relative; left: 10px; top: 5px;">text<span class="abs" id="shifted">a</span></span>
+    </div>
+    <!-- A relative inline ancestor of the containing block contributes too. -->
+    <div class="frame">
+        <span style="position: relative; left: 7px;"><span id="nested-offset" style="position: relative; left: 10px;">text<span class="abs" id="chain-shifted">a</span></span></span>
+    </div>
+
+    <script>
+        test(() => {
+            const rect = (id) => document.getElementById(id).getBoundingClientRect();
+            const alignment = (childId, containingBlockId) => {
+                const child = rect(childId);
+                const containingBlock = rect(containingBlockId);
+                return `${child.x - containingBlock.x},${child.y - containingBlock.y}`;
+            };
+            println(`plain alignment: ${alignment("unshifted", "plain")}`);
+            println(`shifted alignment: ${alignment("shifted", "offset")}`);
+            println(`chain alignment: ${alignment("chain-shifted", "nested-offset")}`);
+        });
+    </script>
+</body>


### PR DESCRIPTION
 - Resolve relpos percentage-inset definiteness on the owner side — compute_inset no longer climbs out of the running formatting context to read ancestor used values. parent computes the beyond-anonymous-root answer at spawn and carries it as a run input.
- Register anchor candidates instead of scanning all used values — anchor() resolution stops enumerating every used-values entry per lookup (O(all boxes) for a membership test). Boxes carrying anchor names register at used-values allocation, preserving the completion-order acceptability semantics in commit, measurement, and replay states.
- Shift inline containing block rects by relative insets — a rendering fix: an absolutely positioned box whose containing block is a relatively positioned inline (or nested in relpos inlines) didn't follow the inline's shifted fragments. The stored rect is now correct at production