### PR TITLE
LibWeb: Parse HTML fragments without temporary documents

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -602,12 +602,6 @@ Layout::NodeArena& Document::layout_node_arena()
     return *m_layout_node_arena;
 }
 
-void Document::set_temporary_document_for_fragment_parsing(Badge<HTML::HTMLParser>)
-{
-    // https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-parsing-algorithm
-    m_temporary_document_for_fragment_parsing = true;
-}
-
 void Document::reset_style_invalidation_counters() const
 {
     m_style_invalidation_counters = {};

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -755,7 +755,6 @@ public:
     GC::Ptr<HTML::HTMLParser> parser() const { return m_parser; }
     u64 parser_generation() const { return m_parser_generation; }
 
-    void set_temporary_document_for_fragment_parsing(Badge<HTML::HTMLParser>);
     [[nodiscard]] bool is_temporary_document_for_fragment_parsing() const { return m_temporary_document_for_fragment_parsing; }
 
     static bool is_valid_name(Utf16View const&);

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -157,6 +157,16 @@ HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mo
     m_document->set_encoding(utf16_string_from_standardized_encoding_label(standardized_encoding.value()));
 }
 
+HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, Utf16View input, FragmentParser fragment_parser)
+    : m_tokenizer(input)
+    , m_parsing_fragment(fragment_parser == FragmentParser::Yes)
+    , m_scripting_mode(scripting_mode)
+    , m_document(document)
+{
+    VERIFY(m_parsing_fragment);
+    m_rust_parser = rust_html_parser_create();
+}
+
 HTMLParser::HTMLParser(DOM::Document& document, ParserScriptingMode scripting_mode, ScriptCreatedParser script_created)
     : m_scripting_mode(scripting_mode)
     , m_script_created(script_created == ScriptCreatedParser::Yes)
@@ -246,8 +256,10 @@ void HTMLParser::configure_element_created_by_rust_parser(DOM::Element& element)
         // AD-HOC: Let <link> elements know which document they were originally parsed for.
         //         This is used for the render-blocking logic.
         auto& link_element = as<HTMLLinkElement>(element);
-        link_element.set_parser_document({}, document());
-        link_element.set_was_enabled_when_created_by_parser({}, !element.has_attribute(HTML::AttributeNames::disabled));
+        if (!m_parsing_fragment) {
+            link_element.set_parser_document({}, document());
+            link_element.set_was_enabled_when_created_by_parser({}, !element.has_attribute(HTML::AttributeNames::disabled));
+        }
         return;
     }
 
@@ -255,10 +267,10 @@ void HTMLParser::configure_element_created_by_rust_parser(DOM::Element& element)
         return;
 
     auto& script_element = as<HTMLScriptElement>(element);
-    if (m_scripting_mode != ParserScriptingMode::Fragment)
+    if (!m_parsing_fragment && m_scripting_mode != ParserScriptingMode::Fragment)
         script_element.set_parser_document(Badge<HTMLParser> {}, document());
     script_element.set_force_async(Badge<HTMLParser> {}, false);
-    if (m_scripting_mode == ParserScriptingMode::Inert)
+    if (m_parsing_fragment && m_scripting_mode != ParserScriptingMode::Fragment)
         script_element.set_already_started(Badge<HTMLParser> {}, true);
 }
 
