### PR TITLE
LibWebView+RequestServer: Update estimated cache sizes after clearing

### DIFF
--- a/Base/res/ladybird/about-pages/settings/privacy.js
+++ b/Base/res/ladybird/about-pages/settings/privacy.js
@@ -179,5 +179,7 @@ document.addEventListener("WebUIMessage", event => {
         loadSettings(event.detail.data);
     } else if (event.detail.name === "estimatedBrowsingDataSizes") {
         updateBrowsingDataSizes(event.detail.data);
+    } else if (event.detail.name === "clearedBrowsingData") {
+        estimateBrowsingDataSizes();
     }
 });

--- a/Libraries/LibRequests/RequestClient.cpp
+++ b/Libraries/LibRequests/RequestClient.cpp
@@ -51,11 +51,14 @@ void RequestClient::die()
 
     for (auto& [id, promise] : m_pending_cache_size_estimations)
         promise->reject(Error::from_string_literal("RequestServer process died"));
+    for (auto& [id, promise] : m_pending_clear_cache_requests)
+        promise->reject(Error::from_string_literal("RequestServer process died"));
 
     auto websockets = move(m_websockets);
 
     m_requests.clear();
     m_pending_cache_size_estimations.clear();
+    m_pending_clear_cache_requests.clear();
     m_websockets.clear();
 
     for (auto& [id, websocket] : websockets) {
@@ -164,6 +167,24 @@ void RequestClient::estimated_cache_size(u64 cache_size_estimation_id, CacheSize
 {
     if (auto promise = m_pending_cache_size_estimations.take(cache_size_estimation_id); promise.has_value())
         (*promise)->resolve(sizes);
+}
+
+NonnullRefPtr<Core::Promise<Empty>> RequestClient::clear_cache(UnixDateTime since)
+{
+    auto promise = Core::Promise<Empty>::construct();
+
+    auto clear_cache_request_id = m_next_clear_cache_request_id++;
+    m_pending_clear_cache_requests.set(clear_cache_request_id, promise);
+
+    async_remove_cache_entries_accessed_since(clear_cache_request_id, since);
+
+    return promise;
+}
+
+void RequestClient::removed_cache_entries(u64 clear_cache_request_id)
+{
+    if (auto promise = m_pending_clear_cache_requests.take(clear_cache_request_id); promise.has_value())
+        (*promise)->resolve({});
 }
 
 void RequestClient::request_started(u64 request_id, IPC::File response_file)

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -55,8 +55,11 @@ public:
     RefPtr<WebSocket> websocket_connect(URL::URL const&, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HTTP::HeaderList const& request_headers);
 
     NonnullRefPtr<Core::Promise<CacheSizes>> estimate_cache_size_accessed_since(UnixDateTime since);
+    NonnullRefPtr<Core::Promise<Empty>> clear_cache(UnixDateTime since);
+
     ErrorOr<bool> store_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData, ReadonlyBytes);
     ErrorOr<Optional<Core::AnonymousBuffer>> retrieve_cache_associated_data(URL::URL const&, ByteString const& method, Optional<HTTP::HeaderList const&> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData);
+
     ErrorOr<bool> create_synthetic_cache_entry(URL::URL const&, ByteString const& method);
 
     Function<String(URL::URL const&, RequestServer::IsPrivate)> on_retrieve_http_cookie;
@@ -85,6 +88,7 @@ private:
     virtual void websocket_certificate_requested(u64 websocket_id) override;
 
     virtual void estimated_cache_size(u64 cache_size_estimation_id, CacheSizes sizes) override;
+    virtual void removed_cache_entries(u64 clear_cache_request_id) override;
 
     HashMap<u64, RefPtr<Request>> m_requests;
     u64 m_next_request_id { 0 };
@@ -95,6 +99,9 @@ private:
 
     HashMap<u64, NonnullRefPtr<Core::Promise<CacheSizes>>> m_pending_cache_size_estimations;
     u64 m_next_cache_size_estimation_id { 0 };
+
+    HashMap<u64, NonnullRefPtr<Core::Promise<Empty>>> m_pending_clear_cache_requests;
+    u64 m_next_clear_cache_request_id { 0 };
 };
 
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -1722,12 +1722,13 @@ NonnullRefPtr<Core::Promise<Application::BrowsingDataSizes>> Application::estima
     return promise;
 }
 
