### PR TITLE
CI+Meta: Bump CI docker image version and add actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         toolchain: ['GNU']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-16vcpu-ubuntu-2404"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13"}']
 
         include:
           - os_name: 'Linux'

--- a/.github/workflows/js-and-wasm-artifacts.yml
+++ b/.github/workflows/js-and-wasm-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
         toolchain: ['Clang']
         package_type: ['Linux-x86_64']
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "js-benchmarks", "self-hosted"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: ['{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/js-and-wasm-benchmarks.yml
+++ b/.github/workflows/js-and-wasm-benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         arch: ['x86_64']
         package_type: ['Linux-x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "js-benchmarks", "self-hosted"]']
-        container: ['{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: ['{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: 'blacksmith-16vcpu-ubuntu-2404'
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13
 
     steps:
       - name: Checkout LadybirdBrowser/ladybird

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13
 
     steps:
       - uses: actions/checkout@v7.0.1
@@ -31,7 +31,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.repository == 'LadybirdBrowser/ladybird'
     container:
-      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29
+      image: ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -24,7 +24,7 @@ jobs:
         toolchain: ['Clang']
         clang_plugins: [false]
         runner_labels: ['["blacksmith-8vcpu-ubuntu-2404-arm"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13"}']
 
         include:
           - os_name: 'Linux'

--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
         os_name: ['Linux']
         arch: ['x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "web-benchmarks", "self-hosted"]']
-        container: ['{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: ['{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.08.13"}']
 
         include:
           - os_name: 'macOS'

--- a/.github/workflows/web-benchmarks.yml
+++ b/.github/workflows/web-benchmarks.yml
@@ -22,7 +22,7 @@ jobs:
         os_name: ['Linux']
         arch: ['x86_64']
         runner_labels: ['["ubuntu-24.04-internal", "web-benchmarks", "self-hosted"]']
-        container: [&ci_container '{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
+        container: ['{"image":"ghcr.io/ladybirdbrowser/ladybird-ci:2026.07.29"}']
 
         include:
           - os_name: 'macOS'

--- a/Meta/Linters/lint_clang_format.py
+++ b/Meta/Linters/lint_clang_format.py
@@ -7,6 +7,7 @@
 import argparse
 import re
 import shutil
+import signal
 import sys
 
 from pathlib import Path
@@ -84,6 +85,9 @@ def get_files_to_format(use_git: bool, additional_files: List[str]) -> List[str]
 
 
 def main():
+    # Terminate by SIGINT on Ctrl+C, so that Meta/lint-ci.sh stops instead of counting the interrupt as a lint failure.
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
     parser = argparse.ArgumentParser(description=f"Format C/C++ files using {CLANG_FORMAT_EXECUTABLE}")
     parser.add_argument("--overwrite-inplace", action="store_true", help="Overwrite files in place", required=True)
     parser.add_argument("files", nargs="*", help="Additional files to format (if none provided, uses git ls-files)")

--- a/Meta/Linters/lint_workflows.sh
+++ b/Meta/Linters/lint_workflows.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/../.." || exit 1
+
+is_workflow_file() {
+    case "$1" in
+        .github/workflows/*.yml | .github/workflows/*.yaml)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+if [ "$#" -eq "0" ]; then
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done < <(
+        git ls-files -- \
+            '.github/workflows/*.yml' \
+            '.github/workflows/*.yaml'
+    )
+else
+    files=()
+    for file in "$@"; do
+        file="${file#"${PWD}/"}"
+        file="${file#./}"
+
+        if is_workflow_file "${file}"; then
+            files+=("${file}")
+        fi
+    done
+fi
+
+if (( ${#files[@]} )); then
+    if ! command -v actionlint >/dev/null 2>&1 ; then
+        echo "Please install actionlint: pip3 install -r Meta/Linters/requirements.txt"
+        exit 1
+    fi
+
+    # actionlint hands the contents of `run:` steps to shellcheck and pyflakes when it finds them on the PATH, which
+    # makes its output depend on what happens to be installed. Disable both so that everyone sees the same results.
+    actionlint -shellcheck= -pyflakes= "${files[@]}"
+else
+    echo "No workflow files to check."
+fi

--- a/Meta/Linters/requirements.txt
+++ b/Meta/Linters/requirements.txt
@@ -1,2 +1,3 @@
+actionlint-py==1.7.12.24
 pyright==1.1.411
 ruff==0.15.22

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -26,7 +26,8 @@ for cmd in \
         Meta/Linters/lint_executable_resources.sh \
         Meta/Linters/lint_prettier.sh \
         Meta/Linters/lint_python.sh \
-        Meta/Linters/lint_shell_scripts.sh; do
+        Meta/Linters/lint_shell_scripts.sh \
+        Meta/Linters/lint_workflows.sh; do
     if "${cmd}" "$@"; then
         echo -e "[${GREEN}OK${NC}]: ${cmd}"
     else


### PR DESCRIPTION
Follow-up of #11111.

* Bumps CI version
* Adds actionlint linter
* Fixes clang-format script's SIGINT handling