### PR TITLE
LibWeb: Support mask-composite when painting CSS masks

### DIFF
--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -172,6 +172,8 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
         clip_shrink.right = context.rounded_device_pixels(border_right.width);
     }
 
+    bool painted_mask_layer = false;
+
     // Note: Background layers are ordered front-to-back, so we paint them in reverse
     for (auto& layer : resolved_background.layers.in_reverse()) {
         DisplayListRecorderStateSaver state { display_list_recorder };
@@ -192,14 +194,39 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
             }
         }
 
-        auto const& image = *layer.background_image;
-        auto image_rect = layer.image_rect;
-        auto background_positioning_area = layer.background_positioning_area;
-
         auto original_context = display_list_recorder.accumulated_visual_context();
         ScopeGuard restore_context = [&] {
             display_list_recorder.set_accumulated_visual_context(original_context);
         };
+
+        auto compositing_and_blending_operator = mix_blend_mode_to_compositing_and_blending_operator(layer.blend_mode);
+        // https://drafts.fxtf.org/css-masking-1/#the-mask-composite
+        // If there is no further mask layer, the compositing operator must be ignored.
+        if (layer.mask_composite.has_value()) {
+            if (painted_mask_layer)
+                compositing_and_blending_operator = *layer.mask_composite;
+            painted_mask_layer = true;
+        }
+        bool applied_blend_layer = false;
+        ScopeGuard restore_blend_layer = [&] {
+            if (applied_blend_layer)
+                display_list_recorder.restore();
+        };
+        auto apply_blend_layer = [&] {
+            if (compositing_and_blending_operator == Gfx::CompositingAndBlendingOperator::Normal)
+                return;
+            display_list_recorder.apply_effects(compositing_and_blending_operator);
+            applied_blend_layer = true;
+        };
+
+        if (!layer.background_image) {
+            apply_blend_layer();
+            continue;
+        }
+
+        auto const& image = *layer.background_image;
+        auto image_rect = layer.image_rect;
+        auto background_positioning_area = layer.background_positioning_area;
 
         switch (layer.attachment) {
         case CSS::BackgroundAttachment::Fixed:
@@ -305,7 +332,6 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                     image_rect.set_x(image_x);
                     auto image_device_rect = context.rounded_device_rect(image_rect);
                     // If the image's dimensions were rounded to zero then they need to be restored to avoid a crash.
-                    // There's no need to check that !image_rect.is_empty() because empty images are discarded in resolve_background_layers.
                     if (image_device_rect.width() == 0)
                         image_device_rect.set_width(1);
                     if (image_device_rect.height() == 0)
@@ -320,15 +346,6 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                     break;
                 image_y += y_step;
             }
-        };
-
-        Gfx::CompositingAndBlendingOperator compositing_and_blending_operator = mix_blend_mode_to_compositing_and_blending_operator(layer.blend_mode);
-        bool applied_blend_layer = false;
-        auto apply_blend_layer = [&] {
-            if (compositing_and_blending_operator == Gfx::CompositingAndBlendingOperator::Normal)
-                return;
-            display_list_recorder.apply_effects(compositing_and_blending_operator);
-            applied_blend_layer = true;
         };
 
         // Past this (super-large) tile count, the non-image branch below covers the area with a single repeating
@@ -361,7 +378,6 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
             // of a repeated background, so the painter has the opportunity to optimize the painting of repeated images.
             auto dest_rect = context.rounded_device_rect(image_rect);
             // If the image's dimensions were rounded to zero then they need to be restored to avoid a crash.
-            // There's no need to check that !image_rect.is_empty() because empty images are discarded in resolve_background_layers.
             if (dest_rect.width() == 0)
                 dest_rect.set_width(1);
             if (dest_rect.height() == 0)
@@ -436,10 +452,6 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
                 image.paint(context, document, image_device_rect, image_rendering, color_scheme);
             });
         }
-
-        if (applied_blend_layer) {
-            display_list_recorder.restore();
-        }
     }
 
     if (paint_into_isolated_group)
@@ -454,7 +466,15 @@ void paint_background(DisplayListRecordingContext& context, Paintable const& pai
     }
 }
 
-ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> const& layers, Paintable const& paintable_box, Color background_color, CSS::BackgroundBox background_color_clip, CSSPixelRect const& border_rect, BorderRadiiData const& border_radii)
+enum class LayerType : u8 {
+    Background,
+    Mask,
+};
+
+// https://drafts.fxtf.org/css-masking-1/#the-mask-image
+static ResolvedBackground resolve_layers(Vector<CSS::BackgroundLayerData> const& layers,
+    Paintable const& paintable_box, Color background_color, CSS::BackgroundBox background_color_clip,
+    CSSPixelRect const& border_rect, BorderRadiiData const& border_radii, LayerType layer_type)
 {
     BackgroundBox border_box {
         border_rect,
@@ -464,12 +484,29 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
     auto color_box = get_box(background_color_clip, border_box, paintable_box);
 
     Vector<ResolvedBackgroundLayerData> resolved_layers;
+    // A value of none counts as a transparent black image layer.
+    // A mask reference that is an empty image (zero width or zero height), that fails to download, is not a reference
+    // to an mask element, is non-existent, or that cannot be displayed (e.g. because it is not in a supported image
+    // format) still counts as an image layer of transparent black.
     for (auto const& layer : layers) {
-        if (!layer.background_image)
-            continue;
+        auto mask_composite = layer_type == LayerType::Mask
+            ? mask_composite_to_compositing_and_blending_operator(layer.mask_composite)
+            : Optional<Gfx::CompositingAndBlendingOperator> {};
+        auto append_transparent_mask_layer = [&] {
+            if (layer_type != LayerType::Mask)
+                return;
+            ResolvedBackgroundLayerData transparent_mask_layer {};
+            transparent_mask_layer.clip = layer.clip;
+            transparent_mask_layer.blend_mode = layer.blend_mode;
+            transparent_mask_layer.mask_composite = mask_composite;
+            resolved_layers.append(move(transparent_mask_layer));
+        };
+
         auto const& document = paintable_box.layout_node().document();
-        if (!layer.background_image->is_paintable(document))
+        if (!layer.background_image || !layer.background_image->is_paintable(document)) {
+            append_transparent_mask_layer();
             continue;
+        }
 
         auto background_positioning_area = get_box(layer.origin, border_box, paintable_box).rect;
 
@@ -500,8 +537,10 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
             background_positioning_area.size());
 
         // If the image has no size, there's nothing to paint.
-        if (concrete_image_size.is_empty())
+        if (concrete_image_size.is_empty()) {
+            append_transparent_mask_layer();
             continue;
+        }
 
         // Size
         CSSPixelRect image_rect;
@@ -526,8 +565,10 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         }
 
         // If after sizing we have a 0px image, we're done. Attempting to paint this would be an infinite loop.
-        if (image_rect.is_empty())
+        if (image_rect.is_empty()) {
+            append_transparent_mask_layer();
             continue;
+        }
 
         // If background-repeat is round for one (or both) dimensions, there is a second step.
         // The UA must scale the image in that dimension (or both dimensions) so that it fits a
@@ -565,8 +606,10 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         }
 
         // If after round adjustments we have a 0px image, we're done.
-        if (image_rect.is_empty())
+        if (image_rect.is_empty()) {
+            append_transparent_mask_layer();
             continue;
+        }
 
         CSSPixels space_x = background_positioning_area.width() - image_rect.width();
         CSSPixels space_y = background_positioning_area.height() - image_rect.height();
@@ -574,7 +617,7 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         CSSPixels position_x = layer.position_x.to_px(space_x);
         CSSPixels position_y = layer.position_y.to_px(space_y);
 
-        resolved_layers.append({ .background_image = *layer.background_image,
+        resolved_layers.append({ .background_image = layer.background_image,
             .attachment = layer.attachment,
             .clip = layer.clip,
             .position_x = position_x,
@@ -583,7 +626,8 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
             .image_rect = image_rect,
             .repeat_x = layer.repeat_x,
             .repeat_y = layer.repeat_y,
-            .blend_mode = layer.blend_mode });
+            .blend_mode = layer.blend_mode,
+            .mask_composite = mask_composite });
     }
 
     return ResolvedBackground {
@@ -593,6 +637,21 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
         .background_rect = border_rect,
         .color = background_color
     };
+}
+
+ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> const& layers,
+    Paintable const& paintable_box, Color background_color, CSS::BackgroundBox background_color_clip,
+    CSSPixelRect const& border_rect, BorderRadiiData const& border_radii)
+{
+    return resolve_layers(layers, paintable_box, background_color, background_color_clip, border_rect, border_radii,
+        LayerType::Background);
+}
+
+ResolvedBackground resolve_mask_layers(Vector<CSS::BackgroundLayerData> const& layers, Paintable const& paintable_box,
+    CSSPixelRect const& border_rect)
+{
+    return resolve_layers(layers, paintable_box, Color::Transparent, CSS::BackgroundBox::BorderBox, border_rect, {},
+        LayerType::Mask);
 }
 
 }