@@ -323,7 +335,7 @@ bool HTMLParser::process_script_end_tag_from_rust_parser(HTMLScriptElement& scri
     m_tokenizer.restore_old_insertion_point();
 
     // At this stage, if the pending parsing-blocking script is not null, then:
-    if (document().pending_parsing_blocking_script()) {
+    if (!m_parsing_fragment && document().pending_parsing_blocking_script()) {
         // -> If the script nesting level is not zero:
         if (script_nesting_level() != 0) {
             // Set the parser pause flag to true,
@@ -414,7 +426,7 @@ bool HTMLParser::process_svg_script_end_tag_from_rust_parser(SVG::SVGScriptEleme
     // If the SVG script registered itself as a pending parsing-blocking script (external fetch in flight),
     // pause the parser and schedule a resume check. The parser will resume from
     // resume_after_parser_blocking_script when the fetch completes.
-    if (document().pending_parsing_blocking_svg_script()) {
+    if (!m_parsing_fragment && document().pending_parsing_blocking_svg_script()) {
         m_parser_pause_flag = true;
         schedule_resume_check();
     }
@@ -462,22 +474,13 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
     if (parser)
         VERIFY(document == parser->m_document);
 
-    // The entirety of "the end" should be a no-op for HTML fragment parsers, because:
-    // - the temporary document is not accessible, making the DOMContentLoaded event and "ready for post load tasks" do
-    //   nothing, making the parser not re-entrant from document.{open,write,close} and document.readyState inaccessible
-    // - there is no Window associated with it and no associated browsing context with the temporary document (meaning
-    //   the Window load event is skipped and making the load timing info inaccessible)
-    // - scripts are not able to be prepared, meaning the script queues are empty.
-    // However, the unconditional "spin the event loop" invocations cause two issues:
-    // - Microtask timing is changed, as "spin the event loop" performs an unconditional microtask checkpoint, causing
-    //   things to happen out of order. For example, YouTube sets the innerHTML of a <template> element in the constructor
-    //   of the ytd-app custom element _before_ setting up class attributes. Since custom elements use microtasks to run
-    //   callbacks, this causes custom element callbacks that rely on attributes setup by the constructor to run before
-    //   the attributes are set up, causing unhandled exceptions.
-    // - Load event delaying can spin forever, e.g. if the fragment contains an <img> element which stops delaying the
-    //   load event from an element task. Since tasks are not considered runnable if they're from a document with no
-    //   browsing context (i.e. the temporary document made for innerHTML), the <img> element will forever delay the load
-    //   event and cause an infinite loop.
+    // The entirety of "the end" should be a no-op for HTML fragment parsers. Fragment parsing does not complete its
+    // context document, dispatch document or Window events, or process the context document's script queues. Moreover,
+    // the unconditional "spin the event loop" invocations perform a microtask checkpoint, causing things to happen out
+    // of order. For example, YouTube sets the innerHTML of a <template> element in the constructor of the ytd-app custom
+    // element _before_ setting up class attributes. Since custom elements use microtasks to run callbacks, this causes
+    // custom element callbacks that rely on attributes setup by the constructor to run before the attributes are set up,
+    // causing unhandled exceptions.
     // We can avoid these issues and also avoid doing unnecessary work by simply skipping "the end" for HTML fragment
     // parsers.
     // See the message of the commit that added this for more details.
@@ -850,7 +853,7 @@ GC::Ref<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, Opt
 
     // AD-HOC: Let <link> elements know which document they were originally parsed for.
     //         This is used for the render-blocking logic.
-    if (local_name == HTML::TagNames::link && namespace_ == Namespace::HTML) {
+    if (!m_parsing_fragment && local_name == HTML::TagNames::link && namespace_ == Namespace::HTML) {
         auto& link_element = as<HTMLLinkElement>(*element);
         link_element.set_parser_document({}, document);
         link_element.set_was_enabled_when_created_by_parser({}, !token.has_attribute(HTML::AttributeNames::disabled));
@@ -1061,29 +1064,12 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
     VERIFY(context);
 
     // 4. Let document be a Document node whose type is "html".
-    auto temp_document = DOM::Document::create_for_fragment_parsing(
-        context->document().page(),
-        context->document().relevant_global_event_target());
-    temp_document->set_document_type(DOM::Document::Type::HTML);
-
-    temp_document->set_temporary_document_for_fragment_parsing({});
-
-    // AD-HOC: We set the about base URL of the document to the same as the context's document.
-    //         This is required for Document::parse_url() to work inside iframe srcdoc documents.
-    //         Spec issue: https://github.com/whatwg/html/issues/12210
-    temp_document->set_about_base_url(context->document().about_base_url());
 
     // 5. Let contextDocument be context's node document.
     auto& context_document = context->document();
 
     // 6. If contextDocument is in quirks mode, then set document's mode to "quirks".
-    if (context_document.in_quirks_mode()) {
-        temp_document->set_quirks_mode(DOM::QuirksMode::Yes);
-    }
     // 7. Otherwise, if contextDocument is in limited-quirks mode, then set document's mode to "limited-quirks".
-    else if (context_document.in_limited_quirks_mode()) {
-        temp_document->set_quirks_mode(DOM::QuirksMode::Limited);
-    }
 
     // 8. Create a new HTML parser whose allow declarative shadow roots is allowDeclarativeShadowRoots, and associate it with document.
     // 9. If contextDocument's scripting is disabled, then set scriptingMode to Disabled.
@@ -1091,10 +1077,13 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
     if (context_document.is_scripting_disabled())
         scripting_mode = HTML::ParserScriptingMode::Disabled;
 
-    auto parser = HTMLParser::create_for_decoded_string(*temp_document, input, scripting_mode, "utf-8"_utf16);
+    // OPTIMIZATION: Use the context document directly while keeping the parser detached from its document parser state.
+    //               The detached root below supplies the temporary tree-builder state, while all output nodes are
+    //               created for their final document. This avoids initializing a complete Document for every fragment.
+    auto parser = GC::Heap::the().allocate<HTMLParser>(context_document, scripting_mode, input, FragmentParser::Yes);
+    parser->initialize(context_document.relevant_settings_object().realm());
     parser->set_allow_declarative_shadow_roots(allow_declarative_shadow_roots);
     parser->m_context_element = context; // FIXME: Is this needed?
-    parser->m_parsing_fragment = true;
 
     // 11. Set the state of the HTML parser's tokenization stage as follows, switching on context:
     bool const context_element_is_html = context->namespace_uri() == Namespace::HTML;
@@ -1141,10 +1130,11 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
     // 12. Let root be the result of creating an element given document, "html", the HTML namespace, null, null, false,
     //     and the result of looking up a custom element registry given target.
     auto root_registry = look_up_a_custom_element_registry(target_node);
-    auto root = MUST(DOM::create_element(*temp_document, HTML::TagNames::html, Namespace::HTML, {}, {}, false, root_registry));
+    auto root = MUST(DOM::create_element(context_document, HTML::TagNames::html, Namespace::HTML, {}, {}, false, root_registry));
 
     // 13. Append root to document.
-    MUST(temp_document->append_child(root));
+    // OPTIMIZATION: Keep the root detached. It is only a sentinel for the tree builder, whose root insertions are
+    //               redirected to the output fragment.
 
     // 14. Set up the HTML parser's stack of open elements so that it contains just the single element root.
     // 15. Let fragment be a new DocumentFragment whose node document is target's node document.
@@ -1218,13 +1208,13 @@ WebIDL::ExceptionOr<GC::Ref<DOM::DocumentFragment>> HTMLParser::parse_html_fragm
         context_local_name.size(),
         context_attributes.data(),
         context_attributes.size(),
-        quirks_mode_to_html_parser_ffi(temp_document->mode()),
+        quirks_mode_to_html_parser_ffi(context_document.mode()),
         allow_declarative_shadow_roots == AllowDeclarativeShadowRoots::Yes,
         parser->m_form_element ? reinterpret_cast<size_t>(parser->m_form_element.ptr()) : 0);
 
     // 22. Place the input into the input stream for the HTML parser just created. The encoding confidence is irrelevant.
     // 23. Start the HTML parser and let it run until it has consumed all the characters just inserted into the input stream.
-    parser->run(context->document().url());
+    parser->run_until_completion();
 
     return fragment;
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -109,8 +109,14 @@ private:
         Yes,
     };
 
+    enum class FragmentParser {
+        No,
+        Yes,
+    };
+
     HTMLParser(DOM::Document&, ParserScriptingMode, StringView input, StringView encoding);
     HTMLParser(DOM::Document&, ParserScriptingMode, Utf16View input, Utf16View encoding);
+    HTMLParser(DOM::Document&, ParserScriptingMode, Utf16View input, FragmentParser);
     HTMLParser(DOM::Document&, ParserScriptingMode, ScriptCreatedParser);
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Tests/LibWeb/Text/expected/HTML/fragment-parser-does-not-leak-parser-created-state.txt
+++ b/Tests/LibWeb/Text/expected/HTML/fragment-parser-does-not-leak-parser-created-state.txt
@@ -1,0 +1,2 @@
+disabled-mode fragment script remained inert after adoption: true
+fragment link did not block document parser: true

--- a/Tests/LibWeb/Text/expected/HTML/fragment-parser-ignores-document-pending-script.txt
+++ b/Tests/LibWeb/Text/expected/HTML/fragment-parser-ignores-document-pending-script.txt
@@ -1,0 +1,2 @@
+fragment parser ignored pending HTML script: true
+fragment parser ignored pending SVG script: true

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/CustomElementRegistry-initialize.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/CustomElementRegistry-initialize.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 13 tests
 
-12 Pass
-1 Fail
+13 Pass
 Pass	initialize throws when the registry scoped is false and the root is the document.
 Pass	initialize throws when the registry scoped is false and the root document already has another registry
 Pass	initialize is a function on both global and scoped CustomElementRegistry
@@ -16,4 +15,4 @@ Pass	initialize sets element.customElementRegistry permantently
 Pass	initialize is no-op on a subtree with a non-null registry
 Pass	initialize works on Document
 Pass	initialize works on DocumentFragment
-Fail	initialize sets registry on shadow root descendants with no registry
+Pass	initialize sets registry on shadow root descendants with no registry

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/Element-innerHTML.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/Element-innerHTML.txt
@@ -2,13 +2,13 @@ Harness status: OK
 
 Found 11 tests
 
-8 Pass
-3 Fail
+9 Pass
+2 Fail
 Pass	innerHTML on a disconnected element should use the scoped registry it was created with
 Pass	nested descendants in innerHTML on a disconnected element should use the scoped registry the element was created with
 Pass	innerHTML on a disconnected element should use the scoped registry it was created with when parsing a simple HTML
 Pass	innerHTML on an inserted element should continue to use the scoped registry it was created with
-Fail	nested descendants in innerHTML should use the null registry when the container element has null registry
+Pass	nested descendants in innerHTML should use the null registry when the container element has null registry
 Fail	insertAdjacentHTML should use the element's registry even when the registry is null
 Fail	createContextualFragment on a range inside a template should use null registry even when the template has a scoped registry
 Pass	createContextualFragment on a range inside an element with scoped registry should use the scoped registry of the element

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 11 tests
 
-4 Pass
-7 Fail
+5 Pass
+6 Fail
 Fail	HTML parser should create a builtin element with null registry if customelementregistry is set
 Pass	Setting customelementregistry content attribute after a builtin element had finishsed parsing should not set null registry
 Fail	Cloning a builtin element with null regsitry should create an element with null registry
@@ -13,5 +13,5 @@ Fail	Cloning a custom element candidate with null regsitry should create an elem
 Fail	HTML parser should create a custom element with null registry if customelementregistry is set
 Pass	Setting customelementregistry content attribute after a custom element had finishsed parsing should not set null registry
 Fail	Cloning a custom element with null regsitry should create an element with null registry
-Fail	Descendants of an element with customelementregistry should use null registry
+Pass	Descendants of an element with customelementregistry should use null registry
 Pass	Setting customelementregistry content attribute during constructor should not make it use null registry

--- a/Tests/LibWeb/Text/input/HTML/fragment-parser-does-not-leak-parser-created-state.html
+++ b/Tests/LibWeb/Text/input/HTML/fragment-parser-does-not-leak-parser-created-state.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    asyncTest(async done => {
+        window.fragmentScriptRan = false;
+
+        const sandboxedFrame = document.createElement("iframe");
+        sandboxedFrame.sandbox = "allow-same-origin";
+        sandboxedFrame.srcdoc = "";
+        await new Promise(resolve => {
+            sandboxedFrame.onload = resolve;
+            document.body.appendChild(sandboxedFrame);
+        });
+
+        const template = sandboxedFrame.contentDocument.createElement("template");
+        template.innerHTML = "<script>top.fragmentScriptRan = true;<\/script>";
+        const script = document.adoptNode(template.content.firstChild);
+        document.body.appendChild(script);
+        println(`disabled-mode fragment script remained inert after adoption: ${!window.fragmentScriptRan}`);
+        script.remove();
+        sandboxedFrame.remove();
+
+        const httpServer = httpTestServer();
+        const testID = crypto.randomUUID();
+        const styleSheetToken = `fragment-link-style-sheet-${testID}`;
+        const styleSheetURL = await httpServer.createEcho("GET", `/fragment-link-style-sheet-${testID}.css`, {
+            status: 200,
+            headers: { "Content-Type": "text/css", "Cache-Control": "no-store" },
+            body: "",
+            wait_for_unblock: styleSheetToken,
+        });
+
+        const parserFrame = document.createElement("iframe");
+        const message = `fragment link inserted ${testID}`;
+        window.fragmentStyleSheetURL = styleSheetURL;
+        window.addEventListener("message", async function onMessage(event) {
+            if (event.data !== message)
+                return;
+            window.removeEventListener("message", onMessage);
+
+            println(`fragment link did not block document parser: ${parserFrame.contentDocument.querySelector("p") !== null}`);
+            await fetch(new URL(`/unblock/${styleSheetToken}`, styleSheetURL));
+            parserFrame.remove();
+            delete window.fragmentStyleSheetURL;
+            done();
+        });
+
+        parserFrame.srcdoc = `
+            <div></div>
+            <script>
+                document.querySelector("div").innerHTML = '<li' + 'nk rel="stylesheet" href="' + parent.fragmentStyleSheetURL + '">';
+                parent.postMessage("${message}", "*");
+            <\/script>
+            <script>void 0;<\/script>
+            <p></p>
+        `;
+        document.body.appendChild(parserFrame);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/fragment-parser-ignores-document-pending-script.html
+++ b/Tests/LibWeb/Text/input/HTML/fragment-parser-ignores-document-pending-script.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body>
+<script>
+    asyncTest(async done => {
+        const httpServer = httpTestServer();
+
+        async function checkFragmentParsingWithPendingScript(scriptMarkup, fragmentMarkup, description) {
+            const testID = crypto.randomUUID();
+            const scriptToken = `fragment-parser-pending-script-${testID}`;
+            const scriptURL = await httpServer.createEcho("GET", `/fragment-parser-pending-script-${testID}.js`, {
+                status: 200,
+                headers: { "Content-Type": "text/javascript", "Cache-Control": "no-store" },
+                body: "",
+                wait_for_unblock: scriptToken,
+            });
+
+            await new Promise(resolve => {
+                const frame = document.createElement("iframe");
+                const message = `parser blocked ${testID}`;
+                const onMessage = async event => {
+                    if (event.data !== message)
+                        return;
+                    window.removeEventListener("message", onMessage);
+
+                    const target = frame.contentDocument.querySelector("div");
+                    target.innerHTML = fragmentMarkup;
+                    println(`${description}: ${target.lastElementChild.localName === "p"}`);
+
+                    await fetch(new URL(`/unblock/${scriptToken}`, scriptURL));
+                    frame.remove();
+                    resolve();
+                };
+                window.addEventListener("message", onMessage);
+
+                frame.srcdoc = `
+                    <div></div>
+                    <script>parent.postMessage("${message}", "*");<\/script>
+                    ${scriptMarkup(scriptURL)}
+                `;
+                document.body.appendChild(frame);
+            });
+        }
+
+        await checkFragmentParsingWithPendingScript(
+            url => `<script src="${url}"><\/script>`,
+            "<script><\/script><p></p>",
+            "fragment parser ignored pending HTML script");
+        await checkFragmentParsingWithPendingScript(
+            url => `<svg><script href="${url}"><\/script></svg>`,
+            "<svg><script><\/script></svg><p></p>",
+            "fragment parser ignored pending SVG script");
+        done();
+    });
+</script>


### PR DESCRIPTION
Associate fragment parsers with the context document while leaving its document parser and parsing metadata unchanged. Use a detached root sentinel for the tree builder, and create output nodes in their final document.

This avoids constructing style, font, editing, timer, and registry state for every fragment parse. It also fixes scoped custom element registry propagation for fragment descendants.

```
Benchmark     Old Score      New Score       Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  -------------  ------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  47.93 ± 11.26  49.77 ± 1.00                1.038  10.91 ± 6.23           10.29 ± 0.68                1.06
Speedometer3  2.81           2.83 ± 0.68                 1.007  10.18                  9.98 ± 0.90                 1.02
```