### PR TITLE
LibWeb: Avoid asserting on dirty layout during editing boundary scans

### DIFF
--- a/Libraries/LibWeb/Editing/VisiblePosition.cpp
+++ b/Libraries/LibWeb/Editing/VisiblePosition.cpp
@@ -101,7 +101,7 @@ static bool has_rendered_text_after(DOM::Text const& text, size_t offset)
 
 static bool is_rendered_atomic_inline(DOM::Node const& node)
 {
-    auto const* layout_node = node.layout_node();
+    auto const* layout_node = node.unsafe_layout_node();
     return layout_node && layout_node->is_atomic_inline();
 }
 

--- a/Tests/LibWeb/Crash/Editing/insert-html-atomic-inline-with-running-animation.html
+++ b/Tests/LibWeb/Crash/Editing/insert-html-atomic-inline-with-running-animation.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<style>
+    @keyframes move { from { top: 0 } to { top: 100px } }
+    .animated { position: fixed; animation: move 1000s linear }
+</style>
+<svg><metadata id="fragment">
+<feFuncB id="animated-atomic" class="animated">x</feFuncB>
+</metadata></svg>
+<del id="host" contenteditable="true">a</del>
+<script>
+    const animation = document.getElementById("animated-atomic").getAnimations()[0];
+    function editWhenAnimationHasAdvanced() {
+        if (!animation.currentTime) {
+            requestAnimationFrame(editWhenAnimationHasAdvanced);
+            return;
+        }
+        getSelection().setPosition(host);
+        document.execCommand("selectAll", false);
+        document.execCommand("insertHTML", false, fragment.outerHTML);
+        document.documentElement.classList.remove("test-wait");
+    }
+    requestAnimationFrame(editWhenAnimationHasAdvanced);
+</script>
+</html>


### PR DESCRIPTION
Previously, an editing boundary scan could read a node's checked layout node after a computed-style query re-dirtied layout, tripping the layout-up-to-date assertion. Read the layout node through the unchecked accessor, matching the neighbouring rendered-text checks.