### PR TITLE
UI/Qt: Include Tab.h from TabBar.h

### DIFF
--- a/UI/Qt/TabBar.cpp
+++ b/UI/Qt/TabBar.cpp
@@ -17,7 +17,6 @@
 #endif
 #include <UI/Qt/Menu.h>
 #include <UI/Qt/StringUtils.h>
-#include <UI/Qt/Tab.h>
 #include <UI/Qt/TabBar.h>
 #include <UI/Qt/WindowControlButton.h>
 

--- a/UI/Qt/TabBar.h
+++ b/UI/Qt/TabBar.h
@@ -10,6 +10,7 @@
 
 #include <AK/TypeCasts.h>
 #include <LibWebView/Settings.h>
+#include <UI/Qt/Tab.h>
 
 #include <QPointer>
 #include <QPushButton>
@@ -37,7 +38,6 @@ class QWheelEvent;
 
 namespace Ladybird {
 
-class Tab;
 class TabPreviewPopup;
 class TabWidget;
 


### PR DESCRIPTION
Fixes #11124.

As noted there, we need the full definition of `Tab` for the `as<Tab>()` call in the `tab()` method. By coincidence we were transitively including it already because of AUTOMOC, but on systems that don't run AUTOMOC, this produced a compile error.