### PR TITLE
Tests: Prefer `test()` or `promiseTest()` to `asyncTest()` where possible

### DIFF
--- a/Tests/LibWeb/Text/input/Cache/http-memory-cache.html
+++ b/Tests/LibWeb/Text/input/Cache/http-memory-cache.html
@@ -3,7 +3,7 @@
 <script>
     // FIXME: http-disk-cache.html should just run for both disk and memory caches. But our memory cache does not yet
     //        handle cache expiration, so for now, memory cache specific tests are here.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const ALPHABET = "abcdefghijklmnabcdefghijklmnopqrstuvwxyz";
 
         const server = httpTestServer();
@@ -43,7 +43,5 @@
 
         text = await response.text();
         println(`Range response: "${text}"`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Cache/reload-revalidates-document.html
+++ b/Tests/LibWeb/Text/input/Cache/reload-revalidates-document.html
@@ -52,7 +52,7 @@
         return Object.keys(headers).map(name => name.toLowerCase());
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const url = await registerDocumentEcho();
 
         // Prime the disk cache with the document. In test mode, the disk cache only stores responses to requests
@@ -88,7 +88,5 @@
         } else {
             println("FAIL: the reload contacted the server without a conditional request");
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Clipboard/clipboarditem.html
+++ b/Tests/LibWeb/Text/input/Clipboard/clipboarditem.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script type="text/javascript">
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const blob = new Blob(['https://example.com'], {type: 'text/uri-list'});
 
         const item = new ClipboardItem({'text/plain': 'hello', 'text/uri-list': blob});
@@ -15,7 +15,5 @@
         const blobOutput2 = await item.getType('text/uri-list');
         const text2 = await (new Response(blobOutput2)).text();
         println(`getType('text/uri-list'): ${text2}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Compression/round-trip.html
+++ b/Tests/LibWeb/Text/input/Compression/round-trip.html
@@ -50,9 +50,8 @@
         }
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await roundTrip('Well hello friends!')
         await roundTrip('Well hello friends!'.repeat(100))
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/CryptoKey-cached-slots.html
+++ b/Tests/LibWeb/Text/input/Crypto/CryptoKey-cached-slots.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         let key = await window.crypto.subtle.generateKey(
             { name: "AES-CTR", length: 128 },
             true,
@@ -32,6 +32,5 @@
         let hmacHashDescriptor = Object.getOwnPropertyDescriptor(hmacKey.algorithm, "hash");
         println(`hmac hash name=${hmacKey.algorithm.hash.name}`);
         println(`hmac hash is data property: ${"value" in hmacHashDescriptor}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-aescbc.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-aescbc.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         var key = new Uint8Array([0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f]);
         var iv = new Uint8Array([0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f]);
         var plaintextEvil = new Uint8Array([
@@ -48,6 +48,5 @@
         // - WebCryptoAPI/encrypt_decrypt/aes_cbc.https.any
         // - WebCryptoAPI/generateKey/successes_AES-CBC.https.any
         // - WebCryptoAPI/import_export/symmetric_importKey.https.any
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-aesgcm.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-aesgcm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const algorithm = "AES-GCM";
 
         // Generate keys and export them, verify length
@@ -16,7 +16,5 @@
         println("exported 128 bit key length: " + exported128bitKey.byteLength);
         println("exported 192 bit key length: " + exported192bitKey.byteLength);
         println("exported 256 bit key length: " + exported256bitKey.byteLength);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-decrypt-aes-ocb.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-decrypt-aes-ocb.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
 
         const keyBytes = new Uint8Array([
             222, 192, 212, 252, 191, 60, 71, 65, 200, 146, 218, 189, 28, 212, 192, 78
@@ -126,7 +126,5 @@
         } catch (e) {
             println(`ERROR: ${e.message}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-deriveBits.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-deriveBits.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const encoder = new TextEncoder();
         const message = "Hello friends";
         const encodedMessage = encoder.encode(message);
@@ -49,7 +49,5 @@
         } else {
             println("Derived bits FAIL");
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-digest.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-digest.html
@@ -8,7 +8,7 @@
         const digest = await window.crypto.subtle.digest(algorithm, encoded_message);
         println(`${algorithm} ${bufferToHex(digest)}`);
     }
-    asyncTest(async done => {
+    promiseTest(async () => {
         const encoder = new TextEncoder();
         const message = "Hello friends";
         const encoded_message = encoder.encode(message);
@@ -17,7 +17,5 @@
         await printDigest("SHA-256", encoded_message);
         await printDigest("SHA-384", encoded_message);
         await printDigest("SHA-512", encoded_message);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-ec-bad-import-key.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-ec-bad-import-key.html
@@ -54,7 +54,7 @@
     return corrupted.buffer;
   }
 
-  asyncTest(async done => {
+  promiseTest(async () => {
     for (const [name, genUsages, pubUsages, privUsages] of [
       ["ECDSA", ["verify", "sign"], ["verify"], ["sign"]],
       ["ECDH", ["deriveBits", "deriveKey"], [], ["deriveBits", "deriveKey"]],
@@ -106,7 +106,5 @@
         }
       }
     }
-
-    done();
   });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-encrypt-aes-ocb.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-encrypt-aes-ocb.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
 
         const keyBytes = new Uint8Array([
             222, 192, 212, 252, 191, 60, 71, 65, 200, 146, 218, 189, 28, 212, 192, 78
@@ -130,7 +130,5 @@
         } catch (e) {
             println(`ERROR: ${e.message}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-encrypt.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-encrypt.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const encoder = new TextEncoder();
         const message = "Hello friends";
         const encodedMessage = encoder.encode(message);
@@ -27,7 +27,5 @@
 
         const buffer = new Uint8Array(ciphertext);
         println(`Encrypted OK with ${buffer.byteLength} bytes`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-exportKey.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-exportKey.html
@@ -5,7 +5,7 @@
         return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, "0")).join("");
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         let algorithm = {
             name: "RSA-OAEP",
             modulusLength: 512,
@@ -45,7 +45,5 @@
         } catch (e) {
             println(`exportKey spki private key: ${e.name} ${e.message}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-generateKey-detached-public-exponent.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-generateKey-detached-public-exponent.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const exponentBuffer = new ArrayBuffer(3);
         const publicExponent = new Uint8Array(exponentBuffer);
         publicExponent.set([0x01, 0x00, 0x01]);
@@ -20,6 +20,5 @@
         } catch (e) {
             println("rejected: " + e.name);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-generateKey.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-generateKey.html
@@ -5,7 +5,7 @@
         return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, "0")).join("");
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         // FIXME: Generate a key with module lengths longer than 256, when they don't take an eternity to generate.
         //        This is #23561
         let algorithm = {
@@ -70,7 +70,5 @@
         } catch (e) {
             println(`Error: ${e}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-hmac.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-hmac.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         await crypto.subtle.exportKey(
             "jwk",
             await crypto.subtle.generateKey(
@@ -17,7 +17,5 @@
         );
 
         println("Does not crash.");
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-PBKDF2.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-PBKDF2.html
@@ -5,7 +5,7 @@
         return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, "0")).join("");
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         let key_material = "password";
         let enc = new TextEncoder();
         let key = await window.crypto.subtle.importKey(
@@ -28,6 +28,5 @@
         let digest = await window.crypto.subtle.digest("SHA-256", encoded_message);
 
         println(`SHA-256 digest: ${bufferToHex(digest)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-chacha20poly1305.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-chacha20poly1305.html
@@ -13,7 +13,7 @@
         return base64String.replace(/=/g, "");
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         var subtle = self.crypto.subtle;
 
 
@@ -37,8 +37,6 @@
         println(key.algorithm.name);
         println(key.type);
         println(key.usages.join(","));
-
-        done();
     });
 
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-export-roundtrip.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-export-roundtrip.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
 
         let jwk = {
             alg: "RSA-OAEP-256",
@@ -67,7 +67,5 @@
         println(`exported dp: ${exported.dp}`);
         println(`exported dq: ${exported.dq}`);
         println(`exported qi: ${exported.qi}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-rsaoaep-minimal_jwk.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-rsaoaep-minimal_jwk.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         var subtle = self.crypto.subtle;
         var key = await subtle.importKey(
             "jwk",
@@ -18,6 +18,5 @@
         println(key.algorithm.name);
         println(key.algorithm.hash.name);
         println(key.algorithm.publicExponent);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-jwk-non-ascii-base64url.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-jwk-non-ascii-base64url.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const jwk = { alg: "A128GCM", kty: "oct", k: "é" };
 
         try {
@@ -10,7 +10,5 @@
         } catch (error) {
             println(error.name);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-rsa-bad-import-key.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-rsa-bad-import-key.html
@@ -37,7 +37,7 @@
     return corrupted.buffer;
   }
 
-  asyncTest(async done => {
+  promiseTest(async () => {
     for (const [name, genUsages, privUsages] of [
       ["RSASSA-PKCS1-v1_5", ["sign", "verify"], ["sign"]],
       ["RSA-PSS", ["sign", "verify"], ["sign"]],
@@ -74,7 +74,5 @@
         }
       }
     }
-
-    done();
   });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-sign.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-sign.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const encoder = new TextEncoder();
         const message = "Hello friends";
         const encodedMessage = encoder.encode(message);
@@ -23,7 +23,5 @@
         );
 
         println(`Signed OK`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-structuredClone-aesctr.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-structuredClone-aesctr.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const keyBytes = new Uint8Array(16);
         for (let i = 0; i < keyBytes.length; ++i)
             keyBytes[i] = i;
@@ -26,7 +26,5 @@
         println(`clone.algorithm.length=${clonedKey.algorithm.length}`);
         println(`roundtrip=${roundTripped}`);
         println(`matches=${roundTripped === "hello structured clone"}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-structuredClone-detached-public-exponent.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-structuredClone-detached-public-exponent.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const keyPair = await crypto.subtle.generateKey({
             name: "RSASSA-PKCS1-v1_5",
             modulusLength: 1024,
@@ -17,6 +17,5 @@
         } catch (e) {
             println("PASS (didn't crash): " + e.name);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-structuredClone.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-structuredClone.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const keyMaterial = await crypto.subtle.importKey(
             "raw",
             new TextEncoder().encode("password"),
@@ -33,7 +33,5 @@
         } catch (e) {
             println(`deriveKey threw: ${e.name}: ${e.message}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-verify.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-verify.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const encoder = new TextEncoder();
         const message = "Hello friends";
         const encodedMessage = encoder.encode(message);
@@ -34,7 +34,5 @@
         } else {
             println(`FAIL: Verification not ok`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/DOM/window-open-and-reopen-custom-target.html
+++ b/Tests/LibWeb/Text/input/DOM/window-open-and-reopen-custom-target.html
@@ -16,9 +16,8 @@
         });
     };
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await runTest(1);
         await runTest(2);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/click-empty-editable-after-focus-layout-change.html
+++ b/Tests/LibWeb/Text/input/Editing/click-empty-editable-after-focus-layout-change.html
@@ -35,7 +35,7 @@
     </div>
 </div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const beforeInputTargetRanges = [];
         const inputSelectionOffsets = [];
         const inputTypes = [];
@@ -84,6 +84,5 @@
         println(`beforeinput target ranges: ${beforeInputTargetRanges.join(", ")}`);
         println(`input types: ${inputTypes.join(", ")}`);
         println(`input selection offsets: ${inputSelectionOffsets.join(", ")}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-copy-rendered-text.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-copy-rendered-text.html
@@ -4,7 +4,7 @@
 <div><br></div>
 <ul><li>One<br></li><li>Two<br></li></ul><div>Last</div></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         host.focus();
         getSelection().selectAllChildren(host);
@@ -17,6 +17,5 @@
         }, { once: true }));
         internals.sendKey(host, "V", platformControl);
         await pasteEvent;
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-paste-sanitization.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-paste-sanitization.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="editor" contenteditable="true">ab</div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -36,6 +36,5 @@
         println(`undo DOM: ${editor.innerHTML}`);
         internals.sendKey(editor, "Z", platformControlShift);
         println(`redo active content: ${editor.querySelectorAll("script, iframe, object, embed, style, link, meta, template, [onclick], [onerror], [href^='javascript:']").length}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-copy-cut.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-copy-cut.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="editor" contenteditable="true">hello world</div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const modCtrl = (1 << 1) | (1 << 3); // Ctrl and Super, to cover the platform clipboard modifier everywhere.
         const editor = document.getElementById("editor");
         const events = [];
@@ -44,6 +44,5 @@
         println(`formats after canceled copy: ${JSON.stringify(clipboardItem.types)}`);
 
         for (const line of events) println(line);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-iframe.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-iframe.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <iframe id="frame" srcdoc="<body contenteditable>blue text</body>"></iframe>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
 
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
@@ -29,6 +29,5 @@
         selection.collapse(body.firstChild, body.firstChild.length);
         internals.sendKey(body, "V", platformControl);
         await pasteEvent;
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-paste.html
+++ b/Tests/LibWeb/Text/input/Editing/clipboard-shortcut-paste.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="editor" contenteditable="true">ab</div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const modCtrl = (1 << 1) | (1 << 3); // Ctrl and Super, to cover the platform clipboard modifier everywhere.
         const editor = document.getElementById("editor");
 
@@ -34,6 +34,5 @@
         println(`canceled paste event data: ${JSON.stringify(await canceledPasteEvent)}`);
         await new Promise(resolve => requestAnimationFrame(resolve));
         println(`editor text after canceled paste: ${JSON.stringify(editor.textContent)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/contenteditable-paste-placeholder.html
+++ b/Tests/LibWeb/Text/input/Editing/contenteditable-paste-placeholder.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="editor" contenteditable><div id="line">Give it a try! <img><br></div></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -25,6 +25,5 @@
 
         internals.sendKey(editor, "Z", platformControlShift);
         println(`redo: ${line.innerHTML} @ ${selection.focusOffset}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/contenteditable-paste-split-style.html
+++ b/Tests/LibWeb/Text/input/Editing/contenteditable-paste-split-style.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="editor" contenteditable><div id="source">Give</div><div id="target"><font color="#ff00">Red text and </font></div></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -26,6 +26,5 @@
 
         internals.sendKey(editor, "Z", platformControlShift);
         println(`redo: ${target.innerHTML} | ${selection.focusNode.data} @ ${selection.focusOffset}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/execCommand-case-insensitivity.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-case-insensitivity.html
@@ -20,10 +20,9 @@
             };
         });
     }
-    asyncTest(async done => {
+    promiseTest(async () => {
         for (command of ["selectall", "SELECTALL", "SeLeCtAlL"]) {
             await execCommandCaseInsensitivityTest(command);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/focus-reentrant-iframe-input-routing.html
+++ b/Tests/LibWeb/Text/input/Editing/focus-reentrant-iframe-input-routing.html
@@ -3,7 +3,7 @@
 <input id="parentInput">
 <iframe id="frame" srcdoc="<input id='childInput'>"></iframe>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
         const childInput = frame.contentDocument.querySelector("#childInput");
 
@@ -15,6 +15,5 @@
         println(`parent active: ${document.activeElement === parentInput}`);
         println(`parent value: ${JSON.stringify(parentInput.value)}`);
         println(`child value: ${JSON.stringify(childInput.value)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-clipboard-sceditor.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-clipboard-sceditor.html
@@ -3,7 +3,7 @@
 <script>
     // This fixture uses the styled runs and images from the SCEditor front-page demo. The expected DOM and selection
     // endpoints were recorded by driving Chromium through WebDriver with the same copy, paste, undo, and redo keys.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -154,6 +154,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} SCEditor rich clipboard assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} SCEditor rich clipboard assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-copy-hidden-content.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-copy-hidden-content.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const host = document.createElement("div");
         host.contentEditable = "true";
@@ -30,6 +30,5 @@
         }, { once: true }));
         internals.sendKey(host, "V", platformControl);
         await pasteEvent;
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-copy-terminal-placeholder.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-copy-terminal-placeholder.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -52,6 +52,5 @@
         internals.sendKey(host, "Z", platformControlShift);
         println(host.innerHTML === pastedHTML ? "PASS: redo DOM" : `FAIL: redo DOM: ${host.innerHTML}`);
         println(selectionString() === "host/2/1/0@14" ? "PASS: redo selection" : `FAIL: redo selection: ${selectionString()}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-atomic-whitespace.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-atomic-whitespace.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -50,6 +50,5 @@
         println(host.innerHTML === pastedHTML ? "PASS: redo DOM" : `FAIL: redo DOM: ${host.innerHTML}`);
         println(selectionString() === "host/1/3@5" ? "PASS: redo selection" : `FAIL: redo selection: ${selectionString()}`);
         println(host.querySelector("#target").childNodes.length === 4 ? "PASS: redo text seams" : `FAIL: redo text seams: ${host.querySelector("#target").childNodes.length}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-block-fragment.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-block-fragment.html
@@ -3,7 +3,7 @@
 <script>
     // This selection and its expected replacement were recorded from Chromium using the SCEditor-derived fixture.
     // It covers the paragraph-splitting path used when a multi-block fragment is pasted into the middle of a line.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -575,6 +575,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} block-fragment paste assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} block-fragment paste assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-empty-terminal-container.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-empty-terminal-container.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const originalHTML = `<div>redblue</div><div><br></div><ul><li>list</li></ul><div>tail</div>`;
@@ -46,6 +46,5 @@
         internals.sendKey(host, "Z", platformControlShift);
         println(host.innerHTML === pastedHTML ? "PASS: redo DOM" : `FAIL: redo DOM: ${host.innerHTML}`);
         println(selectionString() === "host/6/0@0" ? "PASS: redo selection" : `FAIL: redo selection: ${selectionString()}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-integrated-paragraph-whitespace.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-integrated-paragraph-whitespace.html
@@ -3,7 +3,7 @@
 <script>
     // This range comes from the SCEditor-derived Chromium differential fixture. It covers a protected clipboard
     // space whose wrapper becomes redundant when the final pasted paragraph is integrated with the destination.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const failures = [];
@@ -80,6 +80,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} integrated-paragraph assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} integrated-paragraph assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-interchange-newline.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-interchange-newline.html
@@ -15,7 +15,7 @@
     // These selections and replacements were recorded from Chromium using the SCEditor-derived fixture. Chromium's
     // clipboard serializer emits Apple-interchange-newline markers for selected paragraph boundaries. Its replacement
     // path currently retains leading markers in the document while consuming trailing transport markers.
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
 
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
@@ -560,6 +560,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} interchange-newline assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} interchange-newline assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-into-empty-block.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-into-empty-block.html
@@ -3,7 +3,7 @@
 <script>
     // Chromium keeps an empty destination paragraph as the container for pasted block content. This fixture records
     // that topology, including the selection restored by native undo and redo.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -63,6 +63,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} empty-block assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} empty-block assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-list-end-placeholder.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-list-end-placeholder.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const originalHTML = `<div>alpha</div><div>beta</div><ul><li>tail<br></li></ul>`;
@@ -46,6 +46,5 @@
         internals.sendKey(host, "Z", platformControlShift);
         println(host.innerHTML === pastedHTML ? "PASS: redo DOM" : `FAIL: redo DOM: ${host.innerHTML}`);
         println(selectionString() === "host/2/0/1/0@2" ? "PASS: redo selection" : `FAIL: redo selection: ${selectionString()}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-partial-block-wrapper.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-partial-block-wrapper.html
@@ -3,7 +3,7 @@
 <script>
     // These source ranges come from the SCEditor-derived Chromium differential fixture. Each range contains only part
     // of one block even though Range::cloneContents() represents it with a complete div wrapper.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const failures = [];
@@ -191,6 +191,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} partial-block assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} partial-block assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-partial-legacy-font.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-partial-legacy-font.html
@@ -10,7 +10,7 @@
 <script>
     // This selection and its expected replacement were recorded from Chromium using the SCEditor-derived fixture.
     // Its final paragraph ends partway through a legacy font and is merged with the destination paragraph.
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
 
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
@@ -252,6 +252,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} partial-font assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} partial-font assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-preserve-placeholder.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-preserve-placeholder.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -86,6 +86,5 @@
         println(host.children[0].childNodes[0].data === "Give it a t it a try!" ? "PASS: seam redo merges around its rendered start" : `FAIL: seam redo rendered start: ${JSON.stringify(host.children[0].childNodes[0].data)}`);
         println(host.children[0].childNodes[1].data === "\u00a0" ? "PASS: seam redo preserves trailing protected space" : `FAIL: seam redo trailing protected space: ${JSON.stringify(host.children[0].childNodes[1].data)}`);
         println(host.children[1].firstChild.childNodes.length === 2 ? "PASS: seam redo inline text nodes" : `FAIL: seam redo inline text nodes: ${host.children[1].firstChild.childNodes.length}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-replacement-boundary.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-replacement-boundary.html
@@ -3,7 +3,7 @@
 <script>
     // These selections and their expected replacement seams were recorded from Chromium using the SCEditor-derived
     // fixture. They cover the distinction between the original replacement position and the inserted content range.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -156,6 +156,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} replacement-boundary paste assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} replacement-boundary paste assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-style-cleanup.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-style-cleanup.html
@@ -4,7 +4,7 @@
     // These clipboard payloads and resulting DOM/selection states were recorded from Chromium using WebDriver.
     // Chromium's native serializer annotates copied content with its rendered style, then native paste removes the
     // declarations which the destination cascade already supplies.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -92,6 +92,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} rich paste style cleanup assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} rich paste style cleanup assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-terminal-empty-paragraph.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-terminal-empty-paragraph.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const originalHTML = `<div>alpha</div><div><br></div><ul><li>tail</li></ul>`;
@@ -46,6 +46,5 @@
         internals.sendKey(host, "Z", platformControlShift);
         println(host.innerHTML === pastedHTML ? "PASS: redo DOM" : `FAIL: redo DOM: ${host.innerHTML}`);
         println(selectionString() === "host/2/0/1@0" ? "PASS: redo selection" : `FAIL: redo selection: ${selectionString()}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-tracked-insertion-seam.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-tracked-insertion-seam.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -48,6 +48,5 @@
         internals.sendKey(host, "Z", platformControlShift);
         println(host.innerHTML === pastedHTML ? "PASS: redo DOM" : `FAIL: redo DOM: ${host.innerHTML}`);
         println(selectionString() === "host/2/0/2/0/0@4" ? "PASS: redo selection" : `FAIL: redo selection: ${selectionString()}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/rich-paste-tracked-start.html
+++ b/Tests/LibWeb/Text/input/Editing/rich-paste-tracked-start.html
@@ -3,7 +3,7 @@
 <script>
     // This selection and its expected replacement were recorded from Chromium using the SCEditor-derived fixture.
     // It covers cleanup after the first pasted paragraph has moved out of its original fragment wrapper.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const platformControl = internals.MOD_CTRL | internals.MOD_SUPER;
         const platformControlShift = platformControl | internals.MOD_SHIFT;
         const selection = getSelection();
@@ -89,6 +89,5 @@
             println(`FAIL: ${failures.length}/${assertionCount} tracked-start paste assertions failed\n${failures.join("\n")}`);
         else
             println(`PASS: ${assertionCount} tracked-start paste assertions match Chromium`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Fetch/fetch-request-url-search-params.html
+++ b/Tests/LibWeb/Text/input/Fetch/fetch-request-url-search-params.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script type="text/javascript">
-    asyncTest(async done => {
+    promiseTest(async () => {
         const body = new URLSearchParams();
         body.append("username", "buggie");
         body.append("password", "hunter2");
@@ -12,6 +12,5 @@
         });
 
         println(await request.text());
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Fetch/multipart-form-data-crlf.html
+++ b/Tests/LibWeb/Text/input/Fetch/multipart-form-data-crlf.html
@@ -24,13 +24,12 @@
         println(`Data: ${data.get("field")}`);
     };
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await runTest("");
         await runTest("\r");
         await runTest("\n");
         await runTest("\r\n");
         await runTest("junk");
         await runTest("\r\njunk");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Fetch/network-error-on-connection-failure.html
+++ b/Tests/LibWeb/Text/input/Fetch/network-error-on-connection-failure.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         try {
             await fetch("http://127.0.0.1:2/", { mode: "no-cors" });
             println("FAIL: fetch resolved instead of rejecting");
         } catch (e) {
             println(e);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Fetch/prevent-file-from-fetching-file.html
+++ b/Tests/LibWeb/Text/input/Fetch/prevent-file-from-fetching-file.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         try {
             await fetch(`file://${window.location.pathname}`);
             println('FAIL: no exception was thrown');
         } catch (e) {
             println(e);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Fetch/request-constructor-does-not-throw-on-null-body-with-get-or-head-request.html
+++ b/Tests/LibWeb/Text/input/Fetch/request-constructor-does-not-throw-on-null-body-with-get-or-head-request.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         try {
             const dataUrl = "data:,hello";
             new Request(dataUrl, { method: "GET", body: null });
@@ -15,7 +15,5 @@
         } catch (e) {
             println(`Unexpected throw: ${e}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/FileAPI/Blob-initialized-with-strings-read-from-arrayBuffer.html
+++ b/Tests/LibWeb/Text/input/FileAPI/Blob-initialized-with-strings-read-from-arrayBuffer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const blob = new Blob(["This is some data to be read! 🦬"]);
         const arrayBuffer = await blob.arrayBuffer();
         const string = new TextDecoder().decode(new Uint8Array(arrayBuffer));
@@ -9,6 +9,5 @@
             println("PASS");
         else
             println("FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/FileAPI/Blob-initialized-with-strings-read-from-bytes.html
+++ b/Tests/LibWeb/Text/input/FileAPI/Blob-initialized-with-strings-read-from-bytes.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const blob = new Blob(["This is some data to be read! 🦬"]);
         const uint8Array = await blob.bytes();
         const string = new TextDecoder().decode(uint8Array);
@@ -9,6 +9,5 @@
             println("PASS");
         else
             println("FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/FileAPI/Blob-initialized-with-strings-read-from-text.html
+++ b/Tests/LibWeb/Text/input/FileAPI/Blob-initialized-with-strings-read-from-text.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const blob = new Blob(["This is some data to be read! 🦬"]);
         const text = await blob.text();
         if (text === "This is some data to be read! 🦬")
             println("PASS");
         else
             println("FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/FileAPI/blob-methods-receiver-realm.html
+++ b/Tests/LibWeb/Text/input/FileAPI/blob-methods-receiver-realm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         document.body.append(iframe);
         const other = iframe.contentWindow;
@@ -40,7 +40,5 @@
         println(`stream chunk is iframe realm: ${chunk instanceof other.Uint8Array}`);
         println(`stream chunk is parent realm: ${chunk instanceof Uint8Array}`);
         println(`stream chunk values: ${Array.from(chunk).join(",")}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/FileAPI/unpaired-surrogates-in-constructor.html
+++ b/Tests/LibWeb/Text/input/FileAPI/unpaired-surrogates-in-constructor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const unpairedSurrogates = "hello\uDC00friends\uD800:)";
         const replacedSurrogates = "hello\uFFFDfriends\uFFFD:)";
 
@@ -10,7 +10,5 @@
 
         const file = new File([unpairedSurrogates], "someFileName");
         println(await file.text() === replacedSurrogates ? "PASS" : "FAIL")
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-button-pressing.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-button-pressing.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const gamepad = internals.connectVirtualGamepad();
         await handleSDLInputEvents();
         listenForGamepadConnected();
@@ -20,6 +20,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-button-press.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-button-press.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         println(`Initial: ${getStringifiedGamepads()}`);
 
         const gamepad = internals.connectVirtualGamepad();
@@ -17,6 +17,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-negative-axis-movement.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-negative-axis-movement.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         println(`Initial: ${getStringifiedGamepads()}`);
 
         const gamepad = internals.connectVirtualGamepad();
@@ -22,6 +22,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-positive-axis-movement.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-positive-axis-movement.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         println(`Initial: ${getStringifiedGamepads()}`);
 
         const gamepad = internals.connectVirtualGamepad();
@@ -22,6 +22,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-pressing-triggers.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-exposed-after-pressing-triggers.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const gamepad = internals.connectVirtualGamepad();
         await handleSDLInputEvents();
         listenForGamepadConnected();
@@ -22,6 +22,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-haptic-promise-receiver-realm.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-haptic-promise-receiver-realm.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const gamepad = internals.connectVirtualGamepad();
         await handleSDLInputEvents();
 
@@ -34,6 +34,5 @@
 
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-iframe.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-iframe.html
@@ -38,7 +38,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const testIframe = document.getElementById("test-iframe");
 
         const sendMessageAndWait = (message) => {
@@ -79,7 +79,5 @@
         gamepad.disconnect();
         await handleSDLInputEvents();
         println(`After disconnecting gamepad: ${await sendMessageAndWait("getGamepads")}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-moving-axes.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-moving-axes.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const gamepad = internals.connectVirtualGamepad();
         await handleSDLInputEvents();
         listenForGamepadConnected();
@@ -23,6 +23,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/GamepadAPI/gamepad-rumble.html
+++ b/Tests/LibWeb/Text/input/GamepadAPI/gamepad-rumble.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script src="gamepad-helper.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const gamepad = internals.connectVirtualGamepad();
         await handleSDLInputEvents();
 
@@ -68,6 +68,5 @@
         listenForGamepadDisconnected();
         gamepad.disconnect();
         await handleSDLInputEvents();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-audio-play-state.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-audio-play-state.html
@@ -3,7 +3,7 @@
 <script>internals.setAutoplayPolicy("allow-audio-and-video");</script>
 <video autoplay muted loop src="../../../Assets/test-webm.webm"></video>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         internals.setTestTimeout(15_000);
         const video = document.querySelector("video");
         await new Promise(resolve => video.addEventListener("playing", resolve, { once: true }));
@@ -45,6 +45,5 @@
 
         video.load();
         println(`reset media reported as playing audio: ${internals.mediaElementIsPlayingAudio(video)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-load-after-decode-error.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-load-after-decode-error.html
@@ -19,13 +19,12 @@
         video.addEventListener(name, () => logEvent(name));
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         video.src = "../../../Assets/corrupt-video.webm";
 
         await new Promise(resolve => video.addEventListener("error", resolve, { once: true }));
         video.src = "../../../Assets/test-webm.webm";
 
         await new Promise(resolve => video.addEventListener("canplaythrough", resolve, { once: true }));
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-screen-wake-lock.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-screen-wake-lock.html
@@ -12,7 +12,7 @@
         return new Promise(resolve => target.addEventListener(name, resolve, { once: true }));
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         logState("initial");
 
         video.src = "../../../Assets/test-webm.webm";
@@ -47,7 +47,5 @@
         video.removeAttribute("src");
         video.load();
         logState("src cleared and loaded");
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-offscreen-capture-keeps-updating.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-offscreen-capture-keeps-updating.html
@@ -4,7 +4,7 @@
 <script>
     // An unattached <video> is never painted, so only capturing it keeps its video sink updating.
     // Play it while capturing off-screen and confirm the presented frame advances (the clip resizes 320->640).
-    asyncTest(async done => {
+    promiseTest(async () => {
         const video = document.createElement("video");
         video.src = "../../../Assets/resize-320x240-640x480.webm";
         await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
@@ -34,6 +34,5 @@
         capturing = false;
 
         println(`videoWidth advanced to ${video.videoWidth}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-on-reload.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-on-reload.html
@@ -12,7 +12,7 @@
         video.addEventListener(name, () => logEvent(name));
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         logEvent("initial");
         video.src = "../../../Assets/test-webm.webm";
 
@@ -24,7 +24,5 @@
 
         await new Promise(resolve => video.addEventListener("canplaythrough", resolve, { once: true }));
         logEvent("after canplaythrough");
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-on-track-change.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLVideoElement-resize-event-on-track-change.html
@@ -39,7 +39,7 @@
         logEvent("resize");
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const initialTrackChange = waitForTrackChange(0);
         const initialResize = waitForResize(320, 240);
         const loadedMetadata = new Promise(resolve => {
@@ -57,7 +57,5 @@
 
         println(`--- selecting track 0 ---`);
         await selectTrack(0, 320, 240);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/History-pushState-change-query.html
+++ b/Tests/LibWeb/Text/input/HTML/History-pushState-change-query.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest((done) => {
+    test(() => {
         try {
             history.pushState({}, null, "?tweaked");
             println("Good: changing the query via pushState()");
@@ -20,6 +20,5 @@
         } catch (e) {
             println("FAIL: threw on going back to original filename");
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/ImageData-detached-data.html
+++ b/Tests/LibWeb/Text/input/HTML/ImageData-detached-data.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <canvas id="canvas" width="1" height="1"></canvas>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const context = canvas.getContext("2d");
         const pixels = new Uint8ClampedArray([1, 2, 3, 4]);
         const imageData = new ImageData(pixels, 1, 1);
@@ -28,7 +28,5 @@
         } catch (error) {
             println(`createImageBitmap with detached ImageData data: ${error.name}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-FileList.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-FileList.html
@@ -25,9 +25,7 @@
         });
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await runTest("input1");
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
+++ b/Tests/LibWeb/Text/input/HTML/StructuredClone-serializable-objects.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         let blob = structuredClone(new Blob(["Hello, Blob!"], {type: "text/plain"}));
         println(`instanceOf Blob: ${blob instanceof Blob}`);
         println(`Blob.type: ${blob.type}`);
@@ -83,7 +83,5 @@
             const a = imageData.data[i + 3];
             println(`${r}, ${g}, ${b}, ${a}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/audio-ends-without-audio-output.html
+++ b/Tests/LibWeb/Text/input/HTML/audio-ends-without-audio-output.html
@@ -4,7 +4,7 @@
 <script>
     const audio = document.getElementById("audio");
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         audio.src = "../../../Assets/test-webm-audio.ogg";
         await new Promise(resolve => audio.addEventListener("loadedmetadata", resolve, { once: true }));
 
@@ -15,6 +15,5 @@
         await new Promise(resolve => audio.addEventListener("ended", resolve, { once: true }));
 
         println(`ended, currentTime === duration: ${audio.currentTime === audio.duration}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/data-transfer.html
+++ b/Tests/LibWeb/Text/input/HTML/data-transfer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         let dataTransfer = new DataTransfer();
         println(`dropEffect: ${dataTransfer.dropEffect}`);
         println(`effectAllowed: ${dataTransfer.effectAllowed}`);
@@ -53,7 +53,5 @@
         if (dataTransferItemList[3] !== undefined) {
             println("FAILED");
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/displayed-image-survives-decoded-image-cache-pruning.html
+++ b/Tests/LibWeb/Text/input/HTML/displayed-image-survives-decoded-image-cache-pruning.html
@@ -7,7 +7,7 @@
     // still displayed by a live element must survive that pruning: evicting it frees no memory
     // (the displaying element keeps the decoded data alive), but it forces a refetch when script
     // recreates an element with the same URL, e.g. when a framework re-renders the page.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const keptImage = document.createElement("img");
         keptImage.src = "../../../Assets/120.png";
         document.body.appendChild(keptImage);
@@ -36,6 +36,5 @@
         const recreated = document.createElement("img");
         recreated.src = "../../../Assets/120.png";
         println(`recreated image is completely available: ${recreated.complete && recreated.naturalWidth > 0}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-cancels-delayed-parserless-completion.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-cancels-delayed-parserless-completion.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const popup = window.open();
         const popupDocument = popup.document;
 
@@ -35,6 +35,5 @@
         println(`Replacement load events: ${loadCount}`);
         println(`Replacement pageshow events: ${pageshowCount}`);
         popup.close();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-from-deferred-script.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-from-deferred-script.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         window.deferredScriptRan = false;
 
         const iframe = document.createElement("iframe");
@@ -28,6 +28,5 @@
         println(`Replacement text: ${iframeDocument.body.textContent}`);
         iframe.remove();
         delete window.deferredScriptRan;
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/document-open-releases-discarded-script-load-delayers.html
+++ b/Tests/LibWeb/Text/input/HTML/document-open-releases-discarded-script-load-delayers.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         internals.setTestTimeout(15000);
         const httpServer = httpTestServer();
 
@@ -42,6 +42,5 @@
 
         await verifyReplacementLoadsBeforeDiscardedScript("parsing-blocking", "");
         await verifyReplacementLoadsBeforeDiscardedScript("deferred", "defer");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/focus-navigable-container.html
+++ b/Tests/LibWeb/Text/input/HTML/focus-navigable-container.html
@@ -39,7 +39,7 @@
         return object;
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const before = document.getElementById("before");
         const after = document.getElementById("after");
         const object = await createObject();
@@ -112,7 +112,5 @@
         hideAfterFocusFrame.style.display = "none";
         hideAfterFocusFrame.blur();
         println(`hidden focused iframe blur: active=${activeElementName()}, frameBlur=${hideAfterFocusFrameBlurCount}, windowBlur=${hideAfterFocusFrameWindowBlurCount}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/focus-viewport-fallback.html
+++ b/Tests/LibWeb/Text/input/HTML/focus-viewport-fallback.html
@@ -15,7 +15,7 @@
         return document.activeElement.id || document.activeElement.localName;
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => window.addEventListener("load", resolve, { once: true }));
         await timeout(0);
 
@@ -41,7 +41,5 @@
         location.hash = fragmentTarget.id;
         await scrolled;
         println(`after fragment focus fallback: ${activeElementName()}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-detached-image-data-buffer.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-detached-image-data-buffer.html
@@ -12,14 +12,12 @@
     const buffer = imageData.data.buffer;
     window.postMessage("", "*", [buffer]);
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         try {
             const result = await createImageBitmap(imageData);
             println("Failed");
         } catch (error) {
             println(error.message);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-image-data.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-image-data.html
@@ -12,14 +12,13 @@
     ctx.fillRect(0, 0, 10, 10);
     let imageData = ctx.getImageData(0, 0, 20, 20);
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         try {
             const bitmap = await createImageBitmap(imageData);
             println(`[Success]: ${bitmap}`);
         } catch (err) {
             println(`[ Error ]: ${err}`);
         }
-        done();
     });
 </script>
 </body>

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-invalid-types-no-crash.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-invalid-types-no-crash.html
@@ -38,7 +38,7 @@
         [video, "HTMLVideoElement"],
     ];
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         for (const [type, name] of types) {
             try {
                 const result = await createImageBitmap(type, 0, 0, 20, 20);
@@ -47,7 +47,5 @@
                 println(`${name.padEnd(17, " ")} [ Error ]: ${err}`);
             }
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/image-decode-rejects-if-current-request-changes.html
+++ b/Tests/LibWeb/Text/input/HTML/image-decode-rejects-if-current-request-changes.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script>
 // Test: decode() must reject if the image's current request changes after decode begins.
-asyncTest(async done => {
+promiseTest(async () => {
     const server = httpTestServer();
     const slowImageUrl = await server.createEcho("GET", "/decode-mutation-slow.svg", {
         status: 200,
@@ -36,7 +36,5 @@ asyncTest(async done => {
         else
             println("PASS");
     }
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/image-decode-rejects-when-source-changes-before-request.html
+++ b/Tests/LibWeb/Text/input/HTML/image-decode-rejects-when-source-changes-before-request.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-asyncTest(async done => {
+promiseTest(async () => {
     const image = new Image();
     image.src = "../../../Assets/120.png?image-decode-source-change";
 
@@ -14,7 +14,5 @@ asyncTest(async done => {
     } catch (error) {
         println(error.name === "EncodingError" ? "PASS" : `FAIL: ${error.name}`);
     }
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/image-srcset-device-pixel-ratio.html
+++ b/Tests/LibWeb/Text/input/HTML/image-srcset-device-pixel-ratio.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         function basename(url) {
             return url.substring(url.lastIndexOf("/") + 1);
         }
@@ -25,6 +25,5 @@
         println("At 1x: " + (await selectedSourceAt(1)));
         println("At 2x: " + (await selectedSourceAt(2)));
         println("At 3x: " + (await selectedSourceAt(3)));
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/img-pending-load-renders-blank-not-alt-text.html
+++ b/Tests/LibWeb/Text/input/HTML/img-pending-load-renders-blank-not-alt-text.html
@@ -6,7 +6,7 @@
     // must render as blank space, not as its alt text; the fallback text is only for images that
     // failed or that have no source at all. This matches Chrome and Firefox, and avoids flashing
     // alt text on pages that are still loading their images.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const TINY_PNG_BASE64 =
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
@@ -62,7 +62,5 @@
         await fetch(new URL(`/unblock/${unblockToken}`, pendingURL));
         await pendingImageLoaded;
         println(`unblocked image loaded with natural width: ${pendingImage.naturalWidth}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/img-src-change-swaps-alt-and-image-representation.html
+++ b/Tests/LibWeb/Text/input/HTML/img-src-change-swaps-alt-and-image-representation.html
@@ -6,7 +6,7 @@
     // directions: alt text for a broken or source-less image, blank space while a load is in
     // flight, and the image itself once data arrives. Each transition changes which kind of
     // layout node the element gets, so this exercises the invalidation that rebuilds it.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const TINY_PNG_BASE64 =
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
@@ -61,7 +61,5 @@
         img.src = secondBrokenURL;
         await erroredAgain;
         println(`image still renders alt text after another failed load: ${width(img) > 0}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/lang-attribute-empty-1.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-attribute-empty-1.html
@@ -13,13 +13,12 @@
     </body>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 50) {
                 println("OK");
             } else {
                 println("FAIL. If an element contains a lang attribute with an empty value, the value of a lang attribute higher up the document tree will no longer be applied to the content of that element.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lang-attribute-empty-2.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-attribute-empty-2.html
@@ -13,13 +13,12 @@
     </body>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 50) {
                 println("OK");
             } else {
                 println("FAIL. If the meta Content-Language element contains a language declaration but the html element uses an empty lang value, the UA will not recognize the language declared in the meta Content-Language element.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lang-pragma-set-1.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-pragma-set-1.html
@@ -13,13 +13,12 @@
 </html>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 100) {
                 println("OK");
             } else {
                 println("FAIL. If there is a pragma-set default language set, then that is the language of the node.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lang-pragma-set-2.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-pragma-set-2.html
@@ -15,13 +15,12 @@
 </html>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 100) {
                 println("OK");
             } else {
                 println("FAIL. If there is a pragma-set default language set, then that is the language of the node. It should match the first non-whitespace code points from the contet attribute.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lang-pragma-set-3.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-pragma-set-3.html
@@ -13,13 +13,12 @@
 </html>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 50) {
                 println("OK");
             } else {
                 println("FAIL. If the element's content attribute contains a U+002C COMMA character (,) then return.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lang-pragma-set-4.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-pragma-set-4.html
@@ -13,13 +13,12 @@
 </html>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 50) {
                 println("OK");
             } else {
                 println("FAIL. If candidate is the empty string, return.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lang-pragma-set-5.html
+++ b/Tests/LibWeb/Text/input/HTML/lang-pragma-set-5.html
@@ -13,13 +13,12 @@
 </html>
     <script src="../include.js"></script>
     <script>
-        asyncTest((done) => {
+        test(() => {
             if (document.getElementById('box').offsetWidth == 50) {
                 println("OK");
             } else {
                 println("FAIL. If the meta element has no content attribute, then return.");
             }
-            done();
         });
     </script>
 </html>

--- a/Tests/LibWeb/Text/input/HTML/lzw-image-without-EOI-should-still-load.html
+++ b/Tests/LibWeb/Text/input/HTML/lzw-image-without-EOI-should-still-load.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const sources = [
             { format: "GIF",  src: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" },
         ];
@@ -19,6 +19,5 @@
                 image.src = src;
             });
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
+++ b/Tests/LibWeb/Text/input/HTML/parser-created-style-script-blocking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         internals.setTestTimeout(10000);
 
         const httpServer = httpTestServer();
@@ -174,7 +174,5 @@
             ${scriptEnd}
         `);
         println(`SVG media change blocked until import finished: ${changedSvgMediaBlocked}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/picture-source-mutation.html
+++ b/Tests/LibWeb/Text/input/HTML/picture-source-mutation.html
@@ -5,7 +5,7 @@
     const RED_PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==";
     const BLUE_PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgAAIAAAUAAen63NgAAAAASUVORK5CYII=";
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const picture = document.createElement("picture");
         const source = document.createElement("source");
         source.setAttribute("srcset", RED_PNG_DATA_URL);
@@ -46,7 +46,5 @@
         picture.removeChild(newSource);
         await fourthLoaded;
         println(`re-evaluated on source removal: ${img.currentSrc === BLUE_PNG_DATA_URL}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/session-storage-event-fired-to-lazy-window.html
+++ b/Tests/LibWeb/Text/input/HTML/session-storage-event-fired-to-lazy-window.html
@@ -4,7 +4,7 @@
     // Verify that a storage event is fired to a window that has not yet accessed
     // sessionStorage - i.e. its Storage object has not yet been lazily created.
     // See: https://github.com/whatwg/html/issues/10135
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const key = 'my-key';
 
         const eventReceived = Promise.withResolvers();
@@ -25,6 +25,5 @@
         println(`storageArea: ${e.storageAreaString}`);
 
         sessionStorage.removeItem(key);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/video-ends-while-page-hidden.html
+++ b/Tests/LibWeb/Text/input/HTML/video-ends-while-page-hidden.html
@@ -4,7 +4,7 @@
 <script>
     const video = document.getElementById("video");
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         video.src = "../../../Assets/test-webm.webm";
         await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
 
@@ -16,6 +16,5 @@
         await new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
 
         println(`ended while hidden, currentTime === duration: ${video.currentTime === video.duration}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/video-only-ends-while-page-hidden.html
+++ b/Tests/LibWeb/Text/input/HTML/video-only-ends-while-page-hidden.html
@@ -7,7 +7,7 @@
     // verified end time for the track.
     const video = document.getElementById("video");
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         video.src = "../../../Assets/resize-320x240-640x480.webm";
         await new Promise(resolve => video.addEventListener("loadedmetadata", resolve, { once: true }));
 
@@ -16,6 +16,5 @@
         await new Promise(resolve => video.addEventListener("ended", resolve, { once: true }));
 
         println(`ended while hidden, currentTime === duration: ${video.currentTime === video.duration}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/window-open-about-blank-inherits-opener-origin.html
+++ b/Tests/LibWeb/Text/input/HTML/window-open-about-blank-inherits-opener-origin.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const popup = window.open();
         const initialDocument = popup.document;
         const initialTextContent = "Hello Shannon!";
@@ -37,6 +37,5 @@
         }
 
         popup.close();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Layout/image-load-intrinsic-size-invalidation.html
+++ b/Tests/LibWeb/Text/input/Layout/image-load-intrinsic-size-invalidation.html
@@ -50,7 +50,7 @@
         };
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         document.body.offsetWidth;
 
         const cases = Array.from(document.querySelectorAll(".shrink"));
@@ -65,7 +65,5 @@
             const rect = roundedRectForCase(container.id);
             println(`${container.id}: container=${rect.containerWidth} image=${rect.imageWidth}x${rect.imageHeight}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/active-observer-survives-gc.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/active-observer-survives-gc.html
@@ -8,7 +8,7 @@
 <script src="../include.js"></script>
 <div id="target"></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const target = document.getElementById("target");
         let callbackCount = 0;
         let resolveInitialCallback;
@@ -36,6 +36,5 @@
         await timeout(0);
 
         println(`callbacks from resize after dropping observer: ${callbackCount}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/active-target-survives-earlier-callback-gc.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/active-target-survives-earlier-callback-gc.html
@@ -11,7 +11,7 @@
 <script>
     let secondTarget = null;
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         let firstCallbackCount = 0;
         let secondCallbackCount = 0;
         secondTarget = document.getElementById("second");
@@ -45,6 +45,5 @@
         println(`second observer callbacks: ${secondCallbackCount}`);
 
         observers = null;
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/activity-root-released-on-document-destroy.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/activity-root-released-on-document-destroy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const frame = document.createElement("iframe");
         document.body.append(frame);
         frame.contentDocument.body.innerHTML = `<div id="target" style="width: 100px; height: 100px"></div>`;
@@ -12,6 +12,5 @@
         frame.remove();
         await internals.gcAsync();
         println(`root after destroy: ${internals.hasActivityRoot(observer)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/dead-observer-does-not-skip-active-observer.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/dead-observer-does-not-skip-active-observer.html
@@ -10,7 +10,7 @@
 <script>
     let deadBox = null;
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         let deadObserver = new ResizeObserver(() => {
             println("dead observer callback");
         });
@@ -39,7 +39,5 @@
         await animationFrame();
         await timeout(0);
         println(`active callbacks after second rendering opportunity: ${activeCallbackCount}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/disconnect.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/disconnect.html
@@ -23,7 +23,7 @@
 </body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const outerBox = document.getElementById("outer");
         const innerBox = document.getElementById("inner");
 
@@ -66,7 +66,5 @@
 
         // Let event loop run to ensure that observer callback is not invoked.
         await createTimeoutPromise(0);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/notify-if-node-is-removed.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/notify-if-node-is-removed.html
@@ -13,7 +13,7 @@
 </body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const box = document.getElementById("box");
 
         let resolve = null;
@@ -40,7 +40,5 @@
 
         observerCallbackInvocation = createResizeObserverPromise();
         await observerCallbackInvocation;
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/notify-if-parent-is-removed.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/notify-if-parent-is-removed.html
@@ -13,7 +13,7 @@
 </body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const box = document.getElementById("box");
 
         let resolve = null;
@@ -40,7 +40,5 @@
 
         observerCallbackInvocation = createResizeObserverPromise();
         await observerCallbackInvocation;
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/observe-border-box.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/observe-border-box.html
@@ -17,7 +17,7 @@
 </body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const box = document.getElementById("box");
 
         let resolve = null;
@@ -51,7 +51,5 @@
 
         observerCallbackInvocation = createResizeObserverPromise();
         await observerCallbackInvocation;
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/observe.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/observe.html
@@ -13,7 +13,7 @@
 </body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const box = document.getElementById("box");
 
         let resolve = null;
@@ -53,7 +53,5 @@
 
         observerCallbackInvocation = createResizeObserverPromise();
         await observerCallbackInvocation;
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/ResizeObserver/unobserve.html
+++ b/Tests/LibWeb/Text/input/ResizeObserver/unobserve.html
@@ -13,7 +13,7 @@
 </body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const box = document.getElementById("box");
 
         let resolve = null;
@@ -49,7 +49,5 @@
 
         // Let event loop run to ensure that observer callback is not invoked.
         await createTimeoutPromise(0);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/SiteIsolation/cross-site-form-post-origin-and-referer.html
+++ b/Tests/LibWeb/Text/input/SiteIsolation/cross-site-form-post-origin-and-referer.html
@@ -5,7 +5,7 @@
     // WebContent process when site isolation is enabled. The navigation state carried over to the new process
     // must include the initiator origin and referrer, so the request is sent with the correct Origin and
     // Referer headers instead of "Origin: null" and no Referer.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const httpServer = httpTestServer();
         const formPageOrigin = new URL(httpServer.baseURL).origin;
 
@@ -55,6 +55,5 @@
         try {
             popup.close();
         } catch {}
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-locked-stream.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-locked-stream.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(done => {
+    test(() => {
         const transformStream = new TransformStream();
 
         const stream = new ReadableStream();
@@ -13,6 +13,5 @@
         catch (e) {
             println(e);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-to-locked-stream.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-pipeThrough-cannot-pipe-to-locked-stream.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(done => {
+    test(() => {
         const transformStream = new TransformStream();
 
         const stream = new ReadableStream();
@@ -13,6 +13,5 @@
         catch (e) {
             println(e);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-read-detached-chunk.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-read-detached-chunk.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // Reading a stream whose chunk is a Uint8Array backed by a detached ArrayBuffer must resolve with an empty
         // result, not crash. (issue #9965)
         const buffer = new ArrayBuffer(8);
@@ -22,6 +22,5 @@
         } catch (e) {
             println(`rejected: ${e.name}: ${e.message}`);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-read-out-of-bounds-chunk.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-read-out-of-bounds-chunk.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // A fixed-length view whose resizable ArrayBuffer is shrunk below it becomes out-of-bounds; reading such a
         // chunk must resolve empty, not crash. (issue #9965)
         const buffer = new ArrayBuffer(8, { maxByteLength: 8 });
@@ -21,6 +21,5 @@
         } catch (e) {
             println(`rejected: ${e.name}: ${e.message}`);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-read-subview-chunk.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-read-subview-chunk.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // A valid Uint8Array chunk with a non-zero byteOffset must round-trip its exact bytes through
         // Response.arrayBuffer(). (issue #9965)
         const backing = new Uint8Array([10, 11, 12, 13, 14, 15]);
@@ -16,6 +16,5 @@
 
         const out = new Uint8Array(await new Response(stream).arrayBuffer());
         println(`length=${out.length} bytes=${Array.from(out).join(",")}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-min.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-min.html
@@ -63,8 +63,7 @@
         }
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await readStream(readableStream);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-non-transferable-buffer.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-non-transferable-buffer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         {
             const stream = new ReadableStream({ type: "bytes" });
             const reader = stream.getReader({ mode: "byob" });
@@ -57,7 +57,5 @@
 
             println(`RespondWithNewView buffer byteLength: ${memory.buffer.byteLength}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read.html
@@ -30,9 +30,8 @@
     }
   }
 
-  asyncTest(async done => {
+  promiseTest(async () => {
     await testByobRead(Uint8Array);
     await testByobRead(DataView);
-    done();
   });
 </script>

--- a/Tests/LibWeb/Text/input/UIEvents/UIEventInit-view.html
+++ b/Tests/LibWeb/Text/input/UIEvents/UIEventInit-view.html
@@ -9,7 +9,7 @@
 <script src="../include.js"></script>
 <body></body>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         let events = [
             { name: "click", trigger: (x, y) => internals.click(x, y) },
             { name: "dblclick", trigger: (x, y) => internals.click(x, y, 2) },
@@ -40,6 +40,5 @@
             await promise;
             target.remove();
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/UIEvents/gc-mouse-selection-target.html
+++ b/Tests/LibWeb/Text/input/UIEvents/gc-mouse-selection-target.html
@@ -25,13 +25,12 @@
         });
     };
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         for (let i = 0; i < 10; ++i) {
             await runTest();
             internals.gc();
         }
 
         println("PASS (didn't crash)");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/UIEvents/middle-click-generated-content-link-autoscroll.html
+++ b/Tests/LibWeb/Text/input/UIEvents/middle-click-generated-content-link-autoscroll.html
@@ -18,7 +18,7 @@
 <a id="generated" href="about:blank"></a>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         async function middleDragFrom(element) {
             const rect = element.getBoundingClientRect();
             const x = rect.left + rect.width / 2;
@@ -42,7 +42,5 @@
 
         await middleDragFrom(generated);
         println(`generated-content link scrollY: ${scrollY}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/UIEvents/mouse-events.html
+++ b/Tests/LibWeb/Text/input/UIEvents/mouse-events.html
@@ -77,7 +77,7 @@ const clickOnOuterBox = (button) => {
     });
 };
 
-asyncTest(async done => {
+promiseTest(async () => {
     // First move the mouse outside #outer to populate the MouseEvent.relatedTarget property
     internals.mouseMove(150, 150);
     println("> move pointer over #inner");
@@ -90,6 +90,5 @@ asyncTest(async done => {
     await clickOnOuterBox(1);
     println("> click document.body");
     await clickOnBody();
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/Wasm/WebAssembly-exported-function-metadata.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAssembly-exported-function-metadata.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const wasmBytes = new Uint8Array([
             0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
             0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f,
@@ -46,7 +46,5 @@
 
         println(`imported function 0 name: ${importedFunctionInstance.exports.table.get(0).name}`);
         println(`imported function 1 name: ${importedFunctionInstance.exports.table.get(1).name}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Wasm/WebAssembly-grow-hook.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAssembly-grow-hook.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const arrayBuffer = new Uint8Array([
             0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
             0x01, 0x00, 0x05, 0x04, 0x01, 0x01, 0x01, 0x02, 0x07, 0x11, 0x02, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
@@ -17,6 +17,5 @@
         println(`Size after grow, before refresh: ${wasmMemoryBuffer.byteLength}`);
         wasmMemoryBuffer = wasm.instance.exports.memory.buffer;
         println(`Size after grow, after refresh: ${wasmMemoryBuffer.byteLength}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Wasm/WebAssembly-instantiate-streaming.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAssembly-instantiate-streaming.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const WASM_FILE = "../../data/greeter.wasm";
 
         let wasm;
@@ -96,7 +96,5 @@
                 println(`FAILED: Mismatch at byte ${i}`);
             }
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Wasm/WebAssembly-memory-reexport.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAssembly-memory-reexport.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // (module
         //     (import "env" "memory" (memory $mem 1))
         //     (export "memory" (memory $mem))
@@ -15,6 +15,5 @@
         } = await WebAssembly.instantiateStreaming(fetch(WASM_URL), { env: { memory } });
 
         println(`Re-exported memory equals imported memory: ${memory === exports.memory}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Wasm/WebAsssembly-invalid-module-crashes.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAsssembly-invalid-module-crashes.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const testCases = [
             "AGFzbQEAAAAJEhAAHwAABQ==", // Structured else has argument type that isn't StructuredInstructionArgs
             "AGFzbQEAAAANAwEABA==",     // Type index in tag section is out of bounds
@@ -17,6 +17,5 @@
         }
 
         println("PASS! (Didn't crash)");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/WebAudio/OfflineAudioContext.html
+++ b/Tests/LibWeb/Text/input/WebAudio/OfflineAudioContext.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // Once the ctor‑offlineaudiocontext WPT test is updated to check
         // renderQuantumSize and renderSizeHint, this test is not needed.
         const audioContext = new OfflineAudioContext(1, 1, 44100)
@@ -16,7 +16,5 @@
         } catch (e) {
             println(`${e}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/WebSocket/activity-root-released-on-document-destroy.html
+++ b/Tests/LibWeb/Text/input/WebSocket/activity-root-released-on-document-destroy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const frame = document.createElement("iframe");
         document.body.append(frame);
 
@@ -19,6 +19,5 @@
         frame.remove();
         await internals.gcAsync();
         println(`root after destroy: ${internals.hasActivityRoot(webSocket)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Worker/SharedWorker-reuse.html
+++ b/Tests/LibWeb/Text/input/Worker/SharedWorker-reuse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const workerScript = `
             let connections = 0;
             onconnect = event => {
@@ -50,7 +50,5 @@
 
         worker2.port.postMessage("two");
         println(`worker2: ${await nextMessage(worker2)}`); // "echo 2: two"
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Worker/Worker-echo.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-echo.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const work = new Worker("worker.js");
         const channel = new MessageChannel();
 
@@ -25,6 +25,5 @@
 
         println("DONE");
         work.terminate();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/Worker/Worker-name.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-name.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         function nextMessage(target) {
             return new Promise(resolve => {
                 target.addEventListener("message", function handler(event) {
@@ -55,6 +55,5 @@
         println(`shared worker reused by matching name: ${sharedWorkerMessage2.connection === 2}`);
 
         URL.revokeObjectURL(sharedWorkerURL);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-network-error-message.html
+++ b/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-network-error-message.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const server = httpTestServer();
 
         const url = await server.createEcho("GET", "/close-connection", {
@@ -18,6 +18,5 @@
             println(e.name);
             println(e.message);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-override-mimetype-blob.html
+++ b/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-override-mimetype-blob.html
@@ -24,7 +24,7 @@
         });
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         try {
             const httpServer = httpTestServer();
             const url = await httpServer.createEcho("GET", "/xhr-override-mimetype-no-content-type-test", {
@@ -55,6 +55,5 @@
         } catch (err) {
             println("FAIL - " + err);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-request-body-is-reset-on-reopen.html
+++ b/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-request-body-is-reset-on-reopen.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         try {
             const server = httpTestServer();
 
@@ -47,6 +47,5 @@
         } catch (e) {
             println("FAIL: " + e.message);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/XHR/activity-root-released-on-document-destroy.html
+++ b/Tests/LibWeb/Text/input/XHR/activity-root-released-on-document-destroy.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const server = httpTestServer();
         const url = await server.createEcho("GET", "/xhr-activity-root-release", {
             status: 200,
@@ -29,6 +29,5 @@
         frame.remove();
         await internals.gcAsync();
         println(`root after destroy: ${internals.hasActivityRoot(xhr)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-anchor-elsewhere.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-anchor-elsewhere.html
@@ -42,7 +42,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const tooltipBefore = document.getElementById("tooltip").getBoundingClientRect();
@@ -63,6 +63,5 @@
             && rectToString(tooltipBefore) === "90,0,50,15"
             && rectToString(tooltipAfter) === "90,0,50,15"
             && rectToString(child) === "40,120,70,50" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-anchor-inset-style-change.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-anchor-inset-style-change.html
@@ -32,7 +32,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const anchoredBefore = document.getElementById("anchored").getBoundingClientRect();
@@ -55,6 +55,5 @@
             && rectToString(anchor) === "60,40,100,30"
             && rectToString(anchoredBefore) === "10,10,80,25"
             && rectToString(anchoredAfter) === "160,40,80,25" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-anchor-name-inside.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-anchor-name-inside.html
@@ -42,7 +42,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const anchorBefore = document.getElementById("anchor").getBoundingClientRect();
@@ -66,6 +66,5 @@
             && rectToString(targetBefore) === "50,90,60,25"
             && rectToString(anchorAfter) === "50,100,50,20"
             && rectToString(targetAfter) === "50,120,60,25" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-anchor-name-removal.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-anchor-name-removal.html
@@ -42,7 +42,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const consumerBefore = document.getElementById("consumer").getBoundingClientRect();
@@ -60,6 +60,5 @@
         println(partialDelta === 0 && fullDelta >= 1
             && rectToString(consumerBefore) === "100,70,60,25"
             && rectToString(consumerAfter) === "5,5,60,25" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-anchor-repaint-restyle.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-anchor-repaint-restyle.html
@@ -35,7 +35,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         document.getElementById("anchored").style.color = "red";
@@ -51,6 +51,5 @@
         println(`anchored=${rectToString(anchored)}`);
         println(partialDelta === 0 && fullDelta === 1
             && rectToString(anchored) === "60,70,120,60" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-anchor-target-boundary.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-anchor-target-boundary.html
@@ -33,7 +33,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const anchoredBefore = document.getElementById("anchored").getBoundingClientRect();
@@ -57,6 +57,5 @@
             && rectToString(anchoredBefore) === "40,60,120,20"
             && rectToString(anchoredAfter) === "40,60,120,60"
             && rectToString(inner) === "40,60,80,60" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-append-direct-many.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-append-direct-many.html
@@ -28,7 +28,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -57,6 +57,5 @@
             && rectToString(two) === "75,55,25,10"
             && rectToString(three) === "95,80,30,12"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-arena-slot-churn.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-arena-slot-churn.html
@@ -20,7 +20,7 @@
     // Structural partial relayout frees the replaced layout nodes before allocating their
     // replacements. The arena reuses those slots, keeping the per-pass used values store
     // bounded without periodic full passes to compact a separate index space.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const iterations = 400;
@@ -44,6 +44,5 @@
         println(partialDelta === iterations
             && fullDelta === 0
             && boundaryRect.height === 40 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-aspect-ratio.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-aspect-ratio.html
@@ -22,7 +22,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -43,6 +43,5 @@
         println(rectToString(rect) === "20,10,150,100"
             && rectToString(content) === "20,10,80,30"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-backdrop-style-change.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-backdrop-style-change.html
@@ -23,7 +23,7 @@
     // invalidation. A class toggle whose only relayout effect is on the ::backdrop must not
     // ride the boundary-self fast path, or the backdrop keeps stale geometry; it has to take
     // the full layout path.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const dialog = document.getElementById("dialog");
         dialog.showModal();
         document.body.offsetHeight;
@@ -37,6 +37,5 @@
 
         println(`layout-passes partial=${partialDelta} full=${fullDelta}`);
         println(partialDelta === 0 && fullDelta >= 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-basic.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-basic.html
@@ -27,7 +27,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const outsideBefore = document.getElementById("outside").getBoundingClientRect();
@@ -47,6 +47,5 @@
         println(child.left === 40 && child.top === 30 && child.width === 70 && child.height === 60
             && rectToString(outsideBefore) === rectToString(outsideAfter)
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-boundary-style-change.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-boundary-style-change.html
@@ -27,7 +27,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -48,6 +48,5 @@
         println(rectToString(boundaryRect) === "40,30,180,90"
             && rectToString(childRect) === "180,45,30,20"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-contain-toggle.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-contain-toggle.html
@@ -43,7 +43,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -71,6 +71,5 @@
             && partialDeltaAfterToggle === 0 && fullDeltaAfterToggle === 1
             && rectToString(fixedBeforeToggle) === "80,100,50,20"
             && rectToString(fixedAfterToggle) === "30,40,50,20" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-container-query.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-container-query.html
@@ -33,7 +33,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const target = document.getElementById("target");
@@ -56,6 +56,5 @@
             && rectToString(container) === "10,10,200,60"
             && colorAfter === "rgb(0, 128, 0)"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-content-growth-updates-scroller.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-content-growth-updates-scroller.html
@@ -18,7 +18,7 @@
     <div id="boundary"><div id="content"></div></div>
 </div>
 <script>
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const scroller = document.getElementById("scroller");
@@ -40,6 +40,5 @@
         println(boundaryHeight === 400
             && scrollHeightBefore === 150 && scrollHeightAfter === 420
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-continuation.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-continuation.html
@@ -41,7 +41,7 @@
         return `${rect.left - containerRect.left},${rect.top - containerRect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -65,6 +65,5 @@
         println(`rects-match=${rectsMatch}`);
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectsMatch && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-direct-child-geometry.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-direct-child-geometry.html
@@ -43,7 +43,7 @@
         return `${rect.left - containerRect.left},${rect.top - containerRect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const liveBoundary = document.getElementById("live-boundary");
@@ -67,6 +67,5 @@
         println(liveRect === "50,0,14,16"
             && liveRect === referenceRect
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-escaping-fixed-removal.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-escaping-fixed-removal.html
@@ -34,7 +34,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -61,6 +61,5 @@
         println(partialDeltaWhileEscaping === 0 && fullDeltaWhileEscaping === 1
             && partialDeltaAfterRemoval === 1 && fullDeltaAfterRemoval === 0
             && rectToString(child) === "50,60,60,60" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-fixed-cb-toggle.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-fixed-cb-toggle.html
@@ -43,7 +43,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -71,6 +71,5 @@
             && partialDeltaAfterToggle === 0 && fullDeltaAfterToggle === 1
             && rectToString(fixedBeforeToggle) === "90,120,50,20"
             && rectToString(fixedAfterToggle) === "30,40,50,20" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-fixed-cb.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-fixed-cb.html
@@ -32,7 +32,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -53,6 +53,5 @@
             && rectToString(fixed) === "75,80,40,20"
             && rectToString(sibling) === "60,70,80,65"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-fixed-descendant-fallback.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-fixed-descendant-fallback.html
@@ -31,7 +31,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const fixedBefore = document.getElementById("fixed").getBoundingClientRect();
@@ -52,6 +52,5 @@
             && rectToString(fixedBefore) === rectToString(fixedAfter)
             && rectToString(sibling) === "100,100,80,70"
             && partialDelta === 0 && fullDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-grid-area-boundary.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-grid-area-boundary.html
@@ -27,7 +27,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -57,6 +57,5 @@
             && subtreePartialDelta === 1 && subtreeFullDelta === 0
             && selfRect === "110,90,180,100"
             && selfPartialDelta === 0 && selfFullDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-inline-containing-block.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-inline-containing-block.html
@@ -22,7 +22,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -45,6 +45,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(before === after && contentRect.width === 60
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-direct-child.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-direct-child.html
@@ -30,7 +30,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -50,6 +50,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(inserted) === "50,45,30,20"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-display-none.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-display-none.html
@@ -25,7 +25,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const siblingBefore = document.getElementById("sibling").getBoundingClientRect();
@@ -51,6 +51,5 @@
         println(insertedRects === 0
             && rectToString(siblingBefore) === rectToString(siblingAfter)
             && partialDelta === 0 && fullDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-fixed-fallback.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-fixed-fallback.html
@@ -30,7 +30,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -49,6 +49,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(fixedRect) === "25,18,35,20"
             && partialDelta === 0 && fullDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-static-position.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-static-position.html
@@ -35,7 +35,7 @@
         return `${rect.left - containerRect.left},${rect.top - containerRect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -58,6 +58,5 @@
         println(liveRect === "0,25,40,15"
             && liveRect === referenceRect
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-table-row.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-table-row.html
@@ -40,7 +40,7 @@
         return `${rect.left - containerRect.left},${rect.top - containerRect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const outsideBefore = localRectToString(document.getElementById("outside-new"), document.getElementById("outside-table"));
@@ -65,6 +65,5 @@
             && outsideBefore === outsideAfter
             && liveRect === outsideAfter
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-under-body.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-under-body.html
@@ -15,7 +15,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -34,6 +34,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(insertedRect) === "70,45,30,20"
             && partialDelta === 0 && fullDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-insert-under-descendant.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-insert-under-descendant.html
@@ -33,7 +33,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const outsideBefore = document.getElementById("outside").getBoundingClientRect();
@@ -58,6 +58,5 @@
         println(rectToString(inserted) === "55,40,35,20"
             && rectToString(outsideBefore) === rectToString(outsideAfter)
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-inset-stretch.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-inset-stretch.html
@@ -20,7 +20,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -38,6 +38,5 @@
         println(boundary.left === 0 && boundary.top === 0 && boundary.width === 320 && boundary.height === 180
             && child.left === 0 && child.top === 0 && child.width === 100 && child.height === 70
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-min-content-width.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-min-content-width.html
@@ -22,7 +22,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -42,6 +42,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(before === "20,10,60,80" && after === "20,10,110,80"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-before.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-before.html
@@ -52,7 +52,7 @@
         return `${rect.left - containerRect.left},${rect.top - containerRect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const move = document.getElementById("move");
@@ -87,6 +87,5 @@
             && paintCount === 1
             && !oldHitIsMoved
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-inset-only.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-inset-only.html
@@ -20,7 +20,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -39,6 +39,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(rect) === "70,80,100,50"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-margin-change.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-margin-change.html
@@ -20,7 +20,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -39,6 +39,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(rect) === "35,25,100,50"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-multiple-boxes.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-multiple-boxes.html
@@ -23,7 +23,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -48,6 +48,5 @@
             && rectToString(rectB) === "50,150,40,30"
             && rectToString(rectC) === "200,0,40,30"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-percentage-insets.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-percentage-insets.html
@@ -20,7 +20,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -39,6 +39,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(rect) === "200,150,100,50"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-static-position.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-static-position.html
@@ -22,7 +22,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -40,6 +40,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(rect) === "0,60,150,60"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-move-updates-ancestor-overflow.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-move-updates-ancestor-overflow.html
@@ -21,7 +21,7 @@
     <div id="boundary"></div>
 </div>
 <script>
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const scroller = document.getElementById("scroller");
@@ -43,6 +43,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(scrollHeightAfter === 550
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-nested-boundaries.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-nested-boundaries.html
@@ -40,7 +40,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const betweenBefore = document.getElementById("between").getBoundingClientRect();
@@ -66,6 +66,5 @@
             && rectToString(betweenBefore) === rectToString(betweenAfter)
             && rectToString(child) === "70,70,60,40"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-new-container-query.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-new-container-query.html
@@ -27,7 +27,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const holder = document.createElement("div");
@@ -41,6 +41,5 @@
         const cqRect = cqChild.getBoundingClientRect();
         println(`cq-child=${rectToString(cqRect)}`);
         println(cqRect.width === 90 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-overflow-visible.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-overflow-visible.html
@@ -26,7 +26,7 @@
     </div>
 </div>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const scroller = document.getElementById("scroller");
@@ -43,6 +43,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(scrollHeightBefore === 100 && scroller.scrollHeight === 190
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-percentage-size.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-percentage-size.html
@@ -23,7 +23,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -41,6 +41,5 @@
         println(boundary.left === 30 && boundary.top === 20 && boundary.width === 200 && boundary.height === 150
             && child.left === 30 && child.top === 20 && child.width === 75 && child.height === 90
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-remove-reinsert.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-remove-reinsert.html
@@ -30,7 +30,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const moving = document.getElementById("moving");
@@ -50,6 +50,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(movingRect) === "55,40,35,20"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-remove-under-descendant.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-remove-under-descendant.html
@@ -38,7 +38,7 @@
         return displayList.split(`color=${color}`).length - 1;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const removed = document.getElementById("removed");
@@ -64,6 +64,5 @@
             && paintCount === 0
             && rectToString(outsideBefore) === rectToString(outsideAfter)
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-rtl-static-position.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-rtl-static-position.html
@@ -30,7 +30,7 @@
         return `${rect.left - rootRect.left},${rect.top - rootRect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -49,6 +49,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(live === reference
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-scroller.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-scroller.html
@@ -27,7 +27,7 @@
     </div>
 </div>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const scroller = document.getElementById("boundary");
@@ -46,6 +46,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(scroller.scrollTop === 150 && hit && hit.id === "probe"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-selection-preserved.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-selection-preserved.html
@@ -20,7 +20,7 @@
     </div>
 </div>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         // Select the text inside the boundary.
@@ -50,6 +50,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(`selection-painting-matches-full-layout=${afterPartial === afterFull}`);
         println(partialDelta === 1 && fullDelta === 1 && afterPartial === afterFull ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-shadow-child-reveal.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-shadow-child-reveal.html
@@ -27,7 +27,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const shadow = document.getElementById("host").attachShadow({ mode: "open" });
         const revealed = document.createElement("div");
         revealed.style.cssText = "display: none; width: 120px; height: 50px;";
@@ -50,6 +50,5 @@
         println(partialDelta === 0 && fullDelta >= 1
             && rectToString(revealedRect) === "0,0,120,50"
             && rectToString(childRect) === "40,30,60,40" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-shadow-dom.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-shadow-dom.html
@@ -23,7 +23,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         const host = document.getElementById("host");
         const shadow = host.attachShadow({ mode: "open" });
         shadow.innerHTML = `
@@ -58,6 +58,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(childRect) === "55,35,30,20"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-shrink-to-fit.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-shrink-to-fit.html
@@ -26,7 +26,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const boundaryBefore = document.getElementById("boundary").getBoundingClientRect();
@@ -44,6 +44,5 @@
         println(boundaryBefore.width === 80 && boundaryAfter.width === 180
             && rectToString(content) === "25,20,180,20"
             && partialDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-sibling-paint-order.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-sibling-paint-order.html
@@ -33,7 +33,7 @@
     // splice its rebuilt paint subtree back at its original position; reattaching it at the
     // end of the parent's paintable children would move it on top of the later sibling,
     // changing paint and hit-test order compared to a full layout.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const hitBefore = document.elementFromPoint(150, 110);
@@ -51,6 +51,5 @@
         println(partialDelta === 1 && fullDelta === 0
             && hitBefore && hitBefore.id === "second"
             && hitAfter && hitAfter.id === "second" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-static-position.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-static-position.html
@@ -25,7 +25,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const boundaryBefore = document.getElementById("boundary").getBoundingClientRect();
@@ -46,6 +46,5 @@
             && rectToString(boundaryBefore) === rectToString(boundaryAfter)
             && rectToString(child) === "0,70,80,55"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-svg-inside.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-svg-inside.html
@@ -29,7 +29,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const siblingBefore = document.getElementById("sibling").getBoundingClientRect();
@@ -55,6 +55,5 @@
             && rectToString(siblingBefore) === rectToString(siblingAfter)
             && rectToString(pageSibling) === "0,220,120,30"
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-svg-position-flip.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-svg-position-flip.html
@@ -36,7 +36,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -66,6 +66,5 @@
             && rectToString(svgAfterFlip) === "60,120,100,80"
             && rectToString(childAfterFlip) === "40,30,60,40"
             && rectToString(rectAfterInside) === "60,120,70,40" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-text-into-boundary.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-text-into-boundary.html
@@ -21,7 +21,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const boundary = document.getElementById("boundary");
@@ -41,6 +41,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(rectToString(boundaryBefore) === rectToString(boundaryAfter)
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/abspos-relayout-toplayer-fallback.html
+++ b/Tests/LibWeb/Text/input/abspos-relayout-toplayer-fallback.html
@@ -32,7 +32,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const dialog = document.getElementById("modal");
@@ -52,6 +52,5 @@
         println(dialog.open
             && rectToString(dialogRect) === "70,40,80,50"
             && partialDelta === 0 && fullDelta === 1 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/canvas/2d-draw-invalidates-cached-command.html
+++ b/Tests/LibWeb/Text/input/canvas/2d-draw-invalidates-cached-command.html
@@ -2,7 +2,7 @@
 <canvas id="canvas" width="100" height="100"></canvas>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
         const canvasContentGeneration = () => {
             const match = internals.dumpDisplayList().match(/DrawCanvas@\d+ .*content_generation=(\d+)/);
@@ -26,6 +26,5 @@
 
         const generationAfterDraw = canvasContentGeneration();
         println("cached command has new generation: " + (generationAfterDraw > generationBeforeDraw));
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/canvas/export-offscreencanvas.html
+++ b/Tests/LibWeb/Text/input/canvas/export-offscreencanvas.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         let testCounter = 1;
         async function testPart(part) {
             const currentTest = testCounter++;
@@ -26,7 +26,5 @@
             const result = await offscreenCanvas.convertToBlob({ type: "image/jpeg" });
             return { size: result.size, type: result.type };
         });
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/canvas/webgl-draw-does-not-invalidate-display-list.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-draw-does-not-invalidate-display-list.html
@@ -10,7 +10,7 @@
     //
     // Creating a WebGL context is the exception: it must invalidate the display list, since the
     // recorded DrawCanvas command refers to the context's canvas id.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const lines = [];
         const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
 
@@ -35,6 +35,5 @@
 
         for (const line of lines)
             println(line);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/canvas/webgl-draw-invalidates-cached-command.html
+++ b/Tests/LibWeb/Text/input/canvas/webgl-draw-invalidates-cached-command.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
         const canvasContentGeneration = () => {
             const match = internals.dumpDisplayList().match(/DrawCanvas@\d+ .*content_generation=(\d+)/);
@@ -32,6 +32,5 @@
             canvas.remove();
             await nextFrame();
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/checkbox-focus-lost-no-change-event.html
+++ b/Tests/LibWeb/Text/input/checkbox-focus-lost-no-change-event.html
@@ -6,7 +6,7 @@
     checkbox.addEventListener("change", () => {
       changeEventFired = true;
     });
-    asyncTest(async done => {
+    promiseTest(async () => {
         checkbox.focus();
         await new Promise(resolve => setTimeout(resolve, 0));
         checkbox.blur();
@@ -17,7 +17,5 @@
         } else {
             println("PASS: Change event was not fired");
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/content-blocker-replacement-invalidates-iframe-style.html
+++ b/Tests/LibWeb/Text/input/content-blocker-replacement-invalidates-iframe-style.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="./include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
         iframe.srcdoc = `<div class="ad"></div>`;
@@ -17,7 +17,5 @@
 
         internals.setContentBlockers("");
         println(getComputedStyle(target).display);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/content-blocker-shadow-has-state-invalidation.html
+++ b/Tests/LibWeb/Text/input/content-blocker-shadow-has-state-invalidation.html
@@ -2,7 +2,7 @@
 <script src="./include.js"></script>
 <body></body>
 <script>
-    asyncTest(done => {
+    test(() => {
         spoofCurrentURL("https://example.com/content-blocker-shadow-has-state-invalidation.html");
         internals.setContentBlockers("example.com##div.hover-anchor:has(:hover)\nexample.com##div.modal-anchor:has(dialog:modal)");
 
@@ -44,6 +44,5 @@
         println(`modal after close: ${getComputedStyle(modalAnchor).display}`);
 
         internals.setContentBlockers("");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/content-blocker-shadow-pseudo-class-invalidation.html
+++ b/Tests/LibWeb/Text/input/content-blocker-shadow-pseudo-class-invalidation.html
@@ -2,7 +2,7 @@
 <script src="./include.js"></script>
 <body></body>
 <script>
-    asyncTest(done => {
+    test(() => {
         spoofCurrentURL("https://example.com/content-blocker-shadow-pseudo-class-invalidation.html");
         internals.setContentBlockers("example.com##span:hover");
 
@@ -24,6 +24,5 @@
         println(`hover after leave: ${getComputedStyle(target).display}`);
 
         internals.setContentBlockers("");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/content-blocker-srcdoc-frame-cosmetic-source.html
+++ b/Tests/LibWeb/Text/input/content-blocker-srcdoc-frame-cosmetic-source.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="./include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // The srcdoc iframe inherits its base URL from its parent document. We need it to be localhost so that the
         // content blocker's matching rule will apply to it.
         const base = document.createElement("base");
@@ -27,7 +27,5 @@
         } finally {
             internals.setContentBlockers("");
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/cookie-cache-invalidation.html
+++ b/Tests/LibWeb/Text/input/cookie-cache-invalidation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const parentDomain = `cookie-${crypto.randomUUID()}.example.com`;
         spoofCurrentURL(`https://www.${parentDomain}/cookie-cache-invalidation.html`);
 
@@ -14,6 +14,5 @@
         println(document.cookie);
 
         await internals.deleteAllCookies();
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/CSSStyleSheet-replace.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleSheet-replace.html
@@ -6,7 +6,7 @@
 </style>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const newStyle = `
         .test {
             font-size: 14px;
@@ -45,6 +45,5 @@
         for (const rule of sheet.cssRules) {
             println(`Rule: ${rule.cssText}`);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/FontFace-binary-data.html
+++ b/Tests/LibWeb/Text/input/css/FontFace-binary-data.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const badFace = new FontFace("My Cool Font", new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]));
 
         await badFace.loaded.then(() => {
@@ -36,7 +36,5 @@
         () => {
             println("FAILED");
         });
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/FontFace-load-urls.html
+++ b/Tests/LibWeb/Text/input/css/FontFace-load-urls.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         // FIXME: Surely there's a better way to get this font URL
         let fontUrl = new URL(location.href);
         fontUrl.search = "";
@@ -24,7 +24,5 @@
             println(`font load failed because: ${reason}`);
             println(`notExistFont.status: ${notExistFont.status}`);
         });
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/FontFaceSet-load.html
+++ b/Tests/LibWeb/Text/input/css/FontFaceSet-load.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script type="text/javascript">
-    asyncTest(async done => {
+    promiseTest(async () => {
         const fontFaceSet = document.fonts;
 
         const fontFace = new FontFace("Hash Sans", "url(../../../Assets/HashSans.woff)");
@@ -35,7 +35,5 @@
             println("Load valid font: FAIL");
             println(e);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-count-is-document-scoped.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-count-is-document-scoped.html
@@ -3,7 +3,7 @@
 <script>
     const imageURL = "../wpt-import/images/anim-gr.gif";
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         const iframeLoaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
         iframe.srcdoc = `
@@ -31,7 +31,5 @@
 
         println(`top document has animation state: ${topDocumentHasAnimationState}`);
         println(`iframe document timer active: ${iframe.contentWindow.internals.imageAnimationStateForURL(imageURL).timerActive}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-after-base-change.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-after-base-change.html
@@ -11,7 +11,7 @@
 <script>
     const imageURL = new URL("../wpt-import/images/anim-gr.gif", document.baseURI).href;
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => window.addEventListener("load", resolve));
 
         internals.dumpLayoutTree(document);
@@ -28,6 +28,5 @@
         internals.dumpLayoutTree(document);
         const timerActiveAfterRemoval = internals.imageAnimationStateForURL(imageURL).timerActive;
         println(`timer active after removal: ${timerActiveAfterRemoval}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-after-full-layout-tree-teardown.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-after-full-layout-tree-teardown.html
@@ -12,7 +12,7 @@
 <script>
     const imageURL = "../wpt-import/images/anim-gr.gif";
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => window.addEventListener("load", resolve));
 
         internals.dumpLayoutTree(document);
@@ -25,6 +25,5 @@
         target.style.display = "none";
         internals.dumpLayoutTree(document);
         println(`timer active after hiding: ${internals.imageAnimationStateForURL(imageURL).timerActive}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-after-layout-node-replacement.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-after-layout-node-replacement.html
@@ -11,7 +11,7 @@
 <script>
     const imageURL = "../wpt-import/images/anim-gr.gif";
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => window.addEventListener("load", resolve));
 
         internals.dumpLayoutTree(document);
@@ -24,6 +24,5 @@
         target.style.display = "none";
         internals.dumpLayoutTree(document);
         println(`timer active after hiding: ${internals.imageAnimationStateForURL(imageURL).timerActive}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-when-hidden.html
+++ b/Tests/LibWeb/Text/input/css/animated-background-image-timer-doesnt-stop-when-hidden.html
@@ -11,7 +11,7 @@
 <script>
     const imageURL = "../wpt-import/images/anim-gr.gif";
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => window.addEventListener("load", resolve));
 
         internals.dumpLayoutTree(document);
@@ -21,6 +21,5 @@
         internals.dumpLayoutTree(document);
 
         println(`timer active after hiding: ${internals.imageAnimationStateForURL(imageURL).timerActive}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animated-generated-content-image-timer-doesnt-stop-when-hidden.html
+++ b/Tests/LibWeb/Text/input/css/animated-generated-content-image-timer-doesnt-stop-when-hidden.html
@@ -9,7 +9,7 @@
 <script>
     const imageURL = "../wpt-import/images/anim-gr.gif";
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await new Promise(resolve => window.addEventListener("load", resolve));
 
         internals.dumpLayoutTree(document);
@@ -19,6 +19,5 @@
         internals.dumpLayoutTree(document);
 
         println(`timer active after hiding: ${internals.imageAnimationStateForURL(imageURL).timerActive}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animationcancel-fired-on-timeline-removal.html
+++ b/Tests/LibWeb/Text/input/css/animationcancel-fired-on-timeline-removal.html
@@ -17,7 +17,7 @@
 <div id="target"></div>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         let cancelEvents = 0;
 
         target.addEventListener("animationcancel", () => {
@@ -35,6 +35,5 @@
         await animationFrame();
 
         println(`animationcancel events: ${cancelEvents}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/animations-not-started-in-display-none-subtree.html
+++ b/Tests/LibWeb/Text/input/css/animations-not-started-in-display-none-subtree.html
@@ -39,7 +39,7 @@
 <div id="drawer"></div>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // Give any (incorrectly started) animation time to advance past progress 0.
         await animationFrame();
         await animationFrame();
@@ -65,7 +65,5 @@
         box.style.display = "none";
         println("after hiding again, box animations: " + box.getAnimations().length);
         println("after hiding again, child animations: " + child.getAnimations().length);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/custom-property-registration-document-adoption.html
+++ b/Tests/LibWeb/Text/input/css/custom-property-registration-document-adoption.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const parent = document.createElement("div");
         parent.style.setProperty("--foo", "rgb(255, 0, 0)");
 
@@ -42,6 +42,5 @@
             inherits: true,
         });
         println(`after destination generation change color: ${iframe.contentWindow.getComputedStyle(target).color}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/font-face-legacy-woff-media-type.html
+++ b/Tests/LibWeb/Text/input/css/font-face-legacy-woff-media-type.html
@@ -7,13 +7,12 @@
     }
 </style>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         try {
             await document.fonts.load("16px TestFont");
             println("PASS");
         } catch (error) {
             println(`FAIL: ${error}`);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/imported-selector-insights-invalidated.html
+++ b/Tests/LibWeb/Text/input/css/imported-selector-insights-invalidated.html
@@ -8,7 +8,7 @@
         return styleElement.sheet.cssRules[0].styleSheet;
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         internals.setTestTimeout(5000);
 
         const httpServer = httpTestServer();
@@ -51,6 +51,5 @@
         anchor.appendChild(hit);
 
         println(`after: ${getComputedStyle(anchor).color}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/insert-rule-keyframes-shadow-slotted-cross-sheet-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/insert-rule-keyframes-shadow-slotted-cross-sheet-invalidation.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="host"><span id="slotted" class="item">slotted</span></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const host = document.getElementById("host");
         const slotted = document.getElementById("slotted");
         const shadowRoot = host.attachShadow({ mode: "open" });
@@ -24,6 +24,5 @@
         keyframesSheet.insertRule("@keyframes fade { from { opacity: 0.25; } to { opacity: 0.25; } }", keyframesSheet.cssRules.length);
         await animationFrame();
         println(`opacity after keyframes insertRule: ${getComputedStyle(slotted).opacity}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/insert-rule-keyframes-shadow-tree-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/insert-rule-keyframes-shadow-tree-invalidation.html
@@ -3,7 +3,7 @@
 <style id="document-style"></style>
 <div id="host"></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const host = document.getElementById("host");
         const shadowRoot = host.attachShadow({ mode: "open" });
 
@@ -25,7 +25,5 @@
         documentStyleSheet.insertRule("@keyframes fade { from { opacity: 0.25; } to { opacity: 0.25; } }", documentStyleSheet.cssRules.length);
         await animationFrame();
         println(`opacity after keyframes: ${getComputedStyle(target).opacity}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/insert-rule-keyframes-starts-animation.html
+++ b/Tests/LibWeb/Text/input/css/insert-rule-keyframes-starts-animation.html
@@ -8,7 +8,7 @@
 <div id="target"></div>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const target = document.getElementById("target");
         const sheet = document.getElementById("dynamic-style").sheet;
 
@@ -21,7 +21,5 @@
         println(`after: ${animations.length}`);
         if (animations.length > 0)
             println(`keyframes: ${animations[0].effect.getKeyframes().length}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/insert-rule-quoted-keyframes-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/insert-rule-quoted-keyframes-invalidation.html
@@ -9,7 +9,7 @@
 </style>
 <div id="target">target</div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const target = document.getElementById("target");
         const styleSheet = document.getElementById("test-style").sheet;
 
@@ -17,7 +17,5 @@
         styleSheet.insertRule('@keyframes "123fade" { from { opacity: 0.25; } to { opacity: 0.25; } }', styleSheet.cssRules.length);
         await animationFrame();
         println(`opacity after keyframes: ${getComputedStyle(target).opacity}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/insert-rule-shadow-root-slotted-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/insert-rule-shadow-root-slotted-invalidation.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="host"><span id="slotted" class="item">slotted</span><span id="inherited">inherited</span></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const host = document.getElementById("host");
         const slotted = document.getElementById("slotted");
         const inherited = document.getElementById("inherited");
@@ -34,7 +34,5 @@
         styleSheet.insertRule("@keyframes inserted { from { opacity: 0.25; } to { opacity: 0.25; } }", styleSheet.cssRules.length);
         await animationFrame();
         println(`opacity after keyframes: ${getComputedStyle(slotted).opacity}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/keyframes-append-rule-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/keyframes-append-rule-invalidation.html
@@ -13,7 +13,7 @@
 <div id="target"></div>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const target = document.getElementById("target");
         const keyframesRule = document.styleSheets[0].cssRules[1];
 
@@ -22,7 +22,5 @@
         keyframesRule.appendRule("50% { opacity: 0.75; }");
         await animationFrame();
         println("opacity after appendRule: " + getComputedStyle(target).opacity);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/modal-dialog-display-toggle-lays-out.html
+++ b/Tests/LibWeb/Text/input/css/modal-dialog-display-toggle-lays-out.html
@@ -11,7 +11,7 @@
 <dialog id="drawer">Drawer contents</dialog>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const drawer = document.getElementById("drawer");
         drawer.showModal();
 
@@ -27,7 +27,5 @@
         println("computed display: " + getComputedStyle(drawer).display);
         println("has box: " + (rect.width > 0 && rect.height > 0));
         println("width: " + rect.width);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/pseudo-class-invalidation-has-above-common-ancestor.html
+++ b/Tests/LibWeb/Text/input/css/pseudo-class-invalidation-has-above-common-ancestor.html
@@ -73,7 +73,7 @@ body:has(:focus-within) #case2-target { background-color: green; }
 </div>
 
 <script>
-asyncTest(async (done) => {
+promiseTest(async () => {
     document.body.offsetWidth;
 
     const bg = id => getComputedStyle(document.getElementById(id)).backgroundColor;
@@ -132,7 +132,5 @@ asyncTest(async (done) => {
     await animationFrame();
     println(`Case 5 (has + blur, focused): ${case5_focused}`);
     println(`Case 5 (has + blur, blurred): ${bg("blur-target")}`);
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/css/pseudo-class-invalidation-scoped-to-common-ancestor.html
+++ b/Tests/LibWeb/Text/input/css/pseudo-class-invalidation-scoped-to-common-ancestor.html
@@ -39,7 +39,7 @@
 </div>
 
 <script>
-asyncTest(async (done) => {
+promiseTest(async () => {
     document.body.offsetWidth;
 
     // Case 1: Focus input inside .grandparent.
@@ -61,7 +61,5 @@ asyncTest(async (done) => {
     await animationFrame();
     await animationFrame();
     println(`Case 3 (deep nesting): ${getComputedStyle(document.getElementById("case3-target")).backgroundColor}`);
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/css/scope-import-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/scope-import-invalidation.html
@@ -30,7 +30,7 @@
         internals.resetStyleInvalidationCounters();
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const rootImportURL = `data:text/css;base64,${btoa(".x { --root-hit: yes; }")}`;
         const rootStyle = document.getElementById("root-style");
         rootStyle.textContent = `@import "${rootImportURL}" scope((.scope-root));`;
@@ -79,7 +79,5 @@
         removeStyle.remove();
         getComputedStyle(replaceTarget).color;
         println(`stylesheet remove full invalidation: ${internals.getStyleInvalidationCounters().fullStyleInvalidations >= 1}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/shadow-root-host-keyframes-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/shadow-root-host-keyframes-invalidation.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="host"></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const host = document.getElementById("host");
         const shadowRoot = host.attachShadow({ mode: "open" });
         const sheet = new CSSStyleSheet();
@@ -29,7 +29,5 @@
         sheet.deleteRule(sheet.cssRules.length - 1);
         await animationFrame();
         println(`opacity after keyframes delete: ${getComputedStyle(host).opacity}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/shadow-root-replacesync-slotted-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/shadow-root-replacesync-slotted-invalidation.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <div id="host"><span id="slotted" class="item">slotted</span></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const host = document.getElementById("host");
         const slotted = document.getElementById("slotted");
         const shadowRoot = host.attachShadow({ mode: "open" });
@@ -31,6 +31,5 @@
         keyframesSheet.replaceSync("@keyframes fade { from { opacity: 0.5; } to { opacity: 0.5; } }");
         await animationFrame();
         println(`opacity after keyframes replaceSync: ${getComputedStyle(slotted).opacity}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-root-font-media.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-root-font-media.html
@@ -13,7 +13,7 @@
         child.internals.updateStyle();
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -66,7 +66,5 @@
 
         await resizeIframe(iframe, child, 300);
         println(`resized back animated left: ${child.getComputedStyle(target).left}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-targeted-restyle.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-animation-targeted-restyle.html
@@ -5,7 +5,7 @@
         return new Promise(resolve => requestAnimationFrame(resolve));
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -115,7 +115,5 @@
         println(`resized post-style animated width: ${child.getComputedStyle(postStyleAnimationTarget).width}`);
         println(`full invalidations: ${counters.fullStyleInvalidations}`);
         println(`style recomputations bounded: ${counters.elementStyleRecomputations < elementCount}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-compound-font-relative-values.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-compound-font-relative-values.html
@@ -13,7 +13,7 @@
         child.internals.updateStyle();
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -57,7 +57,5 @@
         await resizeIframe(iframe, child, 300);
         println(`resized back box shadow: ${child.getComputedStyle(target).boxShadow}`);
         println(`resized back filter: ${child.getComputedStyle(target).filter}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-layered-import-broad-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-layered-import-broad-invalidation.html
@@ -18,7 +18,7 @@
             await animationFrame();
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -60,7 +60,5 @@
 
         await resizeIframe(iframe, child, 300);
         println(`resized back layered import color: ${child.getComputedStyle(target).color}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-media-query-evaluation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-media-query-evaluation.html
@@ -5,7 +5,7 @@
         return new Promise(resolve => requestAnimationFrame(resolve));
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -102,7 +102,5 @@
         println(`resized back nested color: ${child.getComputedStyle(nestedTarget).color}`);
         println(`media query full invalidations after resize back: ${resizedBackCounters.fullStyleInvalidations}`);
         println(`media query recomputations bounded after resize back: ${resizedBackCounters.elementStyleRecomputations < elementCount / 2}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-shadow-broad-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-shadow-broad-invalidation.html
@@ -13,7 +13,7 @@
         child.internals.updateStyle();
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -61,7 +61,5 @@
         counters = child.internals.getStyleInvalidationCounters();
         println(`resized back shadow host color: ${child.getComputedStyle(host).color}`);
         println(`resized back recomputed host side: ${counters.elementStyleRecomputations > 1}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-targeted-restyle.html
+++ b/Tests/LibWeb/Text/input/css/style-invalidation/viewport-resize-targeted-restyle.html
@@ -100,7 +100,7 @@
         `;
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         iframe.style.border = "0";
         iframe.style.width = "300px";
@@ -139,7 +139,5 @@
         println(`full invalidations: ${counters.fullStyleInvalidations}`);
         println(`style recomputations bounded: ${counters.elementStyleRecomputations < elementCount / 2}`);
         println(`inherited recomputations present: ${counters.elementInheritedStyleRecomputations > 0}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/stylesheet-add-remove-imported-broad-invalidation.html
+++ b/Tests/LibWeb/Text/input/css/stylesheet-add-remove-imported-broad-invalidation.html
@@ -21,7 +21,7 @@
             await animationFrame();
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const target = document.getElementById("target");
         settleAndReset(target);
 
@@ -38,7 +38,5 @@
 
         getComputedStyle(target).color;
         verifyFullRestyleWasScheduled("imported layer-only stylesheet remove schedules full restyle");
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/transition-legacy-event-listener.html
+++ b/Tests/LibWeb/Text/input/css/transition-legacy-event-listener.html
@@ -8,7 +8,7 @@
 <div id="target"></div>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         let eventCount = 0;
         let eventType = "";
         let propertyName = "";
@@ -26,6 +26,5 @@
         println(`legacy transitionend event count: ${eventCount}`);
         println(`legacy transitionend event type: ${eventType}`);
         println(`legacy transitionend property name: ${propertyName}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/transition-on-element-keeps-pseudo-element-font.html
+++ b/Tests/LibWeb/Text/input/css/transition-on-element-keeps-pseudo-element-font.html
@@ -26,7 +26,7 @@
     // pseudo-elements. This used to clobber the ::after box's font with the element's font, because the pseudo
     // box (having no DOM node) was mistaken for an anonymous wrapper when propagating style after each
     // animation update.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         await document.fonts.load("32px TestFont");
         await document.fonts.ready;
         const victim = document.getElementById("victim");
@@ -43,6 +43,5 @@
             println("PASS: ::after width is unchanged by the transition");
         else
             println("FAIL: ::after width was changed by the transition");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/css/transitions-not-started-after-mutations-in-display-none-subtree.html
+++ b/Tests/LibWeb/Text/input/css/transitions-not-started-after-mutations-in-display-none-subtree.html
@@ -11,7 +11,7 @@
 <div id="container3"><div><div class="grandchild" id="g3"></div></div></div>
 <div id="container4"><div><div class="grandchild" id="g4"></div></div></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const nextFrame = () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
         // Resolve the before-change style for all elements while they are rendered.
@@ -51,7 +51,5 @@
         g4.style.opacity = "0";
         await nextFrame();
         println("animations on descendant mutated while being hidden: " + g4.getAnimations().length);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/display_list/body-background-change-invalidates-root.html
+++ b/Tests/LibWeb/Text/input/display_list/body-background-change-invalidates-root.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
 
         // The root element paints the body's propagated background, so changing the body's background must
@@ -18,6 +18,5 @@
         const dump = internals.dumpDisplayList();
         println(`stale propagated background painted: ${dump.includes("rgb(1, 2, 3)")}`);
         println(`fresh propagated background painted: ${dump.includes("rgb(4, 5, 6)")}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/encrypted-media-requestMediaKeySystemAccess-receiver-realm.html
+++ b/Tests/LibWeb/Text/input/encrypted-media-requestMediaKeySystemAccess-receiver-realm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         document.body.append(iframe);
         const other = iframe.contentWindow;
@@ -21,7 +21,5 @@
             println(`requestMediaKeySystemAccess rejection is parent realm: ${error instanceof TypeError}`);
             println(`requestMediaKeySystemAccess rejection message: ${error.message}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/error-stack-must-contain-full-url.html
+++ b/Tests/LibWeb/Text/input/error-stack-must-contain-full-url.html
@@ -2,7 +2,7 @@
 <script src="include.js"></script>
 <div id="script-container"></div>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const scriptContainer = document.getElementById("script-container");
         globalThis.errors = new Map();
 
@@ -48,6 +48,5 @@
             globalThis.println(`${type}: ${normalizedStack}`);
         }
         
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/focus-events.html
+++ b/Tests/LibWeb/Text/input/focus-events.html
@@ -33,12 +33,10 @@
     b.addEventListener('focus', printFocusEvent);
     b.addEventListener('blur', printFocusEvent);
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         a.focus();
         await new Promise(resolve => setTimeout(resolve, 0));
         b.focus();
         await new Promise(resolve => setTimeout(resolve, 0));
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/focus-on-frame-does-not-scroll.html
+++ b/Tests/LibWeb/Text/input/focus-on-frame-does-not-scroll.html
@@ -7,7 +7,7 @@
     // Programmatically focusing a frame must not scroll it into view. Ad scripts
     // commonly steal focus into an offscreen iframe on load; other engines only
     // scroll on focus when the focused element is not embedded content.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const settle = async () => {
             for (let i = 0; i < 3; i++) {
                 await new Promise(resolve => requestAnimationFrame(resolve));
@@ -35,7 +35,5 @@
         document.getElementById("button").focus();
         await settle();
         println(`scrollY after focusing a regular element is nonzero: ${window.scrollY > 0}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/get-bounding-client-rect-pinch-zoom.html
+++ b/Tests/LibWeb/Text/input/get-bounding-client-rect-pinch-zoom.html
@@ -12,7 +12,7 @@
 <div id="target"></div>
 <script src="include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         await animationFrame();
 
         const target = document.getElementById("target");
@@ -28,6 +28,5 @@
         println(`visualViewport scale: ${visualViewport.scale.toFixed(3)}`);
         println(`after: ${after.x.toFixed(3)},${after.y.toFixed(3)} ${after.width.toFixed(3)}x${after.height.toFixed(3)}`);
         println(`size unchanged: ${after.width === before.width && after.height === before.height ? "PASS" : "FAIL"}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/grid/orthogonal-positioned-grid-descendant.html
+++ b/Tests/LibWeb/Text/input/grid/orthogonal-positioned-grid-descendant.html
@@ -34,13 +34,11 @@
     </div>
 </div>
 <script>
-asyncTest(async done => {
+promiseTest(async () => {
     await document.fonts.ready;
     await animationFrame();
 
     let abspos = document.getElementById("abspos");
     println(`${abspos.offsetLeft},${abspos.offsetTop} ${abspos.offsetWidth}x${abspos.offsetHeight}`);
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/grid/positioned-grid-descendants-auto-start-left.html
+++ b/Tests/LibWeb/Text/input/grid/positioned-grid-descendants-auto-start-left.html
@@ -62,14 +62,12 @@
     </div>
 </div>
 <script>
-asyncTest(async done => {
+promiseTest(async () => {
     await animationFrame();
 
     for (let id of [ "abspos1", "abspos2" ]) {
         let abspos = document.getElementById(id);
         println(`${id}: ${abspos.offsetLeft},${abspos.offsetTop} ${abspos.offsetWidth}x${abspos.offsetHeight}`);
     }
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/grid/positioned-grid-descendants-left-static-top.html
+++ b/Tests/LibWeb/Text/input/grid/positioned-grid-descendants-left-static-top.html
@@ -59,14 +59,12 @@
     </div>
 </div>
 <script>
-asyncTest(async done => {
+promiseTest(async () => {
     await animationFrame();
 
     for (let id of [ "abspos1", "abspos2" ]) {
         let abspos = document.getElementById(id);
         println(`${id}: ${abspos.offsetLeft},${abspos.offsetTop} ${abspos.offsetWidth}x${abspos.offsetHeight}`);
     }
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/grid/replaced-element-fallback-size-matrix.html
+++ b/Tests/LibWeb/Text/input/grid/replaced-element-fallback-size-matrix.html
@@ -231,7 +231,7 @@
 <div class="row-case" data-label="block natural height"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='80'%3E%3C/svg%3E"></div>
 <div class="row-case" data-label="block natural dimensions"><img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='80'%3E%3C/svg%3E"></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         await Promise.all(Array.from(document.images, image => image.decode()));
         for (const container of document.querySelectorAll(".case, .row-case")) {
             const image = container.firstElementChild;
@@ -240,6 +240,5 @@
             const trackSize = container.classList.contains("row-case") ? containerRect.height : containerRect.width;
             println(`${container.dataset.label}: track ${trackSize}, image ${imageRect.width}x${imageRect.height}`);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/http-non-ascii-content-type.html
+++ b/Tests/LibWeb/Text/input/http-non-ascii-content-type.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <script src="include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         try {
             const httpServer = httpTestServer();
             const url = await httpServer.createEcho("GET", "/http-non-ascii-content-type-test", {
@@ -19,6 +19,5 @@
         } catch (err) {
             println("FAIL - " + err);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/http-reason-phrase-propagation.html
+++ b/Tests/LibWeb/Text/input/http-reason-phrase-propagation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="./include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const expectedStatusText = "WHF";
 
         try {
@@ -23,6 +23,5 @@
         } catch (err) {
             println("FAIL - " + err);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/image-decode-resolves-after-state-is-completely-available.html
+++ b/Tests/LibWeb/Text/input/image-decode-resolves-after-state-is-completely-available.html
@@ -4,7 +4,7 @@
     // Regression test: HTMLImageElement.decode()'s returned promise must not resolve until the image's current request
     // has transitioned to CompletelyAvailable, so callers reading img.width / img.height from a then() handler see
     // non-zero dimensions for a successfully-decoded image.
-    asyncTest(async done => {
+    promiseTest(async () => {
         const image = new Image();
         image.src = "../../Assets/120.png";
         try {
@@ -13,6 +13,5 @@
         } catch (error) {
             println(`FAIL: decode rejected: ${error}`);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/input-event-inputType.html
+++ b/Tests/LibWeb/Text/input/input-event-inputType.html
@@ -3,7 +3,7 @@
 <textarea id="textArea"></textarea>
 <script src="include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const input = document.getElementById("textInput");
         const textarea = document.getElementById("textArea");
 
@@ -60,7 +60,5 @@
             input.focus();
             internals.sendText(input, "c");
         });
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/input-file-accept.html
+++ b/Tests/LibWeb/Text/input/input-file-accept.html
@@ -25,11 +25,10 @@
         });
     };
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await runTest("input1");
         await runTest("input2");
         await runTest("input3");
         await runTest("input4");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/input-file.html
+++ b/Tests/LibWeb/Text/input/input-file.html
@@ -31,9 +31,8 @@
         });
     };
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await runTest("input1");
         await runTest("input2");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/input-method-insert-text.html
+++ b/Tests/LibWeb/Text/input/input-method-insert-text.html
@@ -6,7 +6,7 @@
 <input id="readonly_input" value="ro" readonly>
 <input id="preedit_input" value="">
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         // Spec for <input>/<textarea> fires 'input' via a queued element task. Wait for it.
         const waitForEvent = (target, type) => new Promise(resolve => {
             target.addEventListener(type, e => resolve({ inputType: e.inputType, data: e.data }), { once: true });
@@ -147,7 +147,5 @@
         window.scrollTo(0, 0);
         const moved = (caret_at_0 && caret_scrolled) ? caret_at_0.y - caret_scrolled.y : null;
         println(`caret rect is viewport-relative (moves with scroll): ${moved !== null && scroll_y > 0 && Math.abs(moved - scroll_y) < 1}`);
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/intersection-observer-visual-viewport-geometry.html
+++ b/Tests/LibWeb/Text/input/intersection-observer-visual-viewport-geometry.html
@@ -28,7 +28,7 @@
         });
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         function fixed(value) {
             return value.toFixed(3);
         }
@@ -57,6 +57,5 @@
         const rightEntry = await observe(document.getElementById("right-target"));
         println(`right target isIntersecting: ${rightEntry.isIntersecting ? "PASS" : "FAIL"}`);
         println(`right target intersectionRatio: ${fixed(rightEntry.intersectionRatio)}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/kerning-across-bidi-neutral.html
+++ b/Tests/LibWeb/Text/input/kerning-across-bidi-neutral.html
@@ -12,13 +12,12 @@
 <p><span id="wrapping">’A</span></p>
 <p><span id="non-wrapping" style="white-space: nowrap">’A</span></p>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         await document.fonts.ready;
 
         const wrappingWidth = document.getElementById("wrapping").getBoundingClientRect().width;
         const nonWrappingWidth = document.getElementById("non-wrapping").getBoundingClientRect().width;
 
         println(`Wrapping and non-wrapping text have equal widths: ${wrappingWidth === nonWrappingWidth}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/media-capabilities-decodingInfo-receiver-realm.html
+++ b/Tests/LibWeb/Text/input/media-capabilities-decodingInfo-receiver-realm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         document.body.append(iframe);
         const other = iframe.contentWindow;
@@ -19,7 +19,5 @@
             println(`decodingInfo rejection is parent realm: ${error instanceof TypeError}`);
             println(`decodingInfo rejection message: ${error.message}`);
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/history-replace-push-state-race.html
+++ b/Tests/LibWeb/Text/input/navigation/history-replace-push-state-race.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(done => {
+    test(() => {
 
         history.replaceState({}, "hello", "history-replace-push-state-race.html");
         history.replaceState({}, "hello", "history-replace-push-state-race.html");
@@ -12,6 +12,5 @@
         // history.replaceState is one possible trigger for the crash.
 
         println("test done!");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-load-after-remove-and-recreate-same-src.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-load-after-remove-and-recreate-same-src.html
@@ -11,7 +11,7 @@
         });
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const src = "about:blank";
 
         const first = await loadFrame(src);
@@ -24,7 +24,5 @@
         const second = await loadFrame(src);
         println("second load");
         second.remove();
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-load-after-remove-and-recreate-with-pending-history.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-load-after-remove-and-recreate-with-pending-history.html
@@ -11,7 +11,7 @@
         });
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         const server = httpTestServer();
         const firstPageUrl = await server.createEcho("GET", "/iframe-recreate-pending-history-first", {
             status: 200,
@@ -32,6 +32,5 @@
 
         await loadFrame(secondPageUrl);
         println("second load");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-navigate-srcdoc.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-navigate-srcdoc.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.getElementById("testIframe");
 
         function navigateIframe(srcdoc) {
@@ -18,8 +18,6 @@
 
         await navigateIframe("<h2>Hello friends!</h2>");
         println(iframe.contentWindow.document.body.innerText);
-
-        done();
     });
 </script>
 <iframe id="testIframe" src="about:blank"></iframe>

--- a/Tests/LibWeb/Text/input/navigation/iframe-pushstate-before-nested-history-ready.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-pushstate-before-nested-history-ready.html
@@ -2,7 +2,7 @@
 <body></body>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const server = httpTestServer();
         const finalPageUrl = await server.createEcho("GET", "/iframe-pushstate-before-nested-history-ready-final", {
             status: 200,
@@ -28,6 +28,5 @@
         iframe.src = finalPageUrl;
         await loaded;
         println("navigation drained");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-pushstate-remove-recreate.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-pushstate-remove-recreate.html
@@ -11,7 +11,7 @@
         return iframe;
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         history.pushState({}, "", "#parent");
         await internals.flushSessionHistoryTraversalQueue();
 
@@ -24,6 +24,5 @@
         await internals.flushSessionHistoryTraversalQueue();
 
         println("PASS");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-remove-and-recreate-after-initial-navigation.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-remove-and-recreate-after-initial-navigation.html
@@ -11,7 +11,7 @@
         });
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         history.pushState({ section: "running" }, "", "#running");
 
         const first = await loadFrame("about:blank");
@@ -22,6 +22,5 @@
 
         await loadFrame("about:blank");
         println("second loaded");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-remove-before-history-update.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-remove-before-history-update.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const iframe = document.createElement("iframe");
         document.body.append(iframe);
 
@@ -13,6 +13,5 @@
         await internals.flushSessionHistoryTraversalQueue();
 
         println("PASS");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/iframe-renavigate-during-history-commit.html
+++ b/Tests/LibWeb/Text/input/navigation/iframe-renavigate-during-history-commit.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const server = httpTestServer();
 
         const finalPageUrl = await server.createEcho("GET", "/iframe-renavigate-during-history-commit-final", {
@@ -40,6 +40,5 @@
 
         iframe.remove();
         println(result);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/location-navigate-then-push-state.html
+++ b/Tests/LibWeb/Text/input/navigation/location-navigate-then-push-state.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const server = httpTestServer();
         const page2Body = `<!DOCTYPE html><script>parent.postMessage("loaded-page2", "*");<\/script>`;
         const page2Url = await server.createEcho("GET", "/location-navigate-then-push-state-page2", {
@@ -32,6 +32,5 @@
         });
         iframe.remove();
         println(result);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/ui-process-session-history-same-document-back.html
+++ b/Tests/LibWeb/Text/input/navigation/ui-process-session-history-same-document-back.html
@@ -29,7 +29,7 @@
         println(`${label}: ui-uses-ui-step-coordinates=${uiHistory.webContentUsesUIStepCoordinates}`);
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         history.replaceState({ replaced: true }, "", "?same-document-back-replaced");
         history.pushState({ pushed: true }, "", "?same-document-back-pushed");
 
@@ -54,6 +54,5 @@
             println(`FAIL: unexpected UI history ${JSON.stringify(uiHistory)}`);
 
         dump("after-back", uiHistory);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/navigation/ui-process-session-history-same-document.html
+++ b/Tests/LibWeb/Text/input/navigation/ui-process-session-history-same-document.html
@@ -25,7 +25,7 @@
         println(`${label}: ui-uses-ui-step-coordinates=${uiHistory.webContentUsesUIStepCoordinates}`);
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         history.replaceState({ replaced: true }, "", "?same-document-replaced");
         history.pushState({ pushed: true }, "", "?same-document-pushed");
 
@@ -38,6 +38,5 @@
             println(`FAIL: unexpected UI history ${JSON.stringify(uiHistory)}`);
 
         dump("after-push-state", uiHistory);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/nested-import-load-events.html
+++ b/Tests/LibWeb/Text/input/nested-import-load-events.html
@@ -2,7 +2,7 @@
 <script src="include.js"></script>
 <div id="target"></div>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const styleElement = document.createElement('style');
         styleElement.textContent = '@import url("../data/import-1.css");';
         await new Promise(resolve => {
@@ -11,6 +11,5 @@
             document.head.append(styleElement);
         });
         println(`Target's background color: ${getComputedStyle(target).backgroundColor}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/position-absolute-float-none.html
+++ b/Tests/LibWeb/Text/input/position-absolute-float-none.html
@@ -5,11 +5,10 @@
 </style>
 <div class="box" id="test">test</div>
 <script>
-  asyncTest(async (done) => {
+  promiseTest(async () => {
     let box = document.getElementById('test');
     let cs = getComputedStyle(box);
     println(`float: ${cs.float}`);
     println(`position: ${cs.position}`);
-    done();
   });
 </script>

--- a/Tests/LibWeb/Text/input/radio-button-focus-lost-no-change-event.html
+++ b/Tests/LibWeb/Text/input/radio-button-focus-lost-no-change-event.html
@@ -6,7 +6,7 @@
     radioButton.addEventListener("change", () => {
       changeEventFired = true;
     });
-    asyncTest(async done => {
+    promiseTest(async () => {
         radioButton.focus();
         await new Promise(resolve => setTimeout(resolve, 0));
         radioButton.blur();
@@ -17,7 +17,5 @@
         } else {
             println("PASS: Change event was not fired");
         }
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/selection-auto-scroll.html
+++ b/Tests/LibWeb/Text/input/selection-auto-scroll.html
@@ -21,7 +21,7 @@ function afterAutoScrollTick() {
     });
 }
 
-asyncTest(async (done) => {
+promiseTest(async () => {
     document.body.offsetWidth; // force layout
 
     println(`before: ${vertical.scrollTop}`);
@@ -47,6 +47,5 @@ asyncTest(async (done) => {
     println(`hidden after: ${hidden.scrollTop}`);
 
     internals.mouseUp(rect.x + 10, rect.y + rect.height + 50);
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/selection-rect-consistency-with-kerning.html
+++ b/Tests/LibWeb/Text/input/selection-rect-consistency-with-kerning.html
@@ -12,7 +12,7 @@ p {
 </style>
 <p>Table</p>
 <script>
-asyncTest(async done => {
+promiseTest(async () => {
     await document.fonts.ready;
 
     const text = document.querySelector("p").firstChild;
@@ -38,7 +38,5 @@ asyncTest(async done => {
     println(`full width: ${full.width}`);
     println(`sum == full: ${charSum === full.width}`);
     println(`T.right == a.left: ${r01.right === r12.left}`);
-
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/selectionchange-event.html
+++ b/Tests/LibWeb/Text/input/selectionchange-event.html
@@ -12,7 +12,7 @@
     Ladybird is an ongoing project to build an independent web browser from scratch.
 </div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         function elementToString(e) {
             let element_string = `<${e.nodeName} `;
             if (e.id) element_string += `id="${e.id}" `;
@@ -39,7 +39,5 @@
         await new Promise(resolve => setTimeout(resolve, 0));
         internals.click(40, 10);
         await new Promise(resolve => setTimeout(resolve, 0));
-
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/smooth-scroll-promise.html
+++ b/Tests/LibWeb/Text/input/smooth-scroll-promise.html
@@ -7,7 +7,7 @@
 </div>
 <div style="height: 1200px"></div>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const scroller = document.getElementById("scroller");
 
         await animationFrame();
@@ -71,6 +71,5 @@
         const scroll_into_view_result = await scroll_into_view_promise;
         println(`scrollIntoView final: ${scroller.scrollLeft},${scroller.scrollTop}`);
         println(`scrollIntoView result: ${scroll_into_view_result}`);
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/svg-relayout-foreignobject-fixed-pos.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-foreignobject-fixed-pos.html
@@ -7,7 +7,7 @@
     </foreignObject>
 </svg>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         // Force initial layout to complete.
         document.body.offsetHeight;
 
@@ -27,6 +27,5 @@
         document.body.offsetHeight;
 
         println("PASS");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/svg-relayout-inline-boundary-structural.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-inline-boundary-structural.html
@@ -6,7 +6,7 @@
 </style>
 <span>before<svg id="boundary" width="40" height="20"></svg>after</span>
 <script>
-    asyncTest((done) => {
+    test(() => {
         document.body.offsetHeight;
 
         const partialBefore = internals.partialLayoutCount();
@@ -27,6 +27,5 @@
         println(`partial-layouts=${partialDelta} full-layouts=${fullDelta}`);
         println(svgRect.width === 40 && svgRect.height === 20
             && partialDelta === 1 && fullDelta === 0 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/svg-relayout-nested-svg-viewbox.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-nested-svg-viewbox.html
@@ -6,7 +6,7 @@
     </svg>
 </svg>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         // Force initial layout to complete.
         document.body.offsetHeight;
 
@@ -18,6 +18,5 @@
         const rect = document.getElementById("r").getBoundingClientRect();
         println(rect.width + "x" + rect.height);
         println(Math.abs(rect.width - 60) < 0.01 && Math.abs(rect.height - 50) < 0.01 ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/svg-relayout-scroll-frames-preserved.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-scroll-frames-preserved.html
@@ -11,7 +11,7 @@
     </foreignObject>
 </svg>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         // Force initial layout to complete.
         document.body.offsetHeight;
 
@@ -30,6 +30,5 @@
         const hit = document.elementFromPoint(30, 40);
         println("hit=" + (hit ? (hit.id || hit.tagName) : "null"));
         println(scroller.scrollTop === 150 && hit && hit.id === "probe" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/svg-relayout-self-size-change.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-self-size-change.html
@@ -17,7 +17,7 @@
         return `${rect.left},${rect.top},${rect.width},${rect.height}`;
     }
 
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         document.getElementById("t").firstChild.data = "hello longer text";
@@ -30,6 +30,5 @@
         println(`svg=${rectToString(svg)}`);
         println(`after=${rectToString(after)}`);
         println(svg.width === 300 && svg.height === 200 && after.top === svg.height ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/svg-relayout-sibling-paint-order.html
+++ b/Tests/LibWeb/Text/input/svg-relayout-sibling-paint-order.html
@@ -29,7 +29,7 @@
     // Overlapping auto-z-index siblings paint in tree order, so a partial relayout of the
     // first sibling must splice its rebuilt paint subtree back at its original position
     // instead of appending it after the second sibling.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         document.body.offsetHeight;
 
         const hitBefore = document.elementFromPoint(150, 110);
@@ -41,6 +41,5 @@
         println(`hit-after=${hitAfter ? hitAfter.id : "null"}`);
         println(hitBefore && hitBefore.id === "second"
             && hitAfter && hitAfter.id === "second" ? "PASS" : "FAIL");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/test-http-test-server.html
+++ b/Tests/LibWeb/Text/input/test-http-test-server.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="./include.js"></script>
 <script>
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         try {
             const httpServer = httpTestServer();
             const url = await httpServer.createEcho("GET", "/test-http-test-server", {
@@ -25,6 +25,5 @@
         } catch (err) {
             println("FAIL - " + err);
         }
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/top-layer-nested-fullscreen-members-keep-painting.html
+++ b/Tests/LibWeb/Text/input/top-layer-nested-fullscreen-members-keep-painting.html
@@ -4,7 +4,7 @@
 <script>
     // Zone rebuilds over nested fullscreen members used to leave detached boxes behind and
     // crash on the next paint; the trailing frames force paints after the last rebuild.
-    asyncTest(async (done) => {
+    promiseTest(async () => {
         const first = document.getElementById("first");
         const last = document.getElementById("last");
 
@@ -34,6 +34,5 @@
         await next_frame();
         await next_frame();
         println("painted");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/video-gc.html
+++ b/Tests/LibWeb/Text/input/video-gc.html
@@ -13,7 +13,7 @@
         });
     }
 
-    asyncTest(async done => {
+    promiseTest(async () => {
         await navigateIframe("../data/video-gc-frame.html");
         await navigateIframe("../data/iframe-test-content-1.html");
         iframe.remove();
@@ -23,6 +23,5 @@
         }
 
         println("PASS (didn't crash)");
-        done();
     });
 </script>

--- a/Tests/LibWeb/Text/input/viewport-auto-scroll.html
+++ b/Tests/LibWeb/Text/input/viewport-auto-scroll.html
@@ -7,7 +7,7 @@ body {
 </style>
 <script src="include.js"></script>
 <script>
-asyncTest(async (done) => {
+promiseTest(async () => {
     let scrolled = new Promise(resolve => {
         document.addEventListener("scroll", resolve, { once: true });
     });
@@ -20,6 +20,5 @@ asyncTest(async (done) => {
     println(`scrollTop: ${document.documentElement.scrollTop}`);
 
     internals.mouseUp(100, 610);
-    done();
 });
 </script>

--- a/Tests/LibWeb/Text/input/wrappers-or-misc/wrapper-realm-stable-across-gc.html
+++ b/Tests/LibWeb/Text/input/wrappers-or-misc/wrapper-realm-stable-across-gc.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <script>
-    asyncTest(async done => {
+    promiseTest(async () => {
         const frame = document.createElement("iframe");
         const loaded = new Promise(resolve => frame.addEventListener("load", resolve, { once: true }));
         document.body.appendChild(frame);
@@ -27,7 +27,5 @@
         println(`reacquired hint-less object exists: ${!!reacquired}`);
         println(`hint-less wrapper realm is stable after gc: ${Object.getPrototypeOf(reacquired) === frameWindow.PerformanceMark.prototype}`);
         println(`hint-less wrapper did not move to parent realm: ${Object.getPrototypeOf(reacquired) !== PerformanceMark.prototype}`);
-
-        done();
     });
 </script>


### PR DESCRIPTION
Hopefully using the correct test type everywhere will stop our robot friends getting confused about how tests should be written when they add or modify them :crossed_fingers: 

These tests were deliberately left alone due to being flaky.

- `Text/input/HTML/HTMLVideoElement-resize-event-during-playback.html`
- `Text/input/Wasm/WebAssembly-instantiate.html`
- `Text/input/HTML/HTMLVideoElement-resize-event-while-not-rendered.html` - timed out