### PR TITLE
LibWeb: Improve style resolution for SVG documents and images

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorMatching.cpp
+++ b/Libraries/LibWeb/CSS/SelectorMatching.cpp
@@ -536,7 +536,12 @@ extern "C" bool selector_ffi_element_is_html_element_in_html_document(void const
 
 extern "C" bool selector_ffi_element_is_document_root(void const* element)
 {
-    return is<HTML::HTMLHtmlElement>(ffi_element(element));
+    // https://drafts.csswg.org/selectors/#root-pseudo
+    // `:root` names the root of the document, which is an `<html>` element only in an HTML
+    // document. A standalone SVG or XML document has one too, and a `<html>` element that is not
+    // its document's root is not it.
+    auto const& subject = ffi_element(element);
+    return &subject == subject.document().document_element();
 }
 
 extern "C" bool selector_ffi_element_is_link(void const* element)

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -37,7 +37,7 @@ public:
     virtual void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const { }
 
     virtual bool is_paintable(DOM::Document const&) const = 0;
-    virtual void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, ImageRendering) const = 0;
+    virtual void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, ImageRendering, PreferredColorScheme) const = 0;
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const { return {}; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -86,7 +86,7 @@ void ConicGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& node
     m_resolved->position = position_value()->resolved(CSSPixelRect { { 0, 0 }, size });
 }
 
-void ConicGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
+void ConicGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme) const
 {
     VERIFY(m_resolved.has_value());
     auto destination_rect = dest_rect.to_type<int>();

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -32,7 +32,7 @@ public:
 
     void serialize(StringBuilder&, SerializationMode) const;
 
-    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
+    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme) const override;
 
     ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const;
     bool equals(StyleValue const& other) const;

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.cpp
@@ -86,6 +86,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         return {};
 
     auto const& current_color = layout_node.computed_values().color();
+    auto const current_color_scheme = document.page().preferred_color_scheme();
 
     // Create a bitmap if needed.
     // The cursor size for a given image never changes. It's based either on the image itself, or our default size,
@@ -117,9 +118,7 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
     }
 
     // Repaint the bitmap if necessary
-    if (m_cached_bitmap_color != current_color) {
-        m_cached_bitmap_color = current_color;
-
+    if (m_cached_bitmap_color != current_color || m_cached_bitmap_color_scheme != current_color_scheme) {
         // Clear whatever was in the bitmap before.
         auto& bitmap = *m_cached_bitmap->bitmap();
         auto painter = Gfx::Painter::create(bitmap);
@@ -133,12 +132,16 @@ Optional<Gfx::ImageCursor> CursorStyleValue::make_image_cursor(Layout::NodeWithS
         DisplayListRecordingContext paint_context { display_list_recorder, document.page().palette(), document.page().client().device_pixels_per_css_pixel(), document.page().chrome_metrics() };
 
         image.resolve_for_size(layout_node, CSSPixelSize { bitmap.size() });
-        image.paint(paint_context, document, DevicePixelRect { bitmap.rect() }, ImageRendering::Auto);
+        // A cursor image is not embedded by any element, so it follows the page's own preference.
+        image.paint(paint_context, document, DevicePixelRect { bitmap.rect() }, ImageRendering::Auto, current_color_scheme);
 
         auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(bitmap);
         Painting::DisplayListPlayerSkia display_list_player;
         display_list_player.execute(*display_list, visual_context_tree, resource_storage, {}, painting_surface);
         display_list_player.flush(*painting_surface);
+
+        m_cached_bitmap_color = current_color;
+        m_cached_bitmap_color_scheme = current_color_scheme;
     }
 
     // "If the values are unspecified, then the natural hotspot defined inside the image resource itself is used.

--- a/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CursorStyleValue.h
@@ -62,6 +62,7 @@ private:
     ValueComparingRefPtr<StyleValue const> m_y;
 
     mutable Optional<Color> m_cached_bitmap_color;
+    mutable Optional<PreferredColorScheme> m_cached_bitmap_color_scheme;
     mutable Optional<Gfx::ShareableBitmap> m_cached_bitmap;
 };
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.cpp
@@ -178,10 +178,10 @@ bool ImageSetStyleValue::is_paintable(DOM::Document const& document) const
     return false;
 }
 
