### PR TITLE
LibWebView: Preserve pending reloads across load completion

### DIFF
--- a/Libraries/LibWebView/CanonicalTraversable.cpp
+++ b/Libraries/LibWebView/CanonicalTraversable.cpp
@@ -183,17 +183,6 @@ Optional<i32> CanonicalTraversable::navigation_api_traversal_target(CanonicalNav
     return target_entry->step;
 }
 
-void CanonicalTraversable::did_cancel_navigation()
-{
-    m_session_history.clear_current_entry_reload_pending();
-}
-
-void CanonicalTraversable::did_finish_navigation(URL::URL const& url)
-{
-    if (auto const* current_entry = m_session_history.current_entry(); current_entry && current_entry->url == url)
-        m_session_history.clear_current_entry_reload_pending();
-}
-
 void CanonicalTraversable::traverse_the_history_by_delta(int delta, CheckForCancelation check_for_cancelation, Function<void()> on_ready)
 {
     if (m_pending_browser_history_traversal.has_value()

--- a/Libraries/LibWebView/CanonicalTraversable.h
+++ b/Libraries/LibWebView/CanonicalTraversable.h
@@ -16,7 +16,6 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
-#include <LibURL/URL.h>
 #include <LibWeb/Bindings/Navigation.h>
 #include <LibWeb/HTML/HistoryOperation.h>
 #include <LibWeb/HTML/LocalNavigable.h>
@@ -102,8 +101,6 @@ public:
     Optional<i32> append_nested_history(CanonicalNavigable const& parent_navigable, Web::HTML::CrossProcessId parent_document_state_id, Web::HTML::CrossProcessId child_navigable_id, Web::HTML::PendingSessionHistoryEntryDescriptor initial_history_entry);
     bool remove_nested_history(CanonicalNavigable const& parent_navigable, Web::HTML::CrossProcessId parent_document_state_id, Web::HTML::CrossProcessId child_navigable_id);
     Optional<i32> navigation_api_traversal_target(CanonicalNavigable const&, Utf16String const& navigation_api_key) const;
-    void did_cancel_navigation();
-    void did_finish_navigation(URL::URL const&);
     void traverse_the_history_by_delta(int delta, CheckForCancelation, Function<void()> on_ready = nullptr);
     void traverse_the_history_to_step(i32 step, CheckForCancelation, Function<void()> on_ready = nullptr);
     void reconstruct_the_history_to_step(i32 step);

--- a/Libraries/LibWebView/SessionHistory.cpp
+++ b/Libraries/LibWebView/SessionHistory.cpp
@@ -138,19 +138,6 @@ void TraversableSessionHistory::mark_current_entry_reload_pending()
     }
 }
 
