### PR TITLE
LibWeb: Avoid redundant wheel hit test target recording

### DIFF
--- a/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecordingContext.h
@@ -123,6 +123,17 @@ public:
     bool has_blocking_wheel_event_listeners() const { return m_has_blocking_wheel_event_listeners; }
     void set_has_blocking_wheel_event_listeners(bool value) { m_has_blocking_wheel_event_listeners = value; }
     bool has_blocking_wheel_event_region_covering_viewport() const { return m_has_blocking_wheel_event_region_covering_viewport; }
+    bool should_record_wheel_hit_test_targets() const { return m_should_record_wheel_hit_test_targets; }
+    void set_should_record_wheel_hit_test_targets(bool value) { m_should_record_wheel_hit_test_targets = value; }
+
+    Optional<Painting::VisualContextIndex> cached_wheel_hit_test_target_for(Painting::Paintable const& paintable) const
+    {
+        return m_wheel_hit_test_target_cache.get(&paintable);
+    }
+    void cache_wheel_hit_test_target_for(Painting::Paintable const& paintable, Painting::VisualContextIndex target)
+    {
+        m_wheel_hit_test_target_cache.set(&paintable, target);
+    }
 
 private:
     Painting::DisplayListRecorder& m_display_list_recorder;
@@ -144,6 +155,8 @@ private:
     Painting::ScrollState const* m_async_scrolling_scroll_state { nullptr };
     bool m_has_blocking_wheel_event_listeners { false };
     bool m_has_blocking_wheel_event_region_covering_viewport { false };
+    bool m_should_record_wheel_hit_test_targets { false };
+    HashMap<Painting::Paintable const*, Painting::VisualContextIndex> m_wheel_hit_test_target_cache;
 };
 
 }

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -677,19 +677,55 @@ static void record_main_thread_wheel_event_region(Paintable const& paintable_box
     });
 }
 
-static Optional<VisualContextIndex> wheel_hit_test_target_scroll_node_index_for(Paintable const& paintable_box)
+static VisualContextIndex wheel_hit_test_target_scroll_node_index_for(Paintable const& paintable_box, DisplayListRecordingContext& context)
 {
-    if (paintable_box.own_scroll_node_index().value() && paintable_box.could_be_scrolled_by_wheel_event())
-        return paintable_box.own_scroll_node_index();
-    if (auto scrollable_ancestor = paintable_box.nearest_scrollable_ancestor())
-        return scrollable_ancestor->own_scroll_node_index();
-    if (auto viewport_paintable = paintable_box.document().paintable(); viewport_paintable && viewport_paintable->could_be_scrolled_by_wheel_event())
-        return viewport_paintable->own_scroll_node_index();
-    return {};
+    Vector<Paintable const*, 16> paintables_to_cache;
+    auto target = VisualContextIndex {};
+    auto const* current = &paintable_box;
+    while (true) {
+        if (auto cached_target = context.cached_wheel_hit_test_target_for(*current); cached_target.has_value()) {
+            target = *cached_target;
+            break;
+        }
+
+        paintables_to_cache.append(current);
+        if (current->own_scroll_node_index().value() && current->could_be_scrolled_by_wheel_event()) {
+            target = current->own_scroll_node_index();
+            break;
+        }
+
+        auto containing_block = current->containing_block();
+        if (containing_block && containing_block->is_fixed_position()) {
+            if (containing_block->own_scroll_node_index().value() && containing_block->could_be_scrolled_by_wheel_event())
+                target = containing_block->own_scroll_node_index();
+            if (target.value())
+                break;
+            containing_block = nullptr;
+        }
+
+        if (containing_block) {
+            current = containing_block.ptr();
+            continue;
+        }
+
+        auto viewport_paintable = current->document().paintable();
+        if (!viewport_paintable || viewport_paintable.ptr() == current)
+            break;
+        current = viewport_paintable.ptr();
+    }
+
+    for (auto const* paintable : paintables_to_cache)
+        context.cache_wheel_hit_test_target_for(*paintable, target);
+    return target;
 }
 
 static void record_wheel_hit_test_target(Paintable const& paintable_box, DisplayListRecordingContext& context)
 {
+    // OPTIMIZATION: The compositor falls back to the viewport when there are no explicit targets.
+    // Avoid generating redundant per-box targets when no non-viewport scroller could need one.
+    if (!context.should_record_wheel_hit_test_targets())
+        return;
+
     if (!paintable_box.is_visible() || !paintable_box.visible_for_hit_testing())
         return;
 
@@ -697,7 +733,7 @@ static void record_wheel_hit_test_target(Paintable const& paintable_box, Display
     if (rect.is_empty())
         return;
 
-    auto target_scroll_node_index = wheel_hit_test_target_scroll_node_index_for(paintable_box).value_or({});
+    auto target_scroll_node_index = wheel_hit_test_target_scroll_node_index_for(paintable_box, context);
     auto corner_radii = paintable_box.border_radii_data().as_corners(context.device_pixel_converter());
     if (corner_radii.has_any_radius()) {
         context.display_list_recorder().compositor_wheel_hit_test_target_with_corner_radii({
@@ -1582,6 +1618,9 @@ bool Paintable::could_be_scrolled_by_wheel_event(ScrollDirection direction) cons
     if (is_viewport_paintable())
         overflow = overflow_value_applied_to_viewport_for_wheel_scrolling(document(), direction);
 
+    if (overflow != CSS::Overflow::Auto && overflow != CSS::Overflow::Scroll)
+        return false;
+
     auto scrollable_overflow_rect = this->scrollable_overflow_rect();
     if (!scrollable_overflow_rect.has_value())
         return false;
@@ -1589,10 +1628,7 @@ bool Paintable::could_be_scrolled_by_wheel_event(ScrollDirection direction) cons
     CSSPixels scrollable_overflow_size = scrollable_overflow_rect->primary_size_for_orientation(orientation);
     CSSPixels scrollport_size = absolute_padding_box_rect().primary_size_for_orientation(orientation);
 
-    if (overflow == CSS::Overflow::Auto || overflow == CSS::Overflow::Scroll)
-        return scrollable_overflow_size > scrollport_size;
-
-    return false;
+    return scrollable_overflow_size > scrollport_size;
 }
 
 bool Paintable::could_be_scrolled_by_wheel_event() const

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -94,6 +94,7 @@ void ViewportPaintable::initialize_async_scrolling_metadata_recording(DisplayLis
         scroll_state(),
         blocking_wheel_event_region_state.has_blocking_wheel_event_listeners,
         blocking_wheel_event_region_state.has_blocking_wheel_event_region_covering_viewport);
+    context.set_should_record_wheel_hit_test_targets(m_has_non_viewport_wheel_scroll_target_candidate);
 }
 
 void ViewportPaintable::finalize_async_scrolling_metadata_recording(DisplayListRecordingContext& context, HTML::LocalNavigable& navigable, Gfx::IntRect viewport_rect)
@@ -218,10 +219,19 @@ void ViewportPaintable::clear_scroll_state()
     m_scroll_state.clear();
     m_scroll_state_snapshot = {};
     m_needs_to_refresh_scroll_state = true;
+    m_has_non_viewport_wheel_scroll_target_candidate = false;
 }
 
 void ViewportPaintable::register_scroll_node(AccumulatedVisualContextTree& visual_context_tree_being_built, VisualContextIndex node_index, Paintable const& paintable_box, VisualContextIndex parent_index)
 {
+    if (!paintable_box.is_viewport_paintable()) {
+        auto overflow_x = paintable_box.layout_node().overflow_x();
+        auto overflow_y = paintable_box.layout_node().overflow_y();
+        if (overflow_x == CSS::Overflow::Auto || overflow_x == CSS::Overflow::Scroll
+            || overflow_y == CSS::Overflow::Auto || overflow_y == CSS::Overflow::Scroll)
+            m_has_non_viewport_wheel_scroll_target_candidate = true;
+    }
+
     auto slot = m_scroll_state.register_scroll_node(node_index, paintable_box, visual_context_tree_being_built.scroll_state_slot_for_node(parent_index));
     visual_context_tree_being_built.node_at(node_index).data.get<ScrollData>().state_slot = slot;
 }

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -91,6 +91,7 @@ private:
     ScrollState m_scroll_state;
     ScrollStateSnapshot m_scroll_state_snapshot;
     bool m_needs_to_refresh_scroll_state { true };
+    bool m_has_non_viewport_wheel_scroll_target_candidate { false };
 
     Vector<WeakPtr<Paintable>> m_paintable_boxes_with_auto_content_visibility;
 

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-event-region-hit-testing.txt
@@ -13,12 +13,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x13]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[20,20 100x100]
   CompositorBlockingWheelEventRegion@2 rect=[20,20 100x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[20,160 100x100]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[20,160 200x100]
   CompositorBlockingWheelEventRegion@4 rect=[20,160 200x100]
 Restore@0
-

--- a/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/blocking-wheel-listener-invalidation.txt
@@ -4,14 +4,8 @@ after routing admission: blocking wheel event listeners
 display list:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1413] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2013]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
 Restore@0