-void ImageSetStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, ImageRendering image_rendering) const
+void ImageSetStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, ImageRendering image_rendering, PreferredColorScheme color_scheme) const
 {
     if (m_selected_image)
-        m_selected_image->paint(context, document, dest_rect, image_rendering);
+        m_selected_image->paint(context, document, dest_rect, image_rendering, color_scheme);
 }
 
 Optional<Gfx::Color> ImageSetStyleValue::color_if_single_pixel_bitmap(DOM::Document const& document) const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageSetStyleValue.h
@@ -36,7 +36,7 @@ public:
 
     virtual void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
     virtual bool is_paintable(DOM::Document const&) const override;
-    virtual void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&, ImageRendering) const override;
+    virtual void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&, ImageRendering, PreferredColorScheme) const override;
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
 
     AbstractImageStyleValue const* selected_image() const { return m_selected_image; }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -181,23 +181,23 @@ bool ImageStyleValue::is_paintable(DOM::Document const& document) const
     return image_data(document);
 }
 
-void ImageStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const
+void ImageStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering, PreferredColorScheme color_scheme) const
 {
     auto image_data = this->image_data(document);
     if (!image_data)
         return;
 
     auto dest_int_rect = dest_rect.to_type<int>();
-    image_data->paint(context, dest_int_rect, image_rendering);
+    image_data->paint(context, dest_int_rect, image_rendering, color_scheme);
 }
 
-Optional<Painting::DisplayListResource> ImageStyleValue::record_display_list(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect) const
+Optional<Painting::DisplayListResource> ImageStyleValue::record_display_list(DisplayListRecordingContext& context, DOM::Document const& document, DevicePixelRect const& dest_rect, PreferredColorScheme color_scheme) const
 {
     auto image_data = this->image_data(document);
     if (!image_data)
         return {};
 
-    return image_data->record_display_list(dest_rect.size().to_type<int>(), context.display_list_recorder().resource_storage());
+    return image_data->record_display_list(dest_rect.size().to_type<int>(), color_scheme, context.display_list_recorder().resource_storage());
 }
 
 Optional<Gfx::DecodedImageFrame> ImageStyleValue::current_frame(DOM::Document const& document, DevicePixelRect const& dest_rect) const

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -87,8 +87,8 @@ public:
     Optional<CSSPixelFraction> natural_aspect_ratio(DOM::Document const&) const override;
 
     virtual bool is_paintable(DOM::Document const&) const override;
-    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
-    Optional<Painting::DisplayListResource> record_display_list(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&) const;
+    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering, PreferredColorScheme) const override;
+    Optional<Painting::DisplayListResource> record_display_list(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const&, PreferredColorScheme) const;
 
     virtual Optional<Gfx::Color> color_if_single_pixel_bitmap(DOM::Document const&) const override;
     Optional<Gfx::DecodedImageFrame> current_frame(DOM::Document const&, DevicePixelRect const& dest_rect = {}) const;

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -192,7 +192,7 @@ void LinearGradientStyleValue::resolve_for_size(Layout::NodeWithStyle const& nod
     }
 }
 
-void LinearGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
+void LinearGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme) const
 {
     VERIFY(m_resolved.has_value());
     context.display_list_recorder().fill_rect_with_linear_gradient(dest_rect.to_type<int>(), m_resolved.value());

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -79,7 +79,7 @@ public:
     void resolve_for_size(Layout::NodeWithStyle const&, CSSPixelSize) const override;
 
     bool is_paintable(DOM::Document const&) const override { return true; }
-    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering) const override;
+    void paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering image_rendering, PreferredColorScheme) const override;
 
 private:
     friend class StyleValue;

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -138,7 +138,7 @@ bool RadialGradientStyleValue::equals(StyleValue const& other) const
         && gradient_color_syntax() == other_gradient.gradient_color_syntax();
 }
 
-void RadialGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const
+void RadialGradientStyleValue::paint(DisplayListRecordingContext& context, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme) const
 {
     VERIFY(m_resolved.has_value());
     auto center = context.rounded_device_point(m_resolved->center).to_type<int>();

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -33,7 +33,7 @@ public:
 
     void serialize(StringBuilder&, SerializationMode) const;
 
-    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
+    void paint(DisplayListRecordingContext&, DOM::Document const&, DevicePixelRect const& dest_rect, CSS::ImageRendering, PreferredColorScheme) const override;
 
     ValueComparingNonnullRefPtr<StyleValue const> absolutized(ComputationContext const&) const;
     bool equals(StyleValue const& other) const;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -561,6 +561,13 @@ public:
         bump_dom_tree_version();
     }
 
