### PR TITLE
LibWeb: Merge adjacent string items in generated content

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -3168,13 +3168,27 @@ static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, 
 
         ContentData content_data;
 
+        Utf16StringBuilder pending_text;
+        bool has_pending_text = false;
+        auto append_text = [&](Utf16View const& text) {
+            pending_text.append(text);
+            has_pending_text = true;
+        };
+        auto flush_pending_text = [&] {
+            if (!has_pending_text)
+                return;
+            content_data.data.append(pending_text.to_string());
+            pending_text.clear();
+            has_pending_text = false;
+        };
+
         for (auto const& item : content_style_value.content().values()) {
             if (item->is_string()) {
-                content_data.data.append(item->as_string().string_value().to_utf16_string());
+                append_text(item->as_string().string_value().view());
             } else if (item->is_keyword()) {
                 switch (item->to_keyword()) {
                 case Keyword::OpenQuote:
-                    content_data.data.append(get_quote_string(true, quote_nesting_level++).to_utf16_string());
+                    append_text(get_quote_string(true, quote_nesting_level++).view());
                     break;
                 case Keyword::CloseQuote:
                     // A 'close-quote' or 'no-close-quote' that would make the depth negative is in error and is ignored
@@ -3183,7 +3197,7 @@ static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, 
                     // - https://www.w3.org/TR/CSS21/generate.html#quotes-insert
                     // (This is missing from the CONTENT-3 spec.)
                     if (quote_nesting_level > 0)
-                        content_data.data.append(get_quote_string(false, --quote_nesting_level).to_utf16_string());
+                        append_text(get_quote_string(false, --quote_nesting_level).view());
                     break;
                 case Keyword::NoOpenQuote:
                     quote_nesting_level++;
@@ -3198,18 +3212,21 @@ static ContentDataAndQuoteNestingLevel resolve_content(StyleValue const& value, 
                     break;
                 }
             } else if (item->is_counter()) {
+                flush_pending_text();
                 content_data.counter_style_dependencies.append(item->as_counter().counter_style()->as_counter_style().resolve_counter_style(element_reference.style_scope()));
                 content_data.data.append(item->as_counter().resolve(element_reference));
             } else if (item->is_image() || item->is_image_set()) {
                 // https://drafts.csswg.org/css-content-3/#typedef-content-list
                 // https://drafts.csswg.org/css-images-4/#typedef-image
                 // <content-list> accepts <image>, and image-set() is an <image>.
+                flush_pending_text();
                 content_data.data.append(NonnullRefPtr { const_cast<AbstractImageStyleValue&>(item->as_abstract_image()) });
             } else {
                 // TODO: Implement images, and other things.
                 dbgln("`{}` is not supported in `content` (yet?)", item->to_string(SerializationMode::Normal));
             }
         }
+        flush_pending_text();
         content_data.type = ContentData::Type::List;
 
         if (auto alt_text = content_style_value.alt_text()) {

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-001.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-001.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table-row-group'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table-row-group'." />
+        <style type="text/css">
+            #test
+            {
+                display: table-row-group;
+                quotes: "P" "S" "A" "S";
+            }
+            #table
+            {
+                display: table;
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="test">
+                <div id="row">
+                    <div id="cell"></div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-002.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-002.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table-header-group'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table-header-group'." />
+        <style type="text/css">
+            #test
+            {
+                display: table-header-group;
+                quotes: "P" "S" "A" "S";
+            }
+            #table
+            {
+                display: table;
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="test">
+                <div id="row">
+                    <div id="cell"></div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-003.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-003.xht
@@ -1,0 +1,44 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table-footer-group'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table-footer-group'." />
+        <style type="text/css">
+            #test
+            {
+                display: table-footer-group;
+                quotes: "P" "S" "A" "S";
+            }
+            #table
+            {
+                display: table;
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="test">
+                <div id="row">
+                    <div id="cell"></div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-004.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-004.xht
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table-row'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table-row'." />
+        <style type="text/css">
+            #table
+            {
+                display: table;
+            }
+            #row
+            {
+                display: table-row;
+                quotes: "P" "S" "A" "S";
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="row">
+                <div id="cell"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-007.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-007.xht
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table-cell'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table-cell'." />
+        <style type="text/css">
+            #table
+            {
+                display: table;
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+                quotes: "P" "S" "A" "S";
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="row">
+                <div id="cell"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-008.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-008.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'inline'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'inline'." />
+        <style type="text/css">
+            div
+            {
+                display: inline;
+                quotes: "P" "S" "A" "S";
+            }
+            div:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div></div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-009.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-009.xht
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'block'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'block'." />
+        <style type="text/css">
+            span
+            {
+                display: block;
+                quotes: "P" "S" "A" "S";
+            }
+            span:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div>
+            <span></span>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-012.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-012.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'inline-block'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'inline-block'." />
+        <style type="text/css">
+            div
+            {
+                display: inline-block;
+                quotes: "P" "S" "A" "S";
+            }
+            div:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div></div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-013.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-013.xht
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table'." />
+        <style type="text/css">
+            #table
+            {
+                display: table;
+                quotes: "P" "S" "A" "S";
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="row">
+                <div id="cell"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-014.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-014.xht
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'inline-table'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'inline-table'." />
+        <style type="text/css">
+            #table
+            {
+                display: inline-table;
+                quotes: "P" "S" "A" "S";
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+            #cell:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="row">
+                <div id="cell"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-015.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/generated-content/quotes-applies-to-015.xht
@@ -1,0 +1,43 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'table-caption'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/generated-content/../../reference/pass_if_pass_below.html"/>
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'table-caption'." />
+        <style type="text/css">
+            #test
+            {
+                display: table-caption;
+                quotes: "P" "S" "A" "S";
+            }
+            #test:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+            #table
+            {
+                display: inline-table;
+            }
+            #row
+            {
+                display: table-row;
+            }
+            #cell
+            {
+                display: table-cell;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div id="table">
+            <div id="test"></div>
+            <div id="row">
+                <div id="cell"></div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-display/run-in/quotes-applies-to-011.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-display/run-in/quotes-applies-to-011.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Quotes applied to elements with 'display' set to 'run-in'</title>
+        <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-quotes" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#quotes-specify" />
+        <link rel="match" href="../../../../../expected/wpt-import/css/css-display/run-in/../../reference/pass_if_pass_below.html" />
+        <meta name="assert" content="The 'quotes' property applies to elements with a 'display' set to 'run-in'." />
+        <style type="text/css">
+            div
+            {
+                display: run-in;
+                quotes: "P" "S" "A" "S";
+            }
+            div:before
+            {
+                content: open-quote open-quote close-quote close-quote;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if there is the word "PASS" below.</p>
+        <div></div>
+    </body>
+</html>


### PR DESCRIPTION
Previously, each item in a resolved `content` value became its own layout node. Adjacent string items were shaped independently, so kerning between them was lost.

Adjacent string items are now merged into a single item, so their text is shaped as one unit.