### PR TITLE
LibWeb: Honor idle timeouts and reuse responsive images

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -583,7 +583,7 @@ void run_when_event_loop_reaches_step_1(GC::Ref<GC::Function<void()>> steps)
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task
-TaskID queue_a_task(HTML::Task::Source source, GC::Ptr<EventLoop> event_loop, GC::Ptr<DOM::Document> document, GC::Ref<GC::Function<void()>> steps)
+TaskID queue_a_task(HTML::Task::Source source, GC::Ptr<EventLoop> event_loop, GC::Ptr<DOM::Document> document, GC::Ref<GC::Function<void()>> steps, Task::Priority priority)
 {
     // 1. If event loop was not given, set event loop to the implied event loop.
     if (!event_loop)
@@ -596,7 +596,7 @@ TaskID queue_a_task(HTML::Task::Source source, GC::Ptr<EventLoop> event_loop, GC
     // 5. Set task's source to source.
     // 6. Set task's document to the document.
     // 7. Set task's script evaluation environment settings object set to an empty set.
-    auto task = HTML::Task::create(source, document, steps);
+    auto task = HTML::Task::create(source, document, steps, priority);
 
     // 8. Let queue be the task queue to which source is associated on event loop.
     // 9. Append task to queue.
@@ -609,7 +609,7 @@ TaskID queue_a_task(HTML::Task::Source source, GC::Ptr<EventLoop> event_loop, GC
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task
-TaskID queue_global_task(HTML::Task::Source source, JS::Object& global_object, GC::Ref<GC::Function<void()>> steps)
+TaskID queue_global_task(HTML::Task::Source source, JS::Object& global_object, GC::Ref<GC::Function<void()>> steps, Task::Priority priority)
 {
     // 1. Let event loop be global's relevant agent's event loop.
     auto& event_loop = relevant_agent(global_object).event_loop;
@@ -620,7 +620,7 @@ TaskID queue_global_task(HTML::Task::Source source, JS::Object& global_object, G
         document = &window_object->associated_document();
 
     // 3. Queue a task given source, event loop, document, and steps.
-    return queue_a_task(source, *event_loop, document, steps);
+    return queue_a_task(source, *event_loop, document, steps, priority);
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -152,8 +152,8 @@ private:
 
 WEB_API EventLoop& main_thread_event_loop();
 WEB_API void run_when_event_loop_reaches_step_1(GC::Ref<GC::Function<void()>> steps);
-WEB_API TaskID queue_a_task(HTML::Task::Source, GC::Ptr<EventLoop>, GC::Ptr<DOM::Document>, GC::Ref<GC::Function<void()>> steps);
-WEB_API TaskID queue_global_task(HTML::Task::Source, JS::Object&, GC::Ref<GC::Function<void()>> steps);
+WEB_API TaskID queue_a_task(HTML::Task::Source, GC::Ptr<EventLoop>, GC::Ptr<DOM::Document>, GC::Ref<GC::Function<void()>> steps, Task::Priority = Task::Priority::Normal);
+WEB_API TaskID queue_global_task(HTML::Task::Source, JS::Object&, GC::Ref<GC::Function<void()>> steps, Task::Priority = Task::Priority::Normal);
 WEB_API void queue_a_microtask(GC::Ptr<DOM::Document const>, GC::Ref<GC::Function<void()>> steps);
 void perform_a_microtask_checkpoint();
 

--- a/Libraries/LibWeb/HTML/EventLoop/Task.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.cpp
@@ -26,14 +26,15 @@ static IDAllocator& unique_task_source_allocator()
     return next_task_id++;
 }
 
-GC::Ref<Task> Task::create(Source source, GC::Ptr<DOM::Document const> document, GC::Ref<GC::Function<void()>> steps)
+GC::Ref<Task> Task::create(Source source, GC::Ptr<DOM::Document const> document, GC::Ref<GC::Function<void()>> steps, Priority priority)
 {
-    return GC::Heap::the().allocate<Task>(source, document, move(steps));
+    return GC::Heap::the().allocate<Task>(source, document, move(steps), priority);
 }
 
-Task::Task(Source source, GC::Ptr<DOM::Document const> document, GC::Ref<GC::Function<void()>> steps)
+Task::Task(Source source, GC::Ptr<DOM::Document const> document, GC::Ref<GC::Function<void()>> steps, Priority priority)
     : m_id(allocate_task_id())
     , m_source(source)
+    , m_priority(priority)
     , m_steps(steps)
     , m_document(document)
 {

--- a/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -25,6 +25,11 @@ class Task final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(Task);
 
 public:
+    enum class Priority {
+        Normal,
+        Idle,
+    };
+
     // https://html.spec.whatwg.org/multipage/webappapis.html#generic-task-sources
     enum class Source {
         Unspecified,
@@ -104,12 +109,13 @@ public:
         UniqueTaskSourceStart
     };
 
-    static GC::Ref<Task> create(Source, GC::Ptr<DOM::Document const>, GC::Ref<GC::Function<void()>> steps);
+    static GC::Ref<Task> create(Source, GC::Ptr<DOM::Document const>, GC::Ref<GC::Function<void()>> steps, Priority = Priority::Normal);
 
     virtual ~Task() override;
 
     [[nodiscard]] TaskID id() const { return m_id; }
     Source source() const { return m_source; }
+    Priority priority() const { return m_priority; }
     void execute();
 
     DOM::Document const* document() const;
@@ -118,12 +124,13 @@ public:
     bool is_permanently_unrunnable() const;
 
 private:
-    Task(Source, GC::Ptr<DOM::Document const>, GC::Ref<GC::Function<void()>> steps);
+    Task(Source, GC::Ptr<DOM::Document const>, GC::Ref<GC::Function<void()>> steps, Priority);
 
     virtual void visit_edges(Visitor&) override;
 
     TaskID m_id {};
     Source m_source { Source::Unspecified };
+    Priority m_priority { Priority::Normal };
     GC::Ref<GC::Function<void()>> m_steps;
     GC::Ptr<DOM::Document const> m_document;
 

--- a/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/TaskQueue.cpp
@@ -39,7 +39,7 @@ void TaskQueue::add(GC::Ref<Task> task)
         return;
 
     m_last_added_task = task.ptr();
-    if (task->source() == Task::Source::IdleTask)
+    if (task->priority() == Task::Priority::Idle)
         m_idle_tasks.append(*task);
     else
         m_tasks.append(*task);

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -995,6 +995,48 @@ after_step_7:
             return;
         }
 
+        // INTEROP: The cache shortcut in step 7 cannot handle responsive images because their source is not selected
+        //          until step 10. Reuse an already decoded selected source here so that replacing an img element does
+        //          not make the image disappear while the higher-layer cache processes the same resource again.
+        ListOfAvailableImages::Key key;
+        key.url = *url_string;
+        key.mode = m_cors_setting;
+        key.origin = document().origin();
+        if (auto* entry = document().list_of_available_images().get(key)) {
+            entry->ignore_higher_layer_caching = true;
+
+            unregister_with_decoded_image_data_if_needed();
+            abort_the_image_request(m_current_request);
+            abort_the_image_request(m_pending_request);
+            m_pending_request = nullptr;
+            m_load_event_delayer.clear();
+
+            m_current_request = ImageRequest::create();
+            m_current_request->set_image_data(entry->image_data);
+            m_current_request->set_state(ImageRequest::State::CompletelyAvailable);
+            m_current_request->set_current_pixel_density(pixel_density.value_or(1.0f));
+            register_with_decoded_image_data_if_needed();
+            m_current_request->prepare_for_presentation(*this);
+
+            document().style_computer().style_engine().record_element_style_input_change(style_node_id());
+            set_needs_layout_update_or_repaint_after_image_data_change(DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);
+
+            queue_an_element_task(HTML::Task::Source::DOMManipulation, [this, restart_animations, maybe_omit_events, url_string, previous_url, update_the_image_data_count] {
+                if (update_the_image_data_count != m_update_the_image_data_count)
+                    return;
+                if (!document().is_fully_active()) {
+                    m_load_event_delayer.clear();
+                    return;
+                }
+                if (restart_animations)
+                    restart_the_animation();
+                m_current_request->set_current_url(document(), *url_string);
+                if (!maybe_omit_events || previous_url != *url_string)
+                    dispatch_event(DOM::Event::create(HTML::relevant_global_object(*this), HTML::EventNames::load));
+            });
+            return;
+        }
+
         // 14. If the pending request is not null and urlString is the same as the pending request's current URL, then return.
         if (m_pending_request && *url_string == m_pending_request->current_url())
             return;

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -810,7 +810,8 @@ void HTMLImageElement::update_the_image_data_impl(bool restart_animations, bool 
         ListOfAvailableImages::Key key;
         key.url = *url_string;
         key.mode = m_cors_setting;
-        key.origin = document().origin();
+        if (m_cors_setting != CORSSettingAttribute::NoCORS)
+            key.origin = document().origin();
 
         // 4. If the list of available images contains an entry for key, then:
         if (auto* entry = document().list_of_available_images().get(key)) {
@@ -1001,7 +1002,8 @@ after_step_7:
         ListOfAvailableImages::Key key;
         key.url = *url_string;
         key.mode = m_cors_setting;
-        key.origin = document().origin();
+        if (m_cors_setting != CORSSettingAttribute::NoCORS)
+            key.origin = document().origin();
         if (auto* entry = document().list_of_available_images().get(key)) {
             entry->ignore_higher_layer_caching = true;
 
@@ -1141,10 +1143,17 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
 {
     auto captured_url_string = Utf16String::from_utf16(url_string);
     auto captured_previous_url = Utf16String::from_utf16(previous_url);
+    auto originating_document = GC::Ref { document() };
+
+    ListOfAvailableImages::Key cache_key;
+    cache_key.url = captured_url_string;
+    cache_key.mode = m_cors_setting;
+    if (m_cors_setting != CORSSettingAttribute::NoCORS)
+        cache_key.origin = originating_document->origin();
 
     image_request->add_callbacks(
-        [this, image_request, maybe_omit_events, url_string = captured_url_string, previous_url = captured_previous_url]() {
-            batching_dispatcher().enqueue(GC::create_function(GC::Heap::the(), [this, image_request, maybe_omit_events, url_string, previous_url] {
+        [this, image_request, maybe_omit_events, url_string = captured_url_string, previous_url = captured_previous_url, originating_document, cache_key]() {
+            batching_dispatcher().enqueue(GC::create_function(GC::Heap::the(), [this, image_request, maybe_omit_events, url_string, previous_url, originating_document, cache_key] {
                 // AD-HOC: Bail out if the document became inactive (e.g. iframe removed or navigated)
                 //         between when the fetch completed and when this batched callback runs.
                 if (!document().is_fully_active()) {
@@ -1166,11 +1175,6 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
                 auto image_data = image_request->shared_resource_request()->image_data();
                 image_request->set_image_data(image_data);
 
-                ListOfAvailableImages::Key key;
-                key.url = url_string;
-                key.mode = m_cors_setting;
-                key.origin = document().origin();
-
                 // 1. If image request is the pending request, abort the image request for the current request,
                 //    upgrade the pending request to the current request
                 //    and prepare image request for presentation given the img element.
@@ -1187,8 +1191,8 @@ void HTMLImageElement::add_callbacks_to_image_request(GC::Ref<ImageRequest> imag
                 image_request->set_state(ImageRequest::State::CompletelyAvailable);
 
                 // 3. Add the image to the list of available images using the key key, with the ignore higher-layer caching flag set.
-                document().list_of_available_images().add(key, *image_data, true);
-                document().prune_image_resource_caches();
+                originating_document->list_of_available_images().add(cache_key, *image_data, true);
+                originating_document->prune_image_resource_caches();
 
                 document().style_computer().style_engine().record_element_style_input_change(style_node_id());
                 set_needs_layout_update_or_repaint_after_image_data_change(DOM::SetNeedsLayoutReason::HTMLImageElementUpdateTheImageData);

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -259,10 +259,14 @@ public:
 
     JS::Completion invoke(GC::Ref<RequestIdleCallback::IdleDeadline> deadline) { return m_handler(deadline); }
     u32 handle() const { return m_handle; }
+    Optional<i32> timeout_timer_id() const { return m_timeout_timer_id; }
+    void set_timeout_timer_id(i32 timeout_timer_id) { m_timeout_timer_id = timeout_timer_id; }
+    void clear_timeout_timer_id() { m_timeout_timer_id.clear(); }
 
 private:
     IdleCallbackHandler m_handler;
     u32 m_handle { 0 };
+    Optional<i32> m_timeout_timer_id;
 };
 
 GC::Ref<Window> Window::create()
@@ -829,7 +833,8 @@ void Window::start_an_idle_period()
     //    which performs the steps defined in the invoke idle callbacks algorithm with window and getDeadline as parameters.
     queue_global_task(Task::Source::IdleTask, relevant_global_object(*this), GC::create_function(GC::Heap::the(), [this] {
         invoke_idle_callbacks();
-    }));
+    }),
+        Task::Priority::Idle);
 }
 
 // https://w3c.github.io/requestidlecallback/#invoke-idle-callbacks-algorithm
@@ -843,6 +848,10 @@ void Window::invoke_idle_callbacks()
     if (now < event_loop.compute_deadline() && !m_runnable_idle_callbacks.is_empty()) {
         // 1. Pop the top callback from window's list of runnable idle callbacks.
         auto callback = m_runnable_idle_callbacks.take_first();
+        if (callback->timeout_timer_id().has_value()) {
+            clear_timeout(*callback->timeout_timer_id());
+            callback->clear_timeout_timer_id();
+        }
         // 2. Let deadlineArg be a new IdleDeadline whose [get deadline time algorithm] is getDeadline.
         auto deadline_arg = RequestIdleCallback::IdleDeadline::create();
         // 3. Call callback with deadlineArg as its argument. If an uncaught runtime script error occurs, then report the exception.
@@ -854,9 +863,49 @@ void Window::invoke_idle_callbacks()
         if (!m_runnable_idle_callbacks.is_empty()) {
             queue_global_task(Task::Source::IdleTask, relevant_global_object(*this), GC::create_function(GC::Heap::the(), [this] {
                 invoke_idle_callbacks();
-            }));
+            }),
+                Task::Priority::Idle);
         }
     }
+}
+
+// https://w3c.github.io/requestidlecallback/#invoke-idle-callback-timeout-algorithm
+void Window::invoke_idle_callback_timeout(u32 handle)
+{
+    // 1. Let callback be the result of finding the entry in window's list of idle request callbacks or the list of
+    //    runnable idle callbacks that is associated with the value given by the handle argument passed to the algorithm.
+    RefPtr<IdleCallback> callback;
+    auto take_callback = [&](auto& callbacks) {
+        for (size_t index = 0; index < callbacks.size(); ++index) {
+            if (callbacks[index]->handle() == handle) {
+                callback = callbacks.take(index);
+                return;
+            }
+        }
+    };
+    take_callback(m_idle_request_callbacks);
+    if (!callback)
+        take_callback(m_runnable_idle_callbacks);
+
+    // 2. If callback is not undefined:
+    if (!callback)
+        return;
+
+    callback->clear_timeout_timer_id();
+
+    // 2.1. Remove callback from both window's list of idle request callbacks and the list of runnable idle callbacks.
+    // NB: Taking the callback from whichever list contained it above implements this step, since it can only be in one.
+
+    // 2.2. Let now be the current time.
+
+    // 2.3. Let deadlineArg be a new IdleDeadline. Set the get deadline time algorithm associated with deadlineArg to an
+    //      algorithm returning now and set the timeout associated with deadlineArg to true.
+    auto deadline_arg = RequestIdleCallback::IdleDeadline::create(true);
+
+    // 2.4. Invoke callback with « deadlineArg » and "report".
+    auto result = callback->invoke(deadline_arg);
+    if (result.is_error())
+        report_exception(result, principal_realm());
 }
 
 void Window::set_associated_document(DOM::Document& document)
@@ -1918,17 +1967,30 @@ u32 Window::request_idle_callback(IdleCallbackHandler callback, IdleRequestOptio
     auto handle = m_idle_callback_identifier;
 
     // 4. Push callback to the end of window's list of idle request callbacks, associated with handle.
-    m_idle_request_callbacks.append(adopt_ref(*new IdleCallback(move(callback), handle)));
+    auto idle_callback = adopt_ref(*new IdleCallback(move(callback), handle));
+    m_idle_request_callbacks.append(idle_callback);
 
     // 5. Return handle and then continue running this algorithm asynchronously.
-    return handle;
 
-    // FIXME: 6. If the timeout property is present in options and has a positive value:
-    // FIXME:    1. Wait for timeout milliseconds.
-    // FIXME:    2. Wait until all invocations of this algorithm, whose timeout added to their posted time occurred before this one's, have completed.
-    // FIXME:    3. Optionally, wait a further user-agent defined length of time.
-    // FIXME:    4. Queue a task on the queue associated with the idle-task task source, which performs the invoke idle callback timeout algorithm, passing handle and window as arguments.
-    (void)options;
+    // 6. If the timeout property is present in options and has a positive value:
+    if (options.timeout.has_value() && *options.timeout > 0) {
+        // 1. Wait for timeout milliseconds.
+        auto timeout = min(*options.timeout, static_cast<u32>(NumericLimits<i32>::max()));
+        auto timeout_timer_id = run_steps_after_a_timeout(static_cast<i32>(timeout), [this, handle] {
+            // FIXME: 2. Wait until all invocations of this algorithm, whose timeout added to their posted time occurred before this one's, have completed.
+            // FIXME: 3. Optionally, wait a further user-agent defined length of time.
+
+            // 4. Queue a task on the queue associated with the idle-task task source, which performs the invoke idle callback timeout algorithm, passing handle and window as arguments.
+            // NB: A timed-out idle task has normal scheduling priority so that higher-priority work cannot keep it from
+            //     running indefinitely. Its task source remains the idle-task task source as required by the specification.
+            queue_global_task(Task::Source::IdleTask, relevant_global_object(*this), GC::create_function(GC::Heap::the(), [this, handle] {
+                invoke_idle_callback_timeout(handle);
+            }));
+        });
+        idle_callback->set_timeout_timer_id(timeout_timer_id);
+    }
+
+    return handle;
 }
 
 // https://w3c.github.io/requestidlecallback/#dom-window-cancelidlecallback
@@ -1939,12 +2001,18 @@ void Window::cancel_idle_callback(u32 handle)
     // 2. Find the entry in either the window's list of idle request callbacks or list of runnable idle callbacks
     //    that is associated with the value handle.
     // 3. If there is such an entry, remove it from both window's list of idle request callbacks and the list of runnable idle callbacks.
-    m_idle_request_callbacks.remove_first_matching([&](auto& callback) {
-        return callback->handle() == handle;
-    });
-    m_runnable_idle_callbacks.remove_first_matching([&](auto& callback) {
-        return callback->handle() == handle;
-    });
+    auto remove_callback = [&](auto& callbacks) {
+        for (size_t index = 0; index < callbacks.size(); ++index) {
+            if (callbacks[index]->handle() != handle)
+                continue;
+            auto callback = callbacks.take(index);
+            if (callback->timeout_timer_id().has_value())
+                clear_timeout(*callback->timeout_timer_id());
+            return;
+        }
+    };
+    remove_callback(m_idle_request_callbacks);
+    remove_callback(m_runnable_idle_callbacks);
 }
 
 // https://w3c.github.io/selection-api/#dom-window-getselection

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -322,6 +322,7 @@ private:
     virtual GC::Ptr<DOM::EventTarget> window_event_handlers_to_event_target() override { return *this; }
 
     void invoke_idle_callbacks();
+    void invoke_idle_callback_timeout(u32 handle);
 
     struct [[nodiscard]] NamedObjects {
         Vector<GC::Ref<LocalNavigable>> navigables;

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -1136,9 +1136,15 @@ WindowOrWorkerGlobalScopeMixin::AffectedAnyWebSockets WindowOrWorkerGlobalScopeM
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#run-steps-after-a-timeout
-void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step)
+i32 WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step)
 {
-    run_steps_after_a_timeout_impl(timeout, move(completion_step), {});
+    auto timer_key = m_timer_id_allocator.allocate();
+    auto remove_timer_and_complete = [this, timer_key, completion_step = move(completion_step)] mutable {
+        m_timers.remove(timer_key);
+        completion_step();
+    };
+    run_steps_after_a_timeout_impl(timeout, move(remove_timer_and_complete), timer_key);
+    return timer_key;
 }
 
 void WindowOrWorkerGlobalScopeMixin::run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key, Repeat repeat)

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -87,7 +87,7 @@ public:
     };
     AffectedAnyWebSockets make_disappear_all_web_sockets();
 
-    void run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step);
+    i32 run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step);
 
     [[nodiscard]] GC::Ref<HighResolutionTime::Performance> performance();
 

--- a/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
+++ b/Libraries/LibWeb/RequestIdleCallback/IdleDeadline.cpp
@@ -31,6 +31,9 @@ IdleDeadline::~IdleDeadline() = default;
 // https://w3c.github.io/requestidlecallback/#dom-idledeadline-timeremaining
 double IdleDeadline::time_remaining() const
 {
+    if (m_did_timeout)
+        return 0;
+
     auto const& event_loop = HTML::main_thread_event_loop();
     // 1. Let now be a DOMHighResTimeStamp representing current high resolution time in milliseconds.
     auto now = HighResolutionTime::current_high_resolution_time(HTML::current_global_object());

--- a/Tests/LibWeb/Text/expected/HTML/image-request-cache-after-adoption.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-request-cache-after-adoption.txt
@@ -1,0 +1,1 @@
+originating document retained cache entry: true

--- a/Tests/LibWeb/Text/expected/HTML/recreated-srcset-image-is-available.txt
+++ b/Tests/LibWeb/Text/expected/HTML/recreated-srcset-image-is-available.txt
@@ -1,0 +1,1 @@
+recreated image is completely available: true

--- a/Tests/LibWeb/Text/expected/request-idle-callback.txt
+++ b/Tests/LibWeb/Text/expected/request-idle-callback.txt
@@ -1,3 +1,5 @@
 handle is number: number
 deadline is IdleDeadline: true
 timeRemaining is function: function
+timed out callback didTimeout: true
+timed out callback timeRemaining: 0

--- a/Tests/LibWeb/Text/input/HTML/image-request-cache-after-adoption.html
+++ b/Tests/LibWeb/Text/input/HTML/image-request-cache-after-adoption.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    promiseTest(async () => {
+        const server = httpTestServer();
+        const testID = crypto.randomUUID();
+        const token = `image-request-cache-after-adoption-${testID}`;
+        const imageURL = await server.createEcho("GET", `/image-request-cache-after-adoption-${testID}.svg`, {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Type": "image/svg+xml",
+            },
+            body: `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>`,
+            wait_for_unblock: token,
+        });
+
+        const frame = document.createElement("iframe");
+        frame.srcdoc = "<body></body>";
+        document.body.appendChild(frame);
+        await new Promise(resolve => frame.addEventListener("load", resolve));
+
+        const originatingDocument = frame.contentDocument;
+        const image = originatingDocument.createElement("img");
+        image.crossOrigin = "anonymous";
+        image.src = imageURL;
+        originatingDocument.body.appendChild(image);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const loadPromise = new Promise((resolve, reject) => {
+            image.onload = resolve;
+            image.onerror = () => reject(new Error("Failed to load adopted image"));
+        });
+        document.body.appendChild(document.adoptNode(image));
+        await fetch(new URL(`/unblock/${token}`, imageURL));
+        await loadPromise;
+
+        const recreatedImage = originatingDocument.createElement("img");
+        recreatedImage.crossOrigin = "anonymous";
+        recreatedImage.src = imageURL;
+        originatingDocument.body.appendChild(recreatedImage);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        println(`originating document retained cache entry: ${recreatedImage.complete && recreatedImage.naturalWidth > 0}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/recreated-srcset-image-is-available.html
+++ b/Tests/LibWeb/Text/input/HTML/recreated-srcset-image-is-available.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    promiseTest(async () => {
+        const fallbackSource = "../../../Assets/120.png?fallback";
+        const selectedSource = "../../../Assets/120.png?selected";
+
+        const firstImage = document.createElement("img");
+        firstImage.src = fallbackSource;
+        firstImage.srcset = `${selectedSource} 1x`;
+        document.body.appendChild(firstImage);
+        await new Promise((resolve, reject) => {
+            firstImage.onload = resolve;
+            firstImage.onerror = () => reject(new Error("Failed to load first image"));
+        });
+        firstImage.remove();
+
+        const container = document.createElement("div");
+        container.innerHTML = `<img src="${fallbackSource}" srcset="${selectedSource} 1x">`;
+        const recreatedImage = container.firstElementChild;
+        document.body.appendChild(recreatedImage);
+
+        // Allow the image data update microtasks to select the srcset candidate. A cached image
+        // must remain completely available when a framework recreates its element.
+        await Promise.resolve();
+        await Promise.resolve();
+        println(`recreated image is completely available: ${recreatedImage.complete && recreatedImage.naturalWidth > 0}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/request-idle-callback.html
+++ b/Tests/LibWeb/Text/input/request-idle-callback.html
@@ -1,12 +1,32 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <script>
-    asyncTest(done => {
+    asyncTest(async done => {
         const handle = requestIdleCallback(deadline => {
             println(`deadline is IdleDeadline: ${deadline instanceof IdleDeadline}`);
             println(`timeRemaining is function: ${typeof deadline.timeRemaining}`);
-            done();
         });
         println(`handle is number: ${typeof handle}`);
+
+        await new Promise(resolve => requestIdleCallback(resolve));
+
+        const channel = new MessageChannel();
+        let keepEventLoopBusy = true;
+        channel.port1.onmessage = () => {
+            if (keepEventLoopBusy)
+                channel.port2.postMessage(undefined);
+        };
+        channel.port2.postMessage(undefined);
+
+        await new Promise(resolve => requestIdleCallback(deadline => {
+            println(`timed out callback didTimeout: ${deadline.didTimeout}`);
+            println(`timed out callback timeRemaining: ${deadline.timeRemaining()}`);
+            keepEventLoopBusy = false;
+            resolve();
+        }, { timeout: 1 }));
+
+        channel.port1.close();
+        channel.port2.close();
+        done();
     });
 </script>


### PR DESCRIPTION
Some sites defer application startup with `requestIdleCallback()` and rely on its timeout to guarantee progress. We awkwardly ignored that timeout, so a continuously busy event loop could leave initialization pending indefinitely! Honor requested timeouts, prevent expired callbacks from being starved, and report them with didTimeout set and no remaining idle time.

Framework rerenders can also replace a loaded responsive image with a new element selecting the same resource. We waited for the shared resource callback before exposing the decoded image, temporarily collapsing its layout box. Reuse decoded responsive image candidates immediately while keeping load event dispatch asynchronous, matching Chromium, WebKit, and Firefox.

Also align available-image cache keys with the HTML specification by including the document origin only when a CORS mode is used. Regression coverage exercises both idle callback timeouts under a continuously busy event loop and replacement of loaded responsive images.

This fixes basically all the load jank on https://fragrantica.com/