### PR TITLE
CI: Check only tests changed by a pull request for flakiness

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -212,10 +212,10 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: bash
         run: |
-          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
+          git fetch --no-tags --depth=2 origin "$(git rev-parse HEAD)"
           "${{ env.pythonLocation }}/bin/python" Meta/check-test-flakiness.py \
             --test-web-binary Build/bin/test-web \
-            --base-ref ${{ github.event.pull_request.base.sha }} \
+            --base-ref HEAD^1 \
             --deadline-seconds 1200 \
             --python-executable "${{ env.pythonLocation }}/bin/python" \
             | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The base revision recorded in the pull request event payload can be older than the revision contained in the checked out merge commit. Tests that landed on the base branch in the interim were then checked as if the pull request had introduced them. 

Diff against the first parent of the merge commit instead, which is always the exact revision the tested tree was merged with.