### PR TITLE
LibWeb: Speed up CSS keyword and property name lookups

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
@@ -32,10 +32,9 @@ private:
 
     explicit StringStyleValue(Utf16FlyString string)
         : StyleValueWithDefaultOperators(Type::String, [&] {
-            auto keyword = keyword_from_string(string);
             auto is_valid_animation_name_custom_ident = !string.equals_ignoring_ascii_case("default"sv)
                 && !string.equals_ignoring_ascii_case("none"sv)
-                && (!keyword.has_value() || !CSS::is_css_wide_keyword(keyword.value()));
+                && !CSS::is_css_wide_keyword(string);
             return StyleValueFFI::rust_style_value_create_string(
                 string.to_raw_leaked(), is_valid_animation_name_custom_ident);
         }())

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -57,6 +57,7 @@ function (generate_css_implementation)
                   -e "${LIBWEB_INPUT_FOLDER}/CSS/Enums.json"
                   -g "${LIBWEB_INPUT_FOLDER}/CSS/LogicalPropertyGroups.json"
         dependencies "${LIBWEB_INPUT_FOLDER}/CSS/Enums.json" "${LIBWEB_INPUT_FOLDER}/CSS/LogicalPropertyGroups.json"
+                     "${LADYBIRD_SOURCE_DIR}/Meta/Utils/utils.py"
     )
 
     invoke_py_generator(
@@ -113,6 +114,7 @@ function (generate_css_implementation)
         "CSS/Keyword.h"
         "CSS/Keyword.cpp"
         arguments -j "${LIBWEB_INPUT_FOLDER}/CSS/Keywords.json"
+        dependencies "${LADYBIRD_SOURCE_DIR}/Meta/Utils/utils.py"
     )
 
     invoke_py_idl_generator(

--- a/Meta/Generators/generate_libweb_css_keyword.py
+++ b/Meta/Generators/generate_libweb_css_keyword.py
@@ -71,6 +71,15 @@ inline bool is_css_wide_keyword(StringView name)
         || name.equals_ignoring_ascii_case("unset"sv);
 }
 
