### PR TITLE
LibWeb: Trace the WebAssembly cache once per collection

### DIFF
--- a/Libraries/LibJS/Runtime/Map.cpp
+++ b/Libraries/LibJS/Runtime/Map.cpp
@@ -114,11 +114,8 @@ void Map::account_external_memory_change(size_t old_external_memory_size)
 void Map::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    for (auto& value : m_entries) {
-        visitor.visit(value.key);
-        visitor.visit(value.value);
-    }
-    // NOTE: The entries in m_keys are already visited by the walk over m_entries above.
+    visitor.visit(m_entries);
+    // NOTE: The entries in m_keys are already visited at m_entries above.
     visitor.ignore(m_keys);
 }
 

--- a/Libraries/LibWeb/Bindings/HostDefined.cpp
+++ b/Libraries/LibWeb/Bindings/HostDefined.cpp
@@ -7,8 +7,22 @@
 #include <LibWeb/Bindings/HostDefined.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/WrapperWorld.h>
+#include <LibWeb/WebAssembly/WebAssembly.h>
 
 namespace Web::Bindings {
+
+HostDefined::HostDefined(GC::Ref<Intrinsics> intrinsics, GC::Ref<WrapperWorld> wrapper_world, GC::Ref<JS::Realm> principal_realm, PrincipalRealmUnderConstruction principal_realm_under_construction)
+    : intrinsics(intrinsics)
+    , wrapper_world(wrapper_world)
+    , principal_realm(principal_realm)
+{
+    if (principal_realm_under_construction == PrincipalRealmUnderConstruction::No) {
+        VERIFY(principal_realm->host_defined());
+        VERIFY(principal_realm->host_defined()->is_principal_host_defined());
+    }
+}
+
+HostDefined::~HostDefined() = default;
 
 void HostDefined::visit_edges(JS::Cell::Visitor& visitor)
 {
@@ -16,6 +30,8 @@ void HostDefined::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(intrinsics);
     visitor.visit(wrapper_world);
     visitor.visit(principal_realm);
+    if (wasm_cache)
+        wasm_cache->visit_edges(visitor);
 }
 
 }

--- a/Libraries/LibWeb/Bindings/HostDefined.h
+++ b/Libraries/LibWeb/Bindings/HostDefined.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/RefPtr.h>
 #include <LibGC/Ptr.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Export.h>
@@ -19,25 +20,18 @@ struct WEB_API HostDefined : public JS::Realm::HostDefined {
         Yes,
     };
 
-    HostDefined(GC::Ref<Intrinsics> intrinsics, GC::Ref<WrapperWorld> wrapper_world, GC::Ref<JS::Realm> principal_realm, PrincipalRealmUnderConstruction principal_realm_under_construction = PrincipalRealmUnderConstruction::No)
-        : intrinsics(intrinsics)
-        , wrapper_world(wrapper_world)
-        , principal_realm(principal_realm)
-    {
-        if (principal_realm_under_construction == PrincipalRealmUnderConstruction::No) {
-            VERIFY(principal_realm->host_defined());
-            VERIFY(principal_realm->host_defined()->is_principal_host_defined());
-        }
-    }
-    virtual ~HostDefined() override = default;
+    HostDefined(GC::Ref<Intrinsics> intrinsics, GC::Ref<WrapperWorld> wrapper_world, GC::Ref<JS::Realm> principal_realm, PrincipalRealmUnderConstruction principal_realm_under_construction = PrincipalRealmUnderConstruction::No);
+    virtual ~HostDefined() override;
     virtual void visit_edges(JS::Cell::Visitor& visitor) override;
 
     GC::Ref<Intrinsics> intrinsics;
     GC::Ref<WrapperWorld> wrapper_world;
-    // Principal realms point this at themselves via PrincipalHostDefined's
-    // construction path. Non-principal realms must point at an already-created
-    // principal realm with a PrincipalHostDefined.
+    // Principal realms point this at themselves via PrincipalHostDefined's construction path. Non-principal realms must
+    // point at an already-created principal realm with a PrincipalHostDefined.
     GC::Ref<JS::Realm> principal_realm;
+    // Created on demand by WebAssembly::Detail::get_cache(). The realm is the only owner that traces it, so the wrapper
+    // maps are visited exactly once per collection no matter how many WebAssembly objects are live.
+    RefPtr<WebAssembly::Detail::WebAssemblyCache> wasm_cache;
 };
 
 }

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -1335,6 +1335,12 @@ class Module;
 class Table;
 class WebAssemblyModule;
 