+    // The used `color-scheme` of the element referencing this document, when it is an SVG being
+    // used as an image. `prefers-color-scheme` inside such a document answers with it rather than
+    // with the page's preference, and the same image can be referenced twice with different
+    // answers.
+    Optional<CSS::PreferredColorScheme> svg_image_color_scheme() const { return m_svg_image_color_scheme; }
+    void set_svg_image_color_scheme(CSS::PreferredColorScheme color_scheme) { m_svg_image_color_scheme = color_scheme; }
+
     bool parser_cannot_change_the_mode() const { return m_parser_cannot_change_the_mode; }
     void set_parser_cannot_change_the_mode(bool parser_cannot_change_the_mode) { m_parser_cannot_change_the_mode = parser_cannot_change_the_mode; }
 
@@ -1481,6 +1488,7 @@ private:
 
     QuirksMode m_quirks_mode { QuirksMode::No };
 
+    Optional<CSS::PreferredColorScheme> m_svg_image_color_scheme;
     bool m_parser_cannot_change_the_mode { false };
 
     // https://dom.spec.whatwg.org/#concept-document-type

--- a/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.cpp
@@ -251,7 +251,7 @@ Optional<CSSPixelFraction> AnimatedBitmapDecodedImageData::intrinsic_aspect_rati
     return CSSPixels(m_size.width()) / CSSPixels(m_size.height());
 }
 
-void AnimatedBitmapDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering image_rendering) const
+void AnimatedBitmapDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering image_rendering, CSS::PreferredColorScheme) const
 {
     auto decoded_frame = current_frame();
     if (!decoded_frame.has_value())

--- a/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/AnimatedBitmapDecodedImageData.h
@@ -46,7 +46,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
-    virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering) const override;
+    virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const override;
 
     void receive_frames(Vector<NonnullRefPtr<Gfx::Bitmap>>, u32 start_frame_index);
 

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.cpp
@@ -62,7 +62,7 @@ Optional<CSSPixelFraction> BitmapDecodedImageData::intrinsic_aspect_ratio() cons
     return CSSPixels(m_frame.width()) / CSSPixels(m_frame.height());
 }
 
-void BitmapDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering image_rendering) const
+void BitmapDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering image_rendering, CSS::PreferredColorScheme) const
 {
     auto scaling_mode = CSS::to_gfx_scaling_mode(image_rendering, m_frame.size(), dst_rect.size());
 

--- a/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
+++ b/Libraries/LibWeb/HTML/BitmapDecodedImageData.h
@@ -32,7 +32,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
-    virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering) const override;
+    virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const override;
 
 private:
     BitmapDecodedImageData(Gfx::DecodedImageFrame&& frame);

--- a/Libraries/LibWeb/HTML/DecodedImageData.cpp
+++ b/Libraries/LibWeb/HTML/DecodedImageData.cpp
@@ -35,7 +35,7 @@ DecodedImageData::DecodedImageData() = default;
 
 DecodedImageData::~DecodedImageData() = default;
 
-Optional<Painting::DisplayListResource> DecodedImageData::record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const
+Optional<Painting::DisplayListResource> DecodedImageData::record_display_list(Gfx::IntSize, CSS::PreferredColorScheme, Painting::DisplayListResourceStorage&) const
 {
     return {};
 }

--- a/Libraries/LibWeb/HTML/DecodedImageData.h
+++ b/Libraries/LibWeb/HTML/DecodedImageData.h
@@ -12,6 +12,7 @@
 #include <LibGfx/ScalingMode.h>
 #include <LibGfx/Size.h>
 #include <LibJS/Heap/Cell.h>
+#include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/DisplayListResourceStorage.h>
 #include <LibWeb/PixelUnits.h>
@@ -39,8 +40,11 @@ public:
     [[nodiscard]] bool is_cors_cross_origin() const { return m_is_cors_cross_origin; }
     void set_is_cors_cross_origin(bool value) { m_is_cors_cross_origin = value; }
 
