### PR TITLE
Make the arena's links the only layout tree topology

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -98,6 +98,11 @@ Node::~Node()
 {
     if (m_paintable)
         m_paintable->detach_from_layout_node({});
+    VERIFY(!parent_ptr());
+    while (auto* child = first_child_ptr()) {
+        RustFFI::layout_arena_remove_child(m_arena->handle(), slot_id(this), slot_id(child));
+        child->unref();
+    }
 }
 
 RustFFI::NodeSlotId Node::slot_id(Node const* node)
@@ -211,21 +216,46 @@ void* Node::arena_handle() const
     return m_arena->handle();
 }
 
-void Node::synchronize_topology()
+void Node::insert_before(NonnullRefPtr<Node> node, Node* before)
 {
-    auto old_parent = m_data->parent;
-    auto new_parent = slot_id(Base::parent_ptr());
-    if (old_parent.index != new_parent.index) {
-        if (old_parent.index != RustFFI::NodeSlotId_INVALID.index)
-            node_arena().note_inline_layout_damage(old_parent);
-        if (new_parent.index != RustFFI::NodeSlotId_INVALID.index)
-            node_arena().note_inline_layout_damage(new_parent);
-    }
-    m_data->parent = new_parent;
-    m_data->first_child = slot_id(Base::first_child_ptr());
-    m_data->last_child = slot_id(Base::last_child_ptr());
-    m_data->previous_sibling = slot_id(Base::previous_sibling_ptr());
-    m_data->next_sibling = slot_id(Base::next_sibling_ptr());
+    RustFFI::layout_arena_insert_child(m_arena->handle(), slot_id(this), slot_id(node.ptr()), slot_id(before));
+    bump_fragment_cache_epoch_of_self_and_ancestors();
+    (void)node.leak_ref();
+}
+
+void Node::append_child(NonnullRefPtr<Node> node)
+{
+    insert_before(move(node), nullptr);
+}
+
+void Node::prepend_child(NonnullRefPtr<Node> node)
+{
+    insert_before(move(node), first_child_ptr());
+}
+
+void Node::remove_child(Node& node)
+{
+    RustFFI::layout_arena_remove_child(m_arena->handle(), slot_id(this), slot_id(&node));
+    bump_fragment_cache_epoch_of_self_and_ancestors();
+    node.unref();
+}
+
+void Node::replace_child(NonnullRefPtr<Node> new_child, Node& old_child)
+{
+    VERIFY(&old_child != new_child.ptr());
+    auto successor_slot = old_child.m_data->next_sibling;
+    RustFFI::layout_arena_remove_child(m_arena->handle(), slot_id(this), slot_id(&old_child));
+    RustFFI::layout_arena_insert_child(m_arena->handle(), slot_id(this), slot_id(new_child.ptr()), successor_slot);
+    bump_fragment_cache_epoch_of_self_and_ancestors();
+    old_child.unref();
+    (void)new_child.leak_ref();
+}
+
+void Node::remove()
+{
+    auto* parent = parent_ptr();
+    VERIFY(parent);
+    parent->remove_child(*this);
 }
 
 void Node::set_containing_block(Box* containing_block)

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -72,13 +72,10 @@ protected:
 class WEB_API Node
     : public RefCounted<Node>
     , public Weakable<Node>
-    , private NodeArenaAllocation
-    , public RefCountedTreeNode<Node> {
+    , private NodeArenaAllocation {
 
 public:
     AK_ALLOC_WITH_KMALLOC_PARTITION(HeapPartition::Layout);
-
-    using Base = RefCountedTreeNode<Node>;
 
     virtual ~Node();
     StringView class_name() const;
@@ -212,6 +209,14 @@ public:
         }
         return false;
     }
+
+    void append_child(NonnullRefPtr<Node>);
+    void prepend_child(NonnullRefPtr<Node>);
+    void insert_before(NonnullRefPtr<Node>, Node* before);
+    void insert_before(NonnullRefPtr<Node> node, Node& before) { insert_before(move(node), &before); }
+    void remove_child(Node&);
+    void replace_child(NonnullRefPtr<Node> new_child, Node& old_child);
+    void remove();
 
     bool is_anonymous() const { return has_flag(RustFFI::NodeFlag::Anonymous); }
     bool insets_use_anchor_functions() const { return has_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions); }