+namespace Detail {
+
+class WebAssemblyCache;
+
+}
+
 }
 
 namespace Web::WebAudio {

--- a/Libraries/LibWeb/WebAssembly/Global.cpp
+++ b/Libraries/LibWeb/WebAssembly/Global.cpp
@@ -65,7 +65,9 @@ Global::Global(NonnullRefPtr<Detail::WebAssemblyCache> cache, Wasm::GlobalAddres
 void Global::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_cache->visit_edges(visitor);
+
+    // NOTE: m_cache is already visited by the realm's HostDefined, which owns it.
+    visitor.ignore(m_cache);
 }
 
 WebIDL::ExceptionOr<Wasm::GlobalType> Global::type() const

--- a/Libraries/LibWeb/WebAssembly/Instance.cpp
+++ b/Libraries/LibWeb/WebAssembly/Instance.cpp
@@ -77,7 +77,9 @@ GC::Ref<Table> Instance::table_instance(Wasm::TableAddress address)
 void Instance::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_cache->visit_edges(visitor);
+
+    // NOTE: m_cache is already visited by the realm's HostDefined, which owns it.
+    visitor.ignore(m_cache);
 }
 
 }

--- a/Libraries/LibWeb/WebAssembly/Memory.cpp
+++ b/Libraries/LibWeb/WebAssembly/Memory.cpp
@@ -292,7 +292,7 @@ GC::Ref<Memory> Memory::create(NonnullRefPtr<Detail::WebAssemblyCache> cache, Wa
 
 WebIDL::ExceptionOr<GC::Ref<Memory>> Memory::create_for_constructor(JS::Object& relevant_global_object, MemoryDescriptor const& descriptor)
 {
-    auto cache = Detail::get_cache(relevant_global_object);
+    auto cache = Detail::get_cache(HTML::relevant_realm(relevant_global_object));
     return Memory::create(move(cache), descriptor);
 }
 
@@ -310,7 +310,9 @@ Memory::Memory(NonnullRefPtr<Detail::WebAssemblyCache> cache, Wasm::MemoryAddres
 void Memory::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_cache->visit_edges(visitor);
+
+    // NOTE: m_cache is already visited by the realm's HostDefined, which owns it.
+    visitor.ignore(m_cache);
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-memory-grow

--- a/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -68,7 +68,9 @@ Table::Table(NonnullRefPtr<Detail::WebAssemblyCache> cache, Wasm::TableAddress a
 void Table::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    m_cache->visit_edges(visitor);
+
+    // NOTE: m_cache is already visited by the realm's HostDefined, which owns it.
+    visitor.ignore(m_cache);
 }
 
 // https://webassembly.github.io/spec/js-api/#dom-table-grow

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -29,6 +29,7 @@
 #include <LibThreading/ThreadPool.h>
 #include <LibURL/Parser.h>
 #include <LibWasm/AbstractMachine/Validator.h>
+#include <LibWeb/Bindings/HostDefined.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Bindings/Wrappable.h>
@@ -61,22 +62,31 @@ static GC::Ref<WebIDL::Promise> compile_potential_webassembly_response(JS::Realm
 
 namespace Detail {
 
-static HashMap<GC::Ptr<JS::Object>, NonnullRefPtr<WebAssemblyCache>>& caches()
+// HostResizeArrayBuffer and HostGrowSharedArrayBuffer have to find the WebAssembly.Memory that owns a given buffer,
+// which the spec phrases as a scan over every Memory object cache. This registry exists only to serve those scans: it
+// owns nothing and takes no part in garbage collection.
+static Vector<WebAssemblyCache*>& live_caches()
 {
-    static NeverDestroyed<HashMap<GC::Ptr<JS::Object>, NonnullRefPtr<WebAssemblyCache>>> caches;
+    static NeverDestroyed<Vector<WebAssemblyCache*>> caches;
     return *caches;
 }
 
-NonnullRefPtr<WebAssemblyCache> get_cache(JS::Object& global_object)
+WebAssemblyCache::WebAssemblyCache()
 {
-    return caches().ensure(global_object, [] {
-        return make_ref_counted<WebAssemblyCache>();
-    });
+    live_caches().append(this);
+}
+
+WebAssemblyCache::~WebAssemblyCache()
+{
+    live_caches().remove_first_matching([this](auto* cache) { return cache == this; });
 }
 
 NonnullRefPtr<WebAssemblyCache> get_cache(JS::Realm& realm)
 {
-    return get_cache(realm.global_object());
+    auto& host_defined = static_cast<Bindings::HostDefined&>(*realm.host_defined());
+    if (!host_defined.wasm_cache)
+        host_defined.wasm_cache = make_ref_counted<WebAssemblyCache>();
+    return *host_defined.wasm_cache;
 }
 
 void WebAssemblyCache::visit_edges(JS::Cell::Visitor& visitor)
@@ -94,21 +104,6 @@ void WebAssemblyCache::visit_edges(JS::Cell::Visitor& visitor)
     } });
 }
 
