### PR TITLE
LibWeb: Read anchor() facts directly from Rust style values in layout

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Array.h>
-#include <AK/Atomic.h>
 #include <AK/Debug.h>
 #include <AK/GenericShorthands.h>
 #include <AK/Math.h>
@@ -71,8 +70,6 @@
 #include <LibWeb/SVG/SVGTextElement.h>
 
 namespace Web::Layout {
-
-static Atomic<size_t> s_outstanding_anchor_name_handles;
 
 static_assert(to_underlying(CSS::StyleGroupIndex::Count) == RustFFI::STYLE_GROUP_COUNT);
 static_assert(to_underlying(CSS::StyleGroupIndex::GridValues) == RustFFI::STYLE_GROUP_INDEX_GRID);
@@ -1099,19 +1096,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
     static_assert(to_underlying(SVG::PreserveAspectRatio::MeetOrSlice::Slice) == 1);
     static_assert(to_underlying(SVG::SVGUnits::ObjectBoundingBox) == 0);
     static_assert(to_underlying(SVG::SVGUnits::UserSpaceOnUse) == 1);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Invalid) == 0);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Top) == 1);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Right) == 2);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Bottom) == 3);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Left) == 4);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Center) == 5);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Start) == 6);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::End) == 7);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::SelfStart) == 8);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::SelfEnd) == 9);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Inside) == 10);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Outside) == 11);
-    static_assert(to_underlying(RustFFI::FfiAnchorSideKind::Percentage) == 12);
     static_assert(to_underlying(Gfx::GlyphRun::TextType::Common) == 0);
     static_assert(to_underlying(Gfx::GlyphRun::TextType::ContextDependent) == 1);
     static_assert(to_underlying(Gfx::GlyphRun::TextType::EndPadding) == 2);
@@ -1145,7 +1129,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             auto const& box = *static_cast<Box const*>(node);
             dbgln("FIXME: InlineFormattingContext::dimension_box_on_line got unexpected box in inline context:");
             dump_tree(box); },
-        .release_anchor_name_handle = ladybird_layout_release_anchor_name_handle,
         .build_svg_facts = [](void*, void* node) {
             auto const* node_with_style = as_if<NodeWithStyle>(*static_cast<Node const*>(node));
             VERIFY(node_with_style);
@@ -1261,126 +1244,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
             if (!anchor_box)
                 return RustFFI::NodeSlotId_INVALID;
             return Node::slot_id(anchor_box); },
