### PR TITLE
LibWeb: Support webkit-prefixed fullscreen APIs

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -8184,7 +8184,7 @@ void Document::run_fullscreen_steps()
     m_pending_fullscreen_events.clear();
 
     // 3. For each (type, element) in pendingEvents:
-    for (auto const& [type, element] : pending_events) {
+    for (auto const& [type, element, request_type] : pending_events) {
         // 1. Let target be element if element is connected and its node document is document, and otherwise let target be document.
         GC::Ref<Node> target { *this };
         if (element->is_connected() && &element->document() == this)
@@ -8194,26 +8194,26 @@ void Document::run_fullscreen_steps()
         switch (type) {
         case PendingFullscreenEvent::Type::Change:
             target->dispatch_event(Event::create_bubbling_composed(
-                HTML::EventNames::fullscreenchange,
+                request_type == Fullscreen::RequestType::WebKit ? HTML::EventNames::webkitfullscreenchange : HTML::EventNames::fullscreenchange,
                 HighResolutionTime::current_high_resolution_time(relevant_global_object(*this))));
             break;
         case PendingFullscreenEvent::Type::Error:
             target->dispatch_event(Event::create_bubbling_composed(
-                HTML::EventNames::fullscreenerror,
+                request_type == Fullscreen::RequestType::WebKit ? HTML::EventNames::webkitfullscreenerror : HTML::EventNames::fullscreenerror,
                 HighResolutionTime::current_high_resolution_time(relevant_global_object(*this))));
             break;
         }
     }
 }
 
-void Document::append_pending_fullscreen_change(PendingFullscreenEvent::Type type, GC::Ref<Element> element)
+void Document::append_pending_fullscreen_change(PendingFullscreenEvent::Type type, GC::Ref<Element> element, Fullscreen::RequestType request_type)
 {
-    m_pending_fullscreen_events.append(PendingFullscreenEvent { type, element });
+    m_pending_fullscreen_events.append(PendingFullscreenEvent { type, element, request_type });
     page().client().request_frame();
 }
 
 // https://fullscreen.spec.whatwg.org/#fullscreen-an-element
-void Document::fullscreen_element_within_doc(GC::Ref<Element> element)
+void Document::fullscreen_element_within_doc(GC::Ref<Element> element, Fullscreen::RequestType request_type)
 {
     // FIXME: Spec issue:  Finding topmost popover ancestor algorithm takes different parameters than those described
     //        by the fullscreen spec. Since the new algorithm takes 4 parameters, with the new "popover list", we must
@@ -8240,6 +8240,7 @@ void Document::fullscreen_element_within_doc(GC::Ref<Element> element)
 
     // 4. Set element’s fullscreen flag.
     element->set_fullscreen_flag(true);
+    element->set_fullscreen_request_type(request_type);
 
     // 5. Remove from the top layer immediately given element.
     remove_an_element_from_the_top_layer_immediately(element);
@@ -8353,7 +8354,7 @@ void Document::exit_fullscreen(GC::Ptr<WebIDL::Promise> promise)
     // 7. If doc’s fullscreen element is not connected:
     if (auto fullscreen_element = doc->fullscreen_element(); !fullscreen_element->is_connected()) {
         // 1. Append (fullscreenchange, doc’s fullscreen element) to doc’s list of pending fullscreen events.
-        doc->append_pending_fullscreen_change(PendingFullscreenEvent::Type::Change, *fullscreen_element);
+        doc->append_pending_fullscreen_change(PendingFullscreenEvent::Type::Change, *fullscreen_element, fullscreen_element->fullscreen_request_type());
 
         // 2. Unfullscreen doc’s fullscreen element.
         doc->unfullscreen_element(*fullscreen_element);
@@ -8361,6 +8362,11 @@ void Document::exit_fullscreen(GC::Ptr<WebIDL::Promise> promise)
 
     // 8. Return promise, and run the remaining steps in parallel.
     page().enqueue_fullscreen_exit(doc, resize, promise);
+}
+
+void Document::webkit_exit_fullscreen()
+{
+    exit_fullscreen(nullptr);
 }
 
 // https://fullscreen.spec.whatwg.org/#unfullscreen-a-document
@@ -9157,6 +9163,26 @@ WebIDL::CallbackType* Document::onfullscreenerror()
 void Document::set_onfullscreenerror(WebIDL::CallbackType* value)
 {
     set_event_handler_attribute(HTML::EventNames::fullscreenerror, value);
+}
+
+WebIDL::CallbackType* Document::onwebkitfullscreenchange()
+{
+    return event_handler_attribute(HTML::EventNames::webkitfullscreenchange);
+}
+
+void Document::set_onwebkitfullscreenchange(WebIDL::CallbackType* value)
+{
+    set_event_handler_attribute(HTML::EventNames::webkitfullscreenchange, value);
+}
+
+WebIDL::CallbackType* Document::onwebkitfullscreenerror()
+{
+    return event_handler_attribute(HTML::EventNames::webkitfullscreenerror);
+}
+
+void Document::set_onwebkitfullscreenerror(WebIDL::CallbackType* value)
+{
+    set_event_handler_attribute(HTML::EventNames::webkitfullscreenerror, value);
 }
 
 // https://drafts.csswg.org/css-view-transitions-1/#dom-document-startviewtransition

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -41,6 +41,7 @@
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/ViewportClient.h>
 #include <LibWeb/Export.h>
+#include <LibWeb/Fullscreen/FullscreenRequestType.h>
 #include <LibWeb/HTML/CrossOrigin/OpenerPolicy.h>
 #include <LibWeb/HTML/DocumentReadyState.h>
 #include <LibWeb/HTML/Focus.h>
@@ -245,6 +246,7 @@ struct PendingFullscreenEvent {
         Error,
     } type;
     GC::Ref<Element> element;
+    Fullscreen::RequestType request_type;
 };
 
 class WEB_API Document
