### PR TITLE
Carry resolved anchor() insets on the abspos layout inputs

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_value_types.rs
@@ -98,7 +98,9 @@ pub struct ComputedLengthBox {
 
 /// Layout of the computed inset, margin, and padding properties, plus the
 /// computed position-anchor name the anchor lookup beside the anchor insets
-/// consults; the zero raw means position-anchor has no name.
+/// consults; the zero raw means position-anchor has no name. Each bare
+/// anchor() inset also carries the calculated wrapper the layout pass
+/// resolves, built with the payload so inset reads borrow it directly.
 #[repr(C)]
 pub struct SurroundValues {
     pub inset: ComputedLengthBox,
@@ -106,6 +108,10 @@ pub struct SurroundValues {
     pub right_anchor_inset: ComputedStyleValueHandle,
     pub bottom_anchor_inset: ComputedStyleValueHandle,
     pub left_anchor_inset: ComputedStyleValueHandle,
+    pub top_anchor_inset_wrapper: ComputedStyleValueHandle,
+    pub right_anchor_inset_wrapper: ComputedStyleValueHandle,
+    pub bottom_anchor_inset_wrapper: ComputedStyleValueHandle,
+    pub left_anchor_inset_wrapper: ComputedStyleValueHandle,
     pub position_anchor_name: crate::css::retained_fly_string::RetainedUtf16FlyString,
     pub margin: ComputedLengthBox,
     pub padding: ComputedLengthBox,

--- a/Libraries/LibWeb/Rust/src/css/computed_values.rs
+++ b/Libraries/LibWeb/Rust/src/css/computed_values.rs
@@ -184,16 +184,39 @@ impl_computed_payload_clone_and_eq!(ComputedLengthBox {
     bottom,
     left,
 });
-impl_computed_payload_clone_and_eq!(SurroundValues {
-    inset,
-    top_anchor_inset,
-    right_anchor_inset,
-    bottom_anchor_inset,
-    left_anchor_inset,
-    position_anchor_name,
-    margin,
-    padding,
-});
+impl Clone for SurroundValues {
+    fn clone(&self) -> Self {
+        Self {
+            inset: self.inset.clone(),
+            top_anchor_inset: self.top_anchor_inset.clone(),
+            right_anchor_inset: self.right_anchor_inset.clone(),
+            bottom_anchor_inset: self.bottom_anchor_inset.clone(),
+            left_anchor_inset: self.left_anchor_inset.clone(),
+            top_anchor_inset_wrapper: self.top_anchor_inset_wrapper.clone(),
+            right_anchor_inset_wrapper: self.right_anchor_inset_wrapper.clone(),
+            bottom_anchor_inset_wrapper: self.bottom_anchor_inset_wrapper.clone(),
+            left_anchor_inset_wrapper: self.left_anchor_inset_wrapper.clone(),
+            position_anchor_name: self.position_anchor_name.clone(),
+            margin: self.margin.clone(),
+            padding: self.padding.clone(),
+        }
+    }
+}
+
+// The anchor-inset wrappers are pure derivatives of the anchor-inset fields,
+// so payload equality excludes them.
+impl PartialEq for SurroundValues {
+    fn eq(&self, other: &Self) -> bool {
+        self.inset == other.inset
+            && self.top_anchor_inset == other.top_anchor_inset
+            && self.right_anchor_inset == other.right_anchor_inset
+            && self.bottom_anchor_inset == other.bottom_anchor_inset
+            && self.left_anchor_inset == other.left_anchor_inset
+            && self.position_anchor_name == other.position_anchor_name
+            && self.margin == other.margin
+            && self.padding == other.padding
+    }
+}
 impl_computed_payload_clone_and_eq!(SVGResetValues {
     cx,
     cy,
@@ -1515,6 +1538,10 @@ impl SurroundValues {
             right_anchor_inset: ComputedStyleValueHandle::empty(),
             bottom_anchor_inset: ComputedStyleValueHandle::empty(),
             left_anchor_inset: ComputedStyleValueHandle::empty(),
+            top_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
+            right_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
+            bottom_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
+            left_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
             position_anchor_name: RetainedUtf16FlyString::none(),
             margin: ComputedLengthBox::zero(),
             padding: ComputedLengthBox::zero(),
@@ -1795,12 +1822,16 @@ pub unsafe extern "C" fn rust_build_surround_group(
                 ComputedStyleValueHandle::empty()
             }
         };
-        let built = SurroundValues {
+        let mut built = SurroundValues {
             inset: ComputedLengthBox::from_data(top, right, bottom, left, true),
             top_anchor_inset: anchor(top),
             right_anchor_inset: anchor(right),
             bottom_anchor_inset: anchor(bottom),
             left_anchor_inset: anchor(left),
+            top_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
+            right_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
+            bottom_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
+            left_anchor_inset_wrapper: ComputedStyleValueHandle::empty(),
             // SAFETY: The caller transfers one leaked reference (or zero for
             // no name), which the payload or this local assumes in every
             // outcome below.
@@ -1817,6 +1848,23 @@ pub unsafe extern "C" fn rust_build_surround_group(
         if built.eq(unsafe { &*default_payload.cast::<SurroundValues>() }) {
             return Some(default_payload);
         }
+
+        // Only a fresh payload builds wrappers: equality excludes them, and a
+        // shared parent payload already carries its own.
+        let wrapper = |handle: &ComputedStyleValueHandle| {
+            if handle.pointer.is_null() {
+                return ComputedStyleValueHandle::empty();
+            }
+            // SAFETY: The handle retains anchor style value data.
+            let calculated = unsafe { crate::css::calc::create_anchor_inset_calculated(handle.pointer.cast()) };
+            ComputedStyleValueHandle {
+                pointer: std::sync::Arc::into_raw(calculated).cast(),
+            }
+        };
+        built.top_anchor_inset_wrapper = wrapper(&built.top_anchor_inset);
+        built.right_anchor_inset_wrapper = wrapper(&built.right_anchor_inset);
+        built.bottom_anchor_inset_wrapper = wrapper(&built.bottom_anchor_inset);
+        built.left_anchor_inset_wrapper = wrapper(&built.left_anchor_inset);
 
         let payload = allocate_payload(vtable(group_index), 1);
         unsafe { payload.cast::<SurroundValues>().write(built) };

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -195,8 +195,9 @@ impl<'pass> AbsposEngine<'pass> {
         node: Node,
         inline_containing_block_rect: Option<PhysicalRect>,
         entry_containing_block_geometry: &ContainingBlockGeometry,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) -> AbsposContainingBlockInfo {
-        let style = self.style(node);
+        let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let (inline_axis_mode, block_axis_mode) = axis_modes(style);
         let containing_block = self.callbacks.containing_block(node);
         assert!(!containing_block.is_invalid());
@@ -520,7 +521,7 @@ impl AbsposEngine<'_> {
         node: Node,
         entry_containing_block_geometry: Option<&ContainingBlockGeometry>,
         entry_coordinate_space_box: Node,
-    ) {
+    ) -> Option<ResolvedAnchorInsets> {
         // Clear a stale default scroll shift before any early return.
         // SAFETY: The node is live and a null anchor clears the weak target.
         unsafe {
@@ -539,12 +540,12 @@ impl AbsposEngine<'_> {
         let bottom_contains_anchor = style.inset_bottom().contains_anchor_function();
         let left_contains_anchor = style.inset_left().contains_anchor_function();
         if !top_contains_anchor && !right_contains_anchor && !bottom_contains_anchor && !left_contains_anchor {
-            return;
+            return None;
         }
 
         let containing_block = self.callbacks.containing_block(node);
         if containing_block.is_invalid() {
-            return;
+            return None;
         }
         let containing_block_geometry = match entry_containing_block_geometry {
             Some(geometry) => *geometry,
@@ -563,7 +564,7 @@ impl AbsposEngine<'_> {
             compensates_for_horizontal_scroll: false,
             compensates_for_vertical_scroll: false,
         };
-        let mut resolved = FfiResolvedAnchorInsets::default();
+        let mut resolved = ResolvedAnchorInsets::default();
 
         if top_contains_anchor {
             let value = self.resolve_anchor_value(
@@ -638,9 +639,6 @@ impl AbsposEngine<'_> {
             resolved.left = value.unwrap_or_default();
         }
 
-        self.state
-            .replace_resolved_anchor_insets(&self.callbacks, node, resolved);
-
         if resolution_state.compensates_for_horizontal_scroll || resolution_state.compensates_for_vertical_scroll {
             // SAFETY: The anchor and positioned box remain live through the
             // pass; C++ stores the anchor as a weak pointer.
@@ -654,6 +652,8 @@ impl AbsposEngine<'_> {
                 );
             }
         }
+
+        Some(resolved)
     }
 }
 
@@ -904,6 +904,7 @@ impl AbsposEngine<'_> {
         )
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn solve_non_replaced_inline_once(
         &self,
         node: Node,
@@ -912,8 +913,9 @@ impl AbsposEngine<'_> {
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
         input_inline_size: AutoPx,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) -> (AutoPx, CssPixels, CssPixels, AutoPx, AutoPx) {
-        let style = self.style(node);
+        let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let used = self.used(node);
         let border_left = style.border_left_width();
         let border_right = style.border_right_width();
@@ -1046,6 +1048,7 @@ impl AbsposEngine<'_> {
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) {
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
         let style = self.style(node);
@@ -1071,6 +1074,7 @@ impl AbsposEngine<'_> {
                 constraints,
                 static_position_rect,
                 initial,
+                resolved_anchor_insets,
             );
 
         if !sizing.should_treat_max_inline_size_as_none(node, available_space.inline_size, constraints) {
@@ -1084,6 +1088,7 @@ impl AbsposEngine<'_> {
                     constraints,
                     static_position_rect,
                     Some(max_inline_size),
+                    resolved_anchor_insets,
                 );
             }
         }
@@ -1098,6 +1103,7 @@ impl AbsposEngine<'_> {
                     constraints,
                     static_position_rect,
                     Some(min_inline_size),
+                    resolved_anchor_insets,
                 );
             }
         }
@@ -1116,11 +1122,12 @@ impl AbsposEngine<'_> {
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) {
         let sizing = self.sizing();
         let inline_size = sizing.compute_inline_size_for_replaced_element(node, available_space, constraints);
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
-        let style = self.style(node);
+        let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let used = self.used(node);
         let available = containing_block_inline_size
             - inline_size
@@ -1155,14 +1162,27 @@ impl AbsposEngine<'_> {
         available_space: AvailableSpace,
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) {
         if self
             .sizing()
             .box_is_sized_as_replaced_element(node, available_space, constraints)
         {
-            self.compute_inline_size_for_replaced(node, available_space, constraints, static_position_rect);
+            self.compute_inline_size_for_replaced(
+                node,
+                available_space,
+                constraints,
+                static_position_rect,
+                resolved_anchor_insets,
+            );
         } else {
-            self.compute_inline_size_for_non_replaced(node, available_space, constraints, static_position_rect);
+            self.compute_inline_size_for_non_replaced(
+                node,
+                available_space,
+                constraints,
+                static_position_rect,
+                resolved_anchor_insets,
+            );
         }
     }
 }
