### PR TITLE
Documentation: Add `qt6-positioning-dev` as an Ubuntu build dependency

### DIFF
--- a/.devcontainer/features/ladybird/install-ubuntu.sh
+++ b/.devcontainer/features/ladybird/install-ubuntu.sh
@@ -31,7 +31,7 @@ install_cmake() {
 ### Install packages
 
 apt update -y
-apt install -y autoconf autoconf-archive automake build-essential ccache curl fonts-liberation2 git glslang-tools libdrm-dev libgl1-mesa-dev libncurses-dev libtool lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
+apt install -y autoconf autoconf-archive automake build-essential ccache curl fonts-liberation2 git glslang-tools libdrm-dev libgl1-mesa-dev libncurses-dev libtool lsb-release nasm ninja-build pkg-config python3 qt6-base-dev qt6-positioning-dev qt6-tools-dev-tools qt6-wayland shellcheck tar unzip zip
 
 install_cmake
 

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -20,7 +20,7 @@ CMake 3.30 or newer must be available in $PATH.
 
 <!-- Note: If you change something here, please also change it in the `devcontainer/devcontainer.json` file. -->
 ```bash
-sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git glslang-tools libdrm-dev libgl1-mesa-dev libncurses-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
+sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git glslang-tools libdrm-dev libgl1-mesa-dev libncurses-dev libtool nasm ninja-build pkg-config python3-venv qt6-base-dev qt6-positioning-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
 ```
 
 #### CMake 3.30 or newer:


### PR DESCRIPTION
This has been required since a28bc7e878  (#10915) after having been introduced as an optional dependency in  dc280c11e8b (#9737).