### PR TITLE
LibWeb: Remove NodeWithStyleAndBoxModelMetrics

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8553,7 +8553,7 @@ Optional<CSSPixelRect> Document::current_caret_rect()
 
     // Empty editable elements have no fragments; fall back to the caret position for the cursor's child offset
     // (which accounts for empty lines rendered by <br>), or the padding-box corner.
-    if (auto* node_with_style = as_if<Layout::NodeWithStyleAndBoxModelMetrics>(*layout_node)) {
+    if (auto* node_with_style = as_if<Layout::NodeWithStyle>(*layout_node)) {
         auto paintable = node_with_style->paintable();
         if (auto const* with_lines = as_if<Painting::PaintableWithLines>(paintable.ptr()))
             return to_viewport_rect(with_lines->caret_rect_for_child_offset(position->offset()));

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -1018,7 +1018,6 @@ class LayoutRustBridge;
 class Node;
 class NodeArena;
 class NodeWithStyle;
-class NodeWithStyleAndBoxModelMetrics;
 class RadioButton;
 class ReplacedBox;
 class SVGSVGBox;

--- a/Libraries/LibWeb/Layout/Box.cpp
+++ b/Libraries/LibWeb/Layout/Box.cpp
@@ -18,7 +18,7 @@
 namespace Web::Layout {
 
 Box::Box(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::ComputedValues const> computed_values)
-    : NodeWithStyleAndBoxModelMetrics(document, node, move(computed_values))
+    : NodeWithStyle(document, node, move(computed_values))
 {
 }
 

--- a/Libraries/LibWeb/Layout/Box.h
+++ b/Libraries/LibWeb/Layout/Box.h
@@ -24,8 +24,8 @@ struct LineBoxFragmentCoordinate {
     size_t fragment_index { 0 };
 };
 
-class WEB_API Box : public NodeWithStyleAndBoxModelMetrics {
-    LAYOUT_NODE(Box, NodeWithStyleAndBoxModelMetrics);
+class WEB_API Box : public NodeWithStyle {
+    LAYOUT_NODE(Box, NodeWithStyle);
 
 public:
     RefPtr<Painting::Paintable const> paintable_box() const;

--- a/Libraries/LibWeb/Layout/BreakNode.cpp
+++ b/Libraries/LibWeb/Layout/BreakNode.cpp
@@ -10,7 +10,7 @@
 namespace Web::Layout {
 
 BreakNode::BreakNode(DOM::Document& document, HTML::HTMLBRElement& element, NonnullRefPtr<CSS::ComputedValues const> style)
-    : Layout::NodeWithStyleAndBoxModelMetrics(document, &element, style)
+    : Layout::NodeWithStyle(document, &element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/BreakNode.h
+++ b/Libraries/LibWeb/Layout/BreakNode.h
@@ -11,8 +11,8 @@
 
 namespace Web::Layout {
 
-class BreakNode final : public NodeWithStyleAndBoxModelMetrics {
-    LAYOUT_NODE(BreakNode, NodeWithStyleAndBoxModelMetrics);
+class BreakNode final : public NodeWithStyle {
+    LAYOUT_NODE(BreakNode, NodeWithStyle);
 
 public:
     BreakNode(DOM::Document&, HTML::HTMLBRElement&, NonnullRefPtr<CSS::ComputedValues const>);

--- a/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -14,7 +14,7 @@
 namespace Web::Layout {
 
 InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::ComputedValues const> style)
-    : Layout::NodeWithStyleAndBoxModelMetrics(document, element, style)
+    : Layout::NodeWithStyle(document, element, style)
 {
 }
 

--- a/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Libraries/LibWeb/Layout/InlineNode.h
@@ -10,8 +10,8 @@
 
 namespace Web::Layout {
 
-class InlineNode final : public NodeWithStyleAndBoxModelMetrics {
-    LAYOUT_NODE(InlineNode, NodeWithStyleAndBoxModelMetrics);
+class InlineNode final : public NodeWithStyle {
+    LAYOUT_NODE(InlineNode, NodeWithStyle);
 
 public:
     InlineNode(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::ComputedValues const>);

--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -1120,7 +1120,7 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
         .document_in_quirks_mode = m_commit_root->document().in_quirks_mode(),
         .static_position_containing_block = [](void*, void* node) { return Node::slot_id(static_cast<Box const*>(node)->static_position_containing_block()); },
         .needs_inset_resolution = [](void*, void* node) {
-            auto const& styled_node = *static_cast<NodeWithStyleAndBoxModelMetrics const*>(node);
+            auto const& styled_node = *static_cast<NodeWithStyle const*>(node);
             if (styled_node.computed_values().position() == CSS::Positioning::Relative)
                 return true;
             auto const* box = as_if<Box>(styled_node);

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -35,7 +35,6 @@
 #include <LibWeb/Painting/PaintableWithLines.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGFilterElement.h>
-#include <LibWeb/SVG/SVGForeignObjectElement.h>
 #include <LibWeb/SVG/SVGGradientElement.h>
 #include <LibWeb/SVG/SVGPatternElement.h>
 #include <LibWeb/SVG/SVGTextContentElement.h>
@@ -915,13 +914,13 @@ bool Node::is_fragmented_inline() const
         || (is_list_item_box() && as<NodeWithStyle>(*this).display().is_inline_outside() && as<NodeWithStyle>(*this).display().is_flow_inside());
 }
 
-NodeWithStyleAndBoxModelMetrics const* Node::nearest_fragmented_inline_ancestor() const
+NodeWithStyle const* Node::nearest_fragmented_inline_ancestor() const
 {
     for (auto const* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
         if (!ancestor->display().is_inline_outside() || !ancestor->display().is_flow_inside())
             break;
         if (ancestor->is_fragmented_inline())
-            return static_cast<NodeWithStyleAndBoxModelMetrics const*>(ancestor);
+            return static_cast<NodeWithStyle const*>(ancestor);
     }
     return nullptr;
 }
@@ -1388,48 +1387,6 @@ bool NodeWithStyle::has_paint_containment() const
     // - if its principal box is an internal ruby box or a non-atomic inline-level box
     // FIXME: Also check for internal ruby boxes.
     if (display().is_inline_outside() && display().is_flow_inside() && !is_replaced_box())
-        return false;
-
-    return true;
-}
-
-bool NodeWithStyleAndBoxModelMetrics::is_inline_flow_interrupting_block() const
-{
-    // This node remains a layout child of its inline-flow parent. InlineLevelIterator emits it as a BlockLevelBox item
-    // so the inline formatting context can lay it out as an interrupting block.
-    if (!parent())
-        return false;
-    auto const& parent_display = parent()->display();
-    if (!parent_display.is_inline_outside() || !parent_display.is_flow_inside())
-        return false;
-
-    // This node must not be inline itself or out of flow (which gets handled separately).
-    if (display().is_inline_outside() || is_out_of_flow())
-        return false;
-
-    // This node must not have `display: contents`; interrupting block handling gets delegated to its children.
-    if (display().is_contents())
-        return false;
-
-    // Internal table display types and table captions are handled by the table fixup algorithm.
-    if (display().is_internal_table() || display().is_table_caption())
-        return false;
-
-    // Parent element must not be <foreignObject>
-    if (is<SVG::SVGForeignObjectElement>(parent()->dom_node()))
-        return false;
-
-    // Non-root SVG elements and foreign object boxes should not interrupt inline flow.
-    if (is_svg_box() || is_svg_foreign_object_box())
-        return false;
-
-    // Nested SVG roots should not interrupt inline flow, but a top-level SVG root inside an HTML inline element should.
-    if (is_svg_svg_box() && (parent()->is_svg_box() || parent()->is_svg_svg_box()))
-        return false;
-
-    // Replaced boxes with children (e.g. media elements with shadow DOM controls)
-    // have their own formatting context; don't let their children interrupt inline flow.
-    if (parent()->is_replaced_box_with_children())
         return false;
 
     return true;

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -173,7 +173,7 @@ public:
     bool is_replaced_element() const;
     bool is_atomic_inline() const;
     bool is_fragmented_inline() const;
-    NodeWithStyleAndBoxModelMetrics const* nearest_fragmented_inline_ancestor() const;
+    NodeWithStyle const* nearest_fragmented_inline_ancestor() const;
 
     // An element is called out of flow if it is floated, absolutely positioned, or is the root element.
     // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
@@ -206,7 +206,6 @@ public:
     virtual bool is_legend_box() const { return false; }
     virtual bool is_table_wrapper() const { return false; }
     virtual bool is_node_with_style() const { return false; }
-    virtual bool is_node_with_style_and_box_model_metrics() const { return false; }
 
     bool is_replaced_box_with_children() const { return is_replaced_box() && can_have_children(); }
 
@@ -467,25 +466,6 @@ private:
 
 template<>
 inline bool Node::fast_is<NodeWithStyle>() const { return is_node_with_style(); }
-
-class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {
-    LAYOUT_NODE(NodeWithStyleAndBoxModelMetrics, NodeWithStyle);
-
-public:
-    bool is_inline_flow_interrupting_block() const;
-
-protected:
-    NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::ComputedValues const> computed_values)
-        : NodeWithStyle(document, node, move(computed_values))
-    {
-    }
-
-private:
-    virtual bool is_node_with_style_and_box_model_metrics() const final { return true; }
-};
-
-template<>
-inline bool Node::fast_is<NodeWithStyleAndBoxModelMetrics>() const { return is_node_with_style_and_box_model_metrics(); }
 
 inline bool Node::has_style_or_parent_with_style() const
 {

--- a/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -17,12 +17,12 @@
 
 namespace Web::Painting {
 
-NonnullRefPtr<InlinePaintable> InlinePaintable::create(Layout::NodeWithStyleAndBoxModelMetrics const& layout_node)
+NonnullRefPtr<InlinePaintable> InlinePaintable::create(Layout::NodeWithStyle const& layout_node)
 {
     return adopt_ref(*new InlinePaintable(layout_node));
 }
 
-InlinePaintable::InlinePaintable(Layout::NodeWithStyleAndBoxModelMetrics const& layout_node)
+InlinePaintable::InlinePaintable(Layout::NodeWithStyle const& layout_node)
     : Paintable(layout_node)
 {
 }

--- a/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -16,7 +16,7 @@ namespace Web::Painting {
 // geometry is the union of those pieces.
 class InlinePaintable final : public Paintable {
 public:
-    static NonnullRefPtr<InlinePaintable> create(Layout::NodeWithStyleAndBoxModelMetrics const&);
+    static NonnullRefPtr<InlinePaintable> create(Layout::NodeWithStyle const&);
     virtual ~InlinePaintable() override;
     virtual StringView class_name() const override { return "InlinePaintable"sv; }
 
@@ -78,7 +78,7 @@ public:
     virtual void set_needs_repaint(InvalidateDisplayList = InvalidateDisplayList::Yes) override;
 
 private:
-    explicit InlinePaintable(Layout::NodeWithStyleAndBoxModelMetrics const&);
+    explicit InlinePaintable(Layout::NodeWithStyle const&);
 
     [[nodiscard]] virtual bool is_inline_paintable() const final { return true; }
 

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -938,7 +938,7 @@ NonnullRefPtr<Paintable> Paintable::create(Layout::Box const& layout_box)
     return adopt_ref(*new Paintable(layout_box));
 }
 
-Paintable::Paintable(Layout::NodeWithStyleAndBoxModelMetrics const& layout_node)
+Paintable::Paintable(Layout::NodeWithStyle const& layout_node)
     : m_layout_node(layout_node)
 {
     auto& computed_values = layout_node.computed_values();
@@ -960,7 +960,7 @@ Paintable::Paintable(Layout::NodeWithStyleAndBoxModelMetrics const& layout_node)
 }
 
 Paintable::Paintable(Layout::Box const& layout_box)
-    : Paintable(static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(layout_box))
+    : Paintable(static_cast<Layout::NodeWithStyle const&>(layout_box))
 {
 }
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -104,12 +104,12 @@ public:
     virtual bool forms_unconnected_subtree() const { return false; }
 
     bool has_layout_node() const { return m_layout_node; }
-    Layout::NodeWithStyleAndBoxModelMetrics const& layout_node() const
+    Layout::NodeWithStyle const& layout_node() const
     {
         VERIFY(m_layout_node);
         return *m_layout_node;
     }
-    Layout::NodeWithStyleAndBoxModelMetrics& layout_node() { return const_cast<Layout::NodeWithStyleAndBoxModelMetrics&>(const_cast<Paintable const&>(*this).layout_node()); }
+    Layout::NodeWithStyle& layout_node() { return const_cast<Layout::NodeWithStyle&>(const_cast<Paintable const&>(*this).layout_node()); }
 
     [[nodiscard]] GC::Ptr<DOM::Node> dom_node();
     [[nodiscard]] GC::Ptr<DOM::Node const> dom_node() const;
@@ -469,7 +469,7 @@ public:
     [[nodiscard]] VisualContextIndex own_scroll_node_index() const { return m_own_scroll_node_index; }
 
 protected:
-    explicit Paintable(Layout::NodeWithStyleAndBoxModelMetrics const&);
+    explicit Paintable(Layout::NodeWithStyle const&);
     explicit Paintable(Layout::Box const&);
 
     void paint_with_inspector_overlay_context(DisplayListRecordingContext&, Function<void()> const&) const;
@@ -511,7 +511,7 @@ private:
     void invalidate_absolute_geometry_cache(InvalidateDescendantGeometry);
 
     GC::Weak<DOM::Node> m_dom_node;
-    WeakPtr<Layout::NodeWithStyleAndBoxModelMetrics const> m_layout_node;
+    WeakPtr<Layout::NodeWithStyle const> m_layout_node;
     Paintable* m_containing_block { nullptr };
 
     SelectionState m_selection_state { SelectionState::None };

--- a/Libraries/LibWeb/Rust/src/layout/node_data.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_data.rs
@@ -108,7 +108,6 @@ pub enum NodeKind {
     NavigableContainerViewport = 14,
     Node = 15,
     NodeWithStyle = 16,
-    NodeWithStyleAndBoxModelMetrics = 17,
     RadioButton = 18,
     RangeInputBox = 19,
     ReplacedBox = 20,

--- a/Libraries/LibWeb/Rust/src/layout/node_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/node_facts.rs
@@ -113,7 +113,6 @@ pub(crate) fn kind_is_box(kind: NodeKind) -> bool {
             | NodeKind::InlineNode
             | NodeKind::Node
             | NodeKind::NodeWithStyle
-            | NodeKind::NodeWithStyleAndBoxModelMetrics
             | NodeKind::GeneratedTextNode
             | NodeKind::TextNode
             | NodeKind::TextSliceNode

--- a/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/tree_builder.rs
@@ -2072,12 +2072,9 @@ fn kind_facts(kind: NodeKind) -> FfiNodeKindFacts {
     };
 
     match kind {
-        NodeKind::Unset
-        | NodeKind::BreakNode
-        | NodeKind::InlineNode
-        | NodeKind::Node
-        | NodeKind::NodeWithStyle
-        | NodeKind::NodeWithStyleAndBoxModelMetrics => NON_BOX,
+        NodeKind::Unset | NodeKind::BreakNode | NodeKind::InlineNode | NodeKind::Node | NodeKind::NodeWithStyle => {
+            NON_BOX
+        }
         NodeKind::GeneratedTextNode | NodeKind::TextNode | NodeKind::TextSliceNode => TEXT,
         NodeKind::Box | NodeKind::ListItemMarkerBox => BOX,
         NodeKind::AudioBox


### PR DESCRIPTION
NodeWithStyleAndBoxModelMetrics has no state or behavior. Inline-flow interruption detection now lives in Rust, so retaining the intermediate base class leaves redundant type predicates across layout and painting.

Make Box, InlineNode, and BreakNode inherit directly from NodeWithStyle. Retype paintables and fragmented-inline helpers with NodeWithStyle, and remove the obsolete C++ type predicate and Rust node kind. The numeric values of the remaining kinds stay unchanged across the FFI boundary.