### PR TITLE
LibWeb: Fetch a web font on first style use, not at parse time

### DIFF
--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -135,6 +135,13 @@ RefPtr<Gfx::Font const> FontLoader::font_with_point_size(float point_size, Gfx::
 
 void FontLoader::start_loading_next_url()
 {
+    // A loader that has settled must not consume another URL: its typeface is final, and fetching a
+    // further src would replace it after subscribers already saw the settled one. load_font_face()
+    // hands back an existing loader for a shared first URL, so a second FontFace can reach here after
+    // the first one finished.
+    if (m_has_completed)
+        return;
+
     // FIXME: Load local() fonts somehow.
     if (m_fetch_controller && m_fetch_controller->state() == Fetch::Infrastructure::FetchController::State::Ongoing)
         return;

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -310,6 +310,15 @@ struct FontComputer::MatchingFontCandidate {
 
         auto font_list = Gfx::FontCascadeList::create();
         for (auto const& face : it->value) {
+            // https://drafts.csswg.org/css-font-loading/#font-face-load
+            // User agents can initiate font loads on their own, whenever they determine that a given font face is
+            // necessary to render something on the page. When this happens, they must act as if they had called the
+            // corresponding FontFace’s load() method described here.
+            // NB: An unloaded face with no subsetting unicode-range starts loading once a style actually selects
+            //     it. Loading happens via FontFace::load(). The font_with_point_size() call below then observes the
+            //     fetch in flight — and so delays the document load event until the fetch has settled.
+            if (face->has_urls() && !face->has_non_default_unicode_range() && face->status() == FontFaceLoadStatus::Unloaded)
+                face->load();
             if (auto face_fonts = face->font_with_point_size(point_size, variations, shape_features)) {
                 font_list->extend(*face_fonts);
                 continue;
@@ -372,7 +381,6 @@ RefPtr<Gfx::FontCascadeList const> FontComputer::font_matching_algorithm(Utf16Fl
     // If a font family match occurs, the user agent assembles the set of font faces in that family and then
     // narrows the set to a single face using other font properties in the order given below.
     Vector<MatchingFontCandidate> matching_family_fonts;
-    // FIXME: URL-backed faces with no typeface yet should trigger a load on demand, matching other engines.
     for (auto const& [map_key, faces] : m_font_faces) {
         if (map_key.family_name.equals_ignoring_ascii_case(family_name)) {
             matching_family_fonts.empend(map_key);
@@ -906,18 +914,11 @@ void FontComputer::load_fonts_from_sheet(CSSStyleSheet& sheet)
             auto font_face = FontFace::create_css_connected(HTML::relevant_realm(document()), *font_face_rule);
             document().fonts()->add_css_connected_font(font_face);
 
-            if (font_face->has_non_default_unicode_range()) {
-                // Register for matching, but defer loading until a rendered codepoint
-                // actually falls in this face's unicode-range.
-                register_font_face(font_face);
-            } else {
-                // NB: Load via FontFace::load(), to satisfy this requirement:
-                // https://drafts.csswg.org/css-font-loading/#font-face-load
-                // User agents can initiate font loads on their own, whenever they determine that a given font face is
-                // necessary to render something on the page. When this happens, they must act as if they had called the
-                // corresponding FontFace’s load() method described here.
-                font_face->load();
-            }
+            // Register the face for font matching without fetching anything. The fetch starts once the face is actually
+            // needed for rendering: When style computation first selects the face — or, for a face with a subsetting
+            // unicode-range, once a rendered codepoint falls within that range.
+            // INTEROP: Blink, Gecko, and WebKit similarly defer @font-face fetches.
+            register_font_face(font_face);
         }
 
         if (auto* font_feature_values_rule = as_if<CSSFontFeatureValuesRule>(rule))

--- a/Libraries/LibWeb/CSS/FontComputer.cpp
+++ b/Libraries/LibWeb/CSS/FontComputer.cpp
@@ -123,6 +123,11 @@ RefPtr<Gfx::Font const> FontLoader::font_with_point_size(float point_size, Gfx::
     if (!m_typeface) {
         if (!m_fetch_controller)
             start_loading_next_url();
+        // INTEROP: Delay the document load event til the fetch for this font has settled. Blink, Gecko, and WebKit all
+        //          keep the document from completing while a font load requested for rendering is pending — so pages
+        //          that measure font-dependent geometry in a load-event handler see the loaded font, not a fallback.
+        if (is_loading() && !m_document_load_event_delayer.has_value())
+            m_document_load_event_delayer.emplace(m_font_computer->document());
         return nullptr;
     }
     return m_typeface->font(point_size, variations, shape_features);
@@ -213,6 +218,7 @@ void FontLoader::font_did_load_or_fail(RefPtr<Gfx::Typeface const> typeface)
         m_font_computer->clear_computed_font_cache(m_family_name);
     }
     m_has_completed = true;
+    m_document_load_event_delayer.clear();
     for (auto& callback : m_subscribers)
         callback->function()(m_typeface);
     m_subscribers.clear();

--- a/Libraries/LibWeb/CSS/FontComputer.h
+++ b/Libraries/LibWeb/CSS/FontComputer.h
@@ -18,6 +18,7 @@
 #include <LibWeb/CSS/FontFeatureData.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/StyleValues/StyleValue.h>
+#include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
@@ -95,6 +96,7 @@ private:
     Vector<URL> m_urls;
     GC::Ptr<Fetch::Infrastructure::FetchController> m_fetch_controller;
     Vector<GC::Ref<GC::Function<void(RefPtr<Gfx::Typeface const>)>>> m_subscribers;
+    Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
     bool m_has_completed { false };
 };
 

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -37,7 +37,6 @@
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
-#include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/Buffers.h>
 #include <LibWeb/WebIDL/Promise.h>
@@ -788,75 +787,77 @@ GC::Ref<WebIDL::Promise> FontFace::load()
         }
     }
 
-    Web::Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(GC::Heap::the(), [this] {
-        // 4. Using the value of font face’s [[Urls]] slot, attempt to load a font as defined in [CSS-FONTS-3],
-        //     as if it was the value of a @font-face rule’s src descriptor.
+    // AD-HOC: The remaining steps run on the current task rather than truly async. So the fetch is observably in flight
+    //         by the time load() returns. Style computation depends on that: When computing a style starts a font load,
+    //         the in-flight fetch must engage the document-load-event delayer within that same style update. Only the
+    //         fetch kickoff happens sync; the load operation itself, and the completion steps below, remain async.
+    // 4. Using the value of font face’s [[Urls]] slot, attempt to load a font as defined in [CSS-FONTS-3],
+    //     as if it was the value of a @font-face rule’s src descriptor.
 
-        // 5. When the load operation completes, successfully or not, queue a task to run the following steps synchronously:
-        auto on_load = GC::create_function(GC::Heap::the(), [this](RefPtr<Gfx::Typeface const> maybe_typeface) {
-            HTML::queue_global_task(HTML::Task::Source::FontLoading, task_global_object(), GC::create_function(GC::Heap::the(), [this, maybe_typeface] {
-                HTML::TemporaryExecutionContext context(*m_environment, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
-                // 1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
-                //    is "NetworkError" and set font face’s status attribute to "error".
-                if (!maybe_typeface) {
-                    // NB: reject_status_promise() also marks the promise as handled: A font that fails to load must not
-                    //     surface an unhandled rejection on a page that never looks at the FontFace API.
-                    reject_status_promise(WebIDL::NetworkError::create("Failed to load font"_utf16));
+    // 5. When the load operation completes, successfully or not, queue a task to run the following steps synchronously:
+    auto on_load = GC::create_function(GC::Heap::the(), [this](RefPtr<Gfx::Typeface const> maybe_typeface) {
+        HTML::queue_global_task(HTML::Task::Source::FontLoading, task_global_object(), GC::create_function(GC::Heap::the(), [this, maybe_typeface] {
+            HTML::TemporaryExecutionContext context(*m_environment, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+            // 1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
+            //    is "NetworkError" and set font face’s status attribute to "error".
+            if (!maybe_typeface) {
+                // NB: reject_status_promise() also marks the promise as handled: A font that fails to load must not
+                //     surface an unhandled rejection on a page that never looks at the FontFace API.
+                reject_status_promise(WebIDL::NetworkError::create("Failed to load font"_utf16));
 
-                    // For each FontFaceSet font face is in:
-                    for (auto& font_face_set : m_containing_sets) {
-                        // 1. Add font face to the FontFaceSet’s [[FailedFonts]] list.
-                        font_face_set->failed_fonts().append(*this);
+                // For each FontFaceSet font face is in:
+                for (auto& font_face_set : m_containing_sets) {
+                    // 1. Add font face to the FontFaceSet’s [[FailedFonts]] list.
+                    font_face_set->failed_fonts().append(*this);
 
-                        // 2. Remove font face from the FontFaceSet’s [[LoadingFonts]] list. If font was the last item
-                        //    in that list (and so the list is now empty), switch the FontFaceSet to loaded.
-                        font_face_set->loading_fonts().remove_all_matching([this](auto const& entry) { return entry == GC::Ref<FontFace> { *this }; });
-                        if (font_face_set->loading_fonts().is_empty())
-                            font_face_set->switch_to_loaded();
-                    }
+                    // 2. Remove font face from the FontFaceSet’s [[LoadingFonts]] list. If font was the last item
+                    //    in that list (and so the list is now empty), switch the FontFaceSet to loaded.
+                    font_face_set->loading_fonts().remove_all_matching([this](auto const& entry) { return entry == GC::Ref<FontFace> { *this }; });
+                    if (font_face_set->loading_fonts().is_empty())
+                        font_face_set->switch_to_loaded();
                 }
-
-                // 2. Otherwise, font face now represents the loaded font; fulfill font face’s [[FontStatusPromise]] with font face
-                //    and set font face’s status attribute to "loaded".
-                else {
-                    auto& realm = m_environment->realm();
-                    m_parsed_font = maybe_typeface;
-                    m_status = FontFaceLoadStatus::Loaded;
-                    resolve_font_face_promise(realm, m_font_status_promise, *this);
-
-                    if (auto font_computer = this->font_computer(); font_computer.has_value())
-                        font_computer->register_font_face(*this);
-
-                    // For each FontFaceSet font face is in:
-                    for (auto& font_face_set : m_containing_sets) {
-                        // 1. Add font face to the FontFaceSet’s [[LoadedFonts]] list.
-                        font_face_set->loaded_fonts().append(*this);
-
-                        // 2. Remove font face from the FontFaceSet’s [[LoadingFonts]] list. If font was the last item
-                        //    in that list (and so the list is now empty), switch the FontFaceSet to loaded.
-                        font_face_set->loading_fonts().remove_all_matching([this](auto const& entry) { return entry == GC::Ref<FontFace> { *this }; });
-                        if (font_face_set->loading_fonts().is_empty())
-                            font_face_set->switch_to_loaded();
-                    }
-                }
-
-                m_font_loader = nullptr;
-            }));
-        });
-
-        // FIXME: We should probably put the 'font cache' on the WindowOrWorkerGlobalScope instead of tying it to the document's style computer
-        if (auto document = m_environment->responsible_document()) {
-            auto& font_computer = document->font_computer();
-
-            if (auto loader = font_computer.load_font_face(parsed_font_face(), move(on_load))) {
-                m_font_loader = loader;
-                loader->start_loading_next_url();
             }
-        } else {
-            // FIXME: Don't know how to load fonts in workers! They don't have a StyleComputer
-            dbgln("FIXME: Worker font loading not implemented");
+
+            // 2. Otherwise, font face now represents the loaded font; fulfill font face’s [[FontStatusPromise]] with font face
+            //    and set font face’s status attribute to "loaded".
+            else {
+                auto& realm = m_environment->realm();
+                m_parsed_font = maybe_typeface;
+                m_status = FontFaceLoadStatus::Loaded;
+                resolve_font_face_promise(realm, m_font_status_promise, *this);
+
+                if (auto font_computer = this->font_computer(); font_computer.has_value())
+                    font_computer->register_font_face(*this);
+
+                // For each FontFaceSet font face is in:
+                for (auto& font_face_set : m_containing_sets) {
+                    // 1. Add font face to the FontFaceSet’s [[LoadedFonts]] list.
+                    font_face_set->loaded_fonts().append(*this);
+
+                    // 2. Remove font face from the FontFaceSet’s [[LoadingFonts]] list. If font was the last item
+                    //    in that list (and so the list is now empty), switch the FontFaceSet to loaded.
+                    font_face_set->loading_fonts().remove_all_matching([this](auto const& entry) { return entry == GC::Ref<FontFace> { *this }; });
+                    if (font_face_set->loading_fonts().is_empty())
+                        font_face_set->switch_to_loaded();
+                }
+            }
+
+            m_font_loader = nullptr;
+        }));
+    });
+
+    // FIXME: We should probably put the 'font cache' on the WindowOrWorkerGlobalScope instead of tying it to the document's style computer
+    if (auto document = m_environment->responsible_document()) {
+        auto& font_computer = document->font_computer();
+
+        if (auto loader = font_computer.load_font_face(parsed_font_face(), move(on_load))) {
+            m_font_loader = loader;
+            loader->start_loading_next_url();
         }
-    }));
+    } else {
+        // FIXME: Don't know how to load fonts in workers! They don't have a StyleComputer
+        dbgln("FIXME: Worker font loading not implemented");
+    }
 
     return font_face.loaded();
 }

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -799,8 +799,9 @@ GC::Ref<WebIDL::Promise> FontFace::load()
                 // 1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
                 //    is "NetworkError" and set font face’s status attribute to "error".
                 if (!maybe_typeface) {
-                    m_status = FontFaceLoadStatus::Error;
-                    WebIDL::reject_promise(m_font_status_promise, WebIDL::NetworkError::create("Failed to load font"_utf16));
+                    // NB: reject_status_promise() also marks the promise as handled: A font that fails to load must not
+                    //     surface an unhandled rejection on a page that never looks at the FontFace API.
+                    reject_status_promise(WebIDL::NetworkError::create("Failed to load font"_utf16));
 
                     // For each FontFaceSet font face is in:
                     for (auto& font_face_set : m_containing_sets) {

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -642,6 +642,10 @@ void HTMLParserEndState::check_progress()
 
     case Phase::WaitingForLoadEventDelay:
         // 8. Spin the event loop until there is nothing that delays the load event in the Document.
+        // AD-HOC: Update style first — so any font fetches that the computed styles depend on get started; an in-flight
+        //         font fetch delays the load event.
+        // INTEROP: Gecko also flushes layout before firing the load event — so lazily-started font loads hold it back.
+        m_document->update_style();
         if (m_document->anything_is_delaying_the_load_event())
             return;
 

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -355,7 +355,10 @@ void XMLDocumentBuilder::document_end()
     }));
 
     // Spin the event loop until there is nothing that delays the load event in the Document.
+    // AD-HOC: Update style first, so any font fetches that the computed styles depend on get started; an in-flight font
+    //         fetch delays the load event.
     HTML::main_thread_event_loop().spin_until(GC::create_function(GC::Heap::the(), [&] {
+        m_document->update_style();
         return !m_document->anything_is_delaying_the_load_event();
     }));
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -20,6 +20,7 @@ Text/input/HTML/HTMLMediaElement-preload-none-does-not-fetch.html
 Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
 Text/input/css/font-face-load-dedups-same-url.html
+Text/input/css/font-load-delays-document-load-event.html
 Text/input/css/unrecognized-font-family-fallback-honors-weight.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_url.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -21,6 +21,7 @@ Text/input/css/FontFace-arraybuffer-matching.html
 Text/input/wpt-import/mediacapture-streams/idlharness.https.window.html
 Text/input/css/font-face-load-dedups-same-url.html
 Text/input/css/font-load-delays-document-load-event.html
+Text/input/css/font-face-unused-face-not-fetched.html
 Text/input/css/unrecognized-font-family-fallback-honors-weight.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_url.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write.html

--- a/Tests/LibWeb/Text/expected/css/font-face-activation-after-stylesheet-media-change.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-activation-after-stylesheet-media-change.txt
@@ -1,4 +1,4 @@
 Initial face count: 0
 Matching face count: 1
-Matching face status: loaded
+Matching face status: unloaded
 Final face count: 0

--- a/Tests/LibWeb/Text/expected/css/font-face-unused-face-not-fetched.txt
+++ b/Tests/LibWeb/Text/expected/css/font-face-unused-face-not-fetched.txt
@@ -1,0 +1,4 @@
+Unused face status: unloaded
+Font requests while unused: 0
+Used face status: loaded
+Font requests after use: 1

--- a/Tests/LibWeb/Text/expected/css/font-load-delays-document-load-event.txt
+++ b/Tests/LibWeb/Text/expected/css/font-load-delays-document-load-event.txt
@@ -1,0 +1,1 @@
+tspan rect at iframe load: left=108 top=108 width=200 height=100

--- a/Tests/LibWeb/Text/input/css/font-face-unused-face-not-fetched.html
+++ b/Tests/LibWeb/Text/input/css/font-face-unused-face-not-fetched.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Verifies that a font declared by @font-face but never selected by any style is not fetched — and that the first
+    // style use of the font family is what starts the fetch. Blink/Gecko/WebKit also only fetch declared fonts on use.
+    promiseTest(async () => {
+        // Serve a copy of Ahem.ttf through the echo server, on a URL unique to this test run.
+        const fontBytes = new Uint8Array(await (await fetch("../wpt-import/fonts/Ahem.ttf")).arrayBuffer());
+        let binary = "";
+        for (const byte of fontBytes)
+            binary += String.fromCharCode(byte);
+        const token = crypto.randomUUID();
+        const registration = await fetch("/echo", {
+            method: "POST",
+            body: JSON.stringify({
+                method: "GET",
+                path: `/echo/unused-face-${token}.ttf`,
+                status: 200,
+                headers: { "Content-Type": "font/ttf", "Access-Control-Allow-Origin": "*" },
+                body: btoa(binary),
+                body_encoding: "base64",
+            }),
+        });
+        const fontUrl = (await registration.json()).url;
+
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `
+            <style>@font-face { font-family: LazyFace; src: url("${fontUrl}"); }</style>
+            <body>Text that never uses the declared font family</body>`;
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
+        document.body.appendChild(iframe);
+        await loaded;
+
+        // Force a style and layout pass, then give a wrongly-started fetch time to become observable.
+        iframe.contentDocument.body.offsetHeight;
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        const fontRequestCount = () =>
+            iframe.contentWindow.performance
+                .getEntriesByType("resource")
+                .filter(entry => entry.name.includes(token)).length;
+
+        const face = [...iframe.contentDocument.fonts][0];
+        println(`Unused face status: ${face.status}`);
+        println(`Font requests while unused: ${fontRequestCount()}`);
+
+        // Control arm: using the family must start the fetch.
+        iframe.contentDocument.body.style.fontFamily = "LazyFace";
+        iframe.contentDocument.body.offsetHeight;
+        await face.loaded;
+        // The resource-timing entry lands in a separately queued task; poll until it appears.
+        // Bounded, so a missing entry fails with a diff rather than hanging until the harness timeout.
+        for (let attempt = 0; attempt < 200 && fontRequestCount() === 0; ++attempt)
+            await new Promise(resolve => setTimeout(resolve, 10));
+        println(`Used face status: ${face.status}`);
+        println(`Font requests after use: ${fontRequestCount()}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/font-load-delays-document-load-event.html
+++ b/Tests/LibWeb/Text/input/css/font-load-delays-document-load-event.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // Verifies that a document's load event waits for in-flight @font-face fetches — so geometry measured in a load-
+    // event handler reflects the loaded font rather than a fallback font.
+    promiseTest(async () => {
+        // Serve a copy of Ahem.ttf through the echo server with a response delay — so the font fetch reliably outlasts
+        // every other part of the iframe document's load.
+        const fontBytes = new Uint8Array(await (await fetch("../wpt-import/fonts/Ahem.ttf")).arrayBuffer());
+        let binary = "";
+        for (const byte of fontBytes)
+            binary += String.fromCharCode(byte);
+        // A unique path per run: the echo-server registration namespace is shared across parallel
+        // workers and --repeat clones, so a fixed path lets one run serve another run's registration.
+        const token = crypto.randomUUID();
+        const registration = await fetch("/echo", {
+            method: "POST",
+            body: JSON.stringify({
+                method: "GET",
+                path: `/echo/slow-ahem-${token}.ttf`,
+                status: 200,
+                headers: { "Content-Type": "font/ttf", "Access-Control-Allow-Origin": "*" },
+                body: btoa(binary),
+                body_encoding: "base64",
+                delay_ms: 400,
+            }),
+        });
+        const fontUrl = (await registration.json()).url;
+
+        const iframe = document.createElement("iframe");
+        iframe.srcdoc = `
+            <style>@font-face { font-family: SlowAhem; src: url("${fontUrl}"); }</style>
+            <svg><text y="180" font-size="100" font-family="SlowAhem">X<tspan>XX</tspan></text></svg>`;
+        const loaded = new Promise(resolve => iframe.addEventListener("load", resolve));
+        document.body.appendChild(iframe);
+        await loaded;
+
+        const rect = iframe.contentDocument.querySelector("tspan").getBoundingClientRect();
+        println(`tspan rect at iframe load: left=${rect.left} top=${rect.top} width=${rect.width} height=${rect.height}`);
+    });
+</script>


### PR DESCRIPTION
**Problem:** Every declared `@font-face` was fetched as soon as its stylesheet was added — even when no element ever used it. A page declaring a family it never applies still paid for the download.

**Cause:** `load_fonts_from_sheet()` called `FontFace::load()` for every valid rule without a subsetting `unicode-range` — at stylesheet-add time. Only faces carrying a `unicode-range` were deferred.

**Fix:** Register every face for font matching without fetching anything, and start the fetch when style computation first selects the face. That’s where Blink, Gecko, and WebKit start theirs: The fetch follows from a rendering request rather than from parsing a rule.

The branch includes a separate preparatory commit to start the fetch synchronously inside `FontFace::load()` — separate because nothing else depends on it yet, and because the trigger above needs the in-flight fetch to be visible within the same style update.

This also includes a fix for a separate, pre-existing bug caught by CodeRabbit: A settled `FontLoader` could still be told to fetch another `src` URL, replacing its typeface after subscribers had already been handed the settled one. `load_font_face()` returns an existing loader when a face shares its first URL, and `subscribe()` fires immediately once that loader has completed — so a second `FontFace` reached `start_loading_next_url()` after the first had finished, and it only declined when a fetch was ongoing or the URL list was empty.

---

Stacked on to top of the changes in #11129. (I noticed this while working on that.)
