### PR TITLE
LibWeb: Co-locate auxiliary data with used values

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -815,8 +815,6 @@ pub(crate) struct LayoutState {
     abspos_layout_pass_is_active: Cell<bool>,
     anchor_inset_store: AnchorInsetStore,
     replaced_content_facts: PagedStore<crate::layout::FfiReplacedContentFacts>,
-    line_data: PagedStore<RefCell<LineData>>,
-    used_values_rare_data: PagedStore<RefCell<UsedValuesRareData>>,
     inline_containing_blocks: RefCell<HashSet<Node>>,
     anchor_candidate_shells: RefCell<Vec<*mut c_void>>,
     purpose: LayoutStatePurpose,
@@ -864,8 +862,6 @@ impl LayoutState {
             abspos_layout_pass_is_active: Cell::new(false),
             anchor_inset_store: AnchorInsetStore::default(),
             replaced_content_facts: PagedStore::default(),
-            line_data: PagedStore::default(),
-            used_values_rare_data: PagedStore::default(),
             inline_containing_blocks: RefCell::new(HashSet::new()),
             anchor_candidate_shells: RefCell::new(Vec::new()),
             purpose,
@@ -1096,16 +1092,15 @@ impl LayoutState {
         used.inset_right.set(geometry.inset_right);
         used.inset_top.set(geometry.inset_top);
         used.inset_bottom.set(geometry.inset_bottom);
-        if self.node_facts(callbacks, node).is_svg_svg_box() {
-            self.used_values_rare_data_mut(slot_index).svg_viewport_size = Some(geometry.svg_viewport_size);
-        }
-
         // Materialization is this box's placement: the previous paintable's
         // committed geometry is final from the moment it is adopted.
         used.has_content_offset.set(true);
         used.seal_committed_box_metrics();
 
         let used = self.used_values.allocate(slot_index, used);
+        if self.node_facts(callbacks, node).is_svg_svg_box() {
+            self.used_values_rare_data_mut(slot_index).svg_viewport_size = Some(geometry.svg_viewport_size);
+        }
         self.register_anchor_candidate_if_carries_anchor_names(callbacks, node);
         Some(used)
     }
@@ -1243,30 +1238,38 @@ impl LayoutState {
     }
 
     pub(crate) fn line_data_cell(&self, slot_index: u32) -> &RefCell<LineData> {
-        self.line_data
-            .get(slot_index)
-            .unwrap_or_else(|| self.line_data.allocate(slot_index, RefCell::new(LineData::default())))
+        self.used_values_by_slot(slot_index)
+            .expect("missing used values")
+            .line_data
+            .get_or_init(LineData::default)
     }
 
     pub(crate) fn line_data(&self, slot_index: u32) -> Option<Ref<'_, LineData>> {
-        self.line_data.get(slot_index).map(RefCell::borrow)
+        self.used_values_by_slot(slot_index)?
+            .line_data
+            .get()
+            .map(RefCell::borrow)
     }
 
     pub(crate) fn line_data_mut_if_present(&self, slot_index: u32) -> Option<RefMut<'_, LineData>> {
-        self.line_data.get(slot_index).map(RefCell::borrow_mut)
+        self.used_values_by_slot(slot_index)?
+            .line_data
+            .get()
+            .map(RefCell::borrow_mut)
     }
 
     pub(crate) fn used_values_rare_data(&self, slot_index: u32) -> Option<Ref<'_, UsedValuesRareData>> {
-        self.used_values_rare_data.get(slot_index).map(RefCell::borrow)
+        self.used_values_by_slot(slot_index)?
+            .rare_data
+            .get()
+            .map(RefCell::borrow)
     }
 
     pub(crate) fn used_values_rare_data_mut(&self, slot_index: u32) -> RefMut<'_, UsedValuesRareData> {
-        self.used_values_rare_data
-            .get(slot_index)
-            .unwrap_or_else(|| {
-                self.used_values_rare_data
-                    .allocate(slot_index, RefCell::new(UsedValuesRareData::default()))
-            })
+        self.used_values_by_slot(slot_index)
+            .expect("missing used values")
+            .rare_data
+            .get_or_init(UsedValuesRareData::default)
             .borrow_mut()
     }
 
@@ -1683,6 +1686,9 @@ impl LayoutState {
 
 impl LayoutState {
     fn used_values_rare_data_mut_if_present(&self, slot_index: u32) -> Option<RefMut<'_, UsedValuesRareData>> {
-        self.used_values_rare_data.get(slot_index).map(RefCell::borrow_mut)
+        self.used_values_by_slot(slot_index)?
+            .rare_data
+            .get()
+            .map(RefCell::borrow_mut)
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -48,6 +48,37 @@ pub(crate) struct SealableCell<T> {
     sealed: Cell<bool>,
 }
 
+/// Lazily owns interior-mutable data without reserving space for `T` in every
+/// `UsedValues` entry.
+pub(crate) struct LazyRefCell<T> {
+    value: OnceCell<Box<RefCell<T>>>,
+}
+
+impl<T> LazyRefCell<T> {
+    pub(crate) const fn new() -> Self {
+        Self { value: OnceCell::new() }
+    }
+
+    pub(crate) fn get(&self) -> Option<&RefCell<T>> {
+        self.value.get().map(Box::as_ref)
+    }
+
+    pub(crate) fn get_or_init(&self, initialize: impl FnOnce() -> T) -> &RefCell<T> {
+        self.value
+            .get_or_init(|| Box::new(RefCell::new(initialize())))
+            .as_ref()
+    }
+}
+
+impl<T> std::fmt::Debug for LazyRefCell<T> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LazyRefCell")
+            .field("initialized", &self.value.get().is_some())
+            .finish()
+    }
+}
+
 impl<T: Copy + std::fmt::Debug> std::fmt::Debug for SealableCell<T> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.value.get().fmt(formatter)
@@ -134,6 +165,9 @@ pub(crate) struct UsedValues {
     // false, so this cannot be represented as Cell<Option<_>>.
     pub has_containing_line_box_fragment: SealableCell<bool>,
     pub containing_line_box_fragment: SealableCell<LineBoxFragmentCoordinate>,
+
+    pub(crate) line_data: LazyRefCell<LineData>,
+    pub(crate) rare_data: LazyRefCell<UsedValuesRareData>,
 }
 
 impl Default for UsedValues {
@@ -173,6 +207,8 @@ impl Default for UsedValues {
             last_baseline: Cell::new(zero),
             has_containing_line_box_fragment: SealableCell::new(false),
             containing_line_box_fragment: SealableCell::new(LineBoxFragmentCoordinate::default()),
+            line_data: LazyRefCell::new(),
+            rare_data: LazyRefCell::new(),
         }
     }
 }


### PR DESCRIPTION
UsedValuesRareData had its own PagedStore, so creating the first rare entry in a layout pass allocated a separate directory, page table, and 16-entry page. LineData duplicated the same sparse-store structure even though both payloads share the lifetime and slot identity of an existing UsedValues entry. Sparse use therefore paid the radix allocation without gaining independent storage, lifetime, or slot identity for the payload.

Keep lazily allocated boxed RefCells on UsedValues and route existing LayoutState accessors through the primary store, removing both auxiliary PagedStore allocations. Boxing keeps absent data to one pointer rather than reserving the full payload size in every UsedValues entry. The SVG partial-relayout path now inserts UsedValues before restoring its rare viewport data, making the ownership invariant explicit at every write.