### PR TITLE
LibWeb: Drop the needs_inset_resolution layout callback

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
+++ b/Libraries/LibWeb/Layout/LayoutRustBridge.cpp
@@ -1118,12 +1118,6 @@ RustFFI::FfiLayoutFcCallbacks LayoutRustBridge::formatting_context_callbacks()
         .arena = m_commit_root->arena_handle(),
         .initial_containing_block_inline_size = m_commit_root->document().viewport_rect().width().raw_value(),
         .document_in_quirks_mode = m_commit_root->document().in_quirks_mode(),
-        .needs_inset_resolution = [](void*, void* node) {
-            auto const& styled_node = *static_cast<NodeWithStyle const*>(node);
-            if (styled_node.computed_values().position() == CSS::Positioning::Relative)
-                return true;
-            auto const* box = as_if<Box>(styled_node);
-            return box && box_inset_properties_contain_anchor_functions(*box); },
         .report_unexpected_fragmented_inline = [](void*, void* node) {
             auto const& box = *static_cast<Box const*>(node);
             dbgln("FIXME: InlineFormattingContext::dimension_box_on_line got unexpected box in inline context:");

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1805,25 +1805,24 @@ impl AbsposEngine {
         treat_block_axis_percentage_insets_as_auto_beyond_root: bool,
     ) {
         // Most boxes are neither relatively positioned nor carry anchor()
-        // insets. Preserve the old C++ fast path without populating the
-        // comprehensive Rust facts caches for those boxes.
-        // SAFETY: The callback only reads the live node's computed values.
-        if !unsafe {
-            (self.callbacks.needs_inset_resolution)(self.callbacks.context, self.callbacks.shell(node))
-        } {
-            return;
-        }
+        // insets, and both facts come straight from the node's style payload.
         let initial_style = self.style(node);
-        let resolved = if initial_style.inset_top().contains_anchor_function()
+        let has_anchor_insets = initial_style.inset_top().contains_anchor_function()
             || initial_style.inset_right().contains_anchor_function()
             || initial_style.inset_bottom().contains_anchor_function()
-            || initial_style.inset_left().contains_anchor_function()
-        {
+            || initial_style.inset_left().contains_anchor_function();
+        if !has_anchor_insets && initial_style.position() != positioning::RELATIVE {
+            return;
+        }
+        // Anchor resolution also refreshes the box's default scroll shift, so
+        // an anchor-bearing box resolves its insets even when it turns out not
+        // to be relatively positioned.
+        let resolved = if has_anchor_insets {
             self.resolve_anchor_insets(node, None, NodeSlotId::INVALID)
         } else {
             None
         };
-        let style = self.style(node).with_resolved_insets(resolved.as_ref());
+        let style = initial_style.with_resolved_insets(resolved.as_ref());
         if style.position() != positioning::RELATIVE {
             return;
         }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -936,7 +936,6 @@ pub struct FfiLayoutFcCallbacks {
     pub arena: *mut c_void,
     pub initial_containing_block_inline_size: CssPixels,
     pub document_in_quirks_mode: bool,
-    pub needs_inset_resolution: unsafe extern "C" fn(*mut c_void, *mut c_void) -> bool,
     pub report_unexpected_fragmented_inline: unsafe extern "C" fn(*mut c_void, *mut c_void),
     pub build_svg_facts: unsafe extern "C" fn(*mut c_void, *mut c_void) -> FfiSvgElementFacts,
     pub read_paintable_geometry:


### PR DESCRIPTION
compute_inset opened with a callback into C++ that answered whether the box is relatively positioned or carries anchor() insets. Both facts are already in the node's style payload, which the code right after the gate reads anyway, so the call was redundant work on a path taken once per in-flow box, once per float, and once per inline node entry while building lines. Its C++ side was also the expensive half: it walked to the box's abstract element and could rebuild four computed style values just to look for anchor() functions.

Compute the gate from the style payload instead. The anchor test stays ahead of the position check, because an anchor-bearing box that is not relatively positioned still has to run anchor resolution, which clears a stale default scroll shift left behind by an earlier pass.