@@ -1204,6 +1206,10 @@ public:
     void set_onfullscreenchange(WebIDL::CallbackType*);
     [[nodiscard]] WebIDL::CallbackType* onfullscreenerror();
     void set_onfullscreenerror(WebIDL::CallbackType*);
+    [[nodiscard]] WebIDL::CallbackType* onwebkitfullscreenchange();
+    void set_onwebkitfullscreenchange(WebIDL::CallbackType*);
+    [[nodiscard]] WebIDL::CallbackType* onwebkitfullscreenerror();
+    void set_onwebkitfullscreenerror(WebIDL::CallbackType*);
 
     // https://drafts.csswg.org/css-view-transitions-1/#dom-document-startviewtransition
     GC::Ptr<ViewTransition::ViewTransition> start_view_transition(GC::Ptr<WebIDL::CallbackType> update_callback, GC::Ref<WebIDL::Promise> ready_promise, GC::Ref<WebIDL::Promise> update_callback_done_promise, GC::Ref<WebIDL::Promise> finished_promise);
@@ -1279,9 +1285,9 @@ public:
 
     // https://fullscreen.spec.whatwg.org/#run-the-fullscreen-steps
     void run_fullscreen_steps();
-    void append_pending_fullscreen_change(PendingFullscreenEvent::Type type, GC::Ref<Element> element);
+    void append_pending_fullscreen_change(PendingFullscreenEvent::Type type, GC::Ref<Element> element, Fullscreen::RequestType request_type);
 
-    void fullscreen_element_within_doc(GC::Ref<Element> element);
+    void fullscreen_element_within_doc(GC::Ref<Element> element, Fullscreen::RequestType request_type);
     GC::Ptr<Element> fullscreen_element() const;
     GC::Ptr<Element> retargeted_fullscreen_element() const;
 
@@ -1290,6 +1296,7 @@ public:
 
     void fully_exit_fullscreen();
     void exit_fullscreen(GC::Ptr<WebIDL::Promise>);
+    void webkit_exit_fullscreen();
 
     void unfullscreen_element(GC::Ref<Element> element);
     void unfullscreen();

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3047,7 +3047,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
 }
 
 // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
