### PR TITLE
LibWeb: Seal a box's committed metrics when it is placed

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -195,6 +195,7 @@ pub(crate) struct BlockFormattingContext<'pass> {
     lowest_right_margin_edge: Cell<CssPixels>,
     lowest_floating_descendant_bottom_margin_edge: Cell<Option<CssPixels>>,
     derived_baselines_of_root_box: Cell<DerivedBaselines>,
+    trailing_collapsed_margin: Cell<Option<(Node, CssPixels)>>,
 }
 
 impl<'pass> BlockFormattingContext<'pass> {
@@ -213,6 +214,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             lowest_right_margin_edge: Cell::new(CssPixels::default()),
             lowest_floating_descendant_bottom_margin_edge: Cell::new(None),
             derived_baselines_of_root_box: Cell::new(DerivedBaselines::default()),
+            trailing_collapsed_margin: Cell::new(None),
         }
     }
 
@@ -2204,7 +2206,10 @@ impl<'pass> BlockFormattingContext<'pass> {
             return;
         }
 
-        // Assign collapsed margin left after children layout of formatting context to the last child box
+        // The run's trailing collapsed margin hangs below the last real in-flow child, but it
+        // aggregates margins of trailing collapse-through siblings laid out after that child was
+        // placed. It is run output, not a property of that child: the child keeps its own placed
+        // margin_bottom, and only the root's automatic block size consumes the aggregate.
         let collapsed_margin = self.margin_state.borrow().current_collapsed_margin();
         if collapsed_margin != CssPixels::default() {
             let flow_children_bottom_up = if root_facts.is_table_wrapper() {
@@ -2220,12 +2225,9 @@ impl<'pass> BlockFormattingContext<'pass> {
                 if self.margins_collapse_through(child) {
                     continue;
                 }
-                self.used_mut(child).margin_bottom.set(collapsed_margin);
+                self.trailing_collapsed_margin.set(Some((child, collapsed_margin)));
                 break;
             }
-            // The margin reassignment above changed a child's margin box, which the root's baselines may
-            // have been derived from (a scroll container child exports its bottom margin edge), so re-derive them.
-            self.compute_and_store_baselines(self.root);
         }
 
         if root_facts.is_list_item_box() {
@@ -2842,6 +2844,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             self.callbacks,
             self.root,
             self.lowest_floating_descendant_bottom_margin_edge.get(),
+            self.trailing_collapsed_margin.get(),
         )
     }
 }
@@ -2890,6 +2893,7 @@ pub(crate) fn automatic_block_size_for_bfc_root(
     callbacks: FfiLayoutFcCallbacks,
     root: Node,
     lowest_floating_descendant_bottom_margin_edge: Option<CssPixels>,
+    trailing_collapsed_margin: Option<(Node, CssPixels)>,
 ) -> CssPixels {
     let facts = state.node_facts(&callbacks, root);
     // https://drafts.csswg.org/css-contain-2/#containment-size
@@ -2938,9 +2942,17 @@ pub(crate) fn automatic_block_size_for_bfc_root(
                 let child_used = state.try_used_values(&callbacks, child);
                 // Children that have not been laid out yet contribute nothing to the automatic block size.
                 if let Some(child_used) = child_used {
+                    // Margins cannot collapse out of a BFC root: below the last real in-flow
+                    // child, the run's trailing collapsed margin (which folds in any trailing
+                    // collapse-through siblings) replaces that child's own bottom margin.
+                    let margin_bottom = match trailing_collapsed_margin {
+                        Some((last_real_child, aggregate)) if last_real_child == child => aggregate,
+                        _ => child_used.margin_bottom.get(),
+                    };
                     let child_bottom = child_used.content_offset.get().y
                         + child_used.content_block_size.get()
-                        + child_used.margin_box_bottom(false);
+                        + child_used.border_box_bottom(false)
+                        + margin_bottom;
                     bottom = Some(bottom.map_or(child_bottom, |value: CssPixels| value.max(child_bottom)));
                 }
             }

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1518,6 +1518,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         block_container: Node,
         bottom_of_lowest_margin_box: &mut CssPixels,
         input: LayoutInput,
+        containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
     ) {
         let available_space = input.available_space;
         let facts = self.facts(node);
@@ -1875,6 +1876,11 @@ impl<'pass> BlockFormattingContext<'pass> {
         );
 
         if let Some(position) = pending_position {
+            if let Some(coordinate) = containing_line_box_fragment {
+                let used = self.used_mut(node);
+                used.has_containing_line_box_fragment.set(true);
+                used.containing_line_box_fragment.set(coordinate);
+            }
             self.place_child(node, position);
         }
 
@@ -1927,6 +1933,7 @@ impl<'pass> BlockFormattingContext<'pass> {
                 block_container,
                 &mut bottom_of_lowest_margin_box,
                 child_input,
+                None,
             );
         }
         self.block_offset_of_current_block_container.set(saved);
@@ -1963,7 +1970,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             } else {
                 caption_input
             };
-            self.layout_block_level_box(run, child, wrapper, &mut bottom_of_lowest_margin_box, child_input);
+            self.layout_block_level_box(run, child, wrapper, &mut bottom_of_lowest_margin_box, child_input, None);
         }
         self.block_offset_of_current_block_container.set(saved);
         self.finish_block_level_children_layout(wrapper, input, available_space_for_children, bottom_of_lowest_margin_box);