@@ -424,7 +429,6 @@ protected:
 
 private:
     friend class NodeWithStyle;
-    friend class RefCountedTreeNode<Node>;
 
     static constexpr u8 encode_generated_for(CSS::PseudoElement pseudo_element)
     {
@@ -434,7 +438,6 @@ private:
 
     void set_containing_block(Box*);
     void set_inline_containing_block(NodeWithStyle const*);
-    void synchronize_topology();
 
     Node* tree_node_from_slot(RustFFI::NodeSlotId id) const
     {

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -20,6 +20,7 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/Export.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Layout/NodeArena.h>
 #include <LibWeb/Layout/TreeBuilderRustFFI.h>
 #include <LibWeb/Painting/DisplayListRecordingContext.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -87,6 +88,130 @@ public:
     u32 arena_slot_index() const { return m_slot.index; }
     void* arena_handle() const;
     NodeArena& node_arena() const { return *m_arena; }
+
+    Node* parent_ptr() { return tree_node_from_slot(m_data->parent); }
+    Node const* parent_ptr() const { return tree_node_from_slot(m_data->parent); }
+    Node* first_child_ptr() { return tree_node_from_slot(m_data->first_child); }
+    Node const* first_child_ptr() const { return tree_node_from_slot(m_data->first_child); }
+    Node* last_child_ptr() { return tree_node_from_slot(m_data->last_child); }
+    Node* next_sibling_ptr() { return tree_node_from_slot(m_data->next_sibling); }
+    Node const* next_sibling_ptr() const { return tree_node_from_slot(m_data->next_sibling); }
+    Node* previous_sibling_ptr() { return tree_node_from_slot(m_data->previous_sibling); }
+    bool has_children() const { return m_data->first_child.index != RustFFI::NodeSlotId_INVALID.index; }
+
+    RefPtr<Node> first_child() { return first_child_ptr(); }
+    RefPtr<Node const> first_child() const { return first_child_ptr(); }
+    RefPtr<Node> next_sibling() { return next_sibling_ptr(); }
+    RefPtr<Node const> next_sibling() const { return next_sibling_ptr(); }
+    RefPtr<Node> previous_sibling() { return previous_sibling_ptr(); }
+    RefPtr<Node const> previous_sibling() const { return const_cast<Node*>(this)->previous_sibling_ptr(); }
+
+    template<typename Callback>
+    TraversalDecision for_each_in_inclusive_subtree(Callback callback) const
+    {
+        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::Yes, callback);
+    }
+
+    template<typename Callback>
+    TraversalDecision for_each_in_inclusive_subtree(Callback callback)
+    {
+        return traverse_ref_counted_preorder(*this, IncludeRefCountedTreeRoot::Yes, callback);
+    }
+
+    template<typename U, typename Callback>
+    TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback)
+    {
+        return for_each_in_inclusive_subtree([callback = move(callback)](Node& node) {
+            if (auto* node_of_type = as_if<U>(node))
+                return callback(*node_of_type);
+            return TraversalDecision::Continue;
+        });
+    }
+
+    template<typename U, typename Callback>
+    TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback) const
+    {
+        return for_each_in_inclusive_subtree([callback = move(callback)](Node const& node) {
+            if (auto const* node_of_type = as_if<U>(node))
+                return callback(*node_of_type);
+            return TraversalDecision::Continue;
+        });
+    }
+
+    template<typename Callback>
+    void for_each_child(Callback callback) const
+    {
+        return const_cast<Node&>(*this).for_each_child(move(callback));
+    }
+
+    template<typename Callback>
+    void for_each_child(Callback callback)
+    {
+        for (auto* node = first_child_ptr(); node; node = node->next_sibling_ptr()) {
+            if (callback(*node) == IterationDecision::Break)
+                return;
+        }
+    }
+
+    template<typename U, typename Callback>
+    void for_each_child_of_type(Callback callback)
+    {
+        for (auto* node = first_child_ptr(); node; node = node->next_sibling_ptr()) {
+            auto* node_of_type = as_if<U>(*node);
+            if (!node_of_type)
+                continue;
+            if (callback(*node_of_type) == IterationDecision::Break)
+                return;
+        }
+    }
+
+    template<typename U, typename Callback>
+    void for_each_child_of_type(Callback callback) const
+    {
+        return const_cast<Node&>(*this).template for_each_child_of_type<U>(move(callback));
+    }
+
+    Node* next_in_pre_order()
+    {
+        if (auto* child = first_child_ptr())
+            return child;
+        for (auto* node = this; node; node = node->parent_ptr()) {
+            if (auto* next = node->next_sibling_ptr())
+                return next;
+        }
+        return nullptr;
+    }
+
+    Node const* next_in_pre_order() const
+    {
+        return const_cast<Node*>(this)->next_in_pre_order();
+    }
+
+    Node* previous_in_pre_order()
+    {
+        if (auto* node = previous_sibling_ptr()) {
+            while (auto* last_child = node->last_child_ptr())
+                node = last_child;
+            return node;
+        }
+        return parent_ptr();
+    }
+
+    Node const* previous_in_pre_order() const
+    {
+        return const_cast<Node*>(this)->previous_in_pre_order();
+    }
+
+    bool is_before(Node const& other) const
+    {
+        if (this == &other)
+            return false;
+        for (auto const* node = this; node; node = node->next_in_pre_order()) {
+            if (node == &other)
+                return true;
+        }
+        return false;
+    }
 
     bool is_anonymous() const { return has_flag(RustFFI::NodeFlag::Anonymous); }
     bool insets_use_anchor_functions() const { return has_flag(RustFFI::NodeFlag::InsetsUseAnchorFunctions); }