-void Element::request_fullscreen(GC::Ptr<WebIDL::Promise> promise, FullscreenRequester fullscreen_requester)
+void Element::request_fullscreen(GC::Ptr<WebIDL::Promise> promise, FullscreenRequester fullscreen_requester, Fullscreen::RequestType request_type)
 {
     // 1. Let pendingDoc be this’s node document.
     auto pending_doc = m_document;
@@ -3072,7 +3072,12 @@ void Element::request_fullscreen(GC::Ptr<WebIDL::Promise> promise, FullscreenReq
     }
 
     // 7. Return promise, and run the remaining steps in parallel.
-    pending_doc->page().enqueue_fullscreen_enter(*this, *pending_doc, error, promise);
+    pending_doc->page().enqueue_fullscreen_enter(*this, *pending_doc, error, promise, request_type);
+}
+
+void Element::webkit_request_fullscreen()
+{
+    request_fullscreen(nullptr, FullscreenRequester::Bindings, Fullscreen::RequestType::WebKit);
 }
 
 // https://fullscreen.spec.whatwg.org/#removing-steps
@@ -3179,6 +3184,26 @@ GC::Ptr<WebIDL::CallbackType> Element::onfullscreenerror()
 void Element::set_onfullscreenerror(GC::Ptr<WebIDL::CallbackType> event_handler)
 {
     set_event_handler_attribute(HTML::EventNames::fullscreenerror, event_handler);
+}
+
+GC::Ptr<WebIDL::CallbackType> Element::onwebkitfullscreenchange()
+{
+    return event_handler_attribute(HTML::EventNames::webkitfullscreenchange);
+}
+
+void Element::set_onwebkitfullscreenchange(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(HTML::EventNames::webkitfullscreenchange, event_handler);
+}
+
+GC::Ptr<WebIDL::CallbackType> Element::onwebkitfullscreenerror()
+{
+    return event_handler_attribute(HTML::EventNames::webkitfullscreenerror);
+}
+
+void Element::set_onwebkitfullscreenerror(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(HTML::EventNames::webkitfullscreenerror, event_handler);
 }
 
 // https://dom.spec.whatwg.org/#insert-adjacent

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -29,6 +29,7 @@
 #include <LibWeb/DOM/Slottable.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Fullscreen/FullscreenRequestType.h>
 #include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/EventLoop/Task.h>
 #include <LibWeb/HTML/Parser/ParserScriptingMode.h>
@@ -372,19 +373,28 @@ public:
         Bindings,
         WebDriver,
     };
-    void request_fullscreen(GC::Ptr<WebIDL::Promise>, FullscreenRequester = FullscreenRequester::Bindings);
+    void request_fullscreen(GC::Ptr<WebIDL::Promise>, FullscreenRequester = FullscreenRequester::Bindings, Fullscreen::RequestType = Fullscreen::RequestType::Standard);
+    void webkit_request_fullscreen();
 
     RequestFullscreenError is_element_allowed_to_enter_fullscreen(FullscreenRequester) const;
     bool is_element_ready_for_fullscreen() const;
 
     void set_fullscreen_flag(bool is_fullscreen) { m_fullscreen_flag = is_fullscreen; }
     bool is_fullscreen_element() const { return m_fullscreen_flag; }
+    void set_fullscreen_request_type(Fullscreen::RequestType request_type) { m_fullscreen_request_type = request_type; }
+    Fullscreen::RequestType fullscreen_request_type() const { return m_fullscreen_request_type; }
 
     GC::Ptr<WebIDL::CallbackType> onfullscreenchange();
     void set_onfullscreenchange(GC::Ptr<WebIDL::CallbackType>);
 
     GC::Ptr<WebIDL::CallbackType> onfullscreenerror();
     void set_onfullscreenerror(GC::Ptr<WebIDL::CallbackType>);
+
+    GC::Ptr<WebIDL::CallbackType> onwebkitfullscreenchange();
+    void set_onwebkitfullscreenchange(GC::Ptr<WebIDL::CallbackType>);
+
+    GC::Ptr<WebIDL::CallbackType> onwebkitfullscreenerror();
+    void set_onwebkitfullscreenerror(GC::Ptr<WebIDL::CallbackType>);
 
     WebIDL::ExceptionOr<Utf16String> outer_html() const;
     WebIDL::ExceptionOr<void> set_outer_html(StringView html);