-    virtual void paint([[maybe_unused]] DisplayListRecordingContext&, [[maybe_unused]] Gfx::IntRect dst_rect, CSS::ImageRendering) const = 0;
-    virtual Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const;
+    virtual void paint([[maybe_unused]] DisplayListRecordingContext&, [[maybe_unused]] Gfx::IntRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const = 0;
+    // An SVG used as an image resolves `prefers-color-scheme` from the used `color-scheme` of the
+    // element referencing it, so the scheme is part of what is being asked for rather than a
+    // property of the page.
+    virtual Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, CSS::PreferredColorScheme, Painting::DisplayListResourceStorage&) const;
 
     virtual Optional<Gfx::DecodedImageFrame> default_frame(Gfx::IntSize = {}) const = 0;
     virtual Optional<Gfx::DecodedImageFrame> current_frame(Gfx::IntSize = {}) const = 0;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -554,7 +554,12 @@ Optional<CSS::FeatureValue> Window::query_media_feature(CSS::MediaFeatureID medi
     case CSS::MediaFeatureID::Pointer:
         return CSS::FeatureValue(CSS::FeatureValue::Type::Ident, CSS::KeywordStyleValue::create(CSS::Keyword::Fine));
     case CSS::MediaFeatureID::PrefersColorScheme: {
-        switch (page().preferred_color_scheme()) {
+        // https://github.com/w3c/csswg-drafts/issues/7213
+        // An SVG used as an image answers with the used `color-scheme` of the element referencing
+        // it rather than with the page's preference, and the same image can be referenced twice on
+        // one page with different answers.
+        auto preference = associated_document().svg_image_color_scheme().value_or(page().preferred_color_scheme());
+        switch (preference) {
         case CSS::PreferredColorScheme::Light:
             return CSS::FeatureValue(CSS::FeatureValue::Type::Ident, CSS::KeywordStyleValue::create(CSS::Keyword::Light));
         case CSS::PreferredColorScheme::Dark:

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -340,6 +340,9 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
         auto tile_count = tile_columns * tile_rows;
 
         auto const& document = paintable_box.layout_node().document();
+        // An SVG used as an image resolves `prefers-color-scheme` from the used `color-scheme` of
+        // the element referencing it.
+        auto const color_scheme = paintable_box.computed_values().color_scheme();
         if (auto color = image.color_if_single_pixel_bitmap(document); color.has_value()) {
             apply_blend_layer();
             // OPTIMIZATION: If the image is a single pixel, we can just fill the whole area with it.
@@ -365,7 +368,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                 dest_rect.set_height(1);
 
             auto const& image_style_value = static_cast<CSS::ImageStyleValue const&>(image);
-            if (auto display_list = image_style_value.record_display_list(context, document, dest_rect); display_list.has_value()) {
+            if (auto display_list = image_style_value.record_display_list(context, document, dest_rect, color_scheme); display_list.has_value()) {
                 apply_blend_layer();
                 auto dest_int_rect = dest_rect.to_type<int>();
                 auto scaling_mode = to_gfx_scaling_mode(image_rendering, dest_int_rect.size(), dest_int_rect.size());
@@ -402,7 +405,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
             auto tile_display_list = DisplayList::create(visual_context_tree);
             DisplayListRecorder tile_recorder(*tile_display_list, visual_context_tree, display_list_recorder.resource_storage());
             auto tile_context = context.clone(tile_recorder);
-            image.paint(tile_context, document, tile_device_rect, image_rendering);
+            image.paint(tile_context, document, tile_device_rect, image_rendering, color_scheme);
 
             // A pattern repeats along both axes. On any non-repeating axis, constrain the coverage to a single tile.
             auto coverage = clip_rect;
@@ -430,7 +433,7 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
         } else {
             apply_blend_layer();
             for_each_image_device_rect([&](auto const& image_device_rect) {
-                image.paint(context, document, image_device_rect, image_rendering);
+                image.paint(context, document, image_device_rect, image_rendering, color_scheme);
             });
         }
 

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -51,7 +51,7 @@ void ImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase phas
                     context.display_list_recorder().save();
                     context.display_list_recorder().add_clip_rect(image_int_rect_device_pixels);
                 }
-                decoded_image_data->paint(context, draw_rect, computed_values().image_rendering());
+                decoded_image_data->paint(context, draw_rect, computed_values().image_rendering(), computed_values().color_scheme());
                 if (draw_rect_needs_clip)
                     context.display_list_recorder().restore();
             }

--- a/Libraries/LibWeb/Painting/SVGImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGImagePaintable.cpp
@@ -65,7 +65,7 @@ void SVGImagePaintable::paint(DisplayListRecordingContext& context, PaintPhase p
         context.display_list_recorder().add_clip_rect(positioning_rectangle);
     }
 
-    decoded_image_data->paint(context, draw_rect, computed_values().image_rendering());
+    decoded_image_data->paint(context, draw_rect, computed_values().image_rendering(), computed_values().color_scheme());
 
     if (draw_rect_needs_clip)
         context.display_list_recorder().restore();

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -232,13 +232,26 @@ void SVGDecodedImageData::append_paint_command_cache_source_resources(Painting::
     document_paintable->append_paint_command_cache_source_resources(retained_resources);
 }
 
-Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list(Gfx::IntSize size, Painting::DisplayListResourceStorage& destination_resource_storage) const
+Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list(Gfx::IntSize size, CSS::PreferredColorScheme color_scheme, Painting::DisplayListResourceStorage& destination_resource_storage) const
 {
     ScopedSVGImageDocument scoped_document { *m_page_client, *m_document, ScopedSVGImageDocument::FrameRequests::RouteToCurrentImage, const_cast<SVGDecodedImageData&>(*this) };
     auto& navigable = *m_document->navigable();
     auto& resource_storage = navigable.display_list_resource_storage();
 
-    if (auto it = m_cached_display_lists.find(size); it != m_cached_display_lists.end()) {
+    RenderKey const key { size, color_scheme };
+
+    // `prefers-color-scheme` inside the image answers with the embedding element's used scheme, so
+    // the media query has to be evaluated again whenever that differs from the last recording.
+    if (m_color_scheme != color_scheme) {
+        m_color_scheme = color_scheme;
+        m_cached_rendered_frames.clear();
+        m_cached_rendered_surfaces.clear();
+        m_document->set_svg_image_color_scheme(color_scheme);
+        m_document->style_scope().invalidate_style_cache();
+        m_document->invalidate_style(DOM::StyleInvalidationReason::SettingsChange);
+    }
+
+    if (auto it = m_cached_display_lists.find(key); it != m_cached_display_lists.end()) {
         copy_referenced_resources_to(destination_resource_storage, resource_storage, it->value.referenced_resources);
         return Painting::DisplayListResource { *it->value.display_list, it->value.visual_context_tree };
     }
@@ -277,7 +290,7 @@ Optional<Painting::DisplayListResource> SVGDecodedImageData::record_display_list
     copy_referenced_resources_to(destination_resource_storage, resource_storage, referenced_resources);
     auto visual_context_tree = document_paintable->visual_context_tree();
     auto display_list_resource = Painting::DisplayListResource { *display_list, visual_context_tree };
-    m_cached_display_lists.set(size, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree), move(referenced_resources) });
+    m_cached_display_lists.set(key, CachedDisplayList { NonnullRefPtr<Painting::DisplayList> { *display_list }, move(visual_context_tree), move(referenced_resources) });
     prune_cached_display_list_resources();
     return display_list_resource;
 }
@@ -297,7 +310,7 @@ RefPtr<Gfx::PaintingSurface> SVGDecodedImageData::render_to_surface(Gfx::IntSize
 
     auto surface = Gfx::PaintingSurface::create_with_size(size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
     Painting::DisplayListResourceStorage resource_storage;
-    auto display_list = record_display_list(size, resource_storage);
+    auto display_list = record_display_list(size, m_color_scheme, resource_storage);
     if (!display_list.has_value())
         return nullptr;
 
@@ -486,9 +499,9 @@ void SVGDecodedImageData::invalidate_cached_rendering()
     prune_cached_display_list_resources();
 }
 
-void SVGDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering) const
+void SVGDecodedImageData::paint(DisplayListRecordingContext& context, Gfx::IntRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme color_scheme) const
 {
-    auto display_list = record_display_list(dst_rect.size(), context.display_list_recorder().resource_storage());
+    auto display_list = record_display_list(dst_rect.size(), color_scheme, context.display_list_recorder().resource_storage());
     if (!display_list.has_value())
         return;
 

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -34,7 +34,7 @@ public:
     virtual Optional<CSSPixels> intrinsic_height() const override;
     virtual Optional<CSSPixelFraction> intrinsic_aspect_ratio() const override;
 
-    virtual Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, Painting::DisplayListResourceStorage&) const override;
+    virtual Optional<Painting::DisplayListResource> record_display_list(Gfx::IntSize, CSS::PreferredColorScheme, Painting::DisplayListResourceStorage&) const override;
 
     // FIXME: Support SVG animations. :^)
     DOM::Document const& svg_document() const { return *m_document; }
@@ -43,7 +43,11 @@ public:
     virtual void finalize() override;
     virtual size_t external_memory_size() const override;
 
-    virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering) const override;
+    virtual void paint(DisplayListRecordingContext&, Gfx::IntRect dst_rect, CSS::ImageRendering, CSS::PreferredColorScheme) const override;
+
+    // The scheme the SVG document currently answers `prefers-color-scheme` with. Held on the image
+    // rather than on the page, because the page is shared with every other image.
+    CSS::PreferredColorScheme color_scheme() const { return m_color_scheme; }
 
 private:
     SVGDecodedImageData(GC::Ref<Page>, GC::Ref<SVGPageClient>, GC::Ref<DOM::Document>, GC::Ref<SVG::SVGSVGElement>);
@@ -58,6 +62,7 @@ private:
     // FIXME: Remove this once everything is using surfaces instead.
     mutable HashMap<Gfx::IntSize, Gfx::DecodedImageFrame> m_cached_rendered_frames;
 
+    mutable CSS::PreferredColorScheme m_color_scheme { CSS::PreferredColorScheme::Auto };
     mutable HashMap<Gfx::IntSize, NonnullRefPtr<Gfx::PaintingSurface>> m_cached_rendered_surfaces;
 
     struct CachedDisplayList {
@@ -66,7 +71,22 @@ private:
         // Precomputed by collect_referenced_resources(); the display list is immutable, so this never changes.
         Painting::DisplayListResourceSet referenced_resources;
     };
-    mutable HashMap<Gfx::IntSize, CachedDisplayList> m_cached_display_lists;
+    // An SVG used as an image resolves `prefers-color-scheme` from the used `color-scheme` of the
+    // element referencing it, so one image can render two ways on one page and the recording is
+    // keyed by both.
+    struct RenderKey {
+        Gfx::IntSize size;
+        CSS::PreferredColorScheme color_scheme;
+        bool operator==(RenderKey const&) const = default;
+    };
+    struct RenderKeyTraits : public Traits<RenderKey> {
+        static unsigned hash(RenderKey const& key)
+        {
+            return pair_int_hash(Traits<Gfx::IntSize>::hash(key.size), to_underlying(key.color_scheme));
+        }
+        static bool equals(RenderKey const& a, RenderKey const& b) { return a == b; }
+    };
+    mutable HashMap<RenderKey, CachedDisplayList, RenderKeyTraits> m_cached_display_lists;
 
     GC::Ref<Page> m_page;
     GC::Ref<SVGPageClient> m_page_client;

--- a/Tests/LibWeb/Layout/expected/svg/standalone-h.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-h.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [0,172 128x256]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-h.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-h.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-w.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-w.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x256] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-wh.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-wh.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x256] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-w.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-w.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [336,0 128x256]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x256] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone-wh.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-wh.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [250,0 300x600]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 800x600] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/standalone.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone.txt
@@ -17,3 +17,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       SVGPathPaintable (SVGGeometryBox<path>) [0,0 128x256]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for SVGSVGBox<svg> [0,0 128x256] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -9,3 +9,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     InlinePaintable (InlineNode<rect>) [0,0 0x16]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<svg> [0,0 800x0] (z-index: auto)

--- a/Tests/LibWeb/Text/expected/css/live-selector-identifiers.txt
+++ b/Tests/LibWeb/Text/expected/css/live-selector-identifiers.txt
@@ -7,4 +7,4 @@ disconnected match: true
 shadow initial match: true
 shadow mutated match: true
 document root: true
-disconnected html root: true
+disconnected html root: false


### PR DESCRIPTION
Teach SVG images to resolve `prefers-color-scheme` from the used `color-scheme` of their embedding element. Thread the scheme through image painting, include it in SVG display-list cache keys, and invalidate styles when it changes so the same resource can render differently at multiple embedding sites.

Also match `:root` against the document element instead of any `HTMLHtmlElement`. This makes it work for standalone SVG and XML documents while preventing detached or non-root `html` elements from matching.