@@ -2027,7 +2034,7 @@ impl<'pass> BlockFormattingContext<'pass> {
                 .block_offset_of_current_block_container
                 .replace(Some(CssPixels::default()));
             let mut dummy_bottom = CssPixels::default();
-            self.layout_block_level_box(run, legend, fieldset, &mut dummy_bottom, child_input);
+            self.layout_block_level_box(run, legend, fieldset, &mut dummy_bottom, child_input, None);
             self.block_offset_of_current_block_container.set(saved);
         }
 
@@ -2059,7 +2066,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             let saved = self.block_offset_of_current_block_container.replace(Some(extra_top));
             for child in self.children(fieldset) {
                 if child != legend {
-                    self.layout_block_level_box(run, child, fieldset, &mut bottom_of_lowest_margin_box, child_input);
+                    self.layout_block_level_box(run, child, fieldset, &mut bottom_of_lowest_margin_box, child_input, None);
                 }
             }
             self.block_offset_of_current_block_container.set(saved);
@@ -2269,12 +2276,23 @@ impl<'pass> BlockFormattingContext<'pass> {
         input: LayoutInput,
         line_builder: &mut LineBuilder<'_, '_, '_>,
     ) {
+        let line_index = line_builder.line_index_for_block_level_box();
         let current_block_offset = line_builder.current_block_offset();
         let saved = self
             .block_offset_of_current_block_container
             .replace(Some(current_block_offset));
         let mut dummy_bottom = CssPixels::default();
-        self.layout_block_level_box(run, node, containing_block, &mut dummy_bottom, input);
+        self.layout_block_level_box(
+            run,
+            node,
+            containing_block,
+            &mut dummy_bottom,
+            input,
+            Some(LineBoxFragmentCoordinate {
+                line_box_index: line_index,
+                fragment_index: 0,
+            }),
+        );
         // SAFETY: The builder remains live and no reference escaped.
         let block_bottom = self
             .block_offset_of_current_block_container
@@ -2283,6 +2301,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         self.block_offset_of_current_block_container.set(saved);
         line_builder.append_block_level_box(
             node,
+            line_index,
             block_bottom,
             self.margin_state.borrow().current_collapsed_margin(),
         );

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -1864,6 +1864,16 @@ impl<'pass> BlockFormattingContext<'pass> {
             );
         }
 
+        let block_container_used = self.used(block_container);
+        self.compute_inset(
+            run,
+            node,
+            LogicalSize {
+                inline_size: block_container_used.content_inline_size.get(),
+                block_size: block_container_used.content_block_size.get(),
+            },
+        );
+
         if let Some(position) = pending_position {
             self.place_child(node, position);
         }
