### PR TITLE
LibWeb: Reduce binding wrapper conversion and caching overhead

### DIFF
--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -204,6 +204,9 @@ public:
     void set_requires_slow_add_own_property() { m_flags |= Flag::RequiresSlowAddOwnProperty; }
     void clear_requires_slow_add_own_property() { m_flags &= ~Flag::RequiresSlowAddOwnProperty; }
 
+    [[nodiscard]] bool is_platform_object() const { return m_flags & Flag::IsPlatformObject; }
+    void set_is_platform_object() { m_flags |= Flag::IsPlatformObject; }
+
     ThrowCompletionOr<bool> ordinary_set_with_own_descriptor(PropertyKey const&, Value, Value, Optional<PropertyDescriptor>, CacheableSetPropertyMetadata* = nullptr, PropertyLookupPhase = PropertyLookupPhase::OwnProperty);
 
     // 10.4.7 Immutable Prototype Exotic Objects, https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects
@@ -430,6 +433,7 @@ private:
         static constexpr u16 IsECMAScriptFunctionObject = 1 << 6;
         static constexpr u16 IsFunction = 1 << 7;
         static constexpr u16 RequiresSlowAddOwnProperty = 1 << 8;
+        static constexpr u16 IsPlatformObject = 1 << 9;
     };
 
     u16 m_flags { Flag::IsExtensible };

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -47,12 +47,14 @@ JS::ThrowCompletionOr<bool> ordinary_define_own_property_and_preserve_wrapper_if
 PlatformObject::PlatformObject(JS::Realm& realm, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
     : JS::Object(realm, nullptr, may_interfere_with_indexed_property_access)
 {
+    set_is_platform_object();
     set_requires_slow_add_own_property();
 }
 
 PlatformObject::PlatformObject(JS::Object& prototype, MayInterfereWithIndexedPropertyAccess may_interfere_with_indexed_property_access)
     : JS::Object(ConstructWithPrototypeTag::Tag, prototype, may_interfere_with_indexed_property_access)
 {
+    set_is_platform_object();
     set_requires_slow_add_own_property();
 }
 

--- a/Libraries/LibWeb/Bindings/PlatformObject.h
+++ b/Libraries/LibWeb/Bindings/PlatformObject.h
@@ -137,3 +137,6 @@ private:
 WEB_API JS::ThrowCompletionOr<bool> ordinary_define_own_property_and_preserve_wrapper_if_needed(PlatformObject&, JS::PropertyKey const&, JS::PropertyDescriptor&, Optional<JS::PropertyDescriptor>* precomputed_get_own_property);
 
 }
+
+template<>
+inline bool JS::Object::fast_is<Web::Bindings::PlatformObject>() const { return is_platform_object(); }

--- a/Libraries/LibWeb/Bindings/Wrappable.h
+++ b/Libraries/LibWeb/Bindings/Wrappable.h
@@ -68,22 +68,29 @@ WEB_API void preserve_wrapper(Wrappable&, PlatformObject&);
 WEB_API bool wrapper_is_preserved(PlatformObject const&);
 
 #ifndef WEB_WRAPPABLE
