### PR TITLE
LibWeb: Survive a network request being finished twice

### DIFF
--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -558,10 +558,8 @@ void ResourceLoader::handle_network_response_headers(LoadRequest const& request,
 
 void ResourceLoader::finish_network_request(NonnullRefPtr<Requests::Request> protocol_request)
 {
-    deferred_invoke([this, protocol_request = move(protocol_request)] {
-        auto did_remove = m_active_requests.remove(protocol_request);
-        VERIFY(did_remove);
-    });
+    if (!m_active_requests.remove(protocol_request))
+        warnln("ResourceLoader: finish_network_request() called for request {}, which is not active", protocol_request->id());
 }
 
 }

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -241,11 +241,7 @@ void ResourceLoader::handle_file_load_request(LoadRequest& request, FileHandler 
 
     auto const& url = request.url().value();
 
-    FileRequest file_request(url.file_path(), [this, request, on_file, on_error, url](ErrorOr<i32> file_or_error) mutable {
-        --m_pending_loads;
-        if (on_load_counter_change)
-            on_load_counter_change();
-
+    FileRequest file_request(url.file_path(), [request, on_file, on_error, url](ErrorOr<i32> file_or_error) mutable {
         if (file_or_error.is_error()) {
             auto const message = ByteString::formatted("{}", file_or_error.error());
             on_error(message);
@@ -298,10 +294,6 @@ void ResourceLoader::handle_file_load_request(LoadRequest& request, FileHandler 
     });
 
     page->client().request_file(move(file_request));
-
-    ++m_pending_loads;
-    if (on_load_counter_change)
-        on_load_counter_change();
 }
 
 template<typename ResourceHandler, typename ErrorHandler>
@@ -528,10 +520,6 @@ RefPtr<Requests::Request> ResourceLoader::start_network_request(LoadRequest cons
         page->client().page_did_start_network_request(protocol_request->id(), request.url().value(), request.method(), request.headers().headers(), request.body(), move(initiator_type_string), referrer_policy, request.is_navigation_request(), request.priority());
     }
 
-    ++m_pending_loads;
-    if (on_load_counter_change)
-        on_load_counter_change();
-
     m_active_requests.set(*protocol_request);
     return protocol_request;
 }
@@ -570,10 +558,6 @@ void ResourceLoader::handle_network_response_headers(LoadRequest const& request,
 
 void ResourceLoader::finish_network_request(NonnullRefPtr<Requests::Request> protocol_request)
 {
-    --m_pending_loads;
-    if (on_load_counter_change)
-        on_load_counter_change();
-
     deferred_invoke([this, protocol_request = move(protocol_request)] {
         auto did_remove = m_active_requests.remove(protocol_request);
         VERIFY(did_remove);

--- a/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AK/ByteString.h>
-#include <AK/Function.h>
 #include <AK/HashTable.h>
 #include <LibCore/EventReceiver.h>
 #include <LibCore/ImmutableBytes.h>
@@ -46,10 +45,6 @@ public:
 
     void prefetch_dns(URL::URL const&, URL::URL const& source_url);
     void preconnect(URL::URL const&, URL::URL const& source_url);
-
-    Function<void()> on_load_counter_change;
-
-    int pending_loads() const { return m_pending_loads; }
 
     static void try_store_hsts_policy_for_url(Page&, URL::URL const&, StringView header_value);
     static bool is_known_hsts_host(Page&, String const& host);
@@ -91,8 +86,6 @@ private:
     RefPtr<Requests::Request> start_network_request(LoadRequest const&, Requests::RequestClient::KeepAliveForTransfer);
     void handle_network_response_headers(LoadRequest const&, HTTP::HeaderList const&);
     void finish_network_request(NonnullRefPtr<Requests::Request>);
-
-    int m_pending_loads { 0 };
 
     GC::Heap& m_heap;
     RefPtr<Requests::RequestClient> m_request_client;


### PR DESCRIPTION
We were `VERIFY`ing on a request being finished, causing 1000 missing subtests in this WPT run:

https://wpt.fyi/results/?diff&filter=ADC&run_id=5092566235348992&run_id=6220900784668672

Change our behavior to a no-op when trying to remove an inactive request, but keep a `warnln()` so we still have an opportunity to see this happen.