-

--- a/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/nested-navigable-wheel-admission.txt
@@ -8,16 +8,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1413] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2013]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2000]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[40,40 160x120]
   CompositorMainThreadWheelEventRegion@1 rect=[40,40 160x120]
   Save@1
     AddClipRect@1 rect=[40,40 160x120]
     DrawCompositedContext@1 dst_rect=[40,40 160x120]
   Restore@1
 Restore@0
-

--- a/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/sticky-areas.txt
@@ -15,15 +15,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,1429] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2029]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x2016]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,16 800x2000]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=1 rect=[0,0 800x16]
   CompositorStickyArea@2 scroll_node_index=2 parent_scroll_node_index=1 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x2016] needs_parent_offset_adjustment=true inset_top=0 inset_right=none inset_bottom=none inset_left=none
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=1 rect=[0,0 800x16]
   CompositorStickyArea@3 scroll_node_index=3 parent_scroll_node_index=2 nearest_scrolling_ancestor_index=1 position_relative_to_scroll_ancestor=[0,0] border_box_size=[800x16] scrollport_size=[800x600] containing_block_region=[0,0 800x16] needs_parent_offset_adjustment=true inset_top=20 inset_right=none inset_bottom=none inset_left=none
   DrawGlyphRun@3 rect=[0,0 45x16] translation=[0,12.796875] color=rgb(0, 0, 0)
 Restore@0
-

--- a/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-target-fast-path.txt
+++ b/Tests/LibWeb/Text/expected/async-scrolling/viewport-wheel-target-fast-path.txt
@@ -1,0 +1,2 @@
+viewport wheel target: viewport
+has explicit wheel hit test targets: false

