### PR TITLE
Publish replaced content facts into the layout node arena

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2098,6 +2098,7 @@ Document::PartialRelayoutResult Document::try_partial_relayout(HashTable<WeakPtr
     if (partial_relayout_roots.is_empty())
         return PartialRelayoutResult::NotEligible;
 
+    layout_node_arena().sync_enrolled_content_for_layout();
     for (auto const& root : partial_relayout_roots) {
         relayout_subtree(*root.box, *root.old_paintable);
         // NB: The subtree commit reset the root's descendant paintables, and the subtree's
@@ -2197,6 +2198,7 @@ void Document::update_layout(UpdateLayoutReason reason)
         // on, so pending changes that escaped classification are accounted for from here on.
         m_partial_relayout_invalidation.clear_escape(PartialRelayoutEscapeClearReason::FullLayoutPass);
 
+        layout_node_arena().sync_enrolled_content_for_layout();
         Layout::LayoutRustBridge bridge;
         bridge.run_root_layout(
             *m_layout_root,

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -7,10 +7,12 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/TableWrapper.h>
+#include <LibWeb/Layout/TextInputBox.h>
 #include <LibWeb/Painting/Paintable.h>
 
 namespace Web::Layout {
@@ -88,6 +90,43 @@ CSS::SizeWithAspectRatio Box::auto_content_box_size() const
         return { 0, 0, {} };
 
     return compute_auto_content_box_size();
+}
+
+RustFFI::FfiReplacedContentFacts Box::build_replaced_content_facts_for_arena() const
+{
+    RustFFI::FfiReplacedContentFacts facts {};
+    auto auto_content_size = auto_content_box_size();
+    facts.has_auto_content_width = auto_content_size.has_width();
+    facts.auto_content_width = auto_content_size.width.value_or(0).raw_value();
+    facts.has_auto_content_height = auto_content_size.has_height();
+    facts.auto_content_height = auto_content_size.height.value_or(0).raw_value();
+    if (auto_content_size.aspect_ratio.has_value()) {
+        facts.auto_content_aspect_ratio_numerator = auto_content_size.aspect_ratio->numerator().raw_value();
+        facts.auto_content_aspect_ratio_denominator = auto_content_size.aspect_ratio->denominator().raw_value();
+    }
+    if (computed_values().appearance() == CSS::Appearance::None) {
+        if (auto const* input = as_if<HTML::HTMLInputElement>(dom_node())) {
+            switch (input->type_state()) {
+            case HTML::HTMLInputElement::TypeAttributeState::Text:
+            case HTML::HTMLInputElement::TypeAttributeState::Search:
+            case HTML::HTMLInputElement::TypeAttributeState::URL:
+            case HTML::HTMLInputElement::TypeAttributeState::Telephone:
+            case HTML::HTMLInputElement::TypeAttributeState::Email:
+            case HTML::HTMLInputElement::TypeAttributeState::Password:
+            case HTML::HTMLInputElement::TypeAttributeState::Number: {
+                auto default_preferred_size = TextInputBox::default_preferred_size_for_text_control(*input, *this);
+                facts.has_default_preferred_width = default_preferred_size.has_width();
+                facts.default_preferred_width = default_preferred_size.width.value_or(0).raw_value();
+                facts.has_default_preferred_height = default_preferred_size.has_height();
+                facts.default_preferred_height = default_preferred_size.height.value_or(0).raw_value();
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return facts;
 }
 
 RefPtr<Painting::Paintable> Box::create_paintable() const

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -50,6 +50,8 @@ public:
     Optional<CSSPixelFraction> preferred_aspect_ratio() const;
     bool has_preferred_aspect_ratio() const { return preferred_aspect_ratio().has_value(); }
 
+    RustFFI::FfiReplacedContentFacts build_replaced_content_facts_for_arena() const;
+
     virtual ~Box() override;
 
     virtual void did_set_content_size() { }

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -41,7 +41,6 @@
 #include <LibWeb/Dump.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/DominantBaseline.h>
 #include <LibWeb/Layout/FieldSetBox.h>
@@ -59,7 +58,6 @@
 #include <LibWeb/Layout/SVGSVGBox.h>
 #include <LibWeb/Layout/SVGTextBox.h>
 #include <LibWeb/Layout/SVGTextPathBox.h>
-#include <LibWeb/Layout/TextInputBox.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/PaintableWithLines.h>
@@ -671,7 +669,6 @@ void LayoutRustBridge::run_root_layout(Box& viewport, CSSPixels viewport_inline_
     };
 
     viewport.document().invalidate_stacking_context_tree();
-    viewport.document().layout_node_arena().sync_enrolled_text_node_content();
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
     {
@@ -696,7 +693,6 @@ void LayoutRustBridge::compute_subtree_layout(Box& root, Painting::Paintable& pa
     };
 
     root.document().invalidate_stacking_context_tree();
-    root.document().layout_node_arena().sync_enrolled_text_node_content();
     auto viewport_rect = root.document().viewport_rect();
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
@@ -723,7 +719,6 @@ void LayoutRustBridge::replay_saved_abspos_layout(Box& box, Painting::Paintable&
     };
 
     box.document().invalidate_stacking_context_tree();
-    box.document().layout_node_arena().sync_enrolled_text_node_content();
     auto callbacks = formatting_context_callbacks();
     auto sink = commit_sink();
     {
@@ -1160,43 +1155,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             dbgln("FIXME: InlineFormattingContext::dimension_box_on_line got unexpected box in inline context:");
             dump_tree(box); },
         .release_anchor_name_handle = ladybird_layout_release_anchor_name_handle,
-        .build_replaced_content_facts = [](void*, void* node) {
-            RustFFI::FfiReplacedContentFacts facts {};
-            auto const* box = as_if<Box>(*static_cast<Node const*>(node));
-            if (!box)
-                return facts;
-            auto auto_content_size = box->auto_content_box_size();
-            facts.has_auto_content_width = auto_content_size.has_width();
-            facts.auto_content_width = auto_content_size.width.value_or(0).raw_value();
-            facts.has_auto_content_height = auto_content_size.has_height();
-            facts.auto_content_height = auto_content_size.height.value_or(0).raw_value();
-            if (auto_content_size.aspect_ratio.has_value()) {
-                facts.auto_content_aspect_ratio_numerator = auto_content_size.aspect_ratio->numerator().raw_value();
-                facts.auto_content_aspect_ratio_denominator = auto_content_size.aspect_ratio->denominator().raw_value();
-            }
-            if (box->computed_values().appearance() == CSS::Appearance::None) {
-                if (auto const* input = as_if<HTML::HTMLInputElement>(box->dom_node())) {
-                    switch (input->type_state()) {
-                    case HTML::HTMLInputElement::TypeAttributeState::Text:
-                    case HTML::HTMLInputElement::TypeAttributeState::Search:
-                    case HTML::HTMLInputElement::TypeAttributeState::URL:
-                    case HTML::HTMLInputElement::TypeAttributeState::Telephone:
-                    case HTML::HTMLInputElement::TypeAttributeState::Email:
-                    case HTML::HTMLInputElement::TypeAttributeState::Password:
-                    case HTML::HTMLInputElement::TypeAttributeState::Number: {
-                        auto default_preferred_size = TextInputBox::default_preferred_size_for_text_control(*input, *box);
-                        facts.has_default_preferred_width = default_preferred_size.has_width();
-                        facts.default_preferred_width = default_preferred_size.width.value_or(0).raw_value();
-                        facts.has_default_preferred_height = default_preferred_size.has_height();
-                        facts.default_preferred_height = default_preferred_size.height.value_or(0).raw_value();
-                        break;
-                    }
-                    default:
-                        break;
-                    }
-                }
-            }
-            return facts; },
         .build_svg_facts = [](void*, void* node) {
             auto const* node_with_style = as_if<NodeWithStyle>(*static_cast<Node const*>(node));
             VERIFY(node_with_style);

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -102,6 +102,17 @@ void Node::set_node_kind(RustFFI::NodeKind kind)
                                                            .is_replaced_box = is_replaced_box(),
                                                        }));
 #endif
+    enroll_for_arena_replaced_content_facts_sync_if_eligible();
+}
+
+void Node::enroll_for_arena_replaced_content_facts_sync_if_eligible()
+{
+    if (m_enrolled_for_arena_replaced_content_facts_sync)
+        return;
+    if (!RustFFI::layout_node_data_may_have_replaced_content_facts(m_data))
+        return;
+    m_enrolled_for_arena_replaced_content_facts_sync = true;
+    node_arena().enroll_node_for_replaced_content_facts_sync(*this);
 }
 
 void* Node::arena_handle() const
@@ -667,6 +678,7 @@ NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRe
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !m_computed_values->anchor_names().is_empty());
     publish_style_container_to_node_data();
     synchronize_table_span_data();
+    enroll_for_arena_replaced_content_facts_sync_if_eligible();
 }
 
 NodeWithStyle::ImageObserver::ImageObserver(NodeWithStyle& owner, NonnullRefPtr<CSS::ImageStyleValue const> image)
@@ -1006,6 +1018,7 @@ void NodeWithStyle::set_computed_values(NonnullRefPtr<CSS::ComputedValues const>
     m_computed_values = move(computed_values);
     set_flag(RustFFI::NodeFlag::HasAnchorNames, !m_computed_values->anchor_names().is_empty());
     publish_style_container_to_node_data();
+    enroll_for_arena_replaced_content_facts_sync_if_eligible();
 
     for (auto* child = first_child_ptr(); child; child = child->next_sibling_ptr()) {
         if (auto* text_child = as_if<TextNode>(*child))

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -314,6 +314,10 @@ private:
     void set_node_kind(RustFFI::NodeKind);
     void synchronize_topology();
 
+protected:
+    void enroll_for_arena_replaced_content_facts_sync_if_eligible();
+
+private:
     // A DOM mutation can disconnect a node before the next layout-tree update. Keep the DOM node alive until this
     // layout node is destroyed so detach hooks never observe a collected image provider or other element state.
     GC::Root<DOM::Node> m_dom_node;
@@ -329,6 +333,8 @@ private:
     InlineNode const* m_inline_containing_block_if_applicable { nullptr };
 
     GC::Weak<DOM::Element> m_pseudo_element_generator;
+
+    bool m_enrolled_for_arena_replaced_content_facts_sync { false };
 };
 
 class NodeKindSetter {

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/Assertions.h>
+#include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/LayoutRustBridge.h>
 #include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TextNode.h>
 
@@ -57,6 +59,37 @@ void NodeArena::sync_enrolled_text_node_content()
         text_node->sync_text_content_to_arena();
     }
     m_text_nodes_enrolled_for_content_sync = move(still_detached_text_nodes);
+}
+
+void NodeArena::enroll_node_for_replaced_content_facts_sync(Node const& node)
+{
+    m_nodes_enrolled_for_replaced_content_facts_sync.append(node.make_weak_ptr<Node>());
+}
+
+void NodeArena::sync_enrolled_content_for_layout()
+{
+    if (layout_pass_currently_running())
+        return;
+    sync_enrolled_text_node_content();
+    sync_enrolled_replaced_content_facts();
+}
+
+void NodeArena::sync_enrolled_replaced_content_facts()
+{
+    bool any_enrolled_node_died = false;
+    for (auto& weak_node : m_nodes_enrolled_for_replaced_content_facts_sync) {
+        auto const* node = weak_node.ptr();
+        if (!node) {
+            any_enrolled_node_died = true;
+            continue;
+        }
+        RustFFI::FfiReplacedContentFacts facts {};
+        if (auto const* box = as_if<Box>(*node))
+            facts = box->build_replaced_content_facts_for_arena();
+        RustFFI::layout_arena_set_replaced_content_facts(m_handle, Node::slot_id(node), facts);
+    }
+    if (any_enrolled_node_died)
+        m_nodes_enrolled_for_replaced_content_facts_sync.remove_all_matching([](auto& weak_node) { return !weak_node.ptr(); });
 }
 
 }

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -16,6 +16,7 @@
 
 namespace Web::Layout {
 
+class Node;
 class TextNode;
 
 static_assert(sizeof(RustFFI::NodeAllocation) == 24);
@@ -36,11 +37,17 @@ public:
     void* handle() const { return m_handle; }
 
     void enroll_text_node_for_content_sync(TextNode const&);
-    void sync_enrolled_text_node_content();
+    void enroll_node_for_replaced_content_facts_sync(Node const&);
+
+    void sync_enrolled_content_for_layout();
 
 private:
+    void sync_enrolled_text_node_content();
+    void sync_enrolled_replaced_content_facts();
+
     void* m_handle { nullptr };
     Vector<WeakPtr<TextNode>> m_text_nodes_enrolled_for_content_sync;
+    Vector<WeakPtr<Node>> m_nodes_enrolled_for_replaced_content_facts_sync;
 };
 
 }

--- a/Libraries/LibWeb/Rust/build.rs
+++ b/Libraries/LibWeb/Rust/build.rs
@@ -803,6 +803,18 @@ fn generate_ffi_header(
 /// Strict variant for the layout headers: dormant layout sources are parsed
 /// by cbindgen before they join the module tree, so a syntax error anywhere
 /// must fail the build instead of silently producing a stale header.
+// CssPixels is a single i32 fixed-point value shared with the CSS module; C++
+// already has the matching CSSPixels class, so expose its raw representation in
+// the generated ABI rather than generating a second C++ pixel type in the
+// RustFFI namespace.
+fn expose_css_pixels_as_raw_i32(config: &mut cbindgen::Config) {
+    config.export.exclude.push("CssPixels".to_string());
+    config
+        .export
+        .rename
+        .insert("CssPixels".to_string(), "int32_t".to_string());
+}
+
 fn generate_ffi_header_strict(
     config: cbindgen::Config,
     sources: &[PathBuf],
@@ -990,6 +1002,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     tree_builder_config.namespaces = Some(vec!["Web".to_string(), "Layout".to_string(), "RustFFI".to_string()]);
     tree_builder_config.export.include = vec![
         "FfiNodeKindFacts".to_string(),
+        "FfiReplacedContentFacts".to_string(),
         "FfiStylePayloads".to_string(),
         "NodeAllocation".to_string(),
         "NodeData".to_string(),
@@ -1001,6 +1014,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "rust_calc_node_create_numeric_dimension".to_string(),
         "rust_calc_resolve".to_string(),
     ];
+    expose_css_pixels_as_raw_i32(&mut tree_builder_config);
     generate_ffi_header_strict(
         tree_builder_config,
         &[
@@ -1015,23 +1029,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Layout engine header - namespace Web::Layout::RustFFI, layered on the tree-builder
-    // header. CssPixels is a single i32 fixed-point value shared with the CSS module; C++
-    // already has the matching CSSPixels class, so expose its raw representation in the
-    // generated ABI rather than generating a second C++ pixel type in the RustFFI namespace.
+    // header.
     let mut layout_config = base_config;
     layout_config.namespaces = Some(vec!["Web".to_string(), "Layout".to_string(), "RustFFI".to_string()]);
     layout_config.export.exclude = vec![
         "rust_calc_node_create_numeric_dimension".to_string(),
         "rust_calc_resolve".to_string(),
-        "CssPixels".to_string(),
         "rust_calc_root_from_calculated".to_string(),
         "rust_calc_external_resolutions".to_string(),
         "rust_calc_external_resolutions_release".to_string(),
     ];
-    layout_config
-        .export
-        .rename
-        .insert("CssPixels".to_string(), "int32_t".to_string());
+    expose_css_pixels_as_raw_i32(&mut layout_config);
     layout_config
         .includes
         .push("LibWeb/Layout/TreeBuilderRustFFI.h".to_string());

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -898,7 +898,6 @@ pub struct FfiLayoutFcCallbacks {
     pub needs_inset_resolution: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub report_unexpected_fragmented_inline: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub release_anchor_name_handle: crate::layout::FfiReleaseAnchorNameHandleCallback,
-    pub build_replaced_content_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> crate::layout::FfiReplacedContentFacts,
     pub build_svg_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgElementFacts,
     pub read_paintable_geometry:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut crate::layout::FfiPaintableGeometry) -> bool,
@@ -946,6 +945,10 @@ impl FfiLayoutFcCallbacks {
         // set_computed_values verifies no pass is running and no layout node
         // is created mid-pass.
         unsafe { &*std::ptr::from_ref(payloads) }
+    }
+
+    pub(crate) fn replaced_content_facts(&self, node: Node) -> Option<crate::layout::FfiReplacedContentFacts> {
+        self.arena().replaced_content_facts(node)
     }
 
     pub(crate) fn computed_values_view_if_styled(&self, node: Node) -> Option<ComputedValuesView<'static>> {

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -8,6 +8,7 @@ use crate::abort_on_panic;
 use crate::layout::AbsposLayoutInputs;
 use crate::layout::AvailableSize;
 use crate::layout::CssPixels;
+use crate::layout::FfiReplacedContentFacts;
 use crate::layout::node_data::{FfiStylePayloads, MAX_NODE_SLOT_COUNT, NodeData, NodeFlag, NodeSlotId};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -143,6 +144,12 @@ struct TextContentSlot {
     content: Option<Box<TextContent>>,
 }
 
+#[derive(Default)]
+struct ReplacedContentFactsSlot {
+    generation: u8,
+    facts: Option<FfiReplacedContentFacts>,
+}
+
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) struct TextChunkCacheKey {
     pub(crate) should_wrap_lines: bool,
@@ -209,6 +216,7 @@ pub(crate) struct LayoutNodeArena {
     saved_abspos_layout_inputs: RefCell<Vec<SavedAbsposLayoutInputsSlot>>,
     text_contents: Vec<TextContentSlot>,
     text_chunk_caches: RefCell<Vec<TextChunkCacheSlot>>,
+    replaced_content_facts: Vec<ReplacedContentFactsSlot>,
     raw_table_column_spans: HashMap<NodeSlotId, u32>,
     owner_thread: thread::ThreadId,
 }
@@ -226,6 +234,7 @@ impl LayoutNodeArena {
             saved_abspos_layout_inputs: RefCell::new(Vec::new()),
             text_contents: Vec::new(),
             text_chunk_caches: RefCell::new(Vec::new()),
+            replaced_content_facts: Vec::new(),
             raw_table_column_spans: HashMap::new(),
             owner_thread: thread::current().id(),
         }
@@ -318,6 +327,9 @@ impl LayoutNodeArena {
         }
         if let Some(slot) = self.text_chunk_caches.get_mut().get_mut(index as usize) {
             *slot = TextChunkCacheSlot::default();
+        }
+        if let Some(slot) = self.replaced_content_facts.get_mut(index as usize) {
+            *slot = ReplacedContentFactsSlot::default();
         }
         self.raw_table_column_spans.remove(&id);
         *self.data_mut(index) = NodeData::default();
@@ -672,6 +684,28 @@ impl LayoutNodeArena {
         }
     }
 
+    pub(crate) fn set_replaced_content_facts(&mut self, id: NodeSlotId, facts: FfiReplacedContentFacts) {
+        self.assert_owner_thread();
+        self.data(id);
+        let index = id.slot_index() as usize;
+        if self.replaced_content_facts.len() <= index {
+            self.replaced_content_facts
+                .resize_with(index + 1, ReplacedContentFactsSlot::default);
+        }
+        self.replaced_content_facts[index] = ReplacedContentFactsSlot {
+            generation: id.generation(),
+            facts: Some(facts),
+        };
+    }
+
+    pub(crate) fn replaced_content_facts(&self, id: NodeSlotId) -> Option<FfiReplacedContentFacts> {
+        assert!(!id.is_invalid(), "invalid layout node arena slot ID");
+        self.replaced_content_facts
+            .get(id.slot_index() as usize)
+            .filter(|slot| slot.generation == id.generation())
+            .and_then(|slot| slot.facts)
+    }
+
     pub(crate) fn set_raw_table_column_span(&mut self, id: NodeSlotId, value: u32) {
         self.assert_owner_thread();
         self.data(id);
@@ -866,6 +900,20 @@ pub unsafe extern "C" fn layout_arena_set_text_content(
             untransformed_text_is_ascii_whitespace,
             may_require_bidi_processing,
         );
+    });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_set_replaced_content_facts(
+    arena: *mut c_void,
+    id: NodeSlotId,
+    facts: FfiReplacedContentFacts,
+) {
+    abort_on_panic(|| {
+        assert!(!arena.is_null(), "layout node arena handle is null");
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { &mut *arena.cast::<LayoutNodeArena>() }.set_replaced_content_facts(id, facts);
     });
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -350,7 +350,21 @@ impl<'pass> NodeFacts<'pass> {
     }
 
     fn replaced_content(&self) -> crate::layout::FfiReplacedContentFacts {
-        self.state.replaced_content_facts(self.callbacks, self.node)
+        let Some(facts) = self.callbacks.replaced_content_facts(self.node) else {
+            // The kind check is cheap enough for release builds; the style
+            // half of the enrollment predicate is debug-only because this
+            // miss path is the steady state for ordinary boxes.
+            assert!(
+                !crate::layout::node_may_have_replaced_content_facts(self.data()),
+                "replaced content facts were not synced to the arena before layout"
+            );
+            debug_assert!(
+                !crate::layout::node_may_have_replaced_content_facts_including_size_containment(self.data()),
+                "replaced content facts were not synced to the arena before layout"
+            );
+            return crate::layout::FfiReplacedContentFacts::default();
+        };
+        facts
     }
 
     pub(crate) fn is_text_node(&self) -> bool {
@@ -836,7 +850,6 @@ pub(crate) struct LayoutState {
     abspos_layout_pass_queue_in_completion_order: RefCell<VecDeque<Node>>,
     abspos_layout_pass_is_active: Cell<bool>,
     anchor_inset_store: AnchorInsetStore,
-    replaced_content_facts: PagedStore<crate::layout::FfiReplacedContentFacts>,
     inline_containing_blocks: RefCell<HashSet<Node>>,
     anchor_candidate_shells: RefCell<Vec<*mut c_void>>,
     purpose: LayoutStatePurpose,
@@ -883,7 +896,6 @@ impl LayoutState {
             abspos_layout_pass_queue_in_completion_order: RefCell::new(VecDeque::new()),
             abspos_layout_pass_is_active: Cell::new(false),
             anchor_inset_store: AnchorInsetStore::default(),
-            replaced_content_facts: PagedStore::default(),
             inline_containing_blocks: RefCell::new(HashSet::new()),
             anchor_candidate_shells: RefCell::new(Vec::new()),
             purpose,
@@ -1197,33 +1209,6 @@ impl LayoutState {
         if resolved.resolves_left {
             replace(InsetField::Left, resolved.left_is_auto, resolved.left);
         }
-    }
-
-    pub(crate) fn replaced_content_facts(
-        &self,
-        callbacks: &FfiLayoutFcCallbacks,
-        node: Node,
-    ) -> crate::layout::FfiReplacedContentFacts {
-        let slot_index = callbacks.slot_index(node);
-        if let Some(facts) = self.replaced_content_facts.get(slot_index) {
-            return *facts;
-        }
-        let data = callbacks.node_data(node);
-        // Size containment gives any box an auto content box size of zero, so
-        // size-contained boxes join the replaced kinds in fetching real facts.
-        let size_containment_may_apply = crate::layout::kind_is_box(data.kind) && !data.style.is_null() && {
-            let style = self.style_facts(callbacks, node);
-            style.has_size_containment() || style.is_size_container()
-        };
-        let facts = if crate::layout::node_may_have_replaced_content_facts(data) || size_containment_may_apply {
-            // SAFETY: The callback table and node are supplied by the live C++
-            // formatting-context shim and remain valid for this layout pass.
-            unsafe { (callbacks.build_replaced_content_facts)(callbacks.context, callbacks.shell(node)) }
-        } else {
-            crate::layout::FfiReplacedContentFacts::default()
-        };
-        self.replaced_content_facts.allocate(slot_index, facts);
-        facts
     }
 
     pub(crate) fn text_chunks(

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -46,6 +46,7 @@ use crate::layout::layout_node_arena::IntrinsicInlineSizeMeasurement;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKey;
 use crate::layout::layout_node_arena::IntrinsicSizeCacheKind;
 use crate::layout::layout_node_arena::LayoutNodeArena;
+pub use crate::layout::node_data::FfiReplacedContentFacts;
 pub use crate::layout::node_data::FfiStylePayloads;
 use crate::layout::node_data::NodeData;
 use crate::layout::node_data::NodeFlag;

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use crate::layout::CssPixels;
 use std::ffi::c_void;
 
 pub const INVALID_NODE_SLOT_INDEX: u32 = u32::MAX;
@@ -12,6 +13,21 @@ pub const GENERATED_FOR_MARKER: u8 = 6;
 // The full C++ StyleGroupIndex space; LayoutRustBridge.cpp static-asserts the
 // count so the style container array and the registered group indices line up.
 pub const STYLE_GROUP_COUNT: usize = 23;
+
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+pub struct FfiReplacedContentFacts {
+    pub has_auto_content_width: bool,
+    pub auto_content_width: CssPixels,
+    pub has_auto_content_height: bool,
+    pub auto_content_height: CssPixels,
+    pub auto_content_aspect_ratio_numerator: CssPixels,
+    pub auto_content_aspect_ratio_denominator: CssPixels,
+    pub has_default_preferred_width: bool,
+    pub default_preferred_width: CssPixels,
+    pub has_default_preferred_height: bool,
+    pub default_preferred_height: CssPixels,
+}
 
 #[derive(Clone, Copy)]
 #[repr(C)]

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -4,26 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-/// Content-derived sizing data that genuinely lives on the C++ side (image
-/// decode state, media metadata, font-resolved default control sizes). Fetched
-/// lazily once per pass, and only for node kinds that can produce any of it.
-#[derive(Clone, Copy, Default)]
-#[repr(C)]
-pub struct FfiReplacedContentFacts {
-    pub has_auto_content_width: bool,
-    pub auto_content_width: CssPixels,
-    pub has_auto_content_height: bool,
-    pub auto_content_height: CssPixels,
-    /// A zero denominator means the auto content box size carries no aspect
-    /// ratio; a valid ratio can never have a zero denominator.
-    pub auto_content_aspect_ratio_numerator: CssPixels,
-    pub auto_content_aspect_ratio_denominator: CssPixels,
-    pub has_default_preferred_width: bool,
-    pub default_preferred_width: CssPixels,
-    pub has_default_preferred_height: bool,
-    pub default_preferred_height: CssPixels,
-}
-
 pub(crate) fn node_may_have_replaced_content_facts(data: &NodeData) -> bool {
     kind_is_replaced_box(data.kind)
         || matches!(
@@ -31,6 +11,23 @@ pub(crate) fn node_may_have_replaced_content_facts(data: &NodeData) -> bool {
             NodeKind::RangeInputBox | NodeKind::TextAreaBox | NodeKind::TextInputBox
         )
         || has_flag(data, NodeFlag::IsHtmlInputElement)
+}
+
+// Size containment gives any box an auto content box size of zero, so
+// size-contained boxes join the replaced kinds in publishing real facts.
+// C++ enrollment and the Rust sync assertion both evaluate this predicate.
+pub(crate) fn node_may_have_replaced_content_facts_including_size_containment(data: &NodeData) -> bool {
+    if node_may_have_replaced_content_facts(data) {
+        return true;
+    }
+    if !kind_is_box(data.kind) || data.style.is_null() {
+        return false;
+    }
+    // SAFETY: A non-null style pointer addresses the container's group
+    // pointer array, which FfiStylePayloads mirrors exactly.
+    let payloads = unsafe { &*data.style.cast::<crate::layout::FfiStylePayloads>() };
+    let style = ComputedValuesView::new(&payloads.groups);
+    style.has_size_containment() || style.is_size_container()
 }
 
 pub(crate) fn node_is_out_of_flow(data: &NodeData, style: Option<ComputedValuesView<'_>>) -> bool {
@@ -169,7 +166,6 @@ fn kind_is_svg_box(kind: NodeKind) -> bool {
             | NodeKind::SVGTextPathBox
     )
 }
-
 
 #[cfg(test)]
 mod node_facts_tests {

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -2130,6 +2130,12 @@ pub extern "C" fn layout_node_kind_facts_match(kind: NodeKind, facts: FfiNodeKin
     facts == kind_facts(kind)
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_node_data_may_have_replaced_content_facts(data: *const NodeData) -> bool {
+    // SAFETY: The C++ caller passes the node's live arena slot.
+    crate::layout::node_may_have_replaced_content_facts_including_size_containment(unsafe { &*data })
+}
+
 fn node_is_generated_for_pseudo_element(data: &NodeData) -> bool {
     data.generated_for != 0
 }


### PR DESCRIPTION
Layout used to fetch replaced content facts (natural sizes, natural aspect ratio, default control sizes) from C++ through a callback and cache them per LayoutState. Every measurement state re-fetched the same facts, and NodeFacts needed the whole callback table just to read data that never changes during layout.

Now C++ pushes the facts into an arena side table before layout starts, the same way text content gets there. A node is enrolled for this sync when a shared predicate says it can have facts: it is a replaced or input box, or it is a box whose style has size containment. The predicate lives in Rust and C++ calls it over FFI, so both sides always agree. Document syncs the enrolled nodes once per layout update, and re-publishing every update keeps the facts fresh without invalidation hooks, because nothing that feeds them can change while layout runs.

On a lookup miss NodeFacts asserts the node was not supposed to have facts (the cheap kind check in release builds, the full predicate in debug builds) and returns empty facts. The
build_replaced_content_facts callback is gone.