### PR TITLE
Make pending abspos registrations immutable after registration

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1760,13 +1760,15 @@ impl AbsposEngine {
         let containing_block_geometry = self.containing_block_geometry_for_pending_child(&child);
         let resolved =
             self.resolve_anchor_insets(child_box, Some(&containing_block_geometry), child.coordinate_space_box);
+        let inline_containing_block_rect =
+            self.inline_containing_block_rect_for_pending_child(&child, &containing_block_geometry);
         let translation_into_containing_block_space =
             point_sub(FfiCssPixelPoint::default(), containing_block_geometry.content_origin_in_entry_space);
-        crate::layout::translate_pending_abspos_payloads(&mut child, translation_into_containing_block_space);
+        child.static_position_rect =
+            crate::layout::translate_static_position_rect(child.static_position_rect, translation_into_containing_block_space);
         let inputs = AbsposLayoutInputs {
             static_position_rect: child.static_position_rect,
             containing_block_info: child.containing_block_info_override.unwrap_or_else(|| {
-                let inline_containing_block_rect = child.inline_containing_block_rect;
                 self.base_containing_block_info(
                     child_box,
                     inline_containing_block_rect,
@@ -1777,6 +1779,29 @@ impl AbsposEngine {
             resolved_anchor_insets: resolved,
         };
         self.layout_element(run, child_box, inputs);
+    }
+
+    /// Joins the entry against the inline containing block rect its IFC
+    /// contributed, folding the payload's resting space into the containing
+    /// block's content-box space (no padding term, unlike anchor rects).
+    fn inline_containing_block_rect_for_pending_child(
+        &self,
+        child: &PendingAbsposChild,
+        containing_block_geometry: &ContainingBlockGeometry,
+    ) -> Option<PhysicalRect> {
+        if child.inline_containing_block.is_invalid() {
+            return None;
+        }
+        let fragments = self.fragments.as_deref()?;
+        let (rect, payload_space) = fragments.find_inline_containing_block_rect(child.inline_containing_block)?;
+        let fold_into_entry_space =
+            self.translation_between_payload_resting_spaces(payload_space, child.coordinate_space_box);
+        Some(PhysicalRect {
+            x: rect.x + fold_into_entry_space.x - containing_block_geometry.content_origin_in_entry_space.x,
+            y: rect.y + fold_into_entry_space.y - containing_block_geometry.content_origin_in_entry_space.y,
+            width: rect.width,
+            height: rect.height,
+        })
     }
 
     fn replay(&self, run: &crate::layout::FormattingContextRun, node: Node) {

--- a/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_engine.rs
@@ -1768,14 +1768,21 @@ impl AbsposEngine {
             crate::layout::translate_static_position_rect(child.static_position_rect, translation_into_containing_block_space);
         let inputs = AbsposLayoutInputs {
             static_position_rect: child.static_position_rect,
-            containing_block_info: child.containing_block_info_override.unwrap_or_else(|| {
-                self.base_containing_block_info(
-                    child_box,
-                    inline_containing_block_rect,
-                    &containing_block_geometry,
-                    resolved.as_ref(),
-                )
-            }),
+            containing_block_info: child
+                .containing_block_info_override
+                .or_else(|| {
+                    self.fragments
+                        .as_deref()
+                        .and_then(|fragments| fragments.find_abspos_containing_block_info(child_box))
+                })
+                .unwrap_or_else(|| {
+                    self.base_containing_block_info(
+                        child_box,
+                        inline_containing_block_rect,
+                        &containing_block_geometry,
+                        resolved.as_ref(),
+                    )
+                }),
             resolved_anchor_insets: resolved,
         };
         self.layout_element(run, child_box, inputs);

--- a/Libraries/LibWeb/Rust/src/layout/abspos_inputs.rs
+++ b/Libraries/LibWeb/Rust/src/layout/abspos_inputs.rs
@@ -66,5 +66,4 @@ pub(crate) struct PendingAbsposChild {
     pub(crate) static_position_rect: StaticPositionRect,
     pub(crate) containing_block_info_override: Option<AbsposContainingBlockInfo>,
     pub(crate) inline_containing_block: Node,
-    pub(crate) inline_containing_block_rect: Option<PhysicalRect>,
 }

--- a/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/formatting_context.rs
@@ -486,7 +486,6 @@ pub(crate) fn register_contained_abspos_child(
             static_position_rect,
             containing_block_info_override,
             inline_containing_block,
-            inline_containing_block_rect: None,
         },
     );
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -49,12 +49,12 @@ pub(crate) struct AnchorCandidate {
     pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
 }
 
-pub(crate) fn translate_pending_abspos_payloads(entry: &mut PendingAbsposChild, offset: FfiCssPixelPoint) {
-    entry.static_position_rect = crate::layout::translate_static_position_rect(entry.static_position_rect, offset);
-    if let Some(rect) = &mut entry.inline_containing_block_rect {
-        rect.x += offset.x;
-        rect.y += offset.y;
-    }
+/// The padding-box rect of an inline box that acts as an abspos containing
+/// block, spanning its first and last content lines.
+pub(crate) struct InlineContainingBlockRect {
+    pub(crate) inline_box: crate::layout::node_data::NodeSlotId,
+    pub(crate) rect: PhysicalRect,
+    pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
 }
 
 trait PropagatedPayload {
@@ -71,7 +71,20 @@ impl PropagatedPayload for PendingAbsposChild {
         self.coordinate_space_box = node;
     }
     fn translate_by(&mut self, offset: FfiCssPixelPoint) {
-        translate_pending_abspos_payloads(self, offset);
+        self.static_position_rect = crate::layout::translate_static_position_rect(self.static_position_rect, offset);
+    }
+}
+
+impl PropagatedPayload for InlineContainingBlockRect {
+    fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId {
+        self.coordinate_space_box
+    }
+    fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId) {
+        self.coordinate_space_box = node;
+    }
+    fn translate_by(&mut self, offset: FfiCssPixelPoint) {
+        self.rect.x += offset.x;
+        self.rect.y += offset.y;
     }
 }
 
@@ -231,6 +244,7 @@ pub(crate) struct UnplacedRootFragment {
     pub(crate) scoped_descendants: Vec<FragmentLink>,
     pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
     pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
+    pub(crate) propagated_inline_containing_block_rects: Vec<InlineContainingBlockRect>,
 }
 
 pub(crate) struct CompletedPassFragments {
@@ -298,6 +312,19 @@ struct PendingFragment {
     children: Vec<FragmentLink>,
     pending_abspos: Vec<PendingAbsposChild>,
     anchor_candidates: Vec<AnchorCandidate>,
+    inline_containing_block_rects: Vec<InlineContainingBlockRect>,
+}
+
+impl PendingFragment {
+    fn new(node: crate::layout::node_data::NodeSlotId) -> Self {
+        Self {
+            node,
+            children: Vec::new(),
+            pending_abspos: Vec::new(),
+            anchor_candidates: Vec::new(),
+            inline_containing_block_rects: Vec::new(),
+        }
+    }
 }
 
 pub(crate) struct RunFragmentBuilder {
@@ -315,6 +342,7 @@ struct RunFragmentBuilderInner {
     child_roots_awaiting_placement: std::collections::HashMap<u32, UnplacedRootFragment>,
     pending_abspos_at_root: Vec<PendingAbsposChild>,
     anchor_candidates_at_root: Vec<AnchorCandidate>,
+    inline_containing_block_rects_at_root: Vec<InlineContainingBlockRect>,
     top_scope_links: Vec<FragmentLink>,
 }
 
@@ -326,18 +354,18 @@ impl RunFragmentBuilderInner {
             .chain(self.pending_abspos_at_root.iter())
     }
 
-    fn iter_pending_abspos_mut(&mut self) -> impl Iterator<Item = &mut PendingAbsposChild> {
-        self.pending_fragments
-            .values_mut()
-            .flat_map(|pending_fragment| pending_fragment.pending_abspos.iter_mut())
-            .chain(self.pending_abspos_at_root.iter_mut())
-    }
-
     fn iter_anchor_candidates(&self) -> impl Iterator<Item = &AnchorCandidate> {
         self.pending_fragments
             .values()
             .flat_map(|pending_fragment| pending_fragment.anchor_candidates.iter())
             .chain(self.anchor_candidates_at_root.iter())
+    }
+
+    fn iter_inline_containing_block_rects(&self) -> impl Iterator<Item = &InlineContainingBlockRect> {
+        self.pending_fragments
+            .values()
+            .flat_map(|pending_fragment| pending_fragment.inline_containing_block_rects.iter())
+            .chain(self.inline_containing_block_rects_at_root.iter())
     }
 }
 
@@ -388,18 +416,64 @@ impl RunFragmentBuilder {
                 if self.is_entry_accumulator {
                     inner.pending_abspos_at_root.push(entry);
                 } else {
-                    inner.pending_fragments.insert(
-                        coordinate_space_box.slot_index(),
-                        PendingFragment {
-                            node: coordinate_space_box,
-                            children: Vec::new(),
-                            pending_abspos: vec![entry],
-                            anchor_candidates: Vec::new(),
-                        },
-                    );
+                    let mut pending_fragment = PendingFragment::new(coordinate_space_box);
+                    pending_fragment.pending_abspos.push(entry);
+                    inner.pending_fragments.insert(coordinate_space_box.slot_index(), pending_fragment);
                 }
             }
         }
+    }
+
+    pub(crate) fn register_inline_containing_block_rect(
+        &self,
+        inline_box: crate::layout::node_data::NodeSlotId,
+        rect: PhysicalRect,
+        coordinate_space_box: crate::layout::node_data::NodeSlotId,
+    ) {
+        let mut inner = self.inner.borrow_mut();
+        #[cfg(debug_assertions)]
+        assert!(
+            !inner.placed_slots.contains(&coordinate_space_box.slot_index()),
+            "an inline containing block rect named an already-placed coordinate-space box"
+        );
+        debug_assert!(
+            !inner
+                .iter_inline_containing_block_rects()
+                .any(|payload| payload.inline_box == inline_box),
+            "an inline box's containing block rect was registered twice"
+        );
+        let payload = InlineContainingBlockRect {
+            inline_box,
+            rect,
+            coordinate_space_box,
+        };
+        if coordinate_space_box == self.root_node {
+            inner.inline_containing_block_rects_at_root.push(payload);
+            return;
+        }
+        match inner.pending_fragments.get_mut(&coordinate_space_box.slot_index()) {
+            Some(pending_fragment) => pending_fragment.inline_containing_block_rects.push(payload),
+            None => {
+                if self.is_entry_accumulator {
+                    inner.inline_containing_block_rects_at_root.push(payload);
+                } else {
+                    let mut pending_fragment = PendingFragment::new(coordinate_space_box);
+                    pending_fragment.inline_containing_block_rects.push(payload);
+                    inner.pending_fragments.insert(coordinate_space_box.slot_index(), pending_fragment);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn find_inline_containing_block_rect(
+        &self,
+        inline_box: crate::layout::node_data::NodeSlotId,
+    ) -> Option<(PhysicalRect, crate::layout::node_data::NodeSlotId)> {
+        self.inner
+            .borrow()
+            .iter_inline_containing_block_rects()
+            .find(|payload| payload.inline_box == inline_box)
+            .map(|payload| (payload.rect, payload.coordinate_space_box))
     }
 
     pub(crate) fn override_containing_block_info_for_pending_abspos_of_containing_block(
@@ -432,23 +506,6 @@ impl RunFragmentBuilder {
             .borrow()
             .iter_pending_abspos()
             .any(|entry| entry.inline_containing_block == inline_box)
-    }
-
-    pub(crate) fn set_inline_containing_block_rect_on_pending_abspos(
-        &self,
-        inline_box: crate::layout::node_data::NodeSlotId,
-        rect: PhysicalRect,
-        expected_space: crate::layout::node_data::NodeSlotId,
-    ) {
-        for entry in self.inner.borrow_mut().iter_pending_abspos_mut() {
-            if entry.inline_containing_block == inline_box {
-                debug_assert!(
-                    entry.coordinate_space_box == expected_space,
-                    "an inline containing block rect met an entry in a different space"
-                );
-                entry.inline_containing_block_rect = Some(rect);
-            }
-        }
     }
 
     pub(crate) fn anchor_candidate_shells(&self, callbacks: &FfiLayoutFcCallbacks) -> Vec<*mut c_void> {
@@ -520,27 +577,22 @@ impl RunFragmentBuilder {
     pub(crate) fn normalize_arrivals_for_placement(&self, node: crate::layout::node_data::NodeSlotId) {
         let mut inner = self.inner.borrow_mut();
         let slot = node.slot_index();
-        let (scoped_descendants, propagated_pending_abspos, propagated_anchor_candidates) =
-            match inner.child_roots_awaiting_placement.remove(&slot) {
-                Some(root) => {
-                    debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
-                    (root.scoped_descendants, root.propagated_pending_abspos, root.propagated_anchor_candidates)
-                }
-                None => (Vec::new(), Vec::new(), Vec::new()),
-            };
-        let pending_fragment = inner.pending_fragments.entry(slot).or_insert_with(|| PendingFragment {
-            node,
-            children: Vec::new(),
-            pending_abspos: Vec::new(),
-            anchor_candidates: Vec::new(),
-        });
+        let root = inner.child_roots_awaiting_placement.remove(&slot);
+        let pending_fragment = inner.pending_fragments.entry(slot).or_insert_with(|| PendingFragment::new(node));
+        let Some(root) = root else {
+            return;
+        };
+        debug_assert!(root.node == node, "a held unplaced root was keyed under a different box");
         debug_assert!(
-            pending_fragment.children.is_empty() || scoped_descendants.is_empty(),
+            pending_fragment.children.is_empty() || root.scoped_descendants.is_empty(),
             "a held unplaced root and an open pending fragment both carry children for slot {slot}"
         );
-        pending_fragment.children.extend(scoped_descendants);
-        pending_fragment.pending_abspos.extend(propagated_pending_abspos);
-        pending_fragment.anchor_candidates.extend(propagated_anchor_candidates);
+        pending_fragment.children.extend(root.scoped_descendants);
+        pending_fragment.pending_abspos.extend(root.propagated_pending_abspos);
+        pending_fragment.anchor_candidates.extend(root.propagated_anchor_candidates);
+        pending_fragment
+            .inline_containing_block_rects
+            .extend(root.propagated_inline_containing_block_rects);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -563,15 +615,13 @@ impl RunFragmentBuilder {
             !inner.child_roots_awaiting_placement.contains_key(&slot),
             "a box was placed without normalizing its held unplaced root (slot {slot})"
         );
-        let (children, pending_abspos_from_placed_box, anchor_candidates_from_placed_box) =
-            match inner.pending_fragments.remove(&slot) {
-                Some(pending_fragment) => (
-                    pending_fragment.children,
-                    pending_fragment.pending_abspos,
-                    pending_fragment.anchor_candidates,
-                ),
-                None => (Vec::new(), Vec::new(), Vec::new()),
-            };
+        let PendingFragment {
+            node: _,
+            children,
+            pending_abspos: pending_abspos_from_placed_box,
+            anchor_candidates: anchor_candidates_from_placed_box,
+            inline_containing_block_rects: inline_containing_block_rects_from_placed_box,
+        } = inner.pending_fragments.remove(&slot).unwrap_or_else(|| PendingFragment::new(node));
         let link = link_fragment(
             snapshot_fragment(node, children, used),
             PlacementData::from_record(used, containing_line_box_index, committed_offset),
@@ -602,6 +652,13 @@ impl RunFragmentBuilder {
                 None => inner.anchor_candidates_at_root.push(candidate),
             }
         }
+        for mut payload in inline_containing_block_rects_from_placed_box {
+            propagate_payload_into_containing_block_space(&mut payload, node, containing_block, content_offset);
+            match inner.pending_fragments.get_mut(&payload.coordinate_space_box.slot_index()) {
+                Some(pending_fragment) => pending_fragment.inline_containing_block_rects.push(payload),
+                None => inner.inline_containing_block_rects_at_root.push(payload),
+            }
+        }
     }
 
     fn attach(
@@ -627,15 +684,9 @@ impl RunFragmentBuilder {
             inner.top_scope_links.push(link);
             return;
         }
-        inner.pending_fragments.insert(
-            containing_block.slot_index(),
-            PendingFragment {
-                node: containing_block,
-                children: vec![link],
-                pending_abspos: Vec::new(),
-                anchor_candidates: Vec::new(),
-            },
-        );
+        let mut pending_fragment = PendingFragment::new(containing_block);
+        pending_fragment.children.push(link);
+        inner.pending_fragments.insert(containing_block.slot_index(), pending_fragment);
     }
 
     pub(crate) fn take_unplaced_root(
@@ -644,14 +695,7 @@ impl RunFragmentBuilder {
         callbacks: &FfiLayoutFcCallbacks,
     ) -> UnplacedRootFragment {
         debug_assert!(!self.is_entry_accumulator, "an entry accumulator closes as a pass, not a run");
-        let (scoped_descendants, propagated_pending_abspos, propagated_anchor_candidates) =
-            self.close(records, callbacks);
-        UnplacedRootFragment {
-            node: self.root_node,
-            scoped_descendants,
-            propagated_pending_abspos,
-            propagated_anchor_candidates,
-        }
+        self.close(records, callbacks)
     }
 
     pub(crate) fn take_completed_pass(
@@ -660,22 +704,21 @@ impl RunFragmentBuilder {
         callbacks: &FfiLayoutFcCallbacks,
     ) -> CompletedPassFragments {
         debug_assert!(self.is_entry_accumulator, "an ordinary run closes as a singular unplaced root");
-        let (roots, _dropped_pending_abspos, _dropped_anchor_candidates) = self.close(records, callbacks);
-        CompletedPassFragments { roots }
+        CompletedPassFragments {
+            roots: self.close(records, callbacks).scoped_descendants,
+        }
     }
 
-    fn close(
-        &self,
-        records: &RunRecords,
-        callbacks: &FfiLayoutFcCallbacks,
-    ) -> (Vec<FragmentLink>, Vec<PendingAbsposChild>, Vec<AnchorCandidate>) {
+    fn close(&self, records: &RunRecords, callbacks: &FfiLayoutFcCallbacks) -> UnplacedRootFragment {
         let mut inner = self.inner.take();
         let mut propagated_pending_abspos = std::mem::take(&mut inner.pending_abspos_at_root);
         let mut propagated_anchor_candidates = std::mem::take(&mut inner.anchor_candidates_at_root);
+        let mut propagated_inline_containing_block_rects = std::mem::take(&mut inner.inline_containing_block_rects_at_root);
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
         for (_, pending_fragment) in pending_fragments {
             propagated_pending_abspos.extend(pending_fragment.pending_abspos);
             propagated_anchor_candidates.extend(pending_fragment.anchor_candidates);
+            propagated_inline_containing_block_rects.extend(pending_fragment.inline_containing_block_rects);
             if pending_fragment.children.is_empty() {
                 continue;
             }
@@ -712,6 +755,15 @@ impl RunFragmentBuilder {
         for candidate in &mut propagated_anchor_candidates {
             propagate_payload_toward_run_root_space(candidate, self.root_node, records, callbacks);
         }
-        (inner.top_scope_links, propagated_pending_abspos, propagated_anchor_candidates)
+        for payload in &mut propagated_inline_containing_block_rects {
+            propagate_payload_toward_run_root_space(payload, self.root_node, records, callbacks);
+        }
+        UnplacedRootFragment {
+            node: self.root_node,
+            scoped_descendants: inner.top_scope_links,
+            propagated_pending_abspos,
+            propagated_anchor_candidates,
+            propagated_inline_containing_block_rects,
+        }
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
+++ b/Libraries/LibWeb/Rust/src/layout/fragment_tree.rs
@@ -57,6 +57,16 @@ pub(crate) struct InlineContainingBlockRect {
     pub(crate) coordinate_space_box: crate::layout::node_data::NodeSlotId,
 }
 
+/// Containing block info a formatting context computed for a pending abspos
+/// child it does not itself register (a grid supplying its grid area to deep
+/// descendants). The rect is relative to the containing block's own content
+/// origin, so the contribution never rebases; it travels as-is to whichever
+/// run drains the child and is joined by child-box identity.
+pub(crate) struct AbsposContainingBlockInfoContribution {
+    pub(crate) child_box: crate::layout::node_data::NodeSlotId,
+    pub(crate) info: AbsposContainingBlockInfo,
+}
+
 trait PropagatedPayload {
     fn coordinate_space_box(&self) -> crate::layout::node_data::NodeSlotId;
     fn set_coordinate_space_box(&mut self, node: crate::layout::node_data::NodeSlotId);
@@ -245,6 +255,7 @@ pub(crate) struct UnplacedRootFragment {
     pub(crate) propagated_pending_abspos: Vec<PendingAbsposChild>,
     pub(crate) propagated_anchor_candidates: Vec<AnchorCandidate>,
     pub(crate) propagated_inline_containing_block_rects: Vec<InlineContainingBlockRect>,
+    pub(crate) propagated_abspos_containing_block_info: Vec<AbsposContainingBlockInfoContribution>,
 }
 
 pub(crate) struct CompletedPassFragments {
@@ -343,6 +354,7 @@ struct RunFragmentBuilderInner {
     pending_abspos_at_root: Vec<PendingAbsposChild>,
     anchor_candidates_at_root: Vec<AnchorCandidate>,
     inline_containing_block_rects_at_root: Vec<InlineContainingBlockRect>,
+    abspos_containing_block_info_contributions: Vec<AbsposContainingBlockInfoContribution>,
     top_scope_links: Vec<FragmentLink>,
 }
 
@@ -476,22 +488,65 @@ impl RunFragmentBuilder {
             .map(|payload| (payload.rect, payload.coordinate_space_box))
     }
 
-    pub(crate) fn override_containing_block_info_for_pending_abspos_of_containing_block(
+    /// Lists pending abspos children whose containing block is the given box
+    /// and whose registration did not already resolve containing block info.
+    /// Only root-resting entries are considered: by the time a containing
+    /// block asks (its run's tail), every interior box is placed, so entries
+    /// it contains have propagated to the root list.
+    pub(crate) fn pending_abspos_children_awaiting_containing_block_info(
         &self,
         containing_block: crate::layout::node_data::NodeSlotId,
         callbacks: &FfiLayoutFcCallbacks,
-        containing_block_info_for_child: impl Fn(crate::layout::node_data::NodeSlotId) -> AbsposContainingBlockInfo,
-    ) {
-        for entry in &mut self.inner.borrow_mut().pending_abspos_at_root {
-            // Entries registered with their containing block info already
-            // resolved keep it; this pass only fills in entries that arrived
-            // from descendant runs.
-            if entry.containing_block_info_override.is_none()
+    ) -> Vec<crate::layout::node_data::NodeSlotId> {
+        let inner = self.inner.borrow();
+        let awaits_info = |entry: &PendingAbsposChild| {
+            entry.containing_block_info_override.is_none()
                 && callbacks.containing_block(entry.child_box) == containing_block
-            {
-                entry.containing_block_info_override = Some(containing_block_info_for_child(entry.child_box));
-            }
-        }
+        };
+        debug_assert!(
+            !inner
+                .pending_fragments
+                .values()
+                .flat_map(|pending_fragment| pending_fragment.pending_abspos.iter())
+                .any(awaits_info),
+            "a pending abspos child awaiting containing block info rests below the root list"
+        );
+        inner
+            .pending_abspos_at_root
+            .iter()
+            .filter(|entry| awaits_info(entry))
+            .map(|entry| entry.child_box)
+            .collect()
+    }
+
+    pub(crate) fn register_abspos_containing_block_info(
+        &self,
+        child_box: crate::layout::node_data::NodeSlotId,
+        info: AbsposContainingBlockInfo,
+    ) {
+        let mut inner = self.inner.borrow_mut();
+        debug_assert!(
+            !inner
+                .abspos_containing_block_info_contributions
+                .iter()
+                .any(|contribution| contribution.child_box == child_box),
+            "an abspos child's containing block info was contributed twice"
+        );
+        inner
+            .abspos_containing_block_info_contributions
+            .push(AbsposContainingBlockInfoContribution { child_box, info });
+    }
+
+    pub(crate) fn find_abspos_containing_block_info(
+        &self,
+        child_box: crate::layout::node_data::NodeSlotId,
+    ) -> Option<AbsposContainingBlockInfo> {
+        self.inner
+            .borrow()
+            .abspos_containing_block_info_contributions
+            .iter()
+            .find(|contribution| contribution.child_box == child_box)
+            .map(|contribution| contribution.info)
     }
 
     pub(crate) fn any_pending_abspos_has_inline_containing_block(&self) -> bool {
@@ -593,6 +648,9 @@ impl RunFragmentBuilder {
         pending_fragment
             .inline_containing_block_rects
             .extend(root.propagated_inline_containing_block_rects);
+        inner
+            .abspos_containing_block_info_contributions
+            .extend(root.propagated_abspos_containing_block_info);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -714,6 +772,7 @@ impl RunFragmentBuilder {
         let mut propagated_pending_abspos = std::mem::take(&mut inner.pending_abspos_at_root);
         let mut propagated_anchor_candidates = std::mem::take(&mut inner.anchor_candidates_at_root);
         let mut propagated_inline_containing_block_rects = std::mem::take(&mut inner.inline_containing_block_rects_at_root);
+        let propagated_abspos_containing_block_info = std::mem::take(&mut inner.abspos_containing_block_info_contributions);
         let pending_fragments = std::mem::take(&mut inner.pending_fragments);
         for (_, pending_fragment) in pending_fragments {
             propagated_pending_abspos.extend(pending_fragment.pending_abspos);
@@ -764,6 +823,7 @@ impl RunFragmentBuilder {
             propagated_pending_abspos,
             propagated_anchor_candidates,
             propagated_inline_containing_block_rects,
+            propagated_abspos_containing_block_info,
         }
     }
 }

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3524,7 +3524,9 @@ impl GridFormattingContext {
             child = next;
         }
         if let Some(fragments) = self.fragments.as_deref() {
-            fragments.override_containing_block_info_for_pending_abspos_of_containing_block(self.grid_container, &self.callbacks, |child| {
+            for child in
+                fragments.pending_abspos_children_awaiting_containing_block_info(self.grid_container, &self.callbacks)
+            {
                 // Deeper descendants inside grid items still get the grid area
                 // as their containing block, but their static position comes
                 // from their in-flow ancestor, so axis modes fall back to
@@ -3536,8 +3538,8 @@ impl GridFormattingContext {
                 let (inline_axis_mode, block_axis_mode) = axis_modes(self.style(child));
                 info.inline_axis_mode = inline_axis_mode;
                 info.block_axis_mode = block_axis_mode;
-                info
-            });
+                fragments.register_abspos_containing_block_info(child, info);
+            }
         }
     }
 

--- a/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/inline_formatting_context.rs
@@ -1286,11 +1286,7 @@ impl<'context> InlineFormattingContext<'context> {
             rect.x += relative_inset_chain.offset_x;
             rect.y += relative_inset_chain.offset_y;
             if let Some(fragments) = self.run.fragments.as_deref() {
-                fragments.set_inline_containing_block_rect_on_pending_abspos(
-                    candidate.inline_containing_block,
-                    rect,
-                    self.containing_block,
-                );
+                fragments.register_inline_containing_block_rect(candidate.inline_containing_block, rect, self.containing_block);
             }
         }
     }


### PR DESCRIPTION
This is a step toward per-formatting-context layout memoization: for a
formatting context run's outputs to be reusable as a frozen value, nothing
may write into them after the run completes. Two places still did — both
mutated pending abspos registrations that had already arrived from
descendant runs:

- The inline formatting context delivered the containing-block rect of an
  inline containing block by scanning every pending registration in the
  builder and stamping the rect into matching entries. This only worked
  while every matching entry happened to rest in the IFC containing block's
  coordinate space (a debug assert guarded exactly that coincidence).
- The grid formatting context delivered the grid area to abspos boxes
  nested deep inside grid items the same way, overwriting the
  containing-block info of arrived entries at its run's tail.

Both are replaced by the pattern anchor candidates already use: the
containing-block owner records its data once as a separate immutable value,
and the drain site joins it back by identity when it manufactures the
abspos layout inputs.

- Inline containing-block rects become a propagated payload (registered by
  the IFC in its own space, rebased by the standard payload protocol, folded
  into the entry's space at drain).
- Grid containing-block info becomes a contribution keyed by child box; its
  rect is relative to the containing block's own content origin, so it
  travels as-is with no coordinate-space bookkeeping. Direct grid children
  keep resolving their info at registration.

A pending abspos registration is now authored once and never written to
again (coordinate rebasing aside), and the scan-and-mutate hooks and their
ordering constraints are gone.