@@ -1226,6 +1246,7 @@ impl AbsposEngine<'_> {
         )
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn solve_non_replaced_block_once(
         &self,
         node: Node,
@@ -1234,8 +1255,9 @@ impl AbsposEngine<'_> {
         static_position_rect: StaticPositionRect,
         pass: BlockSizePass,
         block_size: AutoPx,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) -> BlockAxisSolution {
-        let style = self.style(node);
+        let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
         let containing_block_block_size = available_space.block_size.to_px_or_zero();
         let used = self.used(node);
@@ -1328,6 +1350,7 @@ impl AbsposEngine<'_> {
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
         pass: BlockSizePass,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) {
         let style = self.style(node);
         let mut intrinsic_available_space = available_space;
@@ -1348,8 +1371,15 @@ impl AbsposEngine<'_> {
                     .calculate_inner_block_size(node, intrinsic_available_space, style.height(), constraints),
             )
         };
-        let mut solution =
-            self.solve_non_replaced_block_once(node, available_space, constraints, static_position_rect, pass, initial);
+        let mut solution = self.solve_non_replaced_block_once(
+            node,
+            available_space,
+            constraints,
+            static_position_rect,
+            pass,
+            initial,
+            resolved_anchor_insets,
+        );
 
         if solution.block_size.is_some() && !style.max_height().is_none() {
             let max_block_size = self.sizing().calculate_inner_block_size(
@@ -1366,6 +1396,7 @@ impl AbsposEngine<'_> {
                     static_position_rect,
                     pass,
                     Some(max_block_size),
+                    resolved_anchor_insets,
                 );
             }
         }