@@ -1887,15 +1897,6 @@ impl<'pass> BlockFormattingContext<'pass> {
             .add_margin(self.used(node).margin_bottom.get());
         self.margin_state.borrow_mut().update_open_top_margin_group();
 
-        let block_container_used = self.used(block_container);
-        self.compute_inset(
-            run,
-            node,
-            LogicalSize {
-                inline_size: block_container_used.content_inline_size.get(),
-                block_size: block_container_used.content_block_size.get(),
-            },
-        );
         let used = self.used(node);
         *bottom_of_lowest_margin_box = (*bottom_of_lowest_margin_box)
             .max(used.content_offset.get().y + used.content_block_size.get() + used.margin_box_bottom(false));

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -402,6 +402,7 @@ pub(crate) fn place_child(
     assert!(!used.has_content_offset.get());
     used.has_content_offset.set(true);
     used.content_offset.set(offset);
+    used.seal_committed_box_metrics();
 }
 
 pub(crate) fn register_contained_abspos_child(

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3448,7 +3448,8 @@ impl<'pass> GridFormattingContext<'pass> {
                 x: area.offset.inline_offset + self.item_margin_box_start(item, Axis::Column),
                 y: area.offset.block_offset + self.item_margin_box_start(item, Axis::Row),
             };
-            crate::layout::place_child(self.state, &self.callbacks, item.box_, offset);
+            // Resolve relative-position insets before placement seals the
+            // item's committed metrics.
             crate::layout::compute_inset_native(
                 self.state,
                 self.callbacks,
@@ -3458,6 +3459,7 @@ impl<'pass> GridFormattingContext<'pass> {
                 self.grid_container,
                 run.treat_block_axis_percentage_insets_as_auto_beyond_root,
             );
+            crate::layout::place_child(self.state, &self.callbacks, item.box_, offset);
         }
         self.derived_baselines_of_root_box =
             crate::layout::derive_baselines(self.state, &self.callbacks, self.grid_container, false);

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -1079,7 +1079,6 @@ impl LayoutState {
         used.set_content_block_size(geometry.content_block_size);
         used.has_definite_inline_size.set(true);
         used.has_definite_block_size.set(true);
-        used.has_content_offset.set(true);
         used.content_offset.set(geometry.content_offset);
         used.margin_left.set(geometry.margin_left);
         used.margin_right.set(geometry.margin_right);
@@ -1100,6 +1099,11 @@ impl LayoutState {
         if self.node_facts(callbacks, node).is_svg_svg_box() {
             self.used_values_rare_data_mut(slot_index).svg_viewport_size = Some(geometry.svg_viewport_size);
         }
+
+        // Materialization is this box's placement: the previous paintable's
+        // committed geometry is final from the moment it is adopted.
+        used.has_content_offset.set(true);
+        used.seal_committed_box_metrics();
 
         let used = self.used_values.allocate(slot_index, used);
         self.register_anchor_candidate_if_carries_anchor_names(callbacks, node);

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -339,7 +339,19 @@ impl<'builder, 'context, 'pass> LineBuilder<'builder, 'context, 'pass> {
         self.begin_new_line(true, true, ForcedBreak::No);
     }
 
-    pub(crate) fn append_block_level_box(&mut self, node: Node, block_end: CssPixels, block_end_margin: CssPixels) {
+    pub(crate) fn line_index_for_block_level_box(&mut self) -> usize {
+        let line_index = self.ensure_last_line_index();
+        assert!(self.line(line_index).fragments.is_empty());
+        line_index
+    }
+
+    pub(crate) fn append_block_level_box(
+        &mut self,
+        node: Node,
+        line_index: usize,
+        block_end: CssPixels,
+        block_end_margin: CssPixels,
+    ) {
         let used = self.context().used(node);
         assert!(used.has_content_offset.get());
         let (inline_offset, block_offset) = to_logical(
@@ -359,7 +371,8 @@ impl<'builder, 'context, 'pass> LineBuilder<'builder, 'context, 'pass> {
             used.margin_box_block_size(false),
         )
         .0;
-        let line_index = self.ensure_last_line_index();
+        let ensured_line_index = self.ensure_last_line_index();
+        assert_eq!(line_index, ensured_line_index);
         assert!(self.line(line_index).fragments.is_empty());
         let fragment = LineBoxFragmentData::new(
             node,
@@ -391,12 +404,6 @@ impl<'builder, 'context, 'pass> LineBuilder<'builder, 'context, 'pass> {
                 marker.block_offset += current_block_offset;
             }
         }
-        let used = self.context().used_mut(node);
-        used.has_containing_line_box_fragment.set(true);
-        used.containing_line_box_fragment.set(LineBoxFragmentCoordinate {
-            line_box_index: line_index,
-            fragment_index: 0,
-        });
         self.pending_margin_follows_block_level_box = true;
         self.current_block_offset = block_end;
         self.max_block_size_on_current_line = CssPixels::default();

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -43,33 +43,72 @@ pub(crate) struct LineBoxFragmentCoordinate {
     pub fragment_index: usize,
 }
 
+pub(crate) struct SealableCell<T> {
+    value: Cell<T>,
+    sealed: Cell<bool>,
+}
+
+impl<T: Copy + std::fmt::Debug> std::fmt::Debug for SealableCell<T> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.value.get().fmt(formatter)
+    }
+}
+
+impl<T: Copy> SealableCell<T> {
+    pub(crate) fn new(value: T) -> Self {
+        Self {
+            value: Cell::new(value),
+            sealed: Cell::new(false),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get(&self) -> T {
+        self.value.get()
+    }
+
+    #[track_caller]
+    #[inline]
+    pub(crate) fn set(&self, value: T) {
+        assert!(
+            !self.sealed.get(),
+            "write to a sealed committed box metric after placement"
+        );
+        self.value.set(value);
+    }
+
+    pub(crate) fn seal(&self) {
+        self.sealed.set(true);
+    }
+}
+
 /// The per-box geometry stored in a Rust-owned layout pass.
 #[derive(Debug)]
 pub(crate) struct UsedValues {
     pub node: crate::layout::node_data::NodeSlotId,
 
-    pub content_inline_size: Cell<CssPixels>,
-    pub content_block_size: Cell<CssPixels>,
+    pub content_inline_size: SealableCell<CssPixels>,
+    pub content_block_size: SealableCell<CssPixels>,
 
-    pub margin_left: Cell<CssPixels>,
-    pub margin_right: Cell<CssPixels>,
-    pub margin_top: Cell<CssPixels>,
-    pub margin_bottom: Cell<CssPixels>,
+    pub margin_left: SealableCell<CssPixels>,
+    pub margin_right: SealableCell<CssPixels>,
+    pub margin_top: SealableCell<CssPixels>,
+    pub margin_bottom: SealableCell<CssPixels>,
 
-    pub border_left: Cell<CssPixels>,
-    pub border_right: Cell<CssPixels>,
-    pub border_top: Cell<CssPixels>,
-    pub border_bottom: Cell<CssPixels>,
+    pub border_left: SealableCell<CssPixels>,
+    pub border_right: SealableCell<CssPixels>,
+    pub border_top: SealableCell<CssPixels>,
+    pub border_bottom: SealableCell<CssPixels>,
 
-    pub padding_left: Cell<CssPixels>,
-    pub padding_right: Cell<CssPixels>,
-    pub padding_top: Cell<CssPixels>,
-    pub padding_bottom: Cell<CssPixels>,
+    pub padding_left: SealableCell<CssPixels>,
+    pub padding_right: SealableCell<CssPixels>,
+    pub padding_top: SealableCell<CssPixels>,
+    pub padding_bottom: SealableCell<CssPixels>,
 
-    pub inset_left: Cell<CssPixels>,
-    pub inset_right: Cell<CssPixels>,
-    pub inset_top: Cell<CssPixels>,
-    pub inset_bottom: Cell<CssPixels>,
+    pub inset_left: SealableCell<CssPixels>,
+    pub inset_right: SealableCell<CssPixels>,
+    pub inset_top: SealableCell<CssPixels>,
+    pub inset_bottom: SealableCell<CssPixels>,
 
     pub has_definite_inline_size: Cell<bool>,
     pub has_definite_block_size: Cell<bool>,
@@ -81,8 +120,8 @@ pub(crate) struct UsedValues {
 
     // Keep these as separate cells: content_offset is read by placement code
     // even where has_content_offset is false.
-    pub has_content_offset: Cell<bool>,
-    pub content_offset: Cell<FfiCssPixelPoint>,
+    pub has_content_offset: SealableCell<bool>,
+    pub content_offset: SealableCell<FfiCssPixelPoint>,
 
     // Keep baseline payloads separate so resetting the presence bits does not
     // perturb the payloads observed by the existing derivation flow.
@@ -93,8 +132,8 @@ pub(crate) struct UsedValues {
 
     // Commit copies the coordinate payload even when the presence bit is
     // false, so this cannot be represented as Cell<Option<_>>.
-    pub has_containing_line_box_fragment: Cell<bool>,
-    pub containing_line_box_fragment: Cell<LineBoxFragmentCoordinate>,
+    pub has_containing_line_box_fragment: SealableCell<bool>,
+    pub containing_line_box_fragment: SealableCell<LineBoxFragmentCoordinate>,
 }
 
 impl Default for UsedValues {
@@ -102,39 +141,69 @@ impl Default for UsedValues {
         let zero = CssPixels::from_raw(0);
         Self {
             node: crate::layout::node_data::NodeSlotId::INVALID,
-            content_inline_size: Cell::new(zero),
-            content_block_size: Cell::new(zero),
-            margin_left: Cell::new(zero),
-            margin_right: Cell::new(zero),
-            margin_top: Cell::new(zero),
-            margin_bottom: Cell::new(zero),
-            border_left: Cell::new(zero),
-            border_right: Cell::new(zero),
-            border_top: Cell::new(zero),
-            border_bottom: Cell::new(zero),
-            padding_left: Cell::new(zero),
-            padding_right: Cell::new(zero),
-            padding_top: Cell::new(zero),
-            padding_bottom: Cell::new(zero),
-            inset_left: Cell::new(zero),
-            inset_right: Cell::new(zero),
-            inset_top: Cell::new(zero),
-            inset_bottom: Cell::new(zero),
+            content_inline_size: SealableCell::new(zero),
+            content_block_size: SealableCell::new(zero),
+            margin_left: SealableCell::new(zero),
+            margin_right: SealableCell::new(zero),
+            margin_top: SealableCell::new(zero),
+            margin_bottom: SealableCell::new(zero),
+            border_left: SealableCell::new(zero),
+            border_right: SealableCell::new(zero),
+            border_top: SealableCell::new(zero),
+            border_bottom: SealableCell::new(zero),
+            padding_left: SealableCell::new(zero),
+            padding_right: SealableCell::new(zero),
+            padding_top: SealableCell::new(zero),
+            padding_bottom: SealableCell::new(zero),
+            inset_left: SealableCell::new(zero),
+            inset_right: SealableCell::new(zero),
+            inset_top: SealableCell::new(zero),
+            inset_bottom: SealableCell::new(zero),
             has_definite_inline_size: Cell::new(false),
             has_definite_block_size: Cell::new(false),
             materialized_from_paintable: Cell::new(false),
             uses_collapsing_borders_model: Cell::new(false),
             inline_size_constraint: Cell::new(SizeConstraint::None),
             block_size_constraint: Cell::new(SizeConstraint::None),
-            has_content_offset: Cell::new(false),
-            content_offset: Cell::new(FfiCssPixelPoint::default()),
+            has_content_offset: SealableCell::new(false),
+            content_offset: SealableCell::new(FfiCssPixelPoint::default()),
             has_first_baseline: Cell::new(false),
             first_baseline: Cell::new(zero),
             has_last_baseline: Cell::new(false),
             last_baseline: Cell::new(zero),
-            has_containing_line_box_fragment: Cell::new(false),
-            containing_line_box_fragment: Cell::new(LineBoxFragmentCoordinate::default()),
+            has_containing_line_box_fragment: SealableCell::new(false),
+            containing_line_box_fragment: SealableCell::new(LineBoxFragmentCoordinate::default()),
         }
+    }
+}
+
+impl UsedValues {
+    /// Seals every field that commit emits as part of FfiCommittedBoxMetrics.
+    /// Called when the box is placed: after placement, none of these may
+    /// change again.
+    pub(crate) fn seal_committed_box_metrics(&self) {
+        self.content_inline_size.seal();
+        self.content_block_size.seal();
+        self.margin_left.seal();
+        self.margin_right.seal();
+        self.margin_top.seal();
+        self.margin_bottom.seal();
+        self.border_left.seal();
+        self.border_right.seal();
+        self.border_top.seal();
+        self.border_bottom.seal();
+        self.padding_left.seal();
+        self.padding_right.seal();
+        self.padding_top.seal();
+        self.padding_bottom.seal();
+        self.inset_left.seal();
+        self.inset_right.seal();
+        self.inset_top.seal();
+        self.inset_bottom.seal();
+        self.has_content_offset.seal();
+        self.content_offset.seal();
+        self.has_containing_line_box_fragment.seal();
+        self.containing_line_box_fragment.seal();
     }
 }
 

--- a/Tests/LibWeb/Layout/expected/abspos-inline-containing-block-first-last-line-rule.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-inline-containing-block-first-last-line-rule.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 409 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [0,8] [0+0+0 800 0+0+0] [0+0+0 393 0+0+8] children: not-inline
+    BlockContainer <body> at [0,8] [0+0+0 800 0+0+0] [0+0+0 393 0+0+0] children: not-inline
       BlockContainer <div.frame> at [8,8] [8+0+0 130 0+0+662] [8+0+0 60 0+0+8] children: inline
         TextNode <#text> (not painted)
         InlineNode <span.rel> at [8,10] [0+0+0 126.28125 0+0+0] [0+0+0 56 0+0+0]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/box-with-clearance-and-margin-top.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 267 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 110 0+0+100] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 110 0+0+8] children: not-inline
       BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 110 0+0+0] children: not-inline
         BlockContainer <div.square.white> at [8,8] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
         BlockContainer <div.clearfix> at [8,108] [0+0+0 10 0+0+774] [9999+0+0 10 0+0+100] children: not-inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break-followed-by-block.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-clear-by-line-break-followed-by-block.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 156 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 132 0+0+16] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 132 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 100 0+0+0] children: inline
         BlockContainer <div.a> at [8,8] floating [0+0+0 100 0+0+0] [0+0+0 100 0+0+0] [BFC] children: not-inline
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-vertical-offset-by-preceding-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-vertical-offset-by-preceding-float.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 130 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 48 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 48 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         BlockContainer <div> at [8,16] floating [0+0+0 50 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 41 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,13] [8+0+0 784 0+0+8] [8+0+0 15 0+0+13] children: not-inline
+    BlockContainer <body> at [8,13] [8+0+0 784 0+0+8] [8+0+0 15 0+0+8] children: not-inline
       BlockContainer <pre> at [9,14] [0+1+0 782 0+1+0] [13+1+0 13 0+1+13] children: inline
         InlineNode <span> at [9,14] [0+0+0 6.5 0+0+0] [0+0+0 13 0+0+0]
           frag 0 from TextNode start: 0, length: 1, rect: [9,14 6.5x13] baseline: 10.390625

--- a/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-stress-test.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/intrinsic-sizing-stress-test.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 1760.375 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body> at [0,10] [0+0+0 831.75 0+0+-31.75] [0+0+0 1740.375 0+0+10] children: not-inline
+    BlockContainer <body> at [0,10] [0+0+0 831.75 0+0+-31.75] [0+0+0 1740.375 0+0+0] children: not-inline
       BlockContainer <(anonymous)> at [0,10] [0+0+0 831.75 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/list-markers-intruded-by-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/list-markers-intruded-by-float.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 136 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 96 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 96 0+0+8] children: not-inline
       BlockContainer <div.box> at [18,26] floating [0+10+0 200 0+10+100] [0+10+0 100 0+10+0] [BFC] children: not-inline
       BlockContainer <ul> at [48,16] [0+0+40 744 0+0+0] [16+0+0 96 0+0+16] children: not-inline
         ListItemBox <li> at [48,16] [0+0+0 744 0+0+0] [0+0+0 16 0+0+0] children: inline

--- a/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/margin-collapse-1.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 279 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,25] [8+0+0 784 0+0+8] [8+0+0 229 0+0+25] children: not-inline
+    BlockContainer <body> at [8,25] [8+0+0 784 0+0+8] [8+0+0 229 0+0+8] children: not-inline
       BlockContainer <div#foo> at [34,26] [25+1+0 100 0+1+657] [25+1+0 100 0+1+25] children: inline
         frag 0 from TextNode start: 0, length: 3, rect: [34,26 27.15625x16] baseline: 12.796875
             "foo"

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 153 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 132 0+0+13] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 132 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
         InlineNode <span> at [8,8] [0+0+0 136.609375 0+0+0] [0+0+0 16 0+0+0]
           frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x16] baseline: 12.796875

--- a/Tests/LibWeb/Layout/expected/block-size.txt
+++ b/Tests/LibWeb/Layout/expected/block-size.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 1760 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,70] [8+0+0 784 0+0+8] [8+0+0 1620 0+0+70] children: not-inline
+    BlockContainer <body> at [8,70] [8+0+0 784 0+0+8] [8+0+0 1620 0+0+8] children: not-inline
       BlockContainer <p.min-block-test> at [8,70] [0+0+0 784 0+0+0] [70+0+0 700 0+0+70] children: inline
         frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.875x70] baseline: 55.984375
             "KK"

