### PR TITLE
Return the measured table box size on the wrapper's run result

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -196,6 +196,7 @@ pub(crate) struct BlockFormattingContext<'pass> {
     lowest_floating_descendant_bottom_margin_edge: Cell<Option<CssPixels>>,
     derived_baselines_of_root_box: Cell<DerivedBaselines>,
     trailing_collapsed_margin: Cell<Option<(Node, CssPixels)>>,
+    table_box_in_wrapper_border_box_block_size: Cell<Option<CssPixels>>,
 }
 
 impl<'pass> BlockFormattingContext<'pass> {
@@ -215,7 +216,12 @@ impl<'pass> BlockFormattingContext<'pass> {
             lowest_floating_descendant_bottom_margin_edge: Cell::new(None),
             derived_baselines_of_root_box: Cell::new(DerivedBaselines::default()),
             trailing_collapsed_margin: Cell::new(None),
+            table_box_in_wrapper_border_box_block_size: Cell::new(None),
         }
+    }
+
+    pub(crate) fn table_box_in_wrapper_border_box_block_size(&self) -> Option<CssPixels> {
+        self.table_box_in_wrapper_border_box_block_size.get()
     }
 
     fn facts(&self, node: Node) -> NodeFacts<'_> {
@@ -1790,7 +1796,13 @@ impl<'pass> BlockFormattingContext<'pass> {
                 },
                 participation: ParticipationInParentFormattingContext::BlockLevel,
             };
