### PR TITLE
LibWeb: Prepare apply-the-history-step for a UI process coordinator

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -564,6 +564,7 @@ set(SOURCES
     HTML/GlobalEventHandlers.cpp
     HTML/HashChangeEvent.cpp
     HTML/History.cpp
+    HTML/HistoryOperation.cpp
     HTML/HTMLAllCollection.cpp
     HTML/HTMLAnchorElement.cpp
     HTML/HTMLAreaElement.cpp

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -565,6 +565,7 @@ set(SOURCES
     HTML/GlobalEventHandlers.cpp
     HTML/HashChangeEvent.cpp
     HTML/History.cpp
+    HTML/HistoryOperation.cpp
     HTML/HTMLAllCollection.cpp
     HTML/HTMLAnchorElement.cpp
     HTML/HTMLAreaElement.cpp

--- a/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
+++ b/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/Vector.h>
+#include <LibGC/Function.h>
+#include <LibGC/Ptr.h>
+#include <LibWeb/Bindings/NavigationType.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/LocalNavigable.h>
+#include <LibWeb/HTML/SessionHistoryEntry.h>
+#include <LibWeb/HTML/UserNavigationInvolvement.h>
+
+namespace Web::HTML {
+
+struct ChangingNavigableContinuationState;
+
+enum class SynchronousNavigation : bool {
+    Yes,
+    No,
+};
+
+enum class ChangingNavigableHistoryStepJobDisposition : u8 {
+    // The job ran and enqueued its changing navigable continuation.
+    Ready,
+    // AD-HOC: The job did not apply to its navigable (for example, the navigable is gone, or a newer navigation
+    //         owns it); the rest of the history step continues without this navigable.
+    Skipped,
+    // AD-HOC: The whole history step is stale; a newer navigation has to win.
+    Stale,
+};
+
+struct HistoryObjectLengthAndIndex {
+    u64 script_history_length;
+    u64 script_history_index;
+};
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
+//
+// The per-navigable jobs of apply-the-history-step. The coordinator runs the traversal-wide algorithm and holds its
+// variables; these jobs are the parts of the algorithm that must run where a navigable's documents live. Keeping
+// them behind this interface keeps the coordinator free of document state, so the jobs can be run in the navigable's
+// own process.
+class WEB_API ApplyHistoryStepJobRunner {
+public:
+    virtual ~ApplyHistoryStepJobRunner() = default;
+
+    // One iteration of "12. For each navigable of changingNavigables, queue a global task ...".
+    //
+    // NB: The job also claims its navigable ("2. Set navigable's current session history entry to targetEntry." and
+    //     "3. Set the ongoing navigation for navigable to "traversal"."). The specification claims every changing
+    //     navigable before queueing the first job, but a claim only mutates the navigable being claimed, which
+    //     belongs to the process running the job.
+    struct ChangingNavigableHistoryStepJob {
+        CrossProcessId navigable_id;
+        int target_step { 0 };
+        GC::Ptr<SourceSnapshotParams> source_snapshot_params;
+        UserNavigationInvolvement user_involvement;
+        Optional<Bindings::NavigationType> navigation_type;
+        SynchronousNavigation synchronous_navigation;
+        LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
+        GC::Ptr<DOM::Document> pending_document;
+    };
+    struct ChangingNavigableHistoryStepJobResult {
+        ChangingNavigableHistoryStepJobDisposition disposition;
+        GC::Ptr<ChangingNavigableContinuationState> continuation;
+    };
+    using OnChangingNavigableHistoryStepJobComplete = GC::Function<void(ChangingNavigableHistoryStepJobResult)>;
+    virtual void run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) = 0;
+
+    // The "second part" of a changing navigable's job: "12. In both cases, let afterPotentialUnloads be ...",
+    // applied to the continuation the job enqueued.
+    struct ApplyChangingNavigableHistoryStepContinuation {
+        GC::Ref<ChangingNavigableContinuationState> continuation;
+        HistoryObjectLengthAndIndex history_object_length_and_index;
+        Vector<NonnullRefPtr<SessionHistoryEntry>> entries_for_navigation_api;
+        Optional<Bindings::NavigationType> navigation_type;
+        LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
+        UserNavigationInvolvement user_involvement;
+    };
+    virtual void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) = 0;
+
+    // One iteration of "18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task ...".
+    virtual void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete) = 0;
+};
+
+}

--- a/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
+++ b/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
@@ -61,7 +61,7 @@ public:
     virtual void start_apply_history_step_operation(u64 operation_id, u64 history_initiation_id, LocalNavigable::NavigationAPIAbortBehavior) = 0;
     virtual void complete_apply_history_step_operation(u64 operation_id) = 0;
 
-    virtual void run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) = 0;
+    virtual void run_initiator_sandboxing_check_job(u64 history_initiation_id, CrossProcessId initiator_to_check, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) = 0;
     virtual void run_history_step_unload_cancelation_job(int target_step, Vector<CrossProcessId>, UserNavigationInvolvement, GC::Ref<OnHistoryStepUnloadCancelationComplete>) = 0;
 
     // One iteration of "12. For each navigable of changingNavigables, queue a global task ...".

--- a/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
+++ b/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
@@ -88,7 +88,7 @@ public:
     struct ApplyChangingNavigableHistoryStepContinuation {
         CrossProcessId navigable_id;
         HistoryObjectLengthAndIndex history_object_length_and_index;
-        Vector<NonnullRefPtr<SessionHistoryEntry>> entries_for_navigation_api;
+        Vector<SessionHistoryEntryDescriptor> entries_for_navigation_api;
         Optional<Bindings::NavigationType> navigation_type;
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
         UserNavigationInvolvement user_involvement;

--- a/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
+++ b/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
@@ -20,8 +20,6 @@
 
 namespace Web::HTML {
 
-struct ChangingNavigableContinuationState;
-
 enum class SynchronousNavigation : bool {
     Yes,
     No,
@@ -42,6 +40,14 @@ struct HistoryObjectLengthAndIndex {
     u64 script_history_index;
 };
 
+enum class InitiatorSandboxingCheckResult : u8 {
+    Allowed,
+    Disallowed,
+};
+
+using OnInitiatorSandboxingCheckComplete = GC::Function<void(InitiatorSandboxingCheckResult)>;
+using OnHistoryStepUnloadCancelationComplete = GC::Function<void(HistoryStepResult)>;
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
 //
 // The per-navigable jobs of apply-the-history-step. The coordinator runs the traversal-wide algorithm and holds its
@@ -51,6 +57,12 @@ struct HistoryObjectLengthAndIndex {
 class WEB_API ApplyHistoryStepJobRunner {
 public:
     virtual ~ApplyHistoryStepJobRunner() = default;
+
+    virtual void start_apply_history_step_operation(u64 operation_id, LocalNavigable::NavigationAPIAbortBehavior) = 0;
+    virtual void complete_apply_history_step_operation(u64 operation_id) = 0;
+
+    virtual void run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) = 0;
+    virtual void run_history_step_unload_cancelation_job(int target_step, Vector<CrossProcessId>, UserNavigationInvolvement, GC::Ref<OnHistoryStepUnloadCancelationComplete>) = 0;
 
     // One iteration of "12. For each navigable of changingNavigables, queue a global task ...".
     //
@@ -68,24 +80,20 @@ public:
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
         GC::Ptr<DOM::Document> pending_document;
     };
-    struct ChangingNavigableHistoryStepJobResult {
-        ChangingNavigableHistoryStepJobDisposition disposition;
-        GC::Ptr<ChangingNavigableContinuationState> continuation;
-    };
-    using OnChangingNavigableHistoryStepJobComplete = GC::Function<void(ChangingNavigableHistoryStepJobResult)>;
-    virtual void run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) = 0;
+    using OnChangingNavigableHistoryStepJobComplete = GC::Function<void(ChangingNavigableHistoryStepJobDisposition)>;
+    virtual void run_changing_navigable_history_step_job(u64 operation_id, ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) = 0;
 
     // The "second part" of a changing navigable's job: "12. In both cases, let afterPotentialUnloads be ...",
     // applied to the continuation the job enqueued.
     struct ApplyChangingNavigableHistoryStepContinuation {
-        GC::Ref<ChangingNavigableContinuationState> continuation;
+        CrossProcessId navigable_id;
         HistoryObjectLengthAndIndex history_object_length_and_index;
         Vector<NonnullRefPtr<SessionHistoryEntry>> entries_for_navigation_api;
         Optional<Bindings::NavigationType> navigation_type;
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
         UserNavigationInvolvement user_involvement;
     };
-    virtual void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) = 0;
+    virtual void apply_changing_navigable_history_step_continuation(u64 operation_id, ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) = 0;
 
     // One iteration of "18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task ...".
     virtual void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete) = 0;

--- a/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
+++ b/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
@@ -58,7 +58,7 @@ class WEB_API ApplyHistoryStepJobRunner {
 public:
     virtual ~ApplyHistoryStepJobRunner() = default;
 
-    virtual void start_apply_history_step_operation(u64 operation_id, LocalNavigable::NavigationAPIAbortBehavior) = 0;
+    virtual void start_apply_history_step_operation(u64 operation_id, u64 history_initiation_id, LocalNavigable::NavigationAPIAbortBehavior) = 0;
     virtual void complete_apply_history_step_operation(u64 operation_id) = 0;
 
     virtual void run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) = 0;

--- a/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
+++ b/Libraries/LibWeb/HTML/ApplyHistoryStepJobRunner.h
@@ -73,12 +73,10 @@ public:
     struct ChangingNavigableHistoryStepJob {
         CrossProcessId navigable_id;
         int target_step { 0 };
-        GC::Ptr<SourceSnapshotParams> source_snapshot_params;
         UserNavigationInvolvement user_involvement;
         Optional<Bindings::NavigationType> navigation_type;
         SynchronousNavigation synchronous_navigation;
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
-        GC::Ptr<DOM::Document> pending_document;
     };
     using OnChangingNavigableHistoryStepJobComplete = GC::Function<void(ChangingNavigableHistoryStepJobDisposition)>;
     virtual void run_changing_navigable_history_step_job(u64 operation_id, ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) = 0;

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -58,3 +58,79 @@ ErrorOr<Web::ReloadHistoryOperationParameters> IPC::decode(Decoder& decoder)
         .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
     };
 }
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::TraverseByDeltaHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.traversable_id));
+    TRY(encoder.encode(parameters.delta));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::TraverseByDeltaHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::TraverseByDeltaHistoryOperationParameters {
+        .traversable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .delta = TRY(decoder.decode<i32>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::TraverseToStepHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.traversable_id));
+    TRY(encoder.encode(parameters.target_step));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::TraverseToStepHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::TraverseToStepHistoryOperationParameters {
+        .traversable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .target_step = TRY(decoder.decode<i32>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::NavigationAPITraverseHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.navigable_id));
+    TRY(encoder.encode(parameters.key));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::NavigationAPITraverseHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::NavigationAPITraverseHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .key = TRY(decoder.decode<Utf16String>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::ResumeTraverseHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.navigable_id));
+    TRY(encoder.encode(parameters.target_step));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::ResumeTraverseHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::ResumeTraverseHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .target_step = TRY(decoder.decode<i32>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWeb/HTML/HistoryOperation.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::PushHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.navigable_id));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::PushHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::PushHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::ReplaceHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.navigable_id));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::ReplaceHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::ReplaceHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -185,3 +185,17 @@ ErrorOr<Web::FinalizeSameDocumentNavigationHistoryOperationParameters> IPC::deco
         .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
     };
 }
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::CloseTopLevelTraversableHistoryOperationParameters const& parameters)
+{
+    return encoder.encode(parameters.traversable_id);
+}
+
+template<>
+ErrorOr<Web::CloseTopLevelTraversableHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::CloseTopLevelTraversableHistoryOperationParameters {
+        .traversable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -148,3 +148,17 @@ ErrorOr<Web::NavigableCreationHistoryOperationParameters> IPC::decode(Decoder& d
         .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
     };
 }
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::NavigableDestructionHistoryOperationParameters const& parameters)
+{
+    return encoder.encode(parameters.traversable_id);
+}
+
+template<>
+ErrorOr<Web::NavigableDestructionHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::NavigableDestructionHistoryOperationParameters {
+        .traversable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -162,3 +162,26 @@ ErrorOr<Web::NavigableDestructionHistoryOperationParameters> IPC::decode(Decoder
         .traversable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
     };
 }
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.navigable_id));
+    TRY(encoder.encode(parameters.target_entry));
+    TRY(encoder.encode(parameters.replaces_current_entry));
+    TRY(encoder.encode(parameters.history_handling));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::FinalizeSameDocumentNavigationHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::FinalizeSameDocumentNavigationHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .target_entry = TRY(decoder.decode<Web::HTML::SameDocumentNavigationEntry>()),
+        .replaces_current_entry = TRY(decoder.decode<bool>()),
+        .history_handling = TRY(decoder.decode<Web::HTML::HistoryHandlingBehavior>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -41,3 +41,20 @@ ErrorOr<Web::ReplaceHistoryOperationParameters> IPC::decode(Decoder& decoder)
         .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
     };
 }
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::ReloadHistoryOperationParameters const& parameters)
+{
+    TRY(encoder.encode(parameters.navigable_id));
+    TRY(encoder.encode(parameters.user_involvement));
+    return {};
+}
+
+template<>
+ErrorOr<Web::ReloadHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::ReloadHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+        .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.cpp
+++ b/Libraries/LibWeb/HTML/HistoryOperation.cpp
@@ -134,3 +134,17 @@ ErrorOr<Web::ResumeTraverseHistoryOperationParameters> IPC::decode(Decoder& deco
         .user_involvement = TRY(decoder.decode<Web::HTML::UserNavigationInvolvement>()),
     };
 }
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, Web::NavigableCreationHistoryOperationParameters const& parameters)
+{
+    return encoder.encode(parameters.navigable_id);
+}
+
+template<>
+ErrorOr<Web::NavigableCreationHistoryOperationParameters> IPC::decode(Decoder& decoder)
+{
+    return Web::NavigableCreationHistoryOperationParameters {
+        .navigable_id = TRY(decoder.decode<Web::HTML::CrossProcessId>()),
+    };
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -59,6 +59,10 @@ struct ResumeTraverseHistoryOperationParameters {
     HTML::UserNavigationInvolvement user_involvement;
 };
 
+struct NavigableCreationHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+};
+
 // A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
 // state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
 using HistoryOperationParameters = Variant<
@@ -68,7 +72,8 @@ using HistoryOperationParameters = Variant<
     TraverseByDeltaHistoryOperationParameters,
     TraverseToStepHistoryOperationParameters,
     NavigationAPITraverseHistoryOperationParameters,
-    ResumeTraverseHistoryOperationParameters>;
+    ResumeTraverseHistoryOperationParameters,
+    NavigableCreationHistoryOperationParameters>;
 
 }
 
@@ -108,5 +113,10 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::ResumeTraverseHistoryOperationParameters const&);
 template<>
 WEB_API ErrorOr<Web::ResumeTraverseHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::NavigableCreationHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::NavigableCreationHistoryOperationParameters> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -63,6 +63,10 @@ struct NavigableCreationHistoryOperationParameters {
     HTML::CrossProcessId navigable_id;
 };
 
+struct NavigableDestructionHistoryOperationParameters {
+    HTML::CrossProcessId traversable_id;
+};
+
 // A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
 // state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
 using HistoryOperationParameters = Variant<
@@ -73,7 +77,8 @@ using HistoryOperationParameters = Variant<
     TraverseToStepHistoryOperationParameters,
     NavigationAPITraverseHistoryOperationParameters,
     ResumeTraverseHistoryOperationParameters,
-    NavigableCreationHistoryOperationParameters>;
+    NavigableCreationHistoryOperationParameters,
+    NavigableDestructionHistoryOperationParameters>;
 
 }
 
@@ -118,5 +123,10 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::NavigableCreationHistoryOperationParameters const&);
 template<>
 WEB_API ErrorOr<Web::NavigableCreationHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::NavigableDestructionHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::NavigableDestructionHistoryOperationParameters> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -77,6 +77,10 @@ struct FinalizeSameDocumentNavigationHistoryOperationParameters {
     HTML::UserNavigationInvolvement user_involvement;
 };
 
+struct CloseTopLevelTraversableHistoryOperationParameters {
+    HTML::CrossProcessId traversable_id;
+};
+
 // A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
 // state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
 using HistoryOperationParameters = Variant<
@@ -89,7 +93,8 @@ using HistoryOperationParameters = Variant<
     ResumeTraverseHistoryOperationParameters,
     NavigableCreationHistoryOperationParameters,
     NavigableDestructionHistoryOperationParameters,
-    FinalizeSameDocumentNavigationHistoryOperationParameters>;
+    FinalizeSameDocumentNavigationHistoryOperationParameters,
+    CloseTopLevelTraversableHistoryOperationParameters>;
 
 }
 
@@ -144,5 +149,10 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::FinalizeSameDocumentNavigationHistoryOperationParameters const&);
 template<>
 WEB_API ErrorOr<Web::FinalizeSameDocumentNavigationHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::CloseTopLevelTraversableHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::CloseTopLevelTraversableHistoryOperationParameters> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -11,6 +11,8 @@
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/HistoryHandlingBehavior.h>
+#include <LibWeb/HTML/SameDocumentNavigationEntry.h>
 #include <LibWeb/HTML/UserNavigationInvolvement.h>
 
 namespace Web {
@@ -67,6 +69,14 @@ struct NavigableDestructionHistoryOperationParameters {
     HTML::CrossProcessId traversable_id;
 };
 
+struct FinalizeSameDocumentNavigationHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+    HTML::SameDocumentNavigationEntry target_entry;
+    bool replaces_current_entry;
+    HTML::HistoryHandlingBehavior history_handling;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
 // A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
 // state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
 using HistoryOperationParameters = Variant<
@@ -78,7 +88,8 @@ using HistoryOperationParameters = Variant<
     NavigationAPITraverseHistoryOperationParameters,
     ResumeTraverseHistoryOperationParameters,
     NavigableCreationHistoryOperationParameters,
-    NavigableDestructionHistoryOperationParameters>;
+    NavigableDestructionHistoryOperationParameters,
+    FinalizeSameDocumentNavigationHistoryOperationParameters>;
 
 }
 
@@ -128,5 +139,10 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::NavigableDestructionHistoryOperationParameters const&);
 template<>
 WEB_API ErrorOr<Web::NavigableDestructionHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::FinalizeSameDocumentNavigationHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::FinalizeSameDocumentNavigationHistoryOperationParameters> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Variant.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Export.h>
+#include <LibWeb/HTML/CrossProcessId.h>
+#include <LibWeb/HTML/UserNavigationInvolvement.h>
+
+namespace Web {
+
+enum class HistoryTraversalPrecheck : u8 {
+    Needed,
+    AlreadyDone,
+};
+
+struct PushHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
+struct ReplaceHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
+// A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
+// state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
+using HistoryOperationParameters = Variant<PushHistoryOperationParameters, ReplaceHistoryOperationParameters>;
+
+}
+
+namespace IPC {
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::PushHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::PushHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::ReplaceHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::ReplaceHistoryOperationParameters> decode(Decoder&);
+
+}

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Utf16String.h>
 #include <AK/Variant.h>
 #include <LibIPC/Forward.h>
 #include <LibWeb/Export.h>
@@ -34,9 +35,40 @@ struct ReloadHistoryOperationParameters {
     HTML::UserNavigationInvolvement user_involvement;
 };
 
+struct TraverseByDeltaHistoryOperationParameters {
+    HTML::CrossProcessId traversable_id;
+    i32 delta;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
+struct TraverseToStepHistoryOperationParameters {
+    HTML::CrossProcessId traversable_id;
+    i32 target_step;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
+struct NavigationAPITraverseHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+    Utf16String key;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
+struct ResumeTraverseHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+    i32 target_step;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
 // A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
 // state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
-using HistoryOperationParameters = Variant<PushHistoryOperationParameters, ReplaceHistoryOperationParameters, ReloadHistoryOperationParameters>;
+using HistoryOperationParameters = Variant<
+    PushHistoryOperationParameters,
+    ReplaceHistoryOperationParameters,
+    ReloadHistoryOperationParameters,
+    TraverseByDeltaHistoryOperationParameters,
+    TraverseToStepHistoryOperationParameters,
+    NavigationAPITraverseHistoryOperationParameters,
+    ResumeTraverseHistoryOperationParameters>;
 
 }
 
@@ -56,5 +88,25 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::ReloadHistoryOperationParameters const&);
 template<>
 WEB_API ErrorOr<Web::ReloadHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::TraverseByDeltaHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::TraverseByDeltaHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::TraverseToStepHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::TraverseToStepHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::NavigationAPITraverseHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::NavigationAPITraverseHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::ResumeTraverseHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::ResumeTraverseHistoryOperationParameters> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/HTML/HistoryOperation.h
+++ b/Libraries/LibWeb/HTML/HistoryOperation.h
@@ -29,9 +29,14 @@ struct ReplaceHistoryOperationParameters {
     HTML::UserNavigationInvolvement user_involvement;
 };
 
+struct ReloadHistoryOperationParameters {
+    HTML::CrossProcessId navigable_id;
+    HTML::UserNavigationInvolvement user_involvement;
+};
+
 // A WebContent-initiated operation with value-shaped parameters. The request boundary retains any process-local
 // state under a private initiation ID; the queue and coordinator remain local until the later ownership switch.
-using HistoryOperationParameters = Variant<PushHistoryOperationParameters, ReplaceHistoryOperationParameters>;
+using HistoryOperationParameters = Variant<PushHistoryOperationParameters, ReplaceHistoryOperationParameters, ReloadHistoryOperationParameters>;
 
 }
 
@@ -46,5 +51,10 @@ template<>
 WEB_API ErrorOr<void> encode(Encoder&, Web::ReplaceHistoryOperationParameters const&);
 template<>
 WEB_API ErrorOr<Web::ReplaceHistoryOperationParameters> decode(Decoder&);
+
+template<>
+WEB_API ErrorOr<void> encode(Encoder&, Web::ReloadHistoryOperationParameters const&);
+template<>
+WEB_API ErrorOr<Web::ReloadHistoryOperationParameters> decode(Decoder&);
 
 }

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3039,23 +3039,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                             output->apply_to(*history_entry);
                         auto pending_document = output ? output->document : GC::Ptr<DOM::Document> {};
                         // 1. Append session history traversal steps to navigable's traversable to finalize a cross-document navigation given navigable, historyHandling, userInvolvement, and historyEntry.
-                        traversable_navigable()->append_session_history_traversal_steps(GC::create_function(heap(), [this, history_entry, history_handling, navigation_id, user_involvement, pending_document](NonnullRefPtr<Core::Promise<Empty>> signal) {
-                            if (this->has_been_destroyed()) {
-                                // AD-HOC: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
-                                set_delaying_load_events(false);
-                                signal->resolve({});
-                                return;
-                            }
-                            if (this->ongoing_navigation() != navigation_id) {
-                                // AD-HOC: This check is not in the spec but we should not continue navigation if ongoing navigation id has changed.
-                                set_delaying_load_events(false);
-                                signal->resolve({});
-                                return;
-                            }
-                            finalize_a_cross_document_navigation(*this, to_history_handling_behavior(history_handling), user_involvement, history_entry, pending_document, navigation_id, GC::create_function(heap(), [signal](HistoryStepResult) {
-                                signal->resolve({});
-                            }));
-                        }));
+                        finalize_a_cross_document_navigation(*this, to_history_handling_behavior(history_handling), user_involvement, history_entry, pending_document, navigation_id, GC::create_function(heap(), [](HistoryStepResult) { }));
                     }));
             }));
     }));
@@ -3352,11 +3336,7 @@ void LocalNavigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHa
     history_entry->set_document_state(document_state);
 
     // 14. Append session history traversal steps to targetNavigable's traversable to finalize a cross-document navigation with targetNavigable, historyHandling, userInvolvement, and historyEntry.