@@ -1384,6 +1415,7 @@ impl AbsposEngine<'_> {
                     static_position_rect,
                     pass,
                     Some(min_block_size),
+                    resolved_anchor_insets,
                 );
             }
         }
@@ -1415,12 +1447,13 @@ impl AbsposEngine<'_> {
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
         pass: BlockSizePass,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) {
         let block_size = self
             .sizing()
             .compute_block_size_for_replaced_element(node, available_space, constraints);
         let containing_block_block_size = available_space.block_size.to_px_or_zero();
-        let style = self.style(node);
+        let style = self.style(node).with_resolved_insets(resolved_anchor_insets);
         let used = self.used(node);
         let available = containing_block_block_size
             - block_size
@@ -1464,14 +1497,29 @@ impl AbsposEngine<'_> {
         constraints: ContainingBlockConstraints,
         static_position_rect: StaticPositionRect,
         pass: BlockSizePass,
+        resolved_anchor_insets: Option<&ResolvedAnchorInsets>,
     ) {
         if self
             .sizing()
             .box_is_sized_as_replaced_element(node, available_space, constraints)
         {
-            self.compute_block_size_for_replaced(node, available_space, constraints, static_position_rect, pass);
+            self.compute_block_size_for_replaced(
+                node,
+                available_space,
+                constraints,
+                static_position_rect,
+                pass,
+                resolved_anchor_insets,
+            );
         } else {
-            self.compute_block_size_for_non_replaced(node, available_space, constraints, static_position_rect, pass);
+            self.compute_block_size_for_non_replaced(
+                node,
+                available_space,
+                constraints,
+                static_position_rect,
+                pass,
+                resolved_anchor_insets,
+            );
         }
     }
 }