@@ -310,6 +435,13 @@ private:
     void set_containing_block(Box*);
     void set_inline_containing_block(NodeWithStyle const*);
     void synchronize_topology();
+
+    Node* tree_node_from_slot(RustFFI::NodeSlotId id) const
+    {
+        if (id.index == RustFFI::NodeSlotId_INVALID.index)
+            return nullptr;
+        return static_cast<Node*>(RustFFI::layout_arena_node_data(m_arena->handle(), id)->shell);
+    }
 
 protected:
     void set_node_kind(RustFFI::NodeKind);
@@ -753,12 +885,12 @@ inline Gfx::Font const& Node::font(float scale_factor) const
 
 inline NodeWithStyle const* Node::parent() const
 {
-    return static_cast<NodeWithStyle const*>(Base::parent_ptr());
+    return static_cast<NodeWithStyle const*>(parent_ptr());
 }
 
 inline NodeWithStyle* Node::parent()
 {
-    return static_cast<NodeWithStyle*>(Base::parent_ptr());
+    return static_cast<NodeWithStyle*>(parent_ptr());
 }
 
 inline Gfx::Font const& NodeWithStyle::first_available_font() const

--- a/Libraries/LibWeb/Layout/NodeArena.cpp
+++ b/Libraries/LibWeb/Layout/NodeArena.cpp
@@ -40,11 +40,6 @@ u64 NodeArena::formatting_context_run_cache_hit_count() const
     return RustFFI::layout_arena_fc_run_cache_hit_count(m_handle);
 }
 
-void NodeArena::note_inline_layout_damage(RustFFI::NodeSlotId box)
-{
-    RustFFI::layout_arena_note_inline_layout_damage(m_handle, box);
-}
-
 void NodeArena::enroll_text_node_for_content_sync(TextNode const& text_node)
 {
     m_text_nodes_enrolled_for_content_sync.append(text_node.make_weak_ptr<TextNode>());

--- a/Libraries/LibWeb/Layout/NodeArena.h
+++ b/Libraries/LibWeb/Layout/NodeArena.h
@@ -36,7 +36,6 @@ public:
     void free(RustFFI::NodeSlotId, u32 generation);
     void* handle() const { return m_handle; }
     u64 formatting_context_run_cache_hit_count() const;
-    void note_inline_layout_damage(RustFFI::NodeSlotId);
 
     void enroll_text_node_for_content_sync(TextNode const&);
     void enroll_node_for_replaced_content_facts_sync(Node const&);

--- a/Libraries/LibWeb/RefCountedTreeNode.h
+++ b/Libraries/LibWeb/RefCountedTreeNode.h
@@ -45,12 +45,14 @@ TraversalDecision traverse_ref_counted_preorder(T& root, IncludeRefCountedTreeRo
             continue;
         }
 
-        while (current != &root && !current->next_sibling_ptr())
+        T* ancestor_next_sibling = nullptr;
+        do {
             current = current->parent_ptr();
+        } while (current != &root && !(ancestor_next_sibling = current->next_sibling_ptr()));
         if (current == &root)
             break;
 
-        current = current->next_sibling_ptr();
+        current = ancestor_next_sibling;
     }
     return TraversalDecision::Continue;
 }