-}
-
-void visit_edges(JS::Object& object, JS::Cell::Visitor& visitor)
-{
-    auto& global_object = HTML::relevant_global_object(object);
-    if (auto maybe_cache = Detail::caches().get(global_object); maybe_cache.has_value()) {
-        auto& cache = *maybe_cache.release_value();
-        cache.visit_edges(visitor);
-    }
-}
-
-void finalize(JS::Object& object)
-{
-    auto& global_object = HTML::relevant_global_object(object);
-    Detail::caches().remove(global_object);
 }
 
 // https://webassembly.github.io/spec/js-api/#error-objects
@@ -563,8 +558,7 @@ JS::ThrowCompletionOr<JS::HandledByHost> host_resize_array_buffer(JS::VM& vm, JS
     if (detach_key.is_string() && detach_key.as_string() == JS::PrimitiveString::create(vm, "WebAssembly.Memory"_utf16_fly_string)) {
         // 3. For each memaddr → mem in all Memory object caches,
         bool seen = false;
-        for (auto& cache_entry : caches()) {
-            auto& cache = cache_entry.value;
+        for (auto* cache : live_caches()) {
             auto const& map = cache->memory_instances();
 
             for (auto const& entry : map) {
@@ -620,8 +614,7 @@ JS::ThrowCompletionOr<JS::HandledByHost> host_grow_shared_array_buffer(JS::VM& v
 
         // 3. For each memaddr → mem in all Memory object caches,
         bool seen = false;
-        for (auto& cache_entry : caches()) {
-            auto& cache = cache_entry.value;
+        for (auto* cache : live_caches()) {
             auto const& map = cache->memory_instances();
 
             for (auto const& entry : map) {

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -26,8 +26,6 @@
 
 namespace Web::WebAssembly {
 
-WEB_API void visit_edges(JS::Object&, JS::Cell::Visitor&);
-WEB_API void finalize(JS::Object&);
 WEB_API void initialize(JS::Object&, JS::Realm&);
 
 WEB_API bool validate(JS::Realm&, WebIDL::BufferSource bytes);
@@ -53,6 +51,9 @@ struct CompiledWebAssemblyModule : public RefCounted<CompiledWebAssemblyModule> 
 
 class WebAssemblyCache : public RefCounted<WebAssemblyCache> {
 public:
+    WebAssemblyCache();
+    ~WebAssemblyCache();
+
     void visit_edges(JS::Cell::Visitor&);
 
     void add_compiled_module(NonnullRefPtr<CompiledWebAssemblyModule> module) { m_compiled_modules.append(module); }
@@ -119,7 +120,6 @@ private:
 };
 
 NonnullRefPtr<WebAssemblyCache> get_cache(JS::Realm&);
-NonnullRefPtr<WebAssemblyCache> get_cache(JS::Object&);
 
 JS::ThrowCompletionOr<NonnullRefPtr<Wasm::ModuleInstance>> instantiate_module(JS::Realm&, Wasm::Module const&, GC::Ptr<JS::Object> import_object);
 JS::ThrowCompletionOr<NonnullRefPtr<CompiledWebAssemblyModule>> compile_a_webassembly_module(JS::Realm&, ByteBuffer);

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.idl
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.idl
@@ -5,7 +5,7 @@ dictionary WebAssemblyInstantiatedSource {
 
 // https://webassembly.github.io/spec/js-api/#webassembly-namespace
 // https://webassembly.github.io/spec/web-api/index.html#streaming-modules
-[Exposed=*, WithGCVisitor, WithFinalizer, WithInitializer]
+[Exposed=*, WithInitializer]
 namespace WebAssembly {
     // FIXME: Streaming APIs are supposed to be only exposed to Window, Worker
 

--- a/Tests/LibWeb/Text/expected/Wasm/WebAssembly-cache-traced-once-per-collection.txt
+++ b/Tests/LibWeb/Text/expected/Wasm/WebAssembly-cache-traced-once-per-collection.txt
@@ -1,0 +1,2 @@
+Globals: 80000
+Collection stayed under budget: true

--- a/Tests/LibWeb/Text/input/Wasm/WebAssembly-cache-traced-once-per-collection.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAssembly-cache-traced-once-per-collection.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        // Collection cost must stay linear in the number of live WebAssembly objects. They share one realm-wide cache,
+        // so traversing that cache once per live object rather than a bounded number of times makes every collection
+        // quadratic: at this many globals that is the difference between a few milliseconds and tens of seconds.
+        internals.gc();
+
+        const globals = [];
+        for (let i = 0; i < 80000; ++i)
+            globals.push(new WebAssembly.Global({ value: "i32", mutable: true }, i));
+
+        // Keep the fastest of a few collections, so that a scheduling hiccup on a loaded machine cannot decide the
+        // result. Quadratic tracing is slower than this budget by more than an order of magnitude on every target.
+        let fastest = Infinity;
+        for (let i = 0; i < 3 && fastest > 2000; ++i) {
+            const start = performance.now();
+            internals.gc();
+            fastest = Math.min(fastest, performance.now() - start);
+        }
+        console.log(`fastest collection: ${fastest.toFixed(1)}ms`);
+
+        println(`Globals: ${globals.length}`);
+        println(`Collection stayed under budget: ${fastest < 2000}`);
+    });
+</script>


### PR DESCRIPTION
Loading https://scummvm.kuendig.io/ left the main thread unresponsive for minutes at a time, with single garbage collections taking over nine seconds and two thirds of a cold startup spent inside the collector.

Each realm keeps one WebAssembly cache holding the wrapper maps for exported functions, globals, memories and tables. Every live `Global`, `Memory`, `Table` and `Instance` wrapper visited that cache from its own `visit_edges()`, so a single collection traversed the same maps once per live wrapper. For a module exporting tens of thousands of entries with thousands of live wrappers over them, marking became quadratic.

The cache now hangs off the realm's `HostDefined`, which `Realm::visit_edges()` visits exactly once per collection, and the wrappers stop declaring an edge to it. They keep a `visit_edges()` that ignores `m_cache`, since the reference itself stays and only the tracing moves. That also retires the process-global cache map keyed by global object along with the namespace object's visitor and finalizer hooks, and the cache now dies with its realm rather than with the namespace object, which closes a leak for realms that only ever reached WebAssembly through an ESM import. `HostResizeArrayBuffer` and `HostGrowSharedArrayBuffer` are specified as a scan over every realm's Memory object cache, so a registry of live caches stays behind for those two, holding raw pointers and taking no part in garbage collection. Cache contents, wrapper identity and wrapper lifetime are unchanged; only the number of times the same graph gets walked changes.

Measured on https://scummvm.kuendig.io/, headless, identical 150 second window with a fresh profile per run, timings from `LIBGC_LOG_LEVEL=1`:

| | Before | After |
|--|--:|--:|
| Total time in GC | 101.40 s | 0.34 s |
| Worst single collection | 9625 ms | 46.5 ms |
| Median collection | 9129 ms | 17.7 ms |
| Share of the window in GC | 67.6% | 0.2% |

And one collection against N live globals, fresh page per data point so the cache holds exactly N entries:

| Live globals | Before | After |
|--:|--:|--:|
| 2,500 | 11.2 ms | 0.7 ms |
| 5,000 | 44.9 ms | 0.8 ms |
| 10,000 | 183.1 ms | 0.6 ms |
| 20,000 | 751.8 ms | 0.8 ms |

Before, the cost quadruples with every doubling of N; after, it is flat at this scale.

The added text test builds 80,000 globals and asserts that one collection stays within a two second budget, so a regression fails on its output rather than by hanging. That collection takes about three milliseconds now and roughly 12 seconds without the change. I dislike having an absolute performance metric as a fail/pass case in this test but I dislike adding performance counters in hot paths even more :)