--- a/Tests/LibWeb/Layout/expected/css-counters/basic.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/basic.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 336 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 304 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 304 0+0+8] children: not-inline
       BlockContainer <div> at [8,16] [0+0+0 784 0+0+0] [0+0+0 144 0+0+0] children: not-inline
         BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline
           frag 0 from TextNode start: 0, length: 5, rect: [36.8125,16 44.75x16] baseline: 12.796875

--- a/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 176 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 144 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 144 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline
         frag 0 from TextNode start: 0, length: 1, rect: [26.125,16 14.265625x16] baseline: 12.796875
             "A"

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-matches.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,20] [8+0+0 784 0+0+8] [8+0+0 20 0+0+20] children: not-inline
+    BlockContainer <body> at [8,20] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
       BlockContainer <p> at [8,20] [0+0+0 784 0+0+0] [20+0+0 20 0+0+20] children: inline
         TextNode <#text> (not painted)
         InlineNode <a> at [18,20] [0+0+10 163.9375 10+0+0] [0+0+10 20 10+0+0]

--- a/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-rule-no-match.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 60 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,20] [8+0+0 784 0+0+8] [8+0+0 20 0+0+20] children: not-inline
+    BlockContainer <body> at [8,20] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
       BlockContainer <p> at [8,20] [0+0+0 784 0+0+0] [20+0+0 20 0+0+20] children: inline
         TextNode <#text> (not painted)
         InlineNode <a> at [13,20] [0+0+5 141.390625 5+0+0] [0+0+5 20 5+0+0]