-        .build_anchor_function_facts = [](void*, void const* shell) {
-            auto value = CSS::StyleValue::adopt_rust_style_value_data(
-                CSS::StyleValueFFI::rust_style_value_retain(
-                    static_cast<CSS::StyleValueFFI::StyleValueData const*>(shell)));
-            if (!value->is_anchor()) {
-                return RustFFI::FfiAnchorFunctionFacts {
-                    .has_anchor_name = false,
-                    .anchor_name = 0,
-                    .side_kind = RustFFI::FfiAnchorSideKind::Invalid,
-                    .side_percentage = 0,
-                };
-            }
-            auto const& anchor = value->as_anchor();
-            auto const& side = *anchor.anchor_side();
-            auto side_kind = RustFFI::FfiAnchorSideKind::Invalid;
-            double side_percentage = 0;
-            if (side.is_keyword()) {
-                switch (side.to_keyword()) {
-                case CSS::Keyword::Top:
-                    side_kind = RustFFI::FfiAnchorSideKind::Top;
-                    break;
-                case CSS::Keyword::Right:
-                    side_kind = RustFFI::FfiAnchorSideKind::Right;
-                    break;
-                case CSS::Keyword::Bottom:
-                    side_kind = RustFFI::FfiAnchorSideKind::Bottom;
-                    break;
-                case CSS::Keyword::Left:
-                    side_kind = RustFFI::FfiAnchorSideKind::Left;
-                    break;
-                case CSS::Keyword::Center:
-                    side_kind = RustFFI::FfiAnchorSideKind::Center;
-                    break;
-                case CSS::Keyword::Start:
-                    side_kind = RustFFI::FfiAnchorSideKind::Start;
-                    break;
-                case CSS::Keyword::End:
-                    side_kind = RustFFI::FfiAnchorSideKind::End;
-                    break;
-                case CSS::Keyword::SelfStart:
-                    side_kind = RustFFI::FfiAnchorSideKind::SelfStart;
-                    break;
-                case CSS::Keyword::SelfEnd:
-                    side_kind = RustFFI::FfiAnchorSideKind::SelfEnd;
-                    break;
-                case CSS::Keyword::Inside:
-                    side_kind = RustFFI::FfiAnchorSideKind::Inside;
-                    break;
-                case CSS::Keyword::Outside:
-                    side_kind = RustFFI::FfiAnchorSideKind::Outside;
-                    break;
-                default:
-                    break;
-                }
-            } else if (side.is_percentage()) {
-                side_kind = RustFFI::FfiAnchorSideKind::Percentage;
-                side_percentage = side.as_percentage().percentage().as_fraction();
-            }
-            size_t anchor_name = 0;
-            if (auto name = anchor.anchor_name(); name.has_value()) {
-                anchor_name = name->to_raw_leaked();
-                ++s_outstanding_anchor_name_handles;
-            }
-            return RustFFI::FfiAnchorFunctionFacts {
-                .has_anchor_name = anchor_name != 0,
-                .anchor_name = anchor_name,
-                .side_kind = side_kind,
-                .side_percentage = side_percentage,
-            }; },
-        .anchor_function_fallback = [](void*, void const* shell) {
-            auto value = CSS::StyleValue::adopt_rust_style_value_data(
-                CSS::StyleValueFFI::rust_style_value_retain(
-                    static_cast<CSS::StyleValueFFI::StyleValueData const*>(shell)));
-            if (!value->is_anchor())
-                return RustFFI::FfiAnchorFallbackFacts {
-                    .kind = RustFFI::FfiAnchorFallbackKind::None,
-                    .px = 0,
-                    .fraction = 0,
-                    .value = nullptr,
-                };
-            auto fallback = value->as_anchor().fallback_value();
-            if (!fallback)
-                return RustFFI::FfiAnchorFallbackFacts {
-                    .kind = RustFFI::FfiAnchorFallbackKind::None,
-                    .px = 0,
-                    .fraction = 0,
-                    .value = nullptr,
-                };
-            if (fallback->is_length()) {
-                VERIFY(fallback->as_length().length().is_absolute());
-                return RustFFI::FfiAnchorFallbackFacts {
-                    .kind = RustFFI::FfiAnchorFallbackKind::Px,
-                    .px = fallback->as_length().length().absolute_length_to_px().raw_value(),
-                    .fraction = 0,
-                    .value = nullptr,
-                };
-            }
-            if (fallback->is_percentage()) {
-                return RustFFI::FfiAnchorFallbackFacts {
-                    .kind = RustFFI::FfiAnchorFallbackKind::Percentage,
-                    .px = 0,
-                    .fraction = fallback->as_percentage().percentage().as_fraction(),
-                    .value = nullptr,
-                };
-            }
-            if (fallback->is_calculated()) {
-                return RustFFI::FfiAnchorFallbackFacts {
-                    .kind = RustFFI::FfiAnchorFallbackKind::Calculated,
-                    .px = 0,
-                    .fraction = 0,
-                    .value = fallback->as_calculated().rust_style_value_data(),
-                };
-            }
-            VERIFY(fallback->is_anchor());
-            return RustFFI::FfiAnchorFallbackFacts {
-                .kind = RustFFI::FfiAnchorFallbackKind::Anchor,
-                .px = 0,
-                .fraction = 0,
-                .value = fallback->rust_style_value_data(),
-            }; },
         .set_default_scroll_shift = [](void*, void* node, void* anchor, bool horizontal, bool vertical) {
             auto& box = *static_cast<Box*>(node);
             if (!anchor) {
@@ -1391,13 +1254,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
     };
 }
 