--- a/Libraries/LibWeb/RefCountedTreeNode.h
+++ b/Libraries/LibWeb/RefCountedTreeNode.h
@@ -193,29 +193,10 @@ public:
         node->m_parent = static_cast<T&>(*this);
         m_last_child = node;
 
-        T* appended_child = node.ptr();
         if (previous_last_child)
             previous_last_child->m_next_sibling = move(node);
         else
             m_first_child = move(node);
-        synchronize_topology_around(*appended_child);
-    }
-
-    void prepend_child(NonnullRefPtr<T> node)
-    {
-        VERIFY(!node->parent());
-        VERIFY(!node->next_sibling());
-        VERIFY(!node->previous_sibling());
-
-        if (m_first_child)
-            m_first_child->m_previous_sibling = node;
-        node->m_next_sibling = m_first_child;
-        node->m_parent = static_cast<T&>(*this);
-        T* prepended_child = node.ptr();
-        m_first_child = move(node);
-        if (!m_last_child)
-            m_last_child = m_first_child;
-        synchronize_topology_around(*prepended_child);
     }
 
     void insert_before(NonnullRefPtr<T> node, T* child)
@@ -238,14 +219,7 @@ public:
         else
             m_first_child = node;
 
-        T* inserted_child = node.ptr();
         child->m_previous_sibling = move(node);
-        synchronize_topology_around(*inserted_child);
-    }
-
-    void insert_before(NonnullRefPtr<T> node, T& child)
-    {
-        insert_before(move(node), &child);
     }
 
     void remove_child(T& node)
@@ -275,51 +249,6 @@ public:
         node.m_next_sibling.clear();
         node.m_previous_sibling.clear();
         node.m_parent.clear();
-
-        if constexpr (requires { node.synchronize_topology(); }) {
-            static_cast<T&>(*this).synchronize_topology();
-            node.synchronize_topology();
-            if (previous_sibling)
-                previous_sibling->synchronize_topology();
-            if (next_sibling)
-                next_sibling->synchronize_topology();
-        }
-        note_structural_change_to_layout_caches();
-    }
-
-    void replace_child(NonnullRefPtr<T> new_child, T& old_child)
-    {
-        VERIFY(&old_child != new_child.ptr());
-        VERIFY(static_cast<RefCountedTreeNode<T>&>(old_child).parent().ptr() == static_cast<T*>(this));
-        VERIFY(!new_child->parent());
-        VERIFY(!new_child->next_sibling());
-        VERIFY(!new_child->previous_sibling());
-
-        auto previous_sibling = old_child.previous_sibling();
-        auto next_sibling = old_child.next_sibling();
-        RefPtr<T> old_child_ref = old_child;
-
-        new_child->m_parent = static_cast<T&>(*this);
-        new_child->m_previous_sibling = previous_sibling;
-        new_child->m_next_sibling = next_sibling;
-
-        if (previous_sibling)
-            previous_sibling->m_next_sibling = new_child;
-        else
-            m_first_child = new_child;
-
-        if (next_sibling)
-            next_sibling->m_previous_sibling = new_child;
-        else
-            m_last_child = new_child;
-
-        old_child_ref->m_next_sibling.clear();
-        old_child_ref->m_previous_sibling.clear();
-        old_child_ref->m_parent.clear();
-
-        synchronize_topology_around(*new_child);
-        if constexpr (requires { old_child.synchronize_topology(); })
-            old_child.synchronize_topology();
     }
 
     void remove()
