### PR TITLE
AK+LibLS+LibThreading: A couple memory growth fixes

### DIFF
--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -71,6 +71,10 @@ void ak_kfree(void* ptr)
     free(ptr);
 }
 
+void ak_kmalloc_collect()
+{
+}
+
 extern "C" {
 void* ladybird_rust_alloc(size_t size, size_t alignment);
 void* ladybird_rust_alloc_zeroed(size_t size, size_t alignment);
@@ -123,6 +127,8 @@ void* ak_kmalloc(size_t size)
     return mi_malloc(size);
 }
 
+static thread_local mi_heap_t* s_string_heap = nullptr;
+
 static mi_heap_t* heap_for_partition(HeapPartition partition)
 {
     switch (partition) {
@@ -141,8 +147,9 @@ static mi_heap_t* heap_for_partition(HeapPartition partition)
         static mi_heap_t* painting_heap = mi_heap_new();
         return painting_heap;
     case HeapPartition::String:
-        static thread_local mi_heap_t* string_heap = mi_heap_new();
-        return string_heap;
+        if (!s_string_heap)
+            s_string_heap = mi_heap_new();
+        return s_string_heap;
     }
     VERIFY_NOT_REACHED();
 }
@@ -170,6 +177,16 @@ size_t ak_kmalloc_good_size(size_t size)
 void ak_kfree(void* ptr)
 {
     mi_free(ptr);
+}
+
+void ak_kmalloc_collect()
+{
+    // mi_collect() only visits the calling thread's default heap, so the string heap has to be collected separately.
+    // The remaining partitions are shared between threads and are left to their owners.
+    if (s_string_heap)
+        mi_heap_collect(s_string_heap, true);
+
+    mi_collect(true);
 }
 
 extern "C" {

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -28,6 +28,7 @@ void ak_kfree(void* ptr);
 [[nodiscard]] void* ak_krealloc(void* ptr, size_t size);
 [[nodiscard]] void* ak_krealloc(HeapPartition, void* ptr, size_t size);
 [[nodiscard]] size_t ak_kmalloc_good_size(size_t size);
+void ak_kmalloc_collect();
 
 [[nodiscard]] inline void* kcalloc(size_t count, size_t size)
 {

--- a/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Libraries/LibJS/Bytecode/Executable.cpp
@@ -61,10 +61,10 @@ size_t InstructionStream::external_memory_size() const
         [](Vector<u8> const& bytecode) -> size_t {
             return vector_external_memory_size(bytecode);
         },
-        [](Core::ImmutableBytes const& bytecode) -> size_t {
+        [this](Core::ImmutableBytes const& bytecode) -> size_t {
             if (bytecode.is_file_backed())
                 return 0;
-            return bytecode.size();
+            return m_size;
         });
 }
 

--- a/Libraries/LibJS/Bytecode/Executable.h
+++ b/Libraries/LibJS/Bytecode/Executable.h
@@ -35,7 +35,7 @@
 
 namespace JS::Bytecode {
 
-class InstructionStream {
+class JS_API InstructionStream {
 public:
     explicit InstructionStream(Vector<u8>);
     InstructionStream(Core::ImmutableBytes, size_t offset, size_t size);

--- a/Libraries/LibThreading/ThreadPool.cpp
+++ b/Libraries/LibThreading/ThreadPool.cpp
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Time.h>
+#include <AK/kmalloc.h>
 #include <LibThreading/ThreadPool.h>
 
 static constexpr size_t THREAD_COUNT = 4;
 static constexpr size_t THREAD_STACK_SIZE = 8 * MiB;
+static constexpr auto THREAD_IDLE_MEMORY_COLLECTION_DELAY = AK::Duration::from_seconds(1);
 
 namespace Threading {
 
@@ -32,15 +35,34 @@ ThreadPool::ThreadPool()
 
 intptr_t ThreadPool::worker_thread_func()
 {
+    bool collected_since_last_work = false;
+
     while (true) {
         Function<void()> work;
-
+        bool should_collect = false;
         {
             Sync::MutexLocker locker(m_mutex);
-            m_condition.wait_while([this] { return m_work_queue.is_empty(); });
-            work = m_work_queue.dequeue();
+
+            while (m_work_queue.is_empty()) {
+                if (collected_since_last_work) {
+                    m_condition.wait();
+                } else if (!m_condition.wait_for(THREAD_IDLE_MEMORY_COLLECTION_DELAY) && m_work_queue.is_empty()) {
+                    should_collect = true;
+                    break;
+                }
+            }
+
+            if (!should_collect)
+                work = m_work_queue.dequeue();
         }
 
+        if (should_collect) {
+            ak_kmalloc_collect();
+            collected_since_last_work = true;
+            continue;
+        }
+
+        collected_since_last_work = false;
         work();
     }
 }

--- a/Tests/LibJS/test-bytecode-cache.cpp
+++ b/Tests/LibJS/test-bytecode-cache.cpp
@@ -12,6 +12,7 @@
 #include <LibCore/System.h>
 #include <LibCrypto/Hash/SHA2.h>
 #include <LibFileSystem/FileSystem.h>
+#include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -1029,4 +1030,13 @@ TEST_CASE(bytecode_cache_preserves_re_exported_import_names)
     EXPECT(resolution.is_valid());
     EXPECT_EQ(resolution.module.ptr(), source_module.ptr());
     EXPECT_EQ(resolution.export_name, "pass"sv);
+}
+
+TEST_CASE(in_memory_instruction_stream_accounts_only_for_its_range)
+{
+    Array<u8, 16> bytecode {};
+    auto immutable_bytecode = TRY_OR_FAIL(Core::ImmutableBytes::copy(bytecode.span()));
+    JS::Bytecode::InstructionStream instruction_stream { move(immutable_bytecode), 4, 3 };
+
+    EXPECT_EQ(instruction_stream.external_memory_size(), 3u);
 }


### PR DESCRIPTION
On a Strava activity page, we would previously grow in memory use over time until OOM hit. After letting an activity page sit for 60s, memory usage changed as follows:

| | Before | After | Change |
|---|---:|---:|---:|
| Main WebContent RSS | 905 MiB | 623 MiB | -31.2% |
| GC live cells | 31.4 MiB | 31.3 MiB | - |
| GC live external memory | 17.8 GiB | 61.3 MiB | -99.7% |
| Next GC threshold | 31.2 GiB | 162.3 MiB | -99.5% |