### PR TITLE
LibWeb: Measure grid block size using resolved content width

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -2817,18 +2817,30 @@ impl GridFormattingContext {
             let containing = self.containing_block_size(item, axis);
             let containing_inline = self.containing_block_size(item, Axis::Column);
             let containing_block = self.containing_block_size(item, Axis::Row);
+            let style = self.style(item.box_);
+            let facts = self.facts(item.box_);
+            // https://drafts.csswg.org/css-sizing-3/#max-content-block-size
+            // Usually the block size of the content after layout.
+            // NB: The column pass has already resolved this item's content width and layout_items() lays the item out
+            //     at that width, so block contents must be measured against the same basis. Orthogonal items with
+            //     inline contents instead contribute their inline-axis size to the physical row axis.
+            let use_resolved_content_width = !axis.is_column()
+                && (style.writing_mode() == writing_mode::HORIZONTAL_TB || !facts.children_are_inline());
+            let available_inline = if use_resolved_content_width {
+                self.used(item).content_inline_size.get()
+            } else {
+                containing_inline
+            };
             let available = AvailableSpace {
-                inline_size: AvailableSize::definite(clamp_to_max_dimension_value(containing_inline)),
+                inline_size: AvailableSize::definite(clamp_to_max_dimension_value(available_inline)),
                 block_size: AvailableSize::definite(clamp_to_max_dimension_value(containing_block)),
             };
             let mut constraints = self.grid_area_constraints(item);
             if !axis.is_column() {
                 constraints.percentage_basis_block_size = Some(containing);
             }
-            let style = self.style(item.box_);
             let preferred = axis.select(style.width(), style.height());
             let alignment = self.item_alignment(item, axis);
-            let facts = self.facts(item.box_);
             let has_natural = axis.select(
                 facts.has_auto_content_width() || facts.has_auto_content_height() && facts.has_preferred_aspect_ratio(),
                 facts.has_auto_content_height() || facts.has_auto_content_width() && facts.has_preferred_aspect_ratio(),

--- a/Tests/LibWeb/Layout/expected/grid/grid-item-block-fit-content-uses-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-item-block-fit-content-uses-content-width.txt
@@ -1,0 +1,42 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 96 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 80 0+0+8] children: not-inline
+      Box <div.grid> at [8,8] [0+0+0 784 0+0+0] [0+0+0 40 0+0+0] [GFC] children: not-inline
+        BlockContainer <div> at [8,8] [0+0+0 100 0+0+0] [0+0+0 0 0+0+40] [BFC] children: not-inline
+        BlockContainer <div.item> at [118,18] [0+0+10 80 10+0+0] [0+0+10 20 10+0+0] [BFC] children: inline
+          frag 0 from BlockContainer start: 0, length: 0, rect: [118,18 45x10] baseline: 10
+          frag 1 from BlockContainer start: 0, length: 0, rect: [118,28 45x10] baseline: 10
+          BlockContainer <span> at [118,18] inline-block [0+0+0 45 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+          BlockContainer <span> at [118,28] inline-block [0+0+0 45 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,48] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+      Box <div.grid> at [8,48] [0+0+0 784 0+0+0] [0+0+0 40 0+0+0] [GFC] children: not-inline
+        BlockContainer <div> at [8,48] [0+0+0 100 0+0+0] [0+0+0 0 0+0+40] [BFC] children: not-inline
+        BlockContainer <div.item.orthogonal> at [118,58] [0+0+10 80 10+0+0] [0+0+10 20 10+0+0] [BFC] children: not-inline
+          BlockContainer <div.horizontal> at [118,58] [0+0+0 80 0+0+0] [0+0+0 20 0+0+0] children: inline
+            frag 0 from BlockContainer start: 0, length: 0, rect: [118,58 45x10] baseline: 10
+            frag 1 from BlockContainer start: 0, length: 0, rect: [118,68 45x10] baseline: 10
+            BlockContainer <span> at [118,58] inline-block [0+0+0 45 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+            BlockContainer <span> at [118,68] inline-block [0+0+0 45 0+0+0] [0+0+0 10 0+0+0] [BFC] children: not-inline
+      BlockContainer <(anonymous)> at [8,88] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x96]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x80]
+      Paintable (Box<DIV>.grid) [8,8 784x40]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 100x0]
+        PaintableWithLines (BlockContainer<DIV>.item) [108,8 100x40]
+          PaintableWithLines (BlockContainer<SPAN>) [118,18 45x10]
+          PaintableWithLines (BlockContainer<SPAN>) [118,28 45x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,48 784x0]
+      Paintable (Box<DIV>.grid) [8,48 784x40]
+        PaintableWithLines (BlockContainer<DIV>) [8,48 100x0]
+        PaintableWithLines (BlockContainer<DIV>.item.orthogonal) [108,48 100x40]
+          PaintableWithLines (BlockContainer<DIV>.horizontal) [118,58 80x20]
+            PaintableWithLines (BlockContainer<SPAN>) [118,58 45x10]
+            PaintableWithLines (BlockContainer<SPAN>) [118,68 45x10]
+      PaintableWithLines (BlockContainer(anonymous)) [8,88 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x96] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/grid-item-block-fit-content-uses-content-width.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-item-block-fit-content-uses-content-width.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 100px 100px;
+    align-items: start;
+    background: red;
+}
+.item {
+    padding: 10px;
+    line-height: 0;
+    background: green;
+}
+.item span {
+    display: inline-block;
+    width: 45px;
+    height: 10px;
+    background: blue;
+}
+.orthogonal {
+    width: 80px;
+    writing-mode: vertical-lr;
+}
+.horizontal {
+    writing-mode: horizontal-tb;
+}
+</style>
+<div class="grid"><div></div><div class="item"><span></span><span></span></div></div>
+<div class="grid"><div></div><div class="item orthogonal"><div
+    class="horizontal"><span></span><span></span></div></div></div>


### PR DESCRIPTION
Grid items with non-stretch alignment measured their fit-content block size against the full grid area, even after resolving a narrower content width. This could leave content outside the item border. Use the resolved content width for block sizing when it represents the item's laid-out contents. Preserve the grid-area basis for orthogonal inline content.

Makes the last line stay inside the poll box on https://tweakers.net:

| Before | After |
|--|--|
| <img width="358" height="595" alt="image" src="https://github.com/user-attachments/assets/963b31db-0498-4b83-8b69-4a518d258561" /> | <img width="356" height="612" alt="image" src="https://github.com/user-attachments/assets/283eb242-2826-4c64-8b0e-5d8e6e1e2819" /> |
