### PR TITLE
LibWeb: Delay the document load event for in-flight font fetches

### DIFF
--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -123,6 +123,11 @@ RefPtr<Gfx::Font const> FontLoader::font_with_point_size(float point_size, Gfx::
     if (!m_typeface) {
         if (!m_fetch_controller)
             start_loading_next_url();
+        // INTEROP: Delay the document load event til the fetch for this font has settled. Blink, Gecko, and WebKit all
+        //          keep the document from completing while a font load requested for rendering is pending — so pages
+        //          that measure font-dependent geometry in a load-event handler see the loaded font, not a fallback.
+        if (is_loading() && !m_document_load_event_delayer.has_value())
+            m_document_load_event_delayer.emplace(m_font_computer->document());
         return nullptr;
     }
     return m_typeface->font(point_size, variations, shape_features);
@@ -213,6 +218,7 @@ void FontLoader::font_did_load_or_fail(RefPtr<Gfx::Typeface const> typeface)
         m_font_computer->clear_computed_font_cache(m_family_name);
     }
     m_has_completed = true;
+    m_document_load_event_delayer.clear();
     for (auto& callback : m_subscribers)
         callback->function()(m_typeface);
     m_subscribers.clear();

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -18,6 +18,7 @@
 #include <LibWeb/CSS/FontFeatureData.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
+#include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
@@ -95,6 +96,7 @@ private:
     Vector<URL> m_urls;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;
     Vector<GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>> m_subscribers;
+    Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
     bool m_has_completed { false };
 };
 

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -799,8 +799,9 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                 // 1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
                 //    is "NetworkError" and set font face’s status attribute to "error".
                 if (!maybe_typeface) {
-                    m_status = FontFaceLoadStatus::Error;
-                    WebIDL::reject_promise(m_font_status_promise, WebIDL::NetworkError::create("Failed to load font"_utf16));
+                    // NB: reject_status_promise() also marks the promise as handled: A font that fails to load must not
+                    //     surface an unhandled rejection on a page that never looks at the FontFace API.
+                    reject_status_promise(WebIDL::NetworkError::create("Failed to load font"_utf16));
 
                     // For each FontFaceSet font face is in:
                     for (auto& font_face_set : m_containing_sets) {

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -642,6 +642,10 @@ void HTMLParserEndState::check_progress()
 
     case Phase::WaitingForLoadEventDelay:
         // 8. Spin the event loop until there is nothing that delays the load event in the Document.
+        // AD-HOC: Update style first — so any font fetches that the computed styles depend on get started; an in-flight
+        //         font fetch delays the load event.
+        // INTEROP: Gecko also flushes layout before firing the load event — so lazily-started font loads hold it back.
+        m_document->update_style();
         if (m_document->anything_is_delaying_the_load_event())
             return;
 

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -355,7 +355,10 @@ void XMLDocumentBuilder::document_end()
     }));
 
     // Spin the event loop until there is nothing that delays the load event in the Document.
+    // AD-HOC: Update style first, so any font fetches that the computed styles depend on get started; an in-flight font
+    //         fetch delays the load event.
     HTML::main_thread_event_loop().spin_until(GC::create_function(GC::Heap::the(), [&] {
+        m_document->update_style();
         return !m_document->anything_is_delaying_the_load_event();
     }));
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,6 +20,7 @@ Text/input/HTML/HTMLMediaElement-preload-none-does-not-fetch.html
 Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
 Text/input/css/font-face-load-dedups-same-url.html
+Text/input/css/font-load-delays-document-load-event.html
 Text/input/css/unrecognized-font-family-fallback-honors-weight.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_url.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write.html

--- a/Tests/LibWeb/Text/expected/css/font-load-delays-document-load-event.txt
+++ b/Tests/LibWeb/Text/expected/css/font-load-delays-document-load-event.txt
@@ -1,0 +1,1 @@
+tspan rect at iframe load: left=108 top=108 width=200 height=100

--- a/Tests/LibWeb/Text/input/css/font-load-delays-document-load-event.html
+++ b/Tests/LibWeb/Text/input/css/font-load-delays-document-load-event.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Verifies that a document's load event waits for in-flight @font-face fetches — so geometry measured in a load-
+    // event handler reflects the loaded font rather than a fallback font.
+    promiseTest(async () => {
+        // Serve a copy of Ahem.ttf through the echo server with a response delay — so the font fetch reliably outlasts
+        // every other part of the iframe document's load.
+        const fontBytes = new Uint8Array(await (await fetch("../wpt-import/fonts/Ahem.ttf")).arrayBuffer());
+        let binary = "";
+        for (const byte of fontBytes)
+            binary += String.fromCharCode(byte);
+        // A unique path per run: the echo-server registration namespace is shared across parallel
+        // workers and --repeat clones, so a fixed path lets one run serve another run's registration.
+        const token = crypto.randomUUID();
+        const registration = await fetch("/echo", {
+            method: "POST",
+            body: JSON.stringify({
+                method: "GET",
+                path: `/echo/slow-ahem-${token}.ttf`,
+                status: 200,
+                headers: { "Content-Type": "font/ttf", "Access-Control-Allow-Origin": "*" },
+                body: btoa(binary),
+                body_encoding: "base64",
+                delay_ms: 400,
+            }),
+        });
+        const fontUrl = (await registration.json()).url;
+
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `
+            <style>@font-face { font-family: SlowAhem; src: url("${fontUrl}"); }</style>
+            <svg><text y="180" font-size="100" font-family="SlowAhem">X<tspan>XX</tspan></text></svg>`;
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve));
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const rect = iframe.contentDocument.querySelector("tspan").getBoundingClientRect();
+        println(`tspan rect at iframe load: left=${rect.left} top=${rect.top} width=${rect.width} height=${rect.height}`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** CI flakes with the `cssom-view/cssom-getBoundingClientRect-003` WPT test under the Linux GNU Release job (the only fast CI build running the test, and so the only one failing the underlying race causing this).

**Cause:** Nothing delayed the load event while a font was being fetched. So pages measuring text-dependent geometry in a load-event handler saw fallback-font metrics rather than the metrics of the requested font. A `FontLoader` whose fetch hasn’t settled returns no typeface — so style computation uses a fallback font, and the document completes with that fallback in place. The engine does recover once the font arrives — it recomputes styles and repaints — but by then, the load event has already fired, and anything measured in that handler recorded the fallback.

**Fix:** When style computation asks a `FontLoader` for a font whose fetch has not settled, engage a `DocumentLoadEventDelayer`, and release it when the load settles. Blink/Gecko/WebKit all similarly keep a document from completing while a font load requested for rendering is pending. (Keying this on style use rather than on fetch start matters — because fonts get fetched eagerly here as soon as an `@font-face` rule is seen: A font declared but never used by style must not hold the load event.) And update style before checking whether anything delays the load event — so fonts the computed styles depend on have been requested by the time the check runs. Gecko similarly flushes layout before firing the load event.

The branch includes a separate preparatory commit to route a failed font load’s `[[FontStatusPromise]]` rejection through `reject_status_promise()`, so it’s marked as handled — separate because it fixes a distinct bug that only becomes observable once the load event waits for font fetches.
