### PR TITLE
Resolve grid abspos containing-block info at registration

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -1118,7 +1118,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
         .arena = m_commit_root->arena_handle(),
         .initial_containing_block_inline_size = m_commit_root->document().viewport_rect().width().raw_value(),
         .document_in_quirks_mode = m_commit_root->document().in_quirks_mode(),
-        .static_position_containing_block = [](void*, void* node) { return Node::slot_id(static_cast<Box const*>(node)->static_position_containing_block()); },
         .needs_inset_resolution = [](void*, void* node) {
             auto const& styled_node = *static_cast<NodeWithStyle const*>(node);
             if (styled_node.computed_values().position() == CSS::Positioning::Relative)

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -462,12 +462,6 @@ void Node::recompute_containing_block(Badge<DOM::Document>)
     set_containing_block(nearest_ancestor_capable_of_forming_a_containing_block(*this));
 }
 
-// returns containing block this node would have had if its position was static
-Box const* Node::static_position_containing_block() const
-{
-    return nearest_ancestor_capable_of_forming_a_containing_block(const_cast<Node&>(*this));
-}
-
 Box const* Node::non_anonymous_containing_block() const
 {
     auto nearest_ancestor_box = containing_block();

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -242,9 +242,6 @@ public:
 
     void recompute_containing_block(Badge<DOM::Document>);
 
-    [[nodiscard]] Box const* static_position_containing_block() const;
-    [[nodiscard]] Box* static_position_containing_block() { return const_cast<Box*>(const_cast<Node const*>(this)->static_position_containing_block()); }
-
     // Closest non-anonymous ancestor box, to be used when resolving percentage values.
     // Anonymous block boxes are ignored when resolving percentage values that would refer to it:
     // the closest non-anonymous ancestor box is used instead.

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -936,7 +936,6 @@ pub struct FfiLayoutFcCallbacks {
     pub arena: *mut c_void,
     pub initial_containing_block_inline_size: CssPixels,
     pub document_in_quirks_mode: bool,
-    pub static_position_containing_block: unsafe extern "C" fn(*mut c_void, *mut c_void) -> NodeSlotId,
     pub needs_inset_resolution: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub report_unexpected_fragmented_inline: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub build_svg_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgElementFacts,
@@ -1067,10 +1066,6 @@ impl FfiLayoutFcCallbacks {
 
     pub(crate) fn inline_containing_block(&self, node: Node) -> Node {
         self.node_data(node).inline_containing_block
-    }
-
-    pub(crate) fn static_position_containing_block(&self, node: Node) -> Node {
-        unsafe { (self.static_position_containing_block)(self.context, self.shell(node)) }
     }
 
     pub(crate) fn is_ancestor(&self, ancestor: Node, mut node: Node) -> bool {

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -416,7 +416,12 @@ impl RunFragmentBuilder {
         containing_block_info_for_child: impl Fn(crate::layout::node_data::NodeSlotId) -> AbsposContainingBlockInfo,
     ) {
         for entry in &mut self.inner.borrow_mut().pending_abspos_at_root {
-            if callbacks.containing_block(entry.child_box) == containing_block {
+            // Entries registered with their containing block info already
+            // resolved keep it; this pass only fills in entries that arrived
+            // from descendant runs.
+            if entry.containing_block_info_override.is_none()
+                && callbacks.containing_block(entry.child_box) == containing_block
+            {
                 entry.containing_block_info_override = Some(containing_block_info_for_child(entry.child_box));
             }
         }

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3508,30 +3508,34 @@ impl GridFormattingContext {
                     block_alignment: StaticPositionAlignment::Start,
                     alignment_derives_from_own_computed_values: false,
                 };
+                // The grid area supplies both the containing block and the
+                // static position for the grid's own abspos children.
+                let containing_block_info = (self.callbacks.containing_block(child) == self.grid_container)
+                    .then(|| self.abspos_containing_block_info(child));
                 crate::layout::register_contained_abspos_child(
                     &self.callbacks,
                     self.fragments.as_deref(),
                     self.grid_container,
                     child,
                     rect,
-                    None,
+                    containing_block_info,
                 );
             }
             child = next;
         }
         if let Some(fragments) = self.fragments.as_deref() {
             fragments.override_containing_block_info_for_pending_abspos_of_containing_block(self.grid_container, &self.callbacks, |child| {
+                // Deeper descendants inside grid items still get the grid area
+                // as their containing block, but their static position comes
+                // from their in-flow ancestor, so axis modes fall back to
+                // their own insets.
                 let mut info = self.abspos_containing_block_info(child);
-                let grid_area_is_childs_static_position =
-                    self.callbacks.static_position_containing_block(child) == self.grid_container;
-                if !grid_area_is_childs_static_position {
-                    // Registration-time axis modes read raw style: anchor()
-                    // insets resolve later in layout_pending_child, and an
-                    // anchor-bearing inset is never auto either way.
-                    let (inline_axis_mode, block_axis_mode) = axis_modes(self.style(child));
-                    info.inline_axis_mode = inline_axis_mode;
-                    info.block_axis_mode = block_axis_mode;
-                }
+                // Registration-time axis modes read raw style: anchor()
+                // insets resolve later in layout_pending_child, and an
+                // anchor-bearing inset is never auto either way.
+                let (inline_axis_mode, block_axis_mode) = axis_modes(self.style(child));
+                info.inline_axis_mode = inline_axis_mode;
+                info.block_axis_mode = block_axis_mode;
                 info
             });
         }
@@ -3545,10 +3549,6 @@ impl GridFormattingContext {
             self.absolute_axis_grid_area(Axis::Row, grid_style.row_start, grid_style.row_end, name_raws);
         let (inline_offset, inline_size) =
             self.absolute_axis_grid_area(Axis::Column, grid_style.column_start, grid_style.column_end, name_raws);
-        // An absolutely positioned child of a grid container gets its static
-        // position from grid placement and alignment, but deeper descendants
-        // inside grid items still use the generic static-position behavior from
-        // their in-flow ancestor.
         AbsposContainingBlockInfo {
             rect: LogicalRect {
                 offset: LogicalOffset {


### PR DESCRIPTION
GridFormattingContext::parent_did_dimension() used to register its absolutely positioned children with no containing block info, then stamp grid-area info onto every pending abspos entry whose containing block is the grid container, asking C++ through the static_position_containing_block FFI callback (an unbounded parent walk) to tell direct children apart from deeper descendants that only use the grid area for insets.

That ancestry test is redundant: for entries whose containing block is the grid container, "the grid area supplies the static position" is exactly "the grid's own direct-child loop registered this entry". Loop entries trivially satisfy the walk (a grid container is always capable of forming a containing block), and a descendant entry always has a predicate-passing intermediate, because the tree builder wraps every inline-level child of a flex/grid container in an anonymous block wrapper and inserts out-of-flow blocks as direct children of flex/grid containers, so an all-inline chain under a grid container cannot exist.

The direct-child loop now attaches the grid-area info through the containing_block_info_override argument of register_contained_abspos_child (previously always None), and the stamping pass skips entries that already carry an override, unconditionally applying the inset-derived axis modes to the descendant entries it still reaches. This lets us delete the FFI callback and Node::static_position_containing_block() on the C++ side.