### PR TITLE
LibWeb: Restore the standalone style engine test build

### DIFF
--- a/Libraries/LibWeb/Rust/src/css/style_compute.rs
+++ b/Libraries/LibWeb/Rust/src/css/style_compute.rs
@@ -5357,20 +5357,21 @@ mod tests {
             value: 2.5,
             unit: unit_code("px") as u8,
         };
-        assert_eq!(compute_border_or_outline_width(&length, 2.0).value, 2.5);
+        assert_eq!(compute_border_or_outline_width(&length, 2.0, None).value, 2.5);
         // 0.4px at 1 dppx rounds up to 1 device pixel.
         let thin = StyleValueData::Length {
             value: 0.4,
             unit: unit_code("px") as u8,
         };
-        assert_eq!(compute_border_or_outline_width(&thin, 1.0).value, 1.0);
+        assert_eq!(compute_border_or_outline_width(&thin, 1.0, None).value, 1.0);
         // medium is 3px.
         assert_eq!(
             compute_border_or_outline_width(
                 &StyleValueData::Keyword {
                     keyword: keyword::MEDIUM
                 },
-                1.0
+                1.0,
+                None
             )
             .value,
             3.0

--- a/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
+++ b/Libraries/LibWeb/Rust/src/layout/grid_formatting_context.rs
@@ -3625,22 +3625,6 @@ pub(crate) enum SpaceDistributionPhase {
     MaxContent,
 }
 
-/// Distributes one spanning item's contribution into planned base-size
-/// increases. The caller supplies the affected tracks in span order.
-#[cfg(test)]
-pub(crate) fn distribute_spanning_base_size(
-    tracks: &mut [Track],
-    affected: &[bool],
-    item_size_contribution: CssPixels,
-    phase: SpaceDistributionPhase,
-) -> Vec<CssPixels> {
-    assert_eq!(tracks.len(), affected.len());
-    let spanned = (0..tracks.len()).collect::<Vec<_>>();
-    distribute_spanning_base_size_for_indices(tracks, &spanned, item_size_contribution, phase, |position, _| {
-        affected[position]
-    })
-}
-
 fn distribute_spanning_base_size_for_indices(
     tracks: &mut [Track],
     spanned: &[usize],

--- a/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
+++ b/Libraries/LibWeb/Rust/src/layout/layout_node_arena.rs
@@ -1233,6 +1233,7 @@ mod tests {
         let value = CssPixels::from_raw(128);
         let inline_measurement = IntrinsicInlineSizeMeasurement {
             automatic_content_inline_size: CssPixels::from_raw(192),
+            min_content_inline_size_from_max_content_layout: Some(CssPixels::from_raw(96)),
             available_block_size: AvailableSize::MaxContent,
             content_inline_size: CssPixels::from_raw(192),
             content_block_size: CssPixels::from_raw(256),


### PR DESCRIPTION
Previously, attempting to run the Rust unit tests with `cargo test --release -p libweb_rust` failed. These changes make the tests compile again.

Currently 4 / 558 of the tests fail. I've not included fixes for these in this PR since I'm not 100% confident on what the intended semantics are.