--- a/Libraries/LibWeb/Painting/BackgroundPainting.h
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/CompositingAndBlendingOperator.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/BorderPainting.h>
@@ -14,7 +15,7 @@
 namespace Web::Painting {
 
 struct ResolvedBackgroundLayerData {
-    NonnullRefPtr<CSS::AbstractImageStyleValue const> background_image;
+    RefPtr<CSS::AbstractImageStyleValue const> background_image;
     CSS::BackgroundAttachment attachment;
     CSS::BackgroundBox clip;
     CSSPixels position_x;
@@ -24,6 +25,7 @@ struct ResolvedBackgroundLayerData {
     CSS::Repetition repeat_x;
     CSS::Repetition repeat_y;
     CSS::MixBlendMode blend_mode;
+    Optional<Gfx::CompositingAndBlendingOperator> mask_composite;
 };
 
 struct BackgroundBox {
@@ -46,6 +48,7 @@ struct ResolvedBackground {
 };
 
 WEB_API ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> const& layers, Paintable const& paintable_box, Color background_color, CSS::BackgroundBox background_color_clip, CSSPixelRect const& border_rect, BorderRadiiData const& border_radii);
+ResolvedBackground resolve_mask_layers(Vector<CSS::BackgroundLayerData> const&, Paintable const&, CSSPixelRect const&);
 
 WEB_API void paint_background(DisplayListRecordingContext&, Paintable const&, CSS::ImageRendering, ResolvedBackground const&, BorderRadiiData const&);
 

--- a/Libraries/LibWeb/Painting/Blending.cpp
+++ b/Libraries/LibWeb/Painting/Blending.cpp
@@ -24,4 +24,21 @@ Gfx::CompositingAndBlendingOperator mix_blend_mode_to_compositing_and_blending_o
     }
 }
 
