### PR TITLE
LibWeb: Propagate `vertical-align` to anonymous table wrapper boxes

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1094,6 +1094,7 @@ void NodeWithStyle::reset_table_box_computed_values_used_by_wrapper_to_init_valu
         // Note that there may be more properties that need to be added to this list.
         values.set_z_index(CSS::InitialValues::z_index());
         values.set_clip(CSS::InitialValues::clip());
+        values.set_vertical_align(CSS::InitialValues::vertical_align());
     });
 }
 
@@ -1125,6 +1126,9 @@ void NodeWithStyle::transfer_table_box_computed_values_to_wrapper_computed_value
     builder->set_z_index(computed_values().z_index());
     // "clip" only takes effect on absolutely-positioned elements; the table box isn't one — the wrapper is.
     builder->set_clip(computed_values().clip());
+    // AD-HOC: The wrapper box participates in inline layout in place of the table box, so vertical-align
+    //         must be moved to the wrapper to have any effect.
+    builder->set_vertical_align(computed_values().vertical_align());
 
     reset_table_box_computed_values_used_by_wrapper_to_init_values();
 }

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-bottom-applies-to-014.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-bottom-applies-to-014.xht
@@ -1,0 +1,45 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Border-bottom applied to element with 'display' set to 'inline-table'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-12-03 -->
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-shorthand-properties" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/borders/border-bottom-applies-to-001-ref.xht" />
+
+        <meta name="assert" content="The 'border-bottom' property applies to elements with a 'display' of 'inline-table'." />
+        <style type="text/css">
+            #test
+            {
+                border-bottom: solid green 3px;
+                display: inline-table;
+                table-layout: fixed;
+                vertical-align: top;
+                width: 1in;
+            }
+            .row
+            {
+                display: table-row;
+            }
+            .cell
+            {
+                display: table-cell;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a short horizontal green line.</p>
+
+        <div id="test">
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-bottom-color-applies-to-014.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-bottom-color-applies-to-014.xht
@@ -1,0 +1,47 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Border-bottom-color applied to element with display inline-table</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-12-05 -->
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-color" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/borders/border-bottom-applies-to-001-ref.xht" />
+
+        <meta name="assert" content="The 'border-bottom-color' property applies to elements with a display of inline-table." />
+        <style type="text/css">
+            #table
+            {
+                border-bottom-width: 3px;
+                border-bottom-style: solid;
+                border-bottom-color: green;
+                display: inline-table;
+                table-layout: fixed;
+                vertical-align: top;
+                width: 1in;
+            }
+            .row
+            {
+                display: table-row;
+            }
+            .cell
+            {
+                display: table-cell;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a short horizontal green line.</p>
+
+        <div id="table">
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-top-applies-to-014.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-top-applies-to-014.xht
@@ -1,0 +1,45 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Border-top applied to element with display inline-table</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-12-05 -->
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-top" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-shorthand-properties" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/borders/border-bottom-applies-to-001-ref.xht" />
+
+        <meta name="assert" content="The 'border-top' property applies to elements with a display of inline-table." />
+        <style type="text/css">
+            #test
+            {
+                border-top: solid green 3px;
+                display: inline-table;
+                table-layout: fixed;
+                vertical-align: top;
+                width: 1in;
+            }
+            .row
+            {
+                display: table-row;
+            }
+            .cell
+            {
+                display: table-cell;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a short horizontal green line.</p>
+
+        <div id="test">
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-top-color-applies-to-014.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/borders/border-top-color-applies-to-014.xht
@@ -1,0 +1,47 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Border-top-color applied to element with display inline-table</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-12-05 -->
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-top-color" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/borders/border-bottom-applies-to-001-ref.xht" />
+
+        <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
+        <meta name="assert" content="The 'border-top-color' property applies to elements with a display of inline-table." />
+        <style type="text/css">
+            #table
+            {
+                border-top-width: 3px;
+                border-top-style: solid;
+                border-top-color: green;
+                display: inline-table;
+                table-layout: fixed;
+                vertical-align: top;
+                width: 1in;
+            }
+            .row
+            {
+                display: table-row;
+            }
+            .cell
+            {
+                display: table-cell;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is a short horizontal green line.</p>
+
+        <div id="table">
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+
+            <div class="row">
+                <div class="cell"></div><div class="cell"></div>
+            </div>
+        </div>
+
+    </body>
+</html>


### PR DESCRIPTION
Previously, a table's computed `vertical-align` value remained on the table box, where it had no effect. Inline tables were therefore always baseline aligned. The value is now moved to the anonymous table wrapper box, which participates in inline layout in place of the table box.