-void Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
+NonnullRefPtr<Core::Promise<Empty>> Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
 {
+    RefPtr<Core::Promise<Empty>> promise;
     bool did_change_history = false;
 
     if (options.delete_cached_files == ClearBrowsingDataOptions::Delete::Yes) {
-        m_request_server_client->async_remove_cache_entries_accessed_since(options.since);
+        promise = m_request_server_client->clear_cache(options.since);
 
         // FIXME: Maybe we should forward the "since" parameter to the WebContent process, but the in-memory cache is
         //        transient anyways, so just assuming they were all accessed in the last hour is fine for now.
@@ -1760,6 +1761,16 @@ void Application::clear_browsing_data(ClearBrowsingDataOptions const& options)
 
     if (did_change_history)
         on_recently_closed_entries_changed();
+
+    if (!promise) {
+        promise = Core::Promise<Empty>::construct();
+
+        Core::deferred_invoke([promise]() {
+            promise->resolve({});
+        });
+    }
+
+    return promise.release_nonnull();
 }
 
 void Application::initialize_actions()

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -233,7 +233,7 @@ public:
         Delete delete_download_history { Delete::No };
         Delete delete_site_data { Delete::No };
     };
-    void clear_browsing_data(ClearBrowsingDataOptions const&);
+    NonnullRefPtr<Core::Promise<Empty>> clear_browsing_data(ClearBrowsingDataOptions const&);
 
     Action& reload_action() { return *m_reload_action; }
     Action& copy_selection_action() { return *m_copy_selection_action; }

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -399,7 +399,6 @@ void SettingsUI::estimate_browsing_data_sizes(JsonValue const& options)
         return;
 
     auto& application = Application::the();
-    auto weak_this = static_cast<Core::EventReceiver&>(*this).make_weak_ptr();
 
     auto since = [&]() {
         if (auto since = options.as_object().get_integer<i64>("since"sv); since.has_value())
@@ -408,14 +407,7 @@ void SettingsUI::estimate_browsing_data_sizes(JsonValue const& options)
     }();
 
     application.estimate_browsing_data_size_accessed_since(since)