@@ -604,8 +533,6 @@ public:
             child->m_next_sibling.clear();
             child->m_previous_sibling.clear();
             child->m_parent.clear();
-            if constexpr (requires { child->synchronize_topology(); })
-                child->synchronize_topology();
         }
         m_last_child.clear();
     }
@@ -614,25 +541,6 @@ protected:
     RefCountedTreeNode() = default;
 
 private:
-    void synchronize_topology_around(T& node)
-    {
-        if constexpr (requires { node.synchronize_topology(); }) {
-            static_cast<T&>(*this).synchronize_topology();
-            node.synchronize_topology();
-            if (auto* previous_sibling = node.previous_sibling_ptr())
-                previous_sibling->synchronize_topology();
-            if (auto* next_sibling = node.next_sibling_ptr())
-                next_sibling->synchronize_topology();
-        }
-        note_structural_change_to_layout_caches();
-    }
-
-    void note_structural_change_to_layout_caches()
-    {
-        if constexpr (requires { static_cast<T&>(*this).bump_fragment_cache_epoch_of_self_and_ancestors(); })
-            static_cast<T&>(*this).bump_fragment_cache_epoch_of_self_and_ancestors();
-    }
-
     WeakPtr<T> m_parent;
     RefPtr<T> m_first_child;
     WeakPtr<T> m_last_child;

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -396,7 +396,16 @@ impl LayoutNodeArena {
         }
         self.fc_run_cache_store.remove_entry(index);
         self.raw_table_column_spans.remove(&id);
-        *self.data_mut(index) = NodeData::default();
+        let data = self.data_mut(index);
+        debug_assert!(
+            data.parent.is_invalid()
+                && data.first_child.is_invalid()
+                && data.last_child.is_invalid()
+                && data.previous_sibling.is_invalid()
+                && data.next_sibling.is_invalid(),
+            "layout node arena freed a slot that is still linked into a tree"
+        );
+        *data = NodeData::default();
 
         self.live_count = self
             .live_count
@@ -1216,15 +1225,6 @@ pub unsafe extern "C" fn layout_arena_fc_run_cache_hit_count(arena: *mut c_void)
             .fc_run_cache_store()
             .hit_count()
     })
-}
-
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_note_inline_layout_damage(arena: *mut c_void, box_: NodeSlotId) {
-    abort_on_panic(|| {
-        assert!(!arena.is_null(), "layout node arena handle is null");
-        // SAFETY: The C++ caller keeps the arena and layout tree alive for this synchronous call.
-        unsafe { &*arena.cast::<LayoutNodeArena>() }.note_inline_layout_damage_at_and_above(box_);
-    });
 }
 
 /// # Safety

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -980,6 +980,153 @@ impl LayoutNodeArena {
         };
     }
 