--- a/Tests/LibWeb/Layout/expected/css-text-transform-math-auto.txt
+++ b/Tests/LibWeb/Layout/expected/css-text-transform-math-auto.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline
         frag 0 from TextNode start: 0, length: 35, rect: [8,16 118.40625x16] baseline: 12.796875
             "𝑊𝑒𝑙𝑙, ℎ𝑒𝑙𝑙𝑜 𝑓𝑟𝑖𝑒𝑛𝑑𝑠!"

--- a/Tests/LibWeb/Layout/expected/css/content-for-marker-in-list.txt
+++ b/Tests/LibWeb/Layout/expected/css/content-for-marker-in-list.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html#html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 112 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body#body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+16] children: not-inline
+    BlockContainer <body#body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 80 0+0+16] children: not-inline

--- a/Tests/LibWeb/Layout/expected/div_align.txt
+++ b/Tests/LibWeb/Layout/expected/div_align.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 632 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 604 0+0+20] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 604 0+0+8] children: not-inline
       BlockContainer <div> at [8,8] [0+0+0 784 0+0+0] [0+0+0 136 0+0+0] children: not-inline
         BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: inline
           frag 0 from TextNode start: 0, length: 53, rect: [8,8 436.625x16] baseline: 12.796875

--- a/Tests/LibWeb/Layout/expected/document-write-incomplete-tag.txt
+++ b/Tests/LibWeb/Layout/expected/document-write-incomplete-tag.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 112 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline
         frag 0 from TextNode start: 0, length: 4, rect: [8,16 30.078125x16] baseline: 12.796875
             "Well"

