### PR TITLE
LibWeb: Replace RetainedLayoutHandle with libgfx_rust OwnedPath

### DIFF
--- a/Libraries/LibGfx/Path.cpp
+++ b/Libraries/LibGfx/Path.cpp
@@ -9,6 +9,10 @@
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 
+extern "C" {
+void ladybird_gfx_path_destroy(void*);
+}
+
 namespace Gfx {
 
 Path Path::from_serialized_bytes(ReadonlyBytes bytes)
@@ -42,4 +46,9 @@ ErrorOr<Gfx::Path> decode(Decoder& decoder)
     return Gfx::Path::from_serialized_bytes(path_data);
 }
 
+}
+
+extern "C" void ladybird_gfx_path_destroy(void* path)
+{
+    delete static_cast<Gfx::Path*>(path);
 }

--- a/Libraries/LibGfx/Rust/src/lib.rs
+++ b/Libraries/LibGfx/Rust/src/lib.rs
@@ -9,5 +9,6 @@
 mod rust_allocator;
 
 pub mod font;
+pub mod path;
 pub mod text_layout;
 pub mod yuv;

--- a/Libraries/LibGfx/Rust/src/path.rs
+++ b/Libraries/LibGfx/Rust/src/path.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+use std::ffi::c_void;
+use std::ptr::NonNull;
+
+unsafe extern "C" {
+    fn ladybird_gfx_path_destroy(path: *mut c_void);
+}
+
+/// The sole owner of a heap-allocated `Gfx::Path`, destroying it on drop.
+pub struct OwnedPath {
+    raw: NonNull<c_void>,
+}
+
+impl OwnedPath {
+    /// Assumes sole ownership of a heap-allocated `Gfx::Path`.
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be the only pointer through which the heap-allocated
+    /// `Gfx::Path` is owned or destroyed.
+    #[inline]
+    pub unsafe fn adopt(raw: *mut c_void) -> Self {
+        Self {
+            raw: NonNull::new(raw).expect("Gfx::Path pointer must not be null"),
+        }
+    }
+
+    /// The raw `Gfx::Path` pointer, still owned by this value.
+    #[inline]
+    pub fn as_raw(&self) -> *mut c_void {
+        self.raw.as_ptr()
+    }
+}
+
+impl Drop for OwnedPath {
+    fn drop(&mut self) {
+        // SAFETY: adopt() took sole ownership of the heap-allocated path.
+        unsafe { ladybird_gfx_path_destroy(self.raw.as_ptr()) };
+    }
+}

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -73,7 +73,6 @@
 namespace Web::Layout {
 
 static Atomic<size_t> s_outstanding_anchor_name_handles;
-static Atomic<size_t> s_outstanding_svg_path_handles;
 
 static_assert(to_underlying(CSS::StyleGroupIndex::Count) == RustFFI::STYLE_GROUP_COUNT);
 static_assert(to_underlying(CSS::StyleGroupIndex::GridValues) == RustFFI::STYLE_GROUP_INDEX_GRID);
@@ -582,8 +581,8 @@ static RustFFI::FfiSvgPathResult compute_svg_path(NodeWithStyle const& node, Rus
     }
 
     auto bounding_box = path.bounding_box();
+    // Rust adopts this heap-allocated path and destroys it via ladybird_gfx_path_destroy().
     auto* path_handle = new Gfx::Path(move(path));
-    ++s_outstanding_svg_path_handles;
     return {
         .path_handle = path_handle,
         .bounding_box = {
@@ -597,14 +596,6 @@ static RustFFI::FfiSvgPathResult compute_svg_path(NodeWithStyle const& node, Rus
             .y = text_position.y(),
         },
     };
-}
-
-static void release_svg_path_handle(void const* handle)
-{
-    VERIFY(handle);
-    VERIFY(s_outstanding_svg_path_handles.load() > 0);
-    --s_outstanding_svg_path_handles;
-    delete static_cast<Gfx::Path const*>(handle);
 }
 
 Optional<RustFFI::FfiFormattingContextType> formatting_context_type_created_by_box(Box const& box)
@@ -957,10 +948,10 @@ RustFFI::FfiCommitSink LayoutRustBridge::commit_sink()
         .set_computed_svg_path = [](void*, void* paintable_pointer, void* path_pointer) {
             VERIFY(path_pointer);
             auto& paintable = *static_cast<Painting::Paintable*>(paintable_pointer);
+            // The path stays owned by the Rust layout state; only its contents move out.
             auto* path = static_cast<Gfx::Path*>(path_pointer);
             if (auto* svg_path_paintable = as_if<Painting::SVGPathPaintable>(paintable))
-                svg_path_paintable->set_computed_path(move(*path));
-            release_svg_path_handle(path); },
+                svg_path_paintable->set_computed_path(move(*path)); },
         .set_grid_layout_data = [](void*, void* paintable_pointer, RustFFI::FfiGridLayoutData const* data) {
             VERIFY(data);
             static_cast<Painting::Paintable*>(paintable_pointer)->set_grid_layout_data(build_grid_layout_data(*data)); },
