### PR TITLE
CI: Select Xcode 26.6

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -87,7 +87,7 @@ runs:
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.5'
+        xcode-version: '26.6'
 
     - name: 'Install Dependencies'
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}


### PR DESCRIPTION
Our own runner only has 26.6 available, so update to that and make our web-benchmarks workflow work again.