--- a/Tests/LibWeb/Text/expected/css/text-underline-position.txt
+++ b/Tests/LibWeb/Text/expected/css/text-underline-position.txt
@@ -4,12 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x37]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 27.15625x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[43.15625,8 27.640625x16]
   DrawGlyphRun@1 rect=[8,8 28x16] translation=[8,20.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[8,24] to=[35,24] color=rgb(0, 0, 0) thickness=2 style=Solid
   DrawGlyphRun@1 rect=[35,8 8x16] translation=[35.15625,20.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-nested-opacity-inside-relpos.txt
@@ -7,11 +7,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@7 rect=[8,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
+++ b/Tests/LibWeb/Text/expected/display_list/abspos-inside-opacity-inside-relpos.txt
@@ -6,11 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@4 rect=[8,8 100x100] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/animated-transform-visual-context-update.txt
+++ b/Tests/LibWeb/Text/expected/display_list/animated-transform-visual-context-update.txt
@@ -6,10 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
@@ -21,10 +17,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-change-repaints.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-change-repaints.txt
@@ -5,10 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 200x200]
   Save@1
     AddClipRect@1 rect=[0,0 200x200]
     PaintLinearGradient@1 rect=[0,0 200x600]
@@ -23,10 +19,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 200x200]
   Save@1
     AddClipRect@1 rect=[0,0 200x200]
     PaintLinearGradient@2 rect=[0,0 800x600]

--- a/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
+++ b/Tests/LibWeb/Text/expected/display_list/background-attachment-fixed.txt
@@ -5,12 +5,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=1 rect=[0,0 800x600]
   CompositorScrollNode@0 scroll_node_index=1 parent_scroll_node_index=0 scrollport_rect=[0,0 800x600] min_scroll_offset=[0,0] max_scroll_offset=[0,613] is_viewport=true
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,0 800x1213]
   Save@1
     PaintLinearGradient@2 rect=[0,0 800x600]
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=1 rect=[0,13 800x1200]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
+++ b/Tests/LibWeb/Text/expected/display_list/block-in-inline-no-border-for-phantom-inline-box.txt
@@ -4,12 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x90]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[100,50 50x10]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,3 102x74]
   FillPath@1 path_bounding_rect=[0,3 8x14]
   FillPath@1 path_bounding_rect=[0,63 8x14]
   DrawGlyphRun@1 rect=[2,5 6x10] translation=[2,13] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/border-inner-corner-right-angle-all-edges.txt
+++ b/Tests/LibWeb/Text/expected/display_list/border-inner-corner-right-angle-all-edges.txt
@@ -4,15 +4,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x271]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x250]
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,8 178x120] corner_radii=[40x10,40x10,40x10,40x10]
   FillPath@1 path_bounding_rect=[166,12.651531 20x110.696945]
   FillPath@1 path_bounding_rect=[11.232849,113 168.56511x15]
   FillPath@1 path_bounding_rect=[8,14.061594 8x107.876816]
   FillPath@1 path_bounding_rect=[11.232849,7.999998 168.56511x15.000002]
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,128 180x130] corner_radii=[10x40,10x40,10x40,10x40]
   FillPath@1 path_bounding_rect=[173,134.20204 15.0000305x117.59592]
   FillPath@1 path_bounding_rect=[12.651531,238 170.69693x20]
   FillPath@1 path_bounding_rect=[7.9999995,134.20204 15x117.59592]

--- a/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
+++ b/Tests/LibWeb/Text/expected/display_list/button-with-text-decoration.txt
@@ -4,15 +4,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x41]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 105.671875x20]
   FillRect@1 rect=[8,8 106x20] color=rgb(212, 208, 200)
   FillPath@1 path_bounding_rect=[8,8 106x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[13,10 95.671875x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[13,10 95.671875x16]
   DrawGlyphRun@1 rect=[13,10 96x16] translation=[13,22.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[13,26] to=[109,26] color=rgb(0, 0, 0) thickness=2 style=Solid
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/canvas-compositor-surface.txt
@@ -4,11 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x53]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 32x32]
   DrawCanvas@1 dst_rect=[8,8 32x32] content_generation=0
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-auto-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-auto-invalidation.txt
@@ -5,9 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@1 rect=[8,13 100x100] color=rgb(0, 128, 0)
 Restore@0
 
@@ -19,9 +16,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-invalidation.txt
@@ -6,9 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -21,9 +18,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 100x100]
   FillRect@2 rect=[8,13 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,13 30x16] translation=[8,25.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-empty-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-empty-invalidation.txt
@@ -6,22 +6,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
 After clip-path change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-path-invalidation.txt
@@ -6,10 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -22,10 +18,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
+++ b/Tests/LibWeb/Text/expected/display_list/clip-positioned-descendants.txt
@@ -1,21 +1,12 @@
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
     [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
-      [2] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (PaintableWithLines(BlockContainer<DIV>.clip-path-ancestor))
       [3] clip_path=[bounds: 0,0 200x200, path: M50 50L150 50L150 150L50 150L50 50Z] (PaintableWithLines(BlockContainer<DIV>.abspos))
-      [5] clip=[220,0 100x100] (PaintableWithLines(BlockContainer<DIV>.clip-ancestor))
     [6] clip=[220,0 100x100] (PaintableWithLines(BlockContainer<DIV>.fixed))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x213]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[0,0 200x200]
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[0,0 200x200]
   FillRect@3 rect=[0,0 200x200] color=rgb(255, 0, 0)
-  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[220,0 200x200]
-  CompositorWheelHitTestTarget@6 target_scroll_node_index=0 rect=[220,0 200x200]
   FillRect@6 rect=[220,0 200x200] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/contenteditable-caret.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x41]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x20]
   FillRect@1 rect=[8,8 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 104x24]
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
+++ b/Tests/LibWeb/Text/expected/display_list/css-clip-property.txt
@@ -5,9 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x21]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,13 150x150]
   FillRect@2 rect=[8,13 150x150] color=rgb(128, 0, 128)
   DrawGlyphRun@2 rect=[8,13 71x16] translation=[8,25.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@2 rect=[8,29 72x16] translation=[8,41.796875] color=rgb(0, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/dashed-border-with-border-radius.txt
+++ b/Tests/LibWeb/Text/expected/display_list/dashed-border-with-border-radius.txt
@@ -4,12 +4,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x501]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x480]
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,8 120x80] corner_radii=[30x30,30x30,30x30,30x30]
   StrokePath@1 path_bounding_rect=[8,8 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=29.63
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,88 120x80] corner_radii=[30x30,30x30,30x30,30x30]
   Save@1
     AddClipPath@1 path_bounding_rect=[112,96 16x64]
     StrokePath@1 path_bounding_rect=[110.677666,95.322334 17.322334x65.35534] thickness=10 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=14.75