@@ -885,6 +895,8 @@ private:
     bool m_in_subtree_of_has_pseudo_class_relative_selector_with_sibling_combinator : 1 { false };
     bool m_in_has_scope : 1 { false };
     bool m_fullscreen_flag : 1 { false };
+
+    Fullscreen::RequestType m_fullscreen_request_type { Fullscreen::RequestType::Standard };
 
     size_t m_sibling_invalidation_distance { 0 };
 

--- a/Libraries/LibWeb/Fullscreen/DocumentExtensions.idl
+++ b/Libraries/LibWeb/Fullscreen/DocumentExtensions.idl
@@ -7,4 +7,16 @@ partial interface Document {
 
     attribute EventHandler onfullscreenchange;
     attribute EventHandler onfullscreenerror;
+
+    // Legacy WebKit Fullscreen API aliases.
+    [ImplementedAs=fullscreen] readonly attribute boolean webkitIsFullScreen;
+    [ImplementedAs=retargeted_fullscreen_element] readonly attribute Element? webkitCurrentFullScreenElement;
+    [ImplementedAs=webkit_exit_fullscreen] undefined webkitCancelFullScreen();
+
+    [ImplementedAs=fullscreen_enabled] readonly attribute boolean webkitFullscreenEnabled;
+    [ImplementedAs=retargeted_fullscreen_element] readonly attribute Element? webkitFullscreenElement;
+    [ImplementedAs=webkit_exit_fullscreen] undefined webkitExitFullscreen();
+
+    attribute EventHandler onwebkitfullscreenchange;
+    attribute EventHandler onwebkitfullscreenerror;
 };

--- a/Libraries/LibWeb/Fullscreen/ElementExtensions.idl
+++ b/Libraries/LibWeb/Fullscreen/ElementExtensions.idl
@@ -4,4 +4,11 @@ partial interface Element {
 
     attribute EventHandler onfullscreenchange;
     attribute EventHandler onfullscreenerror;
+
+    // Legacy WebKit Fullscreen API aliases.
+    [ImplementedAs=webkit_request_fullscreen] undefined webkitRequestFullScreen();
+    [ImplementedAs=webkit_request_fullscreen] undefined webkitRequestFullscreen();
+
+    attribute EventHandler onwebkitfullscreenchange;
+    attribute EventHandler onwebkitfullscreenerror;
 };

--- a/Libraries/LibWeb/Fullscreen/FullscreenRequestType.h
+++ b/Libraries/LibWeb/Fullscreen/FullscreenRequestType.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026-present, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Web::Fullscreen {
+
+enum class RequestType : u8 {
+    Standard,
+    WebKit,
+};
+
+}

--- a/Libraries/LibWeb/HTML/EventNames.h
+++ b/Libraries/LibWeb/HTML/EventNames.h
@@ -152,6 +152,8 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(webkitAnimationEnd)       \
     __ENUMERATE_HTML_EVENT(webkitAnimationIteration) \
     __ENUMERATE_HTML_EVENT(webkitAnimationStart)     \
+    __ENUMERATE_HTML_EVENT(webkitfullscreenchange)   \
+    __ENUMERATE_HTML_EVENT(webkitfullscreenerror)    \
     __ENUMERATE_HTML_EVENT(webkitTransitionEnd)
 
 #define __ENUMERATE_HTML_EVENT(name) extern WEB_API Utf16FlyString const& name;

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -1167,9 +1167,9 @@ void Page::update_find_in_page_selection(Vector<GC::Root<DOM::Range>> matches, C
     }
 }
 