@@ -1483,7 +1531,16 @@ impl<'pass> AbsposEngine<'pass> {
     pub(crate) fn dimension_out_of_flow_root(&self, node: Node, inputs: AbsposLayoutInputs) {
         let (available_space, constraints) = out_of_flow_root_space(inputs);
         let containing_block_inline_size = available_space.inline_size.to_px_or_zero();
-        let style = self.style(node);
+        let resolved = inputs.resolved_anchor_insets.as_ref();
+        debug_assert!(
+            resolved.is_some()
+                || !(self.style(node).inset_top().contains_anchor_function()
+                    || self.style(node).inset_right().contains_anchor_function()
+                    || self.style(node).inset_bottom().contains_anchor_function()
+                    || self.style(node).inset_left().contains_anchor_function()),
+            "an out-of-flow root with anchor() insets must arrive with their resolutions"
+        );
+        let style = self.style(node).with_resolved_insets(resolved);
         {
             let used = self.used(node);
             used.border_left.set(style.border_left_width());
@@ -1500,13 +1557,14 @@ impl<'pass> AbsposEngine<'pass> {
                 .set(style.padding_bottom().to_px(containing_block_inline_size));
         }
 
-        self.compute_inline_size(node, available_space, constraints, inputs.static_position_rect);
+        self.compute_inline_size(node, available_space, constraints, inputs.static_position_rect, resolved);
         self.compute_block_size(
             node,
             available_space,
             constraints,
             inputs.static_position_rect,
             BlockSizePass::BeforeInsideLayout,
+            resolved,
         );
 
         {
@@ -1549,7 +1607,8 @@ impl<'pass> AbsposEngine<'pass> {
             inline_size: available_space.inline_size.to_px_or_zero(),
             block_size: available_space.block_size.to_px_or_zero(),
         };
-        let style = self.style(node);
+        let resolved = inputs.resolved_anchor_insets.as_ref();
+        let style = self.style(node).with_resolved_insets(resolved);
         if style.height().is_auto() {
             self.compute_block_size(
                 node,
@@ -1559,6 +1618,7 @@ impl<'pass> AbsposEngine<'pass> {
                 BlockSizePass::AfterInsideLayout {
                     automatic_content_block_size_of_inside_layout,
                 },
+                resolved,
             );
         }
 
@@ -1665,7 +1725,8 @@ impl<'pass> AbsposEngine<'pass> {
         self.records
             .create_used_values(self.state, &self.callbacks, child_box, ContainingBlockConstraints::default());
         let containing_block_geometry = self.containing_block_geometry_for_pending_child(&child);
-        self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
+        let resolved =
+            self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
         let translation_into_containing_block_space =
             point_sub(FfiCssPixelPoint::default(), containing_block_geometry.content_origin_in_entry_space);
         crate::layout::translate_pending_abspos_payloads(&mut child, translation_into_containing_block_space);
@@ -1673,8 +1734,14 @@ impl<'pass> AbsposEngine<'pass> {
             static_position_rect: child.static_position_rect,
             containing_block_info: child.containing_block_info_override.unwrap_or_else(|| {
                 let inline_containing_block_rect = child.inline_containing_block_rect;
-                self.base_containing_block_info(child_box, inline_containing_block_rect, &containing_block_geometry)
+                self.base_containing_block_info(
+                    child_box,
+                    inline_containing_block_rect,
+                    &containing_block_geometry,
+                    resolved.as_ref(),
+                )
             }),
+            resolved_anchor_insets: resolved,
         };
         self.layout_element(run, child_box, inputs);
     }
@@ -1685,7 +1752,8 @@ impl<'pass> AbsposEngine<'pass> {
         assert!(found);
         let mut inputs = saved_inputs.unwrap();
         if !inputs.containing_block_info.derives_from_own_computed_values {
-            let (inline, block) = axis_modes(self.style(node));
+            let (inline, block) =
+                axis_modes(self.style(node).with_resolved_insets(inputs.resolved_anchor_insets.as_ref()));
             inputs.containing_block_info.inline_axis_mode = inline;
             inputs.containing_block_info.block_axis_mode = block;
         }
@@ -1713,14 +1781,16 @@ impl<'pass> AbsposEngine<'pass> {
             return;
         }
         let initial_style = self.style(node);
-        if initial_style.inset_top().contains_anchor_function()
+        let resolved = if initial_style.inset_top().contains_anchor_function()
             || initial_style.inset_right().contains_anchor_function()
             || initial_style.inset_bottom().contains_anchor_function()
             || initial_style.inset_left().contains_anchor_function()
         {
-            self.resolve_anchor_insets(node, None, NodeSlotId::INVALID);
-        }
-        let style = self.style(node);
+            self.resolve_anchor_insets(node, None, NodeSlotId::INVALID)
+        } else {
+            None
+        };
+        let style = self.style(node).with_resolved_insets(resolved.as_ref());
         if style.position() != positioning::RELATIVE {
             return;
         }
@@ -1752,16 +1822,16 @@ impl<'pass> AbsposEngine<'pass> {
                 formatting_context_root,
                 treat_block_axis_percentage_insets_as_auto_beyond_root,
             );
-        let block_axis_inset_value = |value: InsetValue<'pass>| -> InsetValue<'pass> {
-            if treat_block_axis_percentage_insets_as_auto && value.contains_percentage() {
+        fn block_axis_inset_value(value: InsetValue<'_>, treat_percentage_as_auto: bool) -> InsetValue<'_> {
+            if treat_percentage_as_auto && value.contains_percentage() {
                 InsetValue::auto_value()
             } else {
                 value
             }
-        };
+        }
         let (top, bottom) = resolve_opposing(
-            block_axis_inset_value(style.inset_top()),
-            block_axis_inset_value(style.inset_bottom()),
+            block_axis_inset_value(style.inset_top(), treat_block_axis_percentage_insets_as_auto),
+            block_axis_inset_value(style.inset_bottom(), treat_block_axis_percentage_insets_as_auto),
             containing_block_size.block_size,
         );
         let used = self.used(node);

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -18,21 +18,35 @@ pub(crate) enum LayoutMode {
     IntrinsicSizing,
 }
 
+/// The anchor() inset resolutions of one positioned box, produced by the
+/// abspos engine's resolve pass; sides without anchor functions stay
+/// unresolved and read from style.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[repr(C)]
-pub struct FfiResolvedAnchorInsets {
-    pub resolves_top: bool,
-    pub top_is_auto: bool,
-    pub top: CssPixels,
-    pub resolves_right: bool,
-    pub right_is_auto: bool,
-    pub right: CssPixels,
-    pub resolves_bottom: bool,
-    pub bottom_is_auto: bool,
-    pub bottom: CssPixels,
-    pub resolves_left: bool,
-    pub left_is_auto: bool,
-    pub left: CssPixels,
+pub(crate) struct ResolvedAnchorInsets {
+    pub(crate) resolves_top: bool,
+    pub(crate) top_is_auto: bool,
+    pub(crate) top: CssPixels,
+    pub(crate) resolves_right: bool,
+    pub(crate) right_is_auto: bool,
+    pub(crate) right: CssPixels,
+    pub(crate) resolves_bottom: bool,
+    pub(crate) bottom_is_auto: bool,
+    pub(crate) bottom: CssPixels,
+    pub(crate) resolves_left: bool,
+    pub(crate) left_is_auto: bool,
+    pub(crate) left: CssPixels,
+}
+
+impl ResolvedAnchorInsets {
+    pub(crate) fn override_for(&self, field: InsetField) -> Option<ResolvedInsetOverride> {
+        let (resolves, is_auto, px) = match field {
+            InsetField::Top => (self.resolves_top, self.top_is_auto, self.top),
+            InsetField::Right => (self.resolves_right, self.right_is_auto, self.right),
+            InsetField::Bottom => (self.resolves_bottom, self.bottom_is_auto, self.bottom),
+            InsetField::Left => (self.resolves_left, self.left_is_auto, self.left),
+        };
+        resolves.then_some(ResolvedInsetOverride { is_auto, px })
+    }
 }
 
 

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3525,6 +3525,9 @@ impl<'pass> GridFormattingContext<'pass> {
                 let grid_area_is_childs_static_position =
                     self.callbacks.static_position_containing_block(child) == self.grid_container;
                 if !grid_area_is_childs_static_position {
+                    // Registration-time axis modes read raw style: anchor()
+                    // insets resolve later in layout_pending_child, and an
+                    // anchor-bearing inset is never auto either way.
                     let (inline_axis_mode, block_axis_mode) = axis_modes(self.style(child));
                     info.inline_axis_mode = inline_axis_mode;
                     info.block_axis_mode = block_axis_mode;

--- a/Libraries/LibWeb/Rust/src/layout/layout_state.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_state.rs
@@ -4,67 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-const PAGE_BITS: usize = 4;
-const PAGE_SIZE: usize = 1 << PAGE_BITS;
-const PAGE_MASK: usize = PAGE_SIZE - 1;
-const PAGE_TABLE_BITS: usize = 10;
-const PAGE_TABLE_FANOUT: usize = 1 << PAGE_TABLE_BITS;
-const PAGE_TABLE_MASK: usize = PAGE_TABLE_FANOUT - 1;
-const ADDRESSABLE_SLOT_INDEX_COUNT: usize = 1 << (2 * PAGE_TABLE_BITS + PAGE_BITS);
-
-type Page<T> = [OnceCell<T>; PAGE_SIZE];
-type PageTable<T> = [OnceCell<Box<Page<T>>>; PAGE_TABLE_FANOUT];
-type PageTableDirectory<T> = [OnceCell<Box<PageTable<T>>>; PAGE_TABLE_FANOUT];
-
-pub(crate) struct PagedStore<T> {
-    page_table_directory: OnceCell<Box<PageTableDirectory<T>>>,
-}
-
-impl<T> Default for PagedStore<T> {
-    fn default() -> Self {
-        Self {
-            page_table_directory: OnceCell::new(),
-        }
-    }
-}
-
-impl<T> PagedStore<T> {
-    fn empty_level<Entry, const FANOUT: usize>() -> Box<[OnceCell<Entry>; FANOUT]> {
-        Box::new([const { OnceCell::new() }; FANOUT])
-    }
-
-    fn split_index(index: u32) -> (usize, usize, usize) {
-        let index = index as usize;
-        (
-            index >> (PAGE_TABLE_BITS + PAGE_BITS),
-            (index >> PAGE_BITS) & PAGE_TABLE_MASK,
-            index & PAGE_MASK,
-        )
-    }
-
-    #[inline]
-    pub(crate) fn get(&self, index: u32) -> Option<&T> {
-        let (directory_index, page_table_index, entry_index) = Self::split_index(index);
-        self.page_table_directory
-            .get()?
-            .get(directory_index)?
-            .get()?[page_table_index]
-            .get()?[entry_index]
-            .get()
-    }
-
-    pub(crate) fn allocate(&self, index: u32, value: T) -> &T {
-        assert!((index as usize) < ADDRESSABLE_SLOT_INDEX_COUNT);
-        let (directory_index, page_table_index, entry_index) = Self::split_index(index);
-        let page_table =
-            self.page_table_directory.get_or_init(Self::empty_level)[directory_index].get_or_init(Self::empty_level);
-        let entry = &page_table[page_table_index].get_or_init(Self::empty_level)[entry_index];
-        let entry_was_vacant = entry.set(value).is_ok();
-        assert!(entry_was_vacant, "PagedStore index {index} allocated twice");
-        entry.get().unwrap()
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum StaticPositionAlignment {
     Start,
@@ -117,6 +56,7 @@ pub(crate) struct AbsposContainingBlockInfo {
 pub(crate) struct AbsposLayoutInputs {
     pub(crate) static_position_rect: StaticPositionRect,
     pub(crate) containing_block_info: AbsposContainingBlockInfo,
+    pub(crate) resolved_anchor_insets: Option<ResolvedAnchorInsets>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -270,7 +210,6 @@ pub(crate) struct PendingAbsposChild {
     pub(crate) inline_containing_block_rect: Option<PhysicalRect>,
 }
 pub(crate) struct LayoutState {
-    anchor_inset_store: AnchorInsetStore,
     purpose: LayoutStatePurpose,
 }
 
@@ -365,10 +304,7 @@ pub(crate) struct UsedValuesRareData {
 
 impl LayoutState {
     pub(crate) fn new(purpose: LayoutStatePurpose) -> Self {
-        Self {
-            anchor_inset_store: AnchorInsetStore::default(),
-            purpose,
-        }
+        Self { purpose }
     }
 
     pub(crate) fn is_measurement(&self) -> bool {
@@ -605,36 +541,7 @@ impl LayoutState {
         callbacks: &FfiLayoutFcCallbacks,
         node: Node,
     ) -> StyleValues<'pass> {
-        StyleValues::new(
-            callbacks.style_payloads(node),
-            &self.anchor_inset_store,
-            callbacks.slot_index(node),
-        )
-    }
-
-    pub(crate) fn replace_resolved_anchor_insets(
-        &self,
-        callbacks: &FfiLayoutFcCallbacks,
-        node: Node,
-        resolved: crate::layout::FfiResolvedAnchorInsets,
-    ) {
-        let slot_index = callbacks.slot_index(node);
-        let replace = |field: InsetField, is_auto: bool, px: crate::layout::CssPixels| {
-            self.anchor_inset_store
-                .set_override(slot_index, field, ResolvedInsetOverride { is_auto, px });
-        };
-        if resolved.resolves_top {
-            replace(InsetField::Top, resolved.top_is_auto, resolved.top);
-        }
-        if resolved.resolves_right {
-            replace(InsetField::Right, resolved.right_is_auto, resolved.right);
-        }
-        if resolved.resolves_bottom {
-            replace(InsetField::Bottom, resolved.bottom_is_auto, resolved.bottom);
-        }
-        if resolved.resolves_left {
-            replace(InsetField::Left, resolved.left_is_auto, resolved.left);
-        }
+        StyleValues::new(callbacks.style_payloads(node))
     }
 
     pub(crate) fn text_chunks(

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -4,66 +4,22 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-/// The four inset properties; the discriminant indexes the anchor-inset
-/// store fields.
+/// The four inset properties.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum InsetField {
-    Top = 0,
-    Right = 1,
-    Bottom = 2,
-    Left = 3,
+    Top,
+    Right,
+    Bottom,
+    Left,
 }
 
-/// A resolved px-or-auto inset written back by anchor resolution.
+/// A resolved px-or-auto inset produced by anchor resolution. It takes
+/// precedence over every style read and reports
+/// contains_anchor_function() == false.
 #[derive(Clone, Copy)]
 pub(crate) struct ResolvedInsetOverride {
     pub(crate) is_auto: bool,
     pub(crate) px: CssPixels,
-}
-
-#[derive(Default)]
-struct AnchorInsetField {
-    /// Resolved value written by replace_resolved_anchor_insets. It takes
-    /// precedence over every style read and reports
-    /// contains_anchor_function() == false; the abspos engine's early-out on
-    /// re-entry depends on both properties.
-    resolved_override: Cell<Option<ResolvedInsetOverride>>,
-}
-
-#[derive(Default)]
-struct AnchorInsetSlot {
-    fields: [AnchorInsetField; 4],
-}
-
-/// Per-LayoutState side store for the four inset fields of anchor-positioned
-/// nodes, the only style reads whose results are not a pure function of the
-/// immutable group payloads.
-#[derive(Default)]
-pub(crate) struct AnchorInsetStore {
-    slots: PagedStore<AnchorInsetSlot>,
-    /// False until the first override write, so inset reads on anchor-free
-    /// pages never touch the slots store.
-    any_overrides: Cell<bool>,
-}
-
-impl AnchorInsetStore {
-    fn slot(&self, slot_index: u32) -> &AnchorInsetSlot {
-        self.slots
-            .get(slot_index)
-            .unwrap_or_else(|| self.slots.allocate(slot_index, AnchorInsetSlot::default()))
-    }
-
-    fn override_for(&self, slot_index: u32, field: InsetField) -> Option<ResolvedInsetOverride> {
-        if !self.any_overrides.get() {
-            return None;
-        }
-        self.slots.get(slot_index)?.fields[field as usize].resolved_override.get()
-    }
-
-    pub(crate) fn set_override(&self, slot_index: u32, field: InsetField, value: ResolvedInsetOverride) {
-        self.slot(slot_index).fields[field as usize].resolved_override.set(Some(value));
-        self.any_overrides.set(true);
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -130,14 +86,14 @@ impl InsetValue<'_> {
 }
 
 /// The layout pass view of a node's computed style: the pure payload view
-/// plus the per-LayoutState anchor-inset store the four inset reads consult
-/// and the line builder's vertical-align keyword substitution. Every other
-/// read derefs to ComputedValuesView.
+/// plus the resolved anchor insets the abspos engine threads to the four
+/// inset reads of the box it is placing, and the line builder's
+/// vertical-align keyword substitution. Every other read derefs to
+/// ComputedValuesView.
 #[derive(Clone, Copy)]
 pub(crate) struct StyleValues<'a> {
     style: ComputedValuesView<'a>,
-    anchor_insets: &'a AnchorInsetStore,
-    slot_index: u32,
+    resolved_anchor_insets: Option<&'a ResolvedAnchorInsets>,
     vertical_align_override: u16,
 }
 
@@ -151,13 +107,17 @@ impl<'a> std::ops::Deref for StyleValues<'a> {
 
 impl<'a> StyleValues<'a> {
     #[inline]
-    pub(crate) fn new(payloads: &'a FfiStylePayloads, anchor_insets: &'a AnchorInsetStore, slot_index: u32) -> Self {
+    pub(crate) fn new(payloads: &'a FfiStylePayloads) -> Self {
         Self {
             style: ComputedValuesView::new(&payloads.groups),
-            anchor_insets,
-            slot_index,
+            resolved_anchor_insets: None,
             vertical_align_override: u16::MAX,
         }
+    }
+
+    pub(crate) fn with_resolved_insets(mut self, resolved: Option<&'a ResolvedAnchorInsets>) -> Self {
+        self.resolved_anchor_insets = resolved;
+        self
     }
 
     fn bare_anchor_wrapper(self, field: InsetField) -> Option<&'a crate::css::style_value::StyleValueData> {
@@ -174,7 +134,7 @@ impl<'a> StyleValues<'a> {
     }
 
     fn inset_value(self, field: InsetField) -> InsetValue<'a> {
-        if let Some(resolved) = self.anchor_insets.override_for(self.slot_index, field) {
+        if let Some(resolved) = self.resolved_anchor_insets.and_then(|insets| insets.override_for(field)) {
             return InsetValue::Resolved(resolved);
         }
         if let Some(wrapper) = self.bare_anchor_wrapper(field) {

--- a/Libraries/LibWeb/Rust/src/layout/style_facts.rs
+++ b/Libraries/LibWeb/Rust/src/layout/style_facts.rs
@@ -28,11 +28,6 @@ struct AnchorInsetField {
     /// contains_anchor_function() == false; the abspos engine's early-out on
     /// re-entry depends on both properties.
     resolved_override: Cell<Option<ResolvedInsetOverride>>,
-    /// Memoized in-crate calculated wrapper for a bare anchor() inset: the
-    /// single owner of the Arc that the returned inset values borrow.
-    /// Written at most once and never replaced or dropped before the owning
-    /// LayoutState drops.
-    wrapper: std::cell::OnceCell<std::sync::Arc<crate::css::style_value::StyleValueData>>,
 }
 
 #[derive(Default)]
@@ -63,17 +58,6 @@ impl AnchorInsetStore {
             return None;
         }
         self.slots.get(slot_index)?.fields[field as usize].resolved_override.get()
-    }
-
-    fn memoized_bare_anchor_wrapper(
-        &self,
-        slot_index: u32,
-        field: InsetField,
-        build_wrapper: impl FnOnce() -> std::sync::Arc<crate::css::style_value::StyleValueData>,
-    ) -> &crate::css::style_value::StyleValueData {
-        self.slot(slot_index).fields[field as usize]
-            .wrapper
-            .get_or_init(build_wrapper)
     }
 
     pub(crate) fn set_override(&self, slot_index: u32, field: InsetField, value: ResolvedInsetOverride) {
@@ -176,32 +160,25 @@ impl<'a> StyleValues<'a> {
         }
     }
 
-    fn anchor_inset_handle(self, field: InsetField) -> Option<&'a ComputedStyleValueHandle> {
+    fn bare_anchor_wrapper(self, field: InsetField) -> Option<&'a crate::css::style_value::StyleValueData> {
         let values = self.style.surround();
         let handle = match field {
-            InsetField::Top => &values.top_anchor_inset,
-            InsetField::Right => &values.right_anchor_inset,
-            InsetField::Bottom => &values.bottom_anchor_inset,
-            InsetField::Left => &values.left_anchor_inset,
+            InsetField::Top => &values.top_anchor_inset_wrapper,
+            InsetField::Right => &values.right_anchor_inset_wrapper,
+            InsetField::Bottom => &values.bottom_anchor_inset_wrapper,
+            InsetField::Left => &values.left_anchor_inset_wrapper,
         };
-        (!handle.pointer.is_null()).then_some(handle)
+        // SAFETY: The node's style group payload retains the wrapper for the
+        // view's lifetime.
+        unsafe { handle.pointer.cast::<crate::css::style_value::StyleValueData>().as_ref() }
     }
 
     fn inset_value(self, field: InsetField) -> InsetValue<'a> {
         if let Some(resolved) = self.anchor_insets.override_for(self.slot_index, field) {
             return InsetValue::Resolved(resolved);
         }
-        if let Some(handle) = self.anchor_inset_handle(field) {
-            return InsetValue::BareAnchor(self.anchor_insets.memoized_bare_anchor_wrapper(
-                self.slot_index,
-                field,
-                || {
-                    // SAFETY: The handle is non-null, and the node's style
-                    // group payload keeps the anchor value alive for the
-                    // synchronous layout pass.
-                    unsafe { crate::css::calc::create_anchor_inset_calculated(handle.pointer.cast()) }
-                },
-            ));
+        if let Some(wrapper) = self.bare_anchor_wrapper(field) {
+            return InsetValue::BareAnchor(wrapper);
         }
         let values = self.style.surround();
         InsetValue::FromStyle(match field {


### PR DESCRIPTION
Anchor resolution published its results through a pass-global side store
on LayoutState that every later inset style read consulted, running as
an implicit channel parallel to AbsposLayoutInputs, which already
crosses the run boundary into the out-of-flow sizing passes and is
persisted for replay. Make resolve_anchor_insets pure and thread its
result explicitly: the abspos engine stores it on the layout inputs and
hands it to the sizing chain, compute_inset consumes its own resolution
locally, and replay now reuses the resolutions the original pass saved
instead of reading unresolved anchor() values against an empty store.

This removes the last pass-global mutable state from layout:
LayoutState is now only the pass purpose.