### PR TITLE
LibDevTools: Report isPseudoElement on pseudo-elements

### DIFF
--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -569,6 +569,7 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     auto is_scrollable = node.get_bool("scrollable"sv).value_or(false);
 
     auto is_shadow_root = false;
+    auto is_pseudo_element = false;
     auto is_after_pseudo_element = false;
     auto is_before_pseudo_element = false;
     auto is_marker_pseudo_element = false;
@@ -584,6 +585,7 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     if (type == "shadow-root"sv) {
         is_shadow_root = true;
     } else if (type == "pseudo-element"sv) {
+        is_pseudo_element = true;
         auto pseudo_element = node.get_integer<UnderlyingType<Web::CSS::PseudoElement>>("pseudo-element"sv).map([](auto value) {
             VERIFY(value < to_underlying(Web::CSS::PseudoElement::KnownPseudoElementCount));
             return static_cast<Web::CSS::PseudoElement>(value);
@@ -638,6 +640,7 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     serialized.set("isInHTMLDocument"sv, true);
     serialized.set("isMarkerPseudoElement"sv, is_marker_pseudo_element);
     serialized.set("isNativeAnonymous"sv, false);
+    serialized.set("isPseudoElement"sv, is_pseudo_element);
     serialized.set("isScrollable"sv, is_scrollable);
     serialized.set("isShadowHost"sv, false);
     serialized.set("isShadowRoot"sv, is_shadow_root);

--- a/Tests/LibDevTools/TestDevToolsProtocol.cpp
+++ b/Tests/LibDevTools/TestDevToolsProtocol.cpp
@@ -3673,6 +3673,18 @@ TEST_CASE(inspector_walker_highlighter_layout_and_editing)
     auto span_actor = query_selector(client, walker_actor, root_node_actor, "span"sv);
     auto flex_actor = query_selector(client, walker_actor, root_node_actor, "aside"sv);
     auto first_flex_item_actor = query_selector(client, walker_actor, root_node_actor, "p"sv);
+
+    JsonObject target_children;
+    target_children.set("to"sv, walker_actor);
+    target_children.set("type"sv, "children"sv);
+    target_children.set("node"sv, div_actor);
+    auto serialized_target_children = client.request(move(target_children)).get_array("nodes"sv).release_value();
+    auto before = serialized_target_children.values().first_matching([](auto const& child) {
+        return child.as_object().get_string("displayName"sv).value_or({}) == "::before"sv;
+    });
+    VERIFY(before.has_value());
+    EXPECT(before->as_object().get_bool("isPseudoElement"sv).value());
+
     JsonObject previous_sibling;
     previous_sibling.set("to"sv, walker_actor);
     previous_sibling.set("type"sv, "previousSibling"sv);


### PR DESCRIPTION
Firefox's inspector now uses an `isPseudoElement` property to identify pseudo-element nodes, instead of one `isFooPseudoElement` for each type. Those boolean properties are left in for now, as they're not harmful, and this maintains compatibility with older Firefox versions.

Corresponds to this Firefox commit:
https://github.com/mozilla-firefox/firefox/commit/65ea9dbd82de2a873d11b8638c2ce8775dc59672