+    // OPTIMIZATION: The edit invalidates line data at its direct parent and every formatting
+    // ancestor. Preserve the structural proof along the same unbounded path as the fragment
+    // epoch bumps so each affected inline context can reuse its unchanged line prefix.
+    pub(crate) fn note_inline_layout_damage_at_and_above(&self, mut box_: NodeSlotId) {
+        while !box_.is_invalid() {
+            let data = self.data(box_);
+            self.fc_run_cache_store.note_inline_layout_damage(box_);
+            // SAFETY: data() validated that box_ names a live slot, and the layout tree is stable
+            // for the duration of this synchronous topology update.
+            box_ = unsafe { (&raw const (*data).parent).read() };
+        }
+    }
+
+    pub(crate) fn insert_child(&self, parent: NodeSlotId, child: NodeSlotId, before: NodeSlotId) {
+        self.assert_owner_thread();
+        assert_ne!(parent, child, "a layout node cannot become its own child");
+        let parent_data = self.data(parent);
+        let child_data = self.data(child);
+
+        // SAFETY (for every raw access below): data() validated that the slot IDs name live
+        // nodes, and layout tree mutation is serialized on the arena's owner thread.
+        unsafe {
+            let child_parent = (&raw const (*child_data).parent).read();
+            let child_previous_sibling = (&raw const (*child_data).previous_sibling).read();
+            let child_next_sibling = (&raw const (*child_data).next_sibling).read();
+            assert!(
+                child_parent.is_invalid(),
+                "inserted layout node is still linked to a parent"
+            );
+            assert!(
+                child_previous_sibling.is_invalid(),
+                "inserted layout node is still linked to a previous sibling"
+            );
+            assert!(
+                child_next_sibling.is_invalid(),
+                "inserted layout node is still linked to a next sibling"
+            );
+            debug_assert_eq!(
+                (&raw const (*parent_data).first_child).read().is_invalid(),
+                (&raw const (*parent_data).last_child).read().is_invalid(),
+                "layout node child list endpoints disagree"
+            );
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            let mut ancestor = parent;
+            while !ancestor.is_invalid() {
+                assert_ne!(ancestor, child, "layout node insertion would create a cycle");
+                // SAFETY: data() validated that ancestor names a live slot, and parent links
+                // only name live slots.
+                ancestor = unsafe { (&raw const (*self.data(ancestor)).parent).read() };
+            }
+        }
+
+        let before_data = if before.is_invalid() {
+            std::ptr::null_mut()
+        } else {
+            assert_ne!(before, child, "a layout node cannot be inserted before itself");
+            self.data(before)
+        };
+        let previous = if before_data.is_null() {
+            // SAFETY: parent_data addresses a live node validated above.
+            unsafe { (&raw const (*parent_data).last_child).read() }
+        } else {
+            // SAFETY: data() validated that before names a live node.
+            unsafe {
+                let before_parent = (&raw const (*before_data).parent).read();
+                assert_eq!(
+                    before_parent, parent,
+                    "insertion reference is not a child of the parent"
+                );
+                (&raw const (*before_data).previous_sibling).read()
+            }
+        };
+
+        // SAFETY: Every written slot was validated live above (previous comes from a validated
+        // sibling or child-list link), and mutation is serialized on the owner thread.
+        unsafe {
+            (&raw mut (*child_data).parent).write(parent);
+            (&raw mut (*child_data).previous_sibling).write(previous);
+            (&raw mut (*child_data).next_sibling).write(before);
+            if previous.is_invalid() {
+                (&raw mut (*parent_data).first_child).write(child);
+            } else {
+                (&raw mut (*self.data(previous)).next_sibling).write(child);
+            }
+            if before_data.is_null() {
+                (&raw mut (*parent_data).last_child).write(child);
+            } else {
+                (&raw mut (*before_data).previous_sibling).write(child);
+            }
+        }
+
+        self.note_inline_layout_damage_at_and_above(parent);
+    }
+
+    pub(crate) fn remove_child(&self, parent: NodeSlotId, child: NodeSlotId) {
+        self.assert_owner_thread();
+        let parent_data = self.data(parent);
+        let child_data = self.data(child);
+
+        // SAFETY (for every raw access below): data() validated that the slot IDs name live
+        // nodes, sibling and child-list links only name live slots, and layout tree mutation
+        // is serialized on the arena's owner thread.
+        unsafe {
+            let child_parent = (&raw const (*child_data).parent).read();
+            assert_eq!(child_parent, parent, "removed layout node is not a child of the parent");
+            let previous = (&raw const (*child_data).previous_sibling).read();
+            let next = (&raw const (*child_data).next_sibling).read();
+
+            if previous.is_invalid() {
+                let first_child = (&raw const (*parent_data).first_child).read();
+                assert_eq!(first_child, child, "layout node child list lost its first child");
+                (&raw mut (*parent_data).first_child).write(next);
+            } else {
+                let previous_data = self.data(previous);
+                let previous_next_sibling = (&raw const (*previous_data).next_sibling).read();
+                assert_eq!(
+                    previous_next_sibling, child,
+                    "layout node sibling chain is inconsistent"
+                );
+                (&raw mut (*previous_data).next_sibling).write(next);
+            }
+
+            if next.is_invalid() {
+                let last_child = (&raw const (*parent_data).last_child).read();
+                assert_eq!(last_child, child, "layout node child list lost its last child");
+                (&raw mut (*parent_data).last_child).write(previous);
+            } else {
+                let next_data = self.data(next);
+                let next_previous_sibling = (&raw const (*next_data).previous_sibling).read();
+                assert_eq!(
+                    next_previous_sibling, child,
+                    "layout node sibling chain is inconsistent"
+                );
+                (&raw mut (*next_data).previous_sibling).write(previous);
+            }
+
+            (&raw mut (*child_data).parent).write(NodeSlotId::INVALID);
+            (&raw mut (*child_data).previous_sibling).write(NodeSlotId::INVALID);
+            (&raw mut (*child_data).next_sibling).write(NodeSlotId::INVALID);
+        }
+
+        self.note_inline_layout_damage_at_and_above(parent);
+    }
+
     pub(crate) unsafe fn from_handle<'a>(arena: *mut c_void) -> &'a Self {
         assert!(!arena.is_null(), "layout node arena handle is null");
         // SAFETY: Layout passes borrow the document's arena synchronously,
@@ -1072,21 +1219,54 @@ pub unsafe extern "C" fn layout_arena_fc_run_cache_hit_count(arena: *mut c_void)
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn layout_arena_note_inline_layout_damage(arena: *mut c_void, mut box_: NodeSlotId) {
+pub unsafe extern "C" fn layout_arena_note_inline_layout_damage(arena: *mut c_void, box_: NodeSlotId) {
     abort_on_panic(|| {
         assert!(!arena.is_null(), "layout node arena handle is null");
         // SAFETY: The C++ caller keeps the arena and layout tree alive for this synchronous call.
-        let arena = unsafe { &*arena.cast::<LayoutNodeArena>() };
-        // OPTIMIZATION: The edit invalidates line data at its direct parent and every formatting
-        // ancestor. Preserve the structural proof along the same unbounded path as the fragment
-        // epoch bumps so each affected inline context can reuse its unchanged line prefix.
-        while !box_.is_invalid() {
-            let data = arena.data(box_);
-            arena.fc_run_cache_store().note_inline_layout_damage(box_);
-            // SAFETY: data() validated that box_ names a live slot, and the layout tree is stable
-            // for the duration of this synchronous topology update.
-            box_ = unsafe { (&raw const (*data).parent).read() };
-        }
+        unsafe { &*arena.cast::<LayoutNodeArena>() }.note_inline_layout_damage_at_and_above(box_);
+    });
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `id` must
+/// name a live node in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_node_data(arena: *mut c_void, id: NodeSlotId) -> *mut NodeData {
+    abort_on_panic(|| {
+        // SAFETY: The C++ caller keeps the arena alive for this synchronous call.
+        unsafe { LayoutNodeArena::from_handle(arena) }.data(id)
+    })
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `parent`,
+/// `child`, and a valid `before` must name live nodes in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_insert_child(
+    arena: *mut c_void,
+    parent: NodeSlotId,
+    child: NodeSlotId,
+    before: NodeSlotId,
+) {
+    abort_on_panic(|| {
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { LayoutNodeArena::from_handle(arena) }.insert_child(parent, child, before);
+    });
+}
+
+/// # Safety
+///
+/// The arena must remain valid for the duration of the call, and `parent` and
+/// `child` must name live nodes in this arena.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn layout_arena_remove_child(arena: *mut c_void, parent: NodeSlotId, child: NodeSlotId) {
+    abort_on_panic(|| {
+        // SAFETY: The C++ wrapper keeps the arena alive for this call and
+        // serializes all access on the document thread.
+        unsafe { LayoutNodeArena::from_handle(arena) }.remove_child(parent, child);
     });
 }
 


### PR DESCRIPTION
The layout tree topology lived twice: RefCountedTreeNode links on the C++ shells, mirrored into the arena's NodeData links by synchronize_topology. This makes the arena links the single topology: C++ reads resolve slot IDs back to shells, mutation goes through new arena primitives, and each attached child is kept alive by one strong reference owned by its tree edge. The mirror machinery is deleted. First step toward a fully Rust-owned layout tree.