### PR TITLE
LibWeb: Skip fragments of removed boxes when mapping text offsets

### DIFF
--- a/Libraries/LibWeb/Layout/TextOffsetMapping.h
+++ b/Libraries/LibWeb/Layout/TextOffsetMapping.h
@@ -59,7 +59,7 @@ public:
                 return;
 
             for (auto const& paintable_fragment : paintable_with_lines->fragments()) {
-                if (&paintable_fragment.layout_node() != &fragment)
+                if (!paintable_fragment.has_layout_node() || &paintable_fragment.layout_node() != &fragment)
                     continue;
                 if (callback(paintable_fragment) == TraversalDecision::Break) {
                     decision = TraversalDecision::Break;
@@ -86,7 +86,7 @@ public:
                 return;
 
             for (auto& paintable_fragment : paintable_with_lines->fragments()) {
-                if (&paintable_fragment.layout_node() != &fragment)
+                if (!paintable_fragment.has_layout_node() || &paintable_fragment.layout_node() != &fragment)
                     continue;
                 if (callback(paintable_fragment) == TraversalDecision::Break) {
                     decision = TraversalDecision::Break;

--- a/Tests/LibWeb/Crash/Selection/set-base-and-extent-after-inline-block-sibling-removed.html
+++ b/Tests/LibWeb/Crash/Selection/set-base-and-extent-after-inline-block-sibling-removed.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div id="container">hello <span id="inlineBlock" style="display: inline-block">removed</span> world</div>
+<script>
+    container.offsetHeight;
+    inlineBlock.remove();
+    const textNode = container.firstChild;
+    getSelection().setBaseAndExtent(textNode, 0, textNode, 3);
+</script>


### PR DESCRIPTION
Removing an in-flow atomic inline from an inline run detaches its layout subtree immediately. The containing block keeps its fragment list until its next layout, leaving the removed box's fragment with no layout node. Selection updates iterate these fragments before layout runs and crashed on the dead reference. Skip fragments without a layout node. They cannot match any live text node.

Fixes a regression introduced at 351d60159a9 (#11126).

Found with domato, where this crash was present in 19 / 1000 cases.