### PR TITLE
LibWeb: Guarantee used values exist wherever layout reads them

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/display.rs
+++ b/Libraries/LibWeb/Rust/src/css/display.rs
@@ -232,6 +232,13 @@ impl FfiDisplay {
         self.is_internal() && self.internal == DISPLAY_INTERNAL_TABLE_FOOTER_GROUP
     }
 
+    // https://drafts.csswg.org/css-tables-3/#terminology
+    // Mentions of table-row-groups in the tables spec also encompass the
+    // specialized table-header-groups and table-footer-groups.
+    pub fn is_table_row_group_kind(&self) -> bool {
+        self.is_table_row_group() || self.is_table_header_group() || self.is_table_footer_group()
+    }
+
     pub fn is_table_caption(&self) -> bool {
         self.is_internal() && self.internal == DISPLAY_INTERNAL_TABLE_CAPTION
     }

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -86,20 +86,12 @@ impl<'pass> AbsposEngine<'pass> {
         self.state.node_facts(&self.callbacks, node)
     }
 
-    fn used_pointer(&self, node: Node) -> &'pass UsedValues {
+    fn used(&self, node: Node) -> &'pass UsedValues {
         self.state.used_values(&self.callbacks, node)
     }
 
-    fn try_used_pointer(&self, node: Node) -> Option<&'pass UsedValues> {
-        self.state.try_used_values(&self.callbacks, node)
-    }
-
-    fn used(&self, node: Node) -> &'pass UsedValues {
-        self.used_pointer(node)
-    }
-
     fn used_mut(&self, node: Node) -> &'pass UsedValues {
-        self.used_pointer(node)
+        self.used(node)
     }
 
     fn static_position_containing_block(&self, node: Node) -> Node {
@@ -175,11 +167,9 @@ impl<'pass> AbsposEngine<'pass> {
         );
         let mut ancestor = self.callbacks.containing_block(inline_node);
         while !ancestor.is_invalid() && ancestor != abspos_containing_block {
-            if let Some(used) = self.try_used_pointer(ancestor) {
-                let content_offset = used.content_offset.get();
-                rect.x += content_offset.x;
-                rect.y += content_offset.y;
-            }
+            let content_offset = self.used(ancestor).content_offset.get();
+            rect.x += content_offset.x;
+            rect.y += content_offset.y;
             ancestor = self.callbacks.containing_block(ancestor);
         }
         Some(rect)
@@ -1655,10 +1645,8 @@ impl<'pass> AbsposEngine<'pass> {
         debug_assert!(!self.state.is_measurement());
         while let Some(child) = self.state.take_next_contained_abspos_child(run.box_) {
             let child_box = child.child_box;
-            if self.try_used_pointer(child_box).is_none() {
-                self.state
-                    .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
-            }
+            self.state
+                .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
             self.resolve_anchor_insets(child_box);
             let inputs = AbsposLayoutInputs {
                 static_position_rect: self

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -226,20 +226,12 @@ impl<'pass> BlockFormattingContext<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
 
-    fn used_pointer(&self, node: Node) -> &'pass UsedValues {
+    fn used(&self, node: Node) -> &'pass UsedValues {
         self.state.used_values(&self.callbacks, node)
     }
 
-    fn try_used_pointer(&self, node: Node) -> Option<&'pass UsedValues> {
-        self.state.try_used_values(&self.callbacks, node)
-    }
-
-    fn used(&self, node: Node) -> &'pass UsedValues {
-        self.used_pointer(node)
-    }
-
     fn used_mut(&self, node: Node) -> &'pass UsedValues {
-        self.used_pointer(node)
+        self.used(node)
     }
 
     fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> &'pass UsedValues {