-            self.layout_inside(run, node, inside_layout_input, true)
+            let child_layout = self.layout_inside(run, node, inside_layout_input, true);
+            if container_facts.is_table_wrapper() && style.display().is_table_inside() && child_layout.is_some() {
+                let used = self.used(node);
+                self.table_box_in_wrapper_border_box_block_size
+                    .set(Some(used.border_box_block_size(used.uses_collapsing_borders_model.get())));
+            }
+            child_layout
         } else {
             // This box participates in the current block container's flow.
             let space_available_for_children = if facts.is_anonymous() {

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -230,10 +230,10 @@ impl MeasurementState {
         layout_mode: LayoutMode,
         input: LayoutInput,
     ) -> crate::layout::ChildLayoutResult {
-        let rust_state = self.rust_state();
-        let fc_type = crate::layout::independent_formatting_context_type(rust_state, node, &self.callbacks);
+        let layout_state = self.layout_state();
+        let fc_type = crate::layout::independent_formatting_context_type(layout_state, node, &self.callbacks);
         crate::layout::run_formatting_context(
-            rust_state,
+            layout_state,
             node,
             None,
             fc_type,
@@ -245,7 +245,7 @@ impl MeasurementState {
         )
     }
 
-    pub(crate) fn rust_state(&self) -> &LayoutState {
+    pub(crate) fn layout_state(&self) -> &LayoutState {
         &self.state
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -772,6 +772,7 @@ pub(crate) struct ChildLayoutResult {
     pub automatic_content_inline_size: CssPixels,
     pub automatic_content_block_size: CssPixels,
     pub baselines: DerivedBaselines,
+    pub table_box_in_wrapper_border_box_block_size: Option<CssPixels>,
 }
 
 pub(crate) enum ChildLayoutOutcome {
@@ -1516,6 +1517,7 @@ fn run_formatting_context<'pass>(
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
                     baselines,
+                    table_box_in_wrapper_border_box_block_size: context.table_box_in_wrapper_border_box_block_size(),
                 }
             }
             FormattingContextImplementation::Flex(context) => {
@@ -1526,6 +1528,7 @@ fn run_formatting_context<'pass>(
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
                     baselines,
+                    ..ChildLayoutResult::default()
                 }
             }
             FormattingContextImplementation::Grid(context) => {
@@ -1536,6 +1539,7 @@ fn run_formatting_context<'pass>(
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
                     baselines,
+                    ..ChildLayoutResult::default()
                 }
             }
             FormattingContextImplementation::Table(context) => {
@@ -1546,6 +1550,7 @@ fn run_formatting_context<'pass>(
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size,
                     baselines,
+                    ..ChildLayoutResult::default()
                 }
             }
             FormattingContextImplementation::Svg(context) => {

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -2609,7 +2609,7 @@ impl<'pass> GridFormattingContext<'pass> {
         scratch_root.has_definite_inline_size.set(live.has_definite_inline_size.get());
         scratch_root.has_definite_block_size.set(live.has_definite_block_size.get());
         let mut context = GridFormattingContext::new(
-            scratch.rust_state(),
+            scratch.layout_state(),
             subgrid.box_,
             Some(self),
             LayoutMode::IntrinsicSizing,

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -70,5 +70,6 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
         automatic_content_inline_size: content_inline_size,
         automatic_content_block_size: wrapper_layout.automatic_content_block_size,
         baselines: DerivedBaselines::default(),
+        ..ChildLayoutResult::default()
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1854,7 +1854,7 @@ impl<'pass> SizingContext<'pass> {
     ) -> &UsedValues {
         let callbacks = *measurement.callbacks();
         measurement
-            .rust_state()
+            .layout_state()
             .create_used_values(&callbacks, node, constraints)
     }
 
@@ -1900,7 +1900,7 @@ impl<'pass> SizingContext<'pass> {
             .set(table_style.padding_right().to_px(containing_block_inline_size));
 
         let table_run = crate::layout::FormattingContextRun::new(
-            measurement.rust_state(),
+            measurement.layout_state(),
             table_box,
             LayoutMode::IntrinsicSizing,
             *measurement.callbacks(),

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1947,10 +1947,9 @@ impl<'pass> SizingContext<'pass> {
 
         // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
         let available_block_size = containing_block_block_size - margin_top - margin_bottom;
-        let table_box = self.table_box_inside_wrapper(wrapper);
 
         let measurement = MeasurementState::create(self.callbacks, wrapper, table_wrapper_constraints);
-        measurement.run_with_layout_mode(
+        let wrapper_result = measurement.run_with_layout_mode(
             wrapper,
             LayoutMode::IntrinsicSizing,
             LayoutInput {
@@ -1964,8 +1963,9 @@ impl<'pass> SizingContext<'pass> {
             },
         );
 
-        let table_used = measurement.rust_state().used_values(measurement.callbacks(), table_box);
-        let table_used_block_size = table_used.border_box_block_size(table_used.uses_collapsing_borders_model.get());
+        let table_used_block_size = wrapper_result
+            .table_box_in_wrapper_border_box_block_size
+            .expect("a table wrapper's measurement run lays out the table box inside it");
         if matches!(available_space.block_size, AvailableSize::Definite(_)) {
             table_used_block_size.min(available_block_size)
         } else {

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -2020,11 +2020,11 @@ impl<'pass> TableFormattingContext<'pass> {
                 participation: ParticipationInParentFormattingContext::Item,
             },
         );
-        let measured_cell_used = measurement.rust_state().used_values(measurement.callbacks(), cell.box_);
+        let measured_cell_used = measurement.layout_state().used_values(measurement.callbacks(), cell.box_);
         Some(MeasuredCellContent {
             content_block_size: result.automatic_content_block_size,
             first_baseline: crate::layout::box_baseline_with_content_baselines(
-                measurement.rust_state(),
+                measurement.layout_state(),
                 measurement.callbacks(),
                 cell.box_,
                 measured_cell_used,


### PR DESCRIPTION
The table-wrapper block-size measurement reached into the completed
measurement run's state to read the table box's border-box block size
after the run returned. The wrapper's block run now records that size
when it lays the table box out, the value is returned on
ChildLayoutResult, and the wrapper-measure path consumes the run
result like every other caller. Result construction in the other
formatting-context arms switches to functional-update syntax so a
result field with a single producer does not ripple through every
arm.