--- a/Tests/LibWeb/Layout/expected/empty-list-items.txt
+++ b/Tests/LibWeb/Layout/expected/empty-list-items.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 80 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 48 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 48 0+0+8] children: not-inline
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 48 0+0+16] children: not-inline
         ListItemBox <li> at [48,16] [0+0+0 744 0+0+0] [0+0+0 16 0+0+0] children: not-inline
           ListItemMarkerBox <(anonymous)> at [29,16] [0+0+0 18.6875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/fieldset-legend-variations.txt
+++ b/Tests/LibWeb/Layout/expected/fieldset-legend-variations.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 761 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 737 0+0+16] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 737 0+0+8] children: not-inline
       FieldSetBox <fieldset> at [10,10] [0+2+0 780 0+2+0] [0+2+0 30 0+2+16] [BFC] children: not-inline
         LegendBox <legend> at [10,8] [0+0+0 56.5 0+0+0] [0+0+0 16 0+0+0] children: inline
           frag 0 from TextNode start: 0, length: 7, rect: [10,8 56.5x16] baseline: 12.796875

--- a/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
+++ b/Tests/LibWeb/Layout/expected/flex/list-container-display-contents.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       Box <ul.globalnav-list> at [48,16] flex-container(row) [0+0+40 744 0+0+0] [16+0+0 16 0+0+16] [FFC] children: not-inline
         BlockContainer <div#item-1> at [48,16] flex-item [0+0+0 46.734375 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline
           frag 0 from TextNode start: 0, length: 5, rect: [48,16 46.734375x16] baseline: 12.796875

--- a/Tests/LibWeb/Layout/expected/grid/justify-content-cols.txt
+++ b/Tests/LibWeb/Layout/expected/grid/justify-content-cols.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 288 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 260 0+0+20] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 260 0+0+8] children: not-inline
       Box <div.grid.justify-start> at [8,8] [0+0+0 784 0+0+0] [0+0+0 20 0+0+20] [GFC] children: not-inline
         BlockContainer <(anonymous)> (not painted) [BFC] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/import-after-namespace.txt
+++ b/Tests/LibWeb/Layout/expected/import-after-namespace.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 461 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 432 0+0+13] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 432 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline
         frag 0 from TextNode start: 0, length: 35, rect: [8,16 290.765625x16] baseline: 12.796875
             "All divs below should be 100px wide"

--- a/Tests/LibWeb/Layout/expected/inline-flex-baseline-with-wrapped-hidden-text.txt
+++ b/Tests/LibWeb/Layout/expected/inline-flex-baseline-with-wrapped-hidden-text.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 50 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 18 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 18 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 18 0+0+16] children: inline
         frag 0 from TextNode start: 0, length: 4, rect: [8,16 35.15625x16] baseline: 12.796875
             "foo "

--- a/Tests/LibWeb/Layout/expected/inline-size.txt
+++ b/Tests/LibWeb/Layout/expected/inline-size.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 1030 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,70] [8+0+0 784 0+0+8] [8+0+0 890 0+0+70] children: not-inline
+    BlockContainer <body> at [8,70] [8+0+0 784 0+0+8] [8+0+0 890 0+0+8] children: not-inline
       BlockContainer <p.min-inline-test> at [8,70] [0+0+0 784 0+0+0] [70+0+0 200 0+0+70] children: inline
         frag 0 from TextNode start: 0, length: 2, rect: [8,70 85.875x70] baseline: 55.984375
             "KK"