-void TraversableSessionHistory::clear_current_entry_reload_pending()
-{
-    auto current_top_level_entry_index = this->current_top_level_entry_index();
-    if (!current_top_level_entry_index.has_value())
-        return;
-
-    auto document_state_id = m_entries[*current_top_level_entry_index].document_state.id;
-    for (auto& entry : m_entries) {
-        if (entry.document_state.id == document_state_id)
-            entry.document_state.reload_pending = false;
-    }
-}
-
 template<typename UpdateEntry>
 static bool update_session_history_entry_by_navigation_api_key(Vector<TraversableSessionHistory::Entry>& entries, Utf16String const& navigation_api_key, UpdateEntry const& update_entry)
 {

--- a/Libraries/LibWebView/SessionHistory.h
+++ b/Libraries/LibWebView/SessionHistory.h
@@ -54,7 +54,6 @@ public:
     bool initialize_for_testing(Vector<Entry>, Vector<i32> used_steps, size_t current_used_step_index);
     void initialize_with_initial_history_entry(Entry initial_history_entry);
     void mark_current_entry_reload_pending();
-    void clear_current_entry_reload_pending();
     bool update_entry(Optional<Web::HTML::CrossProcessId> nested_history_id, Utf16String const& navigation_api_key, Function<void(Entry&)> const& update_entry);
     bool update_entry_persisted_state(Optional<Web::HTML::CrossProcessId> nested_history_id, Web::HTML::SessionHistoryEntryPersistedState const&);
     bool update_document_state(Optional<Web::HTML::CrossProcessId> nested_history_id, Utf16String const& navigation_api_key, Function<void(Web::HTML::SessionHistoryDocumentStateDescriptor&)> const& update_document_state);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -1962,7 +1962,6 @@ bool ViewImplementation::did_cancel_navigation()
 
     if (m_pending_webdriver_navigation.has_value()) {
         auto navigation_id = m_pending_webdriver_navigation->id;
-        m_top_level_traversable.did_cancel_navigation();
         complete_webdriver_navigation(navigation_id);
         return true;
     }
@@ -1975,8 +1974,6 @@ void ViewImplementation::did_finish_navigation(URL::URL const& url)
 {
     set_loading_state(false);
     m_uncommitted_top_level_navigation.clear();
-
-    m_top_level_traversable.did_finish_navigation(url);
 
     if (!m_pending_webdriver_navigation.has_value())
         return;

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -25,6 +25,9 @@ Text/input/wpt-import/html/syntax/parsing/html5lib_url.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_write_single.html
 
+; Calls reload() on a child window's Location, which requires a shared tuple origin.
+Text/input/wpt-import/html/browsers/history/the-location-interface/reload_document_write.html
+
 ; pushState with path URL requires HTTP(s) scheme.
 Text/input/navigation/history-replace-push-then-back.html
 Text/input/navigation/intercepted-traverse-updates-history-entry.html
@@ -475,6 +478,7 @@ Text/input/input-file-accept.html
 
 ; These are support files used by other WPT imports, not standalone tests.
 Text/input/wpt-import/css/cssom-view/iframe.html
+Text/input/wpt-import/html/browsers/history/the-location-interface/reload_document_write-1.html
 Text/input/wpt-import/html/browsers/origin/cross-origin-objects/frame.html
 
 ; See: https://github.com/LadybirdBrowser/ladybird/issues/7931

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/history/the-location-interface/reload_document_write.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/history/the-location-interface/reload_document_write.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Reload document with document.written content

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/history/the-location-interface/reload_document_write-1.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/history/the-location-interface/reload_document_write-1.html
@@ -1,0 +1,4 @@
+<script>
+document.write(Math.random());
+opener.postMessage(document.body.innerHTML, "*");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/history/the-location-interface/reload_document_write.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/history/the-location-interface/reload_document_write.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Reload document with document.written content</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+var win = window.open("reload_document_write-1.html");
+var t = async_test();
+
+window.onmessage = t.step_func(function(e) {
+  var initial_value = e.data;
+  win.location.reload();
+  window.onmessage = t.step_func(function(e) {
+    assert_not_equals(e.data, initial_value);
+    t.done();
+  });
+});
+
+add_completion_callback(function() {win.close()});
+</script>

--- a/Tests/LibWebView/TestSessionHistory.cpp
+++ b/Tests/LibWebView/TestSessionHistory.cpp
@@ -609,33 +609,6 @@ TEST_CASE(history_log_entries_marks_nested_histories)
                                                          "used_steps=[0:0, 1:1, *2:2]"sv });
 }
 
-TEST_CASE(clear_current_entry_reload_pending)
-{
-    WebView::TraversableSessionHistory history;
-
-    auto update_result = history.initialize_for_testing({
-                                                            entry(0, "https://a.example/"sv),
-                                                            entry_with_reload_pending(1, "https://b.example/"sv, 7, "main"sv, {}),
-                                                            entry_with_reload_pending(2, "https://c.example/"sv, 7, "main"sv, {}),
-                                                        },
-        { 0, 1, 2 }, 1);
-    EXPECT_EQ(update_result, true);
-
-    auto current_entry = history.current_entry();
-    VERIFY(current_entry);
-    EXPECT(current_entry->document_state.reload_pending);
-
-    history.clear_current_entry_reload_pending();
-
-    current_entry = history.current_entry();
-    VERIFY(current_entry);
-    EXPECT(!current_entry->document_state.reload_pending);
-
-    auto shared_document_state_entry = history.entry_at(2);
-    VERIFY(shared_document_state_entry);
-    EXPECT(!shared_document_state_entry->document_state.reload_pending);
-}
-
 TEST_CASE(mark_current_entry_reload_pending)
 {
     WebView::TraversableSessionHistory history;


### PR DESCRIPTION
A same URL navigation can finish after a reload has already marked the current session history entry as reload pending. Clearing that flag from load completion clobbers the newer reload request.

Let applying the history step consume the flag instead. Fixes a flake / timeout for the included WPT test.