-    traversable_navigable()->append_session_history_traversal_steps(GC::create_function(heap(), [this, new_document, history_entry, history_handling, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        finalize_a_cross_document_navigation(*this, history_handling, user_involvement, history_entry, new_document, {}, GC::create_function(heap(), [signal](HistoryStepResult) {
-            signal->resolve({});
-        }));
-    }));
+    finalize_a_cross_document_navigation(*this, history_handling, user_involvement, history_entry, new_document, {}, GC::create_function(heap(), [](HistoryStepResult) { }));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#reload
@@ -3505,12 +3485,18 @@ static void report_finalized_cross_document_navigation_to_ui_process(LocalTraver
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-cross-document-navigation
-void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, NonnullRefPtr<SessionHistoryEntry> history_entry, GC::Ptr<DOM::Document> pending_document, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+static Optional<int> finalize_a_cross_document_navigation_at_queued_position(GC::Ref<LocalNavigable> navigable, HistoryHandlingBehavior history_handling, NonnullRefPtr<SessionHistoryEntry> history_entry, GC::Ptr<DOM::Document> pending_document, Optional<Utf16String> const& expected_ongoing_navigation_id)
 {
     // NOTE: This is not in the spec but we should not navigate destroyed navigable.
     if (navigable->has_been_destroyed()) {
-        on_complete->function()(HistoryStepResult::Applied);
-        return;
+        navigable->set_delaying_load_events(false);
+        return {};
+    }
+
+    // AD-HOC: This check is not in the spec but we should not continue navigation if ongoing navigation id has changed.
+    if (expected_ongoing_navigation_id.has_value() && navigable->ongoing_navigation() != *expected_ongoing_navigation_id) {
+        navigable->set_delaying_load_events(false);
+        return {};
     }
 
     // 1. FIXME: Assert: this is running on navigable's traversable navigable's session history traversal queue.
@@ -3540,8 +3526,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
         if (expected_ongoing_navigation_id.has_value() && navigable->ongoing_navigation() == expected_ongoing_navigation_id)
             navigable->set_ongoing_navigation({});
 
-        on_complete->function()(HistoryStepResult::Applied);
-        return;
+        return {};
     }
 
     // 4. If all of the following are true:
@@ -3580,8 +3565,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
             target_entries_pointer = recreate_missing_nested_history_for_live_child_navigable(*traversable, *navigable);
             if (!target_entries_pointer) {
                 navigable->clear_navigation_load_event_guard();
-                on_complete->function()(HistoryStepResult::Applied);
-                return;
+                return {};
             }
         }
     }
@@ -3611,8 +3595,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
                 // AD-HOC: A non-initial document whose entryToReplace is no longer in targetEntries is the same
                 //         stale child-frame commit case as above.
                 navigable->clear_navigation_load_event_guard();
-                on_complete->function()(HistoryStepResult::Applied);
-                return;
+                return {};
             }
 
             // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
@@ -3631,8 +3614,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
                 entry_to_replace_index = 0;
             if (!entry_to_replace_index.has_value()) {
                 navigable->clear_navigation_load_event_guard();
-                on_complete->function()(HistoryStepResult::Applied);
-                return;
+                return {};
             }
 
             auto replacement_entry = target_entries[*entry_to_replace_index];
@@ -3656,14 +3638,36 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
         report_finalized_cross_document_navigation_to_ui_process(*traversable, navigable, history_entry, entry_to_replace);
     }
 
-    // 10. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
-    traversable->apply_the_push_or_replace_history_step(target_step, history_handling, user_involvement, SynchronousNavigation::No, pending_document, navigable, move(expected_ongoing_navigation_id),
-        GC::create_function(navigable->heap(), [on_complete, navigable](HistoryStepResult result) {
-            // AD-HOC: Trigger a relayout in the container document for size negotiation with SVG documents.
-            if (auto container = navigable->container())
-                container->set_needs_layout_update(DOM::SetNeedsLayoutReason::FinalizeACrossDocumentNavigation);
-            on_complete->function()(result);
-        }));
+    return target_step;
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-cross-document-navigation
+void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, NonnullRefPtr<SessionHistoryEntry> history_entry, GC::Ptr<DOM::Document> pending_document, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+{
+    auto traversable = navigable->traversable_navigable();
+    traversable->request_history_operation(
+        history_handling == HistoryHandlingBehavior::Replace
+            ? HistoryOperationParameters { ReplaceHistoryOperationParameters { .navigable_id = navigable->id(), .user_involvement = user_involvement } }
+            : HistoryOperationParameters { PushHistoryOperationParameters { .navigable_id = navigable->id(), .user_involvement = user_involvement } },
+        {
+            .pending_document = pending_document,
+            .expected_ongoing_navigation_navigable = navigable,
+            .expected_ongoing_navigation_id = expected_ongoing_navigation_id,
+            .pre_steps = GC::create_function(navigable->heap(), [navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id)](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+                auto target_step = finalize_a_cross_document_navigation_at_queued_position(navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id);
+                if (!target_step.has_value()) {
+                    ready->function()(false, {}, HistoryStepResult::Applied);
+                    return;
+                }
+                ready->function()(true, *target_step, HistoryStepResult::Applied);
+            }),
+            .on_apply_complete = GC::create_function(navigable->heap(), [navigable](HistoryStepResult) {
+                // AD-HOC: Trigger a relayout in the container document for size negotiation with SVG documents.
+                if (auto container = navigable->container())
+                    container->set_needs_layout_update(DOM::SetNeedsLayoutReason::FinalizeACrossDocumentNavigation);
+            }),
+            .on_complete = on_complete,
+        });
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3382,12 +3382,11 @@ void LocalNavigable::reload(Optional<StorageSerializationRecord> navigation_api_
         id(), active_session_history_entry()->navigation_api_key(), true);
 
     // 4. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps(GC::create_function(heap(), [traversable, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        // 1. Apply the reload history step to traversable given userInvolvement.
-        traversable->apply_the_reload_history_step(user_involvement, GC::create_function(traversable->heap(), [signal](HistoryStepResult) {
-            signal->resolve({});
-        }));
-    }));
+    // 1. Apply the reload history step to traversable given userInvolvement.
+    traversable->request_history_operation(ReloadHistoryOperationParameters {
+        .navigable_id = id(),
+        .user_involvement = user_involvement,
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-navigation-must-be-a-replace

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3657,7 +3657,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
     }
 
     // 10. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
-    traversable->apply_the_push_or_replace_history_step(target_step, history_handling, user_involvement, LocalTraversableNavigable::SynchronousNavigation::No, pending_document, navigable, move(expected_ongoing_navigation_id),
+    traversable->apply_the_push_or_replace_history_step(target_step, history_handling, user_involvement, SynchronousNavigation::No, pending_document, navigable, move(expected_ongoing_navigation_id),
         GC::create_function(navigable->heap(), [on_complete, navigable](HistoryStepResult result) {
             // AD-HOC: Trigger a relayout in the container document for size negotiation with SVG documents.
             if (auto container = navigable->container())

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3381,12 +3381,11 @@ void LocalNavigable::reload(Optional<StorageSerializationRecord> navigation_api_
         id(), active_session_history_entry()->navigation_api_key(), true);
 
     // 4. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps(GC::create_function(heap(), [traversable, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        // 1. Apply the reload history step to traversable given userInvolvement.
-        traversable->apply_the_reload_history_step(user_involvement, GC::create_function(traversable->heap(), [signal](HistoryStepResult) {
-            signal->resolve({});
-        }));
-    }));
+    // 1. Apply the reload history step to traversable given userInvolvement.
+    traversable->request_history_operation(ReloadHistoryOperationParameters {
+        .navigable_id = id(),
+        .user_involvement = user_involvement,
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-navigation-must-be-a-replace

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3038,23 +3038,7 @@ void LocalNavigable::begin_navigation(NavigateParams params)
                             output->apply_to(*history_entry);
                         auto pending_document = output ? output->document : GC::Ptr<DOM::Document> {};
                         // 1. Append session history traversal steps to navigable's traversable to finalize a cross-document navigation given navigable, historyHandling, userInvolvement, and historyEntry.
-                        traversable_navigable()->append_session_history_traversal_steps(GC::create_function(heap(), [this, history_entry, history_handling, navigation_id, user_involvement, pending_document](NonnullRefPtr<Core::Promise<Empty>> signal) {
-                            if (this->has_been_destroyed()) {
-                                // AD-HOC: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
-                                set_delaying_load_events(false);
-                                signal->resolve({});
-                                return;
-                            }
-                            if (this->ongoing_navigation() != navigation_id) {
-                                // AD-HOC: This check is not in the spec but we should not continue navigation if ongoing navigation id has changed.
-                                set_delaying_load_events(false);
-                                signal->resolve({});
-                                return;
-                            }
-                            finalize_a_cross_document_navigation(*this, to_history_handling_behavior(history_handling), user_involvement, history_entry, pending_document, navigation_id, GC::create_function(heap(), [signal](HistoryStepResult) {
-                                signal->resolve({});
-                            }));
-                        }));
+                        finalize_a_cross_document_navigation(*this, to_history_handling_behavior(history_handling), user_involvement, history_entry, pending_document, navigation_id, GC::create_function(heap(), [](HistoryStepResult) { }));
                     }));
             }));
     }));
@@ -3351,11 +3335,7 @@ void LocalNavigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHa
     history_entry->set_document_state(document_state);
 
     // 14. Append session history traversal steps to targetNavigable's traversable to finalize a cross-document navigation with targetNavigable, historyHandling, userInvolvement, and historyEntry.
-    traversable_navigable()->append_session_history_traversal_steps(GC::create_function(heap(), [this, new_document, history_entry, history_handling, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        finalize_a_cross_document_navigation(*this, history_handling, user_involvement, history_entry, new_document, {}, GC::create_function(heap(), [signal](HistoryStepResult) {
-            signal->resolve({});
-        }));
-    }));
+    finalize_a_cross_document_navigation(*this, history_handling, user_involvement, history_entry, new_document, {}, GC::create_function(heap(), [](HistoryStepResult) { }));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#reload
@@ -3504,12 +3484,18 @@ static void report_finalized_cross_document_navigation_to_ui_process(LocalTraver
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-cross-document-navigation
-void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, NonnullRefPtr<SessionHistoryEntry> history_entry, GC::Ptr<DOM::Document> pending_document, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+static Optional<int> finalize_a_cross_document_navigation_at_queued_position(GC::Ref<LocalNavigable> navigable, HistoryHandlingBehavior history_handling, NonnullRefPtr<SessionHistoryEntry> history_entry, GC::Ptr<DOM::Document> pending_document, Optional<Utf16String> const& expected_ongoing_navigation_id)
 {
     // NOTE: This is not in the spec but we should not navigate destroyed navigable.
     if (navigable->has_been_destroyed()) {
-        on_complete->function()(HistoryStepResult::Applied);
-        return;
+        navigable->set_delaying_load_events(false);
+        return {};
+    }
+
+    // AD-HOC: This check is not in the spec but we should not continue navigation if ongoing navigation id has changed.
+    if (expected_ongoing_navigation_id.has_value() && navigable->ongoing_navigation() != *expected_ongoing_navigation_id) {
+        navigable->set_delaying_load_events(false);
+        return {};
     }
 
     // 1. FIXME: Assert: this is running on navigable's traversable navigable's session history traversal queue.
@@ -3539,8 +3525,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
         if (expected_ongoing_navigation_id.has_value() && navigable->ongoing_navigation() == expected_ongoing_navigation_id)
             navigable->set_ongoing_navigation({});
 
-        on_complete->function()(HistoryStepResult::Applied);
-        return;
+        return {};
     }
 
     // 4. If all of the following are true:
@@ -3579,8 +3564,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
             target_entries_pointer = recreate_missing_nested_history_for_live_child_navigable(*traversable, *navigable);
             if (!target_entries_pointer) {
                 navigable->clear_navigation_load_event_guard();
-                on_complete->function()(HistoryStepResult::Applied);
-                return;
+                return {};
             }
         }
     }
@@ -3610,8 +3594,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
                 // AD-HOC: A non-initial document whose entryToReplace is no longer in targetEntries is the same
                 //         stale child-frame commit case as above.
                 navigable->clear_navigation_load_event_guard();
-                on_complete->function()(HistoryStepResult::Applied);
-                return;
+                return {};
             }
 
             // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
@@ -3630,8 +3613,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
                 entry_to_replace_index = 0;
             if (!entry_to_replace_index.has_value()) {
                 navigable->clear_navigation_load_event_guard();
-                on_complete->function()(HistoryStepResult::Applied);
-                return;
+                return {};
             }
 
             auto replacement_entry = target_entries[*entry_to_replace_index];
@@ -3655,14 +3637,36 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
         report_finalized_cross_document_navigation_to_ui_process(*traversable, navigable, history_entry, entry_to_replace);
     }
 
-    // 10. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
-    traversable->apply_the_push_or_replace_history_step(target_step, history_handling, user_involvement, SynchronousNavigation::No, pending_document, navigable, move(expected_ongoing_navigation_id),
-        GC::create_function(navigable->heap(), [on_complete, navigable](HistoryStepResult result) {
-            // AD-HOC: Trigger a relayout in the container document for size negotiation with SVG documents.
-            if (auto container = navigable->container())
-                container->set_needs_layout_update(DOM::SetNeedsLayoutReason::FinalizeACrossDocumentNavigation);
-            on_complete->function()(result);
-        }));
+    return target_step;
+}
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-cross-document-navigation
+void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, NonnullRefPtr<SessionHistoryEntry> history_entry, GC::Ptr<DOM::Document> pending_document, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+{
+    auto traversable = navigable->traversable_navigable();
+    traversable->request_history_operation(
+        history_handling == HistoryHandlingBehavior::Replace
+            ? HistoryOperationParameters { ReplaceHistoryOperationParameters { .navigable_id = navigable->id(), .user_involvement = user_involvement } }
+            : HistoryOperationParameters { PushHistoryOperationParameters { .navigable_id = navigable->id(), .user_involvement = user_involvement } },
+        {
+            .pending_document = pending_document,
+            .expected_ongoing_navigation_navigable = navigable,
+            .expected_ongoing_navigation_id = expected_ongoing_navigation_id,
+            .pre_steps = GC::create_function(navigable->heap(), [navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id)](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+                auto target_step = finalize_a_cross_document_navigation_at_queued_position(navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id);
+                if (!target_step.has_value()) {
+                    ready->function()(false, {}, HistoryStepResult::Applied);
+                    return;
+                }
+                ready->function()(true, *target_step, HistoryStepResult::Applied);
+            }),
+            .on_apply_complete = GC::create_function(navigable->heap(), [navigable](HistoryStepResult) {
+                // AD-HOC: Trigger a relayout in the container document for size negotiation with SVG documents.
+                if (auto container = navigable->container())
+                    container->set_needs_layout_update(DOM::SetNeedsLayoutReason::FinalizeACrossDocumentNavigation);
+            }),
+            .on_complete = on_complete,
+        });
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3653,7 +3653,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
             .expected_ongoing_navigation_id = expected_ongoing_navigation_id,
             .source_snapshot_params = nullptr,
             .initiator_to_check = nullptr,