@@ -26,11 +21,8 @@ SaveLayer@0
     AddClipPath@1 path_bounding_rect=[16,88 104x16]
     StrokePath@1 path_bounding_rect=[15.322332,87.99999 105.35533x17.322342] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=12.38
   Restore@1
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,168 120x80] corner_radii=[0x0,80x80,0x0,0x0]
   StrokePath@1 path_bounding_rect=[8,168 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=30.92
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,248 120x80] corner_radii=[30x30,30x30,30x30,30x30]
   StrokePath@1 path_bounding_rect=[8,248 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.88
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,328 120x80] corner_radii=[30x30,30x30,30x30,30x30]
   Save@1
     AddClipPath@1 path_bounding_rect=[112,336 16x64]
     StrokePath@1 path_bounding_rect=[110.677666,335.32233 17.322334x65.35535] thickness=10 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=9.84
@@ -47,7 +39,6 @@ SaveLayer@0
     AddClipPath@1 path_bounding_rect=[16,328 104x16]
     StrokePath@1 path_bounding_rect=[15.322332,327.99997 105.35533x17.322357] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=9.90
   Restore@1
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,408 120x80] corner_radii=[0x0,80x80,0x0,0x0]
   StrokePath@1 path_bounding_rect=[8,408 120x80] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.31
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
+++ b/Tests/LibWeb/Text/expected/display_list/deep-branching-tree.txt
@@ -11,25 +11,15 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x225]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x204]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 404x204]
   FillPath@1 path_bounding_rect=[8,8 404x204]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[10,10 195x200]
   FillPath@2 path_bounding_rect=[10,10 195x200]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[215,10 195x200]
   FillPath@2 path_bounding_rect=[215,10 195x200]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[16,16 150x80]
   FillRect@4 rect=[16,16 150x80] color=rgb(255, 0, 0)
   DrawGlyphRun@4 rect=[16,16 15x16] translation=[16,28.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[16,101 150x80]
   FillRect@5 rect=[16,101 150x80] color=rgb(0, 128, 0)
   DrawGlyphRun@5 rect=[16,101 10x16] translation=[16,113.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[221,16 150x80]
   FillRect@7 rect=[221,16 150x80] color=rgb(0, 0, 255)
   DrawGlyphRun@7 rect=[221,16 11x16] translation=[221,28.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@8 target_scroll_node_index=0 rect=[221,101 150x80]
   FillRect@8 rect=[221,101 150x80] color=rgb(255, 165, 0)
   DrawGlyphRun@8 rect=[221,101 12x16] translation=[221,113.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/double-border-with-asymmetric-radii.txt
+++ b/Tests/LibWeb/Text/expected/display_list/double-border-with-asymmetric-radii.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x171]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x150]
-  CompositorWheelHitTestTargetWithCornerRadii@1 target_scroll_node_index=0 rect=[8,8 200x150] corner_radii=[40x40,10x10,40x40,10x10]
   FillPath@1 path_bounding_rect=[192.04163,10.928932 15.958389x135.35535]
   FillPath@1 path_bounding_rect=[182.14214,22 11.857864x114.38478]
   FillPath@1 path_bounding_rect=[10.928932,142.04163 185.35535x15.958389]

--- a/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fieldset-background-with-legend.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x70.59375]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x49.59375]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[10,8 780x49.59375]
   Save@1
     AddClipRect@1 rect=[10,15 780x43]
     FillRect@1 rect=[10,8 780x50] color=rgb(0, 0, 255)
@@ -28,9 +24,6 @@ SaveLayer@0
     FillPath@1 path_bounding_rect=[10,15 780x1]
     FillPath@1 path_bounding_rect=[9,16 782x1]
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[24,8 57.328125x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[24,29.59375 752x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[24,29.59375 752x16]
   DrawGlyphRun@1 rect=[26,8 54x16] translation=[26,20.796875] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[24,29 63x16] translation=[24,42.390625] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
+++ b/Tests/LibWeb/Text/expected/display_list/fixed-position.txt
@@ -5,14 +5,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 150x50]
   FillRect@2 rect=[8,8 150x50] color=rgb(0, 128, 0)
   DrawGlyphRun@2 rect=[8,8 56x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[10,10 80x40]
   FillRect@0 rect=[10,10 80x40] color=rgb(255, 0, 0)
   DrawGlyphRun@0 rect=[10,10 44x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
+++ b/Tests/LibWeb/Text/expected/display_list/grid-gap-rounding.txt
@@ -4,19 +4,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x51]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x30]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 147x30]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 28.59375x30]
   FillRect@1 rect=[8,8 29x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[37.59375,8 28.59375x30]
   FillRect@1 rect=[38,8 28x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[67.1875,8 28.59375x30]
   FillRect@1 rect=[67,8 29x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[96.78125,8 28.59375x30]
   FillRect@1 rect=[97,8 28x30] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[126.375,8 28.59375x30]
   FillRect@1 rect=[126,8 29x30] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
+++ b/Tests/LibWeb/Text/expected/display_list/iframe-compositor-surface.txt
@@ -4,11 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x93]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x80]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 120x80]
   CompositorMainThreadWheelEventRegion@1 rect=[0,0 120x80]
   Save@1
     AddClipRect@1 rect=[0,0 120x80]

--- a/Tests/LibWeb/Text/expected/display_list/image-object-fit-cover-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/image-object-fit-cover-clip.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x40]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x40]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 40x40]
   Save@1
     AddClipRect@1 rect=[0,0 40x40]
     DrawScaledDecodedImageFrame@1 dst_rect=[0,-20 40x80]

--- a/Tests/LibWeb/Text/expected/display_list/input-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-caret.txt
@@ -6,15 +6,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x41]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 106x20]
   FillRect@1 rect=[8,8 106x20] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 106x20]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 100x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 100x16]
   DrawGlyphRun@3 rect=[11,10 37x16] translation=[11,22.796875] color=rgb(0, 0, 0)
   FillRect@3 rect=[11,10 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 110x24]

