### PR TITLE
LibWeb: Lay out abspos children at containing-block completion

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1755,31 +1755,24 @@ pub(crate) fn layout_contained_abspos_children(run: &crate::layout::FormattingCo
     AbsposEngine::new(run.state, run.callbacks).layout_children(run);
 }
 
-/// Lays out every registered abspos child once the in-flow run has finished.
-/// Queues are processed in the order their formatting contexts completed, so
-/// deeper containing blocks come first and the root comes last: the layout
-/// order anchor() acceptability assumes for absolutely positioned anchors.
-/// A formatting context completing during the pass belongs to an absolutely
-/// positioned subtree; its children are laid out at that completion point,
-/// before later boxes of the queue that produced it.
-pub(crate) fn run_abspos_layout_pass(
+pub(crate) fn drain_remaining_abspos_targets(
     state: &LayoutState,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
+    targets: &[Node],
 ) {
-    state.set_abspos_layout_pass_is_active(true);
-    while let Some(root) = state.pop_from_abspos_layout_pass_queue() {
-        if !state.has_contained_abspos_children(root) {
-            continue;
-        }
+    while let Some(target) = targets
+        .iter()
+        .copied()
+        .find(|target| !target.is_invalid() && state.has_contained_abspos_children(*target))
+    {
         let run =
-            crate::layout::FormattingContextRun::new(state, root, LayoutMode::Normal, callbacks, should_collect_devtools_layout_data, false);
+            crate::layout::FormattingContextRun::new(state, target, LayoutMode::Normal, callbacks, should_collect_devtools_layout_data, false);
         layout_contained_abspos_children(&run);
     }
-    state.set_abspos_layout_pass_is_active(false);
     debug_assert!(
         state.all_registered_contained_abspos_children_are_laid_out(),
-        "registered abspos children were left without layout after the pass"
+        "registered abspos children were left without layout after the entry sweep"
     );
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -456,12 +456,28 @@ pub(crate) fn register_contained_abspos_child(
     loop {
         let containing_block = callbacks.containing_block(target);
         let facts = state.node_facts(callbacks, target);
-        if containing_block.is_invalid() || formatting_context_type_created_by_box(facts).is_some() {
+        if containing_block.is_invalid()
+            || (formatting_context_type_created_by_box(facts).is_some()
+                && !containing_block_geometry_is_finalized_by_the_table_run(state, callbacks, target))
+        {
             break;
         }
         target = containing_block;
     }
     state.register_contained_abspos_child(callbacks, target, child, static_position_rect);
+}
+
+fn containing_block_geometry_is_finalized_by_the_table_run(
+    state: &LayoutState,
+    callbacks: &FfiLayoutFcCallbacks,
+    containing_block: Node,
+) -> bool {
+    let facts = state.node_facts(callbacks, containing_block);
+    facts.is_table_cell()
+        || facts.is_table_row()
+        || facts.is_table_row_group()
+        || facts.is_table_header_group()
+        || facts.is_table_footer_group()
 }
 
 pub(crate) fn box_baseline(
@@ -1595,12 +1611,7 @@ fn run_formatting_context<'pass>(
         FormattingContextImplementation::Svg(_) | FormattingContextImplementation::ReplacedWithChildren => {}
         FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => return result,
     }
-    let box_ = run.box_;
-    if run.state.abspos_layout_pass_is_active() {
-        layout_contained_abspos_children(run);
-    } else {
-        run.state.enqueue_for_abspos_layout_pass(box_);
-    }
+    layout_contained_abspos_children(run);
     result
 }
 
@@ -1843,7 +1854,12 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             None,
         );
         place_child(&state, &callbacks, root_for_layout, FfiCssPixelPoint::default());
-        run_abspos_layout_pass(state_ref, callbacks, should_collect_devtools_layout_data);
+        drain_remaining_abspos_targets(
+            state_ref,
+            callbacks,
+            should_collect_devtools_layout_data,
+            &[root, root_for_layout],
+        );
         state.commit_replacing(root, std::ptr::null_mut(), &callbacks, sink);
     });
 }