-void Page::enqueue_fullscreen_enter(GC::Ref<DOM::Element> element, GC::Ref<DOM::Document> pending_doc, DOM::RequestFullscreenError error, GC::Ptr<WebIDL::Promise> promise)
+void Page::enqueue_fullscreen_enter(GC::Ref<DOM::Element> element, GC::Ref<DOM::Document> pending_doc, DOM::RequestFullscreenError error, GC::Ptr<WebIDL::Promise> promise, Fullscreen::RequestType request_type)
 {
-    m_pending_fullscreen_operations.enqueue(PendingFullscreenEnter { element, pending_doc, error, promise });
+    m_pending_fullscreen_operations.enqueue(PendingFullscreenEnter { element, pending_doc, error, promise, request_type });
     // NOTE: Processing is deferred because the spec says "run the remaining steps in parallel",
     //       meaning the caller's synchronous JS should complete before we process the operation.
     Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(GC::Heap::the(), [this]() {
@@ -1237,7 +1237,7 @@ void Page::process_pending_fullscreen_operations()
                 // 10. If error is true:
                 if (enter.error != DOM::RequestFullscreenError::False) {
                     // 1. Append (fullscreenerror, this) to pendingDoc's list of pending fullscreen events.
-                    enter.pending_doc->append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Error, enter.element);
+                    enter.pending_doc->append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Error, enter.element, enter.request_type);
 
                     // 2. Reject promise with a TypeError exception and terminate these steps.
                     if (enter.promise)
@@ -1279,10 +1279,10 @@ void Page::process_pending_fullscreen_operations()
                         as<HTML::HTMLIFrameElement>(*element).set_iframe_fullscreen_flag(true);
 
                     // 4. Fullscreen element within doc.
-                    doc.fullscreen_element_within_doc(element);
+                    doc.fullscreen_element_within_doc(element, enter.request_type);
 
                     // 5. Append (fullscreenchange, element) to doc's list of pending fullscreen events.
-                    doc.append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Change, element);
+                    doc.append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Change, element, enter.request_type);
                 }
 
                 // 14. Resolve promise with undefined
@@ -1330,9 +1330,11 @@ void Page::process_pending_fullscreen_operations()
 
                 // 14. For each exitDoc in exitDocs:
                 for (auto& exit_doc : exit_docs->elements()) {
+                    auto fullscreen_element = exit_doc->fullscreen_element();
+
                     // 1. Append (fullscreenchange, exitDoc's fullscreen element) to exitDoc's list of pending
                     //    fullscreen events.
-                    exit_doc->append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Change, *exit_doc->fullscreen_element());
+                    exit_doc->append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Change, *fullscreen_element, fullscreen_element->fullscreen_request_type());
 
                     // 2. If resize is true, unfullscreen exitDoc.
                     if (exit.resize)
@@ -1344,9 +1346,11 @@ void Page::process_pending_fullscreen_operations()
 
                 // 15. For each descendantDoc in descendantDocs:
                 for (auto& descendant_doc : descendant_docs->elements()) {
+                    auto fullscreen_element = descendant_doc->fullscreen_element();
+
                     // 1. Append (fullscreenchange, descendantDoc's fullscreen element) to descendantDoc's list of
                     //    pending fullscreen events.
-                    descendant_doc->append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Change, *descendant_doc->fullscreen_element());
+                    descendant_doc->append_pending_fullscreen_change(DOM::PendingFullscreenEvent::Type::Change, *fullscreen_element, fullscreen_element->fullscreen_request_type());
 
                     // 2. Unfullscreen descendantDoc.
                     descendant_doc->unfullscreen();

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -43,6 +43,7 @@
 #include <LibWeb/DOM/RequestFullscreenError.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Fullscreen/FullscreenRequestType.h>
 #include <LibWeb/Geolocation/GeolocationCoordinates.h>
 #include <LibWeb/Geolocation/GeolocationPositionError.h>
 #include <LibWeb/HTML/ActivateTab.h>
@@ -325,7 +326,7 @@ public:
     bool listen_for_dom_mutations() const { return m_listen_for_dom_mutations; }
     void set_listen_for_dom_mutations(bool listen_for_dom_mutations) { m_listen_for_dom_mutations = listen_for_dom_mutations; }
 
-    void enqueue_fullscreen_enter(GC::Ref<DOM::Element>, GC::Ref<DOM::Document>, DOM::RequestFullscreenError, GC::Ptr<WebIDL::Promise>);
+    void enqueue_fullscreen_enter(GC::Ref<DOM::Element>, GC::Ref<DOM::Document>, DOM::RequestFullscreenError, GC::Ptr<WebIDL::Promise>, Fullscreen::RequestType);
     void enqueue_fullscreen_exit(GC::Ref<DOM::Document> doc, bool resize, GC::Ptr<WebIDL::Promise>);
     void process_pending_fullscreen_operations();
 