--- a/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/input-focus-switch-selection-and-caret.txt
@@ -8,22 +8,12 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x42]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x21]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x21]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 206x20]
   FillRect@1 rect=[8,8 206x20] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 206x20]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 200x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[222,8 206x20]
   FillRect@1 rect=[222,8 206x20] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[222,8 206x20]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[225,10 200x16]
   DrawGlyphRun@1 rect=[214,13 8x16] translation=[214,25.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,10 200x16]
   DrawGlyphRun@3 rect=[11,10 28x16] translation=[11,22.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[225,10 200x16]
   DrawGlyphRun@5 rect=[225,10 28x16] translation=[225,22.796875] color=rgb(0, 0, 0)
   FillRect@5 rect=[225,10 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[220,6 210x24]

--- a/Tests/LibWeb/Text/expected/display_list/mask-image-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mask-image-invalidation.txt
@@ -6,10 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -36,10 +32,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@1 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@1 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0
@@ -52,10 +44,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(173, 216, 230)
   DrawGlyphRun@2 rect=[8,8 30x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/mask-type-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mask-type-invalidation.txt
@@ -8,11 +8,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
   FillPath@4 path_bounding_rect=[0,0 100x100]
 Restore@0
 MaskDisplayList for context 4:
@@ -32,11 +27,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
   FillPath@4 path_bounding_rect=[0,0 100x100]
 Restore@0
 MaskDisplayList for context 4:

--- a/Tests/LibWeb/Text/expected/display_list/mix-blend-mode-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mix-blend-mode-invalidation.txt
@@ -5,10 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@1 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
@@ -20,10 +16,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
+++ b/Tests/LibWeb/Text/expected/display_list/mixed-sibling-contexts.txt
@@ -7,16 +7,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x123]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x102]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x102]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[118,8 102x102]
   FillPath@1 path_bounding_rect=[118,8 102x102]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[119,9 150x150]
   FillRect@4 rect=[119,9 150x150] color=rgb(173, 216, 230)
   DrawGlyphRun@4 rect=[119,9 55x16] translation=[119,21.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@2 rect=[8,8 88x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-color-change-inside-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-color-change-inside-opacity.txt
@@ -6,14 +6,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x111]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x90]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x13]
   DrawGlyphRun@1 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   DrawGlyphRun@2 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(0, 0, 255)
@@ -28,11 +21,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x397]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x376]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x299]
   DrawGlyphRun@1 rect=[8,85 46x13] translation=[8,95.390625] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,98 214x13] translation=[8,108.390625] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,111 546x13] translation=[8,121.390625] color=rgb(0, 0, 0)
@@ -40,22 +28,13 @@ SaveLayer@0
   DrawGlyphRun@1 rect=[8,137 473x13] translation=[8,147.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,163 74x13] translation=[8,173.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,176 85x13] translation=[8,186.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,189 551x13] translation=[8,199.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,202 541x13] translation=[8,212.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,215 538x13] translation=[8,225.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,228 536x13] translation=[8,238.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,241 542x13] translation=[8,251.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,254 531x13] translation=[8,264.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,267 567x13] translation=[8,277.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,280 567x13] translation=[8,290.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,293 540x13] translation=[8,303.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,306 545x13] translation=[8,316.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,319 546x13] translation=[8,329.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,332 546x13] translation=[8,342.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,345 72x13] translation=[8,355.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,371 40x13] translation=[8,381.39062] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
+  DrawGlyphRun@1 rect=[8,189 531x13] translation=[8,199.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,202 540x13] translation=[8,212.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,215 545x13] translation=[8,225.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,228 546x13] translation=[8,238.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,241 546x13] translation=[8,251.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,254 72x13] translation=[8,264.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,280 40x13] translation=[8,290.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@2 rect=[8,8 82x16] translation=[8,20.796875] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,40 60x16] translation=[8,52.796875] color=rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-opacity.txt
@@ -6,13 +6,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x111]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x90]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x13]
   DrawGlyphRun@1 rect=[8,85 83x13] translation=[8,95.390625] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   FillRect@2 rect=[8,8 81x16] color=rgb(255, 165, 0)
   FillRect@2 rect=[8,24 47x16] color=rgb(255, 165, 0)
   FillRect@2 rect=[8,40 60x16] color=rgb(255, 165, 0)
@@ -30,12 +24,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x436]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x415]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,85 784x338]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 81.21875x64]
   FillRect@1 rect=[8,8 81x16] color=rgb(255, 165, 0)
   FillRect@1 rect=[8,24 47x16] color=rgb(255, 165, 0)
   FillRect@1 rect=[8,40 60x16] color=rgb(255, 165, 0)
@@ -51,22 +39,16 @@ SaveLayer@0
   DrawGlyphRun@1 rect=[8,137 479x13] translation=[8,147.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,163 74x13] translation=[8,173.39062] color=rgb(0, 0, 0)
   DrawGlyphRun@1 rect=[8,176 85x13] translation=[8,186.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,189 551x13] translation=[8,199.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,202 541x13] translation=[8,212.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,215 538x13] translation=[8,225.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,228 536x13] translation=[8,238.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,241 542x13] translation=[8,251.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,254 532x13] translation=[8,264.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,267 567x13] translation=[8,277.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,280 337x13] translation=[8,290.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,293 343x13] translation=[8,303.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,306 345x13] translation=[8,316.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,319 345x13] translation=[8,329.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,332 527x13] translation=[8,342.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,345 532x13] translation=[8,355.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,358 533x13] translation=[8,368.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,371 533x13] translation=[8,381.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,384 72x13] translation=[8,394.39062] color=rgb(0, 0, 0)