-            .pre_steps = GC::create_function(navigable->heap(), [navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id)](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+            .pre_steps = GC::create_function(navigable->heap(), [navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id)](u64, GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
                 auto target_step = finalize_a_cross_document_navigation_at_queued_position(navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id);
                 if (!target_step.has_value()) {
                     ready->function()(false, {}, HistoryStepResult::Applied);

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3656,7 +3656,7 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
     }
 
     // 10. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
-    traversable->apply_the_push_or_replace_history_step(target_step, history_handling, user_involvement, LocalTraversableNavigable::SynchronousNavigation::No, pending_document, navigable, move(expected_ongoing_navigation_id),
+    traversable->apply_the_push_or_replace_history_step(target_step, history_handling, user_involvement, SynchronousNavigation::No, pending_document, navigable, move(expected_ongoing_navigation_id),
         GC::create_function(navigable->heap(), [on_complete, navigable](HistoryStepResult result) {
             // AD-HOC: Trigger a relayout in the container document for size negotiation with SVG documents.
             if (auto container = navigable->container())

--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -3651,6 +3651,8 @@ void finalize_a_cross_document_navigation(GC::Ref<LocalNavigable> navigable, His
             .pending_document = pending_document,
             .expected_ongoing_navigation_navigable = navigable,
             .expected_ongoing_navigation_id = expected_ongoing_navigation_id,
+            .source_snapshot_params = nullptr,
+            .initiator_to_check = nullptr,
             .pre_steps = GC::create_function(navigable->heap(), [navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id)](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
                 auto target_step = finalize_a_cross_document_navigation_at_queued_position(navigable, history_handling, history_entry, pending_document, expected_ongoing_navigation_id);
                 if (!target_step.has_value()) {

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -543,7 +543,7 @@ Vector<int> LocalTraversableNavigable::get_all_used_history_steps() const
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#getting-the-history-object-length-and-index
-LocalTraversableNavigable::HistoryObjectLengthAndIndex LocalTraversableNavigable::get_the_history_object_length_and_index(int step) const
+HistoryObjectLengthAndIndex LocalTraversableNavigable::get_the_history_object_length_and_index(int step) const
 {
     // 1. Let steps be the result of getting all used history steps within traversable.
     auto steps = get_all_used_history_steps();
@@ -797,7 +797,7 @@ public:
         GC::Ptr<SourceSnapshotParams> source_snapshot_params,
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
-        LocalTraversableNavigable::SynchronousNavigation synchronous_navigation,
+        SynchronousNavigation synchronous_navigation,
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
         GC::Ptr<DOM::Document> pending_document,
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
@@ -805,6 +805,7 @@ public:
         GC::Ref<OnApplyHistoryStepComplete> on_complete)
         : m_generation(++traversable->m_apply_history_step_generation_counter)
         , m_traversable(traversable)
+        , m_job_runner(*traversable)
         , m_step(step)
         , m_target_step(target_step)
         , m_source_snapshot_params(source_snapshot_params)
@@ -915,12 +916,14 @@ private:
     Phase m_phase { Phase::WaitingForDocumentPopulation };
     u64 m_generation { 0 };
     GC::Ref<LocalTraversableNavigable> m_traversable;
+    // NB: The runner is the traversable itself for now; it is kept alive through m_traversable.
+    ApplyHistoryStepJobRunner& m_job_runner;
     int m_step;
     int m_target_step;
     GC::Ptr<SourceSnapshotParams> m_source_snapshot_params;
     UserNavigationInvolvement m_user_involvement;
     Optional<Bindings::NavigationType> m_navigation_type;
-    LocalTraversableNavigable::SynchronousNavigation m_synchronous_navigation;
+    SynchronousNavigation m_synchronous_navigation;
     LocalNavigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
     GC::Ptr<DOM::Document> m_pending_document;
     Optional<CrossProcessId> m_expected_ongoing_navigation_navigable_id;
@@ -960,70 +963,19 @@ void ApplyHistoryStepState::start()
         m_non_changing_navigables.append(navigable->id());
 
     // 8. For each navigable of changingNavigables:
+    // NB: Steps 8.2 and 8.3 (claiming the navigable for this traversal) happen inside each dispatched job, because a
+    //     claim mutates the navigable, which belongs to the process running the job. The changing set is complete
+    //     before the first job is dispatched, so job completions cannot advance the phase early.
     auto changing_navigables = m_traversable->get_all_local_navigables_whose_current_session_history_entry_will_change_or_reload(m_target_step);
-    for (auto& navigable : changing_navigables) {
-        if (m_synchronous_navigation == LocalTraversableNavigable::SynchronousNavigation::Yes
-            && synchronous_same_document_navigation_must_preserve_ongoing_navigation(*navigable)) {
-            continue;
-        }
-
-        // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
-        // NB: The creation/destruction update is the bookkeeping step after the child's nested history has been
-        //     attached to its parent document state. If the container's requested navigation has already started, it
-        //     owns the ongoing navigation ID and eventual document activation.
-        if (!m_navigation_type.has_value() && navigable->ongoing_navigation().has<Utf16String>())
-            continue;
-
-        // 1. Let targetEntry be the result of getting the target history entry given navigable and targetStep.
-        auto target_entry = navigable->get_the_target_history_entry_if_present(m_target_step);
-        if (!target_entry)
-            continue;
-
-        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction
-        // AD-HOC: Unconditionally populating a document here could unload and re-navigate a frame because an unrelated
-        //         navigable was created or destroyed — which no other engine does. So we skip such applying-the-target-
-        //         entry-would-cross-documents navigables here. A navigable still showing the initial about:blank
-        //         Document is the exception — activating its populated document is this update's job.
-        //         https://github.com/whatwg/html/issues/12724
-        if (!m_navigation_type.has_value()) {
-            bool would_cross_documents = target_entry->document_state()->document_id() != navigable->active_document_id()
-                || target_entry->document_state()->reload_pending();
-            auto active_document = navigable->active_document();
-            if (would_cross_documents && !(active_document && active_document->is_initial_about_blank()))
-                continue;
-        }
-
-        // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event
-        // NB: Same-document traversals are synchronous in browser engines, but the specification routes them through
-        //     the traversal queue. If a later cross-document navigation has already claimed the navigable by the time
-        //     this queued same-document traversal reaches its bookkeeping step, do not replace that navigation's ID
-        //     with "traversal". The queued traversal is stale reconciliation at that point, and must not cancel the
-        //     newer navigation.
-        if (m_navigation_type == Bindings::NavigationType::Traverse
-            && navigable->ongoing_navigation().has<Utf16String>()
-            && target_entry->document_state()->document_id() == navigable->active_document_id()) {
-            continue;
-        }
-
-        // 2. Set navigable's current session history entry to targetEntry.
-        navigable->set_current_session_history_entry(target_entry);
-
-        // 3. Set navigable's ongoing navigation to "traversal".
-        navigable->set_ongoing_navigation(HTML::LocalNavigable::Traversal::Tag, m_navigation_api_abort_behavior);
-
+    for (auto& navigable : changing_navigables)
         m_changing_navigables.append(navigable->id());
-    }
 
     // 12. For each navigable of changingNavigables, queue a global task on the navigation and traversal task source.
     for (auto navigable_id : m_changing_navigables) {
-        auto navigable = local_navigable_with_id(navigable_id);
-        VERIFY(navigable);
-        auto target_entry = navigable->current_session_history_entry();
-        VERIFY(target_entry);
-        m_traversable->run_changing_navigable_history_step_job(
+        m_job_runner.run_changing_navigable_history_step_job(
             {
                 .navigable_id = navigable_id,
-                .target_entry = target_entry.release_nonnull(),
+                .target_step = m_target_step,
                 .source_snapshot_params = m_source_snapshot_params,
                 .user_involvement = m_user_involvement,
                 .navigation_type = m_navigation_type,
@@ -1031,16 +983,16 @@ void ApplyHistoryStepState::start()
                 .navigation_api_abort_behavior = m_navigation_api_abort_behavior,
                 .pending_document = m_pending_document,
             },
-            GC::create_function(heap(), [this, navigable_id](LocalTraversableNavigable::ChangingNavigableHistoryStepJobResult result) {
+            GC::create_function(heap(), [this, navigable_id](ApplyHistoryStepJobRunner::ChangingNavigableHistoryStepJobResult result) {
                 switch (result.disposition) {
-                case LocalTraversableNavigable::ChangingNavigableHistoryStepJobDisposition::Ready:
+                case ChangingNavigableHistoryStepJobDisposition::Ready:
                     VERIFY(result.continuation);
                     did_receive_continuation(*result.continuation);
                     break;
-                case LocalTraversableNavigable::ChangingNavigableHistoryStepJobDisposition::Skipped:
+                case ChangingNavigableHistoryStepJobDisposition::Skipped:
                     complete_change_job_without_applying(local_navigable_with_id(navigable_id));
                     break;
-                case LocalTraversableNavigable::ChangingNavigableHistoryStepJobDisposition::Stale:
+                case ChangingNavigableHistoryStepJobDisposition::Stale:
                     finish_without_applying();
                     break;
                 }
@@ -1065,7 +1017,65 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
         return;
     }
-    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), navigable, on_complete] {
+    if (job.synchronous_navigation == SynchronousNavigation::Yes
+        && synchronous_same_document_navigation_must_preserve_ongoing_navigation(*navigable)) {
+        on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
+        return;
+    }
+
+    // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
+    // NB: The creation/destruction update is the bookkeeping step after the child's nested history has been
+    //     attached to its parent document state. If the container's requested navigation has already started, it
+    //     owns the ongoing navigation ID and eventual document activation.
+    if (!job.navigation_type.has_value() && navigable->ongoing_navigation().has<Utf16String>()) {
+        on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
+        return;
+    }
+
+    // 1. Let targetEntry be the result of getting the target history entry given navigable and targetStep.
+    auto claimed_target_entry = navigable->get_the_target_history_entry_if_present(job.target_step);
+    if (!claimed_target_entry) {
+        on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
+        return;
+    }
+
+    // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction
+    // AD-HOC: Unconditionally populating a document here could unload and re-navigate a frame because an unrelated
+    //         navigable was created or destroyed — which no other engine does. So we skip such applying-the-target-
+    //         entry-would-cross-documents navigables here. A navigable still showing the initial about:blank
+    //         Document is the exception — activating its populated document is this update's job.
+    //         https://github.com/whatwg/html/issues/12724
+    if (!job.navigation_type.has_value()) {
+        bool would_cross_documents = claimed_target_entry->document_state()->document_id() != navigable->active_document_id()
+            || claimed_target_entry->document_state()->reload_pending();
+        auto active_document = navigable->active_document();
+        if (would_cross_documents && !(active_document && active_document->is_initial_about_blank())) {
+            on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
+            return;
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-traverse-navigate-event
+    // NB: Same-document traversals are synchronous in browser engines, but the specification routes them through
+    //     the traversal queue. If a later cross-document navigation has already claimed the navigable by the time
+    //     this queued same-document traversal reaches its bookkeeping step, do not replace that navigation's ID
+    //     with "traversal". The queued traversal is stale reconciliation at that point, and must not cancel the
+    //     newer navigation.
+    if (job.navigation_type == Bindings::NavigationType::Traverse
+        && navigable->ongoing_navigation().has<Utf16String>()
+        && claimed_target_entry->document_state()->document_id() == navigable->active_document_id()) {
+        on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
+        return;
+    }
+
+    // 2. Set navigable's current session history entry to targetEntry.
+    navigable->set_current_session_history_entry(claimed_target_entry);
+
+    // 3. Set navigable's ongoing navigation to "traversal".
+    navigable->set_ongoing_navigation(HTML::LocalNavigable::Traversal::Tag, job.navigation_api_abort_behavior);
+
+    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), claimed_target_entry = claimed_target_entry.release_nonnull(), navigable, on_complete] {
+
         // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
         if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()) {
             on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
@@ -1077,7 +1087,7 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
 
         // 2. Let targetEntry be navigable's current session history entry.
         auto target_entry = navigable->current_session_history_entry();
-        if (!target_entry || target_entry != job.target_entry) {
+        if (!target_entry || target_entry != claimed_target_entry) {
             // AD-HOC: The HTML Standard expects the session history traversal queue to serialize this task with
             //         later navigations. Our web-compatible deferral of navigations that arrive during traversal
             //         can let a newer navigation replace the current entry before this task runs. Treat this state
@@ -1345,6 +1355,7 @@ void ApplyHistoryStepState::process_continuations()
         // 3. If changingNavigableContinuation is nothing, then continue.
 
         auto continuation = m_continuations[m_continuation_index++];
+        auto continuation_navigable_id = continuation->navigable->id();
 
         m_target_step = m_traversable->get_the_used_step(m_step);
 
@@ -1352,12 +1363,12 @@ void ApplyHistoryStepState::process_continuations()
         auto history_object_length_and_index = m_traversable->get_the_history_object_length_and_index(m_target_step);
 
         // 8. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
-        m_navigables_that_must_wait_before_handling_sync_navigation.set(continuation->navigable->id());
+        m_navigables_that_must_wait_before_handling_sync_navigation.set(continuation_navigable_id);
 
         // 9. Let entriesForNavigationAPI be the result of getting session history entries for the navigation API given navigable and targetStep.
-        auto entries_for_navigation_api = m_traversable->get_session_history_entries_for_the_navigation_api(*continuation->navigable, m_target_step);
+        auto entries_for_navigation_api = m_traversable->get_session_history_entries_for_the_navigation_api(continuation_navigable_id, m_target_step);
 
-        m_traversable->apply_changing_navigable_history_step_continuation(
+        m_job_runner.apply_changing_navigable_history_step_continuation(
             {
                 .continuation = continuation,
                 .history_object_length_and_index = history_object_length_and_index,
@@ -1555,7 +1566,7 @@ void ApplyHistoryStepState::enter_waiting_for_non_changing_jobs()
 
     // 18. For each navigable of nonchangingNavigablesThatStillNeedUpdates, queue a global task on the navigation and traversal task source given navigable's active window to run the steps:
     for (auto navigable_id : m_non_changing_navigables) {
-        m_traversable->update_nonchanging_navigable_history_step_state(
+        m_job_runner.update_nonchanging_navigable_history_step_state(
             navigable_id,
             {
                 .script_history_length = script_history_length,
@@ -2204,6 +2215,16 @@ Vector<NonnullRefPtr<SessionHistoryEntry>> LocalTraversableNavigable::get_sessio
 
     // 10. Return entriesForNavigationAPI.
     return entries_for_navigation_api;
+}
+
+Vector<NonnullRefPtr<SessionHistoryEntry>> LocalTraversableNavigable::get_session_history_entries_for_the_navigation_api(CrossProcessId navigable_id, int target_step)
+{
+    // AD-HOC: The navigable can be gone by the time its continuation is applied. The continuation job completes
+    //         without applying anything in that case, so the entries are never read.
+    auto navigable = local_navigable_with_id(navigable_id);
+    if (!navigable)
+        return {};
+    return get_session_history_entries_for_the_navigation_api(*navigable, target_step);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#clear-the-forward-session-history

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -65,6 +65,8 @@ void LocalTraversableNavigable::visit_edges(Cell::Visitor& visitor)
     for (auto& initiation : m_history_operation_states) {
         visitor.visit(initiation.value.pending_document);
         visitor.visit(initiation.value.expected_ongoing_navigation_navigable);
+        visitor.visit(initiation.value.source_snapshot_params);
+        visitor.visit(initiation.value.initiator_to_check);
         visitor.visit(initiation.value.pre_steps);
         visitor.visit(initiation.value.on_apply_complete);
         visitor.visit(initiation.value.on_complete);
@@ -2515,12 +2517,31 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
                     move(initiation->value.expected_ongoing_navigation_id),
                     on_apply_complete);
             };
+            auto apply_traverse = [&](auto const& parameters, i32 target_step) {
+                apply_the_traverse_history_step(target_step, initiation->value.source_snapshot_params, initiation->value.initiator_to_check, parameters.user_involvement, on_apply_complete);
+            };
             parameters.visit(
                 [&](PushHistoryOperationParameters const& parameters) { apply_push_or_replace(parameters, HistoryHandlingBehavior::Push); },
                 [&](ReplaceHistoryOperationParameters const& parameters) { apply_push_or_replace(parameters, HistoryHandlingBehavior::Replace); },
                 [&](ReloadHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
                     apply_the_reload_history_step(parameters.user_involvement, on_apply_complete);
+                },
+                [&](TraverseByDeltaHistoryOperationParameters const& parameters) {
+                    VERIFY(step_override.has_value());
+                    apply_traverse(parameters, *step_override);
+                },
+                [&](TraverseToStepHistoryOperationParameters const& parameters) {
+                    VERIFY(!step_override.has_value());
+                    apply_traverse(parameters, parameters.target_step);
+                },
+                [&](NavigationAPITraverseHistoryOperationParameters const& parameters) {
+                    VERIFY(step_override.has_value());
+                    apply_traverse(parameters, *step_override);
+                },
+                [&](ResumeTraverseHistoryOperationParameters const& parameters) {
+                    VERIFY(!step_override.has_value());
+                    resume_applying_the_traverse_history_step(parameters.target_step, parameters.user_involvement, on_apply_complete);
                 });
         });
 
@@ -2557,74 +2578,98 @@ void LocalTraversableNavigable::traverse_the_history_by_delta(int delta, GC::Ptr
     }
 
     // 4. Append the following session history traversal steps to traversable:
-    append_session_history_traversal_steps(GC::create_function(heap(), [this, delta, source_snapshot_params, initiator_to_check, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        auto apply_selected_history_step = GC::create_function(heap(), [this, source_snapshot_params, initiator_to_check, user_involvement, signal](Optional<int> target_step) {
-            if (!target_step.has_value()) {
-                signal->resolve({});
-                return;
-            }
+    request_history_operation(
+        TraverseByDeltaHistoryOperationParameters {
+            .traversable_id = id(),
+            .delta = delta,
+            .user_involvement = user_involvement,
+        },
+        {
+            .pending_document = nullptr,
+            .expected_ongoing_navigation_navigable = nullptr,
+            .expected_ongoing_navigation_id = {},
+            .source_snapshot_params = source_snapshot_params,
+            .initiator_to_check = initiator_to_check,
+            .pre_steps = GC::create_function(heap(), [this, delta, source_snapshot_params, initiator_to_check, user_involvement](GC::Ref<OnHistoryOperationReady> ready) {
+                auto apply_selected_history_step = GC::create_function(heap(), [this, source_snapshot_params, initiator_to_check, user_involvement, ready](Optional<int> target_step) {
+                    if (!target_step.has_value()) {
+                        ready->function()(false, {}, HistoryStepResult::Applied);
+                        return;
+                    }
 
-            auto all_steps = get_all_used_history_steps();
-            if (!all_steps.contains_slow(*target_step)) {
-                page().client().page_did_request_traverse_the_history_to_step(*target_step, HistoryTraversalPrecheck::Needed);
-                signal->resolve({});
-                return;
-            }
+                    auto all_steps = get_all_used_history_steps();
+                    if (!all_steps.contains_slow(*target_step)) {
+                        page().client().page_did_request_traverse_the_history_to_step(*target_step, HistoryTraversalPrecheck::Needed);
+                        ready->function()(false, {}, HistoryStepResult::Applied);
+                        return;
+                    }
 
-            if (source_snapshot_params) {
-                RefPtr<SessionHistoryEntry> target_top_level_entry;
-                for (auto const& entry : session_history_entries()) {
-                    auto entry_step = entry->step_value();
-                    if (!entry_step.has_value())
-                        continue;
-                    if (*entry_step > *target_step)
-                        break;
-                    target_top_level_entry = entry;
-                }
+                    if (source_snapshot_params) {
+                        RefPtr<SessionHistoryEntry> target_top_level_entry;
+                        for (auto const& entry : session_history_entries()) {
+                            auto entry_step = entry->step_value();
+                            if (!entry_step.has_value())
+                                continue;
+                            if (*entry_step > *target_step)
+                                break;
+                            target_top_level_entry = entry;
+                        }
 
-                if (target_top_level_entry && current_session_history_entry() && page().client().decide_navigation_process(current_session_history_entry()->url(), target_top_level_entry->url(), NavigationTarget::TopLevel) == NavigationProcessDecision::Remote) {
-                    run_the_history_step_prechecks(*target_step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
-                        GC::create_function(heap(), [this, target_step = *target_step, signal](HistoryStepResult result, int, LocalNavigable::NavigationAPIAbortBehavior) {
-                            if (result == HistoryStepResult::Applied)
-                                page().client().page_did_request_traverse_the_history_to_step(target_step, HistoryTraversalPrecheck::AlreadyDone);
-                            signal->resolve({});
-                        }));
-                    return;
-                }
-            }
+                        if (target_top_level_entry && current_session_history_entry() && page().client().decide_navigation_process(current_session_history_entry()->url(), target_top_level_entry->url(), NavigationTarget::TopLevel) == NavigationProcessDecision::Remote) {
+                            run_the_history_step_prechecks(*target_step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
+                                GC::create_function(heap(), [this, target_step = *target_step, ready](HistoryStepResult result, int, LocalNavigable::NavigationAPIAbortBehavior) {
+                                    if (result == HistoryStepResult::Applied)
+                                        page().client().page_did_request_traverse_the_history_to_step(target_step, HistoryTraversalPrecheck::AlreadyDone);
+                                    ready->function()(false, {}, result);
+                                }));
+                            return;
+                        }
+                    }
 
-            // 5. Apply the traverse history step allSteps[targetStepIndex] to traversable, given sourceSnapshotParams,
-            //    initiatorToCheck, and userInvolvement.
-            apply_the_traverse_history_step(*target_step, source_snapshot_params, initiator_to_check, user_involvement,
-                GC::create_function(heap(), [signal](HistoryStepResult) {
-                    signal->resolve({});
-                }));
+                    // 5. Apply the traverse history step allSteps[targetStepIndex] to traversable, given sourceSnapshotParams,
+                    //    initiatorToCheck, and userInvolvement.
+                    ready->function()(true, *target_step, HistoryStepResult::Applied);
+                });
+
+                // AD-HOC: The UI process owns the canonical traversable session history. Ask it to perform steps 1-4 so a
+                //         WebContent process cannot select a target from an incomplete local session history slice.
+                page().client().page_did_request_history_traversal_target_by_delta(delta, apply_selected_history_step);
+            }),
+            .on_apply_complete = nullptr,
+            .on_complete = nullptr,
         });
-
-        // AD-HOC: The UI process owns the canonical traversable session history. Ask it to perform steps 1-4 so a
-        //         WebContent process cannot select a target from an incomplete local session history slice.
-        page().client().page_did_request_history_traversal_target_by_delta(delta, apply_selected_history_step);
-    }));
 }
 
 void LocalTraversableNavigable::traverse_the_history_to_step(int step, GC::Ref<GC::Function<void(bool step_was_available, HistoryStepResult)>> on_complete)
 {
     // NB: This is used when the UI process owns the top-level session
     //     history and has already resolved the browser UI delta to a stable step.
-    append_session_history_traversal_steps(GC::create_function(heap(), [this, step, on_complete](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        auto all_steps = get_all_used_history_steps();
-        if (!all_steps.contains_slow(step)) {
-            on_complete->function()(false, HistoryStepResult::Applied);
-            signal->resolve({});
-            return;
-        }
-
-        apply_the_traverse_history_step(step, nullptr, nullptr, UserNavigationInvolvement::BrowserUI,
-            GC::create_function(heap(), [signal, on_complete](HistoryStepResult result) {
+    request_history_operation(
+        TraverseToStepHistoryOperationParameters {
+            .traversable_id = id(),
+            .target_step = step,
+            .user_involvement = UserNavigationInvolvement::BrowserUI,
+        },
+         {
+             .pending_document = nullptr,
+             .expected_ongoing_navigation_navigable = nullptr,
+             .expected_ongoing_navigation_id = {},
+             .source_snapshot_params = nullptr,
+             .initiator_to_check = nullptr,
+             .pre_steps = GC::create_function(heap(), [this, step, on_complete](GC::Ref<OnHistoryOperationReady> ready) {
+                auto all_steps = get_all_used_history_steps();
+                if (!all_steps.contains_slow(step)) {
+                    on_complete->function()(false, HistoryStepResult::Applied);
+                    ready->function()(false, {}, HistoryStepResult::Applied);
+                    return;
+                }
+                ready->function()(true, {}, HistoryStepResult::Applied);
+            }),
+            .on_apply_complete = GC::create_function(heap(), [on_complete](HistoryStepResult result) {
                 on_complete->function()(true, result);
-                signal->resolve({});
-            }));
-    }));
+            }),
+            .on_complete = nullptr,
+        });
 }
 
 void LocalTraversableNavigable::check_if_traverse_history_step_is_canceled(int step, GC::Ref<OnApplyHistoryStepComplete> on_complete)

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -789,12 +789,14 @@ class ApplyHistoryStepOperationState : public GC::Cell {
     GC_DECLARE_ALLOCATOR(ApplyHistoryStepOperationState);
 
 public:
-    explicit ApplyHistoryStepOperationState(LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior)
-        : m_navigation_api_abort_behavior(navigation_api_abort_behavior)
+    ApplyHistoryStepOperationState(u64 history_initiation_id, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior)
+        : m_history_initiation_id(history_initiation_id)
+        , m_navigation_api_abort_behavior(navigation_api_abort_behavior)
     {
     }
 
     bool completed() const { return m_completed; }
+    u64 history_initiation_id() const { return m_history_initiation_id; }
     LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior() const { return m_navigation_api_abort_behavior; }
 
     void did_claim_navigable(CrossProcessId navigable_id)
@@ -842,6 +844,7 @@ private:
         visitor.visit(m_continuations);
     }
 
+    u64 m_history_initiation_id { 0 };
     LocalNavigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
     bool m_completed { false };
     HashTable<CrossProcessId> m_claimed_navigables;
@@ -873,7 +876,7 @@ public:
     static constexpr int TIMEOUT_MS = 15000;
 
     ApplyHistoryStepState(
-        GC::Ref<LocalTraversableNavigable> traversable, int step, int target_step,
+        GC::Ref<LocalTraversableNavigable> traversable, u64 history_initiation_id, int step, int target_step,
         GC::Ptr<SourceSnapshotParams> source_snapshot_params,
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
@@ -884,6 +887,7 @@ public:
         Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete)
         : m_generation(++traversable->m_apply_history_step_generation_counter)
+        , m_history_initiation_id(history_initiation_id)
         , m_traversable(traversable)
         , m_job_runner(*traversable)
         , m_step(step)
@@ -909,7 +913,7 @@ public:
             }
         })))
     {
-        m_job_runner.start_apply_history_step_operation(m_generation, m_navigation_api_abort_behavior);
+        m_job_runner.start_apply_history_step_operation(m_generation, m_history_initiation_id, m_navigation_api_abort_behavior);
         m_timeout->start();
     }
 
@@ -994,6 +998,7 @@ private:
 
     Phase m_phase { Phase::WaitingForDocumentPopulation };
     u64 m_generation { 0 };
+    u64 m_history_initiation_id { 0 };
     GC::Ref<LocalTraversableNavigable> m_traversable;
     // NB: The runner is the traversable itself for now; it is kept alive through m_traversable.
     ApplyHistoryStepJobRunner& m_job_runner;
@@ -1081,10 +1086,11 @@ void ApplyHistoryStepState::start()
     try_advance();
 }
 
-void LocalTraversableNavigable::start_apply_history_step_operation(u64 operation_id, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior)
+void LocalTraversableNavigable::start_apply_history_step_operation(u64 operation_id, u64 history_initiation_id, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior)
 {
     VERIFY(!m_apply_history_step_operations.contains(operation_id));
-    m_apply_history_step_operations.set(operation_id, heap().allocate<ApplyHistoryStepOperationState>(navigation_api_abort_behavior));
+    VERIFY(m_history_operation_states.contains(history_initiation_id));
+    m_apply_history_step_operations.set(operation_id, heap().allocate<ApplyHistoryStepOperationState>(history_initiation_id, navigation_api_abort_behavior));
 }
 
 void LocalTraversableNavigable::complete_apply_history_step_operation(u64 operation_id)
@@ -1927,6 +1933,7 @@ void LocalTraversableNavigable::retire_claimed_session_history_step(int step)
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-history-step
 void LocalTraversableNavigable::apply_the_history_step(
+    u64 history_initiation_id,
     int step,
     bool check_for_cancelation,
     GC::Ptr<SourceSnapshotParams> source_snapshot_params,
@@ -1945,7 +1952,7 @@ void LocalTraversableNavigable::apply_the_history_step(
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
 
     run_the_history_step_prechecks(step, check_for_cancelation, source_snapshot_params, initiator_to_check, user_involvement, navigation_type, navigation_api_abort_behavior,
-        GC::create_function(heap(), [this, step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, pending_document, expected_ongoing_navigation_navigable, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id), on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) mutable {
+        GC::create_function(heap(), [this, history_initiation_id, step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, pending_document, expected_ongoing_navigation_navigable, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id), on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) mutable {
             if (result != HistoryStepResult::Applied) {
                 on_complete->function()(result);
                 return;
@@ -1953,7 +1960,7 @@ void LocalTraversableNavigable::apply_the_history_step(
 
             // 6. Let changingNavigables be the result of get all navigables whose current session history entry will
             //    change or reload given traversable and targetStep.
-            apply_the_history_step_after_unload_check(step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+            apply_the_history_step_after_unload_check(history_initiation_id, step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
         }));
 }
 
@@ -2066,6 +2073,7 @@ void LocalTraversableNavigable::run_history_step_unload_cancelation_job(int targ
 }
 
 void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
+    u64 history_initiation_id,
     int step,
     int target_step,
     GC::Ptr<SourceSnapshotParams> source_snapshot_params,
@@ -2083,7 +2091,7 @@ void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
         return;
     }
 
-    auto state = heap().allocate<ApplyHistoryStepState>(*this, step, target_step, source_snapshot_params,
+    auto state = heap().allocate<ApplyHistoryStepState>(*this, history_initiation_id, step, target_step, source_snapshot_params,
         user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document,
         expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
 
@@ -2548,6 +2556,7 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
             auto apply_push_or_replace = [&](auto const& parameters, HistoryHandlingBehavior history_handling) {
                 VERIFY(step_override.has_value());
                 apply_the_push_or_replace_history_step(
+                    initiation_id,
                     *step_override,
                     history_handling,
                     parameters.user_involvement,
@@ -2558,14 +2567,14 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                     on_apply_complete);
             };
             auto apply_traverse = [&](auto const& parameters, i32 target_step) {
-                apply_the_traverse_history_step(target_step, initiation->value.source_snapshot_params, initiation->value.initiator_to_check, parameters.user_involvement, on_apply_complete);
+                apply_the_traverse_history_step(initiation_id, target_step, initiation->value.source_snapshot_params, initiation->value.initiator_to_check, parameters.user_involvement, on_apply_complete);
             };
             parameters.visit(
                 [&](PushHistoryOperationParameters const& parameters) { apply_push_or_replace(parameters, HistoryHandlingBehavior::Push); },
                 [&](ReplaceHistoryOperationParameters const& parameters) { apply_push_or_replace(parameters, HistoryHandlingBehavior::Replace); },
                 [&](ReloadHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
-                    apply_the_reload_history_step(parameters.user_involvement, on_apply_complete);
+                    apply_the_reload_history_step(initiation_id, parameters.user_involvement, on_apply_complete);
                 },
                 [&](TraverseByDeltaHistoryOperationParameters const& parameters) {
                     VERIFY(step_override.has_value());
@@ -2581,19 +2590,19 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                 },
                 [&](ResumeTraverseHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
-                    resume_applying_the_traverse_history_step(parameters.target_step, parameters.user_involvement, on_apply_complete);
+                    resume_applying_the_traverse_history_step(initiation_id, parameters.target_step, parameters.user_involvement, on_apply_complete);
                 },
                 [&](NavigableCreationHistoryOperationParameters const&) {
                     VERIFY(!step_override.has_value());
-                    update_for_navigable_creation_or_destruction(on_apply_complete);
+                    update_for_navigable_creation_or_destruction(initiation_id, on_apply_complete);
                 },
                 [&](NavigableDestructionHistoryOperationParameters const&) {
                     VERIFY(!step_override.has_value());
-                    update_for_navigable_creation_or_destruction(on_apply_complete);
+                    update_for_navigable_creation_or_destruction(initiation_id, on_apply_complete);
                 },
                 [&](FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters) {
                     VERIFY(step_override.has_value());
-                    apply_the_push_or_replace_history_step(*step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {}, on_apply_complete);
+                    apply_the_push_or_replace_history_step(initiation_id, *step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {}, on_apply_complete);
                 },
                 [&](CloseTopLevelTraversableHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
@@ -2777,31 +2786,31 @@ void LocalTraversableNavigable::check_if_traverse_history_step_is_canceled(int s
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction
-void LocalTraversableNavigable::update_for_navigable_creation_or_destruction(GC::Ref<OnApplyHistoryStepComplete> on_complete)
+void LocalTraversableNavigable::update_for_navigable_creation_or_destruction(u64 history_initiation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
 {
     // 1. Let step be traversable's current session history step.
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step to traversable given false, null, null, null, and null.
-    apply_the_history_step(step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
-void LocalTraversableNavigable::apply_the_reload_history_step(UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
+void LocalTraversableNavigable::apply_the_reload_history_step(u64 history_initiation_id, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     // 1. Let step be traversable's current session history step.
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, null, null, null, and "reload".
-    apply_the_history_step(step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-push/replace-history-step
-void LocalTraversableNavigable::apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+void LocalTraversableNavigable::apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given false, null, null, userInvolvement, and historyHandling.
     auto navigation_type = history_handling == HistoryHandlingBehavior::Replace ? Bindings::NavigationType::Replace : Bindings::NavigationType::Push;
-    apply_the_history_step(step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
 }
 
 static void reconcile_same_document_navigation_with_local_session_history(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, int entry_step)
@@ -2997,14 +3006,14 @@ void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u
         m_current_session_history_step = target_step;
 }
 
-void LocalTraversableNavigable::apply_the_traverse_history_step(int step, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<LocalNavigable> initiator_to_check, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
+void LocalTraversableNavigable::apply_the_traverse_history_step(u64 history_initiation_id, int step, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<LocalNavigable> initiator_to_check, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given true, sourceSnapshotParams, initiatorToCheck, userInvolvement, and "traverse".
-    apply_the_history_step(step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#resume-applying-the-traverse-history-step
-void LocalTraversableNavigable::resume_applying_the_traverse_history_step(int step, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
+void LocalTraversableNavigable::resume_applying_the_traverse_history_step(u64 history_initiation_id, int step, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     // To resume applying the traverse history step given a non-negative integer step, a traversable
     // navigable traversable, and user navigation involvement userInvolvement, apply step to
@@ -3014,7 +3023,7 @@ void LocalTraversableNavigable::resume_applying_the_traverse_history_step(int st
     //       same-document traversal. Hence, we can pass false and null for those arguments.
     // NB: The committed navigate event remains ongoing until the same-document entry update runs
     //     the navigate event intercept commit handler steps.
-    apply_the_history_step(step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Preserve, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Preserve, nullptr, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2546,6 +2546,10 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
                 [&](NavigableCreationHistoryOperationParameters const&) {
                     VERIFY(!step_override.has_value());
                     update_for_navigable_creation_or_destruction(on_apply_complete);
+                },
+                [&](NavigableDestructionHistoryOperationParameters const&) {
+                    VERIFY(!step_override.has_value());
+                    update_for_navigable_creation_or_destruction(on_apply_complete);
                 });
         });
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1945,7 +1945,7 @@ void LocalTraversableNavigable::apply_the_history_step(
 
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
 
-    run_the_history_step_prechecks(step, check_for_cancelation, source_snapshot_params, initiator_to_check, user_involvement, navigation_type, navigation_api_abort_behavior,
+    run_the_history_step_prechecks(history_initiation_id, step, check_for_cancelation, source_snapshot_params, initiator_to_check, user_involvement, navigation_type, navigation_api_abort_behavior,
         GC::create_function(heap(), [this, history_initiation_id, step, user_involvement, navigation_type, synchronous_navigation, on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) {
             if (result != HistoryStepResult::Applied) {
                 on_complete->function()(result);
@@ -1959,6 +1959,7 @@ void LocalTraversableNavigable::apply_the_history_step(
 }
 
 void LocalTraversableNavigable::run_the_history_step_prechecks(
+    u64 history_initiation_id,
     int step,
     bool check_for_cancelation,
     GC::Ptr<SourceSnapshotParams> source_snapshot_params,
@@ -1971,36 +1972,15 @@ void LocalTraversableNavigable::run_the_history_step_prechecks(
     // 2. Let targetStep be the result of getting the used step given traversable and step.
     auto target_step = get_the_used_step(step);
 
-    auto continue_after_sandboxing = GC::create_function(heap(), [this, target_step, check_for_cancelation, user_involvement, navigation_type, navigation_api_abort_behavior, on_complete]() mutable {
-        // 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
-        auto navigables_crossing_documents = get_all_local_navigables_that_might_experience_a_cross_document_traversal(target_step);
-
-        // NB: Same-document traversals finish their NavigateEvent during the Navigation API entry
-        //     update, after currententrychange. Preserve that event while applying the history step.
-        if (navigation_type == Bindings::NavigationType::Traverse && navigables_crossing_documents.is_empty())
-            navigation_api_abort_behavior = LocalNavigable::NavigationAPIAbortBehavior::Preserve;
-
-        // 5. If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
-        //    and userInvolvement is not "continue", then return that result.
-        if (!check_for_cancelation) {
-            on_complete->function()(HistoryStepResult::Applied, target_step, navigation_api_abort_behavior);
-            return;
-        }
-
-        Vector<CrossProcessId> navigable_ids;
-        navigable_ids.ensure_capacity(navigables_crossing_documents.size());
-        for (auto const& navigable : navigables_crossing_documents)
-            navigable_ids.unchecked_append(navigable->id());
-        run_history_step_unload_cancelation_job(target_step, move(navigable_ids), user_involvement,
-            GC::create_function(heap(), [target_step, navigation_api_abort_behavior, on_complete](HistoryStepResult result) {
-                on_complete->function()(result, target_step, navigation_api_abort_behavior);
-            }));
-    });
-
     // 3. If initiatorToCheck is not null, then:
     if (initiator_to_check != nullptr) {
         // 1. Assert: sourceSnapshotParams is not null.
         VERIFY(source_snapshot_params);
+
+        auto initiation = m_history_operation_states.find(history_initiation_id);
+        VERIFY(initiation != m_history_operation_states.end());
+        VERIFY(initiation->value.initiator_to_check == initiator_to_check);
+        VERIFY(initiation->value.source_snapshot_params == source_snapshot_params);
 
         Vector<CrossProcessId> navigable_ids;
         auto target_top_level_entry = get_the_target_history_entry(target_step);
@@ -2014,21 +1994,66 @@ void LocalTraversableNavigable::run_the_history_step_prechecks(
                 navigable_ids.append(navigable->id());
         }
 
-        run_initiator_sandboxing_check_job(*initiator_to_check, *source_snapshot_params, move(navigable_ids),
-            GC::create_function(heap(), [target_step, navigation_api_abort_behavior, continue_after_sandboxing, on_complete](InitiatorSandboxingCheckResult result) {
-                if (result == InitiatorSandboxingCheckResult::Disallowed) {
-                    on_complete->function()(HistoryStepResult::InitiatorDisallowed, target_step, navigation_api_abort_behavior);
-                    return;
-                }
-                continue_after_sandboxing->function()();
-            }));
+        auto on_sandboxing_check_complete = GC::create_function(heap(), [this, target_step, check_for_cancelation, user_involvement, navigation_type, navigation_api_abort_behavior, on_complete](InitiatorSandboxingCheckResult result) {
+            if (result == InitiatorSandboxingCheckResult::Disallowed) {
+                on_complete->function()(HistoryStepResult::InitiatorDisallowed, target_step, navigation_api_abort_behavior);
+                return;
+            }
+            run_history_step_prechecks_after_sandboxing(target_step, check_for_cancelation, user_involvement, navigation_type, navigation_api_abort_behavior, on_complete);
+        });
+
+        run_initiator_sandboxing_check_job(history_initiation_id, initiator_to_check->id(), move(navigable_ids), on_sandboxing_check_complete);
         return;
     }
 
-    continue_after_sandboxing->function()();
+    run_history_step_prechecks_after_sandboxing(target_step, check_for_cancelation, user_involvement, navigation_type, navigation_api_abort_behavior, on_complete);
 }
 
-void LocalTraversableNavigable::run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams> source_snapshot_params, Vector<CrossProcessId> navigable_ids, GC::Ref<OnInitiatorSandboxingCheckComplete> on_complete)
+void LocalTraversableNavigable::run_history_step_prechecks_after_sandboxing(
+    int target_step,
+    bool check_for_cancelation,
+    UserNavigationInvolvement user_involvement,
+    Optional<Bindings::NavigationType> navigation_type,
+    LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
+    GC::Ref<OnHistoryStepPrechecksComplete> on_complete)
+{
+    // 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
+    auto navigables_crossing_documents = get_all_local_navigables_that_might_experience_a_cross_document_traversal(target_step);
+
+    // NB: Same-document traversals finish their NavigateEvent during the Navigation API entry
+    //     update, after currententrychange. Preserve that event while applying the history step.
+    if (navigation_type == Bindings::NavigationType::Traverse && navigables_crossing_documents.is_empty())
+        navigation_api_abort_behavior = LocalNavigable::NavigationAPIAbortBehavior::Preserve;
+
+    // 5. If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
+    //    and userInvolvement is not "continue", then return that result.
+    if (!check_for_cancelation) {
+        on_complete->function()(HistoryStepResult::Applied, target_step, navigation_api_abort_behavior);
+        return;
+    }
+
+    Vector<CrossProcessId> navigable_ids;
+    navigable_ids.ensure_capacity(navigables_crossing_documents.size());
+    for (auto const& navigable : navigables_crossing_documents)
+        navigable_ids.unchecked_append(navigable->id());
+    run_history_step_unload_cancelation_job(target_step, move(navigable_ids), user_involvement,
+        GC::create_function(heap(), [target_step, navigation_api_abort_behavior, on_complete](HistoryStepResult result) {
+            on_complete->function()(result, target_step, navigation_api_abort_behavior);
+        }));
+}
+
+void LocalTraversableNavigable::run_initiator_sandboxing_check_job(u64 history_initiation_id, CrossProcessId initiator_to_check_id, Vector<CrossProcessId> navigable_ids, GC::Ref<OnInitiatorSandboxingCheckComplete> on_complete)
+{
+    auto initiation = m_history_operation_states.find(history_initiation_id);
+    VERIFY(initiation != m_history_operation_states.end());
+    VERIFY(initiation->value.initiator_to_check);
+    VERIFY(initiation->value.initiator_to_check->id() == initiator_to_check_id);
+    VERIFY(initiation->value.source_snapshot_params);
+
+    run_initiator_sandboxing_check_job_impl(*initiation->value.initiator_to_check, *initiation->value.source_snapshot_params, move(navigable_ids), on_complete);
+}
+
+void LocalTraversableNavigable::run_initiator_sandboxing_check_job_impl(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams> source_snapshot_params, Vector<CrossProcessId> navigable_ids, GC::Ref<OnInitiatorSandboxingCheckComplete> on_complete)
 {
     for (auto navigable_id : navigable_ids) {
         auto navigable = local_navigable_with_id(navigable_id);
@@ -2600,7 +2625,7 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
         auto initiation = m_history_operation_states.find(initiation_id);
         VERIFY(initiation != m_history_operation_states.end());
         if (initiation->value.pre_steps) {
-            initiation->value.pre_steps->function()(ready);
+            initiation->value.pre_steps->function()(initiation_id, ready);
             return;
         }
         ready->function()(true, {}, HistoryStepResult::Applied);
@@ -2642,8 +2667,8 @@ void LocalTraversableNavigable::traverse_the_history_by_delta(int delta, GC::Ptr
             .expected_ongoing_navigation_id = {},
             .source_snapshot_params = source_snapshot_params,
             .initiator_to_check = initiator_to_check,
-            .pre_steps = GC::create_function(heap(), [this, delta, source_snapshot_params, initiator_to_check, user_involvement](GC::Ref<OnHistoryOperationReady> ready) {
-                auto apply_selected_history_step = GC::create_function(heap(), [this, source_snapshot_params, initiator_to_check, user_involvement, ready](Optional<int> target_step) {
+            .pre_steps = GC::create_function(heap(), [this, delta, source_snapshot_params, initiator_to_check, user_involvement](u64 history_initiation_id, GC::Ref<OnHistoryOperationReady> ready) {
+                auto apply_selected_history_step = GC::create_function(heap(), [this, history_initiation_id, source_snapshot_params, initiator_to_check, user_involvement, ready](Optional<int> target_step) {
                     if (!target_step.has_value()) {
                         ready->function()(false, {}, HistoryStepResult::Applied);
                         return;
@@ -2668,7 +2693,7 @@ void LocalTraversableNavigable::traverse_the_history_by_delta(int delta, GC::Ptr
                         }
 
                         if (target_top_level_entry && current_session_history_entry() && page().client().decide_navigation_process(current_session_history_entry()->url(), target_top_level_entry->url(), NavigationTarget::TopLevel) == NavigationProcessDecision::Remote) {
-                            run_the_history_step_prechecks(*target_step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
+                            run_the_history_step_prechecks(history_initiation_id, *target_step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
                                 GC::create_function(heap(), [this, target_step = *target_step, ready](HistoryStepResult result, int, LocalNavigable::NavigationAPIAbortBehavior) {
                                     if (result == HistoryStepResult::Applied)
                                         page().client().page_did_request_traverse_the_history_to_step(target_step, HistoryTraversalPrecheck::AlreadyDone);
@@ -2702,13 +2727,13 @@ void LocalTraversableNavigable::traverse_the_history_to_step(int step, GC::Ref<G
             .target_step = step,
             .user_involvement = UserNavigationInvolvement::BrowserUI,
         },
-         {
-             .pending_document = nullptr,
-             .expected_ongoing_navigation_navigable = nullptr,
-             .expected_ongoing_navigation_id = {},
-             .source_snapshot_params = nullptr,
-             .initiator_to_check = nullptr,
-             .pre_steps = GC::create_function(heap(), [this, step, on_complete](GC::Ref<OnHistoryOperationReady> ready) {
+        {
+            .pending_document = nullptr,
+            .expected_ongoing_navigation_navigable = nullptr,
+            .expected_ongoing_navigation_id = {},
+            .source_snapshot_params = nullptr,
+            .initiator_to_check = nullptr,
+            .pre_steps = GC::create_function(heap(), [this, step, on_complete](u64, GC::Ref<OnHistoryOperationReady> ready) {
                 auto all_steps = get_all_used_history_steps();
                 if (!all_steps.contains_slow(step)) {
                     on_complete->function()(false, HistoryStepResult::Applied);
@@ -2763,7 +2788,8 @@ void LocalTraversableNavigable::check_if_traverse_history_step_is_canceled(int s
             return;
         }
 
-        run_the_history_step_prechecks(step, true, nullptr, nullptr, UserNavigationInvolvement::BrowserUI, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
+        auto target_step = get_the_used_step(step);
+        run_history_step_prechecks_after_sandboxing(target_step, true, UserNavigationInvolvement::BrowserUI, Bindings::NavigationType::Traverse, LocalNavigable::NavigationAPIAbortBehavior::Abort,
             GC::create_function(heap(), [signal, on_complete](HistoryStepResult result, int, LocalNavigable::NavigationAPIAbortBehavior) {
                 on_complete->function()(result);
                 signal->resolve({});
@@ -2839,7 +2865,7 @@ void LocalTraversableNavigable::finalize_same_document_navigation(GC::Ref<LocalN
     //         the spec's queued synchronous-navigation steps as the fallback for reentrant traversal work and child
     //         navigables whose nested history is not ready yet.
     if (m_apply_history_step_state || m_paused_apply_history_step_state || !target_navigable->has_session_history_entry_and_ready_for_navigation()) {
-        auto pre_steps = GC::create_function(heap(), [this, target_navigable, target_entry, entry_to_replace, parameters](GC::Ref<OnHistoryOperationReady> ready) {
+        auto pre_steps = GC::create_function(heap(), [this, target_navigable, target_entry, entry_to_replace, parameters](u64, GC::Ref<OnHistoryOperationReady> ready) {
             if (target_navigable->has_been_destroyed()) {
                 ready->function()(false, {}, HistoryStepResult::Applied);
                 return;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2542,6 +2542,10 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
                 [&](ResumeTraverseHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
                     resume_applying_the_traverse_history_step(parameters.target_step, parameters.user_involvement, on_apply_complete);
+                },
+                [&](NavigableCreationHistoryOperationParameters const&) {
+                    VERIFY(!step_override.has_value());
+                    update_for_navigable_creation_or_destruction(on_apply_complete);
                 });
         });
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -62,6 +62,13 @@ void LocalTraversableNavigable::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_apply_history_step_state);
     visitor.visit(m_paused_apply_history_step_state);
     visitor.visit(m_apply_history_step_operations);
+    for (auto& initiation : m_history_operation_states) {
+        visitor.visit(initiation.value.pending_document);
+        visitor.visit(initiation.value.expected_ongoing_navigation_navigable);
+        visitor.visit(initiation.value.pre_steps);
+        visitor.visit(initiation.value.on_apply_complete);
+        visitor.visit(initiation.value.on_complete);
+    }
     for (auto& pending_navigation : m_pending_same_document_navigations)
         visitor.visit(pending_navigation.value.target_navigable);
 }
@@ -2446,6 +2453,60 @@ bool LocalTraversableNavigable::can_go_forward() const
     auto current_step_index = all_steps.find_first_index(current_session_history_step());
     VERIFY(current_step_index.has_value());
     return *current_step_index + 1 < all_steps.size();
+}
+
+void LocalTraversableNavigable::complete_history_initiation(u64 initiation_id, HistoryStepResult result, NonnullRefPtr<Core::Promise<Empty>> queue_signal)
+{
+    auto initiation = m_history_operation_states.take(initiation_id);
+    VERIFY(initiation.has_value());
+    if (initiation->on_complete)
+        initiation->on_complete->function()(result);
+    queue_signal->resolve({});
+}
+
+void LocalTraversableNavigable::request_history_operation(HistoryOperationParameters parameters, HistoryOperationState state)
+{
+    auto initiation_id = m_next_history_initiation_id++;
+    m_history_operation_states.set(initiation_id, move(state));
+
+    append_session_history_traversal_steps(GC::create_function(heap(), [this, parameters = move(parameters), initiation_id](NonnullRefPtr<Core::Promise<Empty>> queue_signal) mutable {
+        auto ready = GC::create_function(heap(), [this, parameters = move(parameters), initiation_id, queue_signal](bool proceed, Optional<i32> step_override, HistoryStepResult abandon_result) mutable {
+            if (!proceed) {
+                complete_history_initiation(initiation_id, abandon_result, queue_signal);
+                return;
+            }
+
+            auto initiation = m_history_operation_states.find(initiation_id);
+            VERIFY(initiation != m_history_operation_states.end());
+            VERIFY(step_override.has_value());
+
+            auto apply = [&](auto const& parameters, HistoryHandlingBehavior history_handling) {
+                apply_the_push_or_replace_history_step(
+                    *step_override,
+                    history_handling,
+                    parameters.user_involvement,
+                    SynchronousNavigation::No,
+                    initiation->value.pending_document,
+                    initiation->value.expected_ongoing_navigation_navigable,
+                    move(initiation->value.expected_ongoing_navigation_id),
+                    GC::create_function(heap(), [this, initiation_id, queue_signal](HistoryStepResult result) {
+                        auto initiation = m_history_operation_states.find(initiation_id);
+                        VERIFY(initiation != m_history_operation_states.end());
+                        if (initiation->value.on_apply_complete)
+                            initiation->value.on_apply_complete->function()(result);
+                        complete_history_initiation(initiation_id, result, queue_signal);
+                    }));
+            };
+            parameters.visit(
+                [&](PushHistoryOperationParameters const& parameters) { apply(parameters, HistoryHandlingBehavior::Push); },
+                [&](ReplaceHistoryOperationParameters const& parameters) { apply(parameters, HistoryHandlingBehavior::Replace); });
+        });
+
+        auto initiation = m_history_operation_states.find(initiation_id);
+        VERIFY(initiation != m_history_operation_states.end());
+        VERIFY(initiation->value.pre_steps);
+        initiation->value.pre_steps->function()(ready);
+    }));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -877,12 +877,10 @@ public:
 
     ApplyHistoryStepState(
         GC::Ref<LocalTraversableNavigable> traversable, u64 history_initiation_id, int step, int target_step,
-        GC::Ptr<SourceSnapshotParams> source_snapshot_params,
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation synchronous_navigation,
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
-        GC::Ptr<DOM::Document> pending_document,
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
         Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete)
@@ -892,12 +890,10 @@ public:
         , m_job_runner(*traversable)
         , m_step(step)
         , m_target_step(target_step)
-        , m_source_snapshot_params(source_snapshot_params)
         , m_user_involvement(user_involvement)
         , m_navigation_type(navigation_type)
         , m_synchronous_navigation(synchronous_navigation)
         , m_navigation_api_abort_behavior(navigation_api_abort_behavior)
-        , m_pending_document(pending_document)
         , m_expected_ongoing_navigation_navigable_id(expected_ongoing_navigation_navigable ? Optional<CrossProcessId> { expected_ongoing_navigation_navigable->id() } : OptionalNone {})
         , m_expected_ongoing_navigation_id(move(expected_ongoing_navigation_id))
         , m_on_complete(on_complete)
@@ -959,8 +955,6 @@ private:
     {
         Base::visit_edges(visitor);
         visitor.visit(m_traversable);
-        visitor.visit(m_source_snapshot_params);
-        visitor.visit(m_pending_document);
         visitor.visit(m_on_complete);
         visitor.visit(m_timeout);
     }
@@ -1004,12 +998,10 @@ private:
     ApplyHistoryStepJobRunner& m_job_runner;
     int m_step;
     int m_target_step;
-    GC::Ptr<SourceSnapshotParams> m_source_snapshot_params;
     UserNavigationInvolvement m_user_involvement;
     Optional<Bindings::NavigationType> m_navigation_type;
     SynchronousNavigation m_synchronous_navigation;
     LocalNavigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
-    GC::Ptr<DOM::Document> m_pending_document;
     Optional<CrossProcessId> m_expected_ongoing_navigation_navigable_id;
     Optional<Utf16String> m_expected_ongoing_navigation_id;
     GC::Ptr<OnApplyHistoryStepComplete> m_on_complete;
@@ -1061,12 +1053,10 @@ void ApplyHistoryStepState::start()
             {
                 .navigable_id = navigable_id,
                 .target_step = m_target_step,
-                .source_snapshot_params = m_source_snapshot_params,
                 .user_involvement = m_user_involvement,
                 .navigation_type = m_navigation_type,
                 .synchronous_navigation = m_synchronous_navigation,
                 .navigation_api_abort_behavior = m_navigation_api_abort_behavior,
-                .pending_document = m_pending_document,
             },
             GC::create_function(heap(), [this, navigable_id](ChangingNavigableHistoryStepJobDisposition disposition) {
                 switch (disposition) {
@@ -1110,9 +1100,12 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(u64 oper
     VERIFY(operation_iterator != m_apply_history_step_operations.end());
 
     auto operation = operation_iterator->value;
+    auto initiation_iterator = m_history_operation_states.find(operation->history_initiation_id());
+    VERIFY(initiation_iterator != m_history_operation_states.end());
+
     auto navigable_id = job.navigable_id;
     auto navigation_api_abort_behavior = job.navigation_api_abort_behavior;
-    auto did_claim_navigable = run_changing_navigable_history_step_job_impl(move(job),
+    auto did_claim_navigable = run_changing_navigable_history_step_job_impl(move(job), initiation_iterator->value.source_snapshot_params, initiation_iterator->value.pending_document,
         GC::create_function(heap(), [operation, navigable_id, navigation_api_abort_behavior, on_complete](LocalChangingNavigableHistoryStepJobResult result) {
             if (operation->completed()) {
                 VERIFY(operation->release_navigable(navigable_id));
@@ -1135,7 +1128,7 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(u64 oper
         operation->did_claim_navigable(navigable_id);
 }
 
-bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob job, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete> on_complete)
+bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob job, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<DOM::Document> pending_document, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete> on_complete)
 {
     auto navigable = local_navigable_with_id(job.navigable_id);
     if (!navigable) {
@@ -1207,7 +1200,7 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
     // 3. Set navigable's ongoing navigation to "traversal".
     navigable->set_ongoing_navigation(HTML::LocalNavigable::Traversal::Tag, job.navigation_api_abort_behavior);
 
-    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), claimed_target_entry = claimed_target_entry.release_nonnull(), navigable, on_complete] {
+    queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), source_snapshot_params, pending_document, claimed_target_entry = claimed_target_entry.release_nonnull(), navigable, on_complete] {
         // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
         if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()) {
             on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
@@ -1246,7 +1239,7 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
         changing_navigable_continuation->target_entry = target_entry;
         changing_navigable_continuation->navigable = navigable;
         changing_navigable_continuation->update_only = false;
-        changing_navigable_continuation->pending_document = job.pending_document;
+        changing_navigable_continuation->pending_document = pending_document;
         changing_navigable_continuation->population_output = nullptr;
 
         // 4. If displayedEntry is targetEntry and targetEntry's document state's reload pending is false, then:
@@ -1371,7 +1364,7 @@ bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(Cha
             auto target_snapshot_params = navigable->snapshot_target_snapshot_params();
 
             // 3. Let potentiallyTargetSpecificSourceSnapshotParams be sourceSnapshotParams.
-            auto potentially_target_specific_source_snapshot_params = job.source_snapshot_params;
+            auto potentially_target_specific_source_snapshot_params = source_snapshot_params;
 
             // 4. If potentiallyTargetSpecificSourceSnapshotParams is null, then set it to the result of snapshotting source snapshot params given navigable's active document.
             if (!potentially_target_specific_source_snapshot_params)
@@ -1942,7 +1935,6 @@ void LocalTraversableNavigable::apply_the_history_step(
     Optional<Bindings::NavigationType> navigation_type,
     SynchronousNavigation synchronous_navigation,
     LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
-    GC::Ptr<DOM::Document> pending_document,
     GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
     Optional<Utf16String> expected_ongoing_navigation_id,
     GC::Ref<OnApplyHistoryStepComplete> on_complete)
@@ -1952,7 +1944,7 @@ void LocalTraversableNavigable::apply_the_history_step(
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
 
     run_the_history_step_prechecks(step, check_for_cancelation, source_snapshot_params, initiator_to_check, user_involvement, navigation_type, navigation_api_abort_behavior,
-        GC::create_function(heap(), [this, history_initiation_id, step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, pending_document, expected_ongoing_navigation_navigable, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id), on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) mutable {
+        GC::create_function(heap(), [this, history_initiation_id, step, user_involvement, navigation_type, synchronous_navigation, expected_ongoing_navigation_navigable, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id), on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) mutable {
             if (result != HistoryStepResult::Applied) {
                 on_complete->function()(result);
                 return;
@@ -1960,7 +1952,7 @@ void LocalTraversableNavigable::apply_the_history_step(
 
             // 6. Let changingNavigables be the result of get all navigables whose current session history entry will
             //    change or reload given traversable and targetStep.
-            apply_the_history_step_after_unload_check(history_initiation_id, step, target_step, source_snapshot_params, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+            apply_the_history_step_after_unload_check(history_initiation_id, step, target_step, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
         }));
 }
 
@@ -2076,12 +2068,10 @@ void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
     u64 history_initiation_id,
     int step,
     int target_step,
-    GC::Ptr<SourceSnapshotParams> source_snapshot_params,
     UserNavigationInvolvement user_involvement,
     Optional<Bindings::NavigationType> navigation_type,
     SynchronousNavigation synchronous_navigation,
     LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
-    GC::Ptr<DOM::Document> pending_document,
     GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
     Optional<Utf16String> expected_ongoing_navigation_id,
     GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
@@ -2091,8 +2081,8 @@ void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
         return;
     }
 
-    auto state = heap().allocate<ApplyHistoryStepState>(*this, history_initiation_id, step, target_step, source_snapshot_params,
-        user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, pending_document,
+    auto state = heap().allocate<ApplyHistoryStepState>(*this, history_initiation_id, step, target_step,
+        user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior,
         expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
 
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
@@ -2561,7 +2551,6 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                     history_handling,
                     parameters.user_involvement,
                     SynchronousNavigation::No,
-                    initiation->value.pending_document,
                     initiation->value.expected_ongoing_navigation_navigable,
                     move(initiation->value.expected_ongoing_navigation_id),
                     on_apply_complete);
@@ -2602,7 +2591,7 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                 },
                 [&](FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters) {
                     VERIFY(step_override.has_value());
-                    apply_the_push_or_replace_history_step(initiation_id, *step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {}, on_apply_complete);
+                    apply_the_push_or_replace_history_step(initiation_id, *step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, {}, on_apply_complete);
                 },
                 [&](CloseTopLevelTraversableHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
@@ -2792,7 +2781,7 @@ void LocalTraversableNavigable::update_for_navigable_creation_or_destruction(u64
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step to traversable given false, null, null, null, and null.
-    apply_the_history_step(history_initiation_id, step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
@@ -2802,15 +2791,15 @@ void LocalTraversableNavigable::apply_the_reload_history_step(u64 history_initia
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, null, null, null, and "reload".
-    apply_the_history_step(history_initiation_id, step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-push/replace-history-step
-void LocalTraversableNavigable::apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+void LocalTraversableNavigable::apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given false, null, null, userInvolvement, and historyHandling.
     auto navigation_type = history_handling == HistoryHandlingBehavior::Replace ? Bindings::NavigationType::Replace : Bindings::NavigationType::Push;
-    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, pending_document, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
 }
 
 static void reconcile_same_document_navigation_with_local_session_history(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, int entry_step)
@@ -3009,7 +2998,7 @@ void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u
 void LocalTraversableNavigable::apply_the_traverse_history_step(u64 history_initiation_id, int step, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<LocalNavigable> initiator_to_check, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given true, sourceSnapshotParams, initiatorToCheck, userInvolvement, and "traverse".
-    apply_the_history_step(history_initiation_id, step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#resume-applying-the-traverse-history-step
@@ -3023,7 +3012,7 @@ void LocalTraversableNavigable::resume_applying_the_traverse_history_step(u64 hi
     //       same-document traversal. Hence, we can pass false and null for those arguments.
     // NB: The committed navigate event remains ongoing until the same-document entry update runs
     //     the navigate event intercept commit handler steps.
-    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Preserve, nullptr, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Preserve, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2566,6 +2566,11 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                 [&](FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters) {
                     VERIFY(step_override.has_value());
                     apply_the_push_or_replace_history_step(*step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {}, on_apply_complete);
+                },
+                [&](CloseTopLevelTraversableHistoryOperationParameters const& parameters) {
+                    VERIFY(!step_override.has_value());
+                    VERIFY(parameters.traversable_id == id());
+                    run_close_top_level_traversable_steps(on_apply_complete);
                 });
         });
 
@@ -3012,17 +3017,22 @@ void LocalTraversableNavigable::definitely_close_top_level_traversable()
             return;
 
         // 3. Append the following session history traversal steps to traversable:
-        append_session_history_traversal_steps(GC::create_function(heap(), [this](NonnullRefPtr<Core::Promise<Empty>> signal) {
-            // 1. Let afterAllUnloads be an algorithm step which destroys traversable.
-            auto after_all_unloads = GC::create_function(heap(), [this] {
-                destroy_top_level_traversable();
-            });
-
-            // 2. Unload a document and its descendants given traversable's active document, null, and afterAllUnloads.
-            active_document()->unload_a_document_and_its_descendants({}, after_all_unloads);
-            signal->resolve({});
-        }));
+        request_history_operation(CloseTopLevelTraversableHistoryOperationParameters {
+            .traversable_id = id(),
+        });
     }));
+}
+
+void LocalTraversableNavigable::run_close_top_level_traversable_steps(GC::Ref<OnApplyHistoryStepComplete> on_complete)
+{
+    // 1. Let afterAllUnloads be an algorithm step which destroys traversable.
+    auto after_all_unloads = GC::create_function(heap(), [this] {
+        destroy_top_level_traversable();
+    });
+
+    // 2. Unload a document and its descendants given traversable's active document, null, and afterAllUnloads.
+    active_document()->unload_a_document_and_its_descendants({}, after_all_unloads);
+    on_complete->function()(HistoryStepResult::Applied);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#destroy-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -71,8 +71,10 @@ void LocalTraversableNavigable::visit_edges(Cell::Visitor& visitor)
         visitor.visit(initiation.value.on_apply_complete);
         visitor.visit(initiation.value.on_complete);
     }
-    for (auto& pending_navigation : m_pending_same_document_navigations)
+    for (auto& pending_navigation : m_pending_same_document_navigations) {
         visitor.visit(pending_navigation.value.target_navigable);
+        visitor.visit(pending_navigation.value.ready);
+    }
 }
 
 static OrderedHashTable<LocalTraversableNavigable*>& user_agent_top_level_traversable_set()
@@ -2468,6 +2470,16 @@ void LocalTraversableNavigable::complete_history_initiation(u64 initiation_id, H
 
 void LocalTraversableNavigable::request_history_operation(HistoryOperationParameters parameters, HistoryOperationState state)
 {
+    append_session_history_traversal_steps(create_history_operation_steps(move(parameters), move(state)));
+}
+
+void LocalTraversableNavigable::request_synchronous_navigation_history_operation(GC::Ref<LocalNavigable> target_navigable, HistoryOperationParameters parameters, HistoryOperationState state)
+{
+    append_session_history_synchronous_navigation_steps(target_navigable, create_history_operation_steps(move(parameters), move(state)));
+}
+
+GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_operation_steps(HistoryOperationParameters parameters, HistoryOperationState state)
+{
     if (parameters.has<ReloadHistoryOperationParameters>()) {
         VERIFY(!state.on_apply_complete);
         state.on_apply_complete = GC::create_function(heap(), [this](HistoryStepResult result) {
@@ -2487,7 +2499,7 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
     auto initiation_id = m_next_history_initiation_id++;
     m_history_operation_states.set(initiation_id, move(state));
 
-    append_session_history_traversal_steps(GC::create_function(heap(), [this, parameters = move(parameters), initiation_id](NonnullRefPtr<Core::Promise<Empty>> queue_signal) mutable {
+    return GC::create_function(heap(), [this, parameters = move(parameters), initiation_id](NonnullRefPtr<Core::Promise<Empty>> queue_signal) mutable {
         auto ready = GC::create_function(heap(), [this, parameters = move(parameters), initiation_id, queue_signal](bool proceed, Optional<i32> step_override, HistoryStepResult abandon_result) mutable {
             if (!proceed) {
                 complete_history_initiation(initiation_id, abandon_result, queue_signal);
@@ -2550,6 +2562,10 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
                 [&](NavigableDestructionHistoryOperationParameters const&) {
                     VERIFY(!step_override.has_value());
                     update_for_navigable_creation_or_destruction(on_apply_complete);
+                },
+                [&](FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters) {
+                    VERIFY(step_override.has_value());
+                    apply_the_push_or_replace_history_step(*step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {}, on_apply_complete);
                 });
         });
 
@@ -2560,7 +2576,7 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
             return;
         }
         ready->function()(true, {}, HistoryStepResult::Applied);
-    }));
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta
@@ -2782,22 +2798,43 @@ void LocalTraversableNavigable::finalize_same_document_navigation(GC::Ref<LocalN
     if (target_navigable->has_been_destroyed())
         return;
 
+    auto parameters = FinalizeSameDocumentNavigationHistoryOperationParameters {
+        .navigable_id = target_navigable->id(),
+        .target_entry = create_same_document_navigation_entry(target_entry),
+        .replaces_current_entry = entry_to_replace != nullptr,
+        .history_handling = history_handling,
+        .user_involvement = user_involvement,
+    };
+
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-traversal-parallel-queue-sync-nav-steps
     // AD-HOC: Browser engines commit same-document navigations synchronously when no traversal state is active. Keep
     //         the spec's queued synchronous-navigation steps as the fallback for reentrant traversal work and child
     //         navigables whose nested history is not ready yet.
     if (m_apply_history_step_state || m_paused_apply_history_step_state || !target_navigable->has_session_history_entry_and_ready_for_navigation()) {
-        append_session_history_synchronous_navigation_steps(target_navigable, GC::create_function(heap(), [this, target_navigable, target_entry, entry_to_replace, history_handling, user_involvement](NonnullRefPtr<Core::Promise<Empty>> signal) {
+        auto pre_steps = GC::create_function(heap(), [this, target_navigable, target_entry, entry_to_replace, parameters](GC::Ref<OnHistoryOperationReady> ready) {
             if (target_navigable->has_been_destroyed()) {
-                signal->resolve({});
+                ready->function()(false, {}, HistoryStepResult::Applied);
                 return;
             }
-            begin_same_document_navigation_finalization(target_navigable, target_entry, entry_to_replace, history_handling, user_involvement, signal);
-        }));
+            begin_same_document_navigation_finalization(target_navigable, target_entry, entry_to_replace, parameters, ready);
+        });
+        request_synchronous_navigation_history_operation(
+            target_navigable,
+            move(parameters),
+            {
+                .pending_document = nullptr,
+                .expected_ongoing_navigation_navigable = nullptr,
+                .expected_ongoing_navigation_id = {},
+                .source_snapshot_params = nullptr,
+                .initiator_to_check = nullptr,
+                .pre_steps = pre_steps,
+                .on_apply_complete = nullptr,
+                .on_complete = nullptr,
+            });
         return;
     }
 
-    begin_same_document_navigation_finalization(target_navigable, target_entry, entry_to_replace, history_handling, user_involvement, nullptr);
+    begin_same_document_navigation_finalization(target_navigable, target_entry, entry_to_replace, parameters, nullptr);
 }
 
 void LocalTraversableNavigable::set_history_object_length_and_index(HistoryObjectLengthAndIndex history_object_length_and_index)
@@ -2816,9 +2853,9 @@ void LocalTraversableNavigable::set_history_object_length_and_index(HistoryObjec
     }
 }
 
-void LocalTraversableNavigable::begin_same_document_navigation_finalization(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, RefPtr<Core::Promise<Empty>> signal)
+void LocalTraversableNavigable::begin_same_document_navigation_finalization(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters, GC::Ptr<OnHistoryOperationReady> ready)
 {
-    auto is_queued = signal != nullptr;
+    auto is_queued = ready != nullptr;
     auto provisional_target_step = current_session_history_step();
     Optional<int> provisional_claimed_step;
     if (!entry_to_replace) {
@@ -2836,10 +2873,8 @@ void LocalTraversableNavigable::begin_same_document_navigation_finalization(GC::
         .target_navigable = target_navigable,
         .target_entry = target_entry,
         .entry_to_replace = entry_to_replace,
-        .history_handling = history_handling,
-        .user_involvement = user_involvement,
         .provisional_claimed_step = provisional_claimed_step,
-        .signal = move(signal),
+        .ready = ready,
     };
 
     if (!is_queued) {
@@ -2876,11 +2911,11 @@ void LocalTraversableNavigable::begin_same_document_navigation_finalization(GC::
 
     page().client().page_did_request_finalize_same_document_navigation(
         operation_id,
-        target_navigable->id(),
-        create_same_document_navigation_entry(target_entry),
-        entry_to_replace != nullptr,
-        history_handling,
-        user_involvement);
+        parameters.navigable_id,
+        parameters.target_entry,
+        parameters.replaces_current_entry,
+        parameters.history_handling,
+        parameters.user_involvement);
 }
 
 void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex history_object_length_and_index)
@@ -2893,8 +2928,8 @@ void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u
     auto complete = [&] {
         if (pending_navigation->provisional_claimed_step.has_value())
             retire_claimed_session_history_step(*pending_navigation->provisional_claimed_step);
-        if (pending_navigation->signal)
-            pending_navigation->signal->resolve({});
+        if (pending_navigation->ready)
+            pending_navigation->ready->function()(false, {}, HistoryStepResult::Applied);
     };
 
     if (!committed || pending_navigation->target_navigable->has_been_destroyed()) {
@@ -2912,19 +2947,15 @@ void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u
         return;
     }
 
-    if (pending_navigation->signal) {
+    if (pending_navigation->ready) {
         // The UI process assigns the canonical step, which need not be the step claimed locally. Move the claim onto it
-        // so that applying the history step below retires exactly what is outstanding.
+        // so that the history operation retires exactly what is outstanding when it applies that step.
         if (pending_navigation->provisional_claimed_step.has_value() && *pending_navigation->provisional_claimed_step != target_step) {
             retire_claimed_session_history_step(*pending_navigation->provisional_claimed_step);
             claim_session_history_step(target_step);
         }
 
-        auto signal = pending_navigation->signal;
-        apply_the_push_or_replace_history_step(target_step, pending_navigation->history_handling, pending_navigation->user_involvement, SynchronousNavigation::Yes, nullptr, nullptr, {},
-            GC::create_function(heap(), [signal](HistoryStepResult) {
-                signal->resolve({});
-            }));
+        pending_navigation->ready->function()(true, target_step, HistoryStepResult::Applied);
         return;
     }
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1498,13 +1498,17 @@ void ApplyHistoryStepState::process_continuations()
 
         // 9. Let entriesForNavigationAPI be the result of getting session history entries for the navigation API given navigable and targetStep.
         auto entries_for_navigation_api = m_traversable->get_session_history_entries_for_the_navigation_api(*navigable, m_target_step);
+        Vector<SessionHistoryEntryDescriptor> entry_descriptors_for_navigation_api;
+        entry_descriptors_for_navigation_api.ensure_capacity(entries_for_navigation_api.size());
+        for (auto const& entry : entries_for_navigation_api)
+            entry_descriptors_for_navigation_api.unchecked_append(create_session_history_entry_descriptor(entry));
 
         m_job_runner.apply_changing_navigable_history_step_continuation(
             m_generation,
             {
                 .navigable_id = navigable_id,
                 .history_object_length_and_index = history_object_length_and_index,
-                .entries_for_navigation_api = move(entries_for_navigation_api),
+                .entries_for_navigation_api = move(entry_descriptors_for_navigation_api),
                 .navigation_type = m_navigation_type,
                 .navigation_api_abort_behavior = m_navigation_api_abort_behavior,
                 .user_involvement = m_user_involvement,
@@ -1546,6 +1550,29 @@ static void clear_ongoing_history_traversal(GC::Ptr<LocalNavigable> navigable, L
     navigable->set_ongoing_navigation({}, navigation_api_abort_behavior);
 }
 
+static Vector<NonnullRefPtr<SessionHistoryEntry>> resolve_navigation_api_entry_descriptors(LocalNavigable const& navigable, Vector<SessionHistoryEntryDescriptor> const& descriptors)
+{
+    Vector<NonnullRefPtr<SessionHistoryEntry>> entries;
+    entries.ensure_capacity(descriptors.size());
+
+    auto const& local_entries = navigable.get_session_history_entries();
+    for (auto const& descriptor : descriptors) {
+        RefPtr<SessionHistoryEntry> matching_entry;
+        for (auto const& entry : local_entries) {
+            if (entry->navigation_api_key() != descriptor.navigation_api_key)
+                continue;
+            VERIFY(!matching_entry);
+            matching_entry = entry;
+        }
+
+        VERIFY(matching_entry);
+        VERIFY(session_history_entry_matches_descriptor_ignoring_document_state_id(*matching_entry, descriptor));
+        entries.unchecked_append(matching_entry.release_nonnull());
+    }
+
+    return entries;
+}
+
 void LocalTraversableNavigable::apply_changing_navigable_history_step_continuation(u64 operation_id, ApplyChangingNavigableHistoryStepContinuation command, GC::Ref<GC::Function<void()>> on_complete)
 {
     auto operation = m_apply_history_step_operations.find(operation_id);
@@ -1557,6 +1584,7 @@ void LocalTraversableNavigable::apply_changing_navigable_history_step_continuati
 
 void LocalTraversableNavigable::apply_changing_navigable_history_step_continuation_impl(GC::Ref<ChangingNavigableContinuationState> continuation, ApplyChangingNavigableHistoryStepContinuation command, GC::Ref<GC::Function<void()>> on_complete)
 {
+    auto entries_for_navigation_api = resolve_navigation_api_entry_descriptors(*continuation->navigable, command.entries_for_navigation_api);
 
     // 4. Let displayedDocument be changingNavigableContinuation's displayed document.
     auto displayed_document = continuation->displayed_document;
@@ -1591,7 +1619,7 @@ void LocalTraversableNavigable::apply_changing_navigable_history_step_continuati
     bool const update_only = continuation->update_only;
     RefPtr<SessionHistoryEntry> const target_entry = continuation->target_entry;
     auto const displayed_document_id = continuation->displayed_document_id;
-    auto after_potential_unload = GC::create_function(heap(), [this, navigable, update_only, target_entry, continuation, population_output, old_origin, displayed_document_id, script_history_length, script_history_index, entries_for_navigation_api = move(command.entries_for_navigation_api), navigation_type = command.navigation_type, navigation_api_abort_behavior = command.navigation_api_abort_behavior, on_complete] {
+    auto after_potential_unload = GC::create_function(heap(), [this, navigable, update_only, target_entry, continuation, population_output, old_origin, displayed_document_id, script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api), navigation_type = command.navigation_type, navigation_api_abort_behavior = command.navigation_api_abort_behavior, on_complete] {
         if (update_only || continuation->resolved_document.ptr() == continuation->displayed_document.ptr()) {
             // AD-HOC: Child navigable same-document/update-only tasks are queued without an associated Document so
             //         they can survive the old active Document being deactivated. That also lets them run after the

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2102,6 +2102,9 @@ void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
     GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     if (history_initiation_expected_ongoing_navigation_was_superseded(history_initiation_id)) {
+        // NB: A push or same-document finalization claimed its target step at request time. This return never
+        //     creates the ApplyHistoryStepState whose completion would retire that claim, so retire it here.
+        retire_claimed_session_history_step(target_step);
         on_complete->function()(HistoryStepResult::Applied);
         return;
     }

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -356,6 +356,16 @@ static bool expected_ongoing_navigation_was_superseded(Optional<CrossProcessId> 
     return navigable->ongoing_navigation() != *expected_navigation_id;
 }
 
+bool LocalTraversableNavigable::history_initiation_expected_ongoing_navigation_was_superseded(u64 history_initiation_id) const
+{
+    auto initiation = m_history_operation_states.find(history_initiation_id);
+    VERIFY(initiation != m_history_operation_states.end());
+
+    auto expected_navigable = initiation->value.expected_ongoing_navigation_navigable;
+    auto expected_navigable_id = expected_navigable ? Optional<CrossProcessId> { expected_navigable->id() } : OptionalNone {};
+    return expected_ongoing_navigation_was_superseded(expected_navigable_id, initiation->value.expected_ongoing_navigation_id);
+}
+
 bool LocalTraversableNavigable::replace_top_level_session_history_entries_from_ui_process(Vector<SessionHistoryEntryDescriptor> entries_from_ui_process, size_t current_top_level_entry_index, bool allow_reconstructing_current_entry)
 {
     if (entries_from_ui_process.is_empty() || current_top_level_entry_index >= entries_from_ui_process.size())
@@ -881,8 +891,6 @@ public:
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation synchronous_navigation,
         LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
-        GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
-        Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete)
         : m_generation(++traversable->m_apply_history_step_generation_counter)
         , m_history_initiation_id(history_initiation_id)
@@ -894,8 +902,6 @@ public:
         , m_navigation_type(navigation_type)
         , m_synchronous_navigation(synchronous_navigation)
         , m_navigation_api_abort_behavior(navigation_api_abort_behavior)
-        , m_expected_ongoing_navigation_navigable_id(expected_ongoing_navigation_navigable ? Optional<CrossProcessId> { expected_ongoing_navigation_navigable->id() } : OptionalNone {})
-        , m_expected_ongoing_navigation_id(move(expected_ongoing_navigation_id))
         , m_on_complete(on_complete)
         , m_timeout(Platform::Timer::create_single_shot(heap(), TIMEOUT_MS, GC::create_function(heap(), [this] {
             if (m_phase != Phase::Completed) {
@@ -1002,8 +1008,6 @@ private:
     Optional<Bindings::NavigationType> m_navigation_type;
     SynchronousNavigation m_synchronous_navigation;
     LocalNavigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
-    Optional<CrossProcessId> m_expected_ongoing_navigation_navigable_id;
-    Optional<Utf16String> m_expected_ongoing_navigation_id;
     GC::Ptr<OnApplyHistoryStepComplete> m_on_complete;
     GC::Ref<Platform::Timer> m_timeout;
 
@@ -1024,7 +1028,7 @@ GC_DEFINE_ALLOCATOR(ApplyHistoryStepState);
 
 void ApplyHistoryStepState::start()
 {
-    if (expected_ongoing_navigation_was_superseded(m_expected_ongoing_navigation_navigable_id, m_expected_ongoing_navigation_id)) {
+    if (m_traversable->history_initiation_expected_ongoing_navigation_was_superseded(m_history_initiation_id)) {
         // NB: A cross-document navigation can be superseded after its document has populated but before its queued
         //     history-step application runs. The navigate algorithm's earlier navigation ID check caught the same
         //     condition before appending these steps; this re-check keeps a stale finalization from claiming
@@ -1935,8 +1939,6 @@ void LocalTraversableNavigable::apply_the_history_step(
     Optional<Bindings::NavigationType> navigation_type,
     SynchronousNavigation synchronous_navigation,
     LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
-    GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
-    Optional<Utf16String> expected_ongoing_navigation_id,
     GC::Ref<OnApplyHistoryStepComplete> on_complete)
 {
     // FIXME: 1. Assert: This is running within traversable's session history traversal queue.
@@ -1944,7 +1946,7 @@ void LocalTraversableNavigable::apply_the_history_step(
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
 
     run_the_history_step_prechecks(step, check_for_cancelation, source_snapshot_params, initiator_to_check, user_involvement, navigation_type, navigation_api_abort_behavior,
-        GC::create_function(heap(), [this, history_initiation_id, step, user_involvement, navigation_type, synchronous_navigation, expected_ongoing_navigation_navigable, expected_ongoing_navigation_id = move(expected_ongoing_navigation_id), on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) mutable {
+        GC::create_function(heap(), [this, history_initiation_id, step, user_involvement, navigation_type, synchronous_navigation, on_complete](HistoryStepResult result, int target_step, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior) {
             if (result != HistoryStepResult::Applied) {
                 on_complete->function()(result);
                 return;
@@ -1952,7 +1954,7 @@ void LocalTraversableNavigable::apply_the_history_step(
 
             // 6. Let changingNavigables be the result of get all navigables whose current session history entry will
             //    change or reload given traversable and targetStep.
-            apply_the_history_step_after_unload_check(history_initiation_id, step, target_step, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+            apply_the_history_step_after_unload_check(history_initiation_id, step, target_step, user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, on_complete);
         }));
 }
 
@@ -2072,18 +2074,15 @@ void LocalTraversableNavigable::apply_the_history_step_after_unload_check(
     Optional<Bindings::NavigationType> navigation_type,
     SynchronousNavigation synchronous_navigation,
     LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior,
-    GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
-    Optional<Utf16String> expected_ongoing_navigation_id,
     GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
-    if (expected_ongoing_navigation_was_superseded(expected_ongoing_navigation_navigable ? Optional<CrossProcessId> { expected_ongoing_navigation_navigable->id() } : OptionalNone {}, expected_ongoing_navigation_id)) {
+    if (history_initiation_expected_ongoing_navigation_was_superseded(history_initiation_id)) {
         on_complete->function()(HistoryStepResult::Applied);
         return;
     }
 
     auto state = heap().allocate<ApplyHistoryStepState>(*this, history_initiation_id, step, target_step,
-        user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior,
-        expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+        user_involvement, navigation_type, synchronous_navigation, navigation_api_abort_behavior, on_complete);
 
     VERIFY(!m_apply_history_step_state || m_paused_apply_history_step_state);
     m_apply_history_step_state = state;
@@ -2551,8 +2550,6 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                     history_handling,
                     parameters.user_involvement,
                     SynchronousNavigation::No,
-                    initiation->value.expected_ongoing_navigation_navigable,
-                    move(initiation->value.expected_ongoing_navigation_id),
                     on_apply_complete);
             };
             auto apply_traverse = [&](auto const& parameters, i32 target_step) {
@@ -2591,7 +2588,7 @@ GC::Ref<SessionHistoryTraversalSteps> LocalTraversableNavigable::create_history_
                 },
                 [&](FinalizeSameDocumentNavigationHistoryOperationParameters const& parameters) {
                     VERIFY(step_override.has_value());
-                    apply_the_push_or_replace_history_step(initiation_id, *step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, nullptr, {}, on_apply_complete);
+                    apply_the_push_or_replace_history_step(initiation_id, *step_override, parameters.history_handling, parameters.user_involvement, SynchronousNavigation::Yes, on_apply_complete);
                 },
                 [&](CloseTopLevelTraversableHistoryOperationParameters const& parameters) {
                     VERIFY(!step_override.has_value());
@@ -2781,7 +2778,7 @@ void LocalTraversableNavigable::update_for_navigable_creation_or_destruction(u64
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step to traversable given false, null, null, null, and null.
-    apply_the_history_step(history_initiation_id, step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
@@ -2791,15 +2788,15 @@ void LocalTraversableNavigable::apply_the_reload_history_step(u64 history_initia
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, null, null, null, and "reload".
-    apply_the_history_step(history_initiation_id, step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-push/replace-history-step
-void LocalTraversableNavigable::apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete)
+void LocalTraversableNavigable::apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation, GC::Ref<OnApplyHistoryStepComplete> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given false, null, null, userInvolvement, and historyHandling.
     auto navigation_type = history_handling == HistoryHandlingBehavior::Replace ? Bindings::NavigationType::Replace : Bindings::NavigationType::Push;
-    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, expected_ongoing_navigation_navigable, move(expected_ongoing_navigation_id), on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation, LocalNavigable::NavigationAPIAbortBehavior::Abort, on_complete);
 }
 
 static void reconcile_same_document_navigation_with_local_session_history(GC::Ref<LocalNavigable> target_navigable, NonnullRefPtr<SessionHistoryEntry> target_entry, RefPtr<SessionHistoryEntry> entry_to_replace, int entry_step)
@@ -2998,7 +2995,7 @@ void LocalTraversableNavigable::did_complete_finalize_same_document_navigation(u
 void LocalTraversableNavigable::apply_the_traverse_history_step(u64 history_initiation_id, int step, GC::Ptr<SourceSnapshotParams> source_snapshot_params, GC::Ptr<LocalNavigable> initiator_to_check, UserNavigationInvolvement user_involvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete)
 {
     // 1. Return the result of applying the history step step to traversable given true, sourceSnapshotParams, initiatorToCheck, userInvolvement, and "traverse".
-    apply_the_history_step(history_initiation_id, step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, true, source_snapshot_params, initiator_to_check, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#resume-applying-the-traverse-history-step
@@ -3012,7 +3009,7 @@ void LocalTraversableNavigable::resume_applying_the_traverse_history_step(u64 hi
     //       same-document traversal. Hence, we can pass false and null for those arguments.
     // NB: The committed navigate event remains ongoing until the same-document entry update runs
     //     the navigate event intercept commit handler steps.
-    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Preserve, nullptr, {}, on_complete);
+    apply_the_history_step(history_initiation_id, step, false, {}, {}, user_involvement, Bindings::NavigationType::Traverse, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Preserve, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#close-a-top-level-traversable

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -2466,6 +2466,22 @@ void LocalTraversableNavigable::complete_history_initiation(u64 initiation_id, H
 
 void LocalTraversableNavigable::request_history_operation(HistoryOperationParameters parameters, HistoryOperationState state)
 {
+    if (parameters.has<ReloadHistoryOperationParameters>()) {
+        VERIFY(!state.on_apply_complete);
+        state.on_apply_complete = GC::create_function(heap(), [this](HistoryStepResult result) {
+            if (result == HistoryStepResult::Applied)
+                return;
+
+            // NB: A canceled reload must not keep treating the active
+            //     session history entry as an in-flight reload.
+            if (auto current_entry = current_session_history_entry(); current_entry && current_entry->document_state()->reload_pending()) {
+                current_entry->document_state()->set_reload_pending(false);
+                page().client().page_did_set_session_history_entry_document_state_reload_pending(
+                    id(), current_entry->navigation_api_key(), false);
+            }
+        });
+    }
+
     auto initiation_id = m_next_history_initiation_id++;
     m_history_operation_states.set(initiation_id, move(state));
 
@@ -2478,9 +2494,17 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
 
             auto initiation = m_history_operation_states.find(initiation_id);
             VERIFY(initiation != m_history_operation_states.end());
-            VERIFY(step_override.has_value());
 
-            auto apply = [&](auto const& parameters, HistoryHandlingBehavior history_handling) {
+            auto on_apply_complete = GC::create_function(heap(), [this, initiation_id, queue_signal](HistoryStepResult result) {
+                auto initiation = m_history_operation_states.find(initiation_id);
+                VERIFY(initiation != m_history_operation_states.end());
+                if (initiation->value.on_apply_complete)
+                    initiation->value.on_apply_complete->function()(result);
+                complete_history_initiation(initiation_id, result, queue_signal);
+            });
+
+            auto apply_push_or_replace = [&](auto const& parameters, HistoryHandlingBehavior history_handling) {
+                VERIFY(step_override.has_value());
                 apply_the_push_or_replace_history_step(
                     *step_override,
                     history_handling,
@@ -2489,23 +2513,24 @@ void LocalTraversableNavigable::request_history_operation(HistoryOperationParame
                     initiation->value.pending_document,
                     initiation->value.expected_ongoing_navigation_navigable,
                     move(initiation->value.expected_ongoing_navigation_id),
-                    GC::create_function(heap(), [this, initiation_id, queue_signal](HistoryStepResult result) {
-                        auto initiation = m_history_operation_states.find(initiation_id);
-                        VERIFY(initiation != m_history_operation_states.end());
-                        if (initiation->value.on_apply_complete)
-                            initiation->value.on_apply_complete->function()(result);
-                        complete_history_initiation(initiation_id, result, queue_signal);
-                    }));
+                    on_apply_complete);
             };
             parameters.visit(
-                [&](PushHistoryOperationParameters const& parameters) { apply(parameters, HistoryHandlingBehavior::Push); },
-                [&](ReplaceHistoryOperationParameters const& parameters) { apply(parameters, HistoryHandlingBehavior::Replace); });
+                [&](PushHistoryOperationParameters const& parameters) { apply_push_or_replace(parameters, HistoryHandlingBehavior::Push); },
+                [&](ReplaceHistoryOperationParameters const& parameters) { apply_push_or_replace(parameters, HistoryHandlingBehavior::Replace); },
+                [&](ReloadHistoryOperationParameters const& parameters) {
+                    VERIFY(!step_override.has_value());
+                    apply_the_reload_history_step(parameters.user_involvement, on_apply_complete);
+                });
         });
 
         auto initiation = m_history_operation_states.find(initiation_id);
         VERIFY(initiation != m_history_operation_states.end());
-        VERIFY(initiation->value.pre_steps);
-        initiation->value.pre_steps->function()(ready);
+        if (initiation->value.pre_steps) {
+            initiation->value.pre_steps->function()(ready);
+            return;
+        }
+        ready->function()(true, {}, HistoryStepResult::Applied);
     }));
 }
 
@@ -2666,19 +2691,7 @@ void LocalTraversableNavigable::apply_the_reload_history_step(UserNavigationInvo
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, null, null, null, and "reload".
-    apply_the_history_step(step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {},
-        GC::create_function(heap(), [this, on_complete](HistoryStepResult result) {
-            if (result != HistoryStepResult::Applied) {
-                // NB: A canceled reload must not keep treating the active
-                //     session history entry as an in-flight reload.
-                if (auto current_entry = current_session_history_entry(); current_entry && current_entry->document_state()->reload_pending()) {
-                    current_entry->document_state()->set_reload_pending(false);
-                    page().client().page_did_set_session_history_entry_document_state_reload_pending(
-                        id(), current_entry->navigation_api_key(), false);
-                }
-            }
-            on_complete->function()(result);
-        }));
+    apply_the_history_step(step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No, LocalNavigable::NavigationAPIAbortBehavior::Abort, nullptr, nullptr, {}, on_complete);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-push/replace-history-step

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -61,6 +61,7 @@ void LocalTraversableNavigable::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_storage_shed);
     visitor.visit(m_apply_history_step_state);
     visitor.visit(m_paused_apply_history_step_state);
+    visitor.visit(m_apply_history_step_operations);
     for (auto& pending_navigation : m_pending_same_document_navigations)
         visitor.visit(pending_navigation.value.target_navigable);
 }
@@ -772,6 +773,74 @@ struct ChangingNavigableContinuationState : public JS::Cell {
 
 GC_DEFINE_ALLOCATOR(ChangingNavigableContinuationState);
 
+class ApplyHistoryStepOperationState : public GC::Cell {
+    GC_CELL(ApplyHistoryStepOperationState, GC::Cell);
+    GC_DECLARE_ALLOCATOR(ApplyHistoryStepOperationState);
+
+public:
+    explicit ApplyHistoryStepOperationState(LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior)
+        : m_navigation_api_abort_behavior(navigation_api_abort_behavior)
+    {
+    }
+
+    bool completed() const { return m_completed; }
+    LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior() const { return m_navigation_api_abort_behavior; }
+
+    void did_claim_navigable(CrossProcessId navigable_id)
+    {
+        VERIFY(!m_completed);
+        VERIFY(!m_claimed_navigables.contains(navigable_id));
+        m_claimed_navigables.set(navigable_id);
+    }
+
+    bool release_navigable(CrossProcessId navigable_id)
+    {
+        if (!m_claimed_navigables.contains(navigable_id))
+            return false;
+        m_claimed_navigables.remove(navigable_id);
+        return true;
+    }
+    HashTable<CrossProcessId> const& claimed_navigables() const { return m_claimed_navigables; }
+
+    void store_continuation(CrossProcessId navigable_id, GC::Ref<ChangingNavigableContinuationState> continuation)
+    {
+        VERIFY(!m_completed);
+        VERIFY(m_claimed_navigables.contains(navigable_id));
+        VERIFY(!m_continuations.contains(navigable_id));
+        m_continuations.set(navigable_id, continuation);
+    }
+
+    GC::Ref<ChangingNavigableContinuationState> take_continuation(CrossProcessId navigable_id)
+    {
+        VERIFY(release_navigable(navigable_id));
+        auto continuation = m_continuations.take(navigable_id);
+        VERIFY(continuation.has_value());
+        return continuation.release_value();
+    }
+
+    void complete()
+    {
+        m_completed = true;
+        m_continuations.clear();
+    }
+
+private:
+    virtual void visit_edges(Cell::Visitor& visitor) override
+    {
+        Base::visit_edges(visitor);
+        visitor.visit(m_continuations);
+    }
+
+    LocalNavigable::NavigationAPIAbortBehavior m_navigation_api_abort_behavior;
+    bool m_completed { false };
+    HashTable<CrossProcessId> m_claimed_navigables;
+    HashMap<CrossProcessId, GC::Ref<ChangingNavigableContinuationState>> m_continuations;
+};
+
+GC_DEFINE_ALLOCATOR(ApplyHistoryStepOperationState);
+
+static void clear_ongoing_history_traversal(GC::Ptr<LocalNavigable>, LocalNavigable::NavigationAPIAbortBehavior);
+
 static void queue_apply_history_step_task(GC::Ref<LocalNavigable> navigable, GC::Ptr<DOM::Document> top_level_document, GC::Ref<GC::Function<void()>> steps)
 {
     // AD-HOC: Queue top-level tasks with the active Document instead of using queue_global_task(active_window).
@@ -829,14 +898,16 @@ public:
             }
         })))
     {
+        m_job_runner.start_apply_history_step_operation(m_generation, m_navigation_api_abort_behavior);
         m_timeout->start();
     }
 
     void start();
 
-    void did_receive_continuation(GC::Ref<ChangingNavigableContinuationState> continuation)
+    void did_receive_continuation(CrossProcessId navigable_id)
     {
-        m_continuations.append(continuation);
+        VERIFY(m_phase != Phase::Completed);
+        m_continuations.append(navigable_id);
         signal_progress();
     }
 
@@ -877,7 +948,6 @@ private:
         visitor.visit(m_pending_document);
         visitor.visit(m_on_complete);
         visitor.visit(m_timeout);
-        visitor.visit(m_continuations);
     }
 
     void try_advance()
@@ -909,9 +979,7 @@ private:
     void enter_waiting_for_non_changing_jobs();
     void complete();
     void finish_without_applying();
-    void complete_change_job_without_applying(GC::Ptr<LocalNavigable>);
-    void clear_ongoing_traversal_for_changing_navigable(GC::Ptr<LocalNavigable>);
-    void clear_ongoing_traversals_for_changing_navigables();
+    void complete_change_job_without_applying();
 
     Phase m_phase { Phase::WaitingForDocumentPopulation };
     u64 m_generation { 0 };
@@ -935,7 +1003,7 @@ private:
     Vector<CrossProcessId> m_non_changing_navigables;
 
     size_t m_completed_change_jobs { 0 };
-    Vector<GC::Ref<ChangingNavigableContinuationState>> m_continuations;
+    Vector<CrossProcessId> m_continuations;
     size_t m_continuation_index { 0 };
 
     RefPtr<Core::Promise<Empty>> m_pending_sync_nav_promise;
@@ -973,6 +1041,7 @@ void ApplyHistoryStepState::start()
     // 12. For each navigable of changingNavigables, queue a global task on the navigation and traversal task source.
     for (auto navigable_id : m_changing_navigables) {
         m_job_runner.run_changing_navigable_history_step_job(
+            m_generation,
             {
                 .navigable_id = navigable_id,
                 .target_step = m_target_step,
@@ -983,14 +1052,13 @@ void ApplyHistoryStepState::start()
                 .navigation_api_abort_behavior = m_navigation_api_abort_behavior,
                 .pending_document = m_pending_document,
             },
-            GC::create_function(heap(), [this, navigable_id](ApplyHistoryStepJobRunner::ChangingNavigableHistoryStepJobResult result) {
-                switch (result.disposition) {
+            GC::create_function(heap(), [this, navigable_id](ChangingNavigableHistoryStepJobDisposition disposition) {
+                switch (disposition) {
                 case ChangingNavigableHistoryStepJobDisposition::Ready:
-                    VERIFY(result.continuation);
-                    did_receive_continuation(*result.continuation);
+                    did_receive_continuation(navigable_id);
                     break;
                 case ChangingNavigableHistoryStepJobDisposition::Skipped:
-                    complete_change_job_without_applying(local_navigable_with_id(navigable_id));
+                    complete_change_job_without_applying();
                     break;
                 case ChangingNavigableHistoryStepJobDisposition::Stale:
                     finish_without_applying();
@@ -1002,12 +1070,60 @@ void ApplyHistoryStepState::start()
     try_advance();
 }
 
-void LocalTraversableNavigable::run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob job, GC::Ref<OnChangingNavigableHistoryStepJobComplete> on_complete)
+void LocalTraversableNavigable::start_apply_history_step_operation(u64 operation_id, LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior)
+{
+    VERIFY(!m_apply_history_step_operations.contains(operation_id));
+    m_apply_history_step_operations.set(operation_id, heap().allocate<ApplyHistoryStepOperationState>(navigation_api_abort_behavior));
+}
+
+void LocalTraversableNavigable::complete_apply_history_step_operation(u64 operation_id)
+{
+    auto operation = m_apply_history_step_operations.take(operation_id);
+    VERIFY(operation.has_value());
+
+    auto operation_state = operation.release_value();
+    for (auto navigable_id : operation_state->claimed_navigables())
+        clear_ongoing_history_traversal(local_navigable_with_id(navigable_id), operation_state->navigation_api_abort_behavior());
+    operation_state->complete();
+}
+
+void LocalTraversableNavigable::run_changing_navigable_history_step_job(u64 operation_id, ChangingNavigableHistoryStepJob job, GC::Ref<OnChangingNavigableHistoryStepJobComplete> on_complete)
+{
+    auto operation_iterator = m_apply_history_step_operations.find(operation_id);
+    VERIFY(operation_iterator != m_apply_history_step_operations.end());
+
+    auto operation = operation_iterator->value;
+    auto navigable_id = job.navigable_id;
+    auto navigation_api_abort_behavior = job.navigation_api_abort_behavior;
+    auto did_claim_navigable = run_changing_navigable_history_step_job_impl(move(job),
+        GC::create_function(heap(), [operation, navigable_id, navigation_api_abort_behavior, on_complete](LocalChangingNavigableHistoryStepJobResult result) {
+            if (operation->completed()) {
+                VERIFY(operation->release_navigable(navigable_id));
+                clear_ongoing_history_traversal(local_navigable_with_id(navigable_id), navigation_api_abort_behavior);
+                on_complete->function()(ChangingNavigableHistoryStepJobDisposition::Skipped);
+                return;
+            }
+
+            if (result.disposition == ChangingNavigableHistoryStepJobDisposition::Ready) {
+                VERIFY(result.continuation);
+                operation->store_continuation(navigable_id, *result.continuation);
+            } else {
+                if (operation->release_navigable(navigable_id))
+                    clear_ongoing_history_traversal(local_navigable_with_id(navigable_id), navigation_api_abort_behavior);
+            }
+            on_complete->function()(result.disposition);
+        }));
+
+    if (did_claim_navigable)
+        operation->did_claim_navigable(navigable_id);
+}
+
+bool LocalTraversableNavigable::run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob job, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete> on_complete)
 {
     auto navigable = local_navigable_with_id(job.navigable_id);
     if (!navigable) {
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-        return;
+        return false;
     }
 
     // AD-HOC: If the navigable has been destroyed, or has no active window, skip it.
@@ -1015,12 +1131,12 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
     //         associated with a document from the task queue, which can cause those tasks to never run.
     if (navigable->has_been_destroyed() || !navigable->active_window()) {
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-        return;
+        return false;
     }
     if (job.synchronous_navigation == SynchronousNavigation::Yes
         && synchronous_same_document_navigation_must_preserve_ongoing_navigation(*navigable)) {
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-        return;
+        return false;
     }
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#creating-a-new-child-navigable
@@ -1029,14 +1145,14 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
     //     owns the ongoing navigation ID and eventual document activation.
     if (!job.navigation_type.has_value() && navigable->ongoing_navigation().has<Utf16String>()) {
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-        return;
+        return false;
     }
 
     // 1. Let targetEntry be the result of getting the target history entry given navigable and targetStep.
     auto claimed_target_entry = navigable->get_the_target_history_entry_if_present(job.target_step);
     if (!claimed_target_entry) {
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-        return;
+        return false;
     }
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction
@@ -1051,7 +1167,7 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
         auto active_document = navigable->active_document();
         if (would_cross_documents && !(active_document && active_document->is_initial_about_blank())) {
             on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-            return;
+            return false;
         }
     }
 
@@ -1065,7 +1181,7 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
         && navigable->ongoing_navigation().has<Utf16String>()
         && claimed_target_entry->document_state()->document_id() == navigable->active_document_id()) {
         on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
-        return;
+        return false;
     }
 
     // 2. Set navigable's current session history entry to targetEntry.
@@ -1075,7 +1191,6 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
     navigable->set_ongoing_navigation(HTML::LocalNavigable::Traversal::Tag, job.navigation_api_abort_behavior);
 
     queue_apply_history_step_task(*navigable, navigable->active_document(), GC::create_function(heap(), [this, job = move(job), claimed_target_entry = claimed_target_entry.release_nonnull(), navigable, on_complete] {
-
         // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
         if (navigable->has_been_destroyed() || !navigable->active_window() || !navigable->active_document()) {
             on_complete->function()({ ChangingNavigableHistoryStepJobDisposition::Skipped, nullptr });
@@ -1301,6 +1416,7 @@ void LocalTraversableNavigable::run_changing_navigable_history_step_job(Changing
             after_document_populated->function()(nullptr);
         }
     }));
+    return true;
 }
 
 void ApplyHistoryStepState::process_continuations()
@@ -1354,8 +1470,12 @@ void ApplyHistoryStepState::process_continuations()
 
         // 3. If changingNavigableContinuation is nothing, then continue.
 
-        auto continuation = m_continuations[m_continuation_index++];
-        auto continuation_navigable_id = continuation->navigable->id();
+        auto navigable_id = m_continuations[m_continuation_index++];
+        auto navigable = local_navigable_with_id(navigable_id);
+        if (!navigable) {
+            signal_progress();
+            continue;
+        }
 
         m_target_step = m_traversable->get_the_used_step(m_step);
 
@@ -1363,14 +1483,15 @@ void ApplyHistoryStepState::process_continuations()
         auto history_object_length_and_index = m_traversable->get_the_history_object_length_and_index(m_target_step);
 
         // 8. Append navigable to navigablesThatMustWaitBeforeHandlingSyncNavigation.
-        m_navigables_that_must_wait_before_handling_sync_navigation.set(continuation_navigable_id);
+        m_navigables_that_must_wait_before_handling_sync_navigation.set(navigable_id);
 
         // 9. Let entriesForNavigationAPI be the result of getting session history entries for the navigation API given navigable and targetStep.
-        auto entries_for_navigation_api = m_traversable->get_session_history_entries_for_the_navigation_api(continuation_navigable_id, m_target_step);
+        auto entries_for_navigation_api = m_traversable->get_session_history_entries_for_the_navigation_api(*navigable, m_target_step);
 
         m_job_runner.apply_changing_navigable_history_step_continuation(
+            m_generation,
             {
-                .continuation = continuation,
+                .navigable_id = navigable_id,
                 .history_object_length_and_index = history_object_length_and_index,
                 .entries_for_navigation_api = move(entries_for_navigation_api),
                 .navigation_type = m_navigation_type,
@@ -1414,9 +1535,17 @@ static void clear_ongoing_history_traversal(GC::Ptr<LocalNavigable> navigable, L
     navigable->set_ongoing_navigation({}, navigation_api_abort_behavior);
 }
 
-void LocalTraversableNavigable::apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation command, GC::Ref<GC::Function<void()>> on_complete)
+void LocalTraversableNavigable::apply_changing_navigable_history_step_continuation(u64 operation_id, ApplyChangingNavigableHistoryStepContinuation command, GC::Ref<GC::Function<void()>> on_complete)
 {
-    auto continuation = command.continuation;
+    auto operation = m_apply_history_step_operations.find(operation_id);
+    VERIFY(operation != m_apply_history_step_operations.end());
+
+    auto continuation = operation->value->take_continuation(command.navigable_id);
+    apply_changing_navigable_history_step_continuation_impl(continuation, move(command), on_complete);
+}
+
+void LocalTraversableNavigable::apply_changing_navigable_history_step_continuation_impl(GC::Ref<ChangingNavigableContinuationState> continuation, ApplyChangingNavigableHistoryStepContinuation command, GC::Ref<GC::Function<void()>> on_complete)
+{
 
     // 4. Let displayedDocument be changingNavigableContinuation's displayed document.
     auto displayed_document = continuation->displayed_document;
@@ -1699,6 +1828,7 @@ void ApplyHistoryStepState::complete()
     }
 
     m_traversable->retire_claimed_session_history_step(m_target_step);
+    m_job_runner.complete_apply_history_step_operation(m_generation);
 
     // Clear state BEFORE on_complete, because on_complete may resolve a promise
     // that triggers the next session history traversal queue entry.
@@ -1717,36 +1847,23 @@ void ApplyHistoryStepState::finish_without_applying()
         return;
     m_phase = Phase::Completed;
     m_timeout->stop();
-    clear_ongoing_traversals_for_changing_navigables();
+    m_job_runner.complete_apply_history_step_operation(m_generation);
     m_traversable->retire_claimed_session_history_step(m_target_step);
     m_traversable->m_apply_history_step_state = nullptr;
     if (m_on_complete)
         m_on_complete->function()(HistoryStepResult::Applied);
 }
 
-void ApplyHistoryStepState::complete_change_job_without_applying(GC::Ptr<LocalNavigable> navigable)
+void ApplyHistoryStepState::complete_change_job_without_applying()
 {
     if (m_phase == Phase::Completed)
         return;
-
-    clear_ongoing_traversal_for_changing_navigable(navigable);
 
     // NB: During document population, signal_progress() only advances the state
     //     machine. Later phases let it own the per-change-job accounting.
     if (m_phase == Phase::WaitingForDocumentPopulation)
         ++m_completed_change_jobs;
     signal_progress();
-}
-
-void ApplyHistoryStepState::clear_ongoing_traversal_for_changing_navigable(GC::Ptr<LocalNavigable> navigable)
-{
-    clear_ongoing_history_traversal(navigable, m_navigation_api_abort_behavior);
-}
-
-void ApplyHistoryStepState::clear_ongoing_traversals_for_changing_navigables()
-{
-    for (auto navigable_id : m_changing_navigables)
-        clear_ongoing_traversal_for_changing_navigable(local_navigable_with_id(navigable_id));
 }
 
 int LocalTraversableNavigable::claim_next_session_history_step()
@@ -1814,55 +1931,99 @@ void LocalTraversableNavigable::run_the_history_step_prechecks(
     // 2. Let targetStep be the result of getting the used step given traversable and step.
     auto target_step = get_the_used_step(step);
 
+    auto continue_after_sandboxing = GC::create_function(heap(), [this, target_step, check_for_cancelation, user_involvement, navigation_type, navigation_api_abort_behavior, on_complete]() mutable {
+        // 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
+        auto navigables_crossing_documents = get_all_local_navigables_that_might_experience_a_cross_document_traversal(target_step);
+
+        // NB: Same-document traversals finish their NavigateEvent during the Navigation API entry
+        //     update, after currententrychange. Preserve that event while applying the history step.
+        if (navigation_type == Bindings::NavigationType::Traverse && navigables_crossing_documents.is_empty())
+            navigation_api_abort_behavior = LocalNavigable::NavigationAPIAbortBehavior::Preserve;
+
+        // 5. If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
+        //    and userInvolvement is not "continue", then return that result.
+        if (!check_for_cancelation) {
+            on_complete->function()(HistoryStepResult::Applied, target_step, navigation_api_abort_behavior);
+            return;
+        }
+
+        Vector<CrossProcessId> navigable_ids;
+        navigable_ids.ensure_capacity(navigables_crossing_documents.size());
+        for (auto const& navigable : navigables_crossing_documents)
+            navigable_ids.unchecked_append(navigable->id());
+        run_history_step_unload_cancelation_job(target_step, move(navigable_ids), user_involvement,
+            GC::create_function(heap(), [target_step, navigation_api_abort_behavior, on_complete](HistoryStepResult result) {
+                on_complete->function()(result, target_step, navigation_api_abort_behavior);
+            }));
+    });
+
     // 3. If initiatorToCheck is not null, then:
     if (initiator_to_check != nullptr) {
         // 1. Assert: sourceSnapshotParams is not null.
         VERIFY(source_snapshot_params);
 
+        Vector<CrossProcessId> navigable_ids;
         auto target_top_level_entry = get_the_target_history_entry(target_step);
-        if (target_top_level_entry != current_session_history_entry()
-            && !initiator_to_check->allowed_by_sandboxing_to_navigate(*this, *source_snapshot_params)) {
-            on_complete->function()(HistoryStepResult::InitiatorDisallowed, target_step, navigation_api_abort_behavior);
-            return;
-        }
+        if (target_top_level_entry != current_session_history_entry())
+            navigable_ids.append(id());
 
         // 2. For each navigable of get all navigables whose current session history entry will change or reload:
         //    if initiatorToCheck is not allowed by sandboxing to navigate navigable given sourceSnapshotParams, then return "initiator-disallowed".
         for (auto const& navigable : get_all_local_navigables_whose_current_session_history_entry_will_change_or_reload(target_step)) {
-            if (!initiator_to_check->allowed_by_sandboxing_to_navigate(*navigable, *source_snapshot_params)) {
-                on_complete->function()(HistoryStepResult::InitiatorDisallowed, target_step, navigation_api_abort_behavior);
-                return;
-            }
+            if (!navigable_ids.contains_slow(navigable->id()))
+                navigable_ids.append(navigable->id());
         }
-    }
 
-    // 4. Let navigablesCrossingDocuments be the result of getting all navigables that might experience a cross-document traversal given traversable and targetStep.
-    auto navigables_crossing_documents = get_all_local_navigables_that_might_experience_a_cross_document_traversal(target_step);
-
-    // NB: Same-document traversals finish their NavigateEvent during the Navigation API entry
-    //     update, after currententrychange. Preserve that event while applying the history step.
-    if (navigation_type == Bindings::NavigationType::Traverse && navigables_crossing_documents.is_empty())
-        navigation_api_abort_behavior = LocalNavigable::NavigationAPIAbortBehavior::Preserve;
-
-    // 5. If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
-    //    and userInvolvement is not "continue", then return that result.
-    if (check_for_cancelation) {
-        check_if_unloading_is_canceled(navigables_crossing_documents, *this, target_step, user_involvement,
-            GC::create_function(heap(), [target_step, navigation_api_abort_behavior, on_complete](CheckIfUnloadingIsCanceledResult result) mutable {
-                if (result == CheckIfUnloadingIsCanceledResult::CanceledByBeforeUnload) {
-                    on_complete->function()(HistoryStepResult::CanceledByBeforeUnload, target_step, navigation_api_abort_behavior);
+        run_initiator_sandboxing_check_job(*initiator_to_check, *source_snapshot_params, move(navigable_ids),
+            GC::create_function(heap(), [target_step, navigation_api_abort_behavior, continue_after_sandboxing, on_complete](InitiatorSandboxingCheckResult result) {
+                if (result == InitiatorSandboxingCheckResult::Disallowed) {
+                    on_complete->function()(HistoryStepResult::InitiatorDisallowed, target_step, navigation_api_abort_behavior);
                     return;
                 }
-                if (result == CheckIfUnloadingIsCanceledResult::CanceledByNavigate) {
-                    on_complete->function()(HistoryStepResult::CanceledByNavigate, target_step, navigation_api_abort_behavior);
-                    return;
-                }
-                on_complete->function()(HistoryStepResult::Applied, target_step, navigation_api_abort_behavior);
+                continue_after_sandboxing->function()();
             }));
         return;
     }
 
-    on_complete->function()(HistoryStepResult::Applied, target_step, navigation_api_abort_behavior);
+    continue_after_sandboxing->function()();
+}
+
+void LocalTraversableNavigable::run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams> source_snapshot_params, Vector<CrossProcessId> navigable_ids, GC::Ref<OnInitiatorSandboxingCheckComplete> on_complete)
+{
+    for (auto navigable_id : navigable_ids) {
+        auto navigable = local_navigable_with_id(navigable_id);
+        if (navigable && !initiator_to_check->allowed_by_sandboxing_to_navigate(*navigable, source_snapshot_params)) {
+            on_complete->function()(InitiatorSandboxingCheckResult::Disallowed);
+            return;
+        }
+    }
+    on_complete->function()(InitiatorSandboxingCheckResult::Allowed);
+}
+
+void LocalTraversableNavigable::run_history_step_unload_cancelation_job(int target_step, Vector<CrossProcessId> navigable_ids, UserNavigationInvolvement user_involvement, GC::Ref<OnHistoryStepUnloadCancelationComplete> on_complete)
+{
+    Vector<GC::Root<LocalNavigable>> navigables;
+    navigables.ensure_capacity(navigable_ids.size());
+    for (auto navigable_id : navigable_ids) {
+        if (auto navigable = local_navigable_with_id(navigable_id))
+            navigables.unchecked_append(*navigable);
+    }
+
+    check_if_unloading_is_canceled(move(navigables), *this, target_step, user_involvement,
+        GC::create_function(heap(), [on_complete](CheckIfUnloadingIsCanceledResult result) {
+            switch (result) {
+            case CheckIfUnloadingIsCanceledResult::CanceledByBeforeUnload:
+                on_complete->function()(HistoryStepResult::CanceledByBeforeUnload);
+                return;
+            case CheckIfUnloadingIsCanceledResult::CanceledByNavigate:
+                on_complete->function()(HistoryStepResult::CanceledByNavigate);
+                return;
+            case CheckIfUnloadingIsCanceledResult::Continue:
+                on_complete->function()(HistoryStepResult::Applied);
+                return;
+            }
+            VERIFY_NOT_REACHED();
+        }));
 }
 
 void LocalTraversableNavigable::apply_the_history_step_after_unload_check(

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -14,6 +14,7 @@
 #include <LibWeb/Bindings/NavigationType.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Geolocation/Geolocation.h>
+#include <LibWeb/HTML/ApplyHistoryStepJobRunner.h>
 #include <LibWeb/HTML/LocalNavigable.h>
 #include <LibWeb/HTML/SessionHistoryTraversalQueue.h>
 #include <LibWeb/HTML/VisibilityState.h>
@@ -34,7 +35,9 @@ class ApplyHistoryStepState;
 struct ChangingNavigableContinuationState;
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable
-class WEB_API LocalTraversableNavigable final : public LocalNavigable {
+class WEB_API LocalTraversableNavigable final
+    : public LocalNavigable
+    , public ApplyHistoryStepJobRunner {
     GC_CELL(LocalTraversableNavigable, LocalNavigable);
     GC_DECLARE_ALLOCATOR(LocalTraversableNavigable);
 
@@ -74,52 +77,15 @@ public:
     bool is_created_by_web_content() const { return m_is_created_by_web_content; }
     void set_is_created_by_web_content(bool value) { m_is_created_by_web_content = value; }
 
-    struct HistoryObjectLengthAndIndex {
-        u64 script_history_length;
-        u64 script_history_index;
-    };
     HistoryObjectLengthAndIndex get_the_history_object_length_and_index(int) const;
 
     void apply_the_traverse_history_step(int, GC::Ptr<SourceSnapshotParams>, GC::Ptr<LocalNavigable>, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     void resume_applying_the_traverse_history_step(int, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     void apply_the_reload_history_step(UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
-    enum class SynchronousNavigation : bool {
-        Yes,
-        No,
-    };
 
-    struct ChangingNavigableHistoryStepJob {
-        CrossProcessId navigable_id;
-        NonnullRefPtr<SessionHistoryEntry> target_entry;
-        GC::Ptr<SourceSnapshotParams> source_snapshot_params;
-        UserNavigationInvolvement user_involvement;
-        Optional<Bindings::NavigationType> navigation_type;
-        SynchronousNavigation synchronous_navigation;
-        LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
-        GC::Ptr<DOM::Document> pending_document;
-    };
-    enum class ChangingNavigableHistoryStepJobDisposition {
-        Ready,
-        Skipped,
-        Stale,
-    };
-    struct ChangingNavigableHistoryStepJobResult {
-        ChangingNavigableHistoryStepJobDisposition disposition;
-        GC::Ptr<ChangingNavigableContinuationState> continuation;
-    };
-    using OnChangingNavigableHistoryStepJobComplete = GC::Function<void(ChangingNavigableHistoryStepJobResult)>;
-    void run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>);
-
-    struct ApplyChangingNavigableHistoryStepContinuation {
-        GC::Ref<ChangingNavigableContinuationState> continuation;
-        HistoryObjectLengthAndIndex history_object_length_and_index;
-        Vector<NonnullRefPtr<SessionHistoryEntry>> entries_for_navigation_api;
-        Optional<Bindings::NavigationType> navigation_type;
-        LocalNavigable::NavigationAPIAbortBehavior navigation_api_abort_behavior;
-        UserNavigationInvolvement user_involvement;
-    };
-    void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete);
-    void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete);
+    virtual void run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) override;
+    virtual void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) override;
+    virtual void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete) override;
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
@@ -234,6 +200,7 @@ private:
     void check_if_unloading_is_canceled(Vector<GC::Root<LocalNavigable>> navigables_that_need_before_unload, GC::Ptr<LocalTraversableNavigable> traversable, Optional<int> target_step, Optional<UserNavigationInvolvement> user_involvement_for_navigate_events, GC::Ref<GC::Function<void(CheckIfUnloadingIsCanceledResult)>> callback);
 
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(GC::Ref<LocalNavigable>, int);
+    Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(CrossProcessId, int);
 
     [[nodiscard]] bool can_go_back() const;
     [[nodiscard]] bool can_go_forward() const;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -227,6 +227,7 @@ private:
 
     void complete_history_initiation(u64 initiation_id, HistoryStepResult, NonnullRefPtr<Core::Promise<Empty>> queue_signal);
     GC::Ref<SessionHistoryTraversalSteps> create_history_operation_steps(HistoryOperationParameters, HistoryOperationState);
+    void run_close_top_level_traversable_steps(GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(GC::Ref<LocalNavigable>, int);
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(CrossProcessId, int);

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -103,6 +103,7 @@ public:
         GC::Ptr<OnApplyHistoryStepComplete> on_complete;
     };
     void request_history_operation(HistoryOperationParameters, HistoryOperationState = {});
+    void request_synchronous_navigation_history_operation(GC::Ref<LocalNavigable> target_navigable, HistoryOperationParameters, HistoryOperationState = {});
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
@@ -225,6 +226,7 @@ private:
     void check_if_unloading_is_canceled(Vector<GC::Root<LocalNavigable>> navigables_that_need_before_unload, GC::Ptr<LocalTraversableNavigable> traversable, Optional<int> target_step, Optional<UserNavigationInvolvement> user_involvement_for_navigate_events, GC::Ref<GC::Function<void(CheckIfUnloadingIsCanceledResult)>> callback);
 
     void complete_history_initiation(u64 initiation_id, HistoryStepResult, NonnullRefPtr<Core::Promise<Empty>> queue_signal);
+    GC::Ref<SessionHistoryTraversalSteps> create_history_operation_steps(HistoryOperationParameters, HistoryOperationState);
 
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(GC::Ref<LocalNavigable>, int);
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(CrossProcessId, int);
@@ -274,12 +276,10 @@ private:
         GC::Ref<LocalNavigable> target_navigable;
         NonnullRefPtr<SessionHistoryEntry> target_entry;
         RefPtr<SessionHistoryEntry> entry_to_replace;
-        HistoryHandlingBehavior history_handling;
-        UserNavigationInvolvement user_involvement;
         Optional<int> provisional_claimed_step;
-        RefPtr<Core::Promise<Empty>> signal;
+        GC::Ptr<OnHistoryOperationReady> ready;
     };
-    void begin_same_document_navigation_finalization(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement, RefPtr<Core::Promise<Empty>> signal);
+    void begin_same_document_navigation_finalization(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, FinalizeSameDocumentNavigationHistoryOperationParameters const&, GC::Ptr<OnHistoryOperationReady> ready);
     void set_history_object_length_and_index(HistoryObjectLengthAndIndex);
     u64 m_next_same_document_navigation_operation_id { 1 };
     HashMap<u64, PendingSameDocumentNavigation> m_pending_same_document_navigations;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -107,7 +107,7 @@ public:
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
-    void apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
+    void apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ref<OnApplyHistoryStepComplete> on_complete);
     void update_for_navigable_creation_or_destruction(u64 history_initiation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
     int get_the_used_step(int step) const;
@@ -195,8 +195,6 @@ private:
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation,
         LocalNavigable::NavigationAPIAbortBehavior,
-        GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
-        Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
     void apply_the_history_step_after_unload_check(
@@ -207,9 +205,9 @@ private:
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation,
         LocalNavigable::NavigationAPIAbortBehavior,
-        GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
-        Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete);
+
+    bool history_initiation_expected_ongoing_navigation_was_superseded(u64 history_initiation_id) const;
 
     using OnHistoryStepPrechecksComplete = GC::Function<void(HistoryStepResult, int target_step, LocalNavigable::NavigationAPIAbortBehavior)>;
     void run_the_history_step_prechecks(

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -85,20 +85,21 @@ public:
     void apply_the_reload_history_step(u64 history_initiation_id, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     virtual void start_apply_history_step_operation(u64 operation_id, u64 history_initiation_id, LocalNavigable::NavigationAPIAbortBehavior) override;
     virtual void complete_apply_history_step_operation(u64 operation_id) override;
-    virtual void run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) override;
+    virtual void run_initiator_sandboxing_check_job(u64 history_initiation_id, CrossProcessId initiator_to_check, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) override;
     virtual void run_history_step_unload_cancelation_job(int target_step, Vector<CrossProcessId>, UserNavigationInvolvement, GC::Ref<OnHistoryStepUnloadCancelationComplete>) override;
     virtual void run_changing_navigable_history_step_job(u64 operation_id, ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) override;
     virtual void apply_changing_navigable_history_step_continuation(u64 operation_id, ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) override;
     virtual void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete) override;
 
     using OnHistoryOperationReady = GC::Function<void(bool proceed, Optional<i32> step_override, HistoryStepResult abandon_result)>;
+    using OnHistoryOperationPreSteps = GC::Function<void(u64 history_initiation_id, GC::Ref<OnHistoryOperationReady>)>;
     struct HistoryOperationState {
         GC::Ptr<DOM::Document> pending_document;
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable;
         Optional<Utf16String> expected_ongoing_navigation_id;
         GC::Ptr<SourceSnapshotParams> source_snapshot_params;
         GC::Ptr<LocalNavigable> initiator_to_check;
-        GC::Ptr<GC::Function<void(GC::Ref<OnHistoryOperationReady>)>> pre_steps;
+        GC::Ptr<OnHistoryOperationPreSteps> pre_steps;
         GC::Ptr<OnApplyHistoryStepComplete> on_apply_complete;
         GC::Ptr<OnApplyHistoryStepComplete> on_complete;
     };
@@ -211,6 +212,7 @@ private:
 
     using OnHistoryStepPrechecksComplete = GC::Function<void(HistoryStepResult, int target_step, LocalNavigable::NavigationAPIAbortBehavior)>;
     void run_the_history_step_prechecks(
+        u64 history_initiation_id,
         int step,
         bool check_for_cancelation,
         GC::Ptr<SourceSnapshotParams>,
@@ -219,6 +221,14 @@ private:
         Optional<Bindings::NavigationType> navigation_type,
         LocalNavigable::NavigationAPIAbortBehavior,
         GC::Ref<OnHistoryStepPrechecksComplete>);
+    void run_history_step_prechecks_after_sandboxing(
+        int target_step,
+        bool check_for_cancelation,
+        UserNavigationInvolvement user_involvement,
+        Optional<Bindings::NavigationType> navigation_type,
+        LocalNavigable::NavigationAPIAbortBehavior,
+        GC::Ref<OnHistoryStepPrechecksComplete>);
+    void run_initiator_sandboxing_check_job_impl(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>);
 
     void check_if_unloading_is_canceled(Vector<GC::Root<LocalNavigable>> navigables_that_need_before_unload, GC::Ptr<LocalTraversableNavigable> traversable, Optional<int> target_step, Optional<UserNavigationInvolvement> user_involvement_for_navigate_events, GC::Ref<GC::Function<void(CheckIfUnloadingIsCanceledResult)>> callback);
 

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -91,6 +91,17 @@ public:
     virtual void apply_changing_navigable_history_step_continuation(u64 operation_id, ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) override;
     virtual void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete) override;
 
+    using OnHistoryOperationReady = GC::Function<void(bool proceed, Optional<i32> step_override, HistoryStepResult abandon_result)>;
+    struct HistoryOperationState {
+        GC::Ptr<DOM::Document> pending_document;
+        GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable;
+        Optional<Utf16String> expected_ongoing_navigation_id;
+        GC::Ptr<GC::Function<void(GC::Ref<OnHistoryOperationReady>)>> pre_steps;
+        GC::Ptr<OnApplyHistoryStepComplete> on_apply_complete;
+        GC::Ptr<OnApplyHistoryStepComplete> on_complete;
+    };
+    void request_history_operation(HistoryOperationParameters, HistoryOperationState);
+
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
     void apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
@@ -211,6 +222,8 @@ private:
 
     void check_if_unloading_is_canceled(Vector<GC::Root<LocalNavigable>> navigables_that_need_before_unload, GC::Ptr<LocalTraversableNavigable> traversable, Optional<int> target_step, Optional<UserNavigationInvolvement> user_involvement_for_navigate_events, GC::Ref<GC::Function<void(CheckIfUnloadingIsCanceledResult)>> callback);
 
+    void complete_history_initiation(u64 initiation_id, HistoryStepResult, NonnullRefPtr<Core::Promise<Empty>> queue_signal);
+
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(GC::Ref<LocalNavigable>, int);
     Vector<NonnullRefPtr<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(CrossProcessId, int);
 
@@ -252,6 +265,8 @@ private:
     GC::Ptr<ApplyHistoryStepState> m_paused_apply_history_step_state;
     GC::Ptr<ApplyHistoryStepState> m_apply_history_step_state;
     HashMap<u64, GC::Ref<ApplyHistoryStepOperationState>> m_apply_history_step_operations;
+    u64 m_next_history_initiation_id { 1 };
+    HashMap<u64, HistoryOperationState> m_history_operation_states;
 
     struct PendingSameDocumentNavigation {
         GC::Ref<LocalNavigable> target_navigable;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -80,10 +80,10 @@ public:
 
     HistoryObjectLengthAndIndex get_the_history_object_length_and_index(int) const;
 
-    void apply_the_traverse_history_step(int, GC::Ptr<SourceSnapshotParams>, GC::Ptr<LocalNavigable>, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
-    void resume_applying_the_traverse_history_step(int, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
-    void apply_the_reload_history_step(UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
-    virtual void start_apply_history_step_operation(u64 operation_id, LocalNavigable::NavigationAPIAbortBehavior) override;
+    void apply_the_traverse_history_step(u64 history_initiation_id, int, GC::Ptr<SourceSnapshotParams>, GC::Ptr<LocalNavigable>, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
+    void resume_applying_the_traverse_history_step(u64 history_initiation_id, int, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
+    void apply_the_reload_history_step(u64 history_initiation_id, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
+    virtual void start_apply_history_step_operation(u64 operation_id, u64 history_initiation_id, LocalNavigable::NavigationAPIAbortBehavior) override;
     virtual void complete_apply_history_step_operation(u64 operation_id) override;
     virtual void run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) override;
     virtual void run_history_step_unload_cancelation_job(int target_step, Vector<CrossProcessId>, UserNavigationInvolvement, GC::Ref<OnHistoryStepUnloadCancelationComplete>) override;
@@ -107,8 +107,8 @@ public:
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
-    void apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
-    void update_for_navigable_creation_or_destruction(GC::Ref<OnApplyHistoryStepComplete> on_complete);
+    void apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
+    void update_for_navigable_creation_or_destruction(u64 history_initiation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
     int get_the_used_step(int step) const;
     Vector<GC::Root<LocalNavigable>> get_all_local_navigables_whose_current_session_history_entry_will_change_or_reload(int) const;
@@ -186,6 +186,7 @@ private:
 
     // NB: The HTML Standard spells this algorithm argument "checkForCancelation".
     void apply_the_history_step(
+        u64 history_initiation_id,
         int step,
         bool check_for_cancelation,
         GC::Ptr<SourceSnapshotParams>,
@@ -200,6 +201,7 @@ private:
         GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
     void apply_the_history_step_after_unload_check(
+        u64 history_initiation_id,
         int step,
         int target_step,
         GC::Ptr<SourceSnapshotParams> source_snapshot_params,

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -96,6 +96,8 @@ public:
         GC::Ptr<DOM::Document> pending_document;
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable;
         Optional<Utf16String> expected_ongoing_navigation_id;
+        GC::Ptr<SourceSnapshotParams> source_snapshot_params;
+        GC::Ptr<LocalNavigable> initiator_to_check;
         GC::Ptr<GC::Function<void(GC::Ref<OnHistoryOperationReady>)>> pre_steps;
         GC::Ptr<OnApplyHistoryStepComplete> on_apply_complete;
         GC::Ptr<OnApplyHistoryStepComplete> on_complete;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -100,7 +100,7 @@ public:
         GC::Ptr<OnApplyHistoryStepComplete> on_apply_complete;
         GC::Ptr<OnApplyHistoryStepComplete> on_complete;
     };
-    void request_history_operation(HistoryOperationParameters, HistoryOperationState);
+    void request_history_operation(HistoryOperationParameters, HistoryOperationState = {});
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -32,6 +32,7 @@
 namespace Web::HTML {
 
 class ApplyHistoryStepState;
+class ApplyHistoryStepOperationState;
 struct ChangingNavigableContinuationState;
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable
@@ -82,9 +83,12 @@ public:
     void apply_the_traverse_history_step(int, GC::Ptr<SourceSnapshotParams>, GC::Ptr<LocalNavigable>, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     void resume_applying_the_traverse_history_step(int, UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
     void apply_the_reload_history_step(UserNavigationInvolvement, GC::Ref<GC::Function<void(HistoryStepResult)>> on_complete);
-
-    virtual void run_changing_navigable_history_step_job(ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) override;
-    virtual void apply_changing_navigable_history_step_continuation(ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) override;
+    virtual void start_apply_history_step_operation(u64 operation_id, LocalNavigable::NavigationAPIAbortBehavior) override;
+    virtual void complete_apply_history_step_operation(u64 operation_id) override;
+    virtual void run_initiator_sandboxing_check_job(GC::Ref<LocalNavigable> initiator_to_check, GC::Ref<SourceSnapshotParams>, Vector<CrossProcessId>, GC::Ref<OnInitiatorSandboxingCheckComplete>) override;
+    virtual void run_history_step_unload_cancelation_job(int target_step, Vector<CrossProcessId>, UserNavigationInvolvement, GC::Ref<OnHistoryStepUnloadCancelationComplete>) override;
+    virtual void run_changing_navigable_history_step_job(u64 operation_id, ChangingNavigableHistoryStepJob, GC::Ref<OnChangingNavigableHistoryStepJobComplete>) override;
+    virtual void apply_changing_navigable_history_step_continuation(u64 operation_id, ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete) override;
     virtual void update_nonchanging_navigable_history_step_state(CrossProcessId navigable_id, HistoryObjectLengthAndIndex, GC::Ref<GC::Function<void()>> on_complete) override;
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
@@ -157,6 +161,14 @@ private:
     virtual bool is_traversable() const override { return true; }
 
     virtual void visit_edges(Cell::Visitor&) override;
+
+    struct LocalChangingNavigableHistoryStepJobResult {
+        ChangingNavigableHistoryStepJobDisposition disposition;
+        GC::Ptr<ChangingNavigableContinuationState> continuation;
+    };
+    using OnLocalChangingNavigableHistoryStepJobComplete = GC::Function<void(LocalChangingNavigableHistoryStepJobResult)>;
+    bool run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete>);
+    void apply_changing_navigable_history_step_continuation_impl(GC::Ref<ChangingNavigableContinuationState>, ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete);
 
     // NB: The HTML Standard spells this algorithm argument "checkForCancelation".
     void apply_the_history_step(
@@ -239,6 +251,7 @@ private:
 
     GC::Ptr<ApplyHistoryStepState> m_paused_apply_history_step_state;
     GC::Ptr<ApplyHistoryStepState> m_apply_history_step_state;
+    HashMap<u64, GC::Ref<ApplyHistoryStepOperationState>> m_apply_history_step_operations;
 
     struct PendingSameDocumentNavigation {
         GC::Ref<LocalNavigable> target_navigable;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.h
@@ -107,7 +107,7 @@ public:
 
     void finalize_same_document_navigation(GC::Ref<LocalNavigable>, NonnullRefPtr<SessionHistoryEntry>, RefPtr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
     void did_complete_finalize_same_document_navigation(u64 operation_id, bool committed, int entry_step, int target_step, HistoryObjectLengthAndIndex);
-    void apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<DOM::Document> pending_document, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
+    void apply_the_push_or_replace_history_step(u64 history_initiation_id, int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation, GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable, Optional<Utf16String> expected_ongoing_navigation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
     void update_for_navigable_creation_or_destruction(u64 history_initiation_id, GC::Ref<OnApplyHistoryStepComplete> on_complete);
 
     int get_the_used_step(int step) const;
@@ -181,7 +181,7 @@ private:
         GC::Ptr<ChangingNavigableContinuationState> continuation;
     };
     using OnLocalChangingNavigableHistoryStepJobComplete = GC::Function<void(LocalChangingNavigableHistoryStepJobResult)>;
-    bool run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete>);
+    bool run_changing_navigable_history_step_job_impl(ChangingNavigableHistoryStepJob, GC::Ptr<SourceSnapshotParams>, GC::Ptr<DOM::Document> pending_document, GC::Ref<OnLocalChangingNavigableHistoryStepJobComplete>);
     void apply_changing_navigable_history_step_continuation_impl(GC::Ref<ChangingNavigableContinuationState>, ApplyChangingNavigableHistoryStepContinuation, GC::Ref<GC::Function<void()>> on_complete);
 
     // NB: The HTML Standard spells this algorithm argument "checkForCancelation".
@@ -195,7 +195,6 @@ private:
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation,
         LocalNavigable::NavigationAPIAbortBehavior,
-        GC::Ptr<DOM::Document> pending_document,
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
         Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete);
@@ -204,12 +203,10 @@ private:
         u64 history_initiation_id,
         int step,
         int target_step,
-        GC::Ptr<SourceSnapshotParams> source_snapshot_params,
         UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation,
         LocalNavigable::NavigationAPIAbortBehavior,
-        GC::Ptr<DOM::Document> pending_document,
         GC::Ptr<LocalNavigable> expected_ongoing_navigation_navigable,
         Optional<Utf16String> expected_ongoing_navigation_id,
         GC::Ref<OnApplyHistoryStepComplete> on_complete);

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -358,12 +358,10 @@ void NavigableContainer::destroy_the_child_navigable()
         traversable->page().client().page_did_remove_nested_history(this->navigable()->id(), navigable->id());
 
         // 9. Append the following session history traversal steps to traversable:
-        traversable->append_session_history_traversal_steps(GC::create_function(GC::Heap::the(), [traversable](NonnullRefPtr<Core::Promise<Empty>> signal) {
-            // 1. Update for navigable creation/destruction given traversable.
-            traversable->update_for_navigable_creation_or_destruction(GC::create_function(GC::Heap::the(), [signal](HistoryStepResult) {
-                signal->resolve({});
-            }));
-        }));
+        // 1. Update for navigable creation/destruction given traversable.
+        traversable->request_history_operation(NavigableDestructionHistoryOperationParameters {
+            .traversable_id = traversable->id(),
+        });
     });
 
     // 5. Destroy a document and its descendants given navigable's active document.

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -115,30 +115,41 @@ void NavigableContainer::create_new_child_navigable()
     auto traversable = parent_navigable->traversable_navigable();
 
     // 12. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps(GC::create_function(GC::Heap::the(), [this, navigable, parent_navigable, history_entry, traversable](NonnullRefPtr<Core::Promise<Empty>> signal) mutable {
-        if (navigable->has_been_destroyed() || parent_navigable->has_been_destroyed()) {
-            signal->resolve({});
-            return;
-        }
+    traversable->request_history_operation(
+        NavigableCreationHistoryOperationParameters {
+            .navigable_id = navigable->id(),
+        },
+        {
+            .pending_document = nullptr,
+            .expected_ongoing_navigation_navigable = nullptr,
+            .expected_ongoing_navigation_id = {},
+            .source_snapshot_params = nullptr,
+            .initiator_to_check = nullptr,
+            .pre_steps = GC::create_function(GC::Heap::the(), [this, navigable, parent_navigable, history_entry, traversable](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) mutable {
+                if (navigable->has_been_destroyed() || parent_navigable->has_been_destroyed()) {
+                    ready->function()(false, {}, HistoryStepResult::Applied);
+                    return;
+                }
 
-        // 1-6. Append nestedHistory to parentDocState's nested histories.
-        VERIFY(append_nested_history_for_child_navigable(*parent_navigable, *navigable, *history_entry));
+                // 1-6. Append nestedHistory to parentDocState's nested histories.
+                VERIFY(append_nested_history_for_child_navigable(*parent_navigable, *navigable, *history_entry));
 
-        // 7. Update for navigable creation/destruction given traversable
-        traversable->update_for_navigable_creation_or_destruction(GC::create_function(GC::Heap::the(), [signal](HistoryStepResult) {
-            signal->resolve({});
-        }));
+                // 7. Update for navigable creation/destruction given traversable
+                ready->function()(true, {}, HistoryStepResult::Applied);
 
-        traversable->append_session_history_traversal_steps(GC::create_function(GC::Heap::the(), [this, navigable](NonnullRefPtr<Core::Promise<Empty>> signal) {
-            if (navigable->has_been_destroyed() || content_navigable() != navigable) {
-                signal->resolve({});
-                return;
-            }
+                traversable->append_session_history_traversal_steps(GC::create_function(traversable->heap(), [this, navigable](NonnullRefPtr<Core::Promise<Empty>> signal) {
+                    if (navigable->has_been_destroyed() || content_navigable() != navigable) {
+                        signal->resolve({});
+                        return;
+                    }
 
-            set_content_navigable_has_session_history_entry_and_ready_for_navigation();
-            signal->resolve({});
-        }));
-    }));
+                    set_content_navigable_has_session_history_entry_and_ready_for_navigation();
+                    signal->resolve({});
+                }));
+            }),
+            .on_apply_complete = nullptr,
+            .on_complete = nullptr,
+        });
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#concept-bcc-content-document

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -125,7 +125,7 @@ void NavigableContainer::create_new_child_navigable()
             .expected_ongoing_navigation_id = {},
             .source_snapshot_params = nullptr,
             .initiator_to_check = nullptr,
-            .pre_steps = GC::create_function(GC::Heap::the(), [this, navigable, parent_navigable, history_entry, traversable](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) mutable {
+            .pre_steps = GC::create_function(GC::Heap::the(), [this, navigable, parent_navigable, history_entry, traversable](u64, GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) mutable {
                 if (navigable->has_been_destroyed() || parent_navigable->has_been_destroyed()) {
                     ready->function()(false, {}, HistoryStepResult::Applied);
                     return;

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -723,7 +723,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
                         queue_global_task(HTML::Task::Source::NavigationAndTraversal, HTML::relevant_global_object(window()), GC::create_function(heap(), [this, api_method_tracker] {
                             auto& reject_realm = window().principal_realm();
                             TemporaryExecutionContext execution_context { reject_realm };
-                            WebIDL::reject_promise(reject_realm, api_method_tracker->finished_promise,
+                            reject_the_finished_promise(api_method_tracker,
                                 WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_utf16));
                         }));
                     };

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -715,7 +715,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
             .expected_ongoing_navigation_id = {},
             .source_snapshot_params = source_snapshot_params,
             .initiator_to_check = navigable,
-            .pre_steps = GC::create_function(heap(), [key, api_method_tracker, navigable, traversable, this](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+            .pre_steps = GC::create_function(heap(), [key, api_method_tracker, navigable, traversable, this](u64, GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
                 auto continue_with_target_step = GC::create_function(heap(), [key, api_method_tracker, navigable, ready, this](Optional<int> target_step) {
                     auto reject_finished_promise_with_invalid_state_error = [&] {
                         // 1. Queue a global task on the navigation and traversal task source given navigation's relevant global object
@@ -1354,13 +1354,13 @@ bool Navigation::inner_navigate_event_firing_algorithm(
                     .target_step = target_step,
                     .user_involvement = user_involvement_for_resume,
                 },
-                 {
-                     .pending_document = nullptr,
-                     .expected_ongoing_navigation_navigable = nullptr,
-                     .expected_ongoing_navigation_id = {},
-                     .source_snapshot_params = nullptr,
-                     .initiator_to_check = nullptr,
-                    .pre_steps = GC::create_function(heap(), [this, event](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+                {
+                    .pending_document = nullptr,
+                    .expected_ongoing_navigation_navigable = nullptr,
+                    .expected_ongoing_navigation_id = {},
+                    .source_snapshot_params = nullptr,
+                    .initiator_to_check = nullptr,
+                    .pre_steps = GC::create_function(heap(), [this, event](u64, GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
                         // NB: This appended step can run after a later navigation has aborted the intercepted
                         //     traverse. In that case, the aborted traverse must not be resumed.
                         if (event->abort_controller()->signal()->aborted() || event != m_ongoing_navigate_event) {

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -703,83 +703,96 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
     auto source_snapshot_params = document.snapshot_source_snapshot_params();
 
     // 12. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps(GC::create_function(heap(), [key, api_method_tracker, navigable, source_snapshot_params, traversable, this](NonnullRefPtr<Core::Promise<Empty>> signal) {
-        auto continue_with_target_step = GC::create_function(heap(), [key, api_method_tracker, navigable, source_snapshot_params, traversable, signal, this](Optional<int> target_step) {
-            auto reject_finished_promise_with_invalid_state_error = [&] {
-                // 1. Queue a global task on the navigation and traversal task source given navigation's relevant global object
-                //    to reject the finished promise for apiMethodTracker with an "InvalidStateError" DOMException.
-                queue_global_task(HTML::Task::Source::NavigationAndTraversal, HTML::relevant_global_object(window()), GC::create_function(heap(), [this, api_method_tracker] {
-                    auto& reject_realm = window().principal_realm();
-                    TemporaryExecutionContext execution_context { reject_realm };
-                    WebIDL::reject_promise(reject_realm, api_method_tracker->finished_promise,
-                        WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_utf16));
-                }));
-            };
-
-            if (!target_step.has_value()) {
-                // NOTE: This path is taken if navigation's entry list was outdated compared to navigableSHEs,
-                //       which can occur for brief periods while all the relevant threads and processes are being synchronized in reaction to a history change.
-
-                reject_finished_promise_with_invalid_state_error();
-
-                // 2. Abort these steps.
-                signal->resolve({});
-                return;
-            }
-
-            // 3. If targetSHE is navigable's active session history entry:
-            // AD-HOC: The UI process returns targetSHE's step. Its navigation API key identifies the same entry for
-            //         this comparison without requiring WebContent to find the target in its local entry list.
-            if (auto active_entry = navigable->active_session_history_entry(); active_entry && active_entry->navigation_api_key() == key) {
-                // NOTE: This can occur if a previously queued traversal already took us to this session history entry.
-
-                // 1. Queue a global task on the navigation and traversal task source given navigation's relevant global object
-                //    to reject the finished promise for apiMethodTracker with an "InvalidStateError" DOMException.
-                reject_finished_promise_with_invalid_state_error();
-
-                // 2. Abort these steps.
-                signal->resolve({});
-                return;
-            }
-
-            // 4. Let result be the result of applying the traverse history step given by targetSHE's step to traversable,
-            //    given sourceSnapshotParams, navigable, and "none".
-            traversable->apply_the_traverse_history_step(*target_step, source_snapshot_params, navigable, UserNavigationInvolvement::None,
-                GC::create_function(heap(), [this, signal, api_method_tracker](HistoryStepResult result) {
-                    // NOTE: When result is "canceled-by-beforeunload" or "initiator-disallowed", the navigate event was never fired,
-                    //       aborting the ongoing navigation would not be correct; it would result in a navigateerror event without a
-                    //       preceding navigate event. In the "canceled-by-navigate" case, navigate is fired, but the inner navigate event
-                    //       firing algorithm will take care of aborting the ongoing navigation.
-
-                    // 5. If result is "canceled-by-beforeunload", then queue a global task on the navigation and traversal task source
-                    //    given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
-                    //    new "AbortError" DOMException created in navigation's relevant realm.
-                    auto& realm = window().principal_realm();
-                    auto& global = HTML::relevant_global_object(window());
-                    if (result == HistoryStepResult::CanceledByBeforeUnload) {
-                        queue_global_task(Task::Source::NavigationAndTraversal, global, GC::create_function(heap(), [this, api_method_tracker, &realm] {
-                            TemporaryExecutionContext execution_context { realm };
-                            reject_the_finished_promise(api_method_tracker, WebIDL::AbortError::create(realm, "Navigation cancelled by beforeunload"_utf16));
+    traversable->request_history_operation(
+        NavigationAPITraverseHistoryOperationParameters {
+            .navigable_id = navigable->id(),
+            .key = key,
+            .user_involvement = UserNavigationInvolvement::None,
+        },
+        {
+            .pending_document = nullptr,
+            .expected_ongoing_navigation_navigable = nullptr,
+            .expected_ongoing_navigation_id = {},
+            .source_snapshot_params = source_snapshot_params,
+            .initiator_to_check = navigable,
+            .pre_steps = GC::create_function(heap(), [key, api_method_tracker, navigable, traversable, this](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+                auto continue_with_target_step = GC::create_function(heap(), [key, api_method_tracker, navigable, ready, this](Optional<int> target_step) {
+                    auto reject_finished_promise_with_invalid_state_error = [&] {
+                        // 1. Queue a global task on the navigation and traversal task source given navigation's relevant global object
+                        //    to reject the finished promise for apiMethodTracker with an "InvalidStateError" DOMException.
+                        queue_global_task(HTML::Task::Source::NavigationAndTraversal, HTML::relevant_global_object(window()), GC::create_function(heap(), [this, api_method_tracker] {
+                            auto& reject_realm = window().principal_realm();
+                            TemporaryExecutionContext execution_context { reject_realm };
+                            WebIDL::reject_promise(reject_realm, api_method_tracker->finished_promise,
+                                WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_utf16));
                         }));
+                    };
+
+                    if (!target_step.has_value()) {
+                        // NOTE: This path is taken if navigation's entry list was outdated compared to navigableSHEs,
+                        //       which can occur for brief periods while all the relevant threads and processes are being synchronized in reaction to a history change.
+
+                        reject_finished_promise_with_invalid_state_error();
+
+                        // 2. Abort these steps.
+                        ready->function()(false, {}, HistoryStepResult::Applied);
+                        return;
                     }
 
-                    // 6. If result is "initiator-disallowed", then queue a global task on the navigation and traversal task source
-                    //    given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
-                    //    new "SecurityError" DOMException created in navigation's relevant realm.
-                    if (result == HistoryStepResult::InitiatorDisallowed) {
-                        queue_global_task(Task::Source::NavigationAndTraversal, global, GC::create_function(heap(), [this, api_method_tracker, &realm] {
-                            TemporaryExecutionContext execution_context { realm };
-                            reject_the_finished_promise(api_method_tracker, WebIDL::SecurityError::create(realm, "Navigation disallowed from this origin"_utf16));
-                        }));
+                    // 3. If targetSHE is navigable's active session history entry:
+                    // AD-HOC: The UI process returns targetSHE's step. Its navigation API key identifies the same entry for
+                    //         this comparison without requiring WebContent to find the target in its local entry list.
+                    if (auto active_entry = navigable->active_session_history_entry(); active_entry && active_entry->navigation_api_key() == key) {
+                        // NOTE: This can occur if a previously queued traversal already took us to this session history entry.
+
+                        // 1. Queue a global task on the navigation and traversal task source given navigation's relevant global object
+                        //    to reject the finished promise for apiMethodTracker with an "InvalidStateError" DOMException.
+                        reject_finished_promise_with_invalid_state_error();
+
+                        // 2. Abort these steps.
+                        ready->function()(false, {}, HistoryStepResult::Applied);
+                        return;
                     }
-                    signal->resolve({});
-                }));
+
+                    // 4. Let result be the result of applying the traverse history step given by targetSHE's step to traversable,
+                    //    given sourceSnapshotParams, navigable, and "none".
+                    ready->function()(true, *target_step, HistoryStepResult::Applied);
+                });
+
+                // AD-HOC: The UI process owns the canonical traversable session history. Ask it to perform steps 1-2 so a
+                //         WebContent process cannot select a target from an incomplete local session history slice.
+                traversable->page().client().page_did_request_navigation_api_traversal_target(navigable->id(), key, continue_with_target_step);
+            }),
+            .on_apply_complete = GC::create_function(heap(), [this, api_method_tracker](HistoryStepResult result) {
+                // NOTE: When result is "canceled-by-beforeunload" or "initiator-disallowed", the navigate event was never fired,
+                //       aborting the ongoing navigation would not be correct; it would result in a navigateerror event without a
+                //       preceding navigate event. In the "canceled-by-navigate" case, navigate is fired, but the inner navigate event
+                //       firing algorithm will take care of aborting the ongoing navigation.
+
+                // 5. If result is "canceled-by-beforeunload", then queue a global task on the navigation and traversal task source
+                //    given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
+                //    new "AbortError" DOMException created in navigation's relevant realm.
+                auto& realm = window().principal_realm();
+                auto& global = HTML::relevant_global_object(window());
+                if (result == HistoryStepResult::CanceledByBeforeUnload) {
+                    queue_global_task(Task::Source::NavigationAndTraversal, global, GC::create_function(heap(), [this, api_method_tracker, &realm] {
+                        TemporaryExecutionContext execution_context { realm };
+                        reject_the_finished_promise(api_method_tracker, WebIDL::AbortError::create(realm, "Navigation cancelled by beforeunload"_utf16));
+                    }));
+                }
+
+                // 6. If result is "initiator-disallowed", then queue a global task on the navigation and traversal task source
+                //    given navigation's relevant global object to reject the finished promise for apiMethodTracker with a
+                //    new "SecurityError" DOMException created in navigation's relevant realm.
+                if (result == HistoryStepResult::InitiatorDisallowed) {
+                    queue_global_task(Task::Source::NavigationAndTraversal, global, GC::create_function(heap(), [this, api_method_tracker, &realm] {
+                        TemporaryExecutionContext execution_context { realm };
+                        reject_the_finished_promise(api_method_tracker, WebIDL::SecurityError::create(realm, "Navigation disallowed from this origin"_utf16));
+                    }));
+                }
+            }),
+            .on_complete = nullptr,
         });
-
-        // AD-HOC: The UI process owns the canonical traversable session history. Ask it to perform steps 1-2 so a
-        //         WebContent process cannot select a target from an incomplete local session history slice.
-        traversable->page().client().page_did_request_navigation_api_traversal_target(navigable->id(), key, continue_with_target_step);
-    }));
 
     // 13. Return a navigation API method tracker-derived result for apiMethodTracker.
     return navigation_api_method_tracker_derived_result(api_method_tracker);
@@ -1335,21 +1348,33 @@ bool Navigation::inner_navigate_event_firing_algorithm(
             VERIFY(destination_entry);
             auto target_step = destination_entry->session_history_entry().step().get<int>();
             auto traversable = navigable->traversable_navigable();
-            traversable->append_session_history_traversal_steps(GC::create_function(heap(), [this, event, traversable, target_step, user_involvement_for_resume](NonnullRefPtr<Core::Promise<Empty>> signal) {
-                // NB: This appended step can run after a later navigation has aborted the intercepted
-                //     traverse. In that case, the aborted traverse must not be resumed.
-                if (event->abort_controller()->signal()->aborted() || event != m_ongoing_navigate_event) {
-                    signal->resolve({});
-                    return;
-                }
+            traversable->request_history_operation(
+                ResumeTraverseHistoryOperationParameters {
+                    .navigable_id = navigable->id(),
+                    .target_step = target_step,
+                    .user_involvement = user_involvement_for_resume,
+                },
+                 {
+                     .pending_document = nullptr,
+                     .expected_ongoing_navigation_navigable = nullptr,
+                     .expected_ongoing_navigation_id = {},
+                     .source_snapshot_params = nullptr,
+                     .initiator_to_check = nullptr,
+                    .pre_steps = GC::create_function(heap(), [this, event](GC::Ref<LocalTraversableNavigable::OnHistoryOperationReady> ready) {
+                        // NB: This appended step can run after a later navigation has aborted the intercepted
+                        //     traverse. In that case, the aborted traverse must not be resumed.
+                        if (event->abort_controller()->signal()->aborted() || event != m_ongoing_navigate_event) {
+                            ready->function()(false, {}, HistoryStepResult::Applied);
+                            return;
+                        }
 
-                // 1. Resume applying the traverse history step given event's destination's entry's session history entry's step,
-                //    navigable's traversable navigable, and userInvolvement.
-                traversable->resume_applying_the_traverse_history_step(target_step, user_involvement_for_resume,
-                    GC::create_function(traversable->heap(), [signal](HistoryStepResult) {
-                        signal->resolve({});
-                    }));
-            }));
+                        // 1. Resume applying the traverse history step given event's destination's entry's session history entry's step,
+                        //    navigable's traversable navigable, and userInvolvement.
+                        ready->function()(true, {}, HistoryStepResult::Applied);
+                    }),
+                    .on_apply_complete = nullptr,
+                    .on_complete = nullptr,
+                });
         }
 
         // 7. If navigationType is "push" or "replace", then run the URL and history update steps given document and

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -65,6 +65,7 @@
 #include <LibWeb/IndexedDB/TransactionChanges.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/EventResult.h>
+#include <LibWeb/HTML/HistoryOperation.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>
@@ -451,11 +452,6 @@ private:
 enum class ContextMenuForInputEventsTarget : u8 {
     No,
     Yes,
-};
-
-enum class HistoryTraversalPrecheck : u8 {
-    Needed,
-    AlreadyDone,
 };
 
 enum class NavigationTarget : u8 {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -51,6 +51,7 @@
 #include <LibWeb/HTML/CrossProcessId.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/HistoryHandlingBehavior.h>
+#include <LibWeb/HTML/HistoryOperation.h>
 #include <LibWeb/HTML/NavigationSourceSnapshot.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/ReplicatedNavigableState.h>
@@ -65,7 +66,6 @@
 #include <LibWeb/IndexedDB/TransactionChanges.h>
 #include <LibWeb/Loader/FileRequest.h>
 #include <LibWeb/Page/EventResult.h>
-#include <LibWeb/HTML/HistoryOperation.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Page/ScreenWakeLockHandle.h>
 #include <LibWeb/Page/ViewportIsFullscreen.h>


### PR DESCRIPTION
Prep work for moving session history and apply-the-history-step into
the UI process. The queue and coordinator stay in WebContent and
behavior (aims to be) unchanged.

Coordinator state becomes navigable ids. Each apply run is an
operation, and anything its jobs leave behind in WebContent belongs to
it and is released when it completes. Every way a history operation
starts becomes a request carrying only values, with live state parked
in WebContent under an initiation ID.

After this, moving the coordinator to the UI process is mostly a transport
change. Requests and jobs become IPC messages carrying the same data,
and the document work stays where it is.