### PR TITLE
LibWebView: Keep synchronous history navigations in order

### DIFF
--- a/Libraries/LibWebView/ApplyHistoryStep.cpp
+++ b/Libraries/LibWebView/ApplyHistoryStep.cpp
@@ -230,7 +230,11 @@ void ApplyHistoryStep::process_changing_navigable_continuations()
         //       traversal potentially unloads their document. More details can be found here:
         //       https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigation-steps-queue-jumping-examples
         // 1. If traversable's running nested apply history step is false, then:
-        if (!m_traversable_state.running_nested_apply_history_step) {
+        // AD-HOC: Applying synchronous navigation steps can continue asynchronously. Do not let a later synchronous
+        //         navigation jump into that application. Both pushes could otherwise derive their target from the same
+        //         current history step and the later push could remove the earlier entry as forward history.
+        if (!m_session_history_traversal_queue.current_item_is_synchronous_navigation_steps()
+            && !m_traversable_state.running_nested_apply_history_step) {
             // IPC allows WebContent to append more steps while a nested run is pending. Limit this pass to the steps present at its
             // start so a ready continuation cannot be starved.
             if (!m_synchronous_navigation_steps_to_jump_through.has_value())

--- a/Libraries/LibWebView/SessionHistoryTraversalQueue.cpp
+++ b/Libraries/LibWebView/SessionHistoryTraversalQueue.cpp
@@ -40,7 +40,7 @@ Optional<SessionHistoryTraversalQueue::Item> SessionHistoryTraversalQueue::take_
 
 void SessionHistoryTraversalQueue::process_queue()
 {
-    while (!m_algorithm_set.is_empty()) {
+    for (;;) {
         if (m_running_steps && !m_running_steps->is_resolved() && !m_running_steps->is_rejected()) {
             m_running_steps->when_resolved([weak_this = make_weak_ptr()](Empty) {
                 if (weak_this)
@@ -49,7 +49,12 @@ void SessionHistoryTraversalQueue::process_queue()
             return;
         }
 
+        m_current_item_is_synchronous_navigation_steps = false;
+        if (m_algorithm_set.is_empty())
+            return;
+
         auto item = m_algorithm_set.take_first();
+        m_current_item_is_synchronous_navigation_steps = item.target_navigable.has_value();
         m_running_steps = Core::Promise<Empty>::construct();
         item.steps(*m_running_steps);
     }

--- a/Libraries/LibWebView/SessionHistoryTraversalQueue.h
+++ b/Libraries/LibWebView/SessionHistoryTraversalQueue.h
@@ -48,6 +48,8 @@ public:
 
     u64 last_enqueued_sequence_number() const { return m_last_enqueued_sequence_number; }
 
+    bool current_item_is_synchronous_navigation_steps() const { return m_current_item_is_synchronous_navigation_steps; }
+
     bool is_empty() const { return m_algorithm_set.is_empty(); }
 
 private:
@@ -59,6 +61,7 @@ private:
     u64 m_last_enqueued_sequence_number { 0 };
 
     bool m_processing_scheduled { false };
+    bool m_current_item_is_synchronous_navigation_steps { false };
     RefPtr<Core::Promise<Empty>> m_running_steps;
 };
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/anchor-fragment-history-back-on-click.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/anchor-fragment-history-back-on-click.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Anchor with a fragment href and a click handler that navigates back

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/anchor-fragment-history-back-on-click.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/anchor-fragment-history-back-on-click.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+  // Wait for after the load event so that the navigation doesn't get converted
+  // into a replace navigation.
+  await new Promise(resolve => window.onload = () => t.step_timeout(resolve, 0));
+
+  location.hash = "#1";
+  assert_equals(location.hash, "#1");
+  location.hash = "#2";
+  assert_equals(location.hash, "#2");
+
+  let anchor = document.createElement("a");
+  anchor.href = "#3";
+  anchor.onclick = () => {
+    history.back();
+  };
+
+  let navigations = [];
+  let navigationsPromise = new Promise(resolve => {
+    onpopstate = () => {
+      navigations.push(location.hash);
+      if (navigations.length === 2) {
+        resolve();
+      }
+    }
+  });
+
+  anchor.click();
+  await navigationsPromise;
+
+  // We were on #2 when history.back() was called so we should be on #1 now.
+  assert_equals(location.hash, "#1");
+
+  // While the history navigation back to "#1" was pending, we should have navigated to "#3".
+  assert_array_equals(navigations, ["#3", "#1"]);
+}, "Anchor with a fragment href and a click handler that navigates back");
+</script>


### PR DESCRIPTION
Prevent a later synchronous navigation from jumping into one that is still applying its history step. Otherwise both pushes can derive the same target step and the later navigation can remove the earlier entry.

This preserves the intermediate fragment entry when a click handler starts a back traversal before the anchor default action runs.