-  DrawGlyphRun@1 rect=[8,410 105x13] translation=[8,420.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,189 532x13] translation=[8,199.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,202 337x13] translation=[8,212.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,215 343x13] translation=[8,225.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,228 345x13] translation=[8,238.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,241 345x13] translation=[8,251.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,254 527x13] translation=[8,264.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,267 532x13] translation=[8,277.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,280 533x13] translation=[8,290.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,293 533x13] translation=[8,303.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,306 72x13] translation=[8,316.39062] color=rgb(0, 0, 0)
+  DrawGlyphRun@1 rect=[8,332 105x13] translation=[8,342.39062] color=rgb(0, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/multiline-inline-paint-invalidation.txt
@@ -5,11 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x85]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 69.625x64]
   DrawGlyphRun@1 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(0, 0, 255)
   DrawLine@1 from=[8,24] to=[78,24] color=rgb(0, 0, 255) thickness=2 style=Solid
   DrawGlyphRun@1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(0, 0, 255)
@@ -27,11 +22,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x85]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x64]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 69.625x64]
   DrawGlyphRun@1 rect=[8,8 70x16] translation=[8,20.796875] color=rgb(255, 0, 0)
   DrawLine@1 from=[8,24] to=[78,24] color=rgb(255, 0, 0) thickness=2 style=Solid
   DrawGlyphRun@1 rect=[8,24 48x16] translation=[8,36.796875] color=rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
+++ b/Tests/LibWeb/Text/expected/display_list/nested-branches.txt
@@ -11,25 +11,15 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x295]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x274]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 324x274]
   FillPath@1 path_bounding_rect=[8,8 324x274]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[20,20 145x250]
   FillPath@2 path_bounding_rect=[20,20 145x250]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[175,20 145x250]
   FillPath@2 path_bounding_rect=[175,20 145x250]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[26,26 133x40]
   FillRect@4 rect=[26,26 133x40] color=rgb(255, 136, 136)
   DrawGlyphRun@4 rect=[26,26 20x16] translation=[26,38.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[26,71 133x40]
   FillRect@5 rect=[26,71 133x40] color=rgb(136, 255, 136)
   DrawGlyphRun@5 rect=[26,71 22x16] translation=[26,83.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@7 target_scroll_node_index=0 rect=[181,26 133x40]
   FillRect@7 rect=[181,26 133x40] color=rgb(136, 136, 255)
   DrawGlyphRun@7 rect=[181,26 22x16] translation=[181,38.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@8 target_scroll_node_index=0 rect=[181,71 133x40]
   FillRect@8 rect=[181,71 133x40] color=rgb(255, 255, 136)
   DrawGlyphRun@8 rect=[181,71 25x16] translation=[181,83.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
+++ b/Tests/LibWeb/Text/expected/display_list/opaque-background-image-blend.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x53]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x40]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 40x40]
   FillRect@1 rect=[0,0 40x40] color=rgb(45, 22, 0)
   Save@1
     AddClipRect@1 rect=[0,0 40x40]

--- a/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
+++ b/Tests/LibWeb/Text/expected/display_list/page-focus-rendering.txt
@@ -6,16 +6,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   FillRect@2 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
   Save@2
     AddClipRect@2 rect=[3,3 9x16]
@@ -44,16 +36,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   FillRect@2 rect=[12,3 19x16] color=rgba(16, 16, 16, 0.667)
   Save@2
     AddClipRect@2 rect=[3,3 9x16]
@@ -81,16 +65,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   FillRect@2 rect=[12,3 19x16] color=rgba(101, 2, 0, 0.8)
   Save@2
     AddClipRect@2 rect=[3,3 9x16]
@@ -119,16 +95,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   DrawGlyphRun@2 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
   FillRect@2 rect=[22,3 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[-2,-2 90x26]
@@ -149,16 +117,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   DrawGlyphRun@2 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
   DrawLine@1 from=[81,19] to=[83,17] color=rgba(255, 255, 255, 0.392) thickness=1 style=Solid
   DrawLine@1 from=[80,19] to=[83,16] color=rgba(0, 0, 0, 0.392) thickness=1 style=Solid
@@ -177,16 +137,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x54]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x38]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x22]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,22 800x16]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 86x22]
   FillRect@1 rect=[0,0 86x22] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[0,0 86x22]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[3,3 80x16]
   DrawGlyphRun@2 rect=[3,3 28x16] translation=[3,15.796875] color=rgb(0, 0, 0)
   FillRect@2 rect=[22,3 1x16] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[-2,-2 90x26]

--- a/Tests/LibWeb/Text/expected/display_list/patterned-border-on-a-short-side.txt
+++ b/Tests/LibWeb/Text/expected/display_list/patterned-border-on-a-short-side.txt
@@ -4,17 +4,9 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,28 40x40]
   FillPath@1 path_bounding_rect=[8,28 40x40]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,68 40x40]
   FillPath@1 path_bounding_rect=[8,68 40x40]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 40x20]
   FillPath@1 path_bounding_rect=[8,8 40x20]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[48,8 40x20]
   FillPath@1 path_bounding_rect=[48,8 40x20]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/patterned-border-sharing-corners.txt
+++ b/Tests/LibWeb/Text/expected/display_list/patterned-border-sharing-corners.txt
@@ -4,20 +4,14 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x281]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x260]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 140x20]
   Save@1
     AddClipPath@1 path_bounding_rect=[8,8 140x20]
     StrokePath@1 path_bounding_rect=[-2,8 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,28 140x20]
   Save@1
     AddClipPath@1 path_bounding_rect=[8,28 140x20]
     StrokePath@1 path_bounding_rect=[-2,28 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,48 140x100]
   Save@1
     AddClipPath@1 path_bounding_rect=[128,48 20x100]
     StrokePath@1 path_bounding_rect=[128,38 20x120] thickness=20 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=25.00
@@ -34,7 +28,6 @@ SaveLayer@0
     AddClipPath@1 path_bounding_rect=[8,48 140x20]
     StrokePath@1 path_bounding_rect=[-2,48 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,148 140x100]
   Save@1
     AddClipPath@1 path_bounding_rect=[128,148 20x100]
     StrokePath@1 path_bounding_rect=[128,138 20x120] thickness=20 color=rgb(0, 0, 255) dash_array_size=2 dash_offset=16.67