-}
-
-extern "C" WEB_API void ladybird_layout_release_anchor_name_handle(size_t raw)
-{
-    VERIFY(Web::Layout::s_outstanding_anchor_name_handles.load() > 0);
-    --Web::Layout::s_outstanding_anchor_name_handles;
-    Utf16FlyString::unref_raw(raw);
 }
 
 extern "C" WEB_API u8 ladybird_layout_text_type_for_code_point(u32 code_point)

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.h
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.h
@@ -61,10 +61,6 @@ private:
 
 }
 
-// Releases one position-anchor name reference transferred by a lazy style
-// field decode.
-extern "C" WEB_API void ladybird_layout_release_anchor_name_handle(size_t);
-
 // Per-code-point classification lookups for the Rust text chunker. The
 // line-break-class groupings implement the css-text-4 word-break policies.
 extern "C" WEB_API u8 ladybird_layout_text_type_for_code_point(u32);

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -245,6 +245,47 @@ struct AnchorResolutionState {
     compensates_for_vertical_scroll: bool,
 }
 
+/// The interpreted <anchor-side> argument of an anchor() function; the
+/// percentage carries its value as a fraction.
+#[derive(Clone, Copy, PartialEq)]
+enum AnchorSide {
+    Invalid,
+    Top,
+    Right,
+    Bottom,
+    Left,
+    Center,
+    Start,
+    End,
+    SelfStart,
+    SelfEnd,
+    Inside,
+    Outside,
+    Percentage(f64),
+}
+
+fn anchor_side_from_style_value(side: &crate::css::style_value::StyleValueData) -> AnchorSide {
+    use crate::css::style_value::StyleValueData;
+    match side {
+        StyleValueData::Keyword { keyword } => match *keyword {
+            keyword::TOP => AnchorSide::Top,
+            keyword::RIGHT => AnchorSide::Right,
+            keyword::BOTTOM => AnchorSide::Bottom,
+            keyword::LEFT => AnchorSide::Left,
+            keyword::CENTER => AnchorSide::Center,
+            keyword::START => AnchorSide::Start,
+            keyword::END => AnchorSide::End,
+            keyword::SELF_START => AnchorSide::SelfStart,
+            keyword::SELF_END => AnchorSide::SelfEnd,
+            keyword::INSIDE => AnchorSide::Inside,
+            keyword::OUTSIDE => AnchorSide::Outside,
+            _ => AnchorSide::Invalid,
+        },
+        StyleValueData::Percentage { value } => AnchorSide::Percentage(value / 100.0),
+        _ => AnchorSide::Invalid,
+    }
+}
+
 #[derive(Clone, Copy)]
 struct AnchorValueAxis {
     is_from_end: bool,
@@ -307,7 +348,7 @@ impl AbsposEngine<'_> {
 
     fn anchor_side(
         &self,
-        facts: FfiAnchorFunctionFacts,
+        side: AnchorSide,
         rect: PhysicalRect,
         positioned_box: Node,
         containing_block: Node,
@@ -316,19 +357,19 @@ impl AbsposEngine<'_> {
     ) -> Option<CssPixels> {
         let containing_block_direction = self.style(containing_block).direction();
         let box_direction = self.style(positioned_box).direction();
-        match facts.side_kind {
-            FfiAnchorSideKind::Invalid => None,
-            FfiAnchorSideKind::Top => (!is_horizontal_axis).then_some(rect.top()),
-            FfiAnchorSideKind::Bottom => (!is_horizontal_axis).then_some(rect.bottom()),
-            FfiAnchorSideKind::Left => is_horizontal_axis.then_some(rect.left()),
-            FfiAnchorSideKind::Right => is_horizontal_axis.then_some(rect.right()),
-            FfiAnchorSideKind::Center => Some(if is_horizontal_axis {
+        match side {
+            AnchorSide::Invalid => None,
+            AnchorSide::Top => (!is_horizontal_axis).then_some(rect.top()),
+            AnchorSide::Bottom => (!is_horizontal_axis).then_some(rect.bottom()),
+            AnchorSide::Left => is_horizontal_axis.then_some(rect.left()),
+            AnchorSide::Right => is_horizontal_axis.then_some(rect.right()),
+            AnchorSide::Center => Some(if is_horizontal_axis {
                 rect.left() + rect.width / 2
             } else {
                 rect.top() + rect.height / 2
             }),
-            FfiAnchorSideKind::Start | FfiAnchorSideKind::End => {
-                let is_start = facts.side_kind == FfiAnchorSideKind::Start;
+            AnchorSide::Start | AnchorSide::End => {
+                let is_start = side == AnchorSide::Start;
                 if is_horizontal_axis {
                     let use_left = (containing_block_direction == direction::LTR) == is_start;
                     Some(if use_left { rect.left() } else { rect.right() })
@@ -336,8 +377,8 @@ impl AbsposEngine<'_> {
                     Some(if is_start { rect.top() } else { rect.bottom() })
                 }
             }
-            FfiAnchorSideKind::SelfStart | FfiAnchorSideKind::SelfEnd => {
-                let is_start = facts.side_kind == FfiAnchorSideKind::SelfStart;
+            AnchorSide::SelfStart | AnchorSide::SelfEnd => {
+                let is_start = side == AnchorSide::SelfStart;
                 if is_horizontal_axis {
                     let use_left = (box_direction == direction::LTR) == is_start;
                     Some(if use_left { rect.left() } else { rect.right() })
@@ -345,8 +386,8 @@ impl AbsposEngine<'_> {
                     Some(if is_start { rect.top() } else { rect.bottom() })
                 }
             }
-            FfiAnchorSideKind::Inside | FfiAnchorSideKind::Outside => {
-                let same_side = facts.side_kind == FfiAnchorSideKind::Inside;
+            AnchorSide::Inside | AnchorSide::Outside => {
+                let same_side = side == AnchorSide::Inside;
                 if is_horizontal_axis {
                     Some(if is_from_end == same_side {
                         rect.right()
@@ -361,16 +402,16 @@ impl AbsposEngine<'_> {
                     })
                 }
             }
-            FfiAnchorSideKind::Percentage => {
+            AnchorSide::Percentage(fraction) => {
                 if is_horizontal_axis {
                     let (start, end) = if containing_block_direction == direction::LTR {
                         (rect.left(), rect.right())
                     } else {
                         (rect.right(), rect.left())
                     };
-                    Some(start + CssPixels::nearest_value_for((end - start).to_double() * facts.side_percentage))
+                    Some(start + CssPixels::nearest_value_for((end - start).to_double() * fraction))
                 } else {
-                    Some(rect.top() + CssPixels::nearest_value_for(rect.height.to_double() * facts.side_percentage))
+                    Some(rect.top() + CssPixels::nearest_value_for(rect.height.to_double() * fraction))
                 }
             }
         }
@@ -563,30 +604,38 @@ impl AbsposEngine<'_> {
 }
 
 unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shell: *const c_void) -> *const c_void {
+    use crate::css::style_value::StyleValueData;
     // SAFETY: The CSS calc engine calls this only during resolve_anchor_value,
     // whose stack owns this callback context.
     let context = unsafe { &mut *context.cast::<AnchorCalcCallbackContext<'_>>() };
     // SAFETY: The engine pointer is live for the enclosing resolution.
     let engine = unsafe { &*context.engine };
-    // SAFETY: `shell` is the live Rust style-value handle supplied by the
-    // CSS calc core.
-    let facts = unsafe { (engine.callbacks.build_anchor_function_facts)(engine.callbacks.context, shell) };
+    // SAFETY: `shell` is the live Rust style-value data retained by the CSS
+    // calc core's non-math-function node for this synchronous resolution.
+    let StyleValueData::Anchor {
+        has_anchor_name,
+        anchor_name: explicit_anchor_name,
+        anchor_side,
+        fallback_value,
+    } = (unsafe { &*shell.cast::<StyleValueData>() })
+    else {
+        return std::ptr::null();
+    };
     let style = engine.style(context.positioned_box);
-    let anchor_name = if facts.has_anchor_name {
-        Some(facts.anchor_name)
+    let anchor_name = if *has_anchor_name {
+        Some(explicit_anchor_name.raw())
     } else if style.has_position_anchor() {
         Some(style.position_anchor_name())
     } else {
         None
     };
-    let mut resolved_node = std::ptr::null();
     if engine.facts(context.positioned_box).is_absolutely_positioned()
         && let Some(anchor_name) = anchor_name
         && let Some(anchor_box) = engine.anchor_lookup(context.positioned_box, anchor_name)
     {
         let rect = engine.anchor_rect(anchor_box, context.containing_block);
         if let Some(side) = engine.anchor_side(
-            facts,
+            anchor_side_from_style_value(anchor_side.data()),
             rect,
             context.positioned_box,
             context.containing_block,
@@ -605,35 +654,29 @@ unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shel
             // SAFETY: This CSS crate export transfers one Arc reference to
             // the external-resolution snapshot, which releases it after
             // calc resolution.
-            resolved_node = calc_node_create_px_dimension(inset.to_double());
+            return calc_node_create_px_dimension(inset.to_double());
         }
-    }
-    if facts.has_anchor_name {
-        // SAFETY: The C++ facts callback transferred one raw fly-string
-        // reference for this explicit anchor name.
-        unsafe {
-            (engine.callbacks.release_anchor_name_handle)(facts.anchor_name);
-        }
-    }
-    if !resolved_node.is_null() {
-        return resolved_node;
     }
 
-    // SAFETY: The callback borrows fallback data from the live anchor style
-    // value for this synchronous resolution.
-    let fallback = unsafe { (engine.callbacks.anchor_function_fallback)(engine.callbacks.context, shell) };
-    match fallback.kind {
-        FfiAnchorFallbackKind::None => std::ptr::null(),
-        FfiAnchorFallbackKind::Px => calc_node_create_px_dimension(fallback.px.to_double()),
-        FfiAnchorFallbackKind::Percentage => {
-            calc_node_create_px_dimension(context.containing_block_extent.to_double() * fallback.fraction)
+    match fallback_value.optional_data() {
+        None => std::ptr::null(),
+        Some(StyleValueData::Length { value, unit }) => {
+            // Computed anchor() fallbacks hold absolute lengths only; relative
+            // units carry NaN canonical ratios.
+            let ratio = crate::css::style_compute::LENGTH_UNIT_CANONICAL_PX_RATIOS[*unit as usize];
+            assert!(ratio.is_finite());
+            calc_node_create_px_dimension(CssPixels::nearest_value_for(*value * ratio).to_double())
         }
-        FfiAnchorFallbackKind::Calculated => {
-            assert!(!fallback.value.is_null());
+        Some(StyleValueData::Percentage { value }) => {
+            calc_node_create_px_dimension(context.containing_block_extent.to_double() * (value / 100.0))
+        }
+        Some(StyleValueData::Calculated { .. }) => {
             let mut nested_context = *context;
+            // SAFETY: The anchor() shell retains the fallback calculation for
+            // this synchronous resolution.
             let resolved = unsafe {
                 resolve_calc_with_external_resolutions(
-                    fallback.value,
+                    fallback_value.pointer().cast(),
                     context.containing_block_extent,
                     (&raw mut nested_context).cast(),
                     Some(resolve_anchor_non_math_function),
@@ -644,11 +687,13 @@ unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shel
             }
             calc_node_create_px_dimension(resolved.value)
         }
-        FfiAnchorFallbackKind::Anchor => {
-            assert!(!fallback.value.is_null());
+        Some(StyleValueData::Anchor { .. }) => {
             let mut nested_context = *context;
-            unsafe { resolve_anchor_non_math_function((&raw mut nested_context).cast(), fallback.value) }
+            // SAFETY: The outer anchor() shell retains the nested anchor()
+            // for this synchronous resolution.
+            unsafe { resolve_anchor_non_math_function((&raw mut nested_context).cast(), fallback_value.pointer().cast()) }
         }
+        Some(_) => unreachable!("anchor() fallback must be a length, percentage, calculation or nested anchor()"),
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -18,56 +18,6 @@ pub(crate) enum LayoutMode {
     IntrinsicSizing,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(u8)]
-// NB: Some variants are only constructed by C++ through the FFI.
-#[allow(dead_code)]
-pub enum FfiAnchorSideKind {
-    Invalid,
-    Top,
-    Right,
-    Bottom,
-    Left,
-    Center,
-    Start,
-    End,
-    SelfStart,
-    SelfEnd,
-    Inside,
-    Outside,
-    Percentage,
-}
-
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
-pub struct FfiAnchorFunctionFacts {
-    pub has_anchor_name: bool,
-    pub anchor_name: usize,
-    pub side_kind: FfiAnchorSideKind,
-    pub side_percentage: f64,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u8)]
-// NB: Some variants are only constructed by C++ through the FFI.
-#[allow(dead_code)]
-pub enum FfiAnchorFallbackKind {
-    None,
-    Px,
-    Percentage,
-    Calculated,
-    Anchor,
-}
-
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
-pub struct FfiAnchorFallbackFacts {
-    pub kind: FfiAnchorFallbackKind,
-    pub px: CssPixels,
-    pub fraction: f64,
-    pub value: *const c_void,
-}
-
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct FfiResolvedAnchorInsets {
@@ -924,7 +874,6 @@ pub struct FfiLayoutFcCallbacks {
     pub static_position_containing_block: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub needs_inset_resolution: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub report_unexpected_fragmented_inline: unsafe extern "C" fn(*mut c_void, *mut c_void),
-    pub release_anchor_name_handle: crate::layout::FfiReleaseAnchorNameHandleCallback,
     pub build_svg_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgElementFacts,
     pub read_paintable_geometry:
         unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, *mut crate::layout::FfiPaintableGeometry) -> bool,
@@ -933,8 +882,6 @@ pub struct FfiLayoutFcCallbacks {
     pub compute_svg_path: unsafe extern "C" fn(*mut c_void, *mut c_void, FfiSvgPathRequest) -> FfiSvgPathResult,
     pub svg_image_bounding_box: unsafe extern "C" fn(*mut c_void, *mut c_void, CssPixels, CssPixels) -> FfiFloatRect,
     pub anchor_lookup: unsafe extern "C" fn(*mut c_void, *mut c_void, usize, *const *mut c_void, usize) -> NodeSlotId,
-    pub build_anchor_function_facts: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFunctionFacts,
-    pub anchor_function_fallback: unsafe extern "C" fn(*mut c_void, *const c_void) -> FfiAnchorFallbackFacts,
     pub set_default_scroll_shift: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void, bool, bool),
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-pub type FfiReleaseAnchorNameHandleCallback = unsafe extern "C" fn(usize);
-
 /// The four inset properties; the discriminant indexes the anchor-inset
 /// store fields.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
The abspos engine resolved anchor() functions by calling back into C++ (build_anchor_function_facts / anchor_function_fallback), which wrapped the Rust-owned style value shell back into a C++ StyleValue just to pick apart data the Rust StyleValueData::Anchor variant already carries: the anchor name, the side keyword or percentage, and the fallback value.