### PR TITLE
Tests: Collect from a task in the AudioNode lifetime test

### DIFF
--- a/Tests/LibWeb/Text/input/WebAudio/AudioNode-lifetime.html
+++ b/Tests/LibWeb/Text/input/WebAudio/AudioNode-lifetime.html
@@ -36,18 +36,15 @@
         const playingSource = new WeakRef(source);
         source = null;
 
-        setTimeout(() => {
-            internals.gc();
-            // Churn the heap to dislodge any stale references, then collect again.
-            for (let i = 0; i < 10000; ++i)
-                document.body.appendChild(document.createElement("div"));
-            internals.gc();
-
-            println(`gain nothing feeds into is collected: ${unreachableGain.deref() === undefined}`);
-            println(`playing source is kept alive: ${playingSource.deref() !== undefined}`);
-            println(`gain fed by a playing source is kept alive: ${gainFedBySource.deref() !== undefined}`);
-            println(`gain held through its AudioParam is kept alive: ${gainHeldThroughParam.deref() !== undefined}`);
-            done();
-        }, 0);
+        internals
+            .gcAsync()
+            .then(() => internals.gcAsync())
+            .then(() => {
+                println(`gain nothing feeds into is collected: ${unreachableGain.deref() === undefined}`);
+                println(`playing source is kept alive: ${playingSource.deref() !== undefined}`);
+                println(`gain fed by a playing source is kept alive: ${gainFedBySource.deref() !== undefined}`);
+                println(`gain held through its AudioParam is kept alive: ${gainHeldThroughParam.deref() !== undefined}`);
+                done();
+            });
     });
 </script>


### PR DESCRIPTION
The test asserts that a gain node nothing feeds into is collected, but requested that collection with a synchronous internals.gc() from the callback that had just built the graph. LibGC scans conservatively from the current stack pointer to the top of the stack, so the collector ran on top of the interpreter frames that had handled the node and kept finding stale pointers to it there. Collecting 500 unreachable gain nodes that way leaves 4 or 5 of them alive, and a second synchronous collection still leaves 3, because those frames never go away; the heap churn the test did in between was a workaround for that. Two collections through internals.gcAsync() run from a task instead, below those frames, and leave none.

Fixes the flake sometimes seen in `Tests/LibWeb/Text/input/WebAudio/AudioNode-lifetime.html` on macOS.