### PR TITLE
Replace the global UsedValues store with per run fragment trees

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -66,25 +66,115 @@ fn out_of_flow_root_space(inputs: AbsposLayoutInputs) -> (AvailableSpace, Contai
 
 pub(crate) struct AbsposEngine<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     callbacks: FfiLayoutFcCallbacks,
     fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
 }
 
 impl<'pass> AbsposEngine<'pass> {
-    pub(crate) fn new(
-        state: &'pass LayoutState,
-        callbacks: FfiLayoutFcCallbacks,
-        fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
-    ) -> Self {
+    pub(crate) fn for_run(run: &crate::layout::FormattingContextRun<'pass>) -> Self {
         Self {
-            state,
-            callbacks,
-            fragments,
+            state: run.state,
+            records: run.records.clone(),
+            callbacks: run.callbacks,
+            fragments: run.fragments.clone(),
         }
     }
 
-    fn sizing(&self) -> SizingContext<'_> {
-        SizingContext::new(self.state, self.callbacks)
+    fn containing_block_geometry_for_pending_child(&self, entry: &PendingAbsposChild) -> ContainingBlockGeometry {
+        let containing_block = self.callbacks.containing_block(entry.child_box);
+        let Some(containing_block_used) = self.records.used_values_if_owned(containing_block) else {
+            panic!(
+                "no owned record for the containing block of slot {} (cb slot {})",
+                entry.child_box.slot_index(),
+                containing_block.slot_index()
+            );
+        };
+        let content_origin_in_entry_space =
+            self.origin_of_containing_block_in_entry_space(containing_block, entry.coordinate_space_box);
+        ContainingBlockGeometry::from_used_values(&containing_block_used, content_origin_in_entry_space)
+    }
+
+    fn origin_of_containing_block_in_entry_space(&self, containing_block: Node, entry_space: Node) -> FfiCssPixelPoint {
+        if entry_space == containing_block {
+            return FfiCssPixelPoint::default();
+        }
+        let mut origins_by_chain_box = Vec::new();
+        let mut chain_box = containing_block;
+        let mut origin = FfiCssPixelPoint::default();
+        loop {
+            origins_by_chain_box.push((chain_box, origin));
+            let Some(used) = self
+                .records
+                .used_values_if_owned(chain_box)
+                .filter(|used| used.has_content_offset.get())
+            else {
+                break;
+            };
+            origin = point_add(origin, used.content_offset.get());
+            chain_box = self.callbacks.containing_block(chain_box);
+            if chain_box.is_invalid() {
+                break;
+            }
+        }
+        let mut space_box = entry_space;
+        let mut space_origin = FfiCssPixelPoint::default();
+        loop {
+            if let Some((_, origin)) = origins_by_chain_box.iter().find(|(chain_box, _)| *chain_box == space_box) {
+                return point_sub(*origin, space_origin);
+            }
+            let used = self
+                .records
+                .used_values_if_owned(space_box)
+                .filter(|used| used.has_content_offset.get())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "an entry's space chain crossed an unplaced or foreign record before meeting its containing block's chain (slot {})",
+                        space_box.slot_index()
+                    )
+                });
+            space_origin = point_add(space_origin, used.content_offset.get());
+            space_box = self.callbacks.containing_block(space_box);
+            assert!(
+                !space_box.is_invalid(),
+                "an entry's space chain ended before meeting its containing block's chain"
+            );
+        }
+    }
+
+    fn translation_between_payload_resting_spaces(&self, from_space: Node, to_space: Node) -> FfiCssPixelPoint {
+        if from_space == to_space || from_space.is_invalid() || to_space.is_invalid() {
+            return FfiCssPixelPoint::default();
+        }
+        let mut merge_point = from_space;
+        while merge_point != to_space && !self.callbacks.is_ancestor(merge_point, to_space) {
+            merge_point = self.callbacks.containing_block(merge_point);
+            assert!(!merge_point.is_invalid());
+        }
+        let offset_relative_to_merge_point = |descendant: Node| {
+            let mut offset = FfiCssPixelPoint::default();
+            let mut current = descendant;
+            while current != merge_point {
+                let used = self.records.used_values_if_owned(current).unwrap_or_else(|| {
+                    panic!(
+                        "a payload resting space's chain crossed a record this run does not own (slot {})",
+                        current.slot_index()
+                    )
+                });
+                offset = point_add(offset, used.content_offset.get());
+                current = self.callbacks.containing_block(current);
+                assert!(!current.is_invalid());
+            }
+            offset
+        };
+        point_sub(
+            offset_relative_to_merge_point(from_space),
+            offset_relative_to_merge_point(to_space),
+        )
+    }
+
+    fn sizing(&self) -> SizingContext<'pass> {
+        SizingContext::new(self.state, self.records.clone(), self.callbacks)
     }
 
     fn style(&self, node: Node) -> StyleValues<'pass> {
@@ -95,55 +185,9 @@ impl<'pass> AbsposEngine<'pass> {
         self.state.node_facts(&self.callbacks, node)
     }
 
-    fn used(&self, node: Node) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, node)
-    }
-
-    fn node_is_ancestor(&self, ancestor: Node, node: Node) -> bool {
-        self.callbacks.is_ancestor(ancestor, node)
-    }
-
-    fn containing_block_geometry_for_pending_child(&self, entry: &PendingAbsposChild) -> ContainingBlockGeometry {
-        let containing_block = self.callbacks.containing_block(entry.child_box);
-        assert!(!containing_block.is_invalid());
-        let translation_into_containing_block_space =
-            self.chain_translation_delta_to(containing_block, entry.coordinate_space_box);
-        ContainingBlockGeometry::from_used_values(
-            self.used(containing_block),
-            point_sub(FfiCssPixelPoint::default(), translation_into_containing_block_space),
-        )
-    }
-
-    fn chain_translation_delta_to(
-        &self,
-        actual_containing_block: Node,
-        coordinate_space_box: Node,
-    ) -> FfiCssPixelPoint {
-        if coordinate_space_box.is_invalid() || coordinate_space_box == actual_containing_block {
-            return FfiCssPixelPoint::default();
-        }
-
-        let mut merge_point = coordinate_space_box;
-        while merge_point != actual_containing_block && !self.node_is_ancestor(merge_point, actual_containing_block) {
-            merge_point = self.callbacks.containing_block(merge_point);
-            assert!(!merge_point.is_invalid());
-        }
-
-        let offset_relative_to_merge_point = |descendant: Node| {
-            let mut offset = FfiCssPixelPoint::default();
-            let mut current = descendant;
-            while current != merge_point {
-                let used = self.used(current);
-                offset = point_add(offset, used.content_offset.get());
-                current = self.callbacks.containing_block(current);
-                assert!(!current.is_invalid());
-            }
-            offset
-        };
-        point_sub(
-            offset_relative_to_merge_point(coordinate_space_box),
-            offset_relative_to_merge_point(actual_containing_block),
-        )
+    #[track_caller]
+    fn used(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(node)
     }
 
     fn base_containing_block_info(
@@ -196,7 +240,6 @@ impl<'pass> AbsposEngine<'pass> {
     }
 
 }
-
 
 fn calc_node_create_px_dimension(value: f64) -> *const c_void {
     crate::css::calc::rust_calc_node_create_numeric_dimension(
@@ -303,31 +346,6 @@ impl AbsposEngine<'_> {
             ancestor = self.callbacks.containing_block(ancestor);
         }
         NodeSlotId::INVALID
-    }
-
-    fn translation_between_payload_resting_spaces(&self, from_space: Node, to_space: Node) -> FfiCssPixelPoint {
-        if from_space == to_space || from_space.is_invalid() || to_space.is_invalid() {
-            return FfiCssPixelPoint::default();
-        }
-        let mut merge_point = from_space;
-        while merge_point != to_space && !self.callbacks.is_ancestor(merge_point, to_space) {
-            merge_point = self.callbacks.containing_block(merge_point);
-            assert!(!merge_point.is_invalid());
-        }
-        let offset_relative_to_merge_point = |descendant: Node| {
-            let mut offset = FfiCssPixelPoint::default();
-            let mut current = descendant;
-            while current != merge_point {
-                offset = point_add(offset, self.used(current).content_offset.get());
-                current = self.callbacks.containing_block(current);
-                assert!(!current.is_invalid());
-            }
-            offset
-        };
-        point_sub(
-            offset_relative_to_merge_point(from_space),
-            offset_relative_to_merge_point(to_space),
-        )
     }
 
     fn anchor_rect(
@@ -528,7 +546,12 @@ impl AbsposEngine<'_> {
         if containing_block.is_invalid() {
             return;
         }
-        let containing_block_state = self.used(containing_block);
+        let containing_block_geometry = match entry_containing_block_geometry {
+            Some(geometry) => *geometry,
+            None => {
+                ContainingBlockGeometry::from_used_values(&self.used(containing_block), FfiCssPixelPoint::default())
+            }
+        };
         let default_anchor_box = if style.has_position_anchor() {
             self.anchor_lookup(node, style.position_anchor_name())
                 .unwrap_or(NodeSlotId::INVALID)
@@ -552,9 +575,7 @@ impl AbsposEngine<'_> {
                 AnchorValueAxis {
                     is_from_end: false,
                     is_horizontal: false,
-                    containing_block_extent: containing_block_state.content_block_size.get()
-                        + containing_block_state.padding_top.get()
-                        + containing_block_state.padding_bottom.get(),
+                    containing_block_extent: containing_block_geometry.padding_box_block_size(),
                 },
                 &mut resolution_state,
             );
@@ -572,9 +593,7 @@ impl AbsposEngine<'_> {
                 AnchorValueAxis {
                     is_from_end: true,
                     is_horizontal: true,
-                    containing_block_extent: containing_block_state.content_inline_size.get()
-                        + containing_block_state.padding_left.get()
-                        + containing_block_state.padding_right.get(),
+                    containing_block_extent: containing_block_geometry.padding_box_inline_size(),
                 },
                 &mut resolution_state,
             );
@@ -592,9 +611,7 @@ impl AbsposEngine<'_> {
                 AnchorValueAxis {
                     is_from_end: true,
                     is_horizontal: false,
-                    containing_block_extent: containing_block_state.content_block_size.get()
-                        + containing_block_state.padding_top.get()
-                        + containing_block_state.padding_bottom.get(),
+                    containing_block_extent: containing_block_geometry.padding_box_block_size(),
                 },
                 &mut resolution_state,
             );
@@ -612,9 +629,7 @@ impl AbsposEngine<'_> {
                 AnchorValueAxis {
                     is_from_end: false,
                     is_horizontal: true,
-                    containing_block_extent: containing_block_state.content_inline_size.get()
-                        + containing_block_state.padding_left.get()
-                        + containing_block_state.padding_right.get(),
+                    containing_block_extent: containing_block_geometry.padding_box_inline_size(),
                 },
                 &mut resolution_state,
             );
@@ -1629,8 +1644,8 @@ impl<'pass> AbsposEngine<'pass> {
         used_offset.block_offset += used.margin_top.get() + used.border_box_top(collapsed);
         let is_measurement = self.state.is_measurement();
         if !is_measurement {
-            self.state
-                .used_values_rare_data_for_node_mut(&self.callbacks, node)
+            self.used(node)
+                .rare_data_mut()
                 .abspos_layout_inputs = Some(inputs);
         }
         crate::layout::place_child(
@@ -1647,8 +1662,8 @@ impl<'pass> AbsposEngine<'pass> {
     pub(crate) fn layout_pending_child(&self, run: &crate::layout::FormattingContextRun<'pass>, mut child: PendingAbsposChild) {
         debug_assert!(!self.state.is_measurement());
         let child_box = child.child_box;
-        self.state
-            .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
+        self.records
+            .create_used_values(self.state, &self.callbacks, child_box, ContainingBlockConstraints::default());
         let containing_block_geometry = self.containing_block_geometry_for_pending_child(&child);
         self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
         let translation_into_containing_block_space =
@@ -1656,12 +1671,10 @@ impl<'pass> AbsposEngine<'pass> {
         crate::layout::translate_pending_abspos_payloads(&mut child, translation_into_containing_block_space);
         let inputs = AbsposLayoutInputs {
             static_position_rect: child.static_position_rect,
-            containing_block_info: child
-                .containing_block_info_override
-                .unwrap_or_else(|| {
-                    let inline_containing_block_rect = child.inline_containing_block_rect;
-                    self.base_containing_block_info(child_box, inline_containing_block_rect, &containing_block_geometry)
-                }),
+            containing_block_info: child.containing_block_info_override.unwrap_or_else(|| {
+                let inline_containing_block_rect = child.inline_containing_block_rect;
+                self.base_containing_block_info(child_box, inline_containing_block_rect, &containing_block_geometry)
+            }),
         };
         self.layout_element(run, child_box, inputs);
     }
@@ -1678,8 +1691,8 @@ impl<'pass> AbsposEngine<'pass> {
         }
         // Partial relayout uses a fresh state and creates the replay root
         // exactly once.
-        self.state
-            .create_used_values(&self.callbacks, node, ContainingBlockConstraints::default());
+        self.records
+            .create_used_values(self.state, &self.callbacks, node, ContainingBlockConstraints::default());
         self.layout_element(run, node, inputs);
     }
 
@@ -1733,6 +1746,7 @@ impl<'pass> AbsposEngine<'pass> {
             || style.inset_bottom().contains_percentage())
             && !crate::layout::resolve_block_axis_percentage_inset_basis_is_definite(
                 self.state,
+                &self.records,
                 &self.callbacks,
                 self.callbacks.containing_block(node),
                 formatting_context_root,
@@ -1760,6 +1774,7 @@ impl<'pass> AbsposEngine<'pass> {
 
 pub(crate) fn drain_abspos_with_placed_containing_blocks(
     state: &LayoutState,
+    records: &std::rc::Rc<RunRecords>,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
     entry_fragments: &std::rc::Rc<crate::layout::RunFragmentBuilder>,
@@ -1767,6 +1782,7 @@ pub(crate) fn drain_abspos_with_placed_containing_blocks(
     let accumulator_root = entry_fragments.root_node();
     let run = crate::layout::FormattingContextRun {
         state,
+        records: records.clone(),
         box_: accumulator_root,
         layout_mode: LayoutMode::Normal,
         callbacks,
@@ -1775,35 +1791,30 @@ pub(crate) fn drain_abspos_with_placed_containing_blocks(
         fragments: Some(entry_fragments.clone()),
     };
     loop {
-        let batch = entry_fragments.take_drainable_abspos(accumulator_root, &callbacks);
+        let batch = entry_fragments.take_drainable_abspos(accumulator_root, records, &callbacks);
         if batch.is_empty() {
             break;
         }
-        let engine = AbsposEngine::new(state, callbacks, Some(entry_fragments.clone()));
+        let engine = AbsposEngine::for_run(&run);
         for entry in batch {
             engine.layout_pending_child(&run, entry);
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_inset_native(
-    state: &LayoutState,
-    callbacks: FfiLayoutFcCallbacks,
-    fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
+    run: &crate::layout::FormattingContextRun<'_>,
     node: Node,
     inline_size: CssPixels,
     block_size: CssPixels,
-    formatting_context_root: Node,
-    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 ) {
-    AbsposEngine::new(state, callbacks, fragments).compute_inset(
+    AbsposEngine::for_run(run).compute_inset(
         node,
         LogicalSize {
             inline_size,
             block_size,
         },
-        formatting_context_root,
-        treat_block_axis_percentage_insets_as_auto_beyond_root,
+        run.box_,
+        run.treat_block_axis_percentage_insets_as_auto_beyond_root,
     );
 }

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -67,11 +67,20 @@ fn out_of_flow_root_space(inputs: AbsposLayoutInputs) -> (AvailableSpace, Contai
 pub(crate) struct AbsposEngine<'pass> {
     state: &'pass LayoutState,
     callbacks: FfiLayoutFcCallbacks,
+    fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
 }
 
 impl<'pass> AbsposEngine<'pass> {
-    pub(crate) fn new(state: &'pass LayoutState, callbacks: FfiLayoutFcCallbacks) -> Self {
-        Self { state, callbacks }
+    pub(crate) fn new(
+        state: &'pass LayoutState,
+        callbacks: FfiLayoutFcCallbacks,
+        fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
+    ) -> Self {
+        Self {
+            state,
+            callbacks,
+            fragments,
+        }
     }
 
     fn sizing(&self) -> SizingContext<'_> {
@@ -257,6 +266,8 @@ struct AnchorCalcCallbackContext<'pass> {
     engine: *const AbsposEngine<'pass>,
     positioned_box: Node,
     containing_block: Node,
+    containing_block_geometry: Option<ContainingBlockGeometry>,
+    entry_coordinate_space_box: Node,
     is_from_end: bool,
     is_horizontal_axis: bool,
     containing_block_extent: CssPixels,
@@ -265,11 +276,12 @@ struct AnchorCalcCallbackContext<'pass> {
 
 impl AbsposEngine<'_> {
     fn anchor_lookup(&self, positioned_box: Node, anchor_name: usize) -> Option<Node> {
-        let eligible_anchor_shells = self.state.anchor_candidate_shells();
+        let eligible_anchor_shells = self
+            .fragments
+            .as_deref()
+            .map(|fragments| fragments.anchor_candidate_shells(&self.callbacks))
+            .unwrap_or_default();
         // SAFETY: The name handle is retained by either the style snapshot or
-        // the live anchor() shell. The registry borrow is held only for this
-        // synchronous lookup, and the callback never re-enters layout code
-        // that could register another candidate.
         let anchor_box = unsafe {
             (self.callbacks.anchor_lookup)(
                 self.callbacks.context,
@@ -293,16 +305,66 @@ impl AbsposEngine<'_> {
         NodeSlotId::INVALID
     }
 
-    fn anchor_rect(&self, anchor_box: Node, containing_block: Node) -> PhysicalRect {
-        let anchor_state = self.used(anchor_box);
-        let mut anchor_offset = FfiCssPixelPoint::default();
-        let mut node = anchor_box;
-        while node != containing_block {
-            assert!(!node.is_invalid());
-            anchor_offset = point_add(anchor_offset, self.used(node).content_offset.get());
-            node = self.callbacks.containing_block(node);
+    fn translation_between_payload_resting_spaces(&self, from_space: Node, to_space: Node) -> FfiCssPixelPoint {
+        if from_space == to_space || from_space.is_invalid() || to_space.is_invalid() {
+            return FfiCssPixelPoint::default();
         }
-        anchor_rect_from_geometry(anchor_state, self.used(containing_block), anchor_offset)
+        let mut merge_point = from_space;
+        while merge_point != to_space && !self.callbacks.is_ancestor(merge_point, to_space) {
+            merge_point = self.callbacks.containing_block(merge_point);
+            assert!(!merge_point.is_invalid());
+        }
+        let offset_relative_to_merge_point = |descendant: Node| {
+            let mut offset = FfiCssPixelPoint::default();
+            let mut current = descendant;
+            while current != merge_point {
+                offset = point_add(offset, self.used(current).content_offset.get());
+                current = self.callbacks.containing_block(current);
+                assert!(!current.is_invalid());
+            }
+            offset
+        };
+        point_sub(
+            offset_relative_to_merge_point(from_space),
+            offset_relative_to_merge_point(to_space),
+        )
+    }
+
+    fn anchor_rect(
+        &self,
+        anchor_box: Node,
+        containing_block: Node,
+        entry_containing_block_geometry: Option<&ContainingBlockGeometry>,
+        entry_coordinate_space_box: Node,
+    ) -> PhysicalRect {
+        let (rect, coordinate_space_box) = self
+            .fragments
+            .as_deref()
+            .and_then(|fragments| fragments.find_anchor_candidate(anchor_box))
+            .expect("an accepted anchor is placed in the draining subtree and propagated here");
+        match entry_containing_block_geometry {
+            Some(geometry) => {
+                let fold_into_entry_space =
+                    self.translation_between_payload_resting_spaces(coordinate_space_box, entry_coordinate_space_box);
+                PhysicalRect {
+                    x: rect.x + fold_into_entry_space.x - geometry.content_origin_in_entry_space.x
+                        + geometry.padding_left,
+                    y: rect.y + fold_into_entry_space.y - geometry.content_origin_in_entry_space.y
+                        + geometry.padding_top,
+                    width: rect.width,
+                    height: rect.height,
+                }
+            }
+            None => {
+                let containing_block_used = self.used(containing_block);
+                PhysicalRect {
+                    x: rect.x + containing_block_used.padding_left.get(),
+                    y: rect.y + containing_block_used.padding_top.get(),
+                    width: rect.width,
+                    height: rect.height,
+                }
+            }
+        }
     }
 
     fn anchor_side(
@@ -398,11 +460,14 @@ impl AbsposEngine<'_> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn resolve_anchor_value(
         &self,
         value: InsetValue,
         positioned_box: Node,
         containing_block: Node,
+        containing_block_geometry: Option<ContainingBlockGeometry>,
+        entry_coordinate_space_box: Node,
         axis: AnchorValueAxis,
         resolution_state: &mut AnchorResolutionState,
     ) -> Option<CssPixels> {
@@ -412,6 +477,8 @@ impl AbsposEngine<'_> {
             engine: self,
             positioned_box,
             containing_block,
+            containing_block_geometry,
+            entry_coordinate_space_box,
             is_from_end: axis.is_from_end,
             is_horizontal_axis: axis.is_horizontal,
             containing_block_extent: axis.containing_block_extent,
@@ -430,7 +497,12 @@ impl AbsposEngine<'_> {
         result.resolved.then(|| CssPixels::nearest_value_for(result.value))
     }
 
-    fn resolve_anchor_insets(&self, node: Node) {
+    fn resolve_anchor_insets(
+        &self,
+        node: Node,
+        entry_containing_block_geometry: Option<&ContainingBlockGeometry>,
+        entry_coordinate_space_box: Node,
+    ) {
         // Clear a stale default scroll shift before any early return.
         // SAFETY: The node is live and a null anchor clears the weak target.
         unsafe {
@@ -475,6 +547,8 @@ impl AbsposEngine<'_> {
                 style.inset_top(),
                 node,
                 containing_block,
+                entry_containing_block_geometry.copied(),
+                entry_coordinate_space_box,
                 AnchorValueAxis {
                     is_from_end: false,
                     is_horizontal: false,
@@ -493,6 +567,8 @@ impl AbsposEngine<'_> {
                 style.inset_right(),
                 node,
                 containing_block,
+                entry_containing_block_geometry.copied(),
+                entry_coordinate_space_box,
                 AnchorValueAxis {
                     is_from_end: true,
                     is_horizontal: true,
@@ -511,6 +587,8 @@ impl AbsposEngine<'_> {
                 style.inset_bottom(),
                 node,
                 containing_block,
+                entry_containing_block_geometry.copied(),
+                entry_coordinate_space_box,
                 AnchorValueAxis {
                     is_from_end: true,
                     is_horizontal: false,
@@ -529,6 +607,8 @@ impl AbsposEngine<'_> {
                 style.inset_left(),
                 node,
                 containing_block,
+                entry_containing_block_geometry.copied(),
+                entry_coordinate_space_box,
                 AnchorValueAxis {
                     is_from_end: false,
                     is_horizontal: true,
@@ -592,7 +672,12 @@ unsafe extern "C" fn resolve_anchor_non_math_function(context: *mut c_void, shel
         && let Some(anchor_name) = anchor_name
         && let Some(anchor_box) = engine.anchor_lookup(context.positioned_box, anchor_name)
     {
-        let rect = engine.anchor_rect(anchor_box, context.containing_block);
+        let rect = engine.anchor_rect(
+            anchor_box,
+            context.containing_block,
+            context.containing_block_geometry.as_ref(),
+            context.entry_coordinate_space_box,
+        );
         if let Some(side) = engine.anchor_side(
             anchor_side_from_style_value(anchor_side.data()),
             rect,
@@ -1566,7 +1651,7 @@ impl<'pass> AbsposEngine<'pass> {
         self.state
             .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
         let containing_block_geometry = self.containing_block_geometry_for_pending_child(&child);
-        self.resolve_anchor_insets(child_box);
+        self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
         let translation_into_containing_block_space =
             point_sub(FfiCssPixelPoint::default(), containing_block_geometry.content_origin_in_entry_space);
         crate::layout::translate_pending_abspos_payloads(&mut child, translation_into_containing_block_space);
@@ -1621,7 +1706,7 @@ impl<'pass> AbsposEngine<'pass> {
             || initial_style.inset_bottom().contains_anchor_function()
             || initial_style.inset_left().contains_anchor_function()
         {
-            self.resolve_anchor_insets(node);
+            self.resolve_anchor_insets(node, None, NodeSlotId::INVALID);
         }
         let style = self.style(node);
         if style.position() != positioning::RELATIVE {
@@ -1695,23 +1780,25 @@ pub(crate) fn drain_abspos_with_placed_containing_blocks(
         if batch.is_empty() {
             break;
         }
-        let engine = AbsposEngine::new(state, callbacks);
+        let engine = AbsposEngine::new(state, callbacks, Some(entry_fragments.clone()));
         for entry in batch {
             engine.layout_pending_child(&run, entry);
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_inset_native(
     state: &LayoutState,
     callbacks: FfiLayoutFcCallbacks,
+    fragments: Option<std::rc::Rc<crate::layout::RunFragmentBuilder>>,
     node: Node,
     inline_size: CssPixels,
     block_size: CssPixels,
     formatting_context_root: Node,
     treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 ) {
-    AbsposEngine::new(state, callbacks).compute_inset(
+    AbsposEngine::new(state, callbacks, fragments).compute_inset(
         node,
         LogicalSize {
             inline_size,

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1627,6 +1627,12 @@ impl<'pass> AbsposEngine<'pass> {
         };
         used_offset.inline_offset += used.margin_left.get() + used.border_box_left(collapsed);
         used_offset.block_offset += used.margin_top.get() + used.border_box_top(collapsed);
+        let is_measurement = self.state.is_measurement();
+        if !is_measurement {
+            self.state
+                .used_values_rare_data_for_node_mut(&self.callbacks, node)
+                .abspos_layout_inputs = Some(inputs);
+        }
         crate::layout::place_child(
             run,
             node,
@@ -1634,15 +1640,8 @@ impl<'pass> AbsposEngine<'pass> {
                 x: used_offset.inline_offset,
                 y: used_offset.block_offset,
             },
+            None,
         );
-
-        let is_measurement = self.state.is_measurement();
-        if !is_measurement {
-            self.state
-                .used_values_rare_data_for_node_mut(&self.callbacks, node)
-                .abspos_layout_inputs = Some(inputs);
-        }
-
     }
 
     pub(crate) fn layout_pending_child(&self, run: &crate::layout::FormattingContextRun<'pass>, mut child: PendingAbsposChild) {

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1580,8 +1580,7 @@ impl<'pass> AbsposEngine<'pass> {
         used_offset.inline_offset += used.margin_left.get() + used.border_box_left(collapsed);
         used_offset.block_offset += used.margin_top.get() + used.border_box_top(collapsed);
         crate::layout::place_child(
-            self.state,
-            &self.callbacks,
+            run,
             node,
             FfiCssPixelPoint {
                 x: used_offset.inline_offset,
@@ -1717,14 +1716,22 @@ pub(crate) fn drain_remaining_abspos_targets(
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
     targets: &[Node],
+    entry_fragments: &std::rc::Rc<crate::layout::RunFragmentBuilder>,
 ) {
     while let Some(target) = targets
         .iter()
         .copied()
         .find(|target| !target.is_invalid() && state.has_contained_abspos_children(*target))
     {
-        let run =
-            crate::layout::FormattingContextRun::new(state, target, LayoutMode::Normal, callbacks, should_collect_devtools_layout_data, false);
+        let run = crate::layout::FormattingContextRun {
+            state,
+            box_: target,
+            layout_mode: LayoutMode::Normal,
+            callbacks,
+            should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+            fragments: Some(entry_fragments.clone()),
+        };
         layout_contained_abspos_children(&run);
     }
     debug_assert!(

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -90,10 +90,6 @@ impl<'pass> AbsposEngine<'pass> {
         self.state.used_values(&self.callbacks, node)
     }
 
-    fn static_position_containing_block(&self, node: Node) -> Node {
-        self.callbacks.static_position_containing_block(node)
-    }
-
     fn inline_containing_block(&self, node: Node) -> Node {
         self.callbacks.inline_containing_block(node)
     }
@@ -106,18 +102,27 @@ impl<'pass> AbsposEngine<'pass> {
         self.callbacks.is_ancestor(ancestor, node)
     }
 
-    fn resolve_static_position_relative_to_containing_block(
+    fn containing_block_geometry_for_pending_child(&self, entry: &PendingAbsposChild) -> ContainingBlockGeometry {
+        let containing_block = self.callbacks.containing_block(entry.child_box);
+        assert!(!containing_block.is_invalid());
+        let translation_into_containing_block_space =
+            self.chain_translation_delta_to(containing_block, entry.coordinate_space_box);
+        ContainingBlockGeometry::from_used_values(
+            self.used(containing_block),
+            point_sub(FfiCssPixelPoint::default(), translation_into_containing_block_space),
+        )
+    }
+
+    fn chain_translation_delta_to(
         &self,
-        node: Node,
-        static_position_rect: StaticPositionRect,
-    ) -> StaticPositionRect {
-        let static_position_cb = self.static_position_containing_block(node);
-        let actual_containing_block = self.callbacks.containing_block(node);
-        if static_position_cb.is_invalid() || static_position_cb == actual_containing_block {
-            return static_position_rect;
+        actual_containing_block: Node,
+        coordinate_space_box: Node,
+    ) -> FfiCssPixelPoint {
+        if coordinate_space_box.is_invalid() || coordinate_space_box == actual_containing_block {
+            return FfiCssPixelPoint::default();
         }
 
-        let mut merge_point = static_position_cb;
+        let mut merge_point = coordinate_space_box;
         while merge_point != actual_containing_block && !self.node_is_ancestor(merge_point, actual_containing_block) {
             merge_point = self.callbacks.containing_block(merge_point);
             assert!(!merge_point.is_invalid());
@@ -134,9 +139,8 @@ impl<'pass> AbsposEngine<'pass> {
             }
             offset
         };
-        translate_static_position_between_chains(
-            static_position_rect,
-            offset_relative_to_merge_point(static_position_cb),
+        point_sub(
+            offset_relative_to_merge_point(coordinate_space_box),
             offset_relative_to_merge_point(actual_containing_block),
         )
     }
@@ -171,7 +175,11 @@ impl<'pass> AbsposEngine<'pass> {
         Some(rect)
     }
 
-    fn base_containing_block_info(&self, node: Node) -> AbsposContainingBlockInfo {
+    fn base_containing_block_info(
+        &self,
+        node: Node,
+        entry_containing_block_geometry: &ContainingBlockGeometry,
+    ) -> AbsposContainingBlockInfo {
         let style = self.style(node);
         let (inline_axis_mode, block_axis_mode) = axis_modes(style);
         let containing_block = self.callbacks.containing_block(node);
@@ -199,20 +207,15 @@ impl<'pass> AbsposEngine<'pass> {
             };
         }
 
-        let containing_block_used = self.used(containing_block);
         AbsposContainingBlockInfo {
             rect: LogicalRect {
                 offset: LogicalOffset {
-                    inline_offset: -containing_block_used.padding_left.get(),
-                    block_offset: -containing_block_used.padding_top.get(),
+                    inline_offset: -entry_containing_block_geometry.padding_left,
+                    block_offset: -entry_containing_block_geometry.padding_top,
                 },
                 size: LogicalSize {
-                    inline_size: containing_block_used.content_inline_size.get()
-                        + containing_block_used.padding_left.get()
-                        + containing_block_used.padding_right.get(),
-                    block_size: containing_block_used.content_block_size.get()
-                        + containing_block_used.padding_top.get()
-                        + containing_block_used.padding_bottom.get(),
+                    inline_size: entry_containing_block_geometry.padding_box_inline_size(),
+                    block_size: entry_containing_block_geometry.padding_box_block_size(),
                 },
             },
             inline_axis_mode,
@@ -1597,22 +1600,23 @@ impl<'pass> AbsposEngine<'pass> {
 
     }
 
-    pub(crate) fn layout_children(&self, run: &crate::layout::FormattingContextRun<'pass>) {
+    pub(crate) fn layout_pending_child(&self, run: &crate::layout::FormattingContextRun<'pass>, mut child: PendingAbsposChild) {
         debug_assert!(!self.state.is_measurement());
-        while let Some(child) = self.state.take_next_contained_abspos_child(run.box_) {
-            let child_box = child.child_box;
-            self.state
-                .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
-            self.resolve_anchor_insets(child_box);
-            let inputs = AbsposLayoutInputs {
-                static_position_rect: self
-                    .resolve_static_position_relative_to_containing_block(child_box, child.static_position_rect),
-                containing_block_info: child
-                    .containing_block_info_override
-                    .unwrap_or_else(|| self.base_containing_block_info(child_box)),
-            };
-            self.layout_element(run, child_box, inputs);
-        }
+        let child_box = child.child_box;
+        self.state
+            .create_used_values(&self.callbacks, child_box, ContainingBlockConstraints::default());
+        let containing_block_geometry = self.containing_block_geometry_for_pending_child(&child);
+        self.resolve_anchor_insets(child_box);
+        let translation_into_containing_block_space =
+            point_sub(FfiCssPixelPoint::default(), containing_block_geometry.content_origin_in_entry_space);
+        crate::layout::translate_pending_abspos_payloads(&mut child, translation_into_containing_block_space);
+        let inputs = AbsposLayoutInputs {
+            static_position_rect: child.static_position_rect,
+            containing_block_info: child
+                .containing_block_info_override
+                .unwrap_or_else(|| self.base_containing_block_info(child_box, &containing_block_geometry)),
+        };
+        self.layout_element(run, child_box, inputs);
     }
 
     fn replay(&self, run: &crate::layout::FormattingContextRun<'pass>, node: Node) {
@@ -1707,37 +1711,32 @@ impl<'pass> AbsposEngine<'pass> {
     }
 }
 
-pub(crate) fn layout_contained_abspos_children(run: &crate::layout::FormattingContextRun<'_>) {
-    AbsposEngine::new(run.state, run.callbacks).layout_children(run);
-}
-
-pub(crate) fn drain_remaining_abspos_targets(
+pub(crate) fn drain_abspos_with_placed_containing_blocks(
     state: &LayoutState,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
-    targets: &[Node],
     entry_fragments: &std::rc::Rc<crate::layout::RunFragmentBuilder>,
 ) {
-    while let Some(target) = targets
-        .iter()
-        .copied()
-        .find(|target| !target.is_invalid() && state.has_contained_abspos_children(*target))
-    {
-        let run = crate::layout::FormattingContextRun {
-            state,
-            box_: target,
-            layout_mode: LayoutMode::Normal,
-            callbacks,
-            should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
-            fragments: Some(entry_fragments.clone()),
-        };
-        layout_contained_abspos_children(&run);
+    let accumulator_root = entry_fragments.root_node();
+    let run = crate::layout::FormattingContextRun {
+        state,
+        box_: accumulator_root,
+        layout_mode: LayoutMode::Normal,
+        callbacks,
+        should_collect_devtools_layout_data,
+        treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+        fragments: Some(entry_fragments.clone()),
+    };
+    loop {
+        let batch = entry_fragments.take_drainable_abspos(accumulator_root, &callbacks);
+        if batch.is_empty() {
+            break;
+        }
+        let engine = AbsposEngine::new(state, callbacks);
+        for entry in batch {
+            engine.layout_pending_child(&run, entry);
+        }
     }
-    debug_assert!(
-        state.all_registered_contained_abspos_children_are_laid_out(),
-        "registered abspos children were left without layout after the entry sweep"
-    );
 }
 
 pub(crate) fn compute_inset_native(

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -90,14 +90,6 @@ impl<'pass> AbsposEngine<'pass> {
         self.state.used_values(&self.callbacks, node)
     }
 
-    fn inline_containing_block(&self, node: Node) -> Node {
-        self.callbacks.inline_containing_block(node)
-    }
-
-    fn non_anonymous_containing_block(&self, node: Node) -> Node {
-        self.callbacks.non_anonymous_containing_block(node)
-    }
-
     fn node_is_ancestor(&self, ancestor: Node, node: Node) -> bool {
         self.callbacks.is_ancestor(ancestor, node)
     }
@@ -145,49 +137,17 @@ impl<'pass> AbsposEngine<'pass> {
         )
     }
 
-    fn compute_inline_containing_block_rect(
-        &self,
-        inline_node: Node,
-        abspos_containing_block: Node,
-    ) -> Option<PhysicalRect> {
-        if self.facts(inline_node).is_anonymous() {
-            return None;
-        }
-        let outer_block = self.non_anonymous_containing_block(inline_node);
-        if outer_block.is_invalid() {
-            return None;
-        }
-
-        let mut rect = self
-            .state
-            .inline_containing_block_first_last_rect(self.callbacks.slot_index(inline_node))?;
-        debug_assert!(
-            self.node_is_ancestor(abspos_containing_block, inline_node),
-            "an inline containing block must live inside its children's box containing block"
-        );
-        let mut ancestor = self.callbacks.containing_block(inline_node);
-        while !ancestor.is_invalid() && ancestor != abspos_containing_block {
-            let content_offset = self.used(ancestor).content_offset.get();
-            rect.x += content_offset.x;
-            rect.y += content_offset.y;
-            ancestor = self.callbacks.containing_block(ancestor);
-        }
-        Some(rect)
-    }
-
     fn base_containing_block_info(
         &self,
         node: Node,
+        inline_containing_block_rect: Option<PhysicalRect>,
         entry_containing_block_geometry: &ContainingBlockGeometry,
     ) -> AbsposContainingBlockInfo {
         let style = self.style(node);
         let (inline_axis_mode, block_axis_mode) = axis_modes(style);
         let containing_block = self.callbacks.containing_block(node);
         assert!(!containing_block.is_invalid());
-        let inline_containing_block = self.inline_containing_block(node);
-        if !inline_containing_block.is_invalid()
-            && let Some(rect) = self.compute_inline_containing_block_rect(inline_containing_block, containing_block)
-        {
+        if let Some(rect) = inline_containing_block_rect {
             return AbsposContainingBlockInfo {
                 rect: LogicalRect {
                     offset: LogicalOffset {
@@ -1614,7 +1574,10 @@ impl<'pass> AbsposEngine<'pass> {
             static_position_rect: child.static_position_rect,
             containing_block_info: child
                 .containing_block_info_override
-                .unwrap_or_else(|| self.base_containing_block_info(child_box, &containing_block_geometry)),
+                .unwrap_or_else(|| {
+                    let inline_containing_block_rect = child.inline_containing_block_rect;
+                    self.base_containing_block_info(child_box, inline_containing_block_rect, &containing_block_geometry)
+                }),
         };
         self.layout_element(run, child_box, inputs);
     }

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -311,7 +311,6 @@ impl<'pass> BlockFormattingContext<'pass> {
             alignment_derives_from_own_computed_values: false,
         };
         crate::layout::register_contained_abspos_child(
-            self.state,
             &self.callbacks,
             self.fragments.as_deref(),
             coordinate_space_box,

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -345,6 +345,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         crate::layout::compute_inset_native(
             self.state,
             self.callbacks,
+            self.fragments.clone(),
             node,
             containing_block_size.inline_size,
             containing_block_size.block_size,

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -297,7 +297,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         crate::layout::place_child(&self.formatting_context_run(), node, offset);
     }
 
-    fn register_contained_abspos_child(&self, node: Node, block_offset: CssPixels) {
+    fn register_contained_abspos_child(&self, node: Node, block_offset: CssPixels, coordinate_space_box: Node) {
         let static_position = StaticPositionRect {
             rect: LogicalRect {
                 offset: LogicalOffset {
@@ -310,7 +310,15 @@ impl<'pass> BlockFormattingContext<'pass> {
             block_alignment: StaticPositionAlignment::Start,
             alignment_derives_from_own_computed_values: false,
         };
-        crate::layout::register_contained_abspos_child(self.state, &self.callbacks, node, static_position);
+        crate::layout::register_contained_abspos_child(
+            self.state,
+            &self.callbacks,
+            self.fragments.as_deref(),
+            coordinate_space_box,
+            node,
+            static_position,
+            None,
+        );
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
@@ -1550,6 +1558,7 @@ impl<'pass> BlockFormattingContext<'pass> {
                     self.block_offset_of_current_block_container
                         .get()
                         .expect("a block container flow cursor is active"),
+                    block_container,
                 );
             }
             return;

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -182,6 +182,7 @@ struct FloatPlacement {
 // https://www.w3.org/TR/css-display/#block-formatting-context
 pub(crate) struct BlockFormattingContext<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     root: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
@@ -205,6 +206,7 @@ impl<'pass> BlockFormattingContext<'pass> {
     pub(crate) fn new(run: &FormattingContextRun<'pass>) -> Self {
         Self {
             state: run.state,
+            records: run.records.clone(),
             root: run.box_,
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
@@ -228,6 +230,7 @@ impl<'pass> BlockFormattingContext<'pass> {
     fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
         FormattingContextRun {
             state: self.state,
+            records: self.records.clone(),
             box_: self.root,
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
@@ -249,12 +252,13 @@ impl<'pass> BlockFormattingContext<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
 
-    fn used(&self, node: Node) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, node)
+    #[track_caller]
+    fn used(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(node)
     }
 
-    fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> &'pass UsedValues {
-        self.state.create_used_values(&self.callbacks, node, constraints)
+    fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> std::rc::Rc<UsedValues> {
+        self.records.create_used_values(self.state, &self.callbacks, node, constraints)
     }
 
     fn first_child(&self, node: Node) -> Node {
@@ -289,8 +293,8 @@ impl<'pass> BlockFormattingContext<'pass> {
         ancestor == node || self.is_ancestor_of(ancestor, node)
     }
 
-    fn sizing(&self) -> SizingContext<'_> {
-        SizingContext::new(self.state, self.callbacks)
+    fn sizing(&self) -> SizingContext<'pass> {
+        SizingContext::new(self.state, self.records.clone(), self.callbacks)
     }
 
     fn place_child(&self, node: Node, offset: FfiCssPixelPoint) {
@@ -330,11 +334,11 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
-        let baselines = crate::layout::derive_baselines(self.state, &self.callbacks, node, false);
+        let baselines = crate::layout::derive_baselines(self.state, &self.records, &self.callbacks, node, false);
         if node == self.root {
             self.record_derived_baselines_of_root_box(baselines);
         } else {
-            crate::layout::store_derived_baselines(self.used(node), baselines);
+            crate::layout::store_derived_baselines(&self.used(node), baselines);
         }
     }
 
@@ -351,16 +355,7 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn compute_inset(&self, run: &FormattingContextRun<'pass>, node: Node, containing_block_size: LogicalSize) {
-        crate::layout::compute_inset_native(
-            self.state,
-            self.callbacks,
-            self.fragments.clone(),
-            node,
-            containing_block_size.inline_size,
-            containing_block_size.block_size,
-            self.root,
-            run.treat_block_axis_percentage_insets_as_auto_beyond_root,
-        );
+        crate::layout::compute_inset_native(run, node, containing_block_size.inline_size, containing_block_size.block_size);
     }
 
     fn containing_block_rect(&self, node: Node, position: FfiCssPixelPoint) -> BlockCssPixelRect {
@@ -1185,7 +1180,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             };
             let space = self.intrusions_for_band_into_rect(self.band_at(border_box_block_offset_in_root), band_rect);
             let constrained = space.left > CssPixels::default() || space.right > CssPixels::default();
-            let border_box_left = self.border_box_left_of_box_avoiding_floats(node, used, space);
+            let border_box_left = self.border_box_left_of_box_avoiding_floats(node, &used, space);
             let mut must_clear = constrained
                 && border_box_left + candidate_border_box_inline_size
                     > available_space.inline_size.to_px_or_zero() - space.right;
@@ -1375,7 +1370,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             );
             available_inline_size_within_containing_block -= space.left + space.right;
             // Subtracting the left margin here because it is applied again when the margin box offset is added below.
-            inline_offset = self.border_box_left_of_box_avoiding_floats(node, used, space) - used.margin_left.get();
+            inline_offset = self.border_box_left_of_box_avoiding_floats(node, &used, space) - used.margin_left.get();
         }
 
         let containing_block = self.containing_block(node);
@@ -2303,7 +2298,10 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn margin_box_left_of_float_record(&self, floating_box: FloatingBox) -> CssPixels {
-        self.margin_box_left_of_float_in_root(floating_box, floating_box.containing_block_rect_in_root_coordinate_space)
+        self.margin_box_left_of_float_in_root(
+            floating_box,
+            floating_box.containing_block_rect_in_root_coordinate_space,
+        )
     }
 
     // Run-prelude inline sizing for a block-level root: reproduces the
@@ -2464,7 +2462,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         }
         let placement = self.place_float(
             side,
-            self.used(node),
+            &self.used(node),
             available_space,
             containing_block_rect_now,
             ceiling_in_root,
@@ -2472,7 +2470,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         let content_block_offset = placement.block_start - containing_block_rect_now.y
             + self.used(node).margin_top.get()
             + self.used(node).border_box_top(false);
-        let mut margin_box_rect = Self::margin_box_rect(self.used(node))
+        let mut margin_box_rect = Self::margin_box_rect(&self.used(node))
             .translated(CssPixels::default(), content_block_offset)
             .translated(containing_block_rect.x, containing_block_rect.y);
         let floating_box = FloatingBox {
@@ -2643,6 +2641,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         {
             return independent_root_automatic_block_size(
                 self.state,
+                &self.records,
                 &self.callbacks,
                 node,
                 available_space,
@@ -2661,7 +2660,8 @@ impl<'pass> BlockFormattingContext<'pass> {
         // The element's block size is the distance from its block-start content edge to the first applicable edge below.
         // 1. the bottom edge of the last line box, if the box establishes a inline formatting context with one or more lines
         if facts.children_are_inline() {
-            let line_data = self.state.line_data(self.callbacks.slot_index(node));
+            let node_used = self.used(node);
+            let line_data = node_used.line_data_ref();
             if let Some(last_line) = line_data.as_deref().and_then(|data| data.line_boxes.last()) {
                 let mut block_size = last_line.physical_vertical_end();
                 if last_line.has_block_level_box {
@@ -2775,7 +2775,7 @@ impl<'pass> BlockFormattingContext<'pass> {
 
         let facts = self.facts(node);
         if facts.children_are_inline() {
-            if let Some(data) = self.state.line_data(self.callbacks.slot_index(node)) {
+            if let Some(data) = self.used(node).line_data_ref() {
                 for line in &data.line_boxes {
                     let mut inline_size_here = crate::layout::line_physical_horizontal_extent(line);
                     let line_block_start = line.physical_vertical_end() - line.physical_vertical_extent();
@@ -2850,6 +2850,7 @@ impl<'pass> BlockFormattingContext<'pass> {
     pub(crate) fn automatic_content_block_size(&self) -> CssPixels {
         automatic_block_size_for_bfc_root(
             self.state,
+            &self.records,
             self.callbacks,
             self.root,
             self.lowest_floating_descendant_bottom_margin_edge.get(),
@@ -2899,6 +2900,7 @@ pub(crate) fn table_wrapper_flow_children(state: &LayoutState, callbacks: FfiLay
 // https://www.w3.org/TR/CSS22/visudet.html#root-height
 pub(crate) fn automatic_block_size_for_bfc_root(
     state: &LayoutState,
+    records: &RunRecords,
     callbacks: FfiLayoutFcCallbacks,
     root: Node,
     lowest_floating_descendant_bottom_margin_edge: Option<CssPixels>,
@@ -2914,7 +2916,8 @@ pub(crate) fn automatic_block_size_for_bfc_root(
     if facts.children_are_inline() {
         // If it only has inline-level children, the block size is the distance between
         // the top content edge and the bottom of the bottommost line box.
-        let line_data = state.line_data(callbacks.slot_index(root));
+        let root_used = records.used_values(root);
+        let line_data = root_used.line_data_ref();
         if let Some(last_line) = line_data.as_ref().and_then(|data| data.line_boxes.last()) {
             bottom = Some(last_line.physical_vertical_end());
             // A trailing interrupting block's bottom margin cannot collapse out of a BFC root,
@@ -2946,7 +2949,7 @@ pub(crate) fn automatic_block_size_for_bfc_root(
             if !child_facts.is_flow_layout_participant() || child_facts.is_floating() {
                 continue;
             }
-            let child_used = state.used_values(&callbacks, child);
+            let child_used = records.used_values(child);
             // Margins cannot collapse out of a BFC root: below the last real in-flow
             // child, the run's trailing collapsed margin (which folds in any trailing
             // collapse-through siblings) replaces that child's own bottom margin.

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -294,7 +294,16 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn place_child(&self, node: Node, offset: FfiCssPixelPoint) {
-        crate::layout::place_child(&self.formatting_context_run(), node, offset);
+        self.place_child_on_line(node, offset, None);
+    }
+
+    fn place_child_on_line(
+        &self,
+        node: Node,
+        offset: FfiCssPixelPoint,
+        containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
+    ) {
+        crate::layout::place_child(&self.formatting_context_run(), node, offset, containing_line_box_fragment);
     }
 
     fn register_contained_abspos_child(&self, node: Node, block_offset: CssPixels, coordinate_space_box: Node) {
@@ -1908,12 +1917,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         );
 
         if let Some(position) = pending_position {
-            if let Some(coordinate) = containing_line_box_fragment {
-                let used = self.used(node);
-                used.has_containing_line_box_fragment.set(true);
-                used.containing_line_box_fragment.set(coordinate);
-            }
-            self.place_child(node, position);
+            self.place_child_on_line(node, position, containing_line_box_fragment);
         }
 
         if has_independent_formatting_context || !self.margins_collapse_through(node) {

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -2626,6 +2626,10 @@ impl<'pass> BlockFormattingContext<'pass> {
             );
         }
 
+        if let Some(automatic_content_block_size) = automatic_content_block_size_of_completed_run {
+            return automatic_content_block_size;
+        }
+
         // https://www.w3.org/TR/CSS22/visudet.html#normal-block
         // 10.6.3 Block-level non-replaced elements in normal flow when 'overflow' computes to 'visible'
 

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -196,15 +196,19 @@ pub(crate) struct BlockFormattingContext<'pass> {
     derived_baselines_of_root_box: Cell<DerivedBaselines>,
     trailing_collapsed_margin: Cell<Option<(Node, CssPixels)>>,
     table_box_in_wrapper_border_box_block_size: Cell<Option<CssPixels>>,
+    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    should_collect_devtools_layout_data: bool,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 }
 
 impl<'pass> BlockFormattingContext<'pass> {
-    pub(crate) fn new(state: &'pass LayoutState, root: Node, layout_mode: LayoutMode, callbacks: FfiLayoutFcCallbacks) -> Self {
+    pub(crate) fn new(run: &FormattingContextRun<'pass>) -> Self {
         Self {
-            state,
-            root,
-            layout_mode,
-            callbacks,
+            state: run.state,
+            root: run.box_,
+            layout_mode: run.layout_mode,
+            callbacks: run.callbacks,
+            fragments: run.fragments.clone(),
             block_offset_of_current_block_container: Cell::new(None),
             pending_legend_flow_position: Cell::new(None),
             margin_state: RefCell::new(BlockMarginState::default()),
@@ -216,6 +220,20 @@ impl<'pass> BlockFormattingContext<'pass> {
             derived_baselines_of_root_box: Cell::new(DerivedBaselines::default()),
             trailing_collapsed_margin: Cell::new(None),
             table_box_in_wrapper_border_box_block_size: Cell::new(None),
+            should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+        }
+    }
+
+    fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
+        FormattingContextRun {
+            state: self.state,
+            box_: self.root,
+            layout_mode: self.layout_mode,
+            callbacks: self.callbacks,
+            should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            fragments: self.fragments.clone(),
         }
     }
 
@@ -276,7 +294,7 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn place_child(&self, node: Node, offset: FfiCssPixelPoint) {
-        crate::layout::place_child(self.state, &self.callbacks, node, offset);
+        crate::layout::place_child(&self.formatting_context_run(), node, offset);
     }
 
     fn register_contained_abspos_child(&self, node: Node, block_offset: CssPixels) {

--- a/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/block_formatting_context.rs
@@ -148,9 +148,8 @@ enum FloatSide {
 }
 
 #[derive(Clone, Copy)]
-struct FloatingBox<'pass> {
+struct FloatingBox {
     box_: Node,
-    used_values: &'pass UsedValues,
     side: FloatSide,
 
     // Offset from left/right edge to the left content edge of `box`.
@@ -189,7 +188,7 @@ pub(crate) struct BlockFormattingContext<'pass> {
     block_offset_of_current_block_container: Cell<Option<CssPixels>>,
     pending_legend_flow_position: Cell<Option<LogicalOffset>>,
     margin_state: RefCell<BlockMarginState>,
-    floats: RefCell<Vec<FloatingBox<'pass>>>,
+    floats: RefCell<Vec<FloatingBox>>,
     bands: RefCell<Vec<FloatBand>>,
     lowest_left_margin_edge: Cell<CssPixels>,
     lowest_right_margin_edge: Cell<CssPixels>,
@@ -991,8 +990,7 @@ impl<'pass> BlockFormattingContext<'pass> {
         let pending_adjustment =
             self.block_offset_adjustment_from_pending_ancestor_block_start_margins(floating_box.box_);
         containing_block_rect_in_root.y += pending_adjustment;
-        // SAFETY: The float record points to a stable state-owned entry.
-        let used = floating_box.used_values;
+        let used = self.used(floating_box.box_);
         let root_content_inline_size = self.used(self.root).content_inline_size.get();
         let margin_box_rect = floating_box
             .margin_box_rect_in_root_coordinate_space
@@ -1086,11 +1084,11 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn margin_box_left_of_float_in_root(
+        &self,
         floating_box: FloatingBox,
         containing_block_rect_in_root: BlockCssPixelRect,
     ) -> CssPixels {
-        // SAFETY: The state owns the float's used-values entry.
-        let used = floating_box.used_values;
+        let used = self.used(floating_box.box_);
         if floating_box.side == FloatSide::Left {
             containing_block_rect_in_root.x + floating_box.offset_from_edge
                 - used.margin_left.get()
@@ -2274,10 +2272,7 @@ impl<'pass> BlockFormattingContext<'pass> {
     }
 
     fn margin_box_left_of_float_record(&self, floating_box: FloatingBox) -> CssPixels {
-        Self::margin_box_left_of_float_in_root(
-            floating_box,
-            floating_box.containing_block_rect_in_root_coordinate_space,
-        )
+        self.margin_box_left_of_float_in_root(floating_box, floating_box.containing_block_rect_in_root_coordinate_space)
     }
 
     // Run-prelude inline sizing for a block-level root: reproduces the
@@ -2451,7 +2446,6 @@ impl<'pass> BlockFormattingContext<'pass> {
             .translated(containing_block_rect.x, containing_block_rect.y);
         let floating_box = FloatingBox {
             box_: node,
-            used_values: self.used(node),
             side,
             offset_from_edge: placement.offset_from_edge,
             top_margin_edge: content_block_offset
@@ -2709,8 +2703,7 @@ impl<'pass> BlockFormattingContext<'pass> {
             block_start < floating_box.bottom_margin_edge && block_end > floating_box.top_margin_edge
         };
         let inline_size_to_make_room_for_float_margin_box = |floating_box: &FloatingBox| {
-            // SAFETY: Float records retain stable state-owned used-values pointers.
-            let used = floating_box.used_values;
+            let used = self.used(floating_box.box_);
             if floating_box.side == FloatSide::Left {
                 floating_box.offset_from_edge
                     + used.content_inline_size.get()

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -42,7 +42,6 @@ enum UsedFlexBasis<'pass> {
 
 struct FlexItem<'pass> {
     box_: Node,
-    used_values: &'pass UsedValues,
     used_flex_basis: UsedFlexBasis<'pass>,
     used_flex_basis_is_definite: bool,
     main_size_was_resolved_from_aspect_ratio: bool,
@@ -69,11 +68,10 @@ struct FlexItem<'pass> {
     content_baselines: DerivedBaselines,
 }
 
-impl<'pass> FlexItem<'pass> {
-    fn new(box_: Node, used_values: &'pass UsedValues) -> Self {
+impl FlexItem<'_> {
+    fn new(box_: Node) -> Self {
         Self {
             box_,
-            used_values,
             used_flex_basis: UsedFlexBasis::Content,
             used_flex_basis_is_definite: false,
             main_size_was_resolved_from_aspect_ratio: false,
@@ -177,7 +175,6 @@ struct FlexFormattingContext<'pass> {
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
-    flex_container_state: &'pass UsedValues,
     flex_lines: Vec<FlexLine>,
     flex_items: Vec<FlexItem<'pass>>,
     derived_baselines_of_root_box: DerivedBaselines,
@@ -190,7 +187,6 @@ struct FlexFormattingContext<'pass> {
 
 impl<'pass> FlexFormattingContext<'pass> {
     fn new(run: &FormattingContextRun<'pass>) -> Self {
-        let flex_container_state = run.state.used_values(&run.callbacks, run.box_);
         let flex_direction = run.state.style_facts(&run.callbacks, run.box_).flex_direction();
         Self {
             state: run.state,
@@ -198,7 +194,6 @@ impl<'pass> FlexFormattingContext<'pass> {
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
-            flex_container_state,
             flex_lines: Vec::new(),
             flex_items: Vec::new(),
             derived_baselines_of_root_box: DerivedBaselines::default(),
@@ -211,11 +206,11 @@ impl<'pass> FlexFormattingContext<'pass> {
     }
 
     fn item_used(&self, index: usize) -> &'pass UsedValues {
-        self.flex_items[index].used_values
+        self.state.used_values(&self.callbacks, self.flex_items[index].box_)
     }
 
     fn container_used(&self) -> &'pass UsedValues {
-        self.flex_container_state
+        self.state.used_values(&self.callbacks, self.flex_container)
     }
 
     fn style(&self, node: Node) -> StyleValues<'pass> {
@@ -762,8 +757,8 @@ impl<'pass> FlexFormattingContext<'pass> {
                 if !skip && !facts.is_absolutely_positioned() {
                     // Flex inhibits floating, so only absolute positioning is out of flow here.
                     self.state.set_box_is_flex_item(&self.callbacks, child, true);
-                    let used = self.create_used_values(child);
-                    let item = FlexItem::new(child, used);
+                    self.create_used_values(child);
+                    let item = FlexItem::new(child);
                     buckets.entry(self.style(child).order()).or_default().push(item);
                 }
             }
@@ -2244,7 +2239,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             self.state,
             &self.callbacks,
             item.box_,
-            item.used_values,
+            self.item_used(index),
             crate::layout::BaselineSet::First,
             item.content_baselines,
         )

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -3087,7 +3087,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                         y: item.main_offset,
                     }
                 };
-                crate::layout::place_child(&self.formatting_context_run(), item.box_, offset);
+                crate::layout::place_child(&self.formatting_context_run(), item.box_, offset, None);
             }
             self.derived_baselines_of_root_box =
                 crate::layout::derive_baselines(self.state, &self.callbacks, self.flex_container, true);

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -171,6 +171,7 @@ struct AxisAgnosticAvailableSpace {
 
 struct FlexFormattingContext<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     flex_container: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
@@ -192,6 +193,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         let flex_direction = run.state.style_facts(&run.callbacks, run.box_).flex_direction();
         Self {
             state: run.state,
+            records: run.records.clone(),
             flex_container: run.box_,
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
@@ -209,10 +211,10 @@ impl<'pass> FlexFormattingContext<'pass> {
         }
     }
 
-
     fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
         FormattingContextRun {
             state: self.state,
+            records: self.records.clone(),
             box_: self.flex_container,
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
@@ -222,14 +224,13 @@ impl<'pass> FlexFormattingContext<'pass> {
         }
     }
 
-    fn item_used(&self, index: usize) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, self.flex_items[index].box_)
+    fn item_used(&self, index: usize) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(self.flex_items[index].box_)
     }
 
-    fn container_used(&self) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, self.flex_container)
+    fn container_used(&self) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(self.flex_container)
     }
-
     fn style(&self, node: Node) -> StyleValues<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
@@ -238,13 +239,13 @@ impl<'pass> FlexFormattingContext<'pass> {
         self.state.node_facts(&self.callbacks, node)
     }
 
-    fn sizing(&self) -> SizingContext<'_> {
-        SizingContext::new(self.state, self.callbacks)
+    fn sizing(&self) -> SizingContext<'pass> {
+        SizingContext::new(self.state, self.records.clone(), self.callbacks)
     }
 
-    fn create_used_values(&self, node: Node) -> &'pass UsedValues {
+    fn create_used_values(&self, node: Node) -> std::rc::Rc<UsedValues> {
         let constraints = self.item_percentage_bases;
-        self.state.create_used_values(&self.callbacks, node, constraints)
+        self.records.create_used_values(self.state, &self.callbacks, node, constraints)
     }
 
     fn constraints_for_child_context(
@@ -408,11 +409,11 @@ impl<'pass> FlexFormattingContext<'pass> {
     }
 
     fn has_definite_main_size(&self, index: usize) -> bool {
-        self.has_definite_main_size_used(self.item_used(index))
+        self.has_definite_main_size_used(&self.item_used(index))
     }
 
     fn has_definite_cross_size(&self, index: usize) -> bool {
-        self.has_definite_cross_size_used(self.item_used(index))
+        self.has_definite_cross_size_used(&self.item_used(index))
     }
 
     fn inner_main_size_used(&self, used: &UsedValues) -> CssPixels {
@@ -424,11 +425,11 @@ impl<'pass> FlexFormattingContext<'pass> {
     }
 
     fn inner_main_size(&self, index: usize) -> CssPixels {
-        self.inner_main_size_used(self.item_used(index))
+        self.inner_main_size_used(&self.item_used(index))
     }
 
     fn inner_cross_size(&self, index: usize) -> CssPixels {
-        self.inner_cross_size_used(self.item_used(index))
+        self.inner_cross_size_used(&self.item_used(index))
     }
 
     fn set_has_definite_main_size(&mut self, index: usize) {
@@ -444,19 +445,19 @@ impl<'pass> FlexFormattingContext<'pass> {
     }
 
     fn set_main_size(&mut self, index: usize, size: CssPixels) {
-        self.set_main_size_used(self.item_used(index), size);
+        self.set_main_size_used(&self.item_used(index), size);
     }
 
     fn set_cross_size(&mut self, index: usize, size: CssPixels) {
-        self.set_cross_size_used(self.item_used(index), size);
+        self.set_cross_size_used(&self.item_used(index), size);
     }
 
     fn set_container_main_size(&mut self, size: CssPixels) {
-        self.set_main_size_used(self.container_used(), size);
+        self.set_main_size_used(&self.container_used(), size);
     }
 
     fn set_container_cross_size(&mut self, size: CssPixels) {
-        self.set_cross_size_used(self.container_used(), size);
+        self.set_cross_size_used(&self.container_used(), size);
     }
 
     fn set_main_size_used(&self, used: &UsedValues, size: CssPixels) {
@@ -812,7 +813,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         // For example, percentage values of flex-basis are resolved against the flex item’s containing block
         // (i.e. its flex container); and if that containing block’s size is indefinite,
         // the used value for flex-basis is content.
-        if value.is_percentage() && !self.has_definite_main_size_used(self.container_used()) {
+        if value.is_percentage() && !self.has_definite_main_size_used(&self.container_used()) {
             return UsedFlexBasis::Content;
         }
         UsedFlexBasis::Size { value, property }
@@ -828,7 +829,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         max_cross_size: &ComputedSize,
     ) -> CssPixels {
         let ratio = self.facts(node).preferred_aspect_ratio().unwrap();
-        let reference = self.inner_cross_size_used(self.container_used());
+        let reference = self.inner_cross_size_used(&self.container_used());
         if !self.should_treat_max_size_as_none(node, true) {
             main_size =
                 main_size.min(self.main_size_from_cross_size_and_aspect_ratio(max_cross_size.to_px(reference), ratio));
@@ -848,7 +849,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         max_main_size: &ComputedSize,
     ) -> CssPixels {
         let ratio = self.facts(node).preferred_aspect_ratio().unwrap();
-        let reference = self.inner_main_size_used(self.container_used());
+        let reference = self.inner_main_size_used(&self.container_used());
         if !self.should_treat_max_size_as_none(node, false) {
             cross_size =
                 cross_size.min(self.cross_size_from_main_size_and_aspect_ratio(max_main_size.to_px(reference), ratio));
@@ -1003,10 +1004,10 @@ impl<'pass> FlexFormattingContext<'pass> {
                 } else if value.is_length() {
                     true
                 } else if value.kind == ComputedSizeKind::Calculated {
-                    !value.contains_percentage() || self.has_definite_main_size_used(self.container_used())
+                    !value.contains_percentage() || self.has_definite_main_size_used(&self.container_used())
                 } else {
                     debug_assert!(value.is_percentage());
-                    self.has_definite_main_size_used(self.container_used())
+                    self.has_definite_main_size_used(&self.container_used())
                 }
             }
         };
@@ -1098,9 +1099,9 @@ impl<'pass> FlexFormattingContext<'pass> {
                 && !facts.has_auto_content_width()
                 && !facts.has_auto_content_height()
                 && !self.has_definite_cross_size(index)
-                && self.has_definite_main_size_used(self.container_used())
+                && self.has_definite_main_size_used(&self.container_used())
             {
-                flex_base_size = self.inner_main_size_used(self.container_used());
+                flex_base_size = self.inner_main_size_used(&self.container_used());
             }
             let (min_cross, _) = self.computed_cross_min_size(node);
             let (max_cross, _) = self.computed_cross_max_size(node);
@@ -1208,13 +1209,13 @@ impl<'pass> FlexFormattingContext<'pass> {
     fn main_gap(&self) -> CssPixels {
         let style = self.style(self.flex_container);
         let gap = if self.is_row_layout() { style.column_gap() } else { style.row_gap() };
-        gap.to_px(self.inner_main_size_used(self.container_used()))
+        gap.to_px(self.inner_main_size_used(&self.container_used()))
     }
 
     fn cross_gap(&self) -> CssPixels {
         let style = self.style(self.flex_container);
         let gap = if self.is_row_layout() { style.row_gap() } else { style.column_gap() };
-        gap.to_px(self.inner_cross_size_used(self.container_used()))
+        gap.to_px(self.inner_cross_size_used(&self.container_used()))
     }
 
     // https://www.w3.org/TR/css-flexbox-1/#algo-line-break
@@ -1332,7 +1333,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         {
             self.available_space_for_items.unwrap().main
         } else {
-            AvailableSize::definite(self.inner_main_size_used(self.container_used()))
+            AvailableSize::definite(self.inner_main_size_used(&self.container_used()))
         };
         let item_count = self.flex_lines[line_index].items.len();
         // 1. Determine the used flex factor.
@@ -1547,7 +1548,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                 != self.inline_axis_is_horizontal(self.flex_container);
             let container_has_vertical_inline_main_axis =
                 self.is_row_layout() && !self.inline_axis_is_horizontal(self.flex_container);
-            if self.has_definite_main_size_used(self.container_used())
+            if self.has_definite_main_size_used(&self.container_used())
                 || self.flex_items[index].used_flex_basis_is_definite
                 || self.flex_items[index].main_size_was_resolved_from_aspect_ratio
                 || container_has_vertical_inline_main_axis
@@ -1630,7 +1631,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                 facts.is_replaced_box() && !(facts.has_auto_content_width() && facts.has_auto_content_height());
             if replaced_with_only_natural_ratio && !self.flex_items[index].used_flex_basis_is_definite {
                 self.flex_items[index].hypothetical_cross_size =
-                    css_clamp(self.inner_cross_size_used(self.container_used()), clamp_min, clamp_max);
+                    css_clamp(self.inner_cross_size_used(&self.container_used()), clamp_min, clamp_max);
                 return;
             }
             // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
@@ -1697,8 +1698,8 @@ impl<'pass> FlexFormattingContext<'pass> {
     // https://www.w3.org/TR/css-flexbox-1/#algo-cross-line
     fn calculate_cross_size_of_each_flex_line(&mut self) {
         // If the flex container is single-line and has a definite cross size, the cross size of the flex line is the flex container’s inner cross size.
-        if self.is_single_line() && self.has_definite_cross_size_used(self.container_used()) {
-            self.flex_lines[0].cross_size = self.inner_cross_size_used(self.container_used());
+        if self.is_single_line() && self.has_definite_cross_size_used(&self.container_used()) {
+            self.flex_lines[0].cross_size = self.inner_cross_size_used(&self.container_used());
             return;
         }
         // Otherwise, for each flex line:
@@ -1747,7 +1748,7 @@ impl<'pass> FlexFormattingContext<'pass> {
     // https://drafts.csswg.org/css-flexbox-1/#algo-line-stretch
     fn handle_align_content_stretch(&mut self) {
         // If the flex container has a definite cross size,
-        if !self.has_definite_cross_size_used(self.container_used())
+        if !self.has_definite_cross_size_used(&self.container_used())
             // align-content is stretch,
             || !matches!(
                 self.style(self.flex_container).align_content(),
@@ -1762,7 +1763,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             .fold(CssPixels::default(), |sum, line| sum + line.cross_size);
         // CSS-FLEXBOX-2: Account for gap between flex lines.
         sum += self.cross_gap() * self.flex_lines.len().wrapping_sub(1);
-        let container_size = self.inner_cross_size_used(self.container_used());
+        let container_size = self.inner_cross_size_used(&self.container_used());
         // and the sum of the flex lines' cross sizes is less than the flex container’s inner cross size,
         if sum >= container_size {
             return;
@@ -1897,31 +1898,31 @@ impl<'pass> FlexFormattingContext<'pass> {
                     justify_content::START | justify_content::LEFT => {}
                     justify_content::STRETCH | justify_content::NORMAL | justify_content::FLEX_START => {
                         if self.is_direction_reverse() {
-                            initial_offset = self.inner_main_size_used(self.container_used());
+                            initial_offset = self.inner_main_size_used(&self.container_used());
                         }
                     }
                     justify_content::END => {
-                        initial_offset = self.inner_main_size_used(self.container_used());
+                        initial_offset = self.inner_main_size_used(&self.container_used());
                     }
                     justify_content::RIGHT => {
                         if self.is_row_layout() {
-                            initial_offset = self.inner_main_size_used(self.container_used());
+                            initial_offset = self.inner_main_size_used(&self.container_used());
                         }
                     }
                     justify_content::FLEX_END => {
                         if !self.is_direction_reverse() {
-                            initial_offset = self.inner_main_size_used(self.container_used());
+                            initial_offset = self.inner_main_size_used(&self.container_used());
                         }
                     }
                     justify_content::CENTER => {
-                        initial_offset = (self.inner_main_size_used(self.container_used()) - used_main_space) / 2;
+                        initial_offset = (self.inner_main_size_used(&self.container_used()) - used_main_space) / 2;
                         if self.is_direction_reverse() {
-                            initial_offset = self.inner_main_size_used(self.container_used()) - initial_offset;
+                            initial_offset = self.inner_main_size_used(&self.container_used()) - initial_offset;
                         }
                     }
                     justify_content::SPACE_BETWEEN => {
                         if self.is_direction_reverse() {
-                            initial_offset = self.inner_main_size_used(self.container_used());
+                            initial_offset = self.inner_main_size_used(&self.container_used());
                         }
                         if let Some(free_space) = remaining
                             && number_of_items > 1
@@ -1934,7 +1935,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                             space_between_items = (free_space / number_of_items).max(CssPixels::default());
                         }
                         initial_offset = if self.is_direction_reverse() {
-                            self.inner_main_size_used(self.container_used()) - space_between_items / 2
+                            self.inner_main_size_used(&self.container_used()) - space_between_items / 2
                         } else {
                             space_between_items / 2
                         };
@@ -1944,7 +1945,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                             space_between_items = (free_space / (number_of_items + 1)).max(CssPixels::default());
                         }
                         initial_offset = if self.is_direction_reverse() {
-                            self.inner_main_size_used(self.container_used()) - space_between_items
+                            self.inner_main_size_used(&self.container_used()) - space_between_items
                         } else {
                             space_between_items
                         };
@@ -2133,7 +2134,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             return;
         }
         let reverse_cross_axis = self.cross_axis_is_reverse();
-        let container_cross_size = self.inner_cross_size_used(self.container_used());
+        let container_cross_size = self.inner_cross_size_used(&self.container_used());
         if self.is_single_line() {
             // https://drafts.csswg.org/css-flexbox-1/#flex-lines
             // 'align-content' does not apply to single-line flex containers, so place the line at cross-start.
@@ -2256,7 +2257,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             self.state,
             &self.callbacks,
             item.box_,
-            self.item_used(index),
+            &self.item_used(index),
             crate::layout::BaselineSet::First,
             item.content_baselines,
         )
@@ -2362,16 +2363,7 @@ impl<'pass> FlexFormattingContext<'pass> {
 
         let container_inline_size = self.container_used().content_inline_size.get();
         let container_block_size = self.container_used().content_block_size.get();
-        crate::layout::compute_inset_native(
-            self.state,
-            self.callbacks,
-            self.fragments.clone(),
-            node,
-            container_inline_size,
-            container_block_size,
-            self.flex_container,
-            run.treat_block_axis_percentage_insets_as_auto_beyond_root,
-        );
+        crate::layout::compute_inset_native(run, node, container_inline_size, container_block_size);
     }
 
     // https://drafts.csswg.org/css-flexbox-1/#abspos-items
@@ -2431,8 +2423,8 @@ impl<'pass> FlexFormattingContext<'pass> {
             }
             _ => unreachable!("invalid justify-content"),
         };
-        let main_size = self.inner_main_size_used(self.container_used());
-        let cross_size = self.inner_cross_size_used(self.container_used());
+        let main_size = self.inner_main_size_used(&self.container_used());
+        let cross_size = self.inner_cross_size_used(&self.container_used());
         let (logical_inline_size, logical_block_size) = if self.is_row_layout() {
             (main_size, cross_size)
         } else {
@@ -2559,9 +2551,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                 as u8,
             lines,
         };
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, self.flex_container)
-            .flex_layout_data = Some(data);
+        self.container_used().rare_data_mut().flex_layout_data = Some(data);
     }
 
     // https://drafts.csswg.org/css-sizing-4/#aspect-ratio-automatic
@@ -2579,7 +2569,7 @@ impl<'pass> FlexFormattingContext<'pass> {
             return None;
         }
         let ratio = self.facts(node).preferred_aspect_ratio()?;
-        let main_size = if self.has_definite_main_size_used(self.container_used()) {
+        let main_size = if self.has_definite_main_size_used(&self.container_used()) {
             self.flex_items[index]
                 .main_size
                 .unwrap_or(self.flex_items[index].flex_base_size)
@@ -2918,8 +2908,8 @@ impl<'pass> FlexFormattingContext<'pass> {
         // 3. If a single-line flex container has a definite cross size,
         //    the automatic preferred outer cross size of any stretched flex items is the flex container’s inner cross size
         //    (clamped to the flex item’s min and max cross size) and is considered definite.
-        if self.is_single_line() && self.has_definite_cross_size_used(self.container_used()) {
-            let container_cross_size = self.inner_cross_size_used(self.container_used());
+        if self.is_single_line() && self.has_definite_cross_size_used(&self.container_used()) {
+            let container_cross_size = self.inner_cross_size_used(&self.container_used());
             for index in 0..self.flex_items.len() {
                 if !self.flex_item_is_stretched(index) {
                     continue;
@@ -2961,7 +2951,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         //               algorithm won't have to shrink anything, thus not needing the minimum size.
         let should_skip_automatic_minimum_size_clamp = self.layout_mode != LayoutMode::IntrinsicSizing
             && self.is_single_line()
-            && self.has_definite_main_size_used(self.container_used())
+            && self.has_definite_main_size_used(&self.container_used())
             && self
                 .flex_items
                 .iter()
@@ -3090,7 +3080,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                 crate::layout::place_child(&self.formatting_context_run(), item.box_, offset, None);
             }
             self.derived_baselines_of_root_box =
-                crate::layout::derive_baselines(self.state, &self.callbacks, self.flex_container, true);
+                crate::layout::derive_baselines(self.state, &self.records, &self.callbacks, self.flex_container, true);
         }
 
         if self.should_collect_devtools_layout_data {

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -174,7 +174,9 @@ struct FlexFormattingContext<'pass> {
     flex_container: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
+    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
     should_collect_devtools_layout_data: bool,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     flex_lines: Vec<FlexLine>,
     flex_items: Vec<FlexItem<'pass>>,
     derived_baselines_of_root_box: DerivedBaselines,
@@ -193,7 +195,9 @@ impl<'pass> FlexFormattingContext<'pass> {
             flex_container: run.box_,
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
+            fragments: run.fragments.clone(),
             should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
             flex_lines: Vec::new(),
             flex_items: Vec::new(),
             derived_baselines_of_root_box: DerivedBaselines::default(),
@@ -202,6 +206,19 @@ impl<'pass> FlexFormattingContext<'pass> {
             available_space: None,
             layout_input: None,
             item_percentage_bases: ContainingBlockConstraints::default(),
+        }
+    }
+
+
+    fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
+        FormattingContextRun {
+            state: self.state,
+            box_: self.flex_container,
+            layout_mode: self.layout_mode,
+            callbacks: self.callbacks,
+            should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            fragments: self.fragments.clone(),
         }
     }
 
@@ -3069,7 +3086,7 @@ impl<'pass> FlexFormattingContext<'pass> {
                         y: item.main_offset,
                     }
                 };
-                crate::layout::place_child(self.state, &self.callbacks, item.box_, offset);
+                crate::layout::place_child(&self.formatting_context_run(), item.box_, offset);
             }
             self.derived_baselines_of_root_box =
                 crate::layout::derive_baselines(self.state, &self.callbacks, self.flex_container, true);

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -2365,6 +2365,7 @@ impl<'pass> FlexFormattingContext<'pass> {
         crate::layout::compute_inset_native(
             self.state,
             self.callbacks,
+            self.fragments.clone(),
             node,
             container_inline_size,
             container_block_size,

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -3109,8 +3109,11 @@ impl<'pass> FlexFormattingContext<'pass> {
                 crate::layout::register_contained_abspos_child(
                     self.state,
                     &self.callbacks,
+                    self.fragments.as_deref(),
+                    self.flex_container,
                     child,
                     self.calculate_static_position_rect(child),
+                    None,
                 );
             }
             child = next;

--- a/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/flex_formatting_context.rs
@@ -3107,7 +3107,6 @@ impl<'pass> FlexFormattingContext<'pass> {
             let facts = self.facts(child);
             if facts.is_box() && facts.is_absolutely_positioned() {
                 crate::layout::register_contained_abspos_child(
-                    self.state,
                     &self.callbacks,
                     self.fragments.as_deref(),
                     self.flex_container,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -77,14 +77,9 @@ fn point_sub(left: FfiCssPixelPoint, right: FfiCssPixelPoint) -> FfiCssPixelPoin
     }
 }
 
-pub(crate) fn translate_static_position_between_chains(
-    mut rect: StaticPositionRect,
-    static_chain_offset: FfiCssPixelPoint,
-    containing_chain_offset: FfiCssPixelPoint,
-) -> StaticPositionRect {
-    let physical_offset = point_sub(static_chain_offset, containing_chain_offset);
-    rect.rect.offset.inline_offset += physical_offset.x;
-    rect.rect.offset.block_offset += physical_offset.y;
+pub(crate) fn translate_static_position_rect(mut rect: StaticPositionRect, offset: FfiCssPixelPoint) -> StaticPositionRect {
+    rect.rect.offset.inline_offset += offset.x;
+    rect.rect.offset.block_offset += offset.y;
     rect
 }
 
@@ -355,12 +350,23 @@ pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCss
     used.seal_committed_box_metrics();
     if let Some(fragments) = run.fragments.as_deref() {
         fragments.normalize_arrivals_for_placement(node);
+        loop {
+            let batch = fragments.take_drainable_abspos(node, callbacks);
+            if batch.is_empty() {
+                break;
+            }
+            let engine = crate::layout::AbsposEngine::new(state, *callbacks);
+            for entry in batch {
+                engine.layout_pending_child(run, entry);
+            }
+        }
         let containing_block = callbacks.containing_block(node);
         let containing_block_is_sealed = !containing_block.is_invalid()
             && state
                 .used_values_by_slot(callbacks.slot_index(containing_block))
                 .is_none_or(|used| used.has_content_offset.get());
         fragments.build_fragment_for_placed_box(
+            callbacks,
             node,
             (!containing_block.is_invalid()).then_some(containing_block),
             used,
@@ -405,42 +411,32 @@ fn committed_offset_delta_at_placement(
 pub(crate) fn register_contained_abspos_child(
     state: &LayoutState,
     callbacks: &FfiLayoutFcCallbacks,
+    fragments: Option<&RunFragmentBuilder>,
+    coordinate_space_box: Node,
     child: Node,
     static_position_rect: StaticPositionRect,
+    containing_block_info_override: Option<AbsposContainingBlockInfo>,
 ) {
-    let mut target = callbacks.containing_block(child);
-    if target.is_invalid() {
+    let Some(fragments) = fragments else {
+        debug_assert!(false, "abspos registration outside a committing run");
+        return;
+    };
+    if callbacks.containing_block(child).is_invalid() {
         return;
     }
     let inline_containing_block = callbacks.inline_containing_block(child);
     if !inline_containing_block.is_invalid() {
         state.note_inline_containing_block(inline_containing_block);
     }
-    loop {
-        let containing_block = callbacks.containing_block(target);
-        let facts = state.node_facts(callbacks, target);
-        if containing_block.is_invalid()
-            || (formatting_context_type_created_by_box(facts).is_some()
-                && !containing_block_geometry_is_finalized_by_the_table_run(state, callbacks, target))
-        {
-            break;
-        }
-        target = containing_block;
-    }
-    state.register_contained_abspos_child(callbacks, target, child, static_position_rect);
-}
-
-fn containing_block_geometry_is_finalized_by_the_table_run(
-    state: &LayoutState,
-    callbacks: &FfiLayoutFcCallbacks,
-    containing_block: Node,
-) -> bool {
-    let facts = state.node_facts(callbacks, containing_block);
-    facts.is_table_cell()
-        || facts.is_table_row()
-        || facts.is_table_row_group()
-        || facts.is_table_header_group()
-        || facts.is_table_footer_group()
+    fragments.register_pending_abspos(
+        coordinate_space_box,
+        PendingAbsposChild {
+            child_box: child,
+            coordinate_space_box,
+            static_position_rect,
+            containing_block_info_override,
+        },
+    );
 }
 
 pub(crate) fn box_baseline(
@@ -1204,6 +1200,8 @@ fn register_table_abspos_descendants(run: &FormattingContextRun, parent: Node) {
                 register_contained_abspos_child(
                     run.state,
                     &run.callbacks,
+                    run.fragments.as_deref(),
+                    run.box_,
                     child,
                     StaticPositionRect {
                         rect: Default::default(),
@@ -1211,6 +1209,7 @@ fn register_table_abspos_descendants(run: &FormattingContextRun, parent: Node) {
                         block_alignment: StaticPositionAlignment::Start,
                         alignment_derives_from_own_computed_values: false,
                     },
+                    None,
                 );
             }
             if formatting_context_type_created_by_box(facts).is_none() {
@@ -1549,7 +1548,11 @@ fn run_formatting_context<'pass>(
         ParticipationInParentFormattingContext::Root => {}
     }
 
-    let take_root = || run.fragments.as_ref().map(|fragments| fragments.take_unplaced_root(run.state));
+    let take_root = || {
+        run.fragments
+            .as_ref()
+            .map(|fragments| fragments.take_unplaced_root(run.state, &run.callbacks))
+    };
 
     let registered_abspos_children_could_never_be_laid_out = run.fragments.is_none();
     if registered_abspos_children_could_never_be_laid_out {
@@ -1573,7 +1576,6 @@ fn run_formatting_context<'pass>(
             return run.outputs(result, take_root());
         }
     }
-    layout_contained_abspos_children(run);
     run.state.used_values(&run.callbacks, run.box_).seal_own_metrics();
     run.outputs(result, take_root())
 }
@@ -1844,14 +1846,8 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
         place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default());
-        drain_remaining_abspos_targets(
-            state_ref,
-            callbacks,
-            should_collect_devtools_layout_data,
-            &[root, root_for_layout],
-            &entry_fragments,
-        );
-        let pass_fragments = entry_fragments.take_completed_pass(state_ref);
+        drain_abspos_with_placed_containing_blocks(state_ref, callbacks, should_collect_devtools_layout_data, &entry_fragments);
+        let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
         debug_assert!(!pass_fragments.roots.is_empty(), "the run root always has a fragment");
         state.commit_replacing(root, std::ptr::null_mut(), &callbacks, sink);
     });
@@ -1927,9 +1923,10 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             debug_assert!(unplaced_root.node == root, "the subtree run returned a root for a different box");
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
-        entry_fragments.build_fragment_for_placed_box(root, None, root_used, false, None);
-        drain_remaining_abspos_targets(state_ref, callbacks, false, &[viewport, root], &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass(state_ref);
+        entry_fragments.normalize_arrivals_for_placement(root);
+        entry_fragments.build_fragment_for_placed_box(&callbacks, root, None, root_used, false, None);
+        drain_abspos_with_placed_containing_blocks(state_ref, callbacks, false, &entry_fragments);
+        let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
         debug_assert!(!pass_fragments.roots.is_empty(), "the subtree root always has a fragment");
         state.commit_replacing(root, paintable_to_replace, &callbacks, sink);
     });
@@ -1969,8 +1966,8 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
             fragments: Some(entry_fragments.clone()),
         };
         AbsposEngine::new(state_ref, callbacks).replay(&run, box_);
-        drain_remaining_abspos_targets(state_ref, callbacks, false, &[containing_block], &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass(state_ref);
+        drain_abspos_with_placed_containing_blocks(state_ref, callbacks, false, &entry_fragments);
+        let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
         debug_assert!(!pass_fragments.roots.is_empty(), "the replayed box always has a fragment");
         state.commit_replacing(box_, paintable_to_replace, &callbacks, sink);
     });

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -83,19 +83,6 @@ pub(crate) fn translate_static_position_rect(mut rect: StaticPositionRect, offse
     rect
 }
 
-pub(crate) fn anchor_rect_from_geometry(
-    anchor_state: &UsedValues,
-    containing_block_state: &UsedValues,
-    anchor_offset: FfiCssPixelPoint,
-) -> PhysicalRect {
-    let collapsed = anchor_state.uses_collapsing_borders_model.get();
-    PhysicalRect {
-        x: anchor_offset.x - anchor_state.border_box_left(collapsed) + containing_block_state.padding_left.get(),
-        y: anchor_offset.y - anchor_state.border_box_top(collapsed) + containing_block_state.padding_top.get(),
-        width: anchor_state.border_box_inline_size(collapsed),
-        height: anchor_state.border_box_block_size(collapsed),
-    }
-}
 
 pub(crate) type Node = NodeSlotId;
 
@@ -355,7 +342,7 @@ pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCss
             if batch.is_empty() {
                 break;
             }
-            let engine = crate::layout::AbsposEngine::new(state, *callbacks);
+            let engine = crate::layout::AbsposEngine::new(state, *callbacks, run.fragments.clone());
             for entry in batch {
                 engine.layout_pending_child(run, entry);
             }
@@ -365,6 +352,17 @@ pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCss
             && state
                 .used_values_by_slot(callbacks.slot_index(containing_block))
                 .is_none_or(|used| used.has_content_offset.get());
+        let node_facts = state.node_facts(callbacks, node);
+        let own_anchor_candidate_border_box_rect = (node_facts.is_box() && node_facts.has_anchor_names())
+            .then(|| {
+                let collapsed = used.uses_collapsing_borders_model.get();
+                PhysicalRect {
+                    x: used.content_offset.get().x - used.border_box_left(collapsed),
+                    y: used.content_offset.get().y - used.border_box_top(collapsed),
+                    width: used.border_box_inline_size(collapsed),
+                    height: used.border_box_block_size(collapsed),
+                }
+            });
         fragments.build_fragment_for_placed_box(
             callbacks,
             node,
@@ -372,6 +370,7 @@ pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCss
             used,
             containing_block_is_sealed,
             state.containing_line_box_index(callbacks, node, used),
+            own_anchor_candidate_border_box_rect,
         );
     }
 }
@@ -1270,7 +1269,7 @@ fn apply_root_sizing_directives(
             body_input_with_inner_available_space(run, input)
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::new(run.state, run.callbacks).dimension_out_of_flow_root(run.box_, abspos_inputs);
+            AbsposEngine::new(run.state, run.callbacks, run.fragments.clone()).dimension_out_of_flow_root(run.box_, abspos_inputs);
             body_input_with_inner_available_space(run, input)
         }
         ParticipationInParentFormattingContext::Item => {
@@ -1382,7 +1381,7 @@ fn size_skipped_independent_root(
             parent.finalize_float_root(child, input, None);
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            let engine = AbsposEngine::new(run.state, run.callbacks);
+            let engine = AbsposEngine::new(run.state, run.callbacks, run.fragments.clone());
             engine.dimension_out_of_flow_root(child, abspos_inputs);
             engine.finalize_out_of_flow_root_after_inside_layout(child, abspos_inputs, None);
         }
@@ -1531,7 +1530,7 @@ fn run_formatting_context<'pass>(
             );
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::new(run.state, run.callbacks).finalize_out_of_flow_root_after_inside_layout(
+            AbsposEngine::new(run.state, run.callbacks, run.fragments.clone()).finalize_out_of_flow_root_after_inside_layout(
                 run.box_,
                 abspos_inputs,
                 Some(result.automatic_content_block_size),
@@ -1922,7 +1921,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
         entry_fragments.normalize_arrivals_for_placement(root);
-        entry_fragments.build_fragment_for_placed_box(&callbacks, root, None, root_used, false, None);
+        entry_fragments.build_fragment_for_placed_box(&callbacks, root, None, root_used, false, None, None);
         drain_abspos_with_placed_containing_blocks(state_ref, callbacks, false, &entry_fragments);
         let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
         debug_assert!(!pass_fragments.roots.is_empty(), "the subtree root always has a fragment");
@@ -1963,7 +1962,7 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
             treat_block_axis_percentage_insets_as_auto_beyond_root: false,
             fragments: Some(entry_fragments.clone()),
         };
-        AbsposEngine::new(state_ref, callbacks).replay(&run, box_);
+        AbsposEngine::new(state_ref, callbacks, Some(entry_fragments.clone())).replay(&run, box_);
         drain_abspos_with_placed_containing_blocks(state_ref, callbacks, false, &entry_fragments);
         let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
         debug_assert!(!pass_fragments.roots.is_empty(), "the replayed box always has a fragment");

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -193,6 +193,7 @@ impl MeasurementState {
             input,
             None,
         )
+        .result
     }
 
     pub(crate) fn layout_state(&self) -> &LayoutState {
@@ -342,12 +343,9 @@ pub(crate) enum BaselineSet {
     Last,
 }
 
-pub(crate) fn place_child(
-    state: &LayoutState,
-    callbacks: &FfiLayoutFcCallbacks,
-    node: Node,
-    offset: FfiCssPixelPoint,
-) {
+pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCssPixelPoint) {
+    let state = run.state;
+    let callbacks = &run.callbacks;
     let used = state.used_values(callbacks, node);
     assert!(!used.has_content_offset.get());
     used.has_content_offset.set(true);
@@ -355,6 +353,19 @@ pub(crate) fn place_child(
     used.committed_offset_delta
         .set(committed_offset_delta_at_placement(state, callbacks, node, used));
     used.seal_committed_box_metrics();
+    if let Some(fragments) = run.fragments.as_deref() {
+        fragments.normalize_arrivals_for_placement(node);
+        let containing_block = callbacks.containing_block(node);
+        let containing_block_is_sealed = !containing_block.is_invalid()
+            && state
+                .used_values_by_slot(callbacks.slot_index(containing_block))
+                .is_none_or(|used| used.has_content_offset.get());
+        fragments.build_fragment_for_placed_box(
+            node,
+            (!containing_block.is_invalid()).then_some(containing_block),
+            containing_block_is_sealed,
+        );
+    }
 }
 
 fn committed_offset_delta_at_placement(
@@ -725,6 +736,11 @@ pub(crate) struct ChildLayoutResult {
     pub table_box_in_wrapper_border_box_block_size: Option<CssPixels>,
 }
 
+pub(crate) struct RunOutputs {
+    pub(crate) result: ChildLayoutResult,
+    pub(crate) root: Option<UnplacedRootFragment>,
+}
+
 pub(crate) enum ChildLayoutOutcome {
     Skipped,
     Created(ChildLayoutResult),
@@ -1036,25 +1052,12 @@ pub(crate) struct FormattingContextRun<'pass> {
     pub(crate) callbacks: FfiLayoutFcCallbacks,
     pub(crate) should_collect_devtools_layout_data: bool,
     pub(crate) treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
+    pub(crate) fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
 }
 
-impl<'pass> FormattingContextRun<'pass> {
-    pub(crate) fn new(
-        state: &'pass LayoutState,
-        box_: Node,
-        layout_mode: LayoutMode,
-        callbacks: FfiLayoutFcCallbacks,
-        should_collect_devtools_layout_data: bool,
-        treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
-    ) -> Self {
-        Self {
-            state,
-            box_,
-            layout_mode,
-            callbacks,
-            should_collect_devtools_layout_data,
-            treat_block_axis_percentage_insets_as_auto_beyond_root,
-        }
+impl FormattingContextRun<'_> {
+    pub(crate) fn outputs(&self, result: ChildLayoutResult, root: Option<UnplacedRootFragment>) -> RunOutputs {
+        RunOutputs { result, root }
     }
 }
 
@@ -1173,28 +1176,15 @@ fn create_formatting_context_implementation<'pass>(
     fc_type: FfiFormattingContextType,
 ) -> FormattingContextImplementation<'pass> {
     match fc_type {
-        FfiFormattingContextType::Block => FormattingContextImplementation::Block(Box::new(BlockFormattingContext::new(
-            run.state,
-            run.box_,
-            run.layout_mode,
-            run.callbacks,
-        ))),
+        FfiFormattingContextType::Block => {
+            FormattingContextImplementation::Block(Box::new(BlockFormattingContext::new(run)))
+        }
         FfiFormattingContextType::Flex => FormattingContextImplementation::Flex(Box::new(FlexFormattingContext::new(run))),
-        FfiFormattingContextType::Grid => FormattingContextImplementation::Grid(Box::new(GridFormattingContext::new(
-            run.state,
-            run.box_,
-            parent_grid,
-            run.layout_mode,
-            run.callbacks,
-            run.should_collect_devtools_layout_data,
-        ))),
+        FfiFormattingContextType::Grid => {
+            FormattingContextImplementation::Grid(Box::new(GridFormattingContext::new(run, parent_grid)))
+        }
         FfiFormattingContextType::Table => FormattingContextImplementation::Table(Box::new(TableFormattingContext::new(run))),
-        FfiFormattingContextType::Svg => FormattingContextImplementation::Svg(Box::new(SvgFormattingContext::new(
-            run.state,
-            run.box_,
-            run.layout_mode,
-            run.callbacks,
-        ))),
+        FfiFormattingContextType::Svg => FormattingContextImplementation::Svg(Box::new(SvgFormattingContext::new(run))),
         FfiFormattingContextType::ReplacedWithChildren => FormattingContextImplementation::ReplacedWithChildren,
         FfiFormattingContextType::InternalReplaced => FormattingContextImplementation::InternalReplaced,
         FfiFormattingContextType::InternalDummy => FormattingContextImplementation::InternalDummy,
@@ -1422,16 +1412,23 @@ fn run_formatting_context<'pass>(
     callbacks: FfiLayoutFcCallbacks,
     input: LayoutInput,
     parent_block: Option<&BlockFormattingContext<'pass>>,
-) -> ChildLayoutResult {
+) -> RunOutputs {
     assert!(!box_.is_invalid());
-    let run = FormattingContextRun::new(
+    let run = FormattingContextRun {
         state,
         box_,
         layout_mode,
         callbacks,
         should_collect_devtools_layout_data,
-        input.sizing.treat_block_axis_percentage_insets_as_auto_beyond_root,
-    );
+        treat_block_axis_percentage_insets_as_auto_beyond_root: input.sizing.treat_block_axis_percentage_insets_as_auto_beyond_root,
+        fragments: (layout_mode == LayoutMode::Normal && !state.is_measurement()).then(|| {
+            let root_containing_block = callbacks.containing_block(box_);
+            std::rc::Rc::new(RunFragmentBuilder::new(
+                box_,
+                (!root_containing_block.is_invalid()).then_some(root_containing_block),
+            ))
+        }),
+    };
     let run = &run;
     let body_input = apply_root_sizing_directives(run, &input, parent_block);
 
@@ -1550,10 +1547,11 @@ fn run_formatting_context<'pass>(
         ParticipationInParentFormattingContext::Root => {}
     }
 
-    let registered_abspos_children_could_never_be_laid_out =
-        run.layout_mode != LayoutMode::Normal || run.state.is_measurement();
+    let take_root = || run.fragments.as_ref().map(|fragments| fragments.take_unplaced_root());
+
+    let registered_abspos_children_could_never_be_laid_out = run.fragments.is_none();
     if registered_abspos_children_could_never_be_laid_out {
-        return result;
+        return run.outputs(result, take_root());
     }
     let implementation = implementation.expect("cached measurement replay only occurs on measurement states");
     match &implementation {
@@ -1569,11 +1567,13 @@ fn run_formatting_context<'pass>(
             context.parent_did_dimension();
         }
         FormattingContextImplementation::Svg(_) | FormattingContextImplementation::ReplacedWithChildren => {}
-        FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => return result,
+        FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => {
+            return run.outputs(result, take_root());
+        }
     }
     layout_contained_abspos_children(run);
     run.state.used_values(&run.callbacks, run.box_).seal_own_metrics();
-    result
+    run.outputs(result, take_root())
 }
 
 fn finalize_atomic_root_block_size(
@@ -1678,7 +1678,7 @@ pub(crate) fn layout_inside_child<'pass>(
             run.box_,
             run.treat_block_axis_percentage_insets_as_auto_beyond_root,
         );
-    ChildLayoutOutcome::Created(run_formatting_context(
+    let outputs = run_formatting_context(
         run.state,
         child,
         parent_grid,
@@ -1688,7 +1688,20 @@ pub(crate) fn layout_inside_child<'pass>(
         run.callbacks,
         input,
         parent_block,
-    ))
+    );
+    ChildLayoutOutcome::Created(hold_unplaced_root_and_take_result(run.fragments.as_deref(), child, outputs))
+}
+
+pub(crate) fn hold_unplaced_root_and_take_result(
+    parent_fragments: Option<&RunFragmentBuilder>,
+    child: Node,
+    outputs: RunOutputs,
+) -> ChildLayoutResult {
+    if let (Some(fragments), Some(root)) = (parent_fragments, outputs.root) {
+        debug_assert!(root.node == child, "a child run returned a root for a different box");
+        fragments.hold_unplaced_root(root);
+    }
+    outputs.result
 }
 
 fn independent_formatting_context_type(
@@ -1782,13 +1795,23 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             ..crate::layout::ContainingBlockConstraints::default()
         };
         let viewport_used = state.create_used_values(&callbacks, root, root_constraints);
+        let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));
+        let entry_run = FormattingContextRun {
+            state: &state,
+            box_: root,
+            layout_mode: LayoutMode::Normal,
+            callbacks,
+            should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+            fragments: Some(entry_fragments.clone()),
+        };
 
         let mut root_for_layout = root;
         let first_child = callbacks.first_child(root);
         if !first_child.is_invalid() && state.node_facts(&callbacks, first_child).is_svg_svg_box() {
             viewport_used.set_content_inline_size(viewport_inline_size);
             viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&state, &callbacks, root, FfiCssPixelPoint::default());
+            place_child(&entry_run, root, FfiCssPixelPoint::default());
             state.create_used_values(&callbacks, first_child, root_constraints);
             root_for_layout = first_child;
         }
@@ -1803,7 +1826,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
         .with_forced_sizes(viewport_inline_size, viewport_block_size);
         let state_ref = &state;
         let fc_type = independent_formatting_context_type(state_ref, root_for_layout, &callbacks);
-        run_formatting_context(
+        let outputs = run_formatting_context(
             state_ref,
             root_for_layout,
             None,
@@ -1814,13 +1837,20 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             input,
             None,
         );
-        place_child(&state, &callbacks, root_for_layout, FfiCssPixelPoint::default());
+        if let Some(unplaced_root) = outputs.root {
+            debug_assert!(unplaced_root.node == root_for_layout, "the entry run returned a root for a different box");
+            entry_fragments.hold_unplaced_root(unplaced_root);
+        }
+        place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default());
         drain_remaining_abspos_targets(
             state_ref,
             callbacks,
             should_collect_devtools_layout_data,
             &[root, root_for_layout],
+            &entry_fragments,
         );
+        let pass_fragments = entry_fragments.take_completed_pass();
+        debug_assert!(!pass_fragments.roots.is_empty(), "the run root always has a fragment");
         state.commit_replacing(root, std::ptr::null_mut(), &callbacks, sink);
     });
 }
@@ -1852,6 +1882,16 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let root_used = state
             .populate_from_paintable(&callbacks, root, paintable_to_replace)
             .expect("partial relayout root must have committed geometry");
+        let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));
+        let entry_run = FormattingContextRun {
+            state: &state,
+            box_: root,
+            layout_mode: LayoutMode::Normal,
+            callbacks,
+            should_collect_devtools_layout_data: false,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+            fragments: Some(entry_fragments.clone()),
+        };
         if !viewport.is_invalid() && viewport != root {
             let viewport_inline_size = CssPixels::from_raw(viewport_inline_size_raw);
             let viewport_block_size = CssPixels::from_raw(viewport_block_size_raw);
@@ -1863,7 +1903,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             let viewport_used = state.create_used_values(&callbacks, viewport, viewport_constraints);
             viewport_used.set_content_inline_size(viewport_inline_size);
             viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&state, &callbacks, viewport, FfiCssPixelPoint::default());
+            place_child(&entry_run, viewport, FfiCssPixelPoint::default());
         }
         let input = LayoutInput::new(
             AvailableSpace {
@@ -1880,8 +1920,14 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let facts = state.node_facts(&callbacks, root);
         let fc_type = formatting_context_type_created_by_box(facts)
             .expect("partial relayout root must establish an independent formatting context");
-        run_formatting_context(state_ref, root, None, fc_type, LayoutMode::Normal, false, callbacks, input, None);
-        drain_remaining_abspos_targets(state_ref, callbacks, false, &[viewport, root]);
+        let outputs = run_formatting_context(state_ref, root, None, fc_type, LayoutMode::Normal, false, callbacks, input, None);
+        if let Some(unplaced_root) = outputs.root {
+            debug_assert!(unplaced_root.node == root, "the subtree run returned a root for a different box");
+            entry_fragments.hold_unplaced_root(unplaced_root);
+        }
+        drain_remaining_abspos_targets(state_ref, callbacks, false, &[viewport, root], &entry_fragments);
+        let pass_fragments = entry_fragments.take_completed_pass();
+        debug_assert!(!pass_fragments.roots.is_empty(), "the subtree root always has a fragment");
         state.commit_replacing(root, paintable_to_replace, &callbacks, sink);
     });
 }
@@ -1909,9 +1955,20 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         let state_ref = &state;
         let containing_block = callbacks.containing_block(box_);
         assert!(!containing_block.is_invalid());
-        let run = crate::layout::FormattingContextRun::new(state_ref, containing_block, LayoutMode::Normal, callbacks, false, false);
+        let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(containing_block));
+        let run = crate::layout::FormattingContextRun {
+            state: state_ref,
+            box_: containing_block,
+            layout_mode: LayoutMode::Normal,
+            callbacks,
+            should_collect_devtools_layout_data: false,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+            fragments: Some(entry_fragments.clone()),
+        };
         AbsposEngine::new(state_ref, callbacks).replay(&run, box_);
-        drain_remaining_abspos_targets(state_ref, callbacks, false, &[containing_block]);
+        drain_remaining_abspos_targets(state_ref, callbacks, false, &[containing_block], &entry_fragments);
+        let pass_fragments = entry_fragments.take_completed_pass();
+        debug_assert!(!pass_fragments.roots.is_empty(), "the replayed box always has a fragment");
         state.commit_replacing(box_, paintable_to_replace, &callbacks, sink);
     });
 }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -325,15 +325,18 @@ pub(crate) enum BaselineSet {
     Last,
 }
 
-pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCssPixelPoint) {
+pub(crate) fn place_child(
+    run: &FormattingContextRun,
+    node: Node,
+    offset: FfiCssPixelPoint,
+    containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
+) {
     let state = run.state;
     let callbacks = &run.callbacks;
     let used = state.used_values(callbacks, node);
     assert!(!used.has_content_offset.get());
     used.has_content_offset.set(true);
     used.content_offset.set(offset);
-    used.committed_offset_delta
-        .set(committed_offset_delta_at_placement(state, callbacks, node, used));
     used.seal_committed_box_metrics();
     if let Some(fragments) = run.fragments.as_deref() {
         fragments.normalize_arrivals_for_placement(node);
@@ -369,7 +372,8 @@ pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCss
             (!containing_block.is_invalid()).then_some(containing_block),
             used,
             containing_block_is_sealed,
-            state.containing_line_box_index(callbacks, node, used),
+            state.resolve_containing_line_box_index(callbacks, node, containing_line_box_fragment, offset),
+            point_add(offset, committed_offset_delta_at_placement(state, callbacks, node, used)),
             own_anchor_candidate_border_box_rect,
         );
     }
@@ -1827,7 +1831,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
         if !first_child.is_invalid() && state.node_facts(&callbacks, first_child).is_svg_svg_box() {
             viewport_used.set_content_inline_size(viewport_inline_size);
             viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&entry_run, root, FfiCssPixelPoint::default());
+            place_child(&entry_run, root, FfiCssPixelPoint::default(), None);
             state.create_used_values(&callbacks, first_child, root_constraints);
             root_for_layout = first_child;
         }
@@ -1857,7 +1861,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             debug_assert!(unplaced_root.node == root_for_layout, "the entry run returned a root for a different box");
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
-        place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default());
+        place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default(), None);
         drain_and_commit_entry_pass(
             &state,
             &entry_fragments,
@@ -1918,7 +1922,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             let viewport_used = state.create_used_values(&callbacks, viewport, viewport_constraints);
             viewport_used.set_content_inline_size(viewport_inline_size);
             viewport_used.set_content_block_size(viewport_block_size);
-            place_child(&entry_run, viewport, FfiCssPixelPoint::default());
+            place_child(&entry_run, viewport, FfiCssPixelPoint::default(), None);
         }
         let input = LayoutInput::new(
             AvailableSpace {
@@ -1941,7 +1945,16 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
         entry_fragments.normalize_arrivals_for_placement(root);
-        entry_fragments.build_fragment_for_placed_box(&callbacks, root, None, root_used, false, None, None);
+        entry_fragments.build_fragment_for_placed_box(
+            &callbacks,
+            root,
+            None,
+            root_used,
+            false,
+            None,
+            root_used.content_offset.get(),
+            None,
+        );
         drain_and_commit_entry_pass(
             &state,
             &entry_fragments,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -409,7 +409,6 @@ fn committed_offset_delta_at_placement(
 }
 
 pub(crate) fn register_contained_abspos_child(
-    state: &LayoutState,
     callbacks: &FfiLayoutFcCallbacks,
     fragments: Option<&RunFragmentBuilder>,
     coordinate_space_box: Node,
@@ -425,9 +424,7 @@ pub(crate) fn register_contained_abspos_child(
         return;
     }
     let inline_containing_block = callbacks.inline_containing_block(child);
-    if !inline_containing_block.is_invalid() {
-        state.note_inline_containing_block(inline_containing_block);
-    }
+
     fragments.register_pending_abspos(
         coordinate_space_box,
         PendingAbsposChild {
@@ -435,6 +432,8 @@ pub(crate) fn register_contained_abspos_child(
             coordinate_space_box,
             static_position_rect,
             containing_block_info_override,
+            inline_containing_block,
+            inline_containing_block_rect: None,
         },
     );
 }
@@ -1198,7 +1197,6 @@ fn register_table_abspos_descendants(run: &FormattingContextRun, parent: Node) {
         if facts.is_box() {
             if facts.is_absolutely_positioned() {
                 register_contained_abspos_child(
-                    run.state,
                     &run.callbacks,
                     run.fragments.as_deref(),
                     run.box_,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -1572,6 +1572,7 @@ fn run_formatting_context<'pass>(
         FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => return result,
     }
     layout_contained_abspos_children(run);
+    run.state.used_values(&run.callbacks, run.box_).seal_own_metrics();
     result
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -83,7 +83,6 @@ pub(crate) fn translate_static_position_rect(mut rect: StaticPositionRect, offse
     rect
 }
 
-
 pub(crate) type Node = NodeSlotId;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -134,38 +133,32 @@ pub(crate) enum TableWrapperInlineSizeMode {
 pub(crate) struct MeasurementState {
     state: LayoutState,
     callbacks: FfiLayoutFcCallbacks,
-    root: Node,
 }
 
 impl MeasurementState {
-    pub(crate) fn create(callbacks: FfiLayoutFcCallbacks, node: Node, constraints: ContainingBlockConstraints) -> Self {
-        let state = LayoutState::new(LayoutStatePurpose::Measurement);
-        state.create_used_values(&callbacks, node, constraints);
+    pub(crate) fn create(callbacks: FfiLayoutFcCallbacks) -> Self {
         Self {
-            state,
+            state: LayoutState::new(LayoutStatePurpose::Measurement),
             callbacks,
-            root: node,
         }
     }
 
-    pub(crate) fn root_used(&self) -> &UsedValues {
-        self.state.used_values(&self.callbacks, self.root)
-    }
-
-    fn run(&self, node: Node, input: LayoutInput) -> crate::layout::ChildLayoutResult {
-        self.run_with_layout_mode(node, LayoutMode::IntrinsicSizing, input)
+    fn run(&self, node: Node, node_used: std::rc::Rc<UsedValues>, input: LayoutInput) -> ChildLayoutResult {
+        self.run_with_layout_mode(node, node_used, LayoutMode::IntrinsicSizing, input).result
     }
 
     pub(crate) fn run_with_layout_mode(
         &self,
         node: Node,
+        node_used: std::rc::Rc<UsedValues>,
         layout_mode: LayoutMode,
         input: LayoutInput,
-    ) -> crate::layout::ChildLayoutResult {
+    ) -> RunOutputs {
         let layout_state = self.layout_state();
         let fc_type = crate::layout::independent_formatting_context_type(layout_state, node, &self.callbacks);
         crate::layout::run_formatting_context(
             layout_state,
+            node_used,
             node,
             None,
             fc_type,
@@ -175,7 +168,6 @@ impl MeasurementState {
             input,
             None,
         )
-        .result
     }
 
     pub(crate) fn layout_state(&self) -> &LayoutState {
@@ -184,6 +176,10 @@ impl MeasurementState {
 
     pub(crate) fn callbacks(&self) -> &FfiLayoutFcCallbacks {
         &self.callbacks
+    }
+
+    pub(crate) fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> std::rc::Rc<UsedValues> {
+        self.state.create_used_values(&self.callbacks, node, constraints)
     }
 }
 
@@ -332,29 +328,31 @@ pub(crate) fn place_child(
     containing_line_box_fragment: Option<LineBoxFragmentCoordinate>,
 ) {
     let state = run.state;
+    let records = &*run.records;
     let callbacks = &run.callbacks;
-    let used = state.used_values(callbacks, node);
+    let fragments = run.fragments.as_deref();
+    let used = records.used_values(node);
     assert!(!used.has_content_offset.get());
     used.has_content_offset.set(true);
     used.content_offset.set(offset);
     used.seal_committed_box_metrics();
-    if let Some(fragments) = run.fragments.as_deref() {
+    if let Some(fragments) = fragments {
         fragments.normalize_arrivals_for_placement(node);
         loop {
-            let batch = fragments.take_drainable_abspos(node, callbacks);
+            let batch = fragments.take_drainable_abspos(node, records, callbacks);
             if batch.is_empty() {
                 break;
             }
-            let engine = crate::layout::AbsposEngine::new(state, *callbacks, run.fragments.clone());
+            let engine = crate::layout::AbsposEngine::for_run(run);
             for entry in batch {
                 engine.layout_pending_child(run, entry);
             }
         }
         let containing_block = callbacks.containing_block(node);
         let containing_block_is_sealed = !containing_block.is_invalid()
-            && state
-                .used_values_by_slot(callbacks.slot_index(containing_block))
-                .is_none_or(|used| used.has_content_offset.get());
+            && records
+                .used_values_if_owned(containing_block)
+                .is_none_or(|containing_block_used| containing_block_used.has_content_offset.get());
         let node_facts = state.node_facts(callbacks, node);
         let own_anchor_candidate_border_box_rect = (node_facts.is_box() && node_facts.has_anchor_names())
             .then(|| {
@@ -370,10 +368,13 @@ pub(crate) fn place_child(
             callbacks,
             node,
             (!containing_block.is_invalid()).then_some(containing_block),
-            used,
+            &used,
             containing_block_is_sealed,
-            state.resolve_containing_line_box_index(callbacks, node, containing_line_box_fragment, offset),
-            point_add(offset, committed_offset_delta_at_placement(state, callbacks, node, used)),
+            state.resolve_containing_line_box_index(records, callbacks, node, containing_block, containing_line_box_fragment, offset),
+            point_add(
+                offset,
+                committed_offset_delta_at_placement(state, records, callbacks, node, containing_block, &used),
+            ),
             own_anchor_candidate_border_box_rect,
         );
     }
@@ -381,8 +382,10 @@ pub(crate) fn place_child(
 
 fn committed_offset_delta_at_placement(
     state: &LayoutState,
+    records: &RunRecords,
     callbacks: &FfiLayoutFcCallbacks,
     node: Node,
+    containing_block: Node,
     used: &UsedValues,
 ) -> FfiCssPixelPoint {
     let mut delta = FfiCssPixelPoint::default();
@@ -399,9 +402,10 @@ fn committed_offset_delta_at_placement(
     }
     if facts.is_in_flow() && facts.display().is_block_outside() {
         let chain = state.accumulated_relative_insets_from_inline_ancestor_chain(
+            records,
             callbacks,
             callbacks.parent(node),
-            callbacks.containing_block(node),
+            containing_block,
         );
         if chain.found_fragmented_inline_node {
             delta.x += chain.offset_x;
@@ -420,14 +424,12 @@ pub(crate) fn register_contained_abspos_child(
     containing_block_info_override: Option<AbsposContainingBlockInfo>,
 ) {
     let Some(fragments) = fragments else {
-        debug_assert!(false, "abspos registration outside a committing run");
         return;
     };
     if callbacks.containing_block(child).is_invalid() {
         return;
     }
     let inline_containing_block = callbacks.inline_containing_block(child);
-
     fragments.register_pending_abspos(
         coordinate_space_box,
         PendingAbsposChild {
@@ -572,17 +574,19 @@ pub(crate) fn store_derived_baselines(used: &UsedValues, baselines: DerivedBasel
 
 pub(crate) fn derive_baselines(
     state: &LayoutState,
+    records: &RunRecords,
     callbacks: &FfiLayoutFcCallbacks,
     box_: Node,
     inhibits_floating: bool,
 ) -> DerivedBaselines {
     let facts = state.node_facts(callbacks, box_);
-    let slot_index = callbacks.slot_index(box_);
-    let line_count = state.line_data(slot_index).map_or(0, |data| data.line_boxes.len());
+    let own_used = records.used_values(box_);
+    let own_line_data = own_used.line_data_ref();
+    let line_count = own_line_data.as_ref().map_or(0, |data| data.line_boxes.len());
     if line_count > 0 {
         let baseline_for_line_box = |line_index: usize, baseline_set: BaselineSet| -> CssPixels {
             let (has_block_level_box, block_start, baseline, fragment_count, fragment_node) = {
-                let line = &state.line_data(slot_index).unwrap().line_boxes[line_index];
+                let line = &own_line_data.as_ref().unwrap().line_boxes[line_index];
                 (
                     line.has_block_level_box,
                     line.physical_vertical_end() - line.block_length,
@@ -597,15 +601,15 @@ pub(crate) fn derive_baselines(
 
             assert_eq!(fragment_count, 1);
             let fragment_node = fragment_node.expect("block-level line must have one fragment");
-            let block_child_state = state.used_values(callbacks, fragment_node);
+            let block_child_state = records.used_values(fragment_node);
             let child_offset_from_margin_edge = block_child_state.content_offset.get().y
                 - block_child_state.margin_box_top(block_child_state.uses_collapsing_borders_model.get());
-            child_offset_from_margin_edge + box_baseline(state, callbacks, fragment_node, block_child_state, baseline_set)
+            child_offset_from_margin_edge + box_baseline(state, callbacks, fragment_node, &block_child_state, baseline_set)
         };
 
         let mut first_line_index = 0;
         while first_line_index < line_count {
-            let is_empty = state.line_data(slot_index).unwrap().line_boxes[first_line_index].is_empty();
+            let is_empty = own_line_data.as_ref().unwrap().line_boxes[first_line_index].is_empty();
             if !is_empty {
                 break;
             }
@@ -618,7 +622,7 @@ pub(crate) fn derive_baselines(
 
         let mut last_line_index = line_count - 1;
         while last_line_index > 0 {
-            let is_empty = state.line_data(slot_index).unwrap().line_boxes[last_line_index].is_empty();
+            let is_empty = own_line_data.as_ref().unwrap().line_boxes[last_line_index].is_empty();
             if !is_empty {
                 break;
             }
@@ -668,7 +672,7 @@ pub(crate) fn derive_baselines(
             if container_skips_anonymous_whitespace_runs && callbacks.can_skip_is_anonymous_text_run(child) {
                 continue;
             }
-            let child_state = state.used_values(callbacks, child);
+            let child_state = records.used_values(child);
             match baseline_set {
                 BaselineSet::First if child_state.has_first_baseline.get() => {}
                 BaselineSet::Last if child_state.has_last_baseline.get() => {}
@@ -676,7 +680,7 @@ pub(crate) fn derive_baselines(
             }
             let child_offset_from_margin_edge = child_state.content_offset.get().y
                 - child_state.margin_box_top(child_state.uses_collapsing_borders_model.get());
-            return Some(child_offset_from_margin_edge + box_baseline(state, callbacks, child, child_state, baseline_set));
+            return Some(child_offset_from_margin_edge + box_baseline(state, callbacks, child, &child_state, baseline_set));
         }
         None
     };
@@ -1047,6 +1051,7 @@ impl FfiLayoutFcCallbacks {
 
 pub(crate) struct FormattingContextRun<'pass> {
     pub(crate) state: &'pass LayoutState,
+    pub(crate) records: std::rc::Rc<RunRecords>,
     pub(crate) box_: Node,
     pub(crate) layout_mode: LayoutMode,
     pub(crate) callbacks: FfiLayoutFcCallbacks,
@@ -1055,7 +1060,11 @@ pub(crate) struct FormattingContextRun<'pass> {
     pub(crate) fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
 }
 
-impl FormattingContextRun<'_> {
+impl<'pass> FormattingContextRun<'pass> {
+    pub(crate) fn sizing(&self) -> SizingContext<'pass> {
+        SizingContext::new(self.state, self.records.clone(), self.callbacks)
+    }
+
     pub(crate) fn outputs(&self, result: ChildLayoutResult, root: Option<UnplacedRootFragment>) -> RunOutputs {
         RunOutputs { result, root }
     }
@@ -1225,6 +1234,7 @@ fn register_table_abspos_descendants(run: &FormattingContextRun, parent: Node) {
 
 pub(crate) fn independent_root_automatic_block_size(
     state: &LayoutState,
+    records: &std::rc::Rc<RunRecords>,
     callbacks: &FfiLayoutFcCallbacks,
     node: Node,
     available_inner_space: AvailableSpace,
@@ -1241,7 +1251,7 @@ pub(crate) fn independent_root_automatic_block_size(
         // max-content size.
         // https://drafts.csswg.org/css-flexbox-1/#algo-main-container
         // https://www.w3.org/TR/css-grid-2/#intrinsic-sizes
-        return SizingContext::new(state, *callbacks).calculate_max_content_block_size(
+        return SizingContext::new(state, records.clone(), *callbacks).calculate_max_content_block_size(
             node,
             available_inner_space.inline_size.to_px_or_zero(),
             constraints,
@@ -1264,7 +1274,7 @@ fn apply_root_sizing_directives(
             body_input_with_inner_available_space(run, input)
         }
         ParticipationInParentFormattingContext::AtomicInline => {
-            SizingContext::new(run.state, run.callbacks).dimension_atomic_root(
+            run.sizing().dimension_atomic_root(
                 run.box_,
                 input.available_space,
                 input.containing_block_constraints,
@@ -1273,13 +1283,13 @@ fn apply_root_sizing_directives(
             body_input_with_inner_available_space(run, input)
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::new(run.state, run.callbacks, run.fragments.clone()).dimension_out_of_flow_root(run.box_, abspos_inputs);
+            AbsposEngine::for_run(run).dimension_out_of_flow_root(run.box_, abspos_inputs);
             body_input_with_inner_available_space(run, input)
         }
         ParticipationInParentFormattingContext::Item => {
             if cfg!(debug_assertions) && run.layout_mode == LayoutMode::Normal && !run.state.is_measurement() {
                 debug_assert!(
-                    run.state.used_values(&run.callbacks, run.box_).has_definite_inline_size.get(),
+                    run.records.used_values(run.box_).has_definite_inline_size.get(),
                     "container-internal run root must arrive with a container-assigned inline size"
                 );
             }
@@ -1288,7 +1298,7 @@ fn apply_root_sizing_directives(
         ParticipationInParentFormattingContext::Root => {
             let directives = input.sizing;
             if directives.forced_content_inline_size.is_some() || directives.forced_content_block_size.is_some() {
-                let used = run.state.used_values(&run.callbacks, run.box_);
+                let used = run.records.used_values(run.box_);
                 if let Some(inline_size) = directives.forced_content_inline_size {
                     used.set_content_inline_size(inline_size);
                 }
@@ -1313,7 +1323,7 @@ fn dimension_block_level_root(
     let parent = parent_block.expect("a block-level run requires an enclosing block formatting context");
     parent.commit_block_level_root_inline_size(node, input);
     parent.resolve_block_level_root_block_size_before_body(node, input);
-    let sizing = SizingContext::new(run.state, run.callbacks);
+    let sizing = run.sizing();
     let style = run.state.style_facts(&run.callbacks, node);
     let mut body_input = body_input_with_inner_available_space(run, input);
     let mut measured_content_block_size = None;
@@ -1345,9 +1355,8 @@ fn finalize_block_level_root(
     let node = run.box_;
     let facts = run.state.node_facts(&run.callbacks, node);
     if facts.is_table_wrapper() {
-        run
-            .state
-            .used_values(&run.callbacks, node)
+        run.records
+            .used_values(node)
             .set_content_inline_size(body_result.automatic_content_inline_size);
     }
     let style = run.state.style_facts(&run.callbacks, node);
@@ -1385,7 +1394,7 @@ fn size_skipped_independent_root(
             parent.finalize_float_root(child, input, None);
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            let engine = AbsposEngine::new(run.state, run.callbacks, run.fragments.clone());
+            let engine = AbsposEngine::for_run(run);
             engine.dimension_out_of_flow_root(child, abspos_inputs);
             engine.finalize_out_of_flow_root_after_inside_layout(child, abspos_inputs, None);
         }
@@ -1395,8 +1404,8 @@ fn size_skipped_independent_root(
 
 fn body_input_with_inner_available_space(run: &FormattingContextRun, input: &LayoutInput) -> LayoutInput {
     let inner_available_space = run
-        .state
-        .used_values(&run.callbacks, run.box_)
+        .records
+        .used_values(run.box_)
         .available_inner_space_or_constraints_from(input.available_space);
     let mut body_input = *input;
     body_input.available_space = inner_available_space;
@@ -1406,6 +1415,7 @@ fn body_input_with_inner_available_space(run: &FormattingContextRun, input: &Lay
 #[expect(clippy::too_many_arguments)]
 fn run_formatting_context<'pass>(
     state: &'pass LayoutState,
+    root_used: std::rc::Rc<UsedValues>,
     box_: Node,
     parent_grid: Option<&GridFormattingContext<'pass>>,
     fc_type: FfiFormattingContextType,
@@ -1418,6 +1428,7 @@ fn run_formatting_context<'pass>(
     assert!(!box_.is_invalid());
     let run = FormattingContextRun {
         state,
+        records: std::rc::Rc::new(RunRecords::new(box_, root_used)),
         box_,
         layout_mode,
         callbacks,
@@ -1435,7 +1446,7 @@ fn run_formatting_context<'pass>(
     let body_input = apply_root_sizing_directives(run, &input, parent_block);
 
     let cached_atomic_block_size = if matches!(input.participation, ParticipationInParentFormattingContext::AtomicInline) {
-        SizingContext::new(run.state, run.callbacks).apply_cached_intrinsic_inline_measurement(
+        run.sizing().apply_cached_intrinsic_inline_measurement(
             run.box_,
             input.available_space.inline_size,
             body_input.available_space.block_size,
@@ -1457,7 +1468,7 @@ fn run_formatting_context<'pass>(
             FormattingContextImplementation::Block(context) => {
                 context.run(run, body_input);
                 let baselines = context.derived_baselines_of_root_box();
-                store_derived_baselines(run.state.used_values(&run.callbacks, run.box_), baselines);
+                store_derived_baselines(&run.records.used_values(run.box_), baselines);
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
@@ -1468,7 +1479,7 @@ fn run_formatting_context<'pass>(
             FormattingContextImplementation::Flex(context) => {
                 context.run(run, body_input);
                 let baselines = context.derived_baselines_of_root_box();
-                store_derived_baselines(run.state.used_values(&run.callbacks, run.box_), baselines);
+                store_derived_baselines(&run.records.used_values(run.box_), baselines);
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
@@ -1479,7 +1490,7 @@ fn run_formatting_context<'pass>(
             FormattingContextImplementation::Grid(context) => {
                 context.run(run, body_input);
                 let baselines = context.derived_baselines_of_root_box();
-                store_derived_baselines(run.state.used_values(&run.callbacks, run.box_), baselines);
+                store_derived_baselines(&run.records.used_values(run.box_), baselines);
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size(),
@@ -1490,7 +1501,7 @@ fn run_formatting_context<'pass>(
             FormattingContextImplementation::Table(context) => {
                 context.run(run, body_input);
                 let baselines = context.derived_baselines_of_root_box();
-                store_derived_baselines(run.state.used_values(&run.callbacks, run.box_), baselines);
+                store_derived_baselines(&run.records.used_values(run.box_), baselines);
                 ChildLayoutResult {
                     automatic_content_inline_size: context.automatic_content_inline_size(),
                     automatic_content_block_size: context.automatic_content_block_size,
@@ -1534,7 +1545,7 @@ fn run_formatting_context<'pass>(
             );
         }
         ParticipationInParentFormattingContext::AbsolutelyPositioned(abspos_inputs) => {
-            AbsposEngine::new(run.state, run.callbacks, run.fragments.clone()).finalize_out_of_flow_root_after_inside_layout(
+            AbsposEngine::for_run(run).finalize_out_of_flow_root_after_inside_layout(
                 run.box_,
                 abspos_inputs,
                 Some(result.automatic_content_block_size),
@@ -1542,22 +1553,22 @@ fn run_formatting_context<'pass>(
         }
         ParticipationInParentFormattingContext::Item => {
             if input.sizing.adopt_automatic_content_block_size {
-                let used = run.state.used_values(&run.callbacks, run.box_);
+                let used = run.records.used_values(run.box_);
                 used.set_content_block_size(result.automatic_content_block_size);
             }
         }
         ParticipationInParentFormattingContext::Root => {}
     }
 
-    let take_root = || {
+    let take_run_fragments = || {
         run.fragments
             .as_ref()
-            .map(|fragments| fragments.take_unplaced_root(run.state, &run.callbacks))
+            .map(|fragments| fragments.take_unplaced_root(&run.records, &run.callbacks))
     };
 
     let registered_abspos_children_could_never_be_laid_out = run.fragments.is_none();
     if registered_abspos_children_could_never_be_laid_out {
-        return run.outputs(result, take_root());
+        return run.outputs(result, take_run_fragments());
     }
     let implementation = implementation.expect("cached measurement replay only occurs on measurement states");
     match &implementation {
@@ -1574,11 +1585,11 @@ fn run_formatting_context<'pass>(
         }
         FormattingContextImplementation::Svg(_) | FormattingContextImplementation::ReplacedWithChildren => {}
         FormattingContextImplementation::InternalReplaced | FormattingContextImplementation::InternalDummy => {
-            return run.outputs(result, take_root());
+            return run.outputs(result, take_run_fragments());
         }
     }
-    run.state.used_values(&run.callbacks, run.box_).seal_own_metrics();
-    run.outputs(result, take_root())
+    run.records.used_values(run.box_).seal_own_metrics();
+    run.outputs(result, take_run_fragments())
 }
 
 fn finalize_atomic_root_block_size(
@@ -1591,7 +1602,7 @@ fn finalize_atomic_root_block_size(
     let node = run.box_;
     let available_space = input.available_space;
     let constraints = input.containing_block_constraints;
-    let sizing = SizingContext::new(run.state, run.callbacks);
+    let sizing = run.sizing();
     if sizing.box_is_sized_as_replaced_element(node, available_space, constraints) {
         return;
     }
@@ -1603,8 +1614,8 @@ fn finalize_atomic_root_block_size(
             cached_intrinsic_measurement_block_size,
             || {
                 let available_inner_space = run
-                    .state
-                    .used_values(&run.callbacks, node)
+                    .records
+                    .used_values(node)
                     .available_inner_space_or_constraints_from(available_space);
                 match parent_block {
                     Some(parent) => parent.compute_automatic_block_size_for_block_level_element(
@@ -1615,6 +1626,7 @@ fn finalize_atomic_root_block_size(
                     ),
                     None => independent_root_automatic_block_size(
                         run.state,
+                        &run.records,
                         &run.callbacks,
                         node,
                         available_inner_space,
@@ -1639,7 +1651,7 @@ pub(crate) fn layout_inside_child<'pass>(
     force_independent_context_run: bool,
 ) -> ChildLayoutOutcome {
     let facts = run.state.node_facts(&run.callbacks, child);
-    let used = run.state.used_values(&run.callbacks, child);
+    let used = run.records.used_values(child);
     if let Some((padding_top, padding_bottom)) = input.sizing.table_cell_intrinsic_block_padding {
         debug_assert!(facts.is_table_cell());
         debug_assert!(matches!(input.participation, ParticipationInParentFormattingContext::Item));
@@ -1678,6 +1690,7 @@ pub(crate) fn layout_inside_child<'pass>(
     input.sizing.treat_block_axis_percentage_insets_as_auto_beyond_root =
         treat_block_axis_percentage_insets_as_auto_beyond_anonymous_child_root(
             run.state,
+            &run.records,
             &run.callbacks,
             child,
             run.box_,
@@ -1685,6 +1698,7 @@ pub(crate) fn layout_inside_child<'pass>(
         );
     let outputs = run_formatting_context(
         run.state,
+        used,
         child,
         parent_grid,
         fc_type,
@@ -1709,21 +1723,6 @@ pub(crate) fn hold_unplaced_root_and_take_result(
     outputs.result
 }
 
-fn drain_and_commit_entry_pass(
-    state: &LayoutState,
-    entry_fragments: &std::rc::Rc<RunFragmentBuilder>,
-    callbacks: &FfiLayoutFcCallbacks,
-    should_collect_devtools_layout_data: bool,
-    commit_root: Node,
-    paintable_to_replace: *mut c_void,
-    sink: &FfiCommitSink,
-) {
-    drain_abspos_with_placed_containing_blocks(state, *callbacks, should_collect_devtools_layout_data, entry_fragments);
-    let pass_fragments = entry_fragments.take_completed_pass(state, callbacks);
-    debug_assert!(!pass_fragments.roots.is_empty(), "an entry pass always produces the entry root's fragment");
-    state.commit_replacing(commit_root, paintable_to_replace, callbacks, sink, &pass_fragments);
-}
-
 fn independent_formatting_context_type(
     state: &LayoutState,
     box_: Node,
@@ -1746,6 +1745,7 @@ fn independent_formatting_context_type(
 
 pub(crate) fn resolve_block_axis_percentage_inset_basis_is_definite(
     state: &LayoutState,
+    records: &RunRecords,
     callbacks: &FfiLayoutFcCallbacks,
     containing_block: Node,
     formatting_context_root: Node,
@@ -1755,7 +1755,7 @@ pub(crate) fn resolve_block_axis_percentage_inset_basis_is_definite(
     while !candidate.is_invalid() {
         let facts = state.node_facts(callbacks, candidate);
         if !facts.is_anonymous() || facts.is_table_cell() {
-            return state.used_values(callbacks, candidate).has_definite_block_size();
+            return records.used_values(candidate).has_definite_block_size();
         }
         if candidate == formatting_context_root {
             return !treat_block_axis_percentage_insets_as_auto_beyond_root;
@@ -1767,6 +1767,7 @@ pub(crate) fn resolve_block_axis_percentage_inset_basis_is_definite(
 
 pub(crate) fn treat_block_axis_percentage_insets_as_auto_beyond_anonymous_child_root(
     state: &LayoutState,
+    records: &RunRecords,
     callbacks: &FfiLayoutFcCallbacks,
     child_root: Node,
     formatting_context_root: Node,
@@ -1778,6 +1779,7 @@ pub(crate) fn treat_block_axis_percentage_insets_as_auto_beyond_anonymous_child_
     }
     !resolve_block_axis_percentage_inset_basis_is_definite(
         state,
+        records,
         callbacks,
         callbacks.containing_block(child_root),
         formatting_context_root,
@@ -1814,10 +1816,12 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             percentage_basis_block_size: Some(viewport_block_size),
             ..crate::layout::ContainingBlockConstraints::default()
         };
-        let viewport_used = state.create_used_values(&callbacks, root, root_constraints);
+        let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(root));
+        let viewport_used = entry_records.create_used_values(&state, &callbacks, root, root_constraints);
         let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));
         let entry_run = FormattingContextRun {
             state: &state,
+            records: entry_records.clone(),
             box_: root,
             layout_mode: LayoutMode::Normal,
             callbacks,
@@ -1827,12 +1831,13 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
         };
 
         let mut root_for_layout = root;
+        let mut root_for_layout_used = viewport_used.clone();
         let first_child = callbacks.first_child(root);
         if !first_child.is_invalid() && state.node_facts(&callbacks, first_child).is_svg_svg_box() {
             viewport_used.set_content_inline_size(viewport_inline_size);
             viewport_used.set_content_block_size(viewport_block_size);
             place_child(&entry_run, root, FfiCssPixelPoint::default(), None);
-            state.create_used_values(&callbacks, first_child, root_constraints);
+            root_for_layout_used = entry_records.create_used_values(&state, &callbacks, first_child, root_constraints);
             root_for_layout = first_child;
         }
         let input = LayoutInput::new(
@@ -1848,6 +1853,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
         let fc_type = independent_formatting_context_type(state_ref, root_for_layout, &callbacks);
         let outputs = run_formatting_context(
             state_ref,
+            root_for_layout_used,
             root_for_layout,
             None,
             fc_type,
@@ -1857,13 +1863,11 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             input,
             None,
         );
-        if let Some(unplaced_root) = outputs.root {
-            debug_assert!(unplaced_root.node == root_for_layout, "the entry run returned a root for a different box");
-            entry_fragments.hold_unplaced_root(unplaced_root);
-        }
+        hold_unplaced_root_and_take_result(Some(&entry_fragments), root_for_layout, outputs);
         place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default(), None);
         drain_and_commit_entry_pass(
             &state,
+            &entry_records,
             &entry_fragments,
             &callbacks,
             should_collect_devtools_layout_data,
@@ -1872,6 +1876,29 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             sink,
         );
     });
+}
+
+#[expect(clippy::too_many_arguments)]
+fn drain_and_commit_entry_pass(
+    state: &LayoutState,
+    entry_records: &std::rc::Rc<RunRecords>,
+    entry_fragments: &std::rc::Rc<RunFragmentBuilder>,
+    callbacks: &FfiLayoutFcCallbacks,
+    should_collect_devtools_layout_data: bool,
+    commit_root: Node,
+    paintable_to_replace: *mut c_void,
+    sink: &FfiCommitSink,
+) {
+    drain_abspos_with_placed_containing_blocks(
+        state,
+        entry_records,
+        *callbacks,
+        should_collect_devtools_layout_data,
+        entry_fragments,
+    );
+    let pass_fragments = entry_fragments.take_completed_pass(entry_records, callbacks);
+    debug_assert!(!pass_fragments.roots.is_empty(), "an entry pass always produces the entry root's fragment");
+    state.commit_replacing(commit_root, paintable_to_replace, callbacks, sink, &pass_fragments);
 }
 
 /// # Safety
@@ -1898,12 +1925,15 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let sink = unsafe { &*sink };
 
         let state = LayoutState::new(LayoutStatePurpose::Commit);
+        let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(root));
         let root_used = state
             .populate_from_paintable(&callbacks, root, paintable_to_replace)
             .expect("partial relayout root must have committed geometry");
+        entry_records.register(root, root_used.clone());
         let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(root));
         let entry_run = FormattingContextRun {
             state: &state,
+            records: entry_records.clone(),
             box_: root,
             layout_mode: LayoutMode::Normal,
             callbacks,
@@ -1919,7 +1949,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
                 percentage_basis_block_size: Some(viewport_block_size),
                 ..crate::layout::ContainingBlockConstraints::default()
             };
-            let viewport_used = state.create_used_values(&callbacks, viewport, viewport_constraints);
+            let viewport_used = entry_records.create_used_values(&state, &callbacks, viewport, viewport_constraints);
             viewport_used.set_content_inline_size(viewport_inline_size);
             viewport_used.set_content_block_size(viewport_block_size);
             place_child(&entry_run, viewport, FfiCssPixelPoint::default(), None);
@@ -1939,17 +1969,25 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         let facts = state.node_facts(&callbacks, root);
         let fc_type = formatting_context_type_created_by_box(facts)
             .expect("partial relayout root must establish an independent formatting context");
-        let outputs = run_formatting_context(state_ref, root, None, fc_type, LayoutMode::Normal, false, callbacks, input, None);
-        if let Some(unplaced_root) = outputs.root {
-            debug_assert!(unplaced_root.node == root, "the subtree run returned a root for a different box");
-            entry_fragments.hold_unplaced_root(unplaced_root);
-        }
+        let outputs = run_formatting_context(
+            state_ref,
+            root_used.clone(),
+            root,
+            None,
+            fc_type,
+            LayoutMode::Normal,
+            false,
+            callbacks,
+            input,
+            None,
+        );
+        hold_unplaced_root_and_take_result(Some(&entry_fragments), root, outputs);
         entry_fragments.normalize_arrivals_for_placement(root);
         entry_fragments.build_fragment_for_placed_box(
             &callbacks,
             root,
             None,
-            root_used,
+            &root_used,
             false,
             None,
             root_used.content_offset.get(),
@@ -1957,6 +1995,7 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         );
         drain_and_commit_entry_pass(
             &state,
+            &entry_records,
             &entry_fragments,
             &callbacks,
             false,
@@ -1991,8 +2030,10 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         let containing_block = callbacks.containing_block(box_);
         assert!(!containing_block.is_invalid());
         let entry_fragments = std::rc::Rc::new(RunFragmentBuilder::new_entry_accumulator(containing_block));
+        let entry_records = std::rc::Rc::new(RunRecords::new_unrooted(containing_block));
         let run = crate::layout::FormattingContextRun {
             state: state_ref,
+            records: entry_records.clone(),
             box_: containing_block,
             layout_mode: LayoutMode::Normal,
             callbacks,
@@ -2000,9 +2041,10 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
             treat_block_axis_percentage_insets_as_auto_beyond_root: false,
             fragments: Some(entry_fragments.clone()),
         };
-        AbsposEngine::new(state_ref, callbacks, Some(entry_fragments.clone())).replay(&run, box_);
+        AbsposEngine::for_run(&run).replay(&run, box_);
         drain_and_commit_entry_pass(
             &state,
+            &entry_records,
             &entry_fragments,
             &callbacks,
             false,

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -363,7 +363,9 @@ pub(crate) fn place_child(run: &FormattingContextRun, node: Node, offset: FfiCss
         fragments.build_fragment_for_placed_box(
             node,
             (!containing_block.is_invalid()).then_some(containing_block),
+            used,
             containing_block_is_sealed,
+            state.containing_line_box_index(callbacks, node, used),
         );
     }
 }
@@ -1547,7 +1549,7 @@ fn run_formatting_context<'pass>(
         ParticipationInParentFormattingContext::Root => {}
     }
 
-    let take_root = || run.fragments.as_ref().map(|fragments| fragments.take_unplaced_root());
+    let take_root = || run.fragments.as_ref().map(|fragments| fragments.take_unplaced_root(run.state));
 
     let registered_abspos_children_could_never_be_laid_out = run.fragments.is_none();
     if registered_abspos_children_could_never_be_laid_out {
@@ -1849,7 +1851,7 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             &[root, root_for_layout],
             &entry_fragments,
         );
-        let pass_fragments = entry_fragments.take_completed_pass();
+        let pass_fragments = entry_fragments.take_completed_pass(state_ref);
         debug_assert!(!pass_fragments.roots.is_empty(), "the run root always has a fragment");
         state.commit_replacing(root, std::ptr::null_mut(), &callbacks, sink);
     });
@@ -1925,8 +1927,9 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
             debug_assert!(unplaced_root.node == root, "the subtree run returned a root for a different box");
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
+        entry_fragments.build_fragment_for_placed_box(root, None, root_used, false, None);
         drain_remaining_abspos_targets(state_ref, callbacks, false, &[viewport, root], &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass();
+        let pass_fragments = entry_fragments.take_completed_pass(state_ref);
         debug_assert!(!pass_fragments.roots.is_empty(), "the subtree root always has a fragment");
         state.commit_replacing(root, paintable_to_replace, &callbacks, sink);
     });
@@ -1967,7 +1970,7 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
         };
         AbsposEngine::new(state_ref, callbacks).replay(&run, box_);
         drain_remaining_abspos_targets(state_ref, callbacks, false, &[containing_block], &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass();
+        let pass_fragments = entry_fragments.take_completed_pass(state_ref);
         debug_assert!(!pass_fragments.roots.is_empty(), "the replayed box always has a fragment");
         state.commit_replacing(box_, paintable_to_replace, &callbacks, sink);
     });

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -1705,6 +1705,21 @@ pub(crate) fn hold_unplaced_root_and_take_result(
     outputs.result
 }
 
+fn drain_and_commit_entry_pass(
+    state: &LayoutState,
+    entry_fragments: &std::rc::Rc<RunFragmentBuilder>,
+    callbacks: &FfiLayoutFcCallbacks,
+    should_collect_devtools_layout_data: bool,
+    commit_root: Node,
+    paintable_to_replace: *mut c_void,
+    sink: &FfiCommitSink,
+) {
+    drain_abspos_with_placed_containing_blocks(state, *callbacks, should_collect_devtools_layout_data, entry_fragments);
+    let pass_fragments = entry_fragments.take_completed_pass(state, callbacks);
+    debug_assert!(!pass_fragments.roots.is_empty(), "an entry pass always produces the entry root's fragment");
+    state.commit_replacing(commit_root, paintable_to_replace, callbacks, sink, &pass_fragments);
+}
+
 fn independent_formatting_context_type(
     state: &LayoutState,
     box_: Node,
@@ -1843,10 +1858,15 @@ pub unsafe extern "C" fn rust_layout_run_root_layout(
             entry_fragments.hold_unplaced_root(unplaced_root);
         }
         place_child(&entry_run, root_for_layout, FfiCssPixelPoint::default());
-        drain_abspos_with_placed_containing_blocks(state_ref, callbacks, should_collect_devtools_layout_data, &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
-        debug_assert!(!pass_fragments.roots.is_empty(), "the run root always has a fragment");
-        state.commit_replacing(root, std::ptr::null_mut(), &callbacks, sink);
+        drain_and_commit_entry_pass(
+            &state,
+            &entry_fragments,
+            &callbacks,
+            should_collect_devtools_layout_data,
+            root,
+            std::ptr::null_mut(),
+            sink,
+        );
     });
 }
 
@@ -1922,10 +1942,15 @@ pub unsafe extern "C" fn rust_layout_compute_subtree_layout(
         }
         entry_fragments.normalize_arrivals_for_placement(root);
         entry_fragments.build_fragment_for_placed_box(&callbacks, root, None, root_used, false, None, None);
-        drain_abspos_with_placed_containing_blocks(state_ref, callbacks, false, &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
-        debug_assert!(!pass_fragments.roots.is_empty(), "the subtree root always has a fragment");
-        state.commit_replacing(root, paintable_to_replace, &callbacks, sink);
+        drain_and_commit_entry_pass(
+            &state,
+            &entry_fragments,
+            &callbacks,
+            false,
+            root,
+            paintable_to_replace,
+            sink,
+        );
     });
 }
 
@@ -1963,9 +1988,14 @@ pub unsafe extern "C" fn rust_layout_replay_saved_abspos_layout(
             fragments: Some(entry_fragments.clone()),
         };
         AbsposEngine::new(state_ref, callbacks, Some(entry_fragments.clone())).replay(&run, box_);
-        drain_abspos_with_placed_containing_blocks(state_ref, callbacks, false, &entry_fragments);
-        let pass_fragments = entry_fragments.take_completed_pass(state_ref, &callbacks);
-        debug_assert!(!pass_fragments.roots.is_empty(), "the replayed box always has a fragment");
-        state.commit_replacing(box_, paintable_to_replace, &callbacks, sink);
+        drain_and_commit_entry_pass(
+            &state,
+            &entry_fragments,
+            &callbacks,
+            false,
+            box_,
+            paintable_to_replace,
+            sink,
+        );
     });
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -43,6 +43,87 @@ pub(crate) struct FragmentLink {
     pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
 }
 
+pub(crate) struct AnchorCandidate {
+    pub(crate) node: crate::layout::node_data::NodeSlotId,
+    pub(crate) border_box_rect: PhysicalRect,
+    pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
+}
+
+pub(crate) fn translate_pending_abspos_payloads(entry: &mut PendingAbsposChild, offset: FfiCssPixelPoint) {
+    entry.static_position_rect = crate::layout::translate_static_position_rect(entry.static_position_rect, offset);
+    if let Some(rect) = &mut entry.inline_containing_block_rect {
+        rect.x += offset.x;
+        rect.y += offset.y;
+    }
+}
+
+trait PropagatedPayload {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId;
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId);
+    fn translate_by(&mut self, offset: FfiCssPixelPoint);
+}
+
+impl PropagatedPayload for PendingAbsposChild {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
+        self.coordinate_space_box
+    }
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
+        self.coordinate_space_box = node;
+    }
+    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
+        translate_pending_abspos_payloads(self, offset);
+    }
+}
+
+impl PropagatedPayload for AnchorCandidate {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
+        self.coordinate_space_box
+    }
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
+        self.coordinate_space_box = node;
+    }
+    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
+        self.border_box_rect.x += offset.x;
+        self.border_box_rect.y += offset.y;
+    }
+}
+
+fn propagate_payload_into_containing_block_space<Payload: PropagatedPayload>(
+    payload: &mut Payload,
+    placed_box: crate::layout::node_data::NodeSlotId,
+    containing_block: Option<crate::layout::node_data::NodeSlotId>,
+    placed_box_content_offset: FfiCssPixelPoint,
+) {
+    if payload.coordinate_space_box() == placed_box
+        && let Some(containing_block) = containing_block
+    {
+        payload.translate_by(placed_box_content_offset);
+        payload.set_coordinate_space_box(containing_block);
+    }
+}
+
+fn propagate_payload_toward_run_root_space<Payload: PropagatedPayload>(
+    payload: &mut Payload,
+    run_root: crate::layout::node_data::NodeSlotId,
+    records: &RunRecords,
+    callbacks: &FfiLayoutFcCallbacks,
+) {
+    while payload.coordinate_space_box() != run_root {
+        let Some(used) = records
+            .used_values_if_owned(payload.coordinate_space_box())
+            .filter(|used| used.has_content_offset.get())
+        else {
+            break;
+        };
+        payload.translate_by(used.content_offset.get());
+        let containing_block = callbacks.containing_block(payload.coordinate_space_box());
+        if containing_block.is_invalid() {
+            break;
+        }
+        payload.set_coordinate_space_box(containing_block);
+    }
+}
+
 fn snapshot_fragment(
     node: crate::layout::node_data::NodeSlotId,
     children: Vec<FragmentLink>,
@@ -141,88 +222,19 @@ fn link_fragment(fragment: Box<Fragment>, placement: PlacementData) -> FragmentL
         inset_top: placement.inset_top,
         inset_bottom: placement.inset_bottom,
         containing_line_box_index: placement.containing_line_box_index,
-        abspos_layout_inputs: placement.abspos_layout_inputs,    }
+        abspos_layout_inputs: placement.abspos_layout_inputs,
+    }
 }
 
-pub(crate) struct AnchorCandidate {
+pub(crate) struct UnplacedRootFragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
-    pub(crate) border_box_rect: PhysicalRect,
-    pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
+    pub(crate) scoped_descendants: Vec<FragmentLink>,
+    pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
+    pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
 }
 
-pub(crate) fn translate_pending_abspos_payloads(entry: &mut PendingAbsposChild, offset: FfiCssPixelPoint) {
-    entry.static_position_rect = crate::layout::translate_static_position_rect(entry.static_position_rect, offset);
-    if let Some(rect) = &mut entry.inline_containing_block_rect {
-        rect.x += offset.x;
-        rect.y += offset.y;
-    }
-}
-
-trait PropagatedPayload {
-    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId;
-    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId);
-    fn translate_by(&mut self, offset: FfiCssPixelPoint);
-}
-
-impl PropagatedPayload for PendingAbsposChild {
-    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
-        self.coordinate_space_box
-    }
-    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
-        self.coordinate_space_box = node;
-    }
-    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
-        translate_pending_abspos_payloads(self, offset);
-    }
-}
-
-impl PropagatedPayload for AnchorCandidate {
-    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
-        self.coordinate_space_box
-    }
-    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
-        self.coordinate_space_box = node;
-    }
-    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
-        self.border_box_rect.x += offset.x;
-        self.border_box_rect.y += offset.y;
-    }
-}
-
-fn propagate_payload_into_containing_block_space<Payload: PropagatedPayload>(
-    payload: &mut Payload,
-    placed_box: crate::layout::node_data::NodeSlotId,
-    containing_block: Option<crate::layout::node_data::NodeSlotId>,
-    placed_box_content_offset: FfiCssPixelPoint,
-) {
-    if payload.coordinate_space_box() == placed_box
-        && let Some(containing_block) = containing_block
-    {
-        payload.translate_by(placed_box_content_offset);
-        payload.set_coordinate_space_box(containing_block);
-    }
-}
-
-fn propagate_payload_toward_run_root_space<Payload: PropagatedPayload>(
-    payload: &mut Payload,
-    run_root: crate::layout::node_data::NodeSlotId,
-    state: &LayoutState,
-    callbacks: &FfiLayoutFcCallbacks,
-) {
-    while payload.coordinate_space_box() != run_root {
-        let Some(used) = state
-            .used_values_by_slot(payload.coordinate_space_box().slot_index())
-            .filter(|used| used.has_content_offset.get())
-        else {
-            break;
-        };
-        payload.translate_by(used.content_offset.get());
-        let containing_block = callbacks.containing_block(payload.coordinate_space_box());
-        if containing_block.is_invalid() {
-            break;
-        }
-        payload.set_coordinate_space_box(containing_block);
-    }
+pub(crate) struct CompletedPassFragments {
+    pub(crate) roots: Vec<FragmentLink>,
 }
 
 pub(crate) struct CommitScopes<'tree> {
@@ -281,17 +293,6 @@ fn assert_one_fragment_per_slot_in_whole_pass(links: &[FragmentLink], seen: &mut
     }
 }
 
-pub(crate) struct UnplacedRootFragment {
-    pub(crate) node: crate::layout::node_data::NodeSlotId,
-    pub(crate) scoped_descendants: Vec<FragmentLink>,
-    pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
-    pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
-}
-
-pub(crate) struct CompletedPassFragments {
-    pub(crate) roots: Vec<FragmentLink>,
-}
-
 struct PendingFragment {
     node: crate::layout::node_data::NodeSlotId,
     children: Vec<FragmentLink>,
@@ -310,6 +311,7 @@ pub(crate) struct RunFragmentBuilder {
 #[derive(Default)]
 struct RunFragmentBuilderInner {
     pending_fragments: std::collections::HashMap<u32, PendingFragment>,
+    #[cfg(debug_assertions)]
     placed_slots: std::collections::HashSet<u32>,
     child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
     pending_abspos_at_root: Vec<PendingAbsposChild>,
@@ -473,25 +475,27 @@ impl RunFragmentBuilder {
     pub(crate) fn take_drainable_abspos(
         &self,
         placed: crate::layout::node_data::NodeSlotId,
+        records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
     ) -> Vec<PendingAbsposChild> {
         let mut inner = self.inner.borrow_mut();
-        let inner = &mut *inner;
-        let containing_block_is_placed = |entry: &PendingAbsposChild| {
+        let containing_block_is_owned_and_placed = |entry: &PendingAbsposChild| {
             let containing_block = callbacks.containing_block(entry.child_box);
             !containing_block.is_invalid()
                 && (self.is_entry_accumulator || containing_block != self.root_node)
-                && (containing_block == placed || inner.placed_slots.contains(&containing_block.slot_index()))
+                && records
+                    .used_values_if_owned(containing_block)
+                    .is_some_and(|containing_block_used| containing_block_used.has_content_offset.get())
         };
         let mut taken: Vec<PendingAbsposChild> = inner
             .pending_abspos_at_root
-            .extract_if(.., |entry| containing_block_is_placed(entry))
+            .extract_if(.., |entry| containing_block_is_owned_and_placed(entry))
             .collect();
         if let Some(pending_fragment) = inner.pending_fragments.get_mut(&placed.slot_index()) {
             taken.extend(
                 pending_fragment
                     .pending_abspos
-                    .extract_if(.., |entry| containing_block_is_placed(entry)),
+                    .extract_if(.., |entry| containing_block_is_owned_and_placed(entry)),
             );
         }
         taken.sort_by(|left, right| {
@@ -522,11 +526,7 @@ impl RunFragmentBuilder {
             match inner.child_roots_awaiting_placement.remove(&slot) {
                 Some(root) => {
                     debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
-                    (
-                        root.scoped_descendants,
-                        root.propagated_pending_abspos,
-                        root.propagated_anchor_candidates,
-                    )
+                    (root.scoped_descendants, root.propagated_pending_abspos, root.propagated_anchor_candidates)
                 }
                 None => (Vec::new(), Vec::new(), Vec::new()),
             };
@@ -559,6 +559,7 @@ impl RunFragmentBuilder {
     ) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
+        #[cfg(debug_assertions)]
         assert!(inner.placed_slots.insert(slot), "a box was placed twice in one run");
         debug_assert!(
             !inner.child_roots_awaiting_placement.contains_key(&slot),
@@ -639,10 +640,14 @@ impl RunFragmentBuilder {
         );
     }
 
-    pub(crate) fn take_unplaced_root(&self, state: &LayoutState, callbacks: &FfiLayoutFcCallbacks) -> UnplacedRootFragment {
+    pub(crate) fn take_unplaced_root(
+        &self,
+        records: &RunRecords,
+        callbacks: &FfiLayoutFcCallbacks,
+    ) -> UnplacedRootFragment {
         debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
         let (scoped_descendants, propagated_pending_abspos, propagated_anchor_candidates) =
-            self.close(state, callbacks);
+            self.close(records, callbacks);
         UnplacedRootFragment {
             node: self.root_node,
             scoped_descendants,
@@ -651,45 +656,43 @@ impl RunFragmentBuilder {
         }
     }
 
-    pub(crate) fn take_completed_pass(&self, state: &LayoutState, callbacks: &FfiLayoutFcCallbacks) -> CompletedPassFragments {
+    pub(crate) fn take_completed_pass(
+        &self,
+        records: &RunRecords,
+        callbacks: &FfiLayoutFcCallbacks,
+    ) -> CompletedPassFragments {
         debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
-        let (roots, _dropped_pending_abspos, _dropped_anchor_candidates) = self.close(state, callbacks);
+        let (roots, _dropped_pending_abspos, _dropped_anchor_candidates) = self.close(records, callbacks);
         CompletedPassFragments { roots }
     }
 
     fn close(
         &self,
-        state: &LayoutState,
+        records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
     ) -> (Vec<FragmentLink>, Vec<PendingAbsposChild>, Vec<AnchorCandidate>) {
         let mut inner = self.inner.take();
         let mut propagated_pending_abspos = std::mem::take(&mut inner.pending_abspos_at_root);
         let mut propagated_anchor_candidates = std::mem::take(&mut inner.anchor_candidates_at_root);
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
-        for (slot, pending_fragment) in pending_fragments {
+        for (_, pending_fragment) in pending_fragments {
             propagated_pending_abspos.extend(pending_fragment.pending_abspos);
             propagated_anchor_candidates.extend(pending_fragment.anchor_candidates);
             if pending_fragment.children.is_empty() {
                 continue;
             }
-            let used = state
-                .used_values_by_slot(slot)
-                .expect("a pending fragment's containing block has no record");
+            let used = records.used_values(pending_fragment.node);
             inner.top_scope_links.push(link_fragment(
-                snapshot_fragment(pending_fragment.node, pending_fragment.children, used),
-                PlacementData::from_record(used, None, used.content_offset.get()),
+                snapshot_fragment(pending_fragment.node, pending_fragment.children, &used),
+                PlacementData::from_record(&used, None, used.content_offset.get()),
             ));
         }
         let child_roots_awaiting_placement = std::mem::take(&mut inner.child_roots_awaiting_placement);
-        for (slot, root) in child_roots_awaiting_placement {
-            let used = state
-                .used_values_by_slot(slot)
-                .expect("a held child run's root has no record");
-            propagated_pending_abspos.extend(root.propagated_pending_abspos);
-            propagated_anchor_candidates.extend(root.propagated_anchor_candidates);
+        for (_, root) in child_roots_awaiting_placement {
+            let used = records.used_values(root.node);
             inner.top_scope_links.push(link_fragment(
-                snapshot_fragment(root.node, root.scoped_descendants, used),
-                PlacementData::from_record(used, None, used.content_offset.get()),
+                snapshot_fragment(root.node, root.scoped_descendants, &used),
+                PlacementData::from_record(&used, None, used.content_offset.get()),
             ));
         }
         for entry in &mut propagated_pending_abspos {
@@ -699,42 +702,43 @@ impl RunFragmentBuilder {
                 debug_assert!(
                     containing_block.is_invalid()
                         || containing_block == self.root_node
-                        || !inner.placed_slots.contains(&containing_block.slot_index()),
+                        || records
+                            .used_values_if_owned(containing_block)
+                            .is_none_or(|containing_block_used| !containing_block_used.has_content_offset.get()),
                     "a drainable abspos registration survived its containing block's run (slot {})",
                     entry.child_box.slot_index()
                 );
             }
-            propagate_payload_toward_run_root_space(entry, self.root_node, state, callbacks);
+            propagate_payload_toward_run_root_space(entry, self.root_node, records, callbacks);
         }
-for candidate in &mut propagated_anchor_candidates {
-            propagate_payload_toward_run_root_space(candidate, self.root_node, state, callbacks);
+        for candidate in &mut propagated_anchor_candidates {
+            propagate_payload_toward_run_root_space(candidate, self.root_node, records, callbacks);
         }
         if self.saw_svg_payload_write.take() {
-            refresh_svg_payloads_from_records(&mut inner.top_scope_links, state);
+            refresh_svg_payloads_from_records(&mut inner.top_scope_links, records);
         }
         (inner.top_scope_links, propagated_pending_abspos, propagated_anchor_candidates)
     }
 }
 
-fn refresh_svg_payloads_from_records(links: &mut [FragmentLink], state: &LayoutState) {
+fn refresh_svg_payloads_from_records(links: &mut [FragmentLink], records: &RunRecords) {
     for link in links {
+        let Some(owned_record) = records.used_values_if_owned(link.fragment.node) else {
+            continue;
+        };
         let fragment = &mut *link.fragment;
-        let slot_index = fragment.node.slot_index();
-        if let Some(rare) = state.used_values_rare_data(slot_index) {
+        if let Some(rare_cell) = owned_record.rare_data.get() {
+            let mut rare = rare_cell.borrow_mut();
             if rare.computed_svg_transforms.is_some() {
                 fragment.computed_svg_transforms = rare.computed_svg_transforms;
             }
             if rare.svg_viewport_size.is_some() {
                 fragment.svg_viewport_size = rare.svg_viewport_size;
             }
+            if let Some(path) = rare.computed_svg_path.take() {
+                fragment.computed_svg_path.set(Some(path));
+            }
         }
-        if let Some(path) = state
-            .used_values_by_slot(slot_index)
-            .and_then(|used| used.rare_data.get())
-            .and_then(|rare| rare.borrow_mut().computed_svg_path.take())
-        {
-            fragment.computed_svg_path.set(Some(path));
-        }
-        refresh_svg_payloads_from_records(&mut fragment.children, state);
+        refresh_svg_payloads_from_records(&mut fragment.children, records);
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#[allow(dead_code)]
 pub(crate) struct Fragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
     pub(crate) content_inline_size: CssPixels,
@@ -21,10 +20,15 @@ pub(crate) struct Fragment {
     pub(crate) padding_right: CssPixels,
     pub(crate) padding_top: CssPixels,
     pub(crate) padding_bottom: CssPixels,
+    pub(crate) table_cell_coordinates: Option<FfiTableCellCoordinates>,
+    pub(crate) override_borders_data: Option<FfiBordersData>,
+    pub(crate) line_data: Option<Box<LineData>>,
+    pub(crate) grid_layout_data: Option<OwnedGridLayoutData>,
+    pub(crate) flex_layout_data: Option<OwnedFlexLayoutData>,
+    pub(crate) used_grid_tracks: Option<OwnedUsedGridTracks>,
     pub(crate) children: Vec<FragmentLink>,
 }
 
-#[allow(dead_code)]
 pub(crate) struct FragmentLink {
     pub(crate) fragment: Box<Fragment>,
     pub(crate) committed_offset: FfiCssPixelPoint,
@@ -33,6 +37,7 @@ pub(crate) struct FragmentLink {
     pub(crate) inset_top: CssPixels,
     pub(crate) inset_bottom: CssPixels,
     pub(crate) containing_line_box_index: Option<usize>,
+    pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
 }
 
 fn snapshot_fragment(
@@ -40,6 +45,19 @@ fn snapshot_fragment(
     children: Vec<FragmentLink>,
     used: &UsedValues,
 ) -> Box<Fragment> {
+    let line_data = used.line_data.get().map(|cell| Box::new(cell.take()));
+    let rare_payloads = used.rare_data.get().map(|cell| {
+        let mut rare = cell.borrow_mut();
+        (
+            rare.table_cell_coordinates,
+            rare.override_borders_data,
+            rare.grid_layout_data.take(),
+            rare.flex_layout_data.take(),
+            rare.used_grid_tracks.take(),
+        )
+    });
+    let (table_cell_coordinates, override_borders_data, grid_layout_data, flex_layout_data, used_grid_tracks) =
+        rare_payloads.unwrap_or_default();
     Box::new(Fragment {
         node,
         content_inline_size: used.content_inline_size.get(),
@@ -56,6 +74,12 @@ fn snapshot_fragment(
         padding_right: used.padding_right.get(),
         padding_top: used.padding_top.get(),
         padding_bottom: used.padding_bottom.get(),
+        table_cell_coordinates,
+        override_borders_data,
+        line_data,
+        grid_layout_data,
+        flex_layout_data,
+        used_grid_tracks,
         children,
     })
 }
@@ -67,17 +91,26 @@ pub(crate) struct PlacementData {
     pub(crate) inset_top: CssPixels,
     pub(crate) inset_bottom: CssPixels,
     pub(crate) containing_line_box_index: Option<usize>,
+    pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
 }
 
 impl PlacementData {
-    fn from_record(used: &UsedValues, containing_line_box_index: Option<usize>) -> Self {
+    fn from_record(
+        used: &UsedValues,
+        containing_line_box_index: Option<usize>,
+        committed_offset: FfiCssPixelPoint,
+    ) -> Self {
         Self {
-            committed_offset: crate::layout::point_add(used.content_offset.get(), used.committed_offset_delta.get()),
+            committed_offset,
             inset_left: used.inset_left.get(),
             inset_right: used.inset_right.get(),
             inset_top: used.inset_top.get(),
             inset_bottom: used.inset_bottom.get(),
             containing_line_box_index,
+            abspos_layout_inputs: used
+                .rare_data
+                .get()
+                .and_then(|cell| cell.borrow().abspos_layout_inputs),
         }
     }
 }
@@ -91,7 +124,7 @@ fn link_fragment(fragment: Box<Fragment>, placement: PlacementData) -> FragmentL
         inset_top: placement.inset_top,
         inset_bottom: placement.inset_bottom,
         containing_line_box_index: placement.containing_line_box_index,
-    }
+        abspos_layout_inputs: placement.abspos_layout_inputs,    }
 }
 
 pub(crate) struct AnchorCandidate {
@@ -497,6 +530,7 @@ impl RunFragmentBuilder {
         used: &UsedValues,
         containing_block_is_sealed: bool,
         containing_line_box_index: Option<usize>,
+        committed_offset: FfiCssPixelPoint,
         own_anchor_candidate_border_box_rect: Option<PhysicalRect>,
     ) {
         let mut inner = self.inner.borrow_mut();
@@ -517,7 +551,7 @@ impl RunFragmentBuilder {
             };
         let link = link_fragment(
             snapshot_fragment(node, children, used),
-            PlacementData::from_record(used, containing_line_box_index),
+            PlacementData::from_record(used, containing_line_box_index, committed_offset),
         );
         self.attach(&mut inner, link, containing_block, containing_block_is_sealed);
         let content_offset = used.content_offset.get();
@@ -619,7 +653,7 @@ impl RunFragmentBuilder {
                 .expect("a pending fragment's containing block has no record");
             inner.top_scope_links.push(link_fragment(
                 snapshot_fragment(pending_fragment.node, pending_fragment.children, used),
-                PlacementData::from_record(used, None),
+                PlacementData::from_record(used, None, used.content_offset.get()),
             ));
         }
         let child_roots_awaiting_placement = std::mem::take(&mut inner.child_roots_awaiting_placement);
@@ -631,7 +665,7 @@ impl RunFragmentBuilder {
             propagated_anchor_candidates.extend(root.propagated_anchor_candidates);
             inner.top_scope_links.push(link_fragment(
                 snapshot_fragment(root.node, root.scoped_descendants, used),
-                PlacementData::from_record(used, None),
+                PlacementData::from_record(used, None, used.content_offset.get()),
             ));
         }
         for entry in &mut propagated_pending_abspos {

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -4,16 +4,94 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#[allow(dead_code)]
 pub(crate) struct Fragment {
-    #[allow(dead_code)]
     pub(crate) node: crate::layout::node_data::NodeSlotId,
-    #[allow(dead_code)]
+    pub(crate) content_inline_size: CssPixels,
+    pub(crate) content_block_size: CssPixels,
+    pub(crate) margin_left: CssPixels,
+    pub(crate) margin_right: CssPixels,
+    pub(crate) margin_top: CssPixels,
+    pub(crate) margin_bottom: CssPixels,
+    pub(crate) border_left: CssPixels,
+    pub(crate) border_right: CssPixels,
+    pub(crate) border_top: CssPixels,
+    pub(crate) border_bottom: CssPixels,
+    pub(crate) padding_left: CssPixels,
+    pub(crate) padding_right: CssPixels,
+    pub(crate) padding_top: CssPixels,
+    pub(crate) padding_bottom: CssPixels,
     pub(crate) children: Vec<FragmentLink>,
 }
 
+#[allow(dead_code)]
 pub(crate) struct FragmentLink {
-    #[allow(dead_code)]
     pub(crate) fragment: Box<Fragment>,
+    pub(crate) committed_offset: FfiCssPixelPoint,
+    pub(crate) inset_left: CssPixels,
+    pub(crate) inset_right: CssPixels,
+    pub(crate) inset_top: CssPixels,
+    pub(crate) inset_bottom: CssPixels,
+    pub(crate) containing_line_box_index: Option<usize>,
+}
+
+fn snapshot_fragment(
+    node: crate::layout::node_data::NodeSlotId,
+    children: Vec<FragmentLink>,
+    used: &UsedValues,
+) -> Box<Fragment> {
+    Box::new(Fragment {
+        node,
+        content_inline_size: used.content_inline_size.get(),
+        content_block_size: used.content_block_size.get(),
+        margin_left: used.margin_left.get(),
+        margin_right: used.margin_right.get(),
+        margin_top: used.margin_top.get(),
+        margin_bottom: used.margin_bottom.get(),
+        border_left: used.border_left.get(),
+        border_right: used.border_right.get(),
+        border_top: used.border_top.get(),
+        border_bottom: used.border_bottom.get(),
+        padding_left: used.padding_left.get(),
+        padding_right: used.padding_right.get(),
+        padding_top: used.padding_top.get(),
+        padding_bottom: used.padding_bottom.get(),
+        children,
+    })
+}
+
+pub(crate) struct PlacementData {
+    pub(crate) committed_offset: FfiCssPixelPoint,
+    pub(crate) inset_left: CssPixels,
+    pub(crate) inset_right: CssPixels,
+    pub(crate) inset_top: CssPixels,
+    pub(crate) inset_bottom: CssPixels,
+    pub(crate) containing_line_box_index: Option<usize>,
+}
+
+impl PlacementData {
+    fn from_record(used: &UsedValues, containing_line_box_index: Option<usize>) -> Self {
+        Self {
+            committed_offset: crate::layout::point_add(used.content_offset.get(), used.committed_offset_delta.get()),
+            inset_left: used.inset_left.get(),
+            inset_right: used.inset_right.get(),
+            inset_top: used.inset_top.get(),
+            inset_bottom: used.inset_bottom.get(),
+            containing_line_box_index,
+        }
+    }
+}
+
+fn link_fragment(fragment: Box<Fragment>, placement: PlacementData) -> FragmentLink {
+    FragmentLink {
+        fragment,
+        committed_offset: placement.committed_offset,
+        inset_left: placement.inset_left,
+        inset_right: placement.inset_right,
+        inset_top: placement.inset_top,
+        inset_bottom: placement.inset_bottom,
+        containing_line_box_index: placement.containing_line_box_index,
+    }
 }
 
 pub(crate) struct UnplacedRootFragment {
@@ -102,7 +180,9 @@ impl RunFragmentBuilder {
         &self,
         node: crate::layout::node_data::NodeSlotId,
         containing_block: Option<crate::layout::node_data::NodeSlotId>,
+        used: &UsedValues,
         containing_block_is_sealed: bool,
+        containing_line_box_index: Option<usize>,
     ) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
@@ -116,9 +196,10 @@ impl RunFragmentBuilder {
             Some(pending_fragment) => pending_fragment.children,
             None => Vec::new(),
         };
-        let link = FragmentLink {
-            fragment: Box::new(Fragment { node, children }),
-        };
+        let link = link_fragment(
+            snapshot_fragment(node, children, used),
+            PlacementData::from_record(used, containing_line_box_index),
+        );
         self.attach(&mut inner, link, containing_block, containing_block_is_sealed);
     }
 
@@ -154,41 +235,43 @@ impl RunFragmentBuilder {
         );
     }
 
-    pub(crate) fn take_unplaced_root(&self) -> UnplacedRootFragment {
+    pub(crate) fn take_unplaced_root(&self, state: &LayoutState) -> UnplacedRootFragment {
         debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
         UnplacedRootFragment {
             node: self.root_node,
-            scoped_descendants: self.close(),
+            scoped_descendants: self.close(state),
         }
     }
 
-    pub(crate) fn take_completed_pass(&self) -> CompletedPassFragments {
+    pub(crate) fn take_completed_pass(&self, state: &LayoutState) -> CompletedPassFragments {
         debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
-        CompletedPassFragments { roots: self.close() }
+        CompletedPassFragments { roots: self.close(state) }
     }
 
-    fn close(&self) -> Vec<FragmentLink> {
+    fn close(&self, state: &LayoutState) -> Vec<FragmentLink> {
         let mut inner = self.inner.take();
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
-        for (_, pending_fragment) in pending_fragments {
+        for (slot, pending_fragment) in pending_fragments {
             if pending_fragment.children.is_empty() {
                 continue;
             }
-            inner.top_scope_links.push(FragmentLink {
-                fragment: Box::new(Fragment {
-                    node: pending_fragment.node,
-                    children: pending_fragment.children,
-                }),
-            });
+            let used = state
+                .used_values_by_slot(slot)
+                .expect("a pending fragment's containing block has no record");
+            inner.top_scope_links.push(link_fragment(
+                snapshot_fragment(pending_fragment.node, pending_fragment.children, used),
+                PlacementData::from_record(used, None),
+            ));
         }
         let child_roots_awaiting_placement = std::mem::take(&mut inner.child_roots_awaiting_placement);
-        for (_, root) in child_roots_awaiting_placement {
-            inner.top_scope_links.push(FragmentLink {
-                fragment: Box::new(Fragment {
-                    node: root.node,
-                    children: root.scoped_descendants,
-                }),
-            });
+        for (slot, root) in child_roots_awaiting_placement {
+            let used = state
+                .used_values_by_slot(slot)
+                .expect("a held child run's root has no record");
+            inner.top_scope_links.push(link_fragment(
+                snapshot_fragment(root.node, root.scoped_descendants, used),
+                PlacementData::from_record(used, None),
+            ));
         }
         inner.top_scope_links
     }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -175,6 +175,62 @@ fn propagate_payload_toward_run_root_space<Payload: PropagatedPayload>(
     }
 }
 
+pub(crate) struct CommitScopes<'tree> {
+    links_by_slot: std::collections::HashMap<u32, &'tree FragmentLink>,
+    open_scopes: Vec<&'tree [FragmentLink]>,
+}
+
+impl<'tree> CommitScopes<'tree> {
+    pub(crate) fn for_pass(fragments: &'tree CompletedPassFragments) -> Self {
+        #[cfg(debug_assertions)]
+        assert_one_fragment_per_slot_in_whole_pass(&fragments.roots, &mut std::collections::HashSet::new());
+        let mut scopes = Self {
+            links_by_slot: std::collections::HashMap::new(),
+            open_scopes: Vec::new(),
+        };
+        scopes.open_scope(&fragments.roots);
+        scopes
+    }
+
+    pub(crate) fn link_for_slot(&self, slot: u32) -> Option<&'tree FragmentLink> {
+        self.links_by_slot.get(&slot).copied()
+    }
+
+    pub(crate) fn open_scope(&mut self, links: &'tree [FragmentLink]) {
+        for link in links {
+            let previous = self.links_by_slot.insert(link.fragment.node.slot_index(), link);
+            assert!(
+                previous.is_none(),
+                "two open fragments claim slot {}",
+                link.fragment.node.slot_index()
+            );
+        }
+        self.open_scopes.push(links);
+    }
+
+    pub(crate) fn close_scope(&mut self) {
+        let links = self
+            .open_scopes
+            .pop()
+            .expect("a commit scope was closed without being opened");
+        for link in links {
+            self.links_by_slot.remove(&link.fragment.node.slot_index());
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn assert_one_fragment_per_slot_in_whole_pass(links: &[FragmentLink], seen: &mut std::collections::HashSet<u32>) {
+    for link in links {
+        assert!(
+            seen.insert(link.fragment.node.slot_index()),
+            "two fragments claim slot {}",
+            link.fragment.node.slot_index()
+        );
+        assert_one_fragment_per_slot_in_whole_pass(&link.fragment.children, seen);
+    }
+}
+
 pub(crate) struct UnplacedRootFragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
     pub(crate) scoped_descendants: Vec<FragmentLink>,

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -94,6 +94,12 @@ fn link_fragment(fragment: Box<Fragment>, placement: PlacementData) -> FragmentL
     }
 }
 
+pub(crate) struct AnchorCandidate {
+    pub(crate) node: crate::layout::node_data::NodeSlotId,
+    pub(crate) border_box_rect: PhysicalRect,
+    pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
+}
+
 pub(crate) fn translate_pending_abspos_payloads(entry: &mut PendingAbsposChild, offset: FfiCssPixelPoint) {
     entry.static_position_rect = crate::layout::translate_static_position_rect(entry.static_position_rect, offset);
     if let Some(rect) = &mut entry.inline_containing_block_rect {
@@ -117,6 +123,19 @@ impl PropagatedPayload for PendingAbsposChild {
     }
     fn translate_by(&mut self, offset: FfiCssPixelPoint) {
         translate_pending_abspos_payloads(self, offset);
+    }
+}
+
+impl PropagatedPayload for AnchorCandidate {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
+        self.coordinate_space_box
+    }
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
+        self.coordinate_space_box = node;
+    }
+    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
+        self.border_box_rect.x += offset.x;
+        self.border_box_rect.y += offset.y;
     }
 }
 
@@ -160,6 +179,7 @@ pub(crate) struct UnplacedRootFragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
     pub(crate) scoped_descendants: Vec<FragmentLink>,
     pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
+    pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
 }
 
 pub(crate) struct CompletedPassFragments {
@@ -170,6 +190,7 @@ struct PendingFragment {
     node: crate::layout::node_data::NodeSlotId,
     children: Vec<FragmentLink>,
     pending_abspos: Vec<PendingAbsposChild>,
+    anchor_candidates: Vec<AnchorCandidate>,
 }
 
 pub(crate) struct RunFragmentBuilder {
@@ -185,6 +206,7 @@ struct RunFragmentBuilderInner {
     placed_slots: std::collections::HashSet<u32>,
     child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
     pending_abspos_at_root: Vec<PendingAbsposChild>,
+    anchor_candidates_at_root: Vec<AnchorCandidate>,
     top_scope_links: Vec<FragmentLink>,
 }
 
@@ -201,6 +223,13 @@ impl RunFragmentBuilderInner {
             .values_mut()
             .flat_map(|pending_fragment| pending_fragment.pending_abspos.iter_mut())
             .chain(self.pending_abspos_at_root.iter_mut())
+    }
+
+    fn iter_anchor_candidates(&self) -> impl Iterator<Item = &AnchorCandidate> {
+        self.pending_fragments
+            .values()
+            .flat_map(|pending_fragment| pending_fragment.anchor_candidates.iter())
+            .chain(self.anchor_candidates_at_root.iter())
     }
 }
 
@@ -257,6 +286,7 @@ impl RunFragmentBuilder {
                             node: coordinate_space_box,
                             children: Vec::new(),
                             pending_abspos: vec![entry],
+                            anchor_candidates: Vec::new(),
                         },
                     );
                 }
@@ -308,6 +338,25 @@ impl RunFragmentBuilder {
         }
     }
 
+    pub(crate) fn anchor_candidate_shells(&self, callbacks: &FfiLayoutFcCallbacks) -> Vec<*mut c_void> {
+        self.inner
+            .borrow()
+            .iter_anchor_candidates()
+            .map(|candidate| callbacks.shell(candidate.node))
+            .collect()
+    }
+
+    pub(crate) fn find_anchor_candidate(
+        &self,
+        node: crate::layout::node_data::NodeSlotId,
+    ) -> Option<(PhysicalRect, crate::layout::node_data::NodeSlotId)> {
+        self.inner
+            .borrow()
+            .iter_anchor_candidates()
+            .find(|candidate| candidate.node == node)
+            .map(|candidate| (candidate.border_box_rect, candidate.coordinate_space_box))
+    }
+
     pub(crate) fn take_drainable_abspos(
         &self,
         placed: crate::layout::node_data::NodeSlotId,
@@ -356,18 +405,23 @@ impl RunFragmentBuilder {
     pub(crate) fn normalize_arrivals_for_placement(&self, node: crate::layout::node_data::NodeSlotId) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
-        let (scoped_descendants, propagated_pending_abspos) =
+        let (scoped_descendants, propagated_pending_abspos, propagated_anchor_candidates) =
             match inner.child_roots_awaiting_placement.remove(&slot) {
                 Some(root) => {
                     debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
-                    (root.scoped_descendants, root.propagated_pending_abspos)
+                    (
+                        root.scoped_descendants,
+                        root.propagated_pending_abspos,
+                        root.propagated_anchor_candidates,
+                    )
                 }
-                None => (Vec::new(), Vec::new()),
+                None => (Vec::new(), Vec::new(), Vec::new()),
             };
         let pending_fragment = inner.pending_fragments.entry(slot).or_insert_with(|| PendingFragment {
             node,
             children: Vec::new(),
             pending_abspos: Vec::new(),
+            anchor_candidates: Vec::new(),
         });
         debug_assert!(
             pending_fragment.children.is_empty() || scoped_descendants.is_empty(),
@@ -375,8 +429,10 @@ impl RunFragmentBuilder {
         );
         pending_fragment.children.extend(scoped_descendants);
         pending_fragment.pending_abspos.extend(propagated_pending_abspos);
+        pending_fragment.anchor_candidates.extend(propagated_anchor_candidates);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build_fragment_for_placed_box(
         &self,
         callbacks: &FfiLayoutFcCallbacks,
@@ -385,6 +441,7 @@ impl RunFragmentBuilder {
         used: &UsedValues,
         containing_block_is_sealed: bool,
         containing_line_box_index: Option<usize>,
+        own_anchor_candidate_border_box_rect: Option<PhysicalRect>,
     ) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
@@ -393,10 +450,15 @@ impl RunFragmentBuilder {
             !inner.child_roots_awaiting_placement.contains_key(&slot),
             "a box was placed without normalizing its held unplaced root (slot {slot})"
         );
-        let (children, pending_abspos_from_placed_box) = match inner.pending_fragments.remove(&slot) {
-            Some(pending_fragment) => (pending_fragment.children, pending_fragment.pending_abspos),
-            None => (Vec::new(), Vec::new()),
-        };
+        let (children, pending_abspos_from_placed_box, anchor_candidates_from_placed_box) =
+            match inner.pending_fragments.remove(&slot) {
+                Some(pending_fragment) => (
+                    pending_fragment.children,
+                    pending_fragment.pending_abspos,
+                    pending_fragment.anchor_candidates,
+                ),
+                None => (Vec::new(), Vec::new(), Vec::new()),
+            };
         let link = link_fragment(
             snapshot_fragment(node, children, used),
             PlacementData::from_record(used, containing_line_box_index),
@@ -413,6 +475,18 @@ impl RunFragmentBuilder {
             match inner.pending_fragments.get_mut(&entry.coordinate_space_box.slot_index()) {
                 Some(pending_fragment) => pending_fragment.pending_abspos.push(entry),
                 None => inner.pending_abspos_at_root.push(entry),
+            }
+        }
+        let own_candidate = own_anchor_candidate_border_box_rect.map(|border_box_rect| AnchorCandidate {
+            node,
+            border_box_rect,
+            coordinate_space_box: containing_block.unwrap_or(node),
+        });
+        for mut candidate in anchor_candidates_from_placed_box.into_iter().chain(own_candidate) {
+            propagate_payload_into_containing_block_space(&mut candidate, node, containing_block, content_offset);
+            match inner.pending_fragments.get_mut(&candidate.coordinate_space_box.slot_index()) {
+                Some(pending_fragment) => pending_fragment.anchor_candidates.push(candidate),
+                None => inner.anchor_candidates_at_root.push(candidate),
             }
         }
     }
@@ -446,23 +520,26 @@ impl RunFragmentBuilder {
                 node: containing_block,
                 children: vec![link],
                 pending_abspos: Vec::new(),
+                anchor_candidates: Vec::new(),
             },
         );
     }
 
     pub(crate) fn take_unplaced_root(&self, state: &LayoutState, callbacks: &FfiLayoutFcCallbacks) -> UnplacedRootFragment {
         debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
-        let (scoped_descendants, propagated_pending_abspos) = self.close(state, callbacks);
+        let (scoped_descendants, propagated_pending_abspos, propagated_anchor_candidates) =
+            self.close(state, callbacks);
         UnplacedRootFragment {
             node: self.root_node,
             scoped_descendants,
             propagated_pending_abspos,
+            propagated_anchor_candidates,
         }
     }
 
     pub(crate) fn take_completed_pass(&self, state: &LayoutState, callbacks: &FfiLayoutFcCallbacks) -> CompletedPassFragments {
         debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
-        let (roots, _dropped_pending_abspos) = self.close(state, callbacks);
+        let (roots, _dropped_pending_abspos, _dropped_anchor_candidates) = self.close(state, callbacks);
         CompletedPassFragments { roots }
     }
 
@@ -470,12 +547,14 @@ impl RunFragmentBuilder {
         &self,
         state: &LayoutState,
         callbacks: &FfiLayoutFcCallbacks,
-    ) -> (Vec<FragmentLink>, Vec<PendingAbsposChild>) {
+    ) -> (Vec<FragmentLink>, Vec<PendingAbsposChild>, Vec<AnchorCandidate>) {
         let mut inner = self.inner.take();
         let mut propagated_pending_abspos = std::mem::take(&mut inner.pending_abspos_at_root);
+        let mut propagated_anchor_candidates = std::mem::take(&mut inner.anchor_candidates_at_root);
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
         for (slot, pending_fragment) in pending_fragments {
             propagated_pending_abspos.extend(pending_fragment.pending_abspos);
+            propagated_anchor_candidates.extend(pending_fragment.anchor_candidates);
             if pending_fragment.children.is_empty() {
                 continue;
             }
@@ -493,6 +572,7 @@ impl RunFragmentBuilder {
                 .used_values_by_slot(slot)
                 .expect("a held child run's root has no record");
             propagated_pending_abspos.extend(root.propagated_pending_abspos);
+            propagated_anchor_candidates.extend(root.propagated_anchor_candidates);
             inner.top_scope_links.push(link_fragment(
                 snapshot_fragment(root.node, root.scoped_descendants, used),
                 PlacementData::from_record(used, None),
@@ -512,6 +592,9 @@ impl RunFragmentBuilder {
             }
             propagate_payload_toward_run_root_space(entry, self.root_node, state, callbacks);
         }
-        (inner.top_scope_links, propagated_pending_abspos)
+for candidate in &mut propagated_anchor_candidates {
+            propagate_payload_toward_run_root_space(candidate, self.root_node, state, callbacks);
+        }
+        (inner.top_scope_links, propagated_pending_abspos, propagated_anchor_candidates)
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -96,6 +96,10 @@ fn link_fragment(fragment: Box<Fragment>, placement: PlacementData) -> FragmentL
 
 pub(crate) fn translate_pending_abspos_payloads(entry: &mut PendingAbsposChild, offset: FfiCssPixelPoint) {
     entry.static_position_rect = crate::layout::translate_static_position_rect(entry.static_position_rect, offset);
+    if let Some(rect) = &mut entry.inline_containing_block_rect {
+        rect.x += offset.x;
+        rect.y += offset.y;
+    }
 }
 
 trait PropagatedPayload {
@@ -184,6 +188,22 @@ struct RunFragmentBuilderInner {
     top_scope_links: Vec<FragmentLink>,
 }
 
+impl RunFragmentBuilderInner {
+    fn iter_pending_abspos(&self) -> impl Iterator<Item = &PendingAbsposChild> {
+        self.pending_fragments
+            .values()
+            .flat_map(|pending_fragment| pending_fragment.pending_abspos.iter())
+            .chain(self.pending_abspos_at_root.iter())
+    }
+
+    fn iter_pending_abspos_mut(&mut self) -> impl Iterator<Item = &mut PendingAbsposChild> {
+        self.pending_fragments
+            .values_mut()
+            .flat_map(|pending_fragment| pending_fragment.pending_abspos.iter_mut())
+            .chain(self.pending_abspos_at_root.iter_mut())
+    }
+}
+
 impl RunFragmentBuilder {
     pub(crate) fn new(
         root_node: crate::layout::node_data::NodeSlotId,
@@ -253,6 +273,37 @@ impl RunFragmentBuilder {
         for entry in &mut self.inner.borrow_mut().pending_abspos_at_root {
             if callbacks.containing_block(entry.child_box) == containing_block {
                 entry.containing_block_info_override = Some(containing_block_info_for_child(entry.child_box));
+            }
+        }
+    }
+
+    pub(crate) fn any_pending_abspos_has_inline_containing_block(&self) -> bool {
+        self.inner
+            .borrow()
+            .iter_pending_abspos()
+            .any(|entry| !entry.inline_containing_block.is_invalid())
+    }
+
+    pub(crate) fn any_pending_abspos_names_inline_containing_block(&self, inline_box: crate::layout::node_data::NodeSlotId) -> bool {
+        self.inner
+            .borrow()
+            .iter_pending_abspos()
+            .any(|entry| entry.inline_containing_block == inline_box)
+    }
+
+    pub(crate) fn set_inline_containing_block_rect_on_pending_abspos(
+        &self,
+        inline_box: crate::layout::node_data::NodeSlotId,
+        rect: PhysicalRect,
+        expected_space: crate::layout::node_data::NodeSlotId,
+    ) {
+        for entry in self.inner.borrow_mut().iter_pending_abspos_mut() {
+            if entry.inline_containing_block == inline_box {
+                debug_assert!(
+                    entry.coordinate_space_box == expected_space,
+                    "an inline containing block rect met an entry in a different space"
+                );
+                entry.inline_containing_block_rect = Some(rect);
             }
         }
     }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -26,6 +26,9 @@ pub(crate) struct Fragment {
     pub(crate) grid_layout_data: Option<OwnedGridLayoutData>,
     pub(crate) flex_layout_data: Option<OwnedFlexLayoutData>,
     pub(crate) used_grid_tracks: Option<OwnedUsedGridTracks>,
+    pub(crate) computed_svg_transforms: Option<crate::layout::FfiSvgComputedTransforms>,
+    pub(crate) svg_viewport_size: Option<crate::layout::FfiCssPixelSize>,
+    pub(crate) computed_svg_path: Cell<Option<libgfx_rust::path::OwnedPath>>,
     pub(crate) children: Vec<FragmentLink>,
 }
 
@@ -54,10 +57,21 @@ fn snapshot_fragment(
             rare.grid_layout_data.take(),
             rare.flex_layout_data.take(),
             rare.used_grid_tracks.take(),
+            rare.computed_svg_transforms,
+            rare.svg_viewport_size,
+            rare.computed_svg_path.take(),
         )
     });
-    let (table_cell_coordinates, override_borders_data, grid_layout_data, flex_layout_data, used_grid_tracks) =
-        rare_payloads.unwrap_or_default();
+    let (
+        table_cell_coordinates,
+        override_borders_data,
+        grid_layout_data,
+        flex_layout_data,
+        used_grid_tracks,
+        computed_svg_transforms,
+        svg_viewport_size,
+        computed_svg_path,
+    ) = rare_payloads.unwrap_or_default();
     Box::new(Fragment {
         node,
         content_inline_size: used.content_inline_size.get(),
@@ -80,6 +94,9 @@ fn snapshot_fragment(
         grid_layout_data,
         flex_layout_data,
         used_grid_tracks,
+        computed_svg_transforms,
+        svg_viewport_size,
+        computed_svg_path: Cell::new(computed_svg_path),
         children,
     })
 }
@@ -286,6 +303,7 @@ pub(crate) struct RunFragmentBuilder {
     root_node: crate::layout::node_data::NodeSlotId,
     root_containing_block_slot: Option<u32>,
     is_entry_accumulator: bool,
+    saw_svg_payload_write: Cell<bool>,
     inner: std::cell::RefCell<RunFragmentBuilderInner>,
 }
 
@@ -331,6 +349,7 @@ impl RunFragmentBuilder {
             root_node,
             root_containing_block_slot: root_containing_block.map(|node| node.slot_index()),
             is_entry_accumulator: false,
+            saw_svg_payload_write: Cell::new(false),
             inner: std::cell::RefCell::new(RunFragmentBuilderInner::default()),
         }
     }
@@ -340,12 +359,17 @@ impl RunFragmentBuilder {
             root_node,
             root_containing_block_slot: None,
             is_entry_accumulator: true,
+            saw_svg_payload_write: Cell::new(false),
             inner: std::cell::RefCell::new(RunFragmentBuilderInner::default()),
         }
     }
 
     pub(crate) fn root_node(&self) -> crate::layout::node_data::NodeSlotId {
         self.root_node
+    }
+
+    pub(crate) fn note_svg_payload_write(&self) {
+        self.saw_svg_payload_write.set(true);
     }
 
     pub(crate) fn register_pending_abspos(
@@ -685,6 +709,32 @@ impl RunFragmentBuilder {
 for candidate in &mut propagated_anchor_candidates {
             propagate_payload_toward_run_root_space(candidate, self.root_node, state, callbacks);
         }
+        if self.saw_svg_payload_write.take() {
+            refresh_svg_payloads_from_records(&mut inner.top_scope_links, state);
+        }
         (inner.top_scope_links, propagated_pending_abspos, propagated_anchor_candidates)
+    }
+}
+
+fn refresh_svg_payloads_from_records(links: &mut [FragmentLink], state: &LayoutState) {
+    for link in links {
+        let fragment = &mut *link.fragment;
+        let slot_index = fragment.node.slot_index();
+        if let Some(rare) = state.used_values_rare_data(slot_index) {
+            if rare.computed_svg_transforms.is_some() {
+                fragment.computed_svg_transforms = rare.computed_svg_transforms;
+            }
+            if rare.svg_viewport_size.is_some() {
+                fragment.svg_viewport_size = rare.svg_viewport_size;
+            }
+        }
+        if let Some(path) = state
+            .used_values_by_slot(slot_index)
+            .and_then(|used| used.rare_data.get())
+            .and_then(|rare| rare.borrow_mut().computed_svg_path.take())
+        {
+            fragment.computed_svg_path.set(Some(path));
+        }
+        refresh_svg_payloads_from_records(&mut fragment.children, state);
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -94,9 +94,68 @@ fn link_fragment(fragment: Box<Fragment>, placement: PlacementData) -> FragmentL
     }
 }
 
+pub(crate) fn translate_pending_abspos_payloads(entry: &mut PendingAbsposChild, offset: FfiCssPixelPoint) {
+    entry.static_position_rect = crate::layout::translate_static_position_rect(entry.static_position_rect, offset);
+}
+
+trait PropagatedPayload {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId;
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId);
+    fn translate_by(&mut self, offset: FfiCssPixelPoint);
+}
+
+impl PropagatedPayload for PendingAbsposChild {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
+        self.coordinate_space_box
+    }
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
+        self.coordinate_space_box = node;
+    }
+    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
+        translate_pending_abspos_payloads(self, offset);
+    }
+}
+
+fn propagate_payload_into_containing_block_space<Payload: PropagatedPayload>(
+    payload: &mut Payload,
+    placed_box: crate::layout::node_data::NodeSlotId,
+    containing_block: Option<crate::layout::node_data::NodeSlotId>,
+    placed_box_content_offset: FfiCssPixelPoint,
+) {
+    if payload.coordinate_space_box() == placed_box
+        && let Some(containing_block) = containing_block
+    {
+        payload.translate_by(placed_box_content_offset);
+        payload.set_coordinate_space_box(containing_block);
+    }
+}
+
+fn propagate_payload_toward_run_root_space<Payload: PropagatedPayload>(
+    payload: &mut Payload,
+    run_root: crate::layout::node_data::NodeSlotId,
+    state: &LayoutState,
+    callbacks: &FfiLayoutFcCallbacks,
+) {
+    while payload.coordinate_space_box() != run_root {
+        let Some(used) = state
+            .used_values_by_slot(payload.coordinate_space_box().slot_index())
+            .filter(|used| used.has_content_offset.get())
+        else {
+            break;
+        };
+        payload.translate_by(used.content_offset.get());
+        let containing_block = callbacks.containing_block(payload.coordinate_space_box());
+        if containing_block.is_invalid() {
+            break;
+        }
+        payload.set_coordinate_space_box(containing_block);
+    }
+}
+
 pub(crate) struct UnplacedRootFragment {
     pub(crate) node: crate::layout::node_data::NodeSlotId,
     pub(crate) scoped_descendants: Vec<FragmentLink>,
+    pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
 }
 
 pub(crate) struct CompletedPassFragments {
@@ -106,6 +165,7 @@ pub(crate) struct CompletedPassFragments {
 struct PendingFragment {
     node: crate::layout::node_data::NodeSlotId,
     children: Vec<FragmentLink>,
+    pending_abspos: Vec<PendingAbsposChild>,
 }
 
 pub(crate) struct RunFragmentBuilder {
@@ -118,9 +178,9 @@ pub(crate) struct RunFragmentBuilder {
 #[derive(Default)]
 struct RunFragmentBuilderInner {
     pending_fragments: std::collections::HashMap<u32, PendingFragment>,
-    #[cfg(debug_assertions)]
     placed_slots: std::collections::HashSet<u32>,
     child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
+    pending_abspos_at_root: Vec<PendingAbsposChild>,
     top_scope_links: Vec<FragmentLink>,
 }
 
@@ -146,6 +206,93 @@ impl RunFragmentBuilder {
         }
     }
 
+    pub(crate) fn root_node(&self) -> crate::layout::node_data::NodeSlotId {
+        self.root_node
+    }
+
+    pub(crate) fn register_pending_abspos(
+        &self,
+        coordinate_space_box: crate::layout::node_data::NodeSlotId,
+        entry: PendingAbsposChild,
+    ) {
+        let mut inner = self.inner.borrow_mut();
+        #[cfg(debug_assertions)]
+        assert!(
+            !inner.placed_slots.contains(&coordinate_space_box.slot_index()),
+            "an abspos registration named an already-placed coordinate-space box"
+        );
+        if coordinate_space_box == self.root_node {
+            inner.pending_abspos_at_root.push(entry);
+            return;
+        }
+        match inner.pending_fragments.get_mut(&coordinate_space_box.slot_index()) {
+            Some(pending_fragment) => pending_fragment.pending_abspos.push(entry),
+            None => {
+                if self.is_entry_accumulator {
+                    inner.pending_abspos_at_root.push(entry);
+                } else {
+                    inner.pending_fragments.insert(
+                        coordinate_space_box.slot_index(),
+                        PendingFragment {
+                            node: coordinate_space_box,
+                            children: Vec::new(),
+                            pending_abspos: vec![entry],
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    pub(crate) fn override_containing_block_info_for_pending_abspos_of_containing_block(
+        &self,
+        containing_block: crate::layout::node_data::NodeSlotId,
+        callbacks: &FfiLayoutFcCallbacks,
+        containing_block_info_for_child: impl Fn(crate::layout::node_data::NodeSlotId) -> AbsposContainingBlockInfo,
+    ) {
+        for entry in &mut self.inner.borrow_mut().pending_abspos_at_root {
+            if callbacks.containing_block(entry.child_box) == containing_block {
+                entry.containing_block_info_override = Some(containing_block_info_for_child(entry.child_box));
+            }
+        }
+    }
+
+    pub(crate) fn take_drainable_abspos(
+        &self,
+        placed: crate::layout::node_data::NodeSlotId,
+        callbacks: &FfiLayoutFcCallbacks,
+    ) -> Vec<PendingAbsposChild> {
+        let mut inner = self.inner.borrow_mut();
+        let inner = &mut *inner;
+        let containing_block_is_placed = |entry: &PendingAbsposChild| {
+            let containing_block = callbacks.containing_block(entry.child_box);
+            !containing_block.is_invalid()
+                && (self.is_entry_accumulator || containing_block != self.root_node)
+                && (containing_block == placed || inner.placed_slots.contains(&containing_block.slot_index()))
+        };
+        let mut taken: Vec<PendingAbsposChild> = inner
+            .pending_abspos_at_root
+            .extract_if(.., |entry| containing_block_is_placed(entry))
+            .collect();
+        if let Some(pending_fragment) = inner.pending_fragments.get_mut(&placed.slot_index()) {
+            taken.extend(
+                pending_fragment
+                    .pending_abspos
+                    .extract_if(.., |entry| containing_block_is_placed(entry)),
+            );
+        }
+        taken.sort_by(|left, right| {
+            if left.child_box == right.child_box {
+                std::cmp::Ordering::Equal
+            } else if callbacks.is_before(left.child_box, right.child_box) {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        });
+        taken
+    }
+
     pub(crate) fn hold_unplaced_root(&self, root: UnplacedRootFragment) {
         let slot = root.node.slot_index();
         let previous = self.inner.borrow_mut().child_roots_awaiting_placement.insert(slot, root);
@@ -158,26 +305,30 @@ impl RunFragmentBuilder {
     pub(crate) fn normalize_arrivals_for_placement(&self, node: crate::layout::node_data::NodeSlotId) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
-        let scoped_descendants = match inner.child_roots_awaiting_placement.remove(&slot) {
-            Some(root) => {
-                debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
-                root.scoped_descendants
-            }
-            None => Vec::new(),
-        };
+        let (scoped_descendants, propagated_pending_abspos) =
+            match inner.child_roots_awaiting_placement.remove(&slot) {
+                Some(root) => {
+                    debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
+                    (root.scoped_descendants, root.propagated_pending_abspos)
+                }
+                None => (Vec::new(), Vec::new()),
+            };
         let pending_fragment = inner.pending_fragments.entry(slot).or_insert_with(|| PendingFragment {
             node,
             children: Vec::new(),
+            pending_abspos: Vec::new(),
         });
         debug_assert!(
             pending_fragment.children.is_empty() || scoped_descendants.is_empty(),
             "a held unplaced root and an open pending fragment both carry children for slot {slot}"
         );
         pending_fragment.children.extend(scoped_descendants);
+        pending_fragment.pending_abspos.extend(propagated_pending_abspos);
     }
 
     pub(crate) fn build_fragment_for_placed_box(
         &self,
+        callbacks: &FfiLayoutFcCallbacks,
         node: crate::layout::node_data::NodeSlotId,
         containing_block: Option<crate::layout::node_data::NodeSlotId>,
         used: &UsedValues,
@@ -186,21 +337,33 @@ impl RunFragmentBuilder {
     ) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
-        #[cfg(debug_assertions)]
         assert!(inner.placed_slots.insert(slot), "a box was placed twice in one run");
         debug_assert!(
             !inner.child_roots_awaiting_placement.contains_key(&slot),
             "a box was placed without normalizing its held unplaced root (slot {slot})"
         );
-        let children = match inner.pending_fragments.remove(&slot) {
-            Some(pending_fragment) => pending_fragment.children,
-            None => Vec::new(),
+        let (children, pending_abspos_from_placed_box) = match inner.pending_fragments.remove(&slot) {
+            Some(pending_fragment) => (pending_fragment.children, pending_fragment.pending_abspos),
+            None => (Vec::new(), Vec::new()),
         };
         let link = link_fragment(
             snapshot_fragment(node, children, used),
             PlacementData::from_record(used, containing_line_box_index),
         );
         self.attach(&mut inner, link, containing_block, containing_block_is_sealed);
+        let content_offset = used.content_offset.get();
+        for mut entry in pending_abspos_from_placed_box {
+            debug_assert!(
+                callbacks.containing_block(entry.child_box) != node,
+                "an abspos registration outlived its containing block's placement drain (slot {})",
+                entry.child_box.slot_index()
+            );
+            propagate_payload_into_containing_block_space(&mut entry, node, containing_block, content_offset);
+            match inner.pending_fragments.get_mut(&entry.coordinate_space_box.slot_index()) {
+                Some(pending_fragment) => pending_fragment.pending_abspos.push(entry),
+                None => inner.pending_abspos_at_root.push(entry),
+            }
+        }
     }
 
     fn attach(
@@ -231,27 +394,37 @@ impl RunFragmentBuilder {
             PendingFragment {
                 node: containing_block,
                 children: vec![link],
+                pending_abspos: Vec::new(),
             },
         );
     }
 
-    pub(crate) fn take_unplaced_root(&self, state: &LayoutState) -> UnplacedRootFragment {
+    pub(crate) fn take_unplaced_root(&self, state: &LayoutState, callbacks: &FfiLayoutFcCallbacks) -> UnplacedRootFragment {
         debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
+        let (scoped_descendants, propagated_pending_abspos) = self.close(state, callbacks);
         UnplacedRootFragment {
             node: self.root_node,
-            scoped_descendants: self.close(state),
+            scoped_descendants,
+            propagated_pending_abspos,
         }
     }
 
-    pub(crate) fn take_completed_pass(&self, state: &LayoutState) -> CompletedPassFragments {
+    pub(crate) fn take_completed_pass(&self, state: &LayoutState, callbacks: &FfiLayoutFcCallbacks) -> CompletedPassFragments {
         debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
-        CompletedPassFragments { roots: self.close(state) }
+        let (roots, _dropped_pending_abspos) = self.close(state, callbacks);
+        CompletedPassFragments { roots }
     }
 
-    fn close(&self, state: &LayoutState) -> Vec<FragmentLink> {
+    fn close(
+        &self,
+        state: &LayoutState,
+        callbacks: &FfiLayoutFcCallbacks,
+    ) -> (Vec<FragmentLink>, Vec<PendingAbsposChild>) {
         let mut inner = self.inner.take();
+        let mut propagated_pending_abspos = std::mem::take(&mut inner.pending_abspos_at_root);
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
         for (slot, pending_fragment) in pending_fragments {
+            propagated_pending_abspos.extend(pending_fragment.pending_abspos);
             if pending_fragment.children.is_empty() {
                 continue;
             }
@@ -268,11 +441,26 @@ impl RunFragmentBuilder {
             let used = state
                 .used_values_by_slot(slot)
                 .expect("a held child run's root has no record");
+            propagated_pending_abspos.extend(root.propagated_pending_abspos);
             inner.top_scope_links.push(link_fragment(
                 snapshot_fragment(root.node, root.scoped_descendants, used),
                 PlacementData::from_record(used, None),
             ));
         }
-        inner.top_scope_links
+        for entry in &mut propagated_pending_abspos {
+            #[cfg(debug_assertions)]
+            {
+                let containing_block = callbacks.containing_block(entry.child_box);
+                debug_assert!(
+                    containing_block.is_invalid()
+                        || containing_block == self.root_node
+                        || !inner.placed_slots.contains(&containing_block.slot_index()),
+                    "a drainable abspos registration survived its containing block's run (slot {})",
+                    entry.child_box.slot_index()
+                );
+            }
+            propagate_payload_toward_run_root_space(entry, self.root_node, state, callbacks);
+        }
+        (inner.top_scope_links, propagated_pending_abspos)
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+pub(crate) struct Fragment {
+    #[allow(dead_code)]
+    pub(crate) node: crate::layout::node_data::NodeSlotId,
+    #[allow(dead_code)]
+    pub(crate) children: Vec<FragmentLink>,
+}
+
+pub(crate) struct FragmentLink {
+    #[allow(dead_code)]
+    pub(crate) fragment: Box<Fragment>,
+}
+
+pub(crate) struct UnplacedRootFragment {
+    pub(crate) node: crate::layout::node_data::NodeSlotId,
+    pub(crate) scoped_descendants: Vec<FragmentLink>,
+}
+
+pub(crate) struct CompletedPassFragments {
+    pub(crate) roots: Vec<FragmentLink>,
+}
+
+struct PendingFragment {
+    node: crate::layout::node_data::NodeSlotId,
+    children: Vec<FragmentLink>,
+}
+
+pub(crate) struct RunFragmentBuilder {
+    root_node: crate::layout::node_data::NodeSlotId,
+    root_containing_block_slot: Option<u32>,
+    is_entry_accumulator: bool,
+    inner: std::cell::RefCell<RunFragmentBuilderInner>,
+}
+
+#[derive(Default)]
+struct RunFragmentBuilderInner {
+    pending_fragments: std::collections::HashMap<u32, PendingFragment>,
+    #[cfg(debug_assertions)]
+    placed_slots: std::collections::HashSet<u32>,
+    child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
+    top_scope_links: Vec<FragmentLink>,
+}
+
+impl RunFragmentBuilder {
+    pub(crate) fn new(
+        root_node: crate::layout::node_data::NodeSlotId,
+        root_containing_block: Option<crate::layout::node_data::NodeSlotId>,
+    ) -> Self {
+        Self {
+            root_node,
+            root_containing_block_slot: root_containing_block.map(|node| node.slot_index()),
+            is_entry_accumulator: false,
+            inner: std::cell::RefCell::new(RunFragmentBuilderInner::default()),
+        }
+    }
+
+    pub(crate) fn new_entry_accumulator(root_node: crate::layout::node_data::NodeSlotId) -> Self {
+        Self {
+            root_node,
+            root_containing_block_slot: None,
+            is_entry_accumulator: true,
+            inner: std::cell::RefCell::new(RunFragmentBuilderInner::default()),
+        }
+    }
+
+    pub(crate) fn hold_unplaced_root(&self, root: UnplacedRootFragment) {
+        let slot = root.node.slot_index();
+        let previous = self.inner.borrow_mut().child_roots_awaiting_placement.insert(slot, root);
+        debug_assert!(
+            previous.is_none(),
+            "a child run's root was handed over twice before placement"
+        );
+    }
+
+    pub(crate) fn normalize_arrivals_for_placement(&self, node: crate::layout::node_data::NodeSlotId) {
+        let mut inner = self.inner.borrow_mut();
+        let slot = node.slot_index();
+        let scoped_descendants = match inner.child_roots_awaiting_placement.remove(&slot) {
+            Some(root) => {
+                debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
+                root.scoped_descendants
+            }
+            None => Vec::new(),
+        };
+        let pending_fragment = inner.pending_fragments.entry(slot).or_insert_with(|| PendingFragment {
+            node,
+            children: Vec::new(),
+        });
+        debug_assert!(
+            pending_fragment.children.is_empty() || scoped_descendants.is_empty(),
+            "a held unplaced root and an open pending fragment both carry children for slot {slot}"
+        );
+        pending_fragment.children.extend(scoped_descendants);
+    }
+
+    pub(crate) fn build_fragment_for_placed_box(
+        &self,
+        node: crate::layout::node_data::NodeSlotId,
+        containing_block: Option<crate::layout::node_data::NodeSlotId>,
+        containing_block_is_sealed: bool,
+    ) {
+        let mut inner = self.inner.borrow_mut();
+        let slot = node.slot_index();
+        #[cfg(debug_assertions)]
+        assert!(inner.placed_slots.insert(slot), "a box was placed twice in one run");
+        debug_assert!(
+            !inner.child_roots_awaiting_placement.contains_key(&slot),
+            "a box was placed without normalizing its held unplaced root (slot {slot})"
+        );
+        let children = match inner.pending_fragments.remove(&slot) {
+            Some(pending_fragment) => pending_fragment.children,
+            None => Vec::new(),
+        };
+        let link = FragmentLink {
+            fragment: Box::new(Fragment { node, children }),
+        };
+        self.attach(&mut inner, link, containing_block, containing_block_is_sealed);
+    }
+
+    fn attach(
+        &self,
+        inner: &mut RunFragmentBuilderInner,
+        link: FragmentLink,
+        containing_block: Option<crate::layout::node_data::NodeSlotId>,
+        containing_block_is_sealed: bool,
+    ) {
+        let Some(containing_block) = containing_block else {
+            inner.top_scope_links.push(link);
+            return;
+        };
+        if containing_block == self.root_node || Some(containing_block.slot_index()) == self.root_containing_block_slot {
+            inner.top_scope_links.push(link);
+            return;
+        }
+        if let Some(pending_fragment) = inner.pending_fragments.get_mut(&containing_block.slot_index()) {
+            pending_fragment.children.push(link);
+            return;
+        }
+        if self.is_entry_accumulator || containing_block_is_sealed {
+            inner.top_scope_links.push(link);
+            return;
+        }
+        inner.pending_fragments.insert(
+            containing_block.slot_index(),
+            PendingFragment {
+                node: containing_block,
+                children: vec![link],
+            },
+        );
+    }
+
+    pub(crate) fn take_unplaced_root(&self) -> UnplacedRootFragment {
+        debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
+        UnplacedRootFragment {
+            node: self.root_node,
+            scoped_descendants: self.close(),
+        }
+    }
+
+    pub(crate) fn take_completed_pass(&self) -> CompletedPassFragments {
+        debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
+        CompletedPassFragments { roots: self.close() }
+    }
+
+    fn close(&self) -> Vec<FragmentLink> {
+        let mut inner = self.inner.take();
+        let pending_fragments = std::mem::take(&mut inner.pending_fragments);
+        for (_, pending_fragment) in pending_fragments {
+            if pending_fragment.children.is_empty() {
+                continue;
+            }
+            inner.top_scope_links.push(FragmentLink {
+                fragment: Box::new(Fragment {
+                    node: pending_fragment.node,
+                    children: pending_fragment.children,
+                }),
+            });
+        }
+        let child_roots_awaiting_placement = std::mem::take(&mut inner.child_roots_awaiting_placement);
+        for (_, root) in child_roots_awaiting_placement {
+            inner.top_scope_links.push(FragmentLink {
+                fragment: Box::new(Fragment {
+                    node: root.node,
+                    children: root.scoped_descendants,
+                }),
+            });
+        }
+        inner.top_scope_links
+    }
+}

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3250,7 +3250,7 @@ impl<'pass> GridFormattingContext<'pass> {
                 self.grid_container,
                 run.treat_block_axis_percentage_insets_as_auto_beyond_root,
             );
-            crate::layout::place_child(&self.formatting_context_run(), item.box_, offset);
+            crate::layout::place_child(&self.formatting_context_run(), item.box_, offset, None);
         }
         self.derived_baselines_of_root_box =
             crate::layout::derive_baselines(self.state, &self.callbacks, self.grid_container, false);

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -1050,6 +1050,8 @@ pub(crate) struct GridFormattingContext<'pass> {
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
+    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
     available_space: Option<AvailableSpace>,
     layout_input: Option<LayoutInput>,
     column_lines: Vec<Vec<LineName>>,
@@ -1122,22 +1124,18 @@ impl ParentGridData {
 }
 
 impl<'pass> GridFormattingContext<'pass> {
-    pub(crate) fn new(
-        state: &'pass LayoutState,
-        grid_container: Node,
-        parent_grid: Option<&GridFormattingContext<'_>>,
-        layout_mode: LayoutMode,
-        callbacks: FfiLayoutFcCallbacks,
-        should_collect_devtools_layout_data: bool,
-    ) -> Self {
+    pub(crate) fn new(run: &FormattingContextRun<'pass>, parent_grid: Option<&GridFormattingContext<'_>>) -> Self {
+        let grid_container = run.box_;
         Self {
-            state,
+            state: run.state,
             grid_container,
             derived_baselines_of_root_box: DerivedBaselines::default(),
             parent_grid: parent_grid.map(|parent| ParentGridData::for_child_container(parent, grid_container)),
-            layout_mode,
-            callbacks,
-            should_collect_devtools_layout_data,
+            layout_mode: run.layout_mode,
+            callbacks: run.callbacks,
+            should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            fragments: run.fragments.clone(),
             available_space: None,
             layout_input: None,
             column_lines: Vec::new(),
@@ -1156,6 +1154,19 @@ impl<'pass> GridFormattingContext<'pass> {
             automatic_content_block_size: CssPixels::default(),
             row_alignment_container_size: CssPixels::default(),
             use_row_alignment_container_size: false,
+        }
+    }
+
+
+    fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
+        FormattingContextRun {
+            state: self.state,
+            box_: self.grid_container,
+            layout_mode: self.layout_mode,
+            callbacks: self.callbacks,
+            should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            fragments: self.fragments.clone(),
         }
     }
 
@@ -2474,14 +2485,16 @@ impl<'pass> GridFormattingContext<'pass> {
         live.mirror_box_metrics_and_size_constraints_into(scratch_root);
         scratch_root.has_definite_inline_size.set(live.has_definite_inline_size.get());
         scratch_root.has_definite_block_size.set(live.has_definite_block_size.get());
-        let mut context = GridFormattingContext::new(
-            scratch.layout_state(),
-            subgrid.box_,
-            Some(self),
-            LayoutMode::IntrinsicSizing,
-            self.callbacks,
-            false,
-        );
+        let scratch_run = FormattingContextRun {
+            state: scratch.layout_state(),
+            box_: subgrid.box_,
+            layout_mode: LayoutMode::IntrinsicSizing,
+            callbacks: self.callbacks,
+            should_collect_devtools_layout_data: false,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+            fragments: None,
+        };
+        let mut context = GridFormattingContext::new(&scratch_run, Some(self));
         let mut available = self.available_space.unwrap();
         if !axis.is_column() && self.used(subgrid).has_definite_inline_size() {
             available.inline_size = AvailableSize::definite(self.used(subgrid).content_inline_size.get());
@@ -3236,7 +3249,7 @@ impl<'pass> GridFormattingContext<'pass> {
                 self.grid_container,
                 run.treat_block_axis_percentage_insets_as_auto_beyond_root,
             );
-            crate::layout::place_child(self.state, &self.callbacks, item.box_, offset);
+            crate::layout::place_child(&self.formatting_context_run(), item.box_, offset);
         }
         self.derived_baselines_of_root_box =
             crate::layout::derive_baselines(self.state, &self.callbacks, self.grid_container, false);

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -1044,6 +1044,7 @@ impl GridItem {
 
 pub(crate) struct GridFormattingContext<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     grid_container: Node,
     derived_baselines_of_root_box: DerivedBaselines,
     parent_grid: Option<ParentGridData>,
@@ -1128,6 +1129,7 @@ impl<'pass> GridFormattingContext<'pass> {
         let grid_container = run.box_;
         Self {
             state: run.state,
+            records: run.records.clone(),
             grid_container,
             derived_baselines_of_root_box: DerivedBaselines::default(),
             parent_grid: parent_grid.map(|parent| ParentGridData::for_child_container(parent, grid_container)),
@@ -1157,10 +1159,10 @@ impl<'pass> GridFormattingContext<'pass> {
         }
     }
 
-
     fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
         FormattingContextRun {
             state: self.state,
+            records: self.records.clone(),
             box_: self.grid_container,
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
@@ -1191,14 +1193,13 @@ impl<'pass> GridFormattingContext<'pass> {
         self.use_row_alignment_container_size = false;
     }
 
-    fn container_used(&self) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, self.grid_container)
+    fn container_used(&self) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(self.grid_container)
     }
 
-    fn used(&self, item: GridItem) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, item.box_)
+    fn used(&self, item: GridItem) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(item.box_)
     }
-
     fn style(&self, node: Node) -> StyleValues<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
@@ -1214,8 +1215,8 @@ impl<'pass> GridFormattingContext<'pass> {
         ComputedValuesView::new(&self.callbacks.style_payloads(node).groups).grid_values()
     }
 
-    fn sizing(&self) -> SizingContext<'_> {
-        SizingContext::new(self.state, self.callbacks)
+    fn sizing(&self) -> SizingContext<'pass> {
+        SizingContext::new(self.state, self.records.clone(), self.callbacks)
     }
 
     fn parent_grid(&self) -> Option<&ParentGridData> {
@@ -1643,8 +1644,8 @@ impl<'pass> GridFormattingContext<'pass> {
                             child_grid_style.names.raws(),
                         ),
                     });
-                    self.state
-                        .create_used_values(&self.callbacks, child, ContainingBlockConstraints::default());
+                    self.records
+                        .create_used_values(self.state, &self.callbacks, child, ContainingBlockConstraints::default());
                     nodes.push(child);
                 }
             }
@@ -2479,14 +2480,15 @@ impl<'pass> GridFormattingContext<'pass> {
     }
 
     fn subgrid_item_contributions_to_track_sizing(&self, subgrid: GridItem, axis: Axis) -> Vec<ItemContribution> {
-        let scratch = MeasurementState::create(self.callbacks, subgrid.box_, ContainingBlockConstraints::default());
+        let scratch = MeasurementState::create(self.callbacks);
         let live = self.used(subgrid);
-        let scratch_root = scratch.root_used();
-        live.mirror_box_metrics_and_size_constraints_into(scratch_root);
+        let scratch_root = scratch.create_used_values(subgrid.box_, ContainingBlockConstraints::default());
+        live.mirror_box_metrics_and_size_constraints_into(&scratch_root);
         scratch_root.has_definite_inline_size.set(live.has_definite_inline_size.get());
         scratch_root.has_definite_block_size.set(live.has_definite_block_size.get());
         let scratch_run = FormattingContextRun {
             state: scratch.layout_state(),
+            records: std::rc::Rc::new(RunRecords::new(subgrid.box_, scratch_root)),
             box_: subgrid.box_,
             layout_mode: LayoutMode::IntrinsicSizing,
             callbacks: self.callbacks,
@@ -3240,20 +3242,11 @@ impl<'pass> GridFormattingContext<'pass> {
             };
             // Resolve relative-position insets before placement seals the
             // item's committed metrics.
-            crate::layout::compute_inset_native(
-                self.state,
-                self.callbacks,
-                self.fragments.clone(),
-                item.box_,
-                area.size.inline_size,
-                area.size.block_size,
-                self.grid_container,
-                run.treat_block_axis_percentage_insets_as_auto_beyond_root,
-            );
+            crate::layout::compute_inset_native(run, item.box_, area.size.inline_size, area.size.block_size);
             crate::layout::place_child(&self.formatting_context_run(), item.box_, offset, None);
         }
         self.derived_baselines_of_root_box =
-            crate::layout::derive_baselines(self.state, &self.callbacks, self.grid_container, false);
+            crate::layout::derive_baselines(self.state, &self.records, &self.callbacks, self.grid_container, false);
     }
 
     fn used_track_list_data(&self, axis: Axis, subgrid: bool) -> OwnedUsedGridTrackList {
@@ -3291,8 +3284,8 @@ impl<'pass> GridFormattingContext<'pass> {
             columns: self.used_track_list_data(Axis::Column, self.is_subgridded(Axis::Column, grid_style)),
             rows: self.used_track_list_data(Axis::Row, self.is_subgridded(Axis::Row, grid_style)),
         };
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, self.grid_container)
+        self.container_used()
+            .rare_data_mut()
             .used_grid_tracks = Some(tracks);
     }
 
@@ -3398,8 +3391,8 @@ impl<'pass> GridFormattingContext<'pass> {
             is_subgrid: self.is_subgridded(Axis::Column, grid_style) || self.is_subgridded(Axis::Row, grid_style),
             fragments: vec![fragment],
         };
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, self.grid_container)
+        self.container_used()
+            .rare_data_mut()
             .grid_layout_data = Some(data);
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3514,12 +3514,20 @@ impl<'pass> GridFormattingContext<'pass> {
                     block_alignment: StaticPositionAlignment::Start,
                     alignment_derives_from_own_computed_values: false,
                 };
-                crate::layout::register_contained_abspos_child(self.state, &self.callbacks, child, rect);
+                crate::layout::register_contained_abspos_child(
+                    self.state,
+                    &self.callbacks,
+                    self.fragments.as_deref(),
+                    self.grid_container,
+                    child,
+                    rect,
+                    None,
+                );
             }
             child = next;
         }
-        self.state
-            .override_contained_abspos_child_containing_blocks(self.grid_container, |child| {
+        if let Some(fragments) = self.fragments.as_deref() {
+            fragments.override_containing_block_info_for_pending_abspos_of_containing_block(self.grid_container, &self.callbacks, |child| {
                 let mut info = self.abspos_containing_block_info(child);
                 let grid_area_is_childs_static_position =
                     self.callbacks.static_position_containing_block(child) == self.grid_container;
@@ -3530,6 +3538,7 @@ impl<'pass> GridFormattingContext<'pass> {
                 }
                 info
             });
+        }
     }
 
     // https://www.w3.org/TR/css-grid-2/#abspos-items

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3515,7 +3515,6 @@ impl<'pass> GridFormattingContext<'pass> {
                     alignment_derives_from_own_computed_values: false,
                 };
                 crate::layout::register_contained_abspos_child(
-                    self.state,
                     &self.callbacks,
                     self.fragments.as_deref(),
                     self.grid_container,

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3243,6 +3243,7 @@ impl<'pass> GridFormattingContext<'pass> {
             crate::layout::compute_inset_native(
                 self.state,
                 self.callbacks,
+                self.fragments.clone(),
                 item.box_,
                 area.size.inline_size,
                 area.size.block_size,

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -1005,9 +1005,8 @@ impl Axis {
 }
 
 #[derive(Clone, Copy)]
-struct GridItem<'pass> {
+struct GridItem {
     box_: Node,
-    used_values: &'pass UsedValues,
     row: i32,
     row_span: usize,
     column: i32,
@@ -1020,7 +1019,7 @@ struct GridItem<'pass> {
     extra_margin_left: CssPixels,
 }
 
-impl GridItem<'_> {
+impl GridItem {
     fn placement(self) -> GridItemPlacement {
         GridItemPlacement {
             row: self.row,
@@ -1051,7 +1050,6 @@ pub(crate) struct GridFormattingContext<'pass> {
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
     should_collect_devtools_layout_data: bool,
-    container_used_values: &'pass UsedValues,
     available_space: Option<AvailableSpace>,
     layout_input: Option<LayoutInput>,
     column_lines: Vec<Vec<LineName>>,
@@ -1060,7 +1058,7 @@ pub(crate) struct GridFormattingContext<'pass> {
     rows: Vec<Track>,
     column_gaps: Vec<Track>,
     row_gaps: Vec<Track>,
-    items: Vec<GridItem<'pass>>,
+    items: Vec<GridItem>,
     explicit_column_line_count: usize,
     explicit_row_line_count: usize,
     explicit_column_start: usize,
@@ -1132,7 +1130,6 @@ impl<'pass> GridFormattingContext<'pass> {
         callbacks: FfiLayoutFcCallbacks,
         should_collect_devtools_layout_data: bool,
     ) -> Self {
-        let container_used_values = state.used_values(&callbacks, grid_container);
         Self {
             state,
             grid_container,
@@ -1141,7 +1138,6 @@ impl<'pass> GridFormattingContext<'pass> {
             layout_mode,
             callbacks,
             should_collect_devtools_layout_data,
-            container_used_values,
             available_space: None,
             layout_input: None,
             column_lines: Vec::new(),
@@ -1185,11 +1181,11 @@ impl<'pass> GridFormattingContext<'pass> {
     }
 
     fn container_used(&self) -> &'pass UsedValues {
-        self.container_used_values
+        self.state.used_values(&self.callbacks, self.grid_container)
     }
 
-    fn used(&self, item: GridItem<'pass>) -> &'pass UsedValues {
-        item.used_values
+    fn used(&self, item: GridItem) -> &'pass UsedValues {
+        self.state.used_values(&self.callbacks, item.box_)
     }
 
     fn style(&self, node: Node) -> StyleValues<'pass> {
@@ -1636,10 +1632,9 @@ impl<'pass> GridFormattingContext<'pass> {
                             child_grid_style.names.raws(),
                         ),
                     });
-                    let item_used_values =
-                        self.state
-                            .create_used_values(&self.callbacks, child, ContainingBlockConstraints::default());
-                    nodes.push((child, item_used_values));
+                    self.state
+                        .create_used_values(&self.callbacks, child, ContainingBlockConstraints::default());
+                    nodes.push(child);
                 }
             }
             child = next;
@@ -1686,10 +1681,9 @@ impl<'pass> GridFormattingContext<'pass> {
             self.row_lines = lines;
         }
         for placed in result.items {
-            let (box_, used_values) = nodes[placed.id];
+            let box_ = nodes[placed.id];
             self.items.push(GridItem {
                 box_,
-                used_values,
                 row: placed.row,
                 row_span: placed.row_span,
                 column: placed.column,
@@ -2473,7 +2467,7 @@ impl<'pass> GridFormattingContext<'pass> {
         }
     }
 
-    fn subgrid_item_contributions_to_track_sizing(&self, subgrid: GridItem<'pass>, axis: Axis) -> Vec<ItemContribution> {
+    fn subgrid_item_contributions_to_track_sizing(&self, subgrid: GridItem, axis: Axis) -> Vec<ItemContribution> {
         let scratch = MeasurementState::create(self.callbacks, subgrid.box_, ContainingBlockConstraints::default());
         let live = self.used(subgrid);
         let scratch_root = scratch.root_used();

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -821,6 +821,7 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         crate::layout::compute_inset_native(
             self.state,
             self.callbacks,
+            self.run.fragments.clone(),
             node,
             used.content_inline_size.get(),
             used.content_block_size.get(),

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -561,7 +561,7 @@ pub(crate) fn compute(
         if node_is_inline_containing_block
             && let Some(rect) = padding_box_rect_spanning_first_and_last_content_lines(
                 &corners,
-                used,
+                &used,
                 horizontal,
                 reversed,
                 container_inline_axis_is_reverse,
@@ -693,8 +693,7 @@ pub(crate) struct InlineFormattingContext<'context, 'pass> {
     pub(crate) input: LayoutInput,
     pub(crate) callbacks: FfiLayoutFcCallbacks,
     parent: &'context BlockFormattingContext<'pass>,
-    pub(crate) containing_used_values: &'pass UsedValues,
-    pub(crate) line_data: &'pass RefCell<LineData>,
+    pub(crate) containing_used_values: std::rc::Rc<UsedValues>,
     pub(crate) fragmented_inlines_in_pre_order: Vec<Node>,
     pub(crate) automatic_content_inline_size: CssPixels,
     pub(crate) automatic_content_block_size: CssPixels,
@@ -711,8 +710,8 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         callbacks: FfiLayoutFcCallbacks,
         parent: &'context BlockFormattingContext<'pass>,
     ) -> Self {
-        let containing_used_values = state.used_values(&callbacks, containing_block);
-        let line_data = state.line_data_cell(callbacks.slot_index(containing_block));
+        let containing_used_values = run.records.used_values(containing_block);
+        containing_used_values.line_data_cell();
         Self {
             run,
             state,
@@ -722,7 +721,6 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
             callbacks,
             parent,
             containing_used_values,
-            line_data,
             fragmented_inlines_in_pre_order: Vec::new(),
             automatic_content_inline_size: CssPixels::default(),
             automatic_content_block_size: CssPixels::default(),
@@ -755,27 +753,28 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
     }
 
     pub(crate) fn line_data(&self) -> Ref<'_, LineData> {
-        self.line_data.borrow()
+        self.containing_used_values.line_data_cell().borrow()
     }
 
     pub(crate) fn line_data_mut(&self) -> RefMut<'_, LineData> {
-        self.line_data.borrow_mut()
+        self.containing_used_values.line_data_cell().borrow_mut()
     }
 
-    pub(crate) fn containing_used(&self) -> &'pass UsedValues {
-        self.containing_used_values
+    pub(crate) fn containing_used(&self) -> std::rc::Rc<UsedValues> {
+        self.containing_used_values.clone()
     }
 
-    pub(crate) fn used(&self, node: Node) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, node)
+    #[track_caller]
+    pub(crate) fn used(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        self.run.records.used_values(node)
     }
 
     pub(crate) fn create_used_values(
         &self,
         node: Node,
         constraints: ContainingBlockConstraints,
-    ) -> &'pass UsedValues {
-        self.state.create_used_values(&self.callbacks, node, constraints)
+    ) -> std::rc::Rc<UsedValues> {
+        self.run.records.create_used_values(self.state, &self.callbacks, node, constraints)
     }
 
     pub(crate) fn parent_node(&self, node: Node) -> Node {
@@ -818,16 +817,7 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
 
     pub(crate) fn compute_inset(&self, node: Node) {
         let used = self.containing_used();
-        crate::layout::compute_inset_native(
-            self.state,
-            self.callbacks,
-            self.run.fragments.clone(),
-            node,
-            used.content_inline_size.get(),
-            used.content_block_size.get(),
-            self.run.box_,
-            self.run.treat_block_axis_percentage_insets_as_auto_beyond_root,
-        );
+        crate::layout::compute_inset_native(self.run, node, used.content_inline_size.get(), used.content_block_size.get());
     }
 
     pub(crate) fn parent_commit_pending_margin_before_inline_content(&self) -> CssPixels {
@@ -909,18 +899,14 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
             self.input.containing_block_constraints,
             ParticipationInParentFormattingContext::AtomicInline,
         );
-        let content_baselines_from_cells = |used: &UsedValues| DerivedBaselines {
-            first: used.has_first_baseline.get().then(|| used.first_baseline.get()),
-            last: used.has_last_baseline.get().then(|| used.last_baseline.get()),
-        };
         match crate::layout::layout_inside_child(self.run, Some(self.parent), None, node, self.layout_mode, input, false)
         {
             crate::layout::ChildLayoutOutcome::Created(result) => result.baselines,
             crate::layout::ChildLayoutOutcome::ReenterCurrent => {
                 self.parent.run(self.run, input);
-                content_baselines_from_cells(self.used(node))
+                self.used(node).content_baselines_from_cells()
             }
-            crate::layout::ChildLayoutOutcome::Skipped => content_baselines_from_cells(self.used(node)),
+            crate::layout::ChildLayoutOutcome::Skipped => self.used(node).content_baselines_from_cells(),
         }
     }
 
@@ -1236,12 +1222,12 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         self.automatic_content_inline_size = self
             .parent
             .greatest_child_inline_size_including_floats(self.containing_block);
-        let baselines = crate::layout::derive_baselines(self.state, &self.callbacks, self.containing_block, false);
+        let baselines = crate::layout::derive_baselines(self.state, &self.run.records, &self.callbacks, self.containing_block, false);
         if self.containing_block == self.parent.root_box() {
             self.parent.record_derived_baselines_of_root_box(baselines);
         } else {
             crate::layout::store_derived_baselines(
-                self.state.used_values(&self.callbacks, self.containing_block),
+                &self.used(self.containing_block),
                 baselines,
             );
         }
@@ -1252,6 +1238,7 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
         self.line_data_mut().inline_box_pieces = pieces;
         for candidate in inline_containing_block_rect_candidates {
             let relative_inset_chain = self.state.accumulated_relative_insets_from_inline_ancestor_chain(
+                &self.run.records,
                 &self.callbacks,
                 candidate.inline_containing_block,
                 self.containing_block,
@@ -1284,6 +1271,7 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
                 .entry(first_ancestor)
                 .or_insert_with(|| {
                     let chain = self.state.accumulated_relative_insets_from_inline_ancestor_chain(
+                        &self.run.records,
                         &self.callbacks,
                         first_ancestor,
                         self.containing_block,

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1154,7 +1154,15 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
                     continue;
                 }
                 let (x, y) = fragment.offset();
-                crate::layout::place_child(self.run, fragment.layout_node, FfiCssPixelPoint { x, y });
+                crate::layout::place_child(
+                    self.run,
+                    fragment.layout_node,
+                    FfiCssPixelPoint { x, y },
+                    Some(LineBoxFragmentCoordinate {
+                        line_box_index: line_index,
+                        fragment_index,
+                    }),
+                );
             }
         }
 
@@ -1436,16 +1444,12 @@ fn line_rect(line: &LineBoxData, content_inline_size: CssPixels) -> FfiCssPixelR
 }
 
 pub(crate) fn push_line_data(
-    state: &crate::layout::LayoutState,
-    slot_index: u32,
+    data: &LineData,
     content_inline_size: CssPixels,
     callbacks: &FfiLayoutFcCallbacks,
     sink: FfiLineSinkCallbacks,
-) -> bool {
-    let Some(mut data) = state.line_data_mut_if_present(slot_index) else {
-        return false;
-    };
-    for line in &mut data.line_boxes {
+) {
+    for line in &data.line_boxes {
         let committed_fragment_count = line
             .fragments
             .iter()
@@ -1461,22 +1465,18 @@ pub(crate) fn push_line_data(
                 },
             );
         }
-        for fragment in &mut line.fragments {
+        for fragment in &line.fragments {
             if fragment.is_fully_truncated {
                 continue;
             }
             let (x, y) = fragment.offset();
             let (x, y) = (x + fragment.relpos_delta.x, y + fragment.relpos_delta.y);
             let (width, height) = fragment.size();
-            let glyphs = fragment
-                .glyphs
-                .as_mut()
-                .map(|glyph_data| std::mem::take(&mut glyph_data.glyphs));
             let (glyph_pointer, glyph_count, glyph_font, glyph_text_type, glyph_run_width) =
-                if let (Some(glyphs), Some(glyph_data)) = (glyphs.as_ref(), fragment.glyphs.as_ref()) {
+                if let Some(glyph_data) = fragment.glyphs.as_ref() {
                     (
-                        glyphs.as_ptr(),
-                        glyphs.len(),
+                        glyph_data.glyphs.as_ptr(),
+                        glyph_data.glyphs.len(),
                         glyph_data.font,
                         glyph_data.text_type,
                         glyph_data.width,
@@ -1497,7 +1497,7 @@ pub(crate) fn push_line_data(
                         baseline: fragment.baseline,
                         writing_mode: fragment.writing_mode,
                         has_trailing_whitespace: fragment.has_trailing_whitespace,
-                        has_glyph_run: glyphs.is_some(),
+                        has_glyph_run: fragment.glyphs.is_some(),
                         glyphs: glyph_pointer,
                         glyph_count,
                         glyph_font,
@@ -1529,5 +1529,4 @@ pub(crate) fn push_line_data(
             );
         }
     }
-    true
 }

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1177,7 +1177,15 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
                         break 'lines;
                     }
                 }
-                crate::layout::register_contained_abspos_child(self.state, &self.callbacks, box_, static_position);
+                crate::layout::register_contained_abspos_child(
+                    self.state,
+                    &self.callbacks,
+                    self.run.fragments.as_deref(),
+                    self.containing_block,
+                    box_,
+                    static_position,
+                    None,
+                );
             }
         }
         line_builder.remove_last_line_if_empty();

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1139,12 +1139,7 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
                     continue;
                 }
                 let (x, y) = fragment.offset();
-                crate::layout::place_child(
-                    self.state,
-                    &self.callbacks,
-                    fragment.layout_node,
-                    FfiCssPixelPoint { x, y },
-                );
+                crate::layout::place_child(self.run, fragment.layout_node, FfiCssPixelPoint { x, y });
             }
         }
 

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -260,7 +260,11 @@ pub(crate) fn compute(
     context: &InlineFormattingContext,
 ) -> (Vec<InlineBoxPieceData>, Vec<InlineContainingBlockRectCandidate>) {
     let horizontal = context.style(context.containing_block).writing_mode() == writing_mode::HORIZONTAL_TB;
-    let collect_inline_containing_block_rects = context.state.has_inline_containing_blocks();
+    let collect_inline_containing_block_rects = context
+        .run
+        .fragments
+        .as_deref()
+        .is_some_and(RunFragmentBuilder::any_pending_abspos_has_inline_containing_block);
     let container_inline_axis_is_reverse = collect_inline_containing_block_rects
         && context.facts(context.containing_block).inline_axis_is_reverse();
     let mut inline_containing_block_rect_candidates = Vec::<InlineContainingBlockRectCandidate>::new();
@@ -436,8 +440,12 @@ pub(crate) fn compute(
             )
         };
 
-        let node_is_inline_containing_block =
-            collect_inline_containing_block_rects && context.state.is_inline_containing_block(node);
+        let node_is_inline_containing_block = collect_inline_containing_block_rects
+            && context
+                .run
+                .fragments
+                .as_deref()
+                .is_some_and(|fragments| fragments.any_pending_abspos_names_inline_containing_block(node));
         let mut corners = FirstAndLastContentLineCorners::default();
 
         for line in lines {
@@ -580,7 +588,13 @@ pub(crate) fn compute(
                 ..Default::default()
             }
         };
-        if collect_inline_containing_block_rects && context.state.is_inline_containing_block(node) {
+        if collect_inline_containing_block_rects
+            && context
+                .run
+                .fragments
+                .as_deref()
+                .is_some_and(|fragments| fragments.any_pending_abspos_names_inline_containing_block(node))
+        {
             inline_containing_block_rect_candidates.push(InlineContainingBlockRectCandidate {
                 inline_containing_block: node,
                 rect: PhysicalRect {
@@ -1178,7 +1192,6 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
                     }
                 }
                 crate::layout::register_contained_abspos_child(
-                    self.state,
                     &self.callbacks,
                     self.run.fragments.as_deref(),
                     self.containing_block,
@@ -1237,9 +1250,13 @@ impl<'context, 'pass> InlineFormattingContext<'context, 'pass> {
             let mut rect = candidate.rect;
             rect.x += relative_inset_chain.offset_x;
             rect.y += relative_inset_chain.offset_y;
-            self.state
-                .used_values_rare_data_for_node_mut(&self.callbacks, candidate.inline_containing_block)
-                .inline_containing_block_first_last_rect = Some(rect);
+            if let Some(fragments) = self.run.fragments.as_deref() {
+                fragments.set_inline_containing_block_rect_on_pending_abspos(
+                    candidate.inline_containing_block,
+                    rect,
+                    self.containing_block,
+                );
+            }
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -209,6 +209,14 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
         leading.border += used.border_left.get();
         leading.padding += used.padding_left.get();
         self.context().compute_inset(node);
+        if self.context().layout_mode == LayoutMode::Normal && !self.context().state.is_measurement() {
+            crate::layout::place_child(
+                self.context().state,
+                &self.context().callbacks,
+                node,
+                FfiCssPixelPoint::default(),
+            );
+        }
         self.box_model_node_stack.push(node);
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -209,13 +209,8 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
         leading.border += used.border_left.get();
         leading.padding += used.padding_left.get();
         self.context().compute_inset(node);
-        if self.context().layout_mode == LayoutMode::Normal && !self.context().state.is_measurement() {
-            crate::layout::place_child(
-                self.context().state,
-                &self.context().callbacks,
-                node,
-                FfiCssPixelPoint::default(),
-            );
+        if self.context().run.fragments.is_some() {
+            crate::layout::place_child(self.context().run, node, FfiCssPixelPoint::default());
         }
         self.box_model_node_stack.push(node);
     }

--- a/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_level_iterator.rs
@@ -210,7 +210,7 @@ impl<'iterator, 'context, 'pass> InlineLevelIteratorGenerator<'iterator, 'contex
         leading.padding += used.padding_left.get();
         self.context().compute_inset(node);
         if self.context().run.fragments.is_some() {
-            crate::layout::place_child(self.context().run, node, FfiCssPixelPoint::default());
+            crate::layout::place_child(self.context().run, node, FfiCssPixelPoint::default(), None);
         }
         self.box_model_node_stack.push(node);
     }

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -275,11 +275,12 @@ pub(crate) struct PendingAbsposChild {
     pub(crate) coordinate_space_box: Node,
     pub(crate) static_position_rect: StaticPositionRect,
     pub(crate) containing_block_info_override: Option<AbsposContainingBlockInfo>,
+    pub(crate) inline_containing_block: Node,
+    pub(crate) inline_containing_block_rect: Option<PhysicalRect>,
 }
 pub(crate) struct LayoutState {
     used_values: PagedStore<UsedValues>,
     anchor_inset_store: AnchorInsetStore,
-    inline_containing_blocks: RefCell<HashSet<Node>>,
     anchor_candidate_shells: RefCell<Vec<*mut c_void>>,
     purpose: LayoutStatePurpose,
 }
@@ -314,7 +315,6 @@ pub(crate) struct UsedValuesRareData {
     pub(crate) used_grid_tracks: Option<OwnedUsedGridTracks>,
     pub(crate) override_borders_data: Option<FfiBordersData>,
     pub(crate) abspos_layout_inputs: Option<AbsposLayoutInputs>,
-    pub(crate) inline_containing_block_first_last_rect: Option<PhysicalRect>,
 }
 
 impl LayoutState {
@@ -322,7 +322,6 @@ impl LayoutState {
         Self {
             used_values: PagedStore::default(),
             anchor_inset_store: AnchorInsetStore::default(),
-            inline_containing_blocks: RefCell::new(HashSet::new()),
             anchor_candidate_shells: RefCell::new(Vec::new()),
             purpose,
         }
@@ -565,21 +564,9 @@ impl LayoutState {
         Some(used)
     }
 
-    pub(crate) fn note_inline_containing_block(&self, inline_containing_block: Node) {
-        self.inline_containing_blocks.borrow_mut().insert(inline_containing_block);
-    }
 
-    pub(crate) fn has_inline_containing_blocks(&self) -> bool {
-        !self.inline_containing_blocks.borrow().is_empty()
-    }
 
-    pub(crate) fn is_inline_containing_block(&self, node: Node) -> bool {
-        self.inline_containing_blocks.borrow().contains(&node)
-    }
 
-    pub(crate) fn inline_containing_block_first_last_rect(&self, slot_index: u32) -> Option<PhysicalRect> {
-        self.used_values_rare_data(slot_index)?.inline_containing_block_first_last_rect
-    }
 
     fn register_anchor_candidate_if_carries_anchor_names(&self, callbacks: &FfiLayoutFcCallbacks, node: Node) {
         if !self.node_facts(callbacks, node).has_anchor_names() {

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -281,7 +281,6 @@ pub(crate) struct PendingAbsposChild {
 pub(crate) struct LayoutState {
     used_values: PagedStore<UsedValues>,
     anchor_inset_store: AnchorInsetStore,
-    anchor_candidate_shells: RefCell<Vec<*mut c_void>>,
     purpose: LayoutStatePurpose,
 }
 
@@ -322,7 +321,6 @@ impl LayoutState {
         Self {
             used_values: PagedStore::default(),
             anchor_inset_store: AnchorInsetStore::default(),
-            anchor_candidate_shells: RefCell::new(Vec::new()),
             purpose,
         }
     }
@@ -499,9 +497,7 @@ impl LayoutState {
         used.content_inline_size.set(content_inline_size.unwrap_or_default());
         used.content_block_size.set(content_block_size.unwrap_or_default());
 
-        let used = self.used_values.allocate(slot_index, used);
-        self.register_anchor_candidate_if_carries_anchor_names(callbacks, node);
-        used
+        self.used_values.allocate(slot_index, used)
     }
 
     pub(crate) fn populate_from_paintable(
@@ -560,7 +556,6 @@ impl LayoutState {
         if self.node_facts(callbacks, node).is_svg_svg_box() {
             self.used_values_rare_data_mut(slot_index).svg_viewport_size = Some(geometry.svg_viewport_size);
         }
-        self.register_anchor_candidate_if_carries_anchor_names(callbacks, node);
         Some(used)
     }
 
@@ -568,16 +563,7 @@ impl LayoutState {
 
 
 
-    fn register_anchor_candidate_if_carries_anchor_names(&self, callbacks: &FfiLayoutFcCallbacks, node: Node) {
-        if !self.node_facts(callbacks, node).has_anchor_names() {
-            return;
-        }
-        self.anchor_candidate_shells.borrow_mut().push(callbacks.shell(node));
-    }
 
-    pub(crate) fn anchor_candidate_shells(&self) -> Ref<'_, Vec<*mut c_void>> {
-        self.anchor_candidate_shells.borrow()
-    }
 
     pub(crate) fn set_box_is_grid_item(&self, callbacks: &FfiLayoutFcCallbacks, node: Node, is_grid_item: bool) {
         callbacks.arena().set_node_flag(node, NodeFlag::IsGridItem, is_grid_item);

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -63,8 +63,6 @@ impl<T> PagedStore<T> {
         assert!(entry_was_vacant, "PagedStore index {index} allocated twice");
         entry.get().unwrap()
     }
-
-
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,39 +101,6 @@ pub(crate) enum AbsposAlignment {
     Start,
     Stretch,
     Unsafe,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct ContainingBlockGeometry {
-    pub(crate) content_origin_in_entry_space: FfiCssPixelPoint,
-    pub(crate) padding_left: CssPixels,
-    pub(crate) padding_right: CssPixels,
-    pub(crate) padding_top: CssPixels,
-    pub(crate) padding_bottom: CssPixels,
-    pub(crate) content_inline_size: CssPixels,
-    pub(crate) content_block_size: CssPixels,
-}
-
-impl ContainingBlockGeometry {
-    pub(crate) fn from_used_values(used: &UsedValues, content_origin_in_entry_space: FfiCssPixelPoint) -> Self {
-        Self {
-            content_origin_in_entry_space,
-            padding_left: used.padding_left.get(),
-            padding_right: used.padding_right.get(),
-            padding_top: used.padding_top.get(),
-            padding_bottom: used.padding_bottom.get(),
-            content_inline_size: used.content_inline_size.get(),
-            content_block_size: used.content_block_size.get(),
-        }
-    }
-
-    pub(crate) fn padding_box_inline_size(&self) -> CssPixels {
-        self.content_inline_size + self.padding_left + self.padding_right
-    }
-
-    pub(crate) fn padding_box_block_size(&self) -> CssPixels {
-        self.content_block_size + self.padding_top + self.padding_bottom
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -263,6 +228,39 @@ pub struct FfiCommitSink {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ContainingBlockGeometry {
+    pub(crate) content_origin_in_entry_space: FfiCssPixelPoint,
+    pub(crate) padding_left: CssPixels,
+    pub(crate) padding_right: CssPixels,
+    pub(crate) padding_top: CssPixels,
+    pub(crate) padding_bottom: CssPixels,
+    pub(crate) content_inline_size: CssPixels,
+    pub(crate) content_block_size: CssPixels,
+}
+
+impl ContainingBlockGeometry {
+    pub(crate) fn from_used_values(used: &UsedValues, content_origin_in_entry_space: FfiCssPixelPoint) -> Self {
+        Self {
+            content_origin_in_entry_space,
+            padding_left: used.padding_left.get(),
+            padding_right: used.padding_right.get(),
+            padding_top: used.padding_top.get(),
+            padding_bottom: used.padding_bottom.get(),
+            content_inline_size: used.content_inline_size.get(),
+            content_block_size: used.content_block_size.get(),
+        }
+    }
+
+    pub(crate) fn padding_box_inline_size(&self) -> CssPixels {
+        self.content_inline_size + self.padding_left + self.padding_right
+    }
+
+    pub(crate) fn padding_box_block_size(&self) -> CssPixels {
+        self.content_block_size + self.padding_top + self.padding_bottom
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PendingAbsposChild {
     pub(crate) child_box: Node,
     pub(crate) coordinate_space_box: Node,
@@ -272,9 +270,66 @@ pub(crate) struct PendingAbsposChild {
     pub(crate) inline_containing_block_rect: Option<PhysicalRect>,
 }
 pub(crate) struct LayoutState {
-    used_values: PagedStore<UsedValues>,
     anchor_inset_store: AnchorInsetStore,
     purpose: LayoutStatePurpose,
+}
+
+pub(crate) struct RunRecords {
+    root: Node,
+    map: RefCell<HashMap<u32, std::rc::Rc<UsedValues>>>,
+}
+
+impl RunRecords {
+    pub(crate) fn new(root: Node, root_used: std::rc::Rc<UsedValues>) -> Self {
+        let records = Self::new_unrooted(root);
+        records.register(root, root_used);
+        records
+    }
+
+    pub(crate) fn new_unrooted(root: Node) -> Self {
+        Self {
+            root,
+            map: RefCell::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn register(&self, node: Node, used: std::rc::Rc<UsedValues>) {
+        let previous = self.map.borrow_mut().insert(node.slot_index(), used);
+        assert!(
+            previous.is_none(),
+            "slot {} registered twice in the run rooted at slot {}",
+            node.slot_index(),
+            self.root.slot_index()
+        );
+    }
+
+    pub(crate) fn create_used_values(
+        &self,
+        state: &LayoutState,
+        callbacks: &FfiLayoutFcCallbacks,
+        node: Node,
+        constraints: ContainingBlockConstraints,
+    ) -> std::rc::Rc<UsedValues> {
+        let used = state.create_used_values(callbacks, node, constraints);
+        self.register(node, used.clone());
+        used
+    }
+
+    #[track_caller]
+    pub(crate) fn used_values(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        let caller = std::panic::Location::caller();
+        self.used_values_if_owned(node).unwrap_or_else(|| {
+            panic!(
+                "the run rooted at slot {} does not own the record for slot {} (read at {caller})",
+                self.root.slot_index(),
+                node.slot_index(),
+            )
+        })
+    }
+
+    pub(crate) fn used_values_if_owned(&self, node: Node) -> Option<std::rc::Rc<UsedValues>> {
+        self.map.borrow().get(&node.slot_index()).cloned()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -288,7 +343,6 @@ impl Default for LayoutState {
         Self::new(LayoutStatePurpose::Commit)
     }
 }
-
 
 #[derive(Default)]
 pub(crate) struct LineData {
@@ -312,7 +366,6 @@ pub(crate) struct UsedValuesRareData {
 impl LayoutState {
     pub(crate) fn new(purpose: LayoutStatePurpose) -> Self {
         Self {
-            used_values: PagedStore::default(),
             anchor_inset_store: AnchorInsetStore::default(),
             purpose,
         }
@@ -340,11 +393,9 @@ impl LayoutState {
         callbacks: &FfiLayoutFcCallbacks,
         node: Node,
         constraints: ContainingBlockConstraints,
-    ) -> &UsedValues {
+    ) -> std::rc::Rc<UsedValues> {
         assert!(!node.is_invalid());
         let facts = self.node_facts(callbacks, node);
-        let slot_index = callbacks.slot_index(node);
-        assert!(self.used_values.get(slot_index).is_none());
 
         let style = self.style_facts(callbacks, node);
         let percentage_basis_inline_size = constraints.percentage_basis_inline_size;
@@ -487,7 +538,7 @@ impl LayoutState {
         used.content_inline_size.set(content_inline_size.unwrap_or_default());
         used.content_block_size.set(content_block_size.unwrap_or_default());
 
-        self.used_values.allocate(slot_index, used)
+        std::rc::Rc::new(used)
     }
 
     pub(crate) fn populate_from_paintable(
@@ -495,10 +546,7 @@ impl LayoutState {
         callbacks: &FfiLayoutFcCallbacks,
         node: Node,
         paintable: *mut c_void,
-    ) -> Option<&UsedValues> {
-        let slot_index = callbacks.slot_index(node);
-        assert!(self.used_values.get(slot_index).is_none());
-
+    ) -> Option<std::rc::Rc<UsedValues>> {
         let mut geometry = FfiPaintableGeometry::default();
         let found =
             unsafe {
@@ -538,18 +586,11 @@ impl LayoutState {
         used.has_content_offset.set(true);
         used.seal_committed_box_metrics();
 
-        let used = self.used_values.allocate(slot_index, used);
         if self.node_facts(callbacks, node).is_svg_svg_box() {
-            self.used_values_rare_data_mut(slot_index).svg_viewport_size = Some(geometry.svg_viewport_size);
+            used.rare_data_mut().svg_viewport_size = Some(geometry.svg_viewport_size);
         }
-        Some(used)
+        Some(std::rc::Rc::new(used))
     }
-
-
-
-
-
-
 
     pub(crate) fn set_box_is_grid_item(&self, callbacks: &FfiLayoutFcCallbacks, node: Node, is_grid_item: bool) {
         callbacks.arena().set_node_flag(node, NodeFlag::IsGridItem, is_grid_item);
@@ -629,58 +670,12 @@ impl LayoutState {
         })
     }
 
-    pub(crate) fn line_data_cell(&self, slot_index: u32) -> &RefCell<LineData> {
-        self.used_values_by_slot(slot_index)
-            .expect("missing used values")
-            .line_data
-            .get_or_init(LineData::default)
-    }
-
-    pub(crate) fn line_data(&self, slot_index: u32) -> Option<Ref<'_, LineData>> {
-        self.used_values_by_slot(slot_index)?
-            .line_data
-            .get()
-            .map(RefCell::borrow)
-    }
-
-    pub(crate) fn used_values_rare_data(&self, slot_index: u32) -> Option<Ref<'_, UsedValuesRareData>> {
-        self.used_values_by_slot(slot_index)?
-            .rare_data
-            .get()
-            .map(RefCell::borrow)
-    }
-
-    pub(crate) fn used_values_rare_data_mut(&self, slot_index: u32) -> RefMut<'_, UsedValuesRareData> {
-        self.used_values_by_slot(slot_index)
-            .expect("missing used values")
-            .rare_data
-            .get_or_init(UsedValuesRareData::default)
-            .borrow_mut()
-    }
-
-    pub(crate) fn used_values_rare_data_for_node_mut(
-        &self,
-        callbacks: &FfiLayoutFcCallbacks,
-        node: Node,
-    ) -> RefMut<'_, UsedValuesRareData> {
-        self.used_values_rare_data_mut(callbacks.slot_index(node))
-    }
-
-    fn used_values_by_slot(&self, slot_index: u32) -> Option<&UsedValues> {
-        self.used_values.get(slot_index)
-    }
-
-    pub(crate) fn used_values(&self, callbacks: &FfiLayoutFcCallbacks, node: Node) -> &UsedValues {
-        self.used_values
-            .get(callbacks.slot_index(node))
-            .expect("missing used values")
-    }
-
     /// Accumulates relative-position insets from a chain of inline-flow
     /// ancestors, starting at first_ancestor and walking up until stop_at or
     /// the first ancestor that is not inline-flow.
     pub(crate) fn accumulated_relative_insets_from_inline_ancestor_chain(
         &self,
+        records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
         first_ancestor: Node,
         stop_at: Node,
@@ -702,7 +697,7 @@ impl LayoutState {
                 // committed fragment or piece was entered by its inline
                 // formatting context this pass, which created its used values
                 // and resolved its insets.
-                let used = self.used_values(callbacks, ancestor);
+                let used = records.used_values(ancestor);
                 result.offset_x += used.inset_left.get();
                 result.offset_y += used.inset_top.get();
             }
@@ -715,8 +710,10 @@ impl LayoutState {
     /// survived line post-processing.
     fn resolve_containing_line_box_index(
         &self,
+        records: &RunRecords,
         callbacks: &FfiLayoutFcCallbacks,
         node: Node,
+        containing_block: Node,
         coordinate: Option<LineBoxFragmentCoordinate>,
         placed_offset: FfiCssPixelPoint,
     ) -> Option<usize> {
@@ -725,9 +722,9 @@ impl LayoutState {
         if !facts.is_non_fragmented_box() {
             return None;
         }
-        let containing_block = callbacks.containing_block(node);
         assert!(!containing_block.is_invalid());
-        let data = self.line_data(callbacks.slot_index(containing_block))?;
+        let containing_block_used = records.used_values(containing_block);
+        let data = containing_block_used.line_data_ref()?;
         let line = data.line_boxes.get(coordinate.line_box_index)?;
         if let Some(fragment) = line.fragments.get(coordinate.fragment_index) {
             let (x, y) = fragment.offset();
@@ -752,11 +749,6 @@ impl LayoutState {
     ) {
         let slot_index = callbacks.slot_index(node);
         let entry = scopes.link_for_slot(slot_index);
-        let used = self.used_values_by_slot(slot_index);
-        debug_assert!(
-            entry.is_some() == used.is_some(),
-            "every record has exactly one fragment and every fragment a record"
-        );
         if let Some(link) = entry {
             callbacks.set_saved_abspos_layout_inputs(node, link.abspos_layout_inputs);
         }

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -830,26 +830,15 @@ impl LayoutState {
                 }
             }
 
-            let (transforms, viewport_size, path) = self
-                .used_values_rare_data(slot_index)
-                .map_or((None, None, None), |rare| {
-                    (
-                        rare.computed_svg_transforms,
-                        rare.svg_viewport_size,
-                        rare.computed_svg_path.as_ref().map(libgfx_rust::path::OwnedPath::as_raw),
-                    )
-                });
             unsafe {
-                if let Some(transforms) = transforms {
+                if let Some(transforms) = fragment.computed_svg_transforms {
                     (sink.set_computed_svg_transforms)(sink.context, paintable, transforms);
                 }
-                if let Some(viewport_size) = viewport_size {
+                if let Some(viewport_size) = fragment.svg_viewport_size {
                     (sink.set_svg_viewport_size)(sink.context, paintable, viewport_size);
                 }
-                if let Some(path) = path {
-                    // The sink only borrows the path and moves its contents
-                    // out; the rare data keeps ownership until state teardown.
-                    (sink.set_computed_svg_path)(sink.context, paintable, path);
+                if let Some(path) = fragment.computed_svg_path.take() {
+                    (sink.set_computed_svg_path)(sink.context, paintable, path.as_raw());
                 }
             }
             if let Some(data) = &fragment.grid_layout_data {

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -189,13 +189,6 @@ pub struct FfiCommittedBoxMetrics {
     pub has_containing_line_box_index: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub(crate) enum LineFragmentLookup {
-    NotFound,
-    LineOnly,
-    Found(crate::layout::FfiCssPixelPoint),
-}
-
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct InlineAncestorChainRelativeOffset {
     pub(crate) offset_x: crate::layout::CssPixels,
@@ -367,10 +360,7 @@ impl LayoutState {
         // definite. We model all of those by considering sizes definite once
         // they are assigned through set_content_inline_size() or
         // set_content_block_size().
-        let used = UsedValues {
-            node,
-            ..UsedValues::default()
-        };
+        let used = UsedValues::default();
 
         #[derive(Clone, Copy)]
         enum Axis {
@@ -521,11 +511,7 @@ impl LayoutState {
         // Skip normal node initialization: resolving computed sizes requires
         // percentage bases, and every resulting geometry field is replaced by
         // the previous paintable's committed value immediately.
-        let used = UsedValues {
-            node,
-            ..UsedValues::default()
-        };
-        used.materialized_from_paintable.set(true);
+        let used = UsedValues::default();
         used.set_content_inline_size(geometry.content_inline_size);
         used.set_content_block_size(geometry.content_block_size);
         used.has_definite_inline_size.set(true);
@@ -657,13 +643,6 @@ impl LayoutState {
             .map(RefCell::borrow)
     }
 
-    pub(crate) fn line_data_mut_if_present(&self, slot_index: u32) -> Option<RefMut<'_, LineData>> {
-        self.used_values_by_slot(slot_index)?
-            .line_data
-            .get()
-            .map(RefCell::borrow_mut)
-    }
-
     pub(crate) fn used_values_rare_data(&self, slot_index: u32) -> Option<Ref<'_, UsedValuesRareData>> {
         self.used_values_by_slot(slot_index)?
             .rare_data
@@ -734,55 +713,32 @@ impl LayoutState {
 
     /// The line box index to record for atomic inlines whose containing line
     /// survived line post-processing.
-    fn containing_line_box_index(
+    fn resolve_containing_line_box_index(
         &self,
         callbacks: &FfiLayoutFcCallbacks,
         node: Node,
-        used: &UsedValues,
+        coordinate: Option<LineBoxFragmentCoordinate>,
+        placed_offset: FfiCssPixelPoint,
     ) -> Option<usize> {
-        if used.materialized_from_paintable.get() {
-            return None;
-        }
+        let coordinate = coordinate?;
         let facts = self.node_facts(callbacks, node);
         if !facts.is_non_fragmented_box() {
             return None;
         }
-        match self.line_fragment_lookup(callbacks, used) {
-            LineFragmentLookup::NotFound => None,
-            LineFragmentLookup::LineOnly => Some(used.containing_line_box_fragment.get().line_box_index),
-            LineFragmentLookup::Found(line_fragment_offset) => {
-                debug_assert_eq!(
-                    line_fragment_offset,
-                    used.content_offset.get(),
-                    "stored line fragment offset diverged from the placed offset (is_block_outside={})",
-                    facts.display().is_block_outside()
-                );
-                Some(used.containing_line_box_fragment.get().line_box_index)
-            }
-        }
-    }
-
-    fn line_fragment_lookup(&self, callbacks: &FfiLayoutFcCallbacks, used: &UsedValues) -> LineFragmentLookup {
-        if !used.has_containing_line_box_fragment.get() {
-            return LineFragmentLookup::NotFound;
-        }
-        // SAFETY: Commit traverses the still-live C++ layout tree
-        // synchronously with the pass callback table.
-        let containing_block = callbacks.containing_block(used.node);
+        let containing_block = callbacks.containing_block(node);
         assert!(!containing_block.is_invalid());
-        let slot_index = callbacks.slot_index(containing_block);
-        let Some(data) = self.line_data(slot_index) else {
-            return LineFragmentLookup::NotFound;
-        };
-        let coordinate = used.containing_line_box_fragment.get();
-        let Some(line) = data.line_boxes.get(coordinate.line_box_index) else {
-            return LineFragmentLookup::NotFound;
-        };
-        let Some(fragment) = line.fragments.get(coordinate.fragment_index) else {
-            return LineFragmentLookup::LineOnly;
-        };
-        let (x, y) = fragment.offset();
-        LineFragmentLookup::Found(crate::layout::FfiCssPixelPoint { x, y })
+        let data = self.line_data(callbacks.slot_index(containing_block))?;
+        let line = data.line_boxes.get(coordinate.line_box_index)?;
+        if let Some(fragment) = line.fragments.get(coordinate.fragment_index) {
+            let (x, y) = fragment.offset();
+            debug_assert_eq!(
+                crate::layout::FfiCssPixelPoint { x, y },
+                placed_offset,
+                "stored line fragment offset diverged from the placed offset (is_block_outside={})",
+                facts.display().is_block_outside()
+            );
+        }
+        Some(coordinate.line_box_index)
     }
 
     fn commit_subtree(
@@ -801,11 +757,8 @@ impl LayoutState {
             entry.is_some() == used.is_some(),
             "every record has exactly one fragment and every fragment a record"
         );
-        let abspos_layout_inputs = self
-            .used_values_rare_data(slot_index)
-            .and_then(|rare| rare.abspos_layout_inputs);
-        if entry.is_some() {
-            callbacks.set_saved_abspos_layout_inputs(node, abspos_layout_inputs);
+        if let Some(link) = entry {
+            callbacks.set_saved_abspos_layout_inputs(node, link.abspos_layout_inputs);
         }
         // SAFETY: The C++ sink owns paintables and copies every plain-data
         // input synchronously.
@@ -813,7 +766,7 @@ impl LayoutState {
         let paintable = unsafe { (sink.prepare_node)(sink.context, node_shell, entry.is_some()) };
 
         let mut has_pending_inline_box_geometry = false;
-        if let (Some(link), Some(used)) = (entry, used)
+        if let Some(link) = entry
             && !paintable.is_null()
         {
             let fragment = &link.fragment;
@@ -849,21 +802,16 @@ impl LayoutState {
                 );
             }
 
-            let (override_borders, table_cell_coordinates) =
-                self.used_values_rare_data(slot_index).map_or((None, None), |rare| {
-                    (rare.override_borders_data, rare.table_cell_coordinates)
-                });
             unsafe {
-                if let Some(borders) = override_borders {
+                if let Some(borders) = fragment.override_borders_data {
                     (sink.set_override_borders)(sink.context, paintable, borders);
                 }
-                if let Some(coordinates) = table_cell_coordinates {
+                if let Some(coordinates) = fragment.table_cell_coordinates {
                     (sink.set_table_cell_coordinates)(sink.context, paintable, coordinates);
                 }
             }
 
-            let has_line_data = self.line_data(slot_index).is_some();
-            if has_line_data {
+            if let Some(line_data) = &fragment.line_data {
                 // SAFETY: The sink keeps one line accumulator live between
                 // begin_line_data() and finish_line_data().
                 let accepts_lines = unsafe { (sink.begin_line_data)(sink.context, paintable) };
@@ -874,19 +822,11 @@ impl LayoutState {
                         emit_fragment: sink.emit_fragment,
                         emit_inline_box_piece: sink.emit_inline_box_piece,
                     };
-                    assert!(push_line_data(
-                        self,
-                        slot_index,
-                        used.content_inline_size.get(),
-                        callbacks,
-                        line_sink
-                    ));
+                    push_line_data(line_data, fragment.content_inline_size, callbacks, line_sink);
                     unsafe {
                         (sink.finish_line_data)(sink.context);
                     }
-                    has_pending_inline_box_geometry = self
-                        .line_data(slot_index)
-                        .is_some_and(|data| !data.inline_box_pieces.is_empty());
+                    has_pending_inline_box_geometry = !line_data.inline_box_pieces.is_empty();
                 }
             }
 
@@ -912,28 +852,20 @@ impl LayoutState {
                     (sink.set_computed_svg_path)(sink.context, paintable, path);
                 }
             }
-            if let Some(rare) = self.used_values_rare_data(slot_index) {
-                if let Some(data) = &rare.grid_layout_data {
-                    data.with_ffi_view(|view| {
-                        // SAFETY: The Rust-owned nested vectors remain live
-                        // while the commit sink copies this borrowed view.
-                        unsafe { (sink.set_grid_layout_data)(sink.context, paintable, view) };
-                    });
-                }
-                if let Some(data) = &rare.flex_layout_data {
-                    data.with_ffi_view(|view| {
-                        // SAFETY: The Rust-owned lines and items remain live
-                        // while the commit sink copies this borrowed view.
-                        unsafe { (sink.set_flex_layout_data)(sink.context, paintable, view) };
-                    });
-                }
-                if let Some(tracks) = &rare.used_grid_tracks {
-                    tracks.with_ffi_views(|columns, rows| {
-                        // SAFETY: Both Rust-owned track lists remain live
-                        // while the commit sink copies these borrowed views.
-                        unsafe { (sink.set_used_grid_tracks)(sink.context, paintable, columns, rows) };
-                    });
-                }
+            if let Some(data) = &fragment.grid_layout_data {
+                data.with_ffi_view(|view| {
+                    unsafe { (sink.set_grid_layout_data)(sink.context, paintable, view) };
+                });
+            }
+            if let Some(data) = &fragment.flex_layout_data {
+                data.with_ffi_view(|view| {
+                    unsafe { (sink.set_flex_layout_data)(sink.context, paintable, view) };
+                });
+            }
+            if let Some(tracks) = &fragment.used_grid_tracks {
+                tracks.with_ffi_views(|columns, rows| {
+                    unsafe { (sink.set_used_grid_tracks)(sink.context, paintable, columns, rows) };
+                });
             }
         }
 

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -792,26 +792,31 @@ impl LayoutState {
         insert_before_paintable: *mut c_void,
         callbacks: &FfiLayoutFcCallbacks,
         sink: &FfiCommitSink,
+        scopes: &mut crate::layout::CommitScopes<'_>,
     ) {
         let slot_index = callbacks.slot_index(node);
+        let entry = scopes.link_for_slot(slot_index);
         let used = self.used_values_by_slot(slot_index);
+        debug_assert!(
+            entry.is_some() == used.is_some(),
+            "every record has exactly one fragment and every fragment a record"
+        );
         let abspos_layout_inputs = self
             .used_values_rare_data(slot_index)
             .and_then(|rare| rare.abspos_layout_inputs);
-        if used.is_some() {
+        if entry.is_some() {
             callbacks.set_saved_abspos_layout_inputs(node, abspos_layout_inputs);
         }
         // SAFETY: The C++ sink owns paintables and copies every plain-data
         // input synchronously.
         let node_shell = callbacks.shell(node);
-        let paintable = unsafe { (sink.prepare_node)(sink.context, node_shell, used.is_some()) };
+        let paintable = unsafe { (sink.prepare_node)(sink.context, node_shell, entry.is_some()) };
 
         let mut has_pending_inline_box_geometry = false;
-        if let Some(used) = used
+        if let (Some(link), Some(used)) = (entry, used)
             && !paintable.is_null()
         {
-            let content_offset = point_add(used.content_offset.get(), used.committed_offset_delta.get());
-            let containing_line_box_index = self.containing_line_box_index(callbacks, node, used);
+            let fragment = &link.fragment;
             // SAFETY: Every callback below copies its plain-data argument or
             // consumes one retained handle synchronously.
             unsafe {
@@ -819,27 +824,27 @@ impl LayoutState {
                     sink.context,
                     paintable,
                     FfiCommittedBoxMetrics {
-                        content_offset,
-                        content_inline_size: used.content_inline_size.get(),
-                        content_block_size: used.content_block_size.get(),
-                        margin_left: used.margin_left.get(),
-                        margin_right: used.margin_right.get(),
-                        margin_top: used.margin_top.get(),
-                        margin_bottom: used.margin_bottom.get(),
-                        border_left: used.border_left.get(),
-                        border_right: used.border_right.get(),
-                        border_top: used.border_top.get(),
-                        border_bottom: used.border_bottom.get(),
-                        padding_left: used.padding_left.get(),
-                        padding_right: used.padding_right.get(),
-                        padding_top: used.padding_top.get(),
-                        padding_bottom: used.padding_bottom.get(),
-                        inset_left: used.inset_left.get(),
-                        inset_right: used.inset_right.get(),
-                        inset_top: used.inset_top.get(),
-                        inset_bottom: used.inset_bottom.get(),
-                        containing_line_box_index: containing_line_box_index.unwrap_or(0),
-                        has_containing_line_box_index: containing_line_box_index.is_some(),
+                        content_offset: link.committed_offset,
+                        content_inline_size: fragment.content_inline_size,
+                        content_block_size: fragment.content_block_size,
+                        margin_left: fragment.margin_left,
+                        margin_right: fragment.margin_right,
+                        margin_top: fragment.margin_top,
+                        margin_bottom: fragment.margin_bottom,
+                        border_left: fragment.border_left,
+                        border_right: fragment.border_right,
+                        border_top: fragment.border_top,
+                        border_bottom: fragment.border_bottom,
+                        padding_left: fragment.padding_left,
+                        padding_right: fragment.padding_right,
+                        padding_top: fragment.padding_top,
+                        padding_bottom: fragment.padding_bottom,
+                        inset_left: link.inset_left,
+                        inset_right: link.inset_right,
+                        inset_top: link.inset_top,
+                        inset_bottom: link.inset_bottom,
+                        containing_line_box_index: link.containing_line_box_index.unwrap_or(0),
+                        has_containing_line_box_index: link.containing_line_box_index.is_some(),
                     },
                 );
             }
@@ -945,11 +950,17 @@ impl LayoutState {
         };
         assert_eq!(result.paintable, paintable);
 
+        if let Some(link) = entry {
+            scopes.open_scope(&link.fragment.children);
+        }
         let mut child = callbacks.first_child(node);
         while !child.is_invalid() {
             let next = callbacks.next_sibling(child);
-            self.commit_subtree(child, result.paintable_for_children, null_mut(), callbacks, sink);
+            self.commit_subtree(child, result.paintable_for_children, null_mut(), callbacks, sink, scopes);
             child = next;
+        }
+        if entry.is_some() {
+            scopes.close_scope();
         }
 
         if has_pending_inline_box_geometry {
@@ -966,7 +977,9 @@ impl LayoutState {
         paintable_to_replace: *mut c_void,
         callbacks: &FfiLayoutFcCallbacks,
         sink: &FfiCommitSink,
+        pass_fragments: &crate::layout::CompletedPassFragments,
     ) {
+        let mut scopes = crate::layout::CommitScopes::for_pass(pass_fragments);
         // SAFETY: The sink retains the replaced paintable, detaches it, and
         // returns borrowed insertion pointers that stay live until
         // finish_commit().
@@ -977,6 +990,7 @@ impl LayoutState {
             position.insert_before_paintable,
             callbacks,
             sink,
+            &mut scopes,
         );
         unsafe {
             (sink.finish_commit)(sink.context);

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -64,33 +64,7 @@ impl<T> PagedStore<T> {
         entry.get().unwrap()
     }
 
-    fn for_each_indexed(&self, mut callback: impl FnMut(u32, &T)) {
-        let Some(directory) = self.page_table_directory.get() else {
-            return;
-        };
-        for (directory_index, page_table) in directory.iter().enumerate() {
-            let Some(page_table) = page_table.get() else {
-                continue;
-            };
-            for (page_index, page) in page_table.iter().enumerate() {
-                let Some(page) = page.get() else {
-                    continue;
-                };
-                for (entry_index, entry) in page.iter().enumerate() {
-                    if let Some(entry) = entry.get() {
-                        let index = (directory_index << (PAGE_TABLE_BITS + PAGE_BITS))
-                            | (page_index << PAGE_BITS)
-                            | entry_index;
-                        callback(index as u32, entry);
-                    }
-                }
-            }
-        }
-    }
 
-    pub(crate) fn for_each(&self, mut callback: impl FnMut(&T)) {
-        self.for_each_indexed(|_, value| callback(value));
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -129,6 +103,39 @@ pub(crate) enum AbsposAlignment {
     Start,
     Stretch,
     Unsafe,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ContainingBlockGeometry {
+    pub(crate) content_origin_in_entry_space: FfiCssPixelPoint,
+    pub(crate) padding_left: CssPixels,
+    pub(crate) padding_right: CssPixels,
+    pub(crate) padding_top: CssPixels,
+    pub(crate) padding_bottom: CssPixels,
+    pub(crate) content_inline_size: CssPixels,
+    pub(crate) content_block_size: CssPixels,
+}
+
+impl ContainingBlockGeometry {
+    pub(crate) fn from_used_values(used: &UsedValues, content_origin_in_entry_space: FfiCssPixelPoint) -> Self {
+        Self {
+            content_origin_in_entry_space,
+            padding_left: used.padding_left.get(),
+            padding_right: used.padding_right.get(),
+            padding_top: used.padding_top.get(),
+            padding_bottom: used.padding_bottom.get(),
+            content_inline_size: used.content_inline_size.get(),
+            content_block_size: used.content_block_size.get(),
+        }
+    }
+
+    pub(crate) fn padding_box_inline_size(&self) -> CssPixels {
+        self.content_inline_size + self.padding_left + self.padding_right
+    }
+
+    pub(crate) fn padding_box_block_size(&self) -> CssPixels {
+        self.content_block_size + self.padding_top + self.padding_bottom
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -265,12 +272,12 @@ pub struct FfiCommitSink {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct PendingAbsposChild {
     pub(crate) child_box: Node,
+    pub(crate) coordinate_space_box: Node,
     pub(crate) static_position_rect: StaticPositionRect,
     pub(crate) containing_block_info_override: Option<AbsposContainingBlockInfo>,
 }
 pub(crate) struct LayoutState {
     used_values: PagedStore<UsedValues>,
-    contained_abspos_children: PagedStore<RefCell<VecDeque<PendingAbsposChild>>>,
     anchor_inset_store: AnchorInsetStore,
     inline_containing_blocks: RefCell<HashSet<Node>>,
     anchor_candidate_shells: RefCell<Vec<*mut c_void>>,
@@ -314,7 +321,6 @@ impl LayoutState {
     pub(crate) fn new(purpose: LayoutStatePurpose) -> Self {
         Self {
             used_values: PagedStore::default(),
-            contained_abspos_children: PagedStore::default(),
             anchor_inset_store: AnchorInsetStore::default(),
             inline_containing_blocks: RefCell::new(HashSet::new()),
             anchor_candidate_shells: RefCell::new(Vec::new()),
@@ -716,73 +722,6 @@ impl LayoutState {
         self.used_values
             .get(callbacks.slot_index(node))
             .expect("missing used values")
-    }
-
-    pub(crate) fn register_contained_abspos_child(
-        &self,
-        callbacks: &FfiLayoutFcCallbacks,
-        target_box: Node,
-        child_box: Node,
-        static_position_rect: StaticPositionRect,
-    ) {
-        let slot_index = target_box.slot_index();
-        let children = self.contained_abspos_children.get(slot_index).unwrap_or_else(|| {
-            self.contained_abspos_children
-                .allocate(slot_index, RefCell::new(VecDeque::new()))
-        });
-        let mut children = children.borrow_mut();
-        if cfg!(debug_assertions) {
-            for entry in children.iter() {
-                // Every box is laid out at most once per state, so it can only be registered once.
-                assert_ne!(entry.child_box, child_box);
-            }
-        }
-        // Entries are kept in tree order so consumption follows document order.
-        let insertion_index = children.partition_point(|entry| callbacks.is_before(entry.child_box, child_box));
-        children.insert(
-            insertion_index,
-            PendingAbsposChild {
-                child_box,
-                static_position_rect,
-                containing_block_info_override: None,
-            },
-        );
-    }
-
-    pub(crate) fn has_contained_abspos_children(&self, target_box: Node) -> bool {
-        self.contained_abspos_children
-            .get(target_box.slot_index())
-            .is_some_and(|children| !children.borrow().is_empty())
-    }
-
-    pub(crate) fn all_registered_contained_abspos_children_are_laid_out(&self) -> bool {
-        let mut all_laid_out = true;
-        self.contained_abspos_children.for_each(|children| {
-            all_laid_out &= children.borrow().is_empty();
-        });
-        all_laid_out
-    }
-
-    /// By completion time the grid-area geometry is final and every abspos
-    /// child registering against this containing block has done so.
-    pub(crate) fn override_contained_abspos_child_containing_blocks(
-        &self,
-        target_box: Node,
-        containing_block_info_for_child: impl Fn(Node) -> AbsposContainingBlockInfo,
-    ) {
-        let Some(children) = self.contained_abspos_children.get(target_box.slot_index()) else {
-            return;
-        };
-        for entry in children.borrow_mut().iter_mut() {
-            entry.containing_block_info_override = Some(containing_block_info_for_child(entry.child_box));
-        }
-    }
-
-    pub(crate) fn take_next_contained_abspos_child(&self, target_box: Node) -> Option<PendingAbsposChild> {
-        self.contained_abspos_children
-            .get(target_box.slot_index())?
-            .borrow_mut()
-            .pop_front()
     }
 
     /// Accumulates relative-position insets from a chain of inline-flow

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -256,15 +256,6 @@ impl<'builder, 'context, 'pass> LineBuilder<'builder, 'context, 'pass> {
         );
         self.line_mut(line_index).fragments[fragment_index].content_baselines = Some(content_baselines);
         self.max_block_size_on_current_line = self.max_block_size_on_current_line.max(margin_block_size);
-        let used = self.context().used(node);
-        used.has_containing_line_box_fragment.set(false);
-        if self.context().facts(node).is_atomic_inline() {
-            used.has_containing_line_box_fragment.set(true);
-            used.containing_line_box_fragment.set(LineBoxFragmentCoordinate {
-                line_box_index: line_index,
-                fragment_index,
-            });
-        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/Libraries/LibWeb/Rust/src/layout/line_builder.rs
+++ b/Libraries/LibWeb/Rust/src/layout/line_builder.rs
@@ -643,7 +643,7 @@ impl<'builder, 'context, 'pass> LineBuilder<'builder, 'context, 'pass> {
                     self.context().state,
                     &self.context().callbacks,
                     node,
-                    self.context().used(node),
+                    &self.context().used(node),
                     crate::layout::BaselineSet::Last,
                     content_baselines,
                 )
@@ -652,7 +652,7 @@ impl<'builder, 'context, 'pass> LineBuilder<'builder, 'context, 'pass> {
                     self.context().state,
                     &self.context().callbacks,
                     node,
-                    self.context().used(node),
+                    &self.context().used(node),
                     crate::layout::BaselineSet::Last,
                 )
             };

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -61,6 +61,5 @@ use std::cell::RefCell;
 use std::cell::RefMut;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::ptr::null_mut;

--- a/Libraries/LibWeb/Rust/src/layout/mod.rs
+++ b/Libraries/LibWeb/Rust/src/layout/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use crate::css::css_pixels::*;
 pub(crate) use crate::css::display::*;
 
 include!("node_facts.rs");
+include!("fragment_tree.rs");
 
 include!("formatting_context.rs");
 include!("sizing_context.rs");

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -9,7 +9,7 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
     // object size), so both dimensions are definite for its children — shadow content sized to fill
     // (e.g. width/height: 100%) resolves against them.
     let (content_inline_size, root_content_block_size) = {
-        let root_state = run.state.used_values(&run.callbacks, run.box_);
+        let root_state = run.records.used_values(run.box_);
         root_state.has_definite_inline_size.set(true);
         root_state.has_definite_block_size.set(true);
         (
@@ -36,15 +36,17 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
         return ChildLayoutResult::default();
     }
 
-    let wrapper_constraints = SizingContext::new(run.state, run.callbacks)
+    let wrapper_constraints = run
+        .sizing()
         .constraints_for_child_context(run.box_, layout_input.containing_block_constraints);
     let wrapper_state = run
-        .state
-        .create_used_values(&run.callbacks, wrapper, wrapper_constraints);
+        .records
+        .create_used_values(run.state, &run.callbacks, wrapper, wrapper_constraints);
     wrapper_state.set_content_inline_size(content_inline_size);
 
     let wrapper_layout = crate::layout::run_formatting_context(
         run.state,
+        wrapper_state,
         wrapper,
         None,
         FfiFormattingContextType::Block,

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -64,11 +64,13 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
         None,
     );
 
-    crate::layout::place_child(run.state, &run.callbacks, wrapper, FfiCssPixelPoint::default());
+    let wrapper_result =
+        crate::layout::hold_unplaced_root_and_take_result(run.fragments.as_deref(), wrapper, wrapper_layout);
+    crate::layout::place_child(run, wrapper, FfiCssPixelPoint::default());
 
     ChildLayoutResult {
         automatic_content_inline_size: content_inline_size,
-        automatic_content_block_size: wrapper_layout.automatic_content_block_size,
+        automatic_content_block_size: wrapper_result.automatic_content_block_size,
         baselines: DerivedBaselines::default(),
         ..ChildLayoutResult::default()
     }

--- a/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/replaced_with_children_formatting_context.rs
@@ -66,7 +66,7 @@ fn layout_replaced_with_children(run: &FormattingContextRun, layout_input: Layou
 
     let wrapper_result =
         crate::layout::hold_unplaced_root_and_take_result(run.fragments.as_deref(), wrapper, wrapper_layout);
-    crate::layout::place_child(run, wrapper, FfiCssPixelPoint::default());
+    crate::layout::place_child(run, wrapper, FfiCssPixelPoint::default(), None);
 
     ChildLayoutResult {
         automatic_content_inline_size: content_inline_size,

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -1842,14 +1842,15 @@ impl<'pass> SizingContext<'pass> {
             .padding_right
             .set(table_style.padding_right().to_px(containing_block_inline_size));
 
-        let table_run = crate::layout::FormattingContextRun::new(
-            measurement.layout_state(),
-            table_box,
-            LayoutMode::IntrinsicSizing,
-            *measurement.callbacks(),
-            false,
-            false,
-        );
+        let table_run = crate::layout::FormattingContextRun {
+            state: measurement.layout_state(),
+            box_: table_box,
+            layout_mode: LayoutMode::IntrinsicSizing,
+            callbacks: *measurement.callbacks(),
+            should_collect_devtools_layout_data: false,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: false,
+            fragments: None,
+        };
         let mut table = TableFormattingContext::new(&table_run);
         let table_available = table_used.available_inner_space_or_constraints_from(available_space);
         table.run_until_inline_size_calculation(

--- a/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/sizing_context.rs
@@ -6,12 +6,21 @@
 
 pub(crate) struct SizingContext<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     callbacks: FfiLayoutFcCallbacks,
 }
 
 impl<'pass> SizingContext<'pass> {
-    pub(crate) fn new(state: &'pass LayoutState, callbacks: FfiLayoutFcCallbacks) -> Self {
-        Self { state, callbacks }
+    pub(crate) fn new(
+        state: &'pass LayoutState,
+        records: std::rc::Rc<RunRecords>,
+        callbacks: FfiLayoutFcCallbacks,
+    ) -> Self {
+        Self {
+            state,
+            records,
+            callbacks,
+        }
     }
 
     fn facts(&self, node: Node) -> NodeFacts<'_> {
@@ -22,8 +31,9 @@ impl<'pass> SizingContext<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
 
-    fn used(&self, node: Node) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, node)
+    #[track_caller]
+    fn used(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(node)
     }
 
     fn parent(&self, node: Node) -> Node {
@@ -1132,6 +1142,7 @@ impl<'pass> SizingContext<'pass> {
             self.resolve_used_block_size_if_treated_as_auto(node, inline_definite_space, constraints, None, || {
                 crate::layout::independent_root_automatic_block_size(
                     self.state,
+                    &self.records,
                     &self.callbacks,
                     node,
                     self.used(node)
@@ -1229,16 +1240,17 @@ impl<'pass> SizingContext<'pass> {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn cache_intrinsic_inline_measurement(
         &self,
         node: Node,
         kind: IntrinsicSizeCacheKind,
         key: IntrinsicSizeCacheKey,
-        measurement: &MeasurementState,
+        measurement_root_used: &UsedValues,
         result: ChildLayoutResult,
         available_block_size: AvailableSize,
     ) {
-        let used = measurement.root_used();
+        let used = measurement_root_used;
         self.intrinsic_inline_measurement_cache_put(
             node,
             kind,
@@ -1289,14 +1301,11 @@ impl<'pass> SizingContext<'pass> {
         used.set_content_block_size(measurement.content_block_size);
         used.uses_collapsing_borders_model
             .set(measurement.uses_collapsing_borders_model);
-        used.has_first_baseline.set(measurement.has_first_baseline);
-        used.first_baseline.set(measurement.first_baseline);
-        used.has_last_baseline.set(measurement.has_last_baseline);
-        used.last_baseline.set(measurement.last_baseline);
         let baselines = DerivedBaselines {
             first: measurement.has_first_baseline.then_some(measurement.first_baseline),
             last: measurement.has_last_baseline.then_some(measurement.last_baseline),
         };
+        crate::layout::store_derived_baselines(&used, baselines);
         Some((measurement.automatic_content_block_size, baselines))
     }
 
@@ -1569,8 +1578,8 @@ impl<'pass> SizingContext<'pass> {
             return cached.automatic_content_inline_size;
         }
 
-        let measurement = MeasurementState::create(self.callbacks, node, constraints);
-        let root = measurement.root_used();
+        let measurement = MeasurementState::create(self.callbacks);
+        let root = measurement.create_used_values(node, constraints);
         root.inline_size_constraint.set(size_constraint);
         root.has_definite_inline_size.set(false);
         let block_size = if root.has_definite_block_size() {
@@ -1580,6 +1589,7 @@ impl<'pass> SizingContext<'pass> {
         };
         let mut result = measurement.run(
             node,
+            root.clone(),
             LayoutInput::new(
                 AvailableSpace {
                     inline_size: available_inline_size,
@@ -1591,7 +1601,7 @@ impl<'pass> SizingContext<'pass> {
         );
         result.automatic_content_inline_size = clamp_to_max_dimension_value(result.automatic_content_inline_size);
         let value = result.automatic_content_inline_size;
-        self.cache_intrinsic_inline_measurement(node, kind, key, &measurement, result, block_size);
+        self.cache_intrinsic_inline_measurement(node, kind, key, &root, result, block_size);
         value
     }
 
@@ -1613,13 +1623,14 @@ impl<'pass> SizingContext<'pass> {
             return cached;
         }
 
-        let measurement = MeasurementState::create(self.callbacks, node, constraints);
-        let root = measurement.root_used();
+        let measurement = MeasurementState::create(self.callbacks);
+        let root = measurement.create_used_values(node, constraints);
         root.block_size_constraint.set(size_constraint);
         root.has_definite_block_size.set(false);
         root.set_content_inline_size(inline_size);
         let result = measurement.run(
             node,
+            root,
             LayoutInput::new(
                 AvailableSpace {
                     inline_size: AvailableSize::definite(inline_size),
@@ -1692,13 +1703,16 @@ impl<'pass> SizingContext<'pass> {
         inner_available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
     ) -> CssPixels {
-        let measurement = MeasurementState::create(self.callbacks, node, constraints);
+        let measurement = MeasurementState::create(self.callbacks);
+        let node_used = measurement.create_used_values(node, constraints);
         measurement
             .run_with_layout_mode(
                 node,
+                node_used,
                 layout_mode,
                 LayoutInput::new(inner_available_space, constraints, ParticipationInParentFormattingContext::Root),
             )
+            .result
             .automatic_content_block_size
     }
 
@@ -1790,17 +1804,6 @@ impl<'pass> SizingContext<'pass> {
         find(self, wrapper).expect("table wrapper must contain a table box")
     }
 
-    fn create_measurement_used_values(
-        measurement: &MeasurementState,
-        node: Node,
-        constraints: ContainingBlockConstraints,
-    ) -> &UsedValues {
-        let callbacks = *measurement.callbacks();
-        measurement
-            .layout_state()
-            .create_used_values(&callbacks, node, constraints)
-    }
-
     // 17.5.2 Table width algorithms: the 'table-layout' property
     // https://www.w3.org/TR/CSS22/tables.html#width-layout
     pub(crate) fn compute_table_box_inline_size_inside_wrapper(
@@ -1825,13 +1828,13 @@ impl<'pass> SizingContext<'pass> {
         let available_inline_size = containing_block_inline_size - margin_left - margin_right;
         let table_box = self.table_box_inside_wrapper(wrapper);
 
-        let measurement = MeasurementState::create(self.callbacks, wrapper, table_wrapper_constraints);
+        let measurement = MeasurementState::create(self.callbacks);
 
         // The table wrapper is invisible to percentage resolution, so the table box gets the
         // wrapper's constraints unchanged. Callers measuring a table wrapper for grid alignment
         // pass the grid-area inline size as the wrapper's percentage basis.
         let table_constraints = table_wrapper_constraints;
-        let table_used = Self::create_measurement_used_values(&measurement, table_box, table_constraints);
+        let table_used = measurement.create_used_values(table_box, table_constraints);
         let table_style = self.style(table_box);
         table_used.border_left.set(table_style.border_left_width());
         table_used.border_right.set(table_style.border_right_width());
@@ -1844,6 +1847,7 @@ impl<'pass> SizingContext<'pass> {
 
         let table_run = crate::layout::FormattingContextRun {
             state: measurement.layout_state(),
+            records: std::rc::Rc::new(RunRecords::new(table_box, table_used.clone())),
             box_: table_box,
             layout_mode: LayoutMode::IntrinsicSizing,
             callbacks: *measurement.callbacks(),
@@ -1892,9 +1896,11 @@ impl<'pass> SizingContext<'pass> {
         // table-wrapper can't have borders or paddings but it might have margin taken from table-root.
         let available_block_size = containing_block_block_size - margin_top - margin_bottom;
 
-        let measurement = MeasurementState::create(self.callbacks, wrapper, table_wrapper_constraints);
-        let wrapper_result = measurement.run_with_layout_mode(
+        let measurement = MeasurementState::create(self.callbacks);
+        let wrapper_used = measurement.create_used_values(wrapper, table_wrapper_constraints);
+        let wrapper_outputs = measurement.run_with_layout_mode(
             wrapper,
+            wrapper_used,
             LayoutMode::IntrinsicSizing,
             LayoutInput {
                 available_space: self
@@ -1907,7 +1913,8 @@ impl<'pass> SizingContext<'pass> {
             },
         );
 
-        let table_used_block_size = wrapper_result
+        let table_used_block_size = wrapper_outputs
+            .result
             .table_box_in_wrapper_border_box_block_size
             .expect("a table wrapper's measurement run lays out the table box inside it");
         if matches!(available_space.block_size, AvailableSize::Definite(_)) {

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -511,13 +511,21 @@ impl<'pass> SvgFormattingContext<'pass> {
         has_transforms.then_some(transforms)
     }
 
+    fn note_svg_payload_write(&self) {
+        if let Some(fragments) = &self.fragments {
+            fragments.note_svg_payload_write();
+        }
+    }
+
     fn set_computed_transforms(&self, node: Node, transforms: FfiSvgComputedTransforms) {
+        self.note_svg_payload_write();
         self.state
             .used_values_rare_data_for_node_mut(&self.callbacks, node)
             .computed_svg_transforms = Some(transforms);
     }
 
     fn set_svg_viewport_size(&self, node: Node, viewport_size: FfiCssPixelSize) {
+        self.note_svg_payload_write();
         self.state
             .used_values_rare_data_for_node_mut(&self.callbacks, node)
             .svg_viewport_size = Some(viewport_size);
@@ -967,6 +975,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         let used = used_pointer;
         used.set_content_inline_size(transformed_bounding_box.width);
         used.set_content_block_size(transformed_bounding_box.height);
+        self.note_svg_payload_write();
         self.state
             .used_values_rare_data_for_node_mut(&self.callbacks, graphics_box)
             .computed_svg_path = Some(path);

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -380,6 +380,7 @@ pub(crate) fn scale_and_align_viewbox_content(
 
 struct SvgFormattingContext<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     box_: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
@@ -409,6 +410,7 @@ impl<'pass> SvgFormattingContext<'pass> {
     ) -> Self {
         Self {
             state: run.state,
+            records: run.records.clone(),
             box_,
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
@@ -429,6 +431,7 @@ impl<'pass> SvgFormattingContext<'pass> {
     fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
         FormattingContextRun {
             state: self.state,
+            records: self.records.clone(),
             box_: self.box_,
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
@@ -477,24 +480,25 @@ impl<'pass> SvgFormattingContext<'pass> {
         self.state.style_facts(&self.callbacks, node)
     }
 
-    fn used_values(&self, node: Node) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, node)
+    #[track_caller]
+    fn used_values(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(node)
     }
 
-    fn create_used_values(&self, node: Node) -> &'pass UsedValues {
+    fn create_used_values(&self, node: Node) -> std::rc::Rc<UsedValues> {
         // SVG descendants deliberately carry no percentage basis.
         // SVG layout resolves percentages against the SVG viewport, not a CSS containing
         // block, so boxes inside the SVG subtree carry no percentage basis.
-        self.state
-            .create_used_values(&self.callbacks, node, crate::layout::ContainingBlockConstraints::default())
+        self.records
+            .create_used_values(self.state, &self.callbacks, node, crate::layout::ContainingBlockConstraints::default())
     }
 
     fn computed_transforms(&self, node: Node) -> Option<FfiSvgComputedTransforms> {
-        let slot_index = self.callbacks.slot_index(node);
         if let Some(transforms) = self
-            .state
-            .used_values_rare_data(slot_index)
-            .and_then(|data| data.computed_svg_transforms)
+            .used_values(node)
+            .rare_data
+            .get()
+            .and_then(|cell| cell.borrow().computed_svg_transforms)
         {
             return Some(transforms);
         }
@@ -519,16 +523,12 @@ impl<'pass> SvgFormattingContext<'pass> {
 
     fn set_computed_transforms(&self, node: Node, transforms: FfiSvgComputedTransforms) {
         self.note_svg_payload_write();
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, node)
-            .computed_svg_transforms = Some(transforms);
+        self.used_values(node).rare_data_mut().computed_svg_transforms = Some(transforms);
     }
 
     fn set_svg_viewport_size(&self, node: Node, viewport_size: FfiCssPixelSize) {
         self.note_svg_payload_write();
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, node)
-            .svg_viewport_size = Some(viewport_size);
+        self.used_values(node).rare_data_mut().svg_viewport_size = Some(viewport_size);
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
@@ -560,7 +560,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         let kind = self.node_kind(self.box_);
         let facts = self.svg_facts(self.box_);
         let used_pointer = self.used_values(self.box_);
-        let used = used_pointer;
+        let used = &used_pointer;
 
         if facts.is_document_element && !facts.document_is_decoded_svg && !used.has_content_offset.get() {
             // Overwrite the content width/height with the styled node width/height (from <svg width height ...>)
@@ -836,7 +836,7 @@ impl<'pass> SvgFormattingContext<'pass> {
             parent_viewbox_transform = FfiAffineTransform::default();
         }
 
-        let used = used_pointer;
+        let used = used_pointer.clone();
         used.set_content_inline_size(content_inline_size);
         used.set_content_block_size(content_block_size);
         used.has_definite_inline_size.set(true);
@@ -864,7 +864,7 @@ impl<'pass> SvgFormattingContext<'pass> {
             });
             // Reborrow after recursive layout to avoid keeping a Rust
             // reference across callbacks.
-            let used = used_pointer;
+            let used = &used_pointer;
             used.set_content_inline_size(css_pixels_from_f32(mapped_rect.width));
             used.set_content_block_size(css_pixels_from_f32(mapped_rect.height));
             self.place_child(
@@ -972,13 +972,11 @@ impl<'pass> SvgFormattingContext<'pass> {
         transformed_bounding_box.inflate(stroke_width, stroke_width);
 
         let used_pointer = self.used_values(graphics_box);
-        let used = used_pointer;
+        let used = &used_pointer;
         used.set_content_inline_size(transformed_bounding_box.width);
         used.set_content_block_size(transformed_bounding_box.height);
         self.note_svg_payload_write();
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, graphics_box)
-            .computed_svg_path = Some(path);
+        self.used_values(graphics_box).rare_data_mut().computed_svg_path = Some(path);
         self.place_child(graphics_box, transformed_bounding_box.x, transformed_bounding_box.y);
         used.has_definite_inline_size.set(true);
         used.has_definite_block_size.set(true);
@@ -1002,7 +1000,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         };
         let bounding_box = float_rect_to_css_pixels(to_css_pixels_transform.map_rect(source));
         let used_pointer = self.used_values(image_box);
-        let used = used_pointer;
+        let used = &used_pointer;
         used.set_content_inline_size(bounding_box.width);
         used.set_content_block_size(bounding_box.height);
         self.place_child(image_box, bounding_box.x, bounding_box.y);
@@ -1030,7 +1028,7 @@ impl<'pass> SvgFormattingContext<'pass> {
                 } else {
                     facts.pattern_height.value
                 };
-                let used = used_pointer;
+                let used = &used_pointer;
                 used.set_content_inline_size(css_pixels_from_f32(width));
                 used.set_content_block_size(css_pixels_from_f32(height));
             } else {
@@ -1038,7 +1036,7 @@ impl<'pass> SvgFormattingContext<'pass> {
                 assert!(!parent.is_invalid());
                 let parent_used_pointer = self.used_values(parent);
                 let parent_used = parent_used_pointer;
-                let used = used_pointer;
+                let used = &used_pointer;
                 used.set_content_inline_size(CssPixels::nearest_value_for(
                     facts.pattern_width.value as f64 * parent_used.content_inline_size.get().to_double(),
                 ));
@@ -1055,7 +1053,7 @@ impl<'pass> SvgFormattingContext<'pass> {
             assert!(!parent.is_invalid());
             let parent_used_pointer = self.used_values(parent);
             let parent_used = parent_used_pointer;
-            let used = used_pointer;
+            let used = &used_pointer;
             used.set_content_inline_size(parent_used.content_inline_size.get());
             used.set_content_block_size(parent_used.content_block_size.get());
             // https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute
@@ -1070,19 +1068,19 @@ impl<'pass> SvgFormattingContext<'pass> {
                 );
             }
         } else {
-            let used = used_pointer;
+            let used = &used_pointer;
             used.set_content_inline_size(self.viewport_width);
             used.set_content_block_size(self.viewport_height);
         }
 
-        let used = used_pointer;
+        let used = used_pointer.clone();
         used.has_definite_inline_size.set(true);
         used.has_definite_block_size.set(true);
         // Pretend masks/clips are a viewport so we can scale the contents depending on the `contentUnits`.
         let mut nested_context = Self::new_nested(run, resource, parent_viewbox_transform, Some(FfiAffineTransform::default()));
         nested_context.run(run, self.nested_layout_input());
 
-        let used = used_pointer;
+        let used = &used_pointer;
         let mapped_rect = parent_viewbox_transform.map_rect(FfiFloatRect {
             x: 0.0,
             y: 0.0,
@@ -1141,7 +1139,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         }
 
         let used_pointer = self.used_values(container);
-        let used = used_pointer;
+        let used = &used_pointer;
         used.set_content_inline_size(max_x - min_x);
         used.set_content_block_size(max_y - min_y);
         self.place_child(container, min_x, min_y);

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -524,7 +524,7 @@ impl<'pass> SvgFormattingContext<'pass> {
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
-        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y });
+        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
     }
 
     fn for_each_child(&self, node: Node, mut callback: impl FnMut(Node)) {

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -817,9 +817,6 @@ impl<'pass> SvgFormattingContext<'pass> {
         used.set_content_block_size(content_block_size);
         used.has_definite_inline_size.set(true);
         used.has_definite_block_size.set(true);
-        if facts.has_own_view_box {
-            self.place_child(viewport, content_offset.x, content_offset.y);
-        }
 
         let mut nested_context = Self::new_nested(
             self.state,
@@ -837,6 +834,9 @@ impl<'pass> SvgFormattingContext<'pass> {
                 height: nested_viewport_height,
             },
         );
+        if facts.has_own_view_box {
+            self.place_child(viewport, content_offset.x, content_offset.y);
+        }
 
         if !facts.has_own_view_box {
             let mapped_rect = self.current_viewbox_transform.map_rect(FfiFloatRect {
@@ -958,12 +958,12 @@ impl<'pass> SvgFormattingContext<'pass> {
         let used = used_pointer;
         used.set_content_inline_size(transformed_bounding_box.width);
         used.set_content_block_size(transformed_bounding_box.height);
-        self.place_child(graphics_box, transformed_bounding_box.x, transformed_bounding_box.y);
-        used.has_definite_inline_size.set(true);
-        used.has_definite_block_size.set(true);
         self.state
             .used_values_rare_data_for_node_mut(&self.callbacks, graphics_box)
             .computed_svg_path = Some(path);
+        self.place_child(graphics_box, transformed_bounding_box.x, transformed_bounding_box.y);
+        used.has_definite_inline_size.set(true);
+        used.has_definite_block_size.set(true);
     }
 
     fn layout_image_element(&self, image_box: Node) {

--- a/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/svg_formatting_context.rs
@@ -391,34 +391,50 @@ struct SvgFormattingContext<'pass> {
     viewport_width: CssPixels,
     viewport_height: CssPixels,
     current_text_position: FfiFloatPoint,
+    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    should_collect_devtools_layout_data: bool,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
 }
 
 impl<'pass> SvgFormattingContext<'pass> {
-    fn new(state: &'pass LayoutState, box_: Node, layout_mode: LayoutMode, callbacks: FfiLayoutFcCallbacks) -> Self {
-        Self::new_nested(state, box_, layout_mode, callbacks, FfiAffineTransform::default(), None)
+    fn new(run: &FormattingContextRun<'pass>) -> Self {
+        Self::new_nested(run, run.box_, FfiAffineTransform::default(), None)
     }
 
     fn new_nested(
-        state: &'pass LayoutState,
+        run: &FormattingContextRun<'pass>,
         box_: Node,
-        layout_mode: LayoutMode,
-        callbacks: FfiLayoutFcCallbacks,
         parent_viewbox_transform: FfiAffineTransform,
         parent_svg_transform: Option<FfiAffineTransform>,
     ) -> Self {
         Self {
-            state,
+            state: run.state,
             box_,
-            layout_mode,
-            callbacks,
+            layout_mode: run.layout_mode,
+            callbacks: run.callbacks,
             parent_viewbox_transform,
             parent_svg_transform,
+            fragments: run.fragments.clone(),
             available_space: None,
             quirks_mode_percentage_basis_block_size: None,
             current_viewbox_transform: FfiAffineTransform::default(),
             viewport_width: CssPixels::default(),
             viewport_height: CssPixels::default(),
             current_text_position: FfiFloatPoint::default(),
+            should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
+        }
+    }
+
+    fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
+        FormattingContextRun {
+            state: self.state,
+            box_: self.box_,
+            layout_mode: self.layout_mode,
+            callbacks: self.callbacks,
+            should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            fragments: self.fragments.clone(),
         }
     }
 
@@ -508,7 +524,7 @@ impl<'pass> SvgFormattingContext<'pass> {
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
-        crate::layout::place_child(self.state, &self.callbacks, node, FfiCssPixelPoint { x, y });
+        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y });
     }
 
     fn for_each_child(&self, node: Node, mut callback: impl FnMut(Node)) {
@@ -530,7 +546,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         result
     }
 
-    fn run(&mut self, run: &FormattingContextRun, input: LayoutInput) {
+    fn run(&mut self, run: &FormattingContextRun<'pass>, input: LayoutInput) {
         // NOTE: SVG doesn't have a "formatting context" in the spec, but this is the most
         //       obvious way to drive SVG layout in our engine at the moment.
         let kind = self.node_kind(self.box_);
@@ -672,7 +688,7 @@ impl<'pass> SvgFormattingContext<'pass> {
 
     fn layout_svg_element(
         &mut self,
-        run: &FormattingContextRun,
+        run: &FormattingContextRun<'pass>,
         child: Node,
         input: LayoutInput,
         parent_svg_transform: FfiAffineTransform,
@@ -748,7 +764,7 @@ impl<'pass> SvgFormattingContext<'pass> {
 
     fn layout_nested_viewport(
         &mut self,
-        run: &FormattingContextRun,
+        run: &FormattingContextRun<'pass>,
         viewport: Node,
         parent_svg_transform: FfiAffineTransform,
     ) {
@@ -818,14 +834,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         used.has_definite_inline_size.set(true);
         used.has_definite_block_size.set(true);
 
-        let mut nested_context = Self::new_nested(
-            self.state,
-            viewport,
-            self.layout_mode,
-            self.callbacks,
-            parent_viewbox_transform,
-            Some(parent_svg_transform),
-        );
+        let mut nested_context = Self::new_nested(run, viewport, parent_viewbox_transform, Some(parent_svg_transform));
         nested_context.run(run, self.nested_layout_input());
         self.set_svg_viewport_size(
             viewport,
@@ -860,7 +869,7 @@ impl<'pass> SvgFormattingContext<'pass> {
 
     fn layout_graphics_element(
         &mut self,
-        run: &FormattingContextRun,
+        run: &FormattingContextRun<'pass>,
         graphics_box: Node,
         input: LayoutInput,
         parent_svg_transform: FfiAffineTransform,
@@ -910,7 +919,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         }
     }
 
-    fn layout_path_like_element(&mut self, run: &FormattingContextRun, graphics_box: Node, input: LayoutInput) {
+    fn layout_path_like_element(&mut self, run: &FormattingContextRun<'pass>, graphics_box: Node, input: LayoutInput) {
         let transforms = self
             .computed_transforms(graphics_box)
             .expect("SVG graphics box must have computed transforms");
@@ -992,7 +1001,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         used.has_definite_block_size.set(true);
     }
 
-    fn layout_mask_or_clip(&mut self, run: &FormattingContextRun, resource: Node) {
+    fn layout_mask_or_clip(&mut self, run: &FormattingContextRun<'pass>, resource: Node) {
         let kind = self.node_kind(resource);
         let facts = self.svg_facts(resource);
         assert!(kind_is_svg_resource_box(kind));
@@ -1061,14 +1070,7 @@ impl<'pass> SvgFormattingContext<'pass> {
         used.has_definite_inline_size.set(true);
         used.has_definite_block_size.set(true);
         // Pretend masks/clips are a viewport so we can scale the contents depending on the `contentUnits`.
-        let mut nested_context = Self::new_nested(
-            self.state,
-            resource,
-            self.layout_mode,
-            self.callbacks,
-            parent_viewbox_transform,
-            Some(FfiAffineTransform::default()),
-        );
+        let mut nested_context = Self::new_nested(run, resource, parent_viewbox_transform, Some(FfiAffineTransform::default()));
         nested_context.run(run, self.nested_layout_input());
 
         let used = used_pointer;
@@ -1089,7 +1091,7 @@ impl<'pass> SvgFormattingContext<'pass> {
 
     fn layout_container_element(
         &mut self,
-        run: &FormattingContextRun,
+        run: &FormattingContextRun<'pass>,
         container: Node,
         input: LayoutInput,
         container_svg_transform: FfiAffineTransform,

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -782,6 +782,7 @@ enum TrackAxis {
 
 struct TableFormattingContext<'pass> {
     state: &'pass LayoutState,
+    records: std::rc::Rc<RunRecords>,
     table_box: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
@@ -847,6 +848,7 @@ impl<'pass> TableFormattingContext<'pass> {
     fn new(run: &FormattingContextRun<'pass>) -> Self {
         Self {
             state: run.state,
+            records: run.records.clone(),
             table_box: run.box_,
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
@@ -871,13 +873,14 @@ impl<'pass> TableFormattingContext<'pass> {
         }
     }
 
-    fn sizing(&self) -> SizingContext<'_> {
-        SizingContext::new(self.state, self.callbacks)
+    fn sizing(&self) -> SizingContext<'pass> {
+        SizingContext::new(self.state, self.records.clone(), self.callbacks)
     }
 
     fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
         FormattingContextRun {
             state: self.state,
+            records: self.records.clone(),
             box_: self.table_box,
             layout_mode: self.layout_mode,
             callbacks: self.callbacks,
@@ -904,17 +907,18 @@ impl<'pass> TableFormattingContext<'pass> {
         children
     }
 
-    fn used_values(&self, node: Node) -> &'pass UsedValues {
-        self.state.used_values(&self.callbacks, node)
+    #[track_caller]
+    fn used_values(&self, node: Node) -> std::rc::Rc<UsedValues> {
+        self.records.used_values(node)
     }
 
-    fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> &'pass UsedValues {
-        self.state.create_used_values(&self.callbacks, node, constraints)
+    fn create_used_values(&self, node: Node, constraints: ContainingBlockConstraints) -> std::rc::Rc<UsedValues> {
+        self.records.create_used_values(self.state, &self.callbacks, node, constraints)
     }
 
     fn set_cell_coordinates(&self, cell: TableCell) {
-        self.state
-            .used_values_rare_data_for_node_mut(&self.callbacks, cell.box_)
+        self.used_values(cell.box_)
+            .rare_data_mut()
             .table_cell_coordinates = Some(crate::layout::FfiTableCellCoordinates {
             row_index: cell.row_index,
             column_index: cell.column_index,
@@ -1066,8 +1070,8 @@ impl<'pass> TableFormattingContext<'pass> {
             used.border_bottom.set(resolved.bottom.border_data.width);
             used.border_left.set(resolved.left.border_data.width);
             used.uses_collapsing_borders_model.set(true);
-            self.state
-                .used_values_rare_data_for_node_mut(&self.callbacks, cell.box_)
+            self.used_values(cell.box_)
+                .rare_data_mut()
                 .override_borders_data = Some(resolved);
         }
     }
@@ -1972,7 +1976,7 @@ impl<'pass> TableFormattingContext<'pass> {
             self.state,
             &self.callbacks,
             cell_box,
-            self.used_values(cell_box),
+            &self.used_values(cell_box),
             crate::layout::BaselineSet::First,
             content_baselines,
         )
@@ -1983,7 +1987,7 @@ impl<'pass> TableFormattingContext<'pass> {
             self.state,
             &self.callbacks,
             node,
-            self.used_values(node),
+            &self.used_values(node),
             crate::layout::BaselineSet::First,
         )
     }
@@ -2011,9 +2015,9 @@ impl<'pass> TableFormattingContext<'pass> {
             return None;
         }
 
-        let measurement = MeasurementState::create(self.callbacks, cell.box_, ContainingBlockConstraints::default());
-        let measured_root = measurement.root_used();
-        used.mirror_box_metrics_and_size_constraints_into(measured_root);
+        let measurement = MeasurementState::create(self.callbacks);
+        let measured_root = measurement.create_used_values(cell.box_, ContainingBlockConstraints::default());
+        used.mirror_box_metrics_and_size_constraints_into(&measured_root);
         measured_root
             .has_definite_inline_size
             .set(used.has_definite_inline_size());
@@ -2026,6 +2030,7 @@ impl<'pass> TableFormattingContext<'pass> {
 
         let result = measurement.run_with_layout_mode(
             cell.box_,
+            measured_root.clone(),
             self.layout_mode,
             LayoutInput {
                 available_space: inner,
@@ -2037,15 +2042,16 @@ impl<'pass> TableFormattingContext<'pass> {
                 },
                 participation: ParticipationInParentFormattingContext::Item,
             },
-        );
-        let measured_cell_used = measurement.layout_state().used_values(measurement.callbacks(), cell.box_);
+        )
+        .result;
+        let measured_cell_used = measured_root;
         Some(MeasuredCellContent {
             content_block_size: result.automatic_content_block_size,
             first_baseline: crate::layout::box_baseline_with_content_baselines(
                 measurement.layout_state(),
                 measurement.callbacks(),
                 cell.box_,
-                measured_cell_used,
+                &measured_cell_used,
                 crate::layout::BaselineSet::First,
                 result.baselines,
             ),
@@ -2120,7 +2126,7 @@ impl<'pass> TableFormattingContext<'pass> {
             if defer_inside_layout {
                 // This cell's final inside layout happens once row heights are final; measure its
                 // content in a throwaway state instead of laying out the committing state twice.
-                if let Some(measured) = self.measure_cell(cell, used, inner, true) {
+                if let Some(measured) = self.measure_cell(cell, &used, inner, true) {
                     used.set_content_block_size(measured.content_block_size);
                     measured_baseline = Some(measured.first_baseline);
                 }
@@ -2242,7 +2248,7 @@ impl<'pass> TableFormattingContext<'pass> {
             // The first pass measured this cell at its automatic block size; measure it again at
             // the percentage-resolved size to preserve the baseline its final inside layout will use.
             let baseline = self
-                .measure_cell(cell, used, inner, false)
+                .measure_cell(cell, &used, inner, false)
                 .map_or_else(|| self.box_baseline(cell.box_), |measured| measured.first_baseline);
             self.cells[cell_index].baseline = baseline;
             if !self.rows[cell.row_index].is_collapsed {
@@ -2509,11 +2515,11 @@ impl<'pass> TableFormattingContext<'pass> {
     }
 
     fn compute_and_store_baselines(&self, node: Node) {
-        let baselines = crate::layout::derive_baselines(self.state, &self.callbacks, node, false);
+        let baselines = crate::layout::derive_baselines(self.state, &self.records, &self.callbacks, node, false);
         if node == self.table_box {
             self.derived_baselines_of_root_box.set(baselines);
         } else {
-            crate::layout::store_derived_baselines(self.used_values(node), baselines);
+            crate::layout::store_derived_baselines(&self.used_values(node), baselines);
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -924,7 +924,7 @@ impl<'pass> TableFormattingContext<'pass> {
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
-        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y });
+        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y }, None);
     }
 
     fn border_spacing_inline(&mut self) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/table_formatting_context.rs
@@ -785,6 +785,9 @@ struct TableFormattingContext<'pass> {
     table_box: Node,
     layout_mode: LayoutMode,
     callbacks: FfiLayoutFcCallbacks,
+    fragments: Option<std::rc::Rc<RunFragmentBuilder>>,
+    should_collect_devtools_layout_data: bool,
+    treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     table_constraints: ContainingBlockConstraints,
     participant_constraints: ContainingBlockConstraints,
     available_space: AvailableSpace,
@@ -847,6 +850,9 @@ impl<'pass> TableFormattingContext<'pass> {
             table_box: run.box_,
             layout_mode: run.layout_mode,
             callbacks: run.callbacks,
+            fragments: run.fragments.clone(),
+            should_collect_devtools_layout_data: run.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: run.treat_block_axis_percentage_insets_as_auto_beyond_root,
             table_constraints: ContainingBlockConstraints::default(),
             participant_constraints: ContainingBlockConstraints::default(),
             available_space: AvailableSpace::default(),
@@ -867,6 +873,18 @@ impl<'pass> TableFormattingContext<'pass> {
 
     fn sizing(&self) -> SizingContext<'_> {
         SizingContext::new(self.state, self.callbacks)
+    }
+
+    fn formatting_context_run(&self) -> FormattingContextRun<'pass> {
+        FormattingContextRun {
+            state: self.state,
+            box_: self.table_box,
+            layout_mode: self.layout_mode,
+            callbacks: self.callbacks,
+            should_collect_devtools_layout_data: self.should_collect_devtools_layout_data,
+            treat_block_axis_percentage_insets_as_auto_beyond_root: self.treat_block_axis_percentage_insets_as_auto_beyond_root,
+            fragments: self.fragments.clone(),
+        }
     }
 
     fn parent(&self, node: Node) -> Node {
@@ -906,7 +924,7 @@ impl<'pass> TableFormattingContext<'pass> {
     }
 
     fn place_child(&self, node: Node, x: CssPixels, y: CssPixels) {
-        crate::layout::place_child(self.state, &self.callbacks, node, FfiCssPixelPoint { x, y });
+        crate::layout::place_child(&self.formatting_context_run(), node, FfiCssPixelPoint { x, y });
     }
 
     fn border_spacing_inline(&mut self) -> CssPixels {

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -200,6 +200,18 @@ impl Default for UsedValues {
 }
 
 impl UsedValues {
+    pub(crate) fn rare_data_mut(&self) -> RefMut<'_, UsedValuesRareData> {
+        self.rare_data.get_or_init(UsedValuesRareData::default).borrow_mut()
+    }
+
+    pub(crate) fn line_data_ref(&self) -> Option<Ref<'_, LineData>> {
+        self.line_data.get().map(RefCell::borrow)
+    }
+
+    pub(crate) fn line_data_cell(&self) -> &RefCell<LineData> {
+        self.line_data.get_or_init(LineData::default)
+    }
+
     pub(crate) fn content_baselines_from_cells(&self) -> crate::layout::DerivedBaselines {
         crate::layout::DerivedBaselines {
             first: self.has_first_baseline.get().then(|| self.first_baseline.get()),

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -101,10 +101,7 @@ impl<T: Copy> SealableCell<T> {
     #[track_caller]
     #[inline]
     pub(crate) fn set(&self, value: T) {
-        assert!(
-            !self.sealed.get(),
-            "write to a sealed committed box metric after placement"
-        );
+        assert!(!self.sealed.get(), "write to a sealed committed box metric");
         self.value.set(value);
     }
 
@@ -251,6 +248,23 @@ impl UsedValues {
         self.committed_offset_delta.seal();
         self.has_containing_line_box_fragment.seal();
         self.containing_line_box_fragment.seal();
+    }
+
+    pub(crate) fn seal_own_metrics(&self) {
+        self.content_inline_size.seal();
+        self.content_block_size.seal();
+        self.margin_left.seal();
+        self.margin_right.seal();
+        self.margin_top.seal();
+        self.margin_bottom.seal();
+        self.border_left.seal();
+        self.border_right.seal();
+        self.border_top.seal();
+        self.border_bottom.seal();
+        self.padding_left.seal();
+        self.padding_right.seal();
+        self.padding_top.seal();
+        self.padding_bottom.seal();
     }
 }
 

--- a/Libraries/LibWeb/Rust/src/layout/used_values.rs
+++ b/Libraries/LibWeb/Rust/src/layout/used_values.rs
@@ -113,8 +113,6 @@ impl<T: Copy> SealableCell<T> {
 /// The per-box geometry stored in a Rust-owned layout pass.
 #[derive(Debug)]
 pub(crate) struct UsedValues {
-    pub node: crate::layout::node_data::NodeSlotId,
-
     pub content_inline_size: SealableCell<CssPixels>,
     pub content_block_size: SealableCell<CssPixels>,
 
@@ -140,7 +138,6 @@ pub(crate) struct UsedValues {
 
     pub has_definite_inline_size: Cell<bool>,
     pub has_definite_block_size: Cell<bool>,
-    pub materialized_from_paintable: Cell<bool>,
     pub uses_collapsing_borders_model: Cell<bool>,
 
     pub inline_size_constraint: Cell<SizeConstraint>,
@@ -151,8 +148,6 @@ pub(crate) struct UsedValues {
     pub has_content_offset: SealableCell<bool>,
     pub content_offset: SealableCell<FfiCssPixelPoint>,
 
-    pub committed_offset_delta: SealableCell<FfiCssPixelPoint>,
-
     // Keep baseline payloads separate so resetting the presence bits does not
     // perturb the payloads observed by the existing derivation flow.
     pub has_first_baseline: Cell<bool>,
@@ -160,10 +155,6 @@ pub(crate) struct UsedValues {
     pub has_last_baseline: Cell<bool>,
     pub last_baseline: Cell<CssPixels>,
 
-    // Commit copies the coordinate payload even when the presence bit is
-    // false, so this cannot be represented as Cell<Option<_>>.
-    pub has_containing_line_box_fragment: SealableCell<bool>,
-    pub containing_line_box_fragment: SealableCell<LineBoxFragmentCoordinate>,
 
     pub(crate) line_data: LazyRefCell<LineData>,
     pub(crate) rare_data: LazyRefCell<UsedValuesRareData>,
@@ -173,7 +164,6 @@ impl Default for UsedValues {
     fn default() -> Self {
         let zero = CssPixels::from_raw(0);
         Self {
-            node: crate::layout::node_data::NodeSlotId::INVALID,
             content_inline_size: SealableCell::new(zero),
             content_block_size: SealableCell::new(zero),
             margin_left: SealableCell::new(zero),
@@ -194,19 +184,15 @@ impl Default for UsedValues {
             inset_bottom: SealableCell::new(zero),
             has_definite_inline_size: Cell::new(false),
             has_definite_block_size: Cell::new(false),
-            materialized_from_paintable: Cell::new(false),
             uses_collapsing_borders_model: Cell::new(false),
             inline_size_constraint: Cell::new(SizeConstraint::None),
             block_size_constraint: Cell::new(SizeConstraint::None),
             has_content_offset: SealableCell::new(false),
             content_offset: SealableCell::new(FfiCssPixelPoint::default()),
-            committed_offset_delta: SealableCell::new(FfiCssPixelPoint::default()),
             has_first_baseline: Cell::new(false),
             first_baseline: Cell::new(zero),
             has_last_baseline: Cell::new(false),
             last_baseline: Cell::new(zero),
-            has_containing_line_box_fragment: SealableCell::new(false),
-            containing_line_box_fragment: SealableCell::new(LineBoxFragmentCoordinate::default()),
             line_data: LazyRefCell::new(),
             rare_data: LazyRefCell::new(),
         }
@@ -245,9 +231,6 @@ impl UsedValues {
         self.inset_bottom.seal();
         self.has_content_offset.seal();
         self.content_offset.seal();
-        self.committed_offset_delta.seal();
-        self.has_containing_line_box_fragment.seal();
-        self.containing_line_box_fragment.seal();
     }
 
     pub(crate) fn seal_own_metrics(&self) {

--- a/Tests/LibWeb/Layout/expected/abspos-direct-child-of-relative-table-row-group.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-direct-child-of-relative-table-row-group.txt
@@ -1,0 +1,45 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 76 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 60 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 200 0+0+584] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        Box <div.table> at [8,8] table-box [0+0+0 200 0+0+0] [0+0+0 60 0+0+0] [TFC] children: not-inline
+          Box <div.rows> at [8,8] positioned table-row-group [0+0+0 200 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+            Box <(anonymous)> at [8,8] table-row [0+0+0 200 0+0+0] [0+0+0 0 0+0+0] children: not-inline
+              BlockContainer <(anonymous)> at [8,8] table-cell [0+0+0 200 0+0+0] [0+0+0 0 0+0+0] [BFC] children: not-inline
+                BlockContainer <(anonymous)> at [8,8] [0+0+0 200 0+0+0] [0+0+0 0 0+0+0] children: inline
+                  TextNode <#text> (not painted)
+                  BlockContainer <div.abspos> at [8,8] positioned [0+0+0 50 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+                  TextNode <#text> (not painted)
+            Box <div.row> at [8,8] table-row [0+0+0 200 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+              BlockContainer <div.cell> at [8,8] table-cell [0+0+0 200 0+0+0] [0+0+0 16 14+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.03125x16] baseline: 12.796875
+                    "first"
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <div.row> at [8,38] table-row [0+0+0 200 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+              BlockContainer <div.cell> at [8,38] table-cell [0+0+0 200 0+0+0] [0+0+0 16 14+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [8,38 54.78125x16] baseline: 12.796875
+                    "second"
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,68] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x76]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x60]
+        Paintable (Box<DIV>.table) [8,8 200x60]
+          Paintable (Box<DIV>.rows) [8,8 200x60]
+            Paintable (Box(anonymous)) [8,8 200x0]
+              PaintableWithLines (BlockContainer(anonymous)) [8,8 200x0]
+                PaintableWithLines (BlockContainer(anonymous)) [8,8 200x0]
+                  PaintableWithLines (BlockContainer<DIV>.abspos) [8,8 50x20]
+            Paintable (Box<DIV>.row) [8,8 200x30]
+              PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x30]
+            Paintable (Box<DIV>.row) [8,38 200x30]
+              PaintableWithLines (BlockContainer<DIV>.cell) [8,38 200x30]
+      PaintableWithLines (BlockContainer(anonymous)) [8,68 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x76] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/abspos-direct-child-of-relative-table-row.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-direct-child-of-relative-table-row.txt
@@ -1,0 +1,43 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 76 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 60 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] [0+0+0 200 0+0+584] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        Box <div.table> at [8,8] table-box [0+0+0 200 0+0+0] [0+0+0 60 0+0+0] [TFC] children: not-inline
+          Box <div.row> at [8,8] positioned table-row [0+0+0 200 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+            BlockContainer <div.cell> at [8,8] table-cell [0+0+0 79.359375 0+0+0] [0+0+0 16 14+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.03125x16] baseline: 12.796875
+                  "first"
+              TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> at [87.359375,23] table-cell [0+0+0 120.640625 0+0+0] [0+0+15 0 15+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text> (not painted)
+          Box <div.row> at [8,38] positioned table-row [0+0+0 200 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+            BlockContainer <(anonymous)> at [8,50.796875] table-cell [0+0+0 79.359375 0+0+0] [0+0+12.796875 0 17.203125+0+0] [BFC] children: not-inline
+              BlockContainer <(anonymous)> at [8,50.796875] [0+0+0 79.359375 0+0+0] [0+0+0 0 0+0+0] children: inline
+                TextNode <#text> (not painted)
+                BlockContainer <div.abspos> at [18,43] positioned [0+0+0 50 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+                TextNode <#text> (not painted)
+            BlockContainer <div.cell> at [87.359375,38] table-cell [0+0+0 120.640625 0+0+0] [0+0+0 16 14+0+0] [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 6, rect: [87.359375,38 54.78125x16] baseline: 12.796875
+                  "second"
+              TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,68] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x76]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x60]
+        Paintable (Box<DIV>.table) [8,8 200x60]
+          Paintable (Box<DIV>.row) [8,8 200x30]
+            PaintableWithLines (BlockContainer<DIV>.cell) [8,8 79.359375x30]
+            PaintableWithLines (BlockContainer(anonymous)) [87.359375,8 120.640625x30]
+          Paintable (Box<DIV>.row) [8,38 200x30]
+            PaintableWithLines (BlockContainer(anonymous)) [8,38 79.359375x30]
+              PaintableWithLines (BlockContainer(anonymous)) [8,50.796875 79.359375x0]
+                PaintableWithLines (BlockContainer<DIV>.abspos) [18,43 50x20]
+            PaintableWithLines (BlockContainer<DIV>.cell) [87.359375,38 120.640625x30]
+      PaintableWithLines (BlockContainer(anonymous)) [8,68 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x76] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/abspos-in-cell-relative-to-relative-table.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-in-cell-relative-to-relative-table.txt
@@ -1,0 +1,37 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 76 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 60 0+0+8] children: not-inline
+      TableWrapper <(anonymous)> at [8,8] positioned [0+0+0 200 0+0+584] [0+0+0 60 0+0+0] [BFC] children: not-inline
+        Box <table> at [8,8] table-box [0+0+0 200 0+0+0] [0+0+0 60 0+0+0] [TFC] children: not-inline
+          Box <tbody> at [8,8] table-row-group [0+0+0 200 0+0+0] [0+0+0 60 0+0+0] children: not-inline
+            Box <tr> at [8,8] table-row [0+0+0 200 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+              BlockContainer <td> at [8,15] table-cell [0+0+0 200 0+0+0] [0+0+7 16 7+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [8,15 36.03125x16] baseline: 12.796875
+                    "first"
+                TextNode <#text> (not painted)
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text> (not painted)
+            Box <tr> at [8,38] table-row [0+0+0 200 0+0+0] [0+0+0 30 0+0+0] children: not-inline
+              BlockContainer <td> at [8,45] table-cell [0+0+0 200 0+0+0] [0+0+7 16 7+0+0] [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 6, rect: [8,45 54.78125x16] baseline: 12.796875
+                    "second"
+                BlockContainer <div.abspos> at [20,16] positioned [0+0+0 40 0+0+0] [0+0+0 16 0+0+0] [BFC] children: not-inline
+                TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,68] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x76]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x60]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 200x60]
+        Paintable (Box<TABLE>) [8,8 200x60]
+          Paintable (Box<TBODY>) [8,8 200x60]
+            Paintable (Box<TR>) [8,8 200x30]
+              PaintableWithLines (BlockContainer<TD>) [8,8 200x30]
+            Paintable (Box<TR>) [8,38 200x30]
+              PaintableWithLines (BlockContainer<TD>) [8,38 200x30]
+                PaintableWithLines (BlockContainer<DIV>.abspos) [20,16 40x16]
+      PaintableWithLines (BlockContainer(anonymous)) [8,68 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x76] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -1,42 +1,42 @@
 Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
-  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 288 0+0+0] [BFC] children: not-inline
-    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 272 0+0+8] children: not-inline
-      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 230 0+0+0] children: inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 280 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 264 0+0+8] children: not-inline
+      BlockContainer <(anonymous)> at [8,8] [0+0+0 784 0+0+0] [0+0+0 222 0+0+0] children: inline
         frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 300x150] baseline: 152
         frag 1 from TextNode start: 0, length: 1, rect: [310,147 8x16] baseline: 12.796875
             " "
-        frag 2 from BlockContainer start: 0, length: 0, rect: [319,127 102x110] baseline: 34
+        frag 2 from BlockContainer start: 0, length: 0, rect: [319,127 102x102] baseline: 34
         SVGSVGBox <svg> at [9,9] [0+1+0 300 0+1+0] [0+1+0 150 0+1+0] [SVG] children: not-inline
           SVGGraphicsBox <a> at [33.765625,32.4375] [0+0+0 188.71875 0+0+0] [0+0+0 60.15625 0+0+0] children: not-inline
             SVGTextBox <text> at [33.765625,32.4375] [0+0+0 188.71875 0+0+0] [0+0+0 60.15625 0+0+0] children: inline
               TextNode <#text> (not painted)
         TextNode <#text> (not painted)
-        BlockContainer <math> at [319,127] [0+1+0 102 0+1+0] [0+1+0 110 0+1+0] [BFC] children: not-inline
+        BlockContainer <math> at [319,127] [0+1+0 102 0+1+0] [0+1+0 102 0+1+0] [BFC] children: not-inline
           BlockContainer <a> at [320,128] [0+1+0 100 0+1+0] [0+1+0 100 0+1+0] [BFC] children: inline
             frag 0 from TextNode start: 0, length: 5, rect: [320,128 99.484375x40] baseline: 32
                 "Hello"
             TextNode <#text> (not painted)
         TextNode <#text> (not painted)
-      BlockContainer <div> at [9,239] [0+1+0 782 0+1+0] [0+1+0 40 0+1+0] children: inline
-        InlineNode <a> at [10,239] [0+1+0 99.484375 0+1+0] [0+1+0 40 0+1+0]
-          frag 0 from TextNode start: 0, length: 5, rect: [10,239 99.484375x40] baseline: 32
+      BlockContainer <div> at [9,231] [0+1+0 782 0+1+0] [0+1+0 40 0+1+0] children: inline
+        InlineNode <a> at [10,231] [0+1+0 99.484375 0+1+0] [0+1+0 40 0+1+0]
+          frag 0 from TextNode start: 0, length: 5, rect: [10,231 99.484375x40] baseline: 32
               "Hello"
           TextNode <#text> (not painted)
-      BlockContainer <(anonymous)> at [8,280] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+      BlockContainer <(anonymous)> at [8,272] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
         TextNode <#text> (not painted)
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x288]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x272]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x230]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x280]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x264]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x222]
         SVGSVGPaintable (SVGSVGBox<svg>) [8,8 302x152]
           SVGGraphicsPaintable (SVGGraphicsBox<a>) [33.765625,32.4375 188.71875x60.15625]
             SVGPathPaintable (SVGTextBox<text>) [33.765625,32.4375 188.71875x60.15625]
-        PaintableWithLines (BlockContainer<math>) [318,126 104x112]
+        PaintableWithLines (BlockContainer<math>) [318,126 104x104]
           PaintableWithLines (BlockContainer<a>) [319,127 102x102]
-      PaintableWithLines (BlockContainer<DIV>) [8,238 784x42]
-        InlinePaintable (InlineNode<A>) [9,238 101.484375x42]
-      PaintableWithLines (BlockContainer(anonymous)) [8,280 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,230 784x42]
+        InlinePaintable (InlineNode<A>) [9,230 101.484375x42]
+      PaintableWithLines (BlockContainer(anonymous)) [8,272 784x0]
 
 SC for Viewport<#document> [0,0 800x600] (z-index: auto)
- SC for BlockContainer<HTML> [0,0 800x288] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x280] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/grid-abspos-under-relative-block-inside-item.txt
+++ b/Tests/LibWeb/Layout/expected/grid-abspos-under-relative-block-inside-item.txt
@@ -1,0 +1,40 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 96 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 200 0+0+584] [0+0+0 80 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [8,8] [0+0+0 100 0+0+0] [0+0+0 80 0+0+0] [BFC] children: not-inline
+          BlockContainer <(anonymous)> at [8,8] [0+0+0 100 0+0+0] [0+0+0 0 0+0+0] children: inline
+            TextNode <#text> (not painted)
+          BlockContainer <div.holder> at [18,18] positioned [10+0+0 80 0+0+10] [10+0+0 50 0+0+10] children: inline
+            TextNode <#text> (not painted)
+            BlockContainer <div.abspos> at [25,23] positioned [0+0+0 30 0+0+0] [0+0+0 12 0+0+0] [BFC] children: not-inline
+            TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> at [8,78] [0+0+0 100 0+0+0] [0+0+0 0 0+0+0] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        BlockContainer <div.item> at [108,8] [0+0+0 100 0+0+0] [0+0+0 80 0+0+0] [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 6, rect: [108,8 54.78125x16] baseline: 12.796875
+              "second"
+          TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,88] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x96]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x80]
+      Paintable (Box<DIV>.grid) [8,8 200x80]
+        PaintableWithLines (BlockContainer<DIV>.item) [8,8 100x80]
+          PaintableWithLines (BlockContainer(anonymous)) [8,8 100x0]
+          PaintableWithLines (BlockContainer<DIV>.holder) [18,18 80x50]
+            PaintableWithLines (BlockContainer<DIV>.abspos) [25,23 30x12]
+          PaintableWithLines (BlockContainer(anonymous)) [8,78 100x0]
+        PaintableWithLines (BlockContainer<DIV>.item) [108,8 100x80]
+      PaintableWithLines (BlockContainer(anonymous)) [8,88 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x96] (z-index: auto)

--- a/Tests/LibWeb/Layout/expected/nested-abspos-containing-block-chain.txt
+++ b/Tests/LibWeb/Layout/expected/nested-abspos-containing-block-chain.txt
@@ -1,0 +1,27 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 216 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 200 0+0+8] children: not-inline
+      BlockContainer <div.outer> at [8,8] positioned [0+0+0 300 0+0+484] [0+0+0 200 0+0+0] children: inline
+        TextNode <#text> (not painted)
+        BlockContainer <div.middle> at [38,28] positioned [0+0+0 200 0+0+0] [0+0+0 120 0+0+0] [BFC] children: inline
+          TextNode <#text> (not painted)
+          BlockContainer <div.inner> at [53,38] positioned [0+0+0 80 0+0+0] [0+0+0 40 0+0+0] [BFC] children: inline
+            TextNode <#text> (not painted)
+            BlockContainer <div.innermost> at [107,64] positioned [0+0+0 20 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+            TextNode <#text> (not painted)
+          TextNode <#text> (not painted)
+        TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,208] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>.outer) [8,8 300x200]
+        PaintableWithLines (BlockContainer<DIV>.middle) [38,28 200x120]
+          PaintableWithLines (BlockContainer<DIV>.inner) [53,38 80x40]
+            PaintableWithLines (BlockContainer<DIV>.innermost) [107,64 20x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x216] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/abspos-direct-child-of-relative-table-row-group.html
+++ b/Tests/LibWeb/Layout/input/abspos-direct-child-of-relative-table-row-group.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    .table { display: table; width: 200px; }
+    .rows { display: table-row-group; position: relative; }
+    .row { display: table-row; }
+    .cell { display: table-cell; height: 30px; }
+    .abspos { position: absolute; width: 50px; height: 20px; background: skyblue; }
+</style>
+<div class="table">
+    <div class="rows">
+        <div class="abspos"></div>
+        <div class="row"><div class="cell">first</div></div>
+        <div class="row"><div class="cell">second</div></div>
+    </div>
+</div>

--- a/Tests/LibWeb/Layout/input/abspos-direct-child-of-relative-table-row.html
+++ b/Tests/LibWeb/Layout/input/abspos-direct-child-of-relative-table-row.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+    .table { display: table; width: 200px; }
+    .row { display: table-row; position: relative; }
+    .cell { display: table-cell; height: 30px; }
+    .abspos { position: absolute; top: 5px; left: 10px; width: 50px; height: 20px; background: orange; }
+</style>
+<div class="table">
+    <div class="row"><div class="cell">first</div></div>
+    <div class="row">
+        <div class="abspos"></div>
+        <div class="cell">second</div>
+    </div>
+</div>

--- a/Tests/LibWeb/Layout/input/abspos-in-cell-relative-to-relative-table.html
+++ b/Tests/LibWeb/Layout/input/abspos-in-cell-relative-to-relative-table.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<style>
+    table { position: relative; width: 200px; border-spacing: 0; }
+    td { height: 30px; padding: 0; }
+    .abspos { position: absolute; top: 8px; left: 12px; width: 40px; height: 16px; background: tomato; }
+</style>
+<table>
+    <tr><td>first</td></tr>
+    <tr><td><div class="abspos"></div>second</td></tr>
+</table>

--- a/Tests/LibWeb/Layout/input/grid-abspos-under-relative-block-inside-item.html
+++ b/Tests/LibWeb/Layout/input/grid-abspos-under-relative-block-inside-item.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+    .grid { display: grid; grid-template-columns: 100px 100px; grid-template-rows: 80px; width: 200px; }
+    .item { background: lavender; }
+    .holder { position: relative; margin: 10px; height: 50px; background: thistle; }
+    .abspos { position: absolute; top: 5px; left: 7px; width: 30px; height: 12px; background: crimson; }
+</style>
+<div class="grid">
+    <div class="item">
+        <div class="holder">
+            <div class="abspos"></div>
+        </div>
+    </div>
+    <div class="item">second</div>
+</div>

--- a/Tests/LibWeb/Layout/input/nested-abspos-containing-block-chain.html
+++ b/Tests/LibWeb/Layout/input/nested-abspos-containing-block-chain.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+    .outer { position: relative; width: 300px; height: 200px; background: lightgray; }
+    .middle { position: absolute; top: 20px; left: 30px; width: 200px; height: 120px; background: lightblue; }
+    .inner { position: absolute; top: 10px; left: 15px; width: 80px; height: 40px; background: seagreen; }
+    .innermost { position: absolute; bottom: 4px; right: 6px; width: 20px; height: 10px; background: gold; }
+</style>
+<div class="outer">
+    <div class="middle">
+        <div class="inner">
+            <div class="innermost"></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Layout no longer coordinates through a pass-global used-values table.
Each formatting context run owns the records it creates, and accessing
a record another run owns is a hard error in every build. In place of
the shared store, every run returns an immutable fragment tree: box
metrics are snapshotted from sealed records at placement, placement
data and payloads ride the fragments, and commit emits everything from
the returned trees without reaching back into layout state. Cross-run
concerns — absolutely positioned children, anchor candidates — travel
on the same structure and drain at their containing block's placement.

Together these give each formatting context run a closed contract:
inputs arrive as values, and everything the run produces leaves
through its returned result and fragment tree, with no reads or
writes against shared pass state. That is the precondition for FC run
memoization — a future change can skip a run whose inputs are
unchanged and reuse its fragment tree, which would be unsound as long
as runs communicated through a global store. Rendering is unchanged
across the layout test suite except one deliberate rebaseline (an
inline math box's auto height no longer absorbs the enclosing
context's pending collapsed margin), and new layout tests pin the
placement-time abspos drain paths.