-#    define WEB_WRAPPABLE(class_, base_class)                           \
-        GC_CELL(class_, base_class)                                     \
-    public:                                                             \
-        using Base::initialize;                                         \
-        virtual Bindings::InterfaceName interface_name() const override \
-        {                                                               \
-            return Bindings::InterfaceName::class_;                     \
-        }                                                               \
-        virtual bool implements_interface(                              \
-            String const& interface) const override                     \
-        {                                                               \
-            if (interface == #class_)                                   \
-                return true;                                            \
-            return Base::implements_interface(interface);               \
-        }                                                               \
-                                                                        \
+#    define WEB_WRAPPABLE(class_, base_class)                                               \
+        GC_CELL(class_, base_class)                                                         \
+    public:                                                                                 \
+        using Base::initialize;                                                             \
+        static constexpr auto s_interface_name = Bindings::InterfaceName::class_;           \
+        virtual Bindings::InterfaceName interface_name() const override                     \
+        {                                                                                   \
+            return s_interface_name;                                                        \
+        }                                                                                   \
+        virtual bool implements_interface(Bindings::InterfaceName interface) const override \
+        {                                                                                   \
+            if (interface == s_interface_name)                                              \
+                return true;                                                                \
+            return Base::implements_interface(interface);                                   \
+        }                                                                                   \
+        virtual bool implements_interface(                                                  \
+            String const& interface) const override                                         \
+        {                                                                                   \
+            if (interface == #class_)                                                       \
+                return true;                                                                \
+            return Base::implements_interface(interface);                                   \
+        }                                                                                   \
+                                                                                            \
     public:
 #endif
 
@@ -105,7 +112,33 @@ public:
     virtual ~Wrappable() override = default;
 
     [[nodiscard]] virtual Bindings::InterfaceName interface_name() const { VERIFY_NOT_REACHED(); }
+    [[nodiscard]] virtual bool implements_interface(Bindings::InterfaceName) const { return false; }
     [[nodiscard]] virtual bool implements_interface(String const&) const { return false; }
+
+    template<typename T>
+    requires(IsBaseOf<Wrappable, T> && requires { T::s_interface_name; })
+    bool fast_is() const
+    {
+        return implements_interface(T::s_interface_name);
+    }
+
+    template<typename T>
+    requires(IsBaseOf<Wrappable, T> && requires { T::s_interface_name; })
+    T* fast_as()
+    {
+        if (!fast_is<T>())
+            return nullptr;
+        return static_cast<T*>(this);
+    }
+
+    template<typename T>
+    requires(IsBaseOf<Wrappable, T> && requires { T::s_interface_name; })
+    T const* fast_as() const
+    {
+        if (!fast_is<T>())
+            return nullptr;
+        return static_cast<T const*>(this);
+    }
 
     // https://html.spec.whatwg.org/multipage/browsers.html#extract-an-origin
     // Wrappers forward PlatformObject's extract an origin operation here.

--- a/Libraries/LibWeb/Bindings/WrapperWorld.cpp
+++ b/Libraries/LibWeb/Bindings/WrapperWorld.cpp
@@ -60,11 +60,6 @@ GC::Ptr<PlatformObject> WrapperWorld::wrapper_for(Wrappable const& wrappable, JS
     if (is_main_world()) {
         if (auto wrapper = wrappable.cached_main_world_wrapper(*this))
             return wrapper;
-
-        if (auto* wrapper = m_wrappers.get(wrappable)) {
-            VERIFY(&host_defined_wrapper_world(wrapper->realm()) == this);
-            return const_cast<PlatformObject*>(wrapper);
-        }
         return nullptr;
     }
 
@@ -81,12 +76,6 @@ void WrapperWorld::set_wrapper(Wrappable& wrappable, PlatformObject& wrapper)
     verify_cache_entry(*this, wrappable, wrapper);
 
     if (is_main_world()) {
-        if (auto* existing = m_wrappers.get(wrappable)) {
-            VERIFY(existing == &wrapper);
-            return;
-        }
-
-        m_wrappers.set(wrappable, wrapper);
         wrappable.set_cached_main_world_wrapper(wrapper);
         return;
     }
@@ -104,10 +93,6 @@ void WrapperWorld::clear_wrapper(Wrappable& wrappable, PlatformObject const& wra
     verify_cache_entry(*this, wrappable, wrapper);
 
     if (is_main_world()) {
-        if (auto* existing = m_wrappers.get(wrappable)) {
-            if (existing == &wrapper)
-                m_wrappers.remove(wrappable);
-        }
         wrappable.clear_cached_main_world_wrapper(wrapper);
         return;
     }


### PR DESCRIPTION
Avoid RTTI during generated binding conversions by tagging platform objects and checking WebIDL interface identities through their inheritance chain.

Also remove the redundant WrapperWorld weak-map entry for main-world wrappers, since each wrappable already caches that wrapper directly. Non-main worlds continue using the map for world-specific wrappers.

```
Benchmark     Old Score     New Score        Score Improvement  Old Total Time (ms)    New Total Time (ms)      Speedup
------------  ------------  -------------  -------------------  ---------------------  ---------------------  ---------
Speedometer2  48.63 ± 2.13  52.46 ± 27.57                1.079  10.29 ± 0.49           9.90 ± 5.98                1.039
Speedometer3  2.78 ± 0.09   2.95 ± 0.71                  1.062  9.86 ± 0.36            9.38 ± 2.71                1.051
```