--- a/Tests/LibWeb/Layout/expected/inside-list-item-content-offset.txt
+++ b/Tests/LibWeb/Layout/expected/inside-list-item-content-offset.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 416 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,200] [8+0+0 784 0+0+8] [8+0+0 16 0+0+200] children: not-inline
+    BlockContainer <body> at [8,200] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       ListItemBox <span> at [208,200] [200+0+0 384 0+0+200] [200+0+0 16 0+0+200] children: inline
         frag 0 from ListItemMarkerBox start: 0, length: 0, rect: [208,200 13.84375x16] baseline: 12.796875
         ListItemMarkerBox <(anonymous)> at [208,200] [0+0+0 13.84375 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/inline-element-position-change.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 74.875 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,21.4375] [8+0+0 784 0+0+8] [8+0+0 32 0+0+21.4375] children: inline
+    BlockContainer <body> at [8,21.4375] [8+0+0 784 0+0+8] [8+0+0 32 0+0+8] children: inline
       InlineNode <a> at [8,21.4375] [0+0+0 0 0+0+0] [0+0+0 0 0+0+0]
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,21.4375 784x32] baseline: 0
         InlineNode <span#foo> at [8,21.4375] [0+0+0 0 0+0+0] [0+0+0 16 0+0+0]

--- a/Tests/LibWeb/Layout/expected/layout-tree-update/transform-longhands-clear.txt
+++ b/Tests/LibWeb/Layout/expected/layout-tree-update/transform-longhands-clear.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 368 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 340 0+0+20] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 340 0+0+8] children: not-inline
       BlockContainer <div#scaled> at [8,8] [0+0+0 100 0+0+684] [0+0+0 100 0+0+20] children: not-inline
       BlockContainer <(anonymous)> at [8,128] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/leading-metrics.txt
+++ b/Tests/LibWeb/Layout/expected/leading-metrics.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 65 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,13] [8+0+0 784 0+0+8] [8+0+0 39 0+0+13] children: not-inline
+    BlockContainer <body> at [8,13] [8+0+0 784 0+0+8] [8+0+0 39 0+0+8] children: not-inline
       BlockContainer <div> at [8,13] [0+0+0 784 0+0+0] [0+0+0 39 0+0+0] children: not-inline
         BlockContainer <(anonymous)> at [8,13] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/list-item-marker-content-height.txt
+++ b/Tests/LibWeb/Layout/expected/list-item-marker-content-height.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 168 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 136 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 136 0+0+8] children: not-inline
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 60 0+0+16] children: not-inline
         BlockContainer <(anonymous)> at [48,16] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/list-marker-rtl.txt
+++ b/Tests/LibWeb/Layout/expected/list-marker-rtl.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       BlockContainer <ul> at [8,16] [0+0+0 744 40+0+0] [16+0+0 16 0+0+16] children: not-inline
         BlockContainer <(anonymous)> at [8,16] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/misc/invalid-slotted-selector.txt
+++ b/Tests/LibWeb/Layout/expected/misc/invalid-slotted-selector.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       BlockContainer <div> at [8,16] [0+0+0 784 0+0+0] [0+0+0 16 0+0+0] children: not-inline
         Box <ul> at [48,16] flex-container(row) [0+0+40 744 0+0+0] [16+0+0 16 0+0+16] [FFC] children: not-inline
           ListItemBox <li> at [48,16] flex-item [0+0+0 57.296875 0+0+0] [0+0+0 16 0+0+0] [BFC] children: inline

--- a/Tests/LibWeb/Layout/expected/multi-code-point-graphemes.txt
+++ b/Tests/LibWeb/Layout/expected/multi-code-point-graphemes.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 112 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline
         frag 0 from TextNode start: 0, length: 5, rect: [8,16 20.3125x16] baseline: 12.796875
             "🧑‍🚒"

--- a/Tests/LibWeb/Layout/expected/ol-render-deep-hybrid-list-item-list.txt
+++ b/Tests/LibWeb/Layout/expected/ol-render-deep-hybrid-list-item-list.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 368 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 336 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 336 0+0+8] children: not-inline
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 336 0+0+16] children: not-inline
         BlockContainer <(anonymous)> at [48,16] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/ol-render-item-values.txt
+++ b/Tests/LibWeb/Layout/expected/ol-render-item-values.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 96 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 64 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 64 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 64 0+0+16] children: not-inline

--- a/Tests/LibWeb/Layout/expected/ol-render-style-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/ol-render-style-list-item.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 192 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 160 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 160 0+0+8] children: not-inline
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 160 0+0+16] children: not-inline
         BlockContainer <(anonymous)> at [48,16] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/ordered-list.txt
+++ b/Tests/LibWeb/Layout/expected/ordered-list.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 160 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 128 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 128 0+0+8] children: not-inline
       BlockContainer <ol> at [48,16] [0+0+40 744 0+0+0] [16+0+0 48 0+0+16] children: not-inline
         BlockContainer <(anonymous)> at [48,16] [0+0+0 744 0+0+0] [0+0+0 0 0+0+0] children: inline
           TextNode <#text> (not painted)

--- a/Tests/LibWeb/Layout/expected/pdf-viewer.txt
+++ b/Tests/LibWeb/Layout/expected/pdf-viewer.txt
@@ -345,7 +345,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
             BlockContainer <div#viewerContainer> at [0,32] positioned [0+0+0 800 0+0+0] [0+0+0 568 0+0+0] [BFC] children: not-inline
               BlockContainer <(anonymous)> at [0,32] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
                 TextNode <#text> (not painted)