+inline bool is_css_wide_keyword(Utf16View name)
+{
+    return name.equals_ignoring_ascii_case("inherit"sv)
+        || name.equals_ignoring_ascii_case("initial"sv)
+        || name.equals_ignoring_ascii_case("revert"sv)
+        || name.equals_ignoring_ascii_case("revert-layer"sv)
+        || name.equals_ignoring_ascii_case("unset"sv);
+}
+
 inline bool is_css_wide_keyword(Keyword keyword)
 {
     switch (keyword) {

--- a/Meta/Generators/generate_libweb_css_keyword.py
+++ b/Meta/Generators/generate_libweb_css_keyword.py
@@ -17,6 +17,7 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from Utils.utils import title_casify
 from Utils.utils import underlying_type_for_enum
+from Utils.utils import write_case_insensitive_ascii_string_to_enum_lookup
 
 
 def keyword_name(dashy_name: str) -> str:
@@ -102,49 +103,29 @@ inline bool is_css_wide_keyword(Keyword keyword)
 def write_implementation_file(out: TextIO, keyword_data: list) -> None:
     out.write("""
 #include <AK/Assertions.h>
-#include <AK/HashMap.h>
-#include <AK/NeverDestroyed.h>
+#include <AK/CharacterTypes.h>
 #include <AK/Utf16FlyString.h>
 #include <LibWeb/CSS/Keyword.h>
 
 namespace Web::CSS {
-
-static HashMap<StringView, Keyword, AK::CaseInsensitiveASCIIStringViewTraits> const& stringview_to_keyword_map()
-{
-    static auto const& map = *new HashMap<StringView, Keyword, AK::CaseInsensitiveASCIIStringViewTraits> {
 """)
 
-    for name in keyword_data:
-        out.write(f"""
-    {{"{name}"sv, Keyword::{keyword_name(name)}}},
-""")
+    write_case_insensitive_ascii_string_to_enum_lookup(
+        out,
+        "keyword_from_string_impl",
+        "Keyword",
+        {name: f"Keyword::{keyword_name(name)}" for name in keyword_data},
+    )
 
     out.write("""
-    };
-    return map;
-}
-
 Optional<Keyword> keyword_from_string(StringView string)
 {
-    return stringview_to_keyword_map().get(string);
+    return keyword_from_string_impl(string);
 }
 
 Optional<Keyword> keyword_from_string(Utf16View string)
 {
-    if (string.has_ascii_storage()) {
-        auto span = string.ascii_span();
-        return keyword_from_string(StringView { span.data(), span.size() });
-    }
-""")
-
-    for name in keyword_data:
-        out.write(f"""
-    if (string.equals_ignoring_ascii_case("{name}"_utf16_fly_string.view()))
-        return Keyword::{keyword_name(name)};
-""")
-
-    out.write("""
-    return {};
+    return keyword_from_string_impl(string);
 }
 
 StringView string_from_keyword(Keyword keyword) {

--- a/Meta/Generators/generate_libweb_css_property_id.py
+++ b/Meta/Generators/generate_libweb_css_property_id.py
@@ -20,6 +20,7 @@ from Utils.utils import camel_casify
 from Utils.utils import snake_casify
 from Utils.utils import title_casify
 from Utils.utils import underlying_type_for_enum
+from Utils.utils import write_case_insensitive_ascii_string_to_enum_lookup
 
 
 def is_legacy_alias(prop: dict) -> bool:
@@ -348,6 +349,7 @@ struct Formatter<Web::CSS::PropertyID> : Formatter<Utf16FlyString> {
 def write_implementation_file(out: TextIO, properties: dict, logical_property_groups: dict, enum_names: list) -> None:
     out.write("""
 #include <AK/Assertions.h>
+#include <AK/CharacterTypes.h>
 #include <AK/NeverDestroyed.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Parser/Parser.h>
@@ -392,30 +394,25 @@ Optional<PropertyID> property_id_from_camel_case_string(Utf16View string)
     return {};
 }
 
-static auto generate_properties_table()
-{
-    HashMap<StringView, PropertyID, CaseInsensitiveASCIIStringViewTraits> table;
 """)
 
+    property_ids_by_name = {}
     for name, value in properties.items():
         legacy_alias_for = value.get("legacy-alias-for")
         target = title_casify(legacy_alias_for) if legacy_alias_for is not None else title_casify(name)
-        out.write(f"""
-    table.set("{name}"sv, PropertyID::{target});
-""")
+        property_ids_by_name[name] = f"PropertyID::{target}"
+    write_case_insensitive_ascii_string_to_enum_lookup(
+        out, "property_id_from_string_impl", "PropertyID", property_ids_by_name
+    )
 
     out.write("""
-    return table;
-}
-
-static auto const& properties_table = *new HashMap<StringView, PropertyID, CaseInsensitiveASCIIStringViewTraits>(generate_properties_table());
 
 Optional<PropertyID> property_id_from_string(StringView string)
 {
     if (is_a_custom_property_name_string(string))
         return PropertyID::Custom;
 
-    return properties_table.get(string);
+    return property_id_from_string_impl(string);
 }
 
 Optional<PropertyID> property_id_from_string(Utf16View string)
@@ -423,14 +420,7 @@ Optional<PropertyID> property_id_from_string(Utf16View string)
     if (is_a_custom_property_name_string(string))
         return PropertyID::Custom;
 
-    if (string.has_ascii_storage())
-        return properties_table.get(StringView { string.bytes() });
-
-    for (auto const& entry : properties_table) {
-        if (string.equals_ignoring_ascii_case(entry.key))
-            return entry.value;
-    }
-    return {};
+    return property_id_from_string_impl(string);
 }
 
 Utf16FlyString const& string_from_property_id(PropertyID property_id) {

--- a/Meta/Utils/utils.py
+++ b/Meta/Utils/utils.py
@@ -8,6 +8,7 @@ import sys
 
 from pathlib import Path
 from typing import Optional
+from typing import TextIO
 from typing import Union
 
 
@@ -57,6 +58,66 @@ def string_hash(string: str) -> int:
     h = (h + (h << 15)) & 0xFFFFFFFF
 
     return h
+
+
+def write_case_insensitive_ascii_string_to_enum_lookup(
+    out: TextIO, function_name: str, enum_type: str, entries: dict[str, str]
+) -> None:
+    entries_by_length_and_first_character = {}
+    for name, value in entries.items():
+        entries_by_length_and_first_character.setdefault((len(name), name[0]), []).append((name, value))
+
+    out.write(f"""
+static size_t {function_name}_length(StringView string)
+{{
+    return string.length();
+}}
+
+static size_t {function_name}_length(Utf16View string)
+{{
+    return string.length_in_code_units();
+}}
+
+static u32 {function_name}_first_character(StringView string)
+{{
+    return string[0];
+}}
+
+static u32 {function_name}_first_character(Utf16View string)
+{{
+    return string.code_unit_at(0);
+}}
+
+template<typename StringType>
+static Optional<{enum_type}> {function_name}(StringType string)
+{{
+    switch ({function_name}_length(string)) {{
+""")
+
+    lengths = sorted({length for length, _ in entries_by_length_and_first_character})
+    for length in lengths:
+        out.write(f"""    case {length}:
+        switch (AK::to_ascii_lowercase({function_name}_first_character(string))) {{
+""")
+        first_characters = sorted(
+            first_character
+            for entry_length, first_character in entries_by_length_and_first_character
+            if entry_length == length
+        )
+        for first_character in first_characters:
+            out.write(f"        case {first_character!r}:\n")
+            for name, value in entries_by_length_and_first_character[(length, first_character)]:
+                out.write(
+                    f'            if (string.equals_ignoring_ascii_case("{name}"sv))\n                return {value};\n'
+                )
+            out.write("            break;\n")
+        out.write("        }\n        break;\n")
+
+    out.write("""
+    }
+    return {};
+}
+""")
 
 
 def title_casify(dashy_name: str) -> str:

--- a/Tests/LibWeb/TestCSSIDSpeed.cpp
+++ b/Tests/LibWeb/TestCSSIDSpeed.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <LibWeb/CSS/Keyword.h>
+#include <LibWeb/CSS/PropertyID.h>
 
 TEST_CASE(basic)
 {
@@ -17,11 +18,62 @@ TEST_CASE(basic)
     EXPECT_EQ(Web::CSS::keyword_from_string("SMALL"sv).value(), Web::CSS::Keyword::Small);
     EXPECT_EQ(Web::CSS::keyword_from_string("Small"sv).value(), Web::CSS::Keyword::Small);
     EXPECT_EQ(Web::CSS::keyword_from_string("smALl"sv).value(), Web::CSS::Keyword::Small);
+    EXPECT_EQ(Web::CSS::keyword_from_string(u"INLINE"sv).value(), Web::CSS::Keyword::Inline);
+    EXPECT(!Web::CSS::keyword_from_string("not-a-keyword"sv).has_value());
+    EXPECT(!Web::CSS::keyword_from_string(u"not-a-keyword"sv).has_value());
+
+    EXPECT_EQ(Web::CSS::property_id_from_string("background-color"sv).value(), Web::CSS::PropertyID::BackgroundColor);
+    EXPECT_EQ(Web::CSS::property_id_from_string(u"BACKGROUND-COLOR"sv).value(), Web::CSS::PropertyID::BackgroundColor);
+    EXPECT_EQ(Web::CSS::property_id_from_string("--custom"sv).value(), Web::CSS::PropertyID::Custom);
+    EXPECT_EQ(Web::CSS::property_id_from_string(u"--custom"sv).value(), Web::CSS::PropertyID::Custom);
+    EXPECT(!Web::CSS::property_id_from_string("not-a-property"sv).has_value());
+    EXPECT(!Web::CSS::property_id_from_string(u"not-a-property"sv).has_value());
 }
 
 BENCHMARK_CASE(keyword_from_string)
 {
     for (size_t i = 0; i < 10'000'000; ++i) {
         EXPECT_EQ(Web::CSS::keyword_from_string("inline"sv).value(), Web::CSS::Keyword::Inline);
+    }
+}
+
+BENCHMARK_CASE(keyword_from_utf16_string)
+{
+    for (size_t i = 0; i < 10'000'000; ++i) {
+        EXPECT_EQ(Web::CSS::keyword_from_string(u"inline"sv).value(), Web::CSS::Keyword::Inline);
+    }
+}
+
+BENCHMARK_CASE(all_properties_from_string)
+{
+    Vector<String> names;
+    for (auto i = to_underlying(Web::CSS::first_property_id); i <= to_underlying(Web::CSS::last_property_id); ++i)
+        names.append(MUST(Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)).view().to_utf8()));
+
+    for (size_t iteration = 0; iteration < 20'000; ++iteration) {
+        for (auto i = to_underlying(Web::CSS::first_property_id); i <= to_underlying(Web::CSS::last_property_id); ++i) {
+            auto property_id = static_cast<Web::CSS::PropertyID>(i);
+            EXPECT_EQ(Web::CSS::property_id_from_string(names[i - to_underlying(Web::CSS::first_property_id)]).value(), property_id);
+        }
+    }
+}
+
+BENCHMARK_CASE(all_properties_from_utf16_string)
+{
+    Vector<Vector<char16_t>> names;
+    for (auto i = to_underlying(Web::CSS::first_property_id); i <= to_underlying(Web::CSS::last_property_id); ++i) {
+        Vector<char16_t> name;
+        auto property_name = Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)).view();
+        for (size_t j = 0; j < property_name.length_in_code_units(); ++j)
+            name.append(property_name.code_unit_at(j));
+        names.append(move(name));
+    }
+
+    for (size_t iteration = 0; iteration < 20'000; ++iteration) {
+        for (auto i = to_underlying(Web::CSS::first_property_id); i <= to_underlying(Web::CSS::last_property_id); ++i) {
+            auto property_id = static_cast<Web::CSS::PropertyID>(i);
+            auto const& name = names[i - to_underlying(Web::CSS::first_property_id)];
+            EXPECT_EQ(Web::CSS::property_id_from_string(Utf16View { name.data(), name.size() }).value(), property_id);
+        }
     }
 }


### PR DESCRIPTION
Avoid consulting the full CSS keyword table when classifying string style values for animation-name. Compare directly against the small fixed set of excluded identifiers instead.

Replace the runtime keyword and property-name hash tables, along with their UTF-16 linear scans, with generated dispatch by string length and initial character. The generated lookup is shared by StringView and Utf16View.

Across all canonical properties, the new lookup is approximately 10% faster for ASCII and 21× faster for UTF-16. Add correctness coverage and benchmarks for both representations.