### PR TITLE
test-web: Set up the run context before printing the test count

### DIFF
--- a/Tests/LibWeb/test-web/main.cpp
+++ b/Tests/LibWeb/test-web/main.cpp
@@ -1141,6 +1141,11 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
         s_view_index_by_view.set(view.ptr(), i);
     }
 
+    auto tests_remaining = tests.size();
+    TestRunContext context { tests, tests_remaining, total_tests };
+    s_run_context = &context;
+    ScopeGuard clear_run_context = [&] { s_run_context = nullptr; };
+
     display.begin_run();
     ScopeGuard clear_live_display = [&] { display.clear_live_display(); };
 
@@ -1148,12 +1153,7 @@ static ErrorOr<int> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePix
     s_view_run_next_test.resize_and_keep_capacity(concurrency);
 
     s_all_tests_complete = Core::Promise<Empty>::construct();
-    auto tests_remaining = tests.size();
     auto current_test = 0uz;
-
-    TestRunContext context { tests, tests_remaining, total_tests };
-    s_run_context = &context;
-    ScopeGuard clear_run_context = [&] { s_run_context = nullptr; };
 
     Vector<TestCompletion> non_passing_tests;
     bool fail_fast_triggered = false;


### PR DESCRIPTION
The message announcing how many tests will run reads the total through the global run context. That context was assigned after the message was printed, so the harness always reported that zero tests were running. Assign the run context before the display begins the run.

Fixes a regression introduced in 3ca76a42ecd (#8939)