+// https://drafts.fxtf.org/css-masking-1/#the-mask-composite
+Gfx::CompositingAndBlendingOperator mask_composite_to_compositing_and_blending_operator(
+    CSS::CompositingOperator compositing_operator)
+{
+    switch (compositing_operator) {
+    case CSS::CompositingOperator::Add:
+        return Gfx::CompositingAndBlendingOperator::Normal;
+    case CSS::CompositingOperator::Subtract:
+        return Gfx::CompositingAndBlendingOperator::SourceOut;
+    case CSS::CompositingOperator::Intersect:
+        return Gfx::CompositingAndBlendingOperator::SourceIn;
+    case CSS::CompositingOperator::Exclude:
+        return Gfx::CompositingAndBlendingOperator::Xor;
+    }
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Libraries/LibWeb/Painting/Blending.h
+++ b/Libraries/LibWeb/Painting/Blending.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibGfx/CompositingAndBlendingOperator.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::Painting {
@@ -32,5 +33,6 @@ namespace Web::Painting {
     E(PlusLighter)
 
 Gfx::CompositingAndBlendingOperator mix_blend_mode_to_compositing_and_blending_operator(CSS::MixBlendMode blend_mode);
+Gfx::CompositingAndBlendingOperator mask_composite_to_compositing_and_blending_operator(CSS::CompositingOperator);
 
 }

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -509,7 +509,7 @@ void StackingContext::paint(DisplayListRecordingContext& context) const
             DisplayListRecorder display_list_recorder(*mask_display_list, visual_context_tree, context.display_list_recorder().resource_storage());
             auto mask_painting_context = context.clone(display_list_recorder);
             auto mask_rect = CSSPixelRect { {}, mask_layer.area.size() };
-            auto resolved_mask = resolve_background_layers(mask_layers, paintable_box(), Color::Transparent, CSS::BackgroundBox::BorderBox, mask_rect, {});
+            auto resolved_mask = resolve_mask_layers(mask_layers, paintable_box(), mask_rect);
 
             // FIXME: Respect `image-rendering` here.
             paint_background(mask_painting_context, paintable_box(), CSS::ImageRendering::Auto, resolved_mask, {});

--- a/Tests/LibWeb/Ref/expected/css/css-masking/mask-composite-transparent-layer-ref.html
+++ b/Tests/LibWeb/Ref/expected/css/css-masking/mask-composite-transparent-layer-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: repeat(4, 40px);
+}
+.test {
+    width: 40px;
+    height: 40px;
+}
+.visible {
+    background: green;
+}
+</style>
+<div class="grid">
+    <div class="test visible"></div>
+    <div class="test visible"></div>
+    <div class="test"></div>
+    <div class="test visible"></div>
+</div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-masking/mask-image/mask-composite-1-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-masking/mask-image/mask-composite-1-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS mask-composite reference</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <style type="text/css">
+      div {
+        position: absolute;
+        margin: 0px;
+        padding: 0px;
+        width: 100px;
+        height: 100px;
+        top: 10px;
+      }
+
+      div.add {
+        left: 10px;
+        background-image: url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+
+      div.intersect {
+        left: 230px;
+        background-image: url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="add"></div>
+    <div class="intersect"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-masking/mask-image/mask-composite-2-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-masking/mask-image/mask-composite-2-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS mask-composite reference</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <style type="text/css">
+      div {
+        position: absolute;
+        margin: 0px;
+        padding: 0px;
+        width: 100px;
+        height: 100px;
+        top: 10px;
+      }
+
+      div.add {
+        left: 10px;
+        background-color: blue;
+      }
+
+      div.subtract {
+        left: 120px;
+        background-image: url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+
+      div.exclude {
+        left: 340px;
+        background-color: blue;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="add"></div>
+    <div class="subtract"></div>
+    <div class="exclude"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-masking/mask-image/mask-image-clip-exclude-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-masking/mask-image/mask-image-clip-exclude-ref.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>CSS test reference</title>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+    border: 10px solid green;
+  }
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/images/blue-100x50-transparent-100x50.svg
+++ b/Tests/LibWeb/Ref/expected/wpt-import/images/blue-100x50-transparent-100x50.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <rect x="0" y="0"  width="100%" height="50%" fill="blue" fill-opacity="0"/>
+  <rect x="0" y="50%" width="100%" height="50%" fill="blue" fill-opacity="1"/>
+</svg>

--- a/Tests/LibWeb/Ref/input/css/css-masking/mask-composite-transparent-layer.html
+++ b/Tests/LibWeb/Ref/input/css/css-masking/mask-composite-transparent-layer.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<link rel="match" href="../../../expected/css/css-masking/mask-composite-transparent-layer-ref.html">
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: repeat(4, 40px);
+}
+.test {
+    width: 40px;
+    height: 40px;
+    background: green;
+    mask-image: linear-gradient(black, black), linear-gradient(black, black);
+    mask-repeat: no-repeat;
+    mask-size: auto, 0 0;
+}
+.add {
+    mask-composite: add;
+}
+.subtract {
+    mask-composite: subtract;
+}
+.intersect {
+    mask-composite: intersect;
+}
+.exclude {
+    mask-composite: exclude;
+}
+</style>
+<div class="grid">
+    <div class="test add"></div>
+    <div class="test subtract"></div>
+    <div class="test intersect"></div>
+    <div class="test exclude"></div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-composite-1a.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-composite-1a.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Masking: mask-composite: compose vector image</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-composite">
+    <link rel="match" href="../../../../../expected/wpt-import/css/css-masking/mask-image/mask-composite-1-ref.html">
+    <meta name="assert" content="Test checks that vector-mask-image can be composed correctly by different mask-composite value.">
+    <style type="text/css">
+      div {
+        background-color: blue;
+        position: absolute;
+        margin: 0px;
+        padding: 0px;
+        width: 100px;
+        height: 100px;
+        top:10px;
+        mask-image: url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+
+      div.add {
+        left: 10px;
+        mask-composite: add;
+      }
+
+      div.subtract {
+        left: 120px;
+        mask-composite: subtract;
+      }
+
+      div.intersect {
+        left: 230px;
+        mask-composite: intersect;
+      }
+
+      div.exclude {
+        left: 340px;
+        mask-composite: exclude;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="add"></div>
+    <div class="subtract"></div>
+    <div class="intersect"></div>
+    <div class="exclude"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-composite-1d.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-composite-1d.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Masking: mask-composite: compose vector image</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-composite">
+    <link rel="match" href="../../../../../expected/wpt-import/css/css-masking/mask-image/mask-composite-1-ref.html">
+    <meta name="assert" content="Test checks that whether mask-composite is filled automatically according to the number of mask layers.">
+    <style type="text/css">
+      div {
+        background-color: blue;
+        position: absolute;
+        margin: 0px;
+        padding: 0px;
+        width: 100px;
+        height: 100px;
+        top: 10px;
+      }
+
+      div.add {
+        left: 10px;
+        mask-composite: add;
+        mask-image: url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+
+      div.intersect {
+        left: 120px;
+        mask-composite: intersect;
+        mask-image: url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/transparent-100x50-blue-100x50.svg),
+                    linear-gradient(rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 100%);
+      }
+
+      div.subtract {
+        left: 230px;
+        mask-composite: subtract;
+        mask-image: url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+
+      div.exclude {
+        left: 340px;
+        mask-composite: exclude;
+        mask-image: url(../../../images/transparent-100x50-blue-100x50.svg),
+                    linear-gradient(rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 100%),
+                    url(../../../images/blue-100x50-transparent-100x50.svg);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="add"></div>
+    <div class="intersect"></div>
+    <div class="subtract"></div>
+    <div class="exclude"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-composite-2a.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-composite-2a.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Masking: mask-composite: compose vector image</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-composite">
+    <link rel="match" href="../../../../../expected/wpt-import/css/css-masking/mask-image/mask-composite-2-ref.html">
+    <meta name="assert" content="Test checks that vector-mask-image can be composed correctly by different mask-composite value.">
+    <style type="text/css">
+      div {
+        background-color: blue;
+        position: absolute;
+        margin: 0px;
+        padding: 0px;
+        width: 100px;
+        height: 100px;
+        top:10px;
+        mask-image: url(../../../images/blue-100x50-transparent-100x50.svg),
+                    url(../../../images/transparent-100x50-blue-100x50.svg);
+      }
+
+      div.add {
+        left: 10px;
+        mask-composite: add;
+      }
+
+      div.subtract {
+        left: 120px;
+        mask-composite: subtract;
+      }
+
+      div.intersect {
+        left: 230px;
+        mask-composite: intersect;
+      }
+
+      div.exclude {
+        left: 340px;
+        mask-composite: exclude;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="add"></div>
+    <div class="subtract"></div>
+    <div class="intersect"></div>
+    <div class="exclude"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-image-4a.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-image-4a.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Masking: mask-image: unresovlable mask url</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://www.w3.org/TR/css-masking-1/#the-mask-image">
+    <link rel="match" href="../../../../../expected/wpt-import//css/reference/blank.html">
+    <meta name="assert" content="Test checks non-existent url should be counted as an image layer of transparent black.">
+    <style type="text/css">
+      div {
+        background-color: purple;
+        width: 100px;
+        height: 100px;
+      }
+
+      div.mask-by-png {
+        mask-image: url(non-existent.png);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="mask-by-png"></div>
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-image-clip-exclude.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-masking/mask-image/mask-image-clip-exclude.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1697311">
+<link rel="author" href="" title="Ana Tudor">
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<link rel="match" href="../../../../../expected/wpt-import/css/css-masking/mask-image/mask-image-clip-exclude-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2000">
+<title>mask-image + mask-clip + mask-composite: exclude on different background boxes</title>
+<style>
+div {
+  display: inline-block;
+  width: 100px;
+  height: 100px;
+  padding: 10px;
+  background: linear-gradient(green, green) border-box;
+  mask: linear-gradient(red, red) content-box exclude, linear-gradient(red, red);
+}
+</style>
+<div></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/images/blue-100x50-transparent-100x50.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/images/blue-100x50-transparent-100x50.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <rect x="0" y="0"  width="100%" height="50%" fill="blue" fill-opacity="0"/>
+  <rect x="0" y="50%" width="100%" height="50%" fill="blue" fill-opacity="1"/>
+</svg>

--- a/Tests/LibWeb/Ref/input/wpt-import/images/transparent-100x50-blue-100x50.svg
+++ b/Tests/LibWeb/Ref/input/wpt-import/images/transparent-100x50-blue-100x50.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <rect x="0" y="0"  width="100%" height="50%" fill="blue" fill-opacity="1"/>
+  <rect x="0" y="50%" width="100%" height="50%" fill="blue" fill-opacity="0"/>
+</svg>


### PR DESCRIPTION
Fixes the mouse-following radial gradient's intensity on https://www.zeroramp.com:

| Before | After |
|--|--|
| <img width="984" height="914" alt="Screenshot 2026-08-10 at 13 58 50" src="https://github.com/user-attachments/assets/07549ad8-f3bf-45e9-9ad7-2217edf3f2a1" /> | <img width="993" height="917" alt="Screenshot 2026-08-10 at 13 58 00" src="https://github.com/user-attachments/assets/4ed1506f-037a-46ec-89ee-e67d3f27d357" /> |