@@ -1221,7 +1212,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             auto const* node_with_style = as_if<NodeWithStyle>(*static_cast<Node const*>(node));
             VERIFY(node_with_style);
             return compute_svg_path(*node_with_style, request); },
-        .release_svg_path = [](void*, void* path_handle) { release_svg_path_handle(path_handle); },
         .svg_image_bounding_box = [](void*, void* node, i32 viewport_width, i32 viewport_height) {
             auto const& image_box = as<SVGImageBox>(*static_cast<Node const*>(node));
             auto bounding_box = image_box.dom_node().bounding_box({

--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -3746,6 +3746,8 @@ mod ffi_test_stubs {
     extern "C" fn ladybird_utf16_fly_string_ref(_raw: usize) {}
     #[unsafe(no_mangle)]
     extern "C" fn ladybird_string_unref(_raw: usize) {}
+    #[unsafe(no_mangle)]
+    extern "C" fn ladybird_gfx_path_destroy(_path: *mut std::ffi::c_void) {}
 }
 
 #[cfg(test)]

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -931,7 +931,6 @@ pub struct FfiLayoutFcCallbacks {
     pub read_paintable_svg_transforms:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut FfiSvgComputedTransforms) -> bool,
     pub compute_svg_path: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiSvgPathRequest) -> FfiSvgPathResult,
-    pub release_svg_path: crate::layout::ReleaseRetainedLayoutHandle,
     pub svg_image_bounding_box: unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> FfiFloatRect,
     pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
     pub build_anchor_function_facts: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFunctionFacts,

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -262,49 +262,6 @@ pub struct FfiCommitSink {
     pub assign_inline_box_geometry: unsafe extern "C" fn(*mut c_void, *mut c_void),
 }
 
-pub(crate) type ReleaseRetainedLayoutHandle = unsafe extern "C" fn(*mut c_void, *mut c_void);
-
-pub(crate) struct RetainedLayoutHandle {
-    handle: *mut c_void,
-    callback_context: *mut c_void,
-    release: ReleaseRetainedLayoutHandle,
-}
-
-impl RetainedLayoutHandle {
-    pub(crate) fn new(
-        handle: *mut c_void,
-        callback_context: *mut c_void,
-        release: ReleaseRetainedLayoutHandle,
-    ) -> Self {
-        assert!(!handle.is_null());
-        Self {
-            handle,
-            callback_context,
-            release,
-        }
-    }
-
-    pub(crate) fn take(&mut self) -> *mut c_void {
-        let handle = self.handle;
-        self.handle = null_mut();
-        handle
-    }
-}
-
-impl Drop for RetainedLayoutHandle {
-    fn drop(&mut self) {
-        if self.handle.is_null() {
-            return;
-        }
-        // SAFETY: Each retained layout handle is returned with one ownership
-        // unit by its creating callback and is either transferred to the
-        // commit sink or released exactly once with the paired callback.
-        unsafe {
-            (self.release)(self.callback_context, self.handle);
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PendingAbsposChild {
     pub(crate) child_box: Node,
@@ -342,7 +299,7 @@ pub(crate) struct LineData {
 #[derive(Default)]
 pub(crate) struct UsedValuesRareData {
     pub(crate) table_cell_coordinates: Option<FfiTableCellCoordinates>,
-    pub(crate) computed_svg_path: Option<RetainedLayoutHandle>,
+    pub(crate) computed_svg_path: Option<libgfx_rust::path::OwnedPath>,
     pub(crate) computed_svg_transforms: Option<crate::layout::FfiSvgComputedTransforms>,
     pub(crate) svg_viewport_size: Option<crate::layout::FfiCssPixelSize>,
     pub(crate) grid_layout_data: Option<OwnedGridLayoutData>,
@@ -1017,12 +974,12 @@ impl LayoutState {
             }
 
             let (transforms, viewport_size, path) = self
-                .used_values_rare_data_mut_if_present(slot_index)
-                .map_or((None, None, None), |mut rare| {
+                .used_values_rare_data(slot_index)
+                .map_or((None, None, None), |rare| {
                     (
                         rare.computed_svg_transforms,
                         rare.svg_viewport_size,
-                        rare.computed_svg_path.as_mut().map(RetainedLayoutHandle::take),
+                        rare.computed_svg_path.as_ref().map(libgfx_rust::path::OwnedPath::as_raw),
                     )
                 });
             unsafe {
@@ -1033,6 +990,8 @@ impl LayoutState {
                     (sink.set_svg_viewport_size)(sink.context, paintable, viewport_size);
                 }
                 if let Some(path) = path {
+                    // The sink only borrows the path and moves its contents
+                    // out; the rare data keeps ownership until state teardown.
                     (sink.set_computed_svg_path)(sink.context, paintable, path);
                 }
             }
@@ -1110,14 +1069,5 @@ impl LayoutState {
         unsafe {
             (sink.finish_commit)(sink.context);
         }
-    }
-}
-
-impl LayoutState {
-    fn used_values_rare_data_mut_if_present(&self, slot_index: u32) -> Option<RefMut<'_, UsedValuesRareData>> {
-        self.used_values_by_slot(slot_index)?
-            .rare_data
-            .get()
-            .map(RefCell::borrow_mut)
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -918,7 +918,7 @@ impl<'pass> SvgFormattingContext<'pass> {
 
         let facts = self.svg_facts(graphics_box);
         // SAFETY: The callback computes geometry synchronously and transfers
-        // one retained path handle into the result.
+        // sole ownership of a heap-allocated path into the result.
         let result = unsafe {
             (self.callbacks.compute_svg_path)(
                 self.callbacks.context,
@@ -930,7 +930,8 @@ impl<'pass> SvgFormattingContext<'pass> {
                 },
             )
         };
-        assert!(!result.path_handle.is_null());
+        // SAFETY: The callback just handed over its one owning pointer.
+        let path = unsafe { libgfx_rust::path::OwnedPath::adopt(result.path_handle) };
 
         if self.node_kind(graphics_box) == NodeKind::SVGTextBox {
             // Descendant and following text elements continue from the text position after this element's own text run.
@@ -961,11 +962,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         used.has_definite_block_size.set(true);
         self.state
             .used_values_rare_data_for_node_mut(&self.callbacks, graphics_box)
-            .computed_svg_path = Some(crate::layout::RetainedLayoutHandle::new(
-            result.path_handle,
-            self.callbacks.context,
-            self.callbacks.release_svg_path,
-        ));
+            .computed_svg_path = Some(path);
     }
 
     fn layout_image_element(&self, image_box: Node) {


### PR DESCRIPTION
The SVG formatting context now adopts the computed path into an
OwnedPath right after the compute callback returns, and the commit
sink only borrows it: C++ moves the path contents into the paintable
while the layout state keeps ownership until teardown.

This gives the path exactly one owner from creation to destruction,
so the take()/null-state handling, the per-handle release callback,
and the outstanding-handle leak tripwire all go away. It also means
the destroy path runs on every layout pass instead of only on
discarded measurement passes.