-              BlockContainer <div#viewer.pdfViewer> at [0,33] [0+0+0 800 0+0+0] [0+0+0 151 0+0+-8] children: not-inline
+              BlockContainer <div#viewer.pdfViewer> at [0,33] [0+0+0 800 0+0+0] [0+0+0 151 0+0+0] children: not-inline
                 BlockContainer <div.page> at [233.5,42] positioned [224.5+9+0 333 0+9+224.5] [1+9+0 133 0+9+-8] children: not-inline
                   BlockContainer <div.canvasWrapper> at [233.5,42] [0+0+0 333 0+0+0] [0+0+0 133 0+0+0] [BFC] children: not-inline
                     CanvasBox <canvas> at [233.5,42] positioned [0+0+0 333 0+0+0] [0+0+0 133 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/position-empty-pseudo-elements.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 175 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,25] [8+0+0 784 0+0+8] [8+0+0 125 0+0+25] children: not-inline
+    BlockContainer <body> at [8,25] [8+0+0 784 0+0+8] [8+0+0 125 0+0+8] children: not-inline
       BlockContainer <div.empty_content> at [33,25] [25+0+0 50 0+0+709] [25+0+0 50 0+0+25] children: not-inline
         BlockContainer <(anonymous)> at [33,75] [0+0+0 50 0+0+0] [0+0+50 0 0+0+0] children: inline
           GeneratedTextNode <(anonymous)> (not painted)

--- a/Tests/LibWeb/Layout/expected/quirks/input-in-pre-quirks-mode.txt
+++ b/Tests/LibWeb/Layout/expected/quirks/input-in-pre-quirks-mode.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 610 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,13] [8+0+0 784 0+0+8] [8+0+0 584 0+0+13] children: not-inline
+    BlockContainer <body> at [8,13] [8+0+0 784 0+0+8] [8+0+0 584 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,13] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <pre> at [8,13] [0+0+0 784 0+0+0] [13+0+0 17 0+0+13] children: inline

--- a/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
+++ b/Tests/LibWeb/Layout/expected/set-margin-of-floating-box.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 116 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
         ImageBox <img> at [8,16] floating [0+0+0 200 0+0+20] [0+0+0 100 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table-caption-auto-height.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 140 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 108 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 108 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [48,16] [40+0+0 106 0+0+638] [16+0+0 108 0+0+16] [BFC] children: not-inline
         Box <figure> at [50,70] table-box [0+2+0 102 0+2+0] [0+2+0 52 0+2+0] [TFC] children: not-inline
           Box <(anonymous)> at [50,70] table-row [0+0+0 102 0+0+0] [0+0+0 52 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 404 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,100] [8+0+0 784 0+0+8] [8+0+0 204 0+0+100] children: not-inline
+    BlockContainer <body> at [8,100] [8+0+0 784 0+0+8] [8+0+0 204 0+0+8] children: not-inline
       TableWrapper <(anonymous)> at [108,100] [100+0+0 89.34375 0+0+594.65625] [100+0+0 204 0+0+100] [BFC] children: not-inline
         Box <table> at [109,101] table-box [0+1+0 87.34375 0+1+0] [0+1+0 202 0+1+0] [TFC] children: not-inline
           Box <tbody> at [111,103] table-row-group [0+0+0 83.34375 0+0+0] [0+0+0 198 0+0+0] children: not-inline

--- a/Tests/LibWeb/Layout/expected/ul-render.txt
+++ b/Tests/LibWeb/Layout/expected/ul-render.txt
@@ -2,7 +2,7 @@ Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 112 0+0+0] [BFC] children: not-inline
     BlockContainer <(anonymous)> at [0,0] [0+0+0 800 0+0+0] [0+0+0 0 0+0+0] children: inline
       TextNode <#text> (not painted)
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <ul.A> at [48,16] [0+0+40 744 0+0+0] [16+0+0 32 0+0+16] children: not-inline

--- a/Tests/LibWeb/Layout/expected/utf-16-be-xhtml-file-should-decode-correctly.txt
+++ b/Tests/LibWeb/Layout/expected/utf-16-be-xhtml-file-should-decode-correctly.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
   BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 48 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+16] children: not-inline
+    BlockContainer <body> at [8,16] [8+0+0 784 0+0+8] [8+0+0 16 0+0+8] children: not-inline
       BlockContainer <(anonymous)> at [8,16] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
       BlockContainer <p> at [8,16] [0+0+0 784 0+0+0] [16+0+0 16 0+0+16] children: inline

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -205,9 +205,9 @@ justify-content: normal
 justify-items: legacy
 justify-self: auto
 left: auto
-margin-block-end: 13px
+margin-block-end: 8px
 margin-block-start: 8px
-margin-bottom: 13px
+margin-bottom: 8px
 margin-inline-end: 8px
 margin-inline-start: 8px
 margin-left: 8px


### PR DESCRIPTION
"When is this box's geometry final?" used to have a different answer
per field and per box class, and nothing checked any of them. Every
consumer of placed geometry was correct only by global ordering
arguments nobody could verify locally, and a production timing mistake
would ship as a silent misrender.

Establish the invariant that placement is the seal point: after
place_child() returns, no field of that box's UsedValues that commit
emits may change again. The sealed set is exactly the
FfiCommittedBoxMetrics payload — content offset, content sizes,
margins, borders, paddings, insets, and the containing-line-box
coordinate. Working state commit never reads (definiteness flags, size
constraints, baselines, the collapsing-borders flag) stays freely
mutable, and rare data is a separate store with its own rules. A box
materialized from a previous paintable is sealed at materialization,
which is that box's placement. The seal point is placement, not the end
of the box's inside layout: everything the engine finishes between
those two moments (float root finalization, abspos alignment insets,
table cell stretch) remains legal.