@@ -1904,7 +1920,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let fc_type = formatting_context_type_created_by_box(facts)
             .expect("partial relayout root must establish an independent formatting context");
         run_formatting_context(state_ref, root, None, fc_type, LayoutMode::Normal, false, callbacks, input, None);
-        run_abspos_layout_pass(state_ref, callbacks, false);
+        drain_remaining_abspos_targets(state_ref, callbacks, false, &[viewport, root]);
         state.commit_replacing(root, paintable_to_replace, &callbacks, sink);
     });
 }
@@ -1934,7 +1950,7 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         assert!(!containing_block.is_invalid());
         let run = crate::layout::FormattingContextRun::new(state_ref, containing_block, LayoutMode::Normal, callbacks, false, false);
         AbsposEngine::new(state_ref, callbacks).replay(&run, box_);
-        run_abspos_layout_pass(state_ref, callbacks, false);
+        drain_remaining_abspos_targets(state_ref, callbacks, false, &[containing_block]);
         state.commit_replacing(box_, paintable_to_replace, &callbacks, sink);
     });
 }

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -833,8 +833,6 @@ impl<'pass> NodeFacts<'pass> {
 pub(crate) struct LayoutState {
     used_values: PagedStore<UsedValues>,
     contained_abspos_children: PagedStore<RefCell<VecDeque<PendingAbsposChild>>>,
-    abspos_layout_pass_queue_in_completion_order: RefCell<VecDeque<Node>>,
-    abspos_layout_pass_is_active: Cell<bool>,
     anchor_inset_store: AnchorInsetStore,
     replaced_content_facts: PagedStore<crate::layout::FfiReplacedContentFacts>,
     inline_containing_blocks: RefCell<HashSet<Node>>,
@@ -880,8 +878,6 @@ impl LayoutState {
         Self {
             used_values: PagedStore::default(),
             contained_abspos_children: PagedStore::default(),
-            abspos_layout_pass_queue_in_completion_order: RefCell::new(VecDeque::new()),
-            abspos_layout_pass_is_active: Cell::new(false),
             anchor_inset_store: AnchorInsetStore::default(),
             replaced_content_facts: PagedStore::default(),
             inline_containing_blocks: RefCell::new(HashSet::new()),
@@ -1356,27 +1352,6 @@ impl LayoutState {
             all_laid_out &= children.borrow().is_empty();
         });
         all_laid_out
-    }
-
-    /// Every completed root enqueues even when its queue is still empty:
-    /// fixed-position descendants of abspos subtrees register against the
-    /// viewport only while the pass lays those subtrees out.
-    pub(crate) fn enqueue_for_abspos_layout_pass(&self, target_box: Node) {
-        self.abspos_layout_pass_queue_in_completion_order
-            .borrow_mut()
-            .push_back(target_box);
-    }
-
-    pub(crate) fn pop_from_abspos_layout_pass_queue(&self) -> Option<Node> {
-        self.abspos_layout_pass_queue_in_completion_order.borrow_mut().pop_front()
-    }
-
-    pub(crate) fn abspos_layout_pass_is_active(&self) -> bool {
-        self.abspos_layout_pass_is_active.get()
-    }
-
-    pub(crate) fn set_abspos_layout_pass_is_active(&self, is_active: bool) {
-        self.abspos_layout_pass_is_active.set(is_active);
     }
 
     /// By completion time the grid-area geometry is final and every abspos


### PR DESCRIPTION
Absolutely positioned boxes were laid out in a deferred pass after all in-flow layout: each completed formatting context enqueued itself, and a driver replayed the queue after the root run returned. Every run's tail already has everything that layout needs — the containing block's final padding and content sizes, and the fully laid out subtree that static position and anchor() resolution read — and tails complete in exactly the order the deferred pass replayed. The pass queue, its reentrancy flag, and the driver are deleted; each run lays out the absolutely positioned children registered against its box before returning, and the FFI entry points sweep the targets that have no run of their own (the viewport, the SVG document root, and the replay containing block).

Registrations whose containing block is a table cell, row, or row group are handled at the table grid box's completion instead: their containing block geometry is only final once the table run finishes row sizing.