@@ -2487,7 +2479,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             .translated(containing_block_rect.x, containing_block_rect.y);
         let floating_box = FloatingBox {
             box_: node,
-            used_values: self.used_pointer(node),
+            used_values: self.used(node),
             side,
             offset_from_edge: placement.offset_from_edge,
             top_margin_edge: content_block_offset
@@ -2794,12 +2786,10 @@ impl<'pass> BlockFormattingContext<'pass> {
         } else {
             drop(floats);
             for child in self.children(node) {
-                if self.facts(child).is_absolutely_positioned() {
+                if !self.facts(child).is_flow_layout_participant() {
                     continue;
                 }
-                if let Some(child_used) = self.try_used_pointer(child) {
-                    max_inline_size = max_inline_size.max(child_used.margin_box_inline_size(false));
-                }
+                max_inline_size = max_inline_size.max(self.used(child).margin_box_inline_size(false));
             }
         }
         max_inline_size
@@ -2901,7 +2891,6 @@ pub(crate) fn automatic_block_size_for_bfc_root(
     if facts.node_has_size_containment() {
         return CssPixels::default();
     }
-    let used = state.used_values(&callbacks, root);
     let mut bottom = None;
     if facts.children_are_inline() {
         // If it only has inline-level children, the block size is the distance between
@@ -2935,27 +2924,22 @@ pub(crate) fn automatic_block_size_for_bfc_root(
         };
         for child in flow_children {
             let child_facts = state.node_facts(&callbacks, child);
-            if child_facts.is_list_item_marker_box() {
+            if !child_facts.is_flow_layout_participant() || child_facts.is_floating() {
                 continue;
             }
-            if child_facts.is_box() && !child_facts.is_absolutely_positioned() && !child_facts.is_floating() {
-                let child_used = state.try_used_values(&callbacks, child);
-                // Children that have not been laid out yet contribute nothing to the automatic block size.
-                if let Some(child_used) = child_used {
-                    // Margins cannot collapse out of a BFC root: below the last real in-flow
-                    // child, the run's trailing collapsed margin (which folds in any trailing
-                    // collapse-through siblings) replaces that child's own bottom margin.
-                    let margin_bottom = match trailing_collapsed_margin {
-                        Some((last_real_child, aggregate)) if last_real_child == child => aggregate,
-                        _ => child_used.margin_bottom.get(),
-                    };
-                    let child_bottom = child_used.content_offset.get().y
-                        + child_used.content_block_size.get()
-                        + child_used.border_box_bottom(false)
-                        + margin_bottom;
-                    bottom = Some(bottom.map_or(child_bottom, |value: CssPixels| value.max(child_bottom)));
-                }
-            }
+            let child_used = state.used_values(&callbacks, child);
+            // Margins cannot collapse out of a BFC root: below the last real in-flow
+            // child, the run's trailing collapsed margin (which folds in any trailing
+            // collapse-through siblings) replaces that child's own bottom margin.
+            let margin_bottom = match trailing_collapsed_margin {
+                Some((last_real_child, aggregate)) if last_real_child == child => aggregate,
+                _ => child_used.margin_bottom.get(),
+            };
+            let child_bottom = child_used.content_offset.get().y
+                + child_used.content_block_size.get()
+                + child_used.border_box_bottom(false)
+                + margin_bottom;
+            bottom = Some(bottom.map_or(child_bottom, |value: CssPixels| value.max(child_bottom)));
         }
     }
     // In addition, if the element has any floating descendants
@@ -2964,7 +2948,6 @@ pub(crate) fn automatic_block_size_for_bfc_root(
     if let Some(lowest) = lowest_floating_descendant_bottom_margin_edge {
         bottom = Some(bottom.map_or(lowest, |value| value.max(lowest)));
     }
-    let _ = used;
     floor_list_item_automatic_block_size_by_marker_line_height(
         state,
         callbacks,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -624,6 +624,9 @@ pub(crate) fn derive_baselines(
     // (last) grid item in row-major grid order.
     // FIXME: This does not yet select the spec-defined startmost/endmost flex item, or the first/last grid item in
     //        row-major grid order.
+    let container_display = facts.display();
+    let container_skips_anonymous_whitespace_runs =
+        container_display.is_flex_inside() || container_display.is_grid_inside();
     let baseline_from_children = |baseline_set: BaselineSet| -> Option<CssPixels> {
         let mut children = Vec::new();
         let mut child = callbacks.first_child(box_);
@@ -636,18 +639,16 @@ pub(crate) fn derive_baselines(
         }
         for child in children {
             let child_facts = state.node_facts(callbacks, child);
-            if !child_facts.is_box() {
+            if !child_facts.is_flow_layout_participant() || (!inhibits_floating && child_facts.is_floating()) {
                 continue;
             }
-            if child_facts.is_absolutely_positioned() || (!inhibits_floating && child_facts.is_floating()) {
+            if !child_participates_in_table_run(container_display, &child_facts) {
                 continue;
             }
-            if child_facts.is_list_item_marker_box() {
+            if container_skips_anonymous_whitespace_runs && callbacks.can_skip_is_anonymous_text_run(child) {
                 continue;
             }
-            let Some(child_state) = state.try_used_values(callbacks, child) else {
-                continue;
-            };
+            let child_state = state.used_values(callbacks, child);
             match baseline_set {
                 BaselineSet::First if child_state.has_first_baseline.get() => {}
                 BaselineSet::Last if child_state.has_last_baseline.get() => {}
@@ -1275,9 +1276,8 @@ fn apply_root_sizing_directives(
         }
         ParticipationInParentFormattingContext::Item => {
             if cfg!(debug_assertions) && run.layout_mode == LayoutMode::Normal && !run.state.is_measurement() {
-                let used = run.state.try_used_values(&run.callbacks, run.box_);
                 debug_assert!(
-                    used.is_some_and(|used| used.has_definite_inline_size.get()),
+                    run.state.used_values(&run.callbacks, run.box_).has_definite_inline_size.get(),
                     "container-internal run root must arrive with a container-assigned inline size"
                 );
             }
@@ -1629,23 +1629,20 @@ pub(crate) fn layout_inside_child<'pass>(
     force_independent_context_run: bool,
 ) -> ChildLayoutOutcome {
     let facts = run.state.node_facts(&run.callbacks, child);
+    let used = run.state.used_values(&run.callbacks, child);
     if let Some((padding_top, padding_bottom)) = input.sizing.table_cell_intrinsic_block_padding {
         debug_assert!(facts.is_table_cell());
         debug_assert!(matches!(input.participation, ParticipationInParentFormattingContext::Item));
-        let used = run.state.used_values(&run.callbacks, child);
         used.padding_top.set(used.padding_top.get() + padding_top);
         used.padding_bottom.set(used.padding_bottom.get() + padding_bottom);
     }
-    let used = run.state.try_used_values(&run.callbacks, child);
     if !force_independent_context_run
         && layout_mode == LayoutMode::IntrinsicSizing
         && !facts.is_inline()
-        && used.is_some_and(|used| {
-            used.inline_size_constraint.get() == SizeConstraint::None
-                && used.block_size_constraint.get() == SizeConstraint::None
-                && used.has_definite_inline_size()
-                && used.has_definite_block_size()
-        })
+        && used.inline_size_constraint.get() == SizeConstraint::None
+        && used.block_size_constraint.get() == SizeConstraint::None
+        && used.has_definite_inline_size()
+        && used.has_definite_block_size()
     {
         size_skipped_independent_root(run, parent_block, child, &input);
         return ChildLayoutOutcome::Skipped;

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -1618,17 +1618,6 @@ impl<'pass> GridFormattingContext<'pass> {
         }
     }
 
-    fn create_item_used_values(&self, node: Node) -> &'pass UsedValues {
-        // Intrinsic subgrid contribution contexts revisit descendants that
-        // already have pass-local used values instead of allocating the same
-        // state entry twice.
-        let existing = self.state.try_used_values(&self.callbacks, node);
-        if let Some(existing) = existing {
-            return existing;
-        }
-        self.state
-            .create_used_values(&self.callbacks, node, ContainingBlockConstraints::default())
-    }
 
     fn clamp_area_to_subgrid(start: &mut i32, span: &mut usize, track_count: usize) {
         if track_count == 0 {
@@ -1703,7 +1692,10 @@ impl<'pass> GridFormattingContext<'pass> {
                             child_grid_style.names.raws(),
                         ),
                     });
-                    nodes.push((child, self.create_item_used_values(child)));
+                    let item_used_values =
+                        self.state
+                            .create_used_values(&self.callbacks, child, ContainingBlockConstraints::default());
+                    nodes.push((child, item_used_values));
                 }
             }
             child = next;

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -157,8 +157,7 @@ struct PerLine {
     first_direct_fragment_block_start: Option<CssPixels>,
     max_direct_fragment_block_length: CssPixels,
     fallback_block_start_from_contributions: Option<CssPixels>,
-    interrupting_block_position: Option<(CssPixels, CssPixels)>,
-    interrupting_block_logical_extent: Option<CandidateLineCorners>,
+    interrupting_block: Option<((CssPixels, CssPixels), CandidateLineCorners)>,
     first_fragment_index: Option<u32>,
     fragment_count: u32,
 }
@@ -171,8 +170,7 @@ impl PerLine {
             first_direct_fragment_block_start: None,
             max_direct_fragment_block_length: CssPixels::default(),
             fallback_block_start_from_contributions: None,
-            interrupting_block_position: None,
-            interrupting_block_logical_extent: None,
+            interrupting_block: None,
             first_fragment_index: None,
             fragment_count: 0,
         }
@@ -276,7 +274,11 @@ pub(crate) fn compute(
             }
             let fragment_index = committed_fragment_index;
             committed_fragment_index += 1;
-            let interrupting = context.style(fragment.style_source).display().is_block_outside();
+            let interrupting = line.has_block_level_box;
+            debug_assert!(
+                !interrupting || context.style(fragment.style_source).display().is_block_outside(),
+                "an interrupting line's fragment must be a block-level box"
+            );
             let position = fragment.offset();
             let size = fragment.size();
             let mut inline_start = if horizontal { position.0 } else { position.1 };
@@ -284,10 +286,8 @@ pub(crate) fn compute(
             let block_start = if horizontal { position.1 } else { position.0 };
             let block_length = if horizontal { size.1 } else { size.0 };
 
-            if !interrupting
-                && fragment.is_atomic_inline
-                && let Some(used) = context.try_used_pointer(fragment.layout_node)
-            {
+            if !interrupting && fragment.is_atomic_inline {
+                let used = context.used(fragment.layout_node);
                 if horizontal {
                     inline_start -= used.margin_left.get() + used.border_box_left(false);
                     inline_end += used.margin_right.get() + used.border_box_right(false);
@@ -297,34 +297,36 @@ pub(crate) fn compute(
                 }
             }
 
-            let interrupting_block_logical_extent = if interrupting {
-                context.try_used_pointer(fragment.layout_node).map(|block_used| {
-                    let collapsed = block_used.uses_collapsing_borders_model.get();
-                    let (border_box_inline_low, border_box_block_low, border_box_inline_size, border_box_block_size) =
-                        if horizontal {
-                            (
-                                block_used.border_box_left(collapsed),
-                                block_used.border_box_top(collapsed),
-                                block_used.border_box_inline_size(collapsed),
-                                block_used.border_box_block_size(collapsed),
-                            )
-                        } else {
-                            (
-                                block_used.border_box_top(collapsed),
-                                block_used.border_box_left(collapsed),
-                                block_used.border_box_block_size(collapsed),
-                                block_used.border_box_inline_size(collapsed),
-                            )
-                        };
-                    let extent_inline_start = inline_start - border_box_inline_low;
-                    let extent_block_start = block_start - border_box_block_low;
+            let interrupting_block = if interrupting {
+                let block_used = context.used(fragment.layout_node);
+                let collapsed = block_used.uses_collapsing_borders_model.get();
+                let (border_box_inline_low, border_box_block_low, border_box_inline_size, border_box_block_size) =
+                    if horizontal {
+                        (
+                            block_used.border_box_left(collapsed),
+                            block_used.border_box_top(collapsed),
+                            block_used.border_box_inline_size(collapsed),
+                            block_used.border_box_block_size(collapsed),
+                        )
+                    } else {
+                        (
+                            block_used.border_box_top(collapsed),
+                            block_used.border_box_left(collapsed),
+                            block_used.border_box_block_size(collapsed),
+                            block_used.border_box_inline_size(collapsed),
+                        )
+                    };
+                let extent_inline_start = inline_start - border_box_inline_low;
+                let extent_block_start = block_start - border_box_block_low;
+                Some((
+                    position,
                     CandidateLineCorners {
                         inline_start: extent_inline_start,
                         inline_end: extent_inline_start + border_box_inline_size,
                         block_start: extent_block_start,
                         block_end: extent_block_start + border_box_block_size,
-                    }
-                })
+                    },
+                ))
             } else {
                 None
             };
@@ -356,11 +358,8 @@ pub(crate) fn compute(
                 let line = ensure_line(per_node, line_index);
                 let first = *line.first_fragment_index.get_or_insert(fragment_index);
                 line.fragment_count = fragment_index + 1 - first;
-                if interrupting {
-                    line.interrupting_block_position.get_or_insert(position);
-                    if let Some(extent) = interrupting_block_logical_extent {
-                        line.interrupting_block_logical_extent.get_or_insert(extent);
-                    }
+                if let Some(interrupting_block) = interrupting_block {
+                    line.interrupting_block.get_or_insert(interrupting_block);
                     ancestor = context.nearest_fragmented_inline_ancestor(ancestor);
                     continue;
                 }
@@ -407,7 +406,7 @@ pub(crate) fn compute(
                 std::mem::take(&mut per_node.lines),
             )
         };
-        let used = context.try_used_pointer(node);
+        let used = context.used(node);
         let reversed = context.facts(node).inline_axis_is_reverse();
         let (
             border_padding_low,
@@ -416,34 +415,23 @@ pub(crate) fn compute(
             border_padding_block_high,
             margin_low,
             margin_high,
-        ) = if let Some(used) = used {
-            if horizontal {
-                (
-                    used.border_box_left(false),
-                    used.border_box_right(false),
-                    used.border_box_top(false),
-                    used.border_box_bottom(false),
-                    used.margin_left.get(),
-                    used.margin_right.get(),
-                )
-            } else {
-                (
-                    used.border_box_top(false),
-                    used.border_box_bottom(false),
-                    used.border_box_left(false),
-                    used.border_box_right(false),
-                    used.margin_top.get(),
-                    used.margin_bottom.get(),
-                )
-            }
+        ) = if horizontal {
+            (
+                used.border_box_left(false),
+                used.border_box_right(false),
+                used.border_box_top(false),
+                used.border_box_bottom(false),
+                used.margin_left.get(),
+                used.margin_right.get(),
+            )
         } else {
             (
-                CssPixels::default(),
-                CssPixels::default(),
-                CssPixels::default(),
-                CssPixels::default(),
-                CssPixels::default(),
-                CssPixels::default(),
+                used.border_box_top(false),
+                used.border_box_bottom(false),
+                used.border_box_left(false),
+                used.border_box_right(false),
+                used.margin_top.get(),
+                used.margin_bottom.get(),
             )
         };
 
@@ -453,10 +441,8 @@ pub(crate) fn compute(
 
         for line in lines {
             let Some((contributions_inline_start, contributions_inline_end)) = line.contributions_inline_range else {
-                if let Some(position) = line.interrupting_block_position {
-                    if node_is_inline_containing_block
-                        && let Some(extent) = line.interrupting_block_logical_extent
-                    {
+                if let Some((position, extent)) = line.interrupting_block {
+                    if node_is_inline_containing_block {
                         corners.first.get_or_insert(extent);
                         corners.last = Some(extent);
                     }
@@ -578,9 +564,7 @@ pub(crate) fn compute(
     }
 
     for (index, node) in without_fragments.into_iter().enumerate() {
-        if context.try_used_pointer(node).is_none() {
-            continue;
-        }
+        context.used(node);
         let line_height = context.style(node).line_height();
         let placeholder_rect = if horizontal {
             InlineCssPixelRect {
@@ -625,7 +609,7 @@ pub(crate) fn compute(
 
 fn padding_box_rect_spanning_first_and_last_content_lines(
     corners: &FirstAndLastContentLineCorners,
-    used: Option<&UsedValues>,
+    used: &UsedValues,
     horizontal: bool,
     inline_axis_is_reverse: bool,
     container_inline_axis_is_reverse: bool,
@@ -633,20 +617,20 @@ fn padding_box_rect_spanning_first_and_last_content_lines(
     let first = corners.first?;
     let last = corners.last?;
 
-    let (border_inline_low, border_inline_high, border_block_low, border_block_high) = match used {
-        Some(used) if horizontal => (
+    let (border_inline_low, border_inline_high, border_block_low, border_block_high) = if horizontal {
+        (
             used.border_left.get(),
             used.border_right.get(),
             used.border_top.get(),
             used.border_bottom.get(),
-        ),
-        Some(used) => (
+        )
+    } else {
+        (
             used.border_top.get(),
             used.border_bottom.get(),
             used.border_left.get(),
             used.border_right.get(),
-        ),
-        None => Default::default(),
+        )
     };
     let direction_matches = inline_axis_is_reverse == container_inline_axis_is_reverse;
     let (contracted_inline_low, contracted_inline_high) = if direction_matches {
@@ -772,10 +756,6 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         self.state.used_values(&self.callbacks, node)
     }
 
-    pub(crate) fn try_used_pointer(&self, node: Node) -> Option<&'pass UsedValues> {
-        self.state.try_used_values(&self.callbacks, node)
-    }
-
     pub(crate) fn create_used_values(
         &self,
         node: Node,
@@ -803,7 +783,8 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
             if !display.is_inline_outside() || !display.is_flow_inside() {
                 break;
             }
-            if self.facts(ancestor).is_fragmented_inline() {
+            let facts = self.facts(ancestor);
+            if facts.is_fragmented_inline() && !facts.is_floating_or_absolutely_positioned() {
                 return ancestor;
             }
             ancestor = self.parent_node(ancestor);
@@ -1396,12 +1377,10 @@ fn line_rect(line: &LineBoxData, content_inline_size: CssPixels) -> FfiCssPixelR
 pub(crate) fn push_line_data(
     state: &crate::layout::LayoutState,
     slot_index: u32,
+    content_inline_size: CssPixels,
     callbacks: &FfiLayoutFcCallbacks,
     sink: FfiLineSinkCallbacks,
 ) -> bool {
-    let content_inline_size = state
-        .used_values_by_slot(slot_index)
-        .map_or(CssPixels::default(), |used| used.content_inline_size.get());
     let Some(mut data) = state.line_data_mut_if_present(slot_index) else {
         return false;
     };

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -130,8 +130,7 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
     }
 
     fn is_out_of_flow(&self, node: Node) -> bool {
-        let facts = self.context().facts(node);
-        facts.is_floating() || facts.is_absolutely_positioned()
+        self.context().facts(node).is_floating_or_absolutely_positioned()
     }
 
     fn compute_is_unidirectional_left_to_right(&mut self) -> bool {
@@ -547,9 +546,7 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
         }
 
         let used = if self.box_model_node_stack.last().copied() == Some(node) {
-            self.context()
-                .try_used_pointer(node)
-                .expect("inline box must have precreated used values")
+            self.context().used(node)
         } else {
             self.context()
                 .create_used_values(node, self.context().input.containing_block_constraints)

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -397,6 +397,11 @@ impl<'pass> NodeFacts<'pass> {
         !crate::layout::node_is_out_of_flow(self.data(), self.computed_values_view_if_styled())
     }
 
+    pub(crate) fn is_floating_or_absolutely_positioned(&self) -> bool {
+        self.computed_values_view_if_styled()
+            .is_some_and(|style| style.is_floating() || style.is_absolutely_positioned())
+    }
+
     pub(crate) fn is_inline(&self) -> bool {
         crate::layout::kind_is_text(self.data().kind)
             || self
@@ -495,6 +500,14 @@ impl<'pass> NodeFacts<'pass> {
 
     pub(crate) fn is_svg_clip_box(&self) -> bool {
         self.data().kind == NodeKind::SVGClipBox
+    }
+
+    pub(crate) fn is_flow_layout_participant(&self) -> bool {
+        self.is_box()
+            && !self.is_absolutely_positioned()
+            && !self.is_list_item_marker_box()
+            && !self.is_svg_mask_box()
+            && !self.is_svg_clip_box()
     }
 
     pub(crate) fn display_before_box_type_transformation_is_block_outside(&self) -> bool {
@@ -765,6 +778,10 @@ impl<'pass> NodeFacts<'pass> {
 
     pub(crate) fn is_table_footer_group(&self) -> bool {
         self.display().is_table_footer_group()
+    }
+
+    pub(crate) fn is_table_row_group_kind(&self) -> bool {
+        self.display().is_table_row_group_kind()
     }
 
     pub(crate) fn is_table_row(&self) -> bool {
@@ -1281,7 +1298,7 @@ impl LayoutState {
         self.used_values_rare_data_mut(callbacks.slot_index(node))
     }
 
-    pub(crate) fn used_values_by_slot(&self, slot_index: u32) -> Option<&UsedValues> {
+    fn used_values_by_slot(&self, slot_index: u32) -> Option<&UsedValues> {
         self.used_values.get(slot_index)
     }
 
@@ -1289,14 +1306,6 @@ impl LayoutState {
         self.used_values
             .get(callbacks.slot_index(node))
             .expect("missing used values")
-    }
-
-    pub(crate) fn try_used_values(
-        &self,
-        callbacks: &FfiLayoutFcCallbacks,
-        node: Node,
-    ) -> Option<&UsedValues> {
-        self.used_values.get(callbacks.slot_index(node))
     }
 
     pub(crate) fn register_contained_abspos_child(
@@ -1409,13 +1418,13 @@ impl LayoutState {
             }
             result.found_fragmented_inline_node |= facts.is_fragmented_inline();
             if facts.is_relatively_positioned() {
-                // An inline that never went through inline layout this pass has
-                // no used values; its committed box model is zeroed, so it
-                // contributes no inset.
-                if let Some(used) = self.try_used_values(callbacks, ancestor) {
-                    result.offset_x += used.inset_left.get();
-                    result.offset_y += used.inset_top.get();
-                }
+                // A relatively positioned inline-flow ancestor reachable from a
+                // committed fragment or piece was entered by its inline
+                // formatting context this pass, which created its used values
+                // and resolved its insets.
+                let used = self.used_values(callbacks, ancestor);
+                result.offset_x += used.inset_left.get();
+                result.offset_y += used.inset_top.get();
             }
             ancestor = callbacks.parent(ancestor);
         }
@@ -1577,7 +1586,13 @@ impl LayoutState {
                         emit_fragment: sink.emit_fragment,
                         emit_inline_box_piece: sink.emit_inline_box_piece,
                     };
-                    assert!(push_line_data(self, slot_index, callbacks, line_sink));
+                    assert!(push_line_data(
+                        self,
+                        slot_index,
+                        used.content_inline_size.get(),
+                        callbacks,
+                        line_sink
+                    ));
                     unsafe {
                         (sink.finish_line_data)(sink.context);
                     }

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -35,6 +35,19 @@ fn line_style_score(line_style: u8) -> u8 {
     }
 }
 
+pub(crate) fn child_participates_in_table_run(container_display: FfiDisplay, child_facts: &NodeFacts<'_>) -> bool {
+    if container_display.is_table_inside() {
+        let child_display = child_facts.display();
+        child_display.is_table_row() || child_display.is_table_row_group_kind()
+    } else if container_display.is_table_row_group_kind() {
+        child_facts.display().is_table_row()
+    } else if container_display.is_table_row() {
+        child_facts.display().is_table_cell()
+    } else {
+        true
+    }
+}
+
 pub(crate) fn border_is_less_specific(incumbent: FfiBorderData, candidate: FfiBorderData) -> bool {
     // Implements criteria for steps 1, 2 and 3 of border conflict resolution algorithm, as described in
     // https://www.w3.org/TR/CSS22/tables.html#border-conflict-resolution.
@@ -1042,9 +1055,7 @@ impl<'pass> TableFormattingContext<'pass> {
     }
 
     fn seed_table_participant_used_values(&mut self) {
-        for group in self.matching_children(self.table_box, |facts| {
-            facts.is_table_row_group() || facts.is_table_header_group() || facts.is_table_footer_group()
-        }) {
+        for group in self.matching_children(self.table_box, |display| display.is_table_row_group_kind()) {
             self.create_used_values(group, self.participant_constraints);
         }
         for row in &self.rows {
@@ -2279,9 +2290,7 @@ impl<'pass> TableFormattingContext<'pass> {
         }
 
         let mut group_block_offset = self.table_box_content_block_offset_in_wrapper + block_spacing;
-        for group in self.matching_children(self.table_box, |facts| {
-            facts.is_table_row_group() || facts.is_table_header_group() || facts.is_table_footer_group()
-        }) {
+        for group in self.matching_children(self.table_box, |display| display.is_table_row_group_kind()) {
             let group_rows = self.matching_children(group, |facts| facts.is_table_row());
             let mut block_size = CssPixels::default();
             let mut inline_size = CssPixels::default();
@@ -2504,9 +2513,7 @@ impl<'pass> TableFormattingContext<'pass> {
         for row in &self.rows {
             self.compute_and_store_baselines(row.box_);
         }
-        for group in self.matching_children(self.table_box, |facts| {
-            facts.is_table_row_group() || facts.is_table_header_group() || facts.is_table_footer_group()
-        }) {
+        for group in self.matching_children(self.table_box, |display| display.is_table_row_group_kind()) {
             self.compute_and_store_baselines(group);
         }
         self.compute_and_store_baselines(self.table_box);


### PR DESCRIPTION
LayoutState::try_used_values let callers probe whether a box has per-pass used values, conflating "give me the used values" with "did this box participate in layout this pass". The Option-ness was C++ heritage from the retired engine's nullable LayoutState::get(); against pass-local state, every layout-time read site can know the answer statically. Restructure so used values are guaranteed to exist at every read, then drop try_used_values and the per-context try_used_pointer wrappers.