@@ -51,7 +44,6 @@ SaveLayer@0
     AddClipPath@1 path_bounding_rect=[8,148 140x20]
     StrokePath@1 path_bounding_rect=[-2,148 160x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=17.50
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,248 100x20]
   StrokePath@1 path_bounding_rect=[-2,248 120x20] thickness=20 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=25.00
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-basic.txt
@@ -6,11 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(0, 0, 255)
   DrawGlyphRun@3 rect=[8,8 21x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/perspective-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/perspective-invalidation.txt
@@ -6,11 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 
@@ -23,11 +18,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
+++ b/Tests/LibWeb/Text/expected/display_list/positioned-with-transformed-ancestor.txt
@@ -5,14 +5,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 200x200]
   FillRect@2 rect=[8,8 200x200] color=rgb(211, 211, 211)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 200x90]
   FillRect@2 rect=[8,8 200x90] color=rgb(173, 216, 230)
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[33,33 100x50]
   FillRect@2 rect=[33,33 100x50] color=rgb(255, 127, 80)
   DrawGlyphRun@2 rect=[33,33 84x16] translation=[33,45.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
+++ b/Tests/LibWeb/Text/expected/display_list/relative-with-inline-transformed-intermediate.txt
@@ -4,14 +4,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x321]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x300]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 300x300]
   FillRect@1 rect=[8,8 300x300] color=rgb(211, 211, 211)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@1 rect=[8,8 100x100] color=rgb(173, 216, 230)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[13,13 100x100]
   FillRect@1 rect=[13,13 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@1 rect=[13,13 65x16] translation=[13,25.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
+++ b/Tests/LibWeb/Text/expected/display_list/repeated-svg-background-is-display-list.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x101]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x80]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 120x80]
   Save@1
     AddClipRect@1 rect=[8,8 120x80]
     DrawRepeatedDisplayList@1 dst_rect=[8,8 20x20] clip_rect=[8,8 120x80] scaling_mode=NearestNeighbor

--- a/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-overflow-containers.txt
@@ -8,18 +8,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x103]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x82]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x82]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 102x82]
   FillPath@1 path_bounding_rect=[8,8 102x82]
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[9,9 150x120]
   FillRect@3 rect=[9,9 150x120] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[9,9 110x16] translation=[9,21.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[130,8 102x82]
   FillPath@1 path_bounding_rect=[130,8 102x82]
-  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[131,9 150x120]
   FillRect@5 rect=[131,9 150x120] color=rgb(144, 238, 144)
   DrawGlyphRun@5 rect=[131,9 119x16] translation=[131,21.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
+++ b/Tests/LibWeb/Text/expected/display_list/sibling-transforms.txt
@@ -6,14 +6,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x101]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x80]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x80]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 80x80]
   FillRect@2 rect=[8,8 80x80] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,8 15x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[98,8 80x80]
   FillRect@3 rect=[98,8 80x80] color=rgb(0, 0, 255)
   DrawGlyphRun@3 rect=[98,8 10x16] translation=[98,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
+++ b/Tests/LibWeb/Text/expected/display_list/simple-overflow-hidden.txt
@@ -6,12 +6,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x125]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x104]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 204x104]
   FillPath@1 path_bounding_rect=[8,8 204x104]
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[10,10 300x150]
   FillRect@3 rect=[10,10 300x150] color=rgb(240, 128, 128)
   DrawGlyphRun@3 rect=[10,10 38x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
+++ b/Tests/LibWeb/Text/expected/display_list/skip-zero-area-clip-commands.txt
@@ -5,11 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,108 100x100]
-  CompositorWheelHitTestTarget@6 target_scroll_node_index=0 rect=[8,108 50x50]
   FillRect@6 rect=[8,108 50x50] color=rgb(255, 0, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/solid-border-edge-before-a-groove-edge.txt
+++ b/Tests/LibWeb/Text/expected/display_list/solid-border-edge-before-a-groove-edge.txt
@@ -4,10 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 140x100]
   FillPath@1 path_bounding_rect=[8,8 140x20]
   FillPath@1 path_bounding_rect=[138,8 10x100]
   FillPath@1 path_bounding_rect=[128,18 10x80]

--- a/Tests/LibWeb/Text/expected/display_list/solid-border-edges-with-a-dashed-edge.txt
+++ b/Tests/LibWeb/Text/expected/display_list/solid-border-edges-with-a-dashed-edge.txt
@@ -4,16 +4,11 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x181]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x160]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 120x80]
   FillPath@1 path_bounding_rect=[8,8 120x80]
   Save@1
     AddClipPath@1 path_bounding_rect=[8,8 10x80]
     StrokePath@1 path_bounding_rect=[8,3 10x90] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.00
   Restore@1
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,88 120x80]
   Save@1
     AddClipPath@1 path_bounding_rect=[8,88 120x10]
     StrokePath@1 path_bounding_rect=[3,88 130x10] thickness=10 color=rgb(255, 0, 0) dash_array_size=2 dash_offset=10.00

--- a/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-foreignobject-mask-after-relayout.txt
@@ -9,13 +9,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 100x100]
-  CompositorWheelHitTestTarget@5 target_scroll_node_index=0 rect=[0,0 100x100]
-  CompositorWheelHitTestTarget@6 target_scroll_node_index=0 rect=[0,0 100x100]
   FillRect@6 rect=[0,0 100x100] color=rgb(0, 0, 0)
 Restore@0
 MaskDisplayList for context 5:

--- a/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-in-img-is-nested.txt
@@ -4,15 +4,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,13 300x200]
   PaintNestedDisplayList@1 rect=[8,13 300x200]
     SaveLayer@0
-      CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 300x200]
-      CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 300x200]
       FillPath@6 path_bounding_rect=[0,0 100x100]
       FillPath@6 path_bounding_rect=[0,100 100x100]
       FillPath@8 path_bounding_rect=[0,0 100x100]