@@ -433,6 +434,7 @@ private:
         GC::Ref<DOM::Document> pending_doc;
         DOM::RequestFullscreenError error;
         GC::Ptr<WebIDL::Promise> promise;
+        Fullscreen::RequestType request_type;
     };
 
     struct PendingFullscreenExit {

--- a/Tests/LibWeb/Text/expected/fullscreen/webkit-fullscreen-api.txt
+++ b/Tests/LibWeb/Text/expected/fullscreen/webkit-fullscreen-api.txt
@@ -1,0 +1,11 @@
+webkitRequestFullscreen returns undefined: true
+webkitfullscreenerror
+webkitRequestFullScreen returns undefined: true
+webkitfullscreenchange 1
+webkitIsFullScreen: true
+webkitFullscreenElement: true
+webkitCurrentFullScreenElement: true
+webkitCancelFullScreen returns undefined: true
+webkitfullscreenchange 2
+webkitIsFullScreen: false
+webkitFullscreenElement: null

--- a/Tests/LibWeb/Text/expected/wpt-import/fullscreen/api/historical.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/fullscreen/api/historical.txt
@@ -2,50 +2,51 @@ Harness status: OK
 
 Found 85 tests
 
-85 Pass
-Pass	<video> member must not be supported: onwebkitfullscreenchange
-Pass	Document member must not be supported: onwebkitfullscreenchange
+74 Pass
+11 Fail
+Fail	<video> member must not be supported: onwebkitfullscreenchange
+Fail	Document member must not be supported: onwebkitfullscreenchange
 Pass	<video> member must not be supported: onmozfullscreenchange
 Pass	Document member must not be supported: onmozfullscreenchange
 Pass	<video> member must not be supported: onmsfullscreenchange
 Pass	Document member must not be supported: onmsfullscreenchange
-Pass	<video> member must not be supported: onwebkitfullscreenerror
-Pass	Document member must not be supported: onwebkitfullscreenerror
+Fail	<video> member must not be supported: onwebkitfullscreenerror
+Fail	Document member must not be supported: onwebkitfullscreenerror
 Pass	<video> member must not be supported: onmozfullscreenerror
 Pass	Document member must not be supported: onmozfullscreenerror
 Pass	<video> member must not be supported: onmsfullscreenerror
 Pass	Document member must not be supported: onmsfullscreenerror
 Pass	<video> member must not be supported: webkitCurrentFullScreenElement (uppercase S)
-Pass	Document member must not be supported: webkitCurrentFullScreenElement (uppercase S)
+Fail	Document member must not be supported: webkitCurrentFullScreenElement (uppercase S)
 Pass	<video> member must not be supported: mozCurrentFullScreenElement (uppercase S)
 Pass	Document member must not be supported: mozCurrentFullScreenElement (uppercase S)
 Pass	<video> member must not be supported: msCurrentFullScreenElement (uppercase S)
 Pass	Document member must not be supported: msCurrentFullScreenElement (uppercase S)
 Pass	<video> member must not be supported: webkitFullscreenElement
-Pass	Document member must not be supported: webkitFullscreenElement
+Fail	Document member must not be supported: webkitFullscreenElement
 Pass	<video> member must not be supported: mozFullscreenElement
 Pass	Document member must not be supported: mozFullscreenElement
 Pass	<video> member must not be supported: msFullscreenElement
 Pass	Document member must not be supported: msFullscreenElement
 Pass	<video> member must not be supported: webkitFullscreenEnabled
-Pass	Document member must not be supported: webkitFullscreenEnabled
+Fail	Document member must not be supported: webkitFullscreenEnabled
 Pass	<video> member must not be supported: mozFullscreenEnabled
 Pass	Document member must not be supported: mozFullscreenEnabled
 Pass	<video> member must not be supported: msFullscreenEnabled
 Pass	Document member must not be supported: msFullscreenEnabled
 Pass	<video> member must not be supported: webkitIsFullScreen (uppercase S)
-Pass	Document member must not be supported: webkitIsFullScreen (uppercase S)
+Fail	Document member must not be supported: webkitIsFullScreen (uppercase S)
 Pass	<video> member must not be supported: mozIsFullScreen (uppercase S)
 Pass	Document member must not be supported: mozIsFullScreen (uppercase S)
 Pass	<video> member must not be supported: msIsFullScreen (uppercase S)
 Pass	Document member must not be supported: msIsFullScreen (uppercase S)
-Pass	<video> member must not be supported: webkitRequestFullScreen (uppercase S)
+Fail	<video> member must not be supported: webkitRequestFullScreen (uppercase S)
 Pass	Document member must not be supported: webkitRequestFullScreen (uppercase S)
 Pass	<video> member must not be supported: mozRequestFullScreen (uppercase S)
 Pass	Document member must not be supported: mozRequestFullScreen (uppercase S)
 Pass	<video> member must not be supported: msRequestFullScreen (uppercase S)
 Pass	Document member must not be supported: msRequestFullScreen (uppercase S)
-Pass	<video> member must not be supported: webkitRequestFullscreen
+Fail	<video> member must not be supported: webkitRequestFullscreen
 Pass	Document member must not be supported: webkitRequestFullscreen
 Pass	<video> member must not be supported: mozRequestFullscreen
 Pass	Document member must not be supported: mozRequestFullscreen
@@ -76,7 +77,7 @@ Pass	Document member must not be supported: mozExitFullScreen (uppercase S)
 Pass	<video> member must not be supported: msExitFullScreen (uppercase S)
 Pass	Document member must not be supported: msExitFullScreen (uppercase S)
 Pass	<video> member must not be supported: webkitExitFullscreen
-Pass	Document member must not be supported: webkitExitFullscreen
+Fail	Document member must not be supported: webkitExitFullscreen
 Pass	<video> member must not be supported: mozExitFullscreen
 Pass	Document member must not be supported: mozExitFullscreen
 Pass	<video> member must not be supported: msExitFullscreen

--- a/Tests/LibWeb/Text/input/fullscreen/webkit-fullscreen-api.html
+++ b/Tests/LibWeb/Text/input/fullscreen/webkit-fullscreen-api.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<style>
+    body { margin: 0; }
+    #target { width: 100px; height: 100px; }
+</style>
+<div id="target"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const target = document.getElementById("target");
+        let changeEventCount = 0;
+
+        document.addEventListener("fullscreenchange", () => {
+            println("unexpected fullscreenchange");
+        });
+
+        document.addEventListener("fullscreenerror", () => {
+            println("unexpected fullscreenerror");
+        });
+
+        document.addEventListener("webkitfullscreenerror", () => {
+            println("webkitfullscreenerror");
+            internals.click(0, 0);
+        }, { once: true });
+
+        document.addEventListener("webkitfullscreenchange", () => {
+            ++changeEventCount;
+            println(`webkitfullscreenchange ${changeEventCount}`);
+
+            if (changeEventCount === 1) {
+                println(`webkitIsFullScreen: ${document.webkitIsFullScreen}`);
+                println(`webkitFullscreenElement: ${document.webkitFullscreenElement === target}`);
+                println(`webkitCurrentFullScreenElement: ${document.webkitCurrentFullScreenElement === target}`);
+                println(`webkitCancelFullScreen returns undefined: ${document.webkitCancelFullScreen() === undefined}`);
+                return;
+            }
+
+            println(`webkitIsFullScreen: ${document.webkitIsFullScreen}`);
+            println(`webkitFullscreenElement: ${document.webkitFullscreenElement}`);
+            done();
+        });
+
+        target.addEventListener("click", () => {
+            println(`webkitRequestFullScreen returns undefined: ${target.webkitRequestFullScreen() === undefined}`);
+        });
+
+        const disconnected = document.createElement("div");
+        println(`webkitRequestFullscreen returns undefined: ${disconnected.webkitRequestFullscreen() === undefined}`);
+    });
+</script>


### PR DESCRIPTION
Plex apparently checks for these when enabling fullscreen, so we have to include them as aliases to display the fullscreen toggle button.