### PR TITLE
LibWeb: Respect minimum contributions in flexible columns

### DIFF
--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3957,10 +3957,10 @@ pub(crate) fn resolve_intrinsic_track_sizes(
     };
     let mut contributions = vec![CssPixels::default(); tracks.len()];
     for item in items {
-        // NB: This step repeats the content-sized track step, but only distributes space to flexible tracks.
-        // For min-content column sizing, the later "Expand Flexible Tracks" step resolves the flex fraction
-        // to zero, so fixed-min flexible columns must not grow from their items' intrinsic width here.
-        // Keep min-content row sizing here so intrinsic-height grids still account for their contents.
+        // NB: This step repeats the content-sized track step, but only distributes space to flexible tracks. For
+        //     min-content column sizing, the later "Expand Flexible Tracks" step resolves the flex fraction to zero, so
+        //     flexible columns must not grow beyond their items' minimum contribution here. Keep min-content row sizing
+        //     here so intrinsic-height grids still account for their contents.
         let mut total_flex = 0.0;
         let mut flexible_count = 0usize;
         let mut non_flexible_space = CssPixels::default();
@@ -3977,9 +3977,9 @@ pub(crate) fn resolve_intrinsic_track_sizes(
         if flexible_count == 0 {
             continue;
         }
-        // If the grid container is being sized under a min- or max-content constraint, use the items' limited
-        // min-content contributions in place of their minimum contributions here.
-        let mut contribution = if available.is_intrinsic_sizing_constraint() {
+        let use_limited_min_content =
+            available == AvailableSize::MaxContent || (row_axis && available == AvailableSize::MinContent);
+        let mut contribution = if use_limited_min_content {
             if total_flex == 0.0 && item.is_scroll_container {
                 // https://drafts.csswg.org/css-grid-2/#min-size-auto
                 // A grid item's automatic minimum size is zero if its computed overflow is a scrollable

--- a/Tests/LibWeb/Layout/expected/grid/nested-grid-flex-track-minimum-contribution.txt
+++ b/Tests/LibWeb/Layout/expected/grid/nested-grid-flex-track-minimum-contribution.txt
@@ -1,0 +1,39 @@
+Viewport <#document> at [0,0] [0+0+0 800 0+0+0] [0+0+0 600 0+0+0] [BFC] children: not-inline
+  BlockContainer <html> at [0,0] [0+0+0 800 0+0+0] [0+0+0 36 0+0+0] [BFC] children: not-inline
+    BlockContainer <body> at [8,8] [8+0+0 784 0+0+8] [8+0+0 20 0+0+8] children: not-inline
+      Box <div.parent> at [8,8] [0+0+0 784 0+0+0] [0+0+0 20 0+0+0] [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+        Box <div.outer> at [8,8] [0+0+0 300 0+0+0] [0+0+0 20 0+0+0] [GFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+          Box <div.inner> at [8,8] [0+0+0 300 0+0+0] [0+0+0 20 0+0+0] [GFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            BlockContainer <div> at [8,8] [0+0+0 40 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+            Box <div.middle> at [48,8] flex-container(row) [0+0+0 260 0+0+0] [0+0+0 20 0+0+0] [FFC] children: not-inline
+              BlockContainer <div.content> at [48,8] flex-item [0+0+0 260 0+0+0] [0+0+0 20 0+0+0] [BFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+              TextNode <#text> (not painted)
+          BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+            TextNode <#text> (not painted)
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text> (not painted)
+      BlockContainer <(anonymous)> at [8,28] [0+0+0 784 0+0+0] [0+0+0 0 0+0+0] children: inline
+        TextNode <#text> (not painted)
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x36]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x20]
+      Paintable (Box<DIV>.parent) [8,8 784x20]
+        Paintable (Box<DIV>.outer) [8,8 300x20]
+          Paintable (Box<DIV>.inner) [8,8 300x20]
+            PaintableWithLines (BlockContainer<DIV>) [8,8 40x20]
+            Paintable (Box<DIV>.middle) [48,8 260x20]
+              PaintableWithLines (BlockContainer<DIV>.content) [48,8 260x20]
+      PaintableWithLines (BlockContainer(anonymous)) [8,28 784x0]
+
+SC for Viewport<#document> [0,0 800x600] (z-index: auto)
+ SC for BlockContainer<HTML> [0,0 800x36] (z-index: auto)

--- a/Tests/LibWeb/Layout/input/grid/nested-grid-flex-track-minimum-contribution.html
+++ b/Tests/LibWeb/Layout/input/grid/nested-grid-flex-track-minimum-contribution.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<style>
+.parent {
+    display: grid;
+    grid-template-columns: 300px;
+}
+.outer {
+    display: grid;
+}
+.inner {
+    display: grid;
+    grid-template-columns: 40px 1fr;
+}
+.middle {
+    display: flex;
+    min-width: 0;
+}
+.content {
+    width: 400px;
+    height: 20px;
+}
+</style>
+<div class="parent">
+    <div class="outer">
+        <div class="inner">
+            <div></div>
+            <div class="middle"><div class="content"></div></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Nested grids could expand beyond their containing track because flexible columns used their full min-content contribution while the grid was sized under a min-content constraint.

Use the item minimum contribution for min-content column sizing so the flexible track can remain within the available space.

Fixes the layout on https://tweakers.net:

| Before | After |
|--|--|
| <img width="733" height="561" alt="image" src="https://github.com/user-attachments/assets/39ddf256-74a9-44ba-8dca-a29cfdd55c10" /> | <img width="734" height="561" alt="image" src="https://github.com/user-attachments/assets/3963c46d-5b3f-4ae8-ac62-379432d3ba1e" /> |