--- a/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-overflow-on-inner-elements.txt
@@ -6,11 +6,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 200x200]
   FillPath@3 path_bounding_rect=[10,10 100x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
+++ b/Tests/LibWeb/Text/expected/display_list/svg-transform-with-opacity.txt
@@ -8,11 +8,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
   FillPath@5 path_bounding_rect=[0,0 100x100]
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
+++ b/Tests/LibWeb/Text/expected/display_list/text-decoration-underline-partial-selection.txt
@@ -4,11 +4,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x71]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x50]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x50]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,-17 168.54688x100]
   FillRect@1 rect=[69,-17 47x100] color=rgba(101, 2, 0, 0.8)
   Save@1
     AddClipRect@1 rect=[8,-17 61x100]

--- a/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
+++ b/Tests/LibWeb/Text/expected/display_list/textarea-caret.txt
@@ -5,15 +5,8 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x53]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x32]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 106x32]
   FillRect@1 rect=[8,8 106x32] color=rgb(255, 255, 255)
   FillPath@1 path_bounding_rect=[8,8 106x32]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,11 100x13]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[11,11 100x13]
   DrawGlyphRun@2 rect=[11,11 30x13] translation=[11,21.390625] color=rgb(0, 0, 0)
   FillRect@2 rect=[11,11 1x13] color=rgb(0, 0, 0)
   FillPath@1 path_bounding_rect=[6,6 110x36]

--- a/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
+++ b/Tests/LibWeb/Text/expected/display_list/three-way-branch.txt
@@ -7,17 +7,10 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x81]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x60]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x60]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 60x60]
   FillRect@2 rect=[8,8 60x60] color=rgb(255, 0, 0)
   DrawGlyphRun@2 rect=[8,8 7x16] translation=[8,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[73,8 60x60]
   FillRect@3 rect=[73,8 60x60] color=rgb(0, 128, 0)
   DrawGlyphRun@3 rect=[73,8 9x16] translation=[73,20.796875] color=rgb(0, 0, 0)
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[138,8 60x60]
   FillRect@4 rect=[138,8 60x60] color=rgb(0, 0, 255)
   DrawGlyphRun@4 rect=[138,8 10x16] translation=[138,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-basic.txt
@@ -5,10 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 0, 255)
   DrawGlyphRun@2 rect=[8,8 38x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-invertibility-invalidation.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-invertibility-invalidation.txt
@@ -1,13 +1,9 @@
 Before transform change:
 AccumulatedVisualContext Tree:
   [0] transform=[1,0,0,1,0,0] origin=(0,0) (ViewportPaintable(Viewport<#document>))
-    [1] scroll (PaintableWithLines(BlockContainer<PRE>#out))
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
 Restore@0
 
 After transform change:
@@ -18,10 +14,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x121]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x100]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@2 rect=[8,8 100x100] color=rgb(0, 128, 0)
 Restore@0
 

--- a/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-nested.txt
@@ -6,12 +6,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@2 target_scroll_node_index=0 rect=[8,8 200x200]
   FillRect@2 rect=[8,8 200x200] color=rgb(173, 216, 230)
-  CompositorWheelHitTestTarget@3 target_scroll_node_index=0 rect=[8,8 100x100]
   FillRect@3 rect=[8,8 100x100] color=rgb(255, 127, 80)
   DrawGlyphRun@3 rect=[8,8 52x16] translation=[8,20.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
+++ b/Tests/LibWeb/Text/expected/display_list/transform-with-clip.txt
@@ -7,12 +7,7 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x175]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x154]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 154x154]
   FillPath@1 path_bounding_rect=[8,8 154x154]
-  CompositorWheelHitTestTarget@4 target_scroll_node_index=0 rect=[10,10 200x200]
   FillRect@4 rect=[10,10 200x200] color=rgb(144, 238, 144)
   DrawGlyphRun@4 rect=[10,10 185x16] translation=[10,22.796875] color=rgb(0, 0, 0)
 Restore@0

--- a/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
+++ b/Tests/LibWeb/Text/expected/display_list/z-index-change-no-double-paint.txt
@@ -5,11 +5,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 50x50]
   FillRect@1 rect=[8,8 50x50] color=rgb(0, 0, 255)
 Restore@0
 
@@ -20,11 +15,6 @@ AccumulatedVisualContext Tree:
 
 DisplayList:
 SaveLayer@0
-  CompositorWheelHitTestTarget@0 target_scroll_node_index=0 rect=[0,0 800x600]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[0,0 800x221]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 784x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 200x200]
-  CompositorWheelHitTestTarget@1 target_scroll_node_index=0 rect=[8,8 50x50]
   FillRect@1 rect=[8,8 50x50] color=rgb(0, 0, 255)
 Restore@0
 

--- a/Tests/LibWeb/Text/input/async-scrolling/viewport-wheel-target-fast-path.html
+++ b/Tests/LibWeb/Text/input/async-scrolling/viewport-wheel-target-fast-path.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #spacer {
+        height: 2000px;
+    }
+</style>
+<div id="spacer"></div>
+<script>
+    test(() => {
+        println(`viewport wheel target: ${internals.asyncScrollingStateWheelTargetAt(50, 50, 0, 100)}`);
+        println(`has explicit wheel hit test targets: ${internals.dumpDisplayList().includes("CompositorWheelHitTestTarget")}`);
+    });
+</script>


### PR DESCRIPTION
Avoid recording per-box wheel hit test targets when the viewport is the only wheel-scrollable candidate. The compositor already falls back to the viewport after checking blocking and main-thread wheel regions.

Track non-viewport candidates while building the visual context tree, so viewport-only pages do not pay for another traversal. Memoize target resolution when element scrollers exist. Reject non-scrollable overflow styles before measuring overflow geometry.

Add coverage for viewport fallback without explicit targets. Update display list expectations to omit the redundant commands.