-        ->when_resolved([weak_this](Application::BrowsingDataSizes const& sizes) {
-            if (!weak_this)
-                return;
-
-            auto& settings_ui = static_cast<SettingsUI&>(*weak_this.ptr());
-            if (!settings_ui.is_open())
-                return;
-
+        ->when_resolved([weak_this = make_weak_ptr<SettingsUI>()](Application::BrowsingDataSizes const& sizes) {
             JsonObject result;
 
             result.set("cacheSizeSinceRequestedTime"sv, sizes.cache_size_since_requested_time);
@@ -424,7 +416,8 @@ void SettingsUI::estimate_browsing_data_sizes(JsonValue const& options)
             result.set("siteDataSizeSinceRequestedTime"sv, sizes.site_data_size_since_requested_time);
             result.set("totalSiteDataSize"sv, sizes.total_site_data_size);
 
-            settings_ui.async_send_message("estimatedBrowsingDataSizes"sv, move(result));
+            if (auto self = weak_this.strong_ref())
+                self->async_send_message("estimatedBrowsingDataSizes"sv, move(result));
         })
         .when_rejected([](Error const& error) {
             dbgln("Failed to estimate browsing data sizes: {}", error);

--- a/Libraries/LibWebView/WebUI/SettingsUI.cpp
+++ b/Libraries/LibWebView/WebUI/SettingsUI.cpp
@@ -456,7 +456,16 @@ void SettingsUI::clear_browsing_data(JsonValue const& options)
         ? Application::ClearBrowsingDataOptions::Delete::Yes
         : Application::ClearBrowsingDataOptions::Delete::No;
 
-    Application::the().clear_browsing_data(clear_browsing_data_options);
+    auto& application = Application::the();
+
+    application.clear_browsing_data(clear_browsing_data_options)
+        ->when_resolved([weak_this = make_weak_ptr<SettingsUI>()](Empty) {
+            if (auto self = weak_this.strong_ref())
+                self->async_send_message("clearedBrowsingData"sv, {});
+        })
+        .when_rejected([](Error const& error) {
+            dbgln("Failed to clear browser data: {}", error);
+        });
 }
 
 void SettingsUI::set_global_privacy_control(JsonValue const& global_privacy_control)

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -507,10 +507,12 @@ void ConnectionFromClient::estimate_cache_size_accessed_since(u64 cache_size_est
     async_estimated_cache_size(cache_size_estimation_id, sizes);
 }
 
-void ConnectionFromClient::remove_cache_entries_accessed_since(UnixDateTime since)
+void ConnectionFromClient::remove_cache_entries_accessed_since(u64 clear_cache_request_id, UnixDateTime since)
 {
     if (m_disk_cache.has_value())
         m_disk_cache->remove_entries_accessed_since(since);
+
+    async_removed_cache_entries(clear_cache_request_id);
 }
 
 Messages::RequestServer::StoreCacheAssociatedDataResponse ConnectionFromClient::store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data)

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -71,9 +71,11 @@ private:
     virtual void retrieved_http_cookie(int client_id, u64 request_id, RequestServer::RequestType request_type, String cookie) override;
 
     virtual void estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) override;
-    virtual void remove_cache_entries_accessed_since(UnixDateTime since) override;
+    virtual void remove_cache_entries_accessed_since(u64 clear_cache_request_id, UnixDateTime since) override;
+
     virtual Messages::RequestServer::StoreCacheAssociatedDataResponse store_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData, Core::AnonymousBuffer) override;
     virtual Messages::RequestServer::RetrieveCacheAssociatedDataResponse retrieve_cache_associated_data(URL::URL, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData) override;
+
     virtual Messages::RequestServer::CreateSyntheticCacheEntryResponse create_synthetic_cache_entry(URL::URL, ByteString method) override;
 
     virtual void websocket_connect(u64 websocket_id, URL::URL, ByteString, Vector<ByteString>, Vector<ByteString>, Vector<HTTP::Header>) override;

--- a/Services/RequestServer/RequestClient.ipc
+++ b/Services/RequestServer/RequestClient.ipc
@@ -32,4 +32,5 @@ endpoint RequestClient
     certificate_requested(u64 request_id) =|
 
     estimated_cache_size(u64 cache_size_estimation_id, Requests::CacheSizes sizes) =|
+    removed_cache_entries(u64 clear_cache_request_id) =|
 }

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -38,9 +38,11 @@ endpoint RequestServer
     retrieved_http_cookie(int client_id, u64 request_id, ::RequestServer::RequestType request_type, String cookie) =|
 
     estimate_cache_size_accessed_since(u64 cache_size_estimation_id, UnixDateTime since) =|
-    remove_cache_entries_accessed_since(UnixDateTime since) =|
+    remove_cache_entries_accessed_since(u64 clear_cache_request_id, UnixDateTime since) =|
+
     store_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data, Core::AnonymousBuffer data) => (bool stored)
     retrieve_cache_associated_data(URL::URL url, ByteString method, Vector<HTTP::Header> request_headers, Optional<u64> vary_key, HTTP::CacheEntryAssociatedData associated_data) => (Optional<Core::AnonymousBuffer> data)
+
     create_synthetic_cache_entry(URL::URL url, ByteString method) => (bool created)
 
     // Websocket Connection API


### PR DESCRIPTION
Previously, after issuing a request to clear cache, we would continue displaying the old estimated cache size in the UI. This was pretty confusing. We now update the estimates once the cache is cleared.