### PR TITLE
LibWeb: Tolerate stale layout when text control sizing changes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1684,10 +1684,8 @@ void HTMLInputElement::form_associated_element_attribute_changed(Utf16FlyString 
     } else if (name == HTML::AttributeNames::size) {
         // size feeds the element's default preferred width, which reaches layout only
         // through the replaced-content facts; nothing else schedules a relayout.
-        if (old_value != value) {
-            if (auto* layout_node = this->layout_node())
-                layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::DefaultPreferredSizeAttributeChange);
-        }
+        if (old_value != value)
+            set_needs_layout_update(DOM::SetNeedsLayoutReason::DefaultPreferredSizeAttributeChange);
     }
 
     // AD-HOC: A change to any of these attributes can change whether the element satisfies its constraints, and

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -463,10 +463,8 @@ void HTMLTextAreaElement::form_associated_element_attribute_changed(Utf16FlyStri
     } else if (first_is_one_of(name, HTML::AttributeNames::rows, HTML::AttributeNames::cols)) {
         // rows and cols feed the element's default preferred size, which reaches layout
         // only through the replaced-content facts; nothing else schedules a relayout.
-        if (old_value != value) {
-            if (auto* layout_node = this->layout_node())
-                layout_node->set_needs_layout_update(DOM::SetNeedsLayoutReason::DefaultPreferredSizeAttributeChange);
-        }
+        if (old_value != value)
+            set_needs_layout_update(DOM::SetNeedsLayoutReason::DefaultPreferredSizeAttributeChange);
     }
 
     // AD-HOC: A change to any of these attributes can change whether the element satisfies its constraints, and

--- a/Tests/LibWeb/Crash/Layout/input-size-attribute-with-stale-layout.html
+++ b/Tests/LibWeb/Crash/Layout/input-size-attribute-with-stale-layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<input id="input" type="text">
+<script>
+    document.body.offsetHeight;
+    document.body.appendChild(document.createElement("div"));
+    input.size = 40;
+</script>

--- a/Tests/LibWeb/Crash/Layout/textarea-cols-attribute-with-stale-layout.html
+++ b/Tests/LibWeb/Crash/Layout/textarea-cols-attribute-with-stale-layout.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<textarea id="textarea"></textarea>
+<script>
+    document.body.offsetHeight;
+    document.body.appendChild(document.createElement("div"));
+    textarea.cols = 40;
+</script>


### PR DESCRIPTION
Attribute change steps may run while layout is dirty. These handlers fetched their layout node through the checked accessor, which asserts that layout is up to date. Use the node-level helper instead, which tolerates a stale layout node.

Fixes a regression introduced in #11105

Found with domato, where this crash was present in 56 / 1000 cases.