### PR TITLE
LibWeb: Notify navigation observers after update-only history steps

### DIFF
--- a/Libraries/LibWeb/HTML/LocalNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalNavigable.cpp
@@ -892,11 +892,17 @@ void LocalNavigable::activate_history_entry(RefPtr<SessionHistoryEntry> entry, G
     if (new_document->completely_loaded_deferred())
         new_document->completely_finish_loading();
 
-    if (m_ongoing_navigation.has<Empty>()) {
-        for (auto& navigation_observer : m_navigation_observers) {
-            if (navigation_observer.navigation_complete())
-                navigation_observer.navigation_complete()->function()();
-        }
+    notify_navigation_observers_navigation_complete();
+}
+
+void LocalNavigable::notify_navigation_observers_navigation_complete()
+{
+    if (!m_ongoing_navigation.has<Empty>())
+        return;
+
+    for (auto& navigation_observer : m_navigation_observers) {
+        if (navigation_observer.navigation_complete())
+            navigation_observer.navigation_complete()->function()();
     }
 }
 

--- a/Libraries/LibWeb/HTML/LocalNavigable.h
+++ b/Libraries/LibWeb/HTML/LocalNavigable.h
@@ -108,6 +108,7 @@ public:
     void consume_child_navigable_history_reconstruction_id(size_t index);
 
     void activate_history_entry(RefPtr<SessionHistoryEntry>, GC::Ref<DOM::Document>);
+    void notify_navigation_observers_navigation_complete();
 
     GC::Ptr<DOM::Document> active_document() const;
     Optional<UniqueNodeID> active_document_id() const;

--- a/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/LocalTraversableNavigable.cpp
@@ -1002,13 +1002,16 @@ void LocalTraversableNavigable::apply_changing_navigable_history_step_continuati
         // 3. Let updateDocument be an algorithm step which performs update document for history step application given
         //    targetEntry's document, targetEntry, changingNavigableContinuation's update-only, scriptHistoryLength,
         //    scriptHistoryIndex, navigationType, entriesForNavigationAPI, and previousEntry.
-        auto update_document = [script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api), target_entry, update_only, navigation_type, previous_entry, resolved_document] {
+        auto update_document = [script_history_length, script_history_index, entries_for_navigation_api = move(entries_for_navigation_api), target_entry, update_only, navigation_type, previous_entry, resolved_document, navigable] {
             // NB: The specification initializes the navigation API entries for every newly activated document.
             //     Gating this on a non-null navigationType left documents activated by a creation/destruction
             //     update without an initialized navigation API entry list, which crashes the first same-document
             //     update on them (for example a document.open() on a child that finished loading while the
             //     creation update was still queued).
             resolved_document->update_for_history_step_application(*target_entry, update_only, script_history_length, script_history_index, navigation_type, entries_for_navigation_api, previous_entry, true);
+
+            if (update_only)
+                navigable->notify_navigation_observers_navigation_complete();
         };
 
         // 4. If targetEntry's document is equal to displayedDocument, then perform updateDocument.

--- a/Tests/LibWebView/test-webdriver-session-history.py
+++ b/Tests/LibWebView/test-webdriver-session-history.py
@@ -21,6 +21,7 @@ from typing import cast
 BLOCKED_RESPONSE_TIMEOUT_SECONDS = 30
 EVENT_TIMEOUT_SECONDS = 30
 WEBDRIVER_REQUEST_TIMEOUT_SECONDS = 60
+WEB_ELEMENT_IDENTIFIER = "element-6066-11e4-a52e-4f735466cecf"
 
 
 class TestPageServer(http.server.ThreadingHTTPServer):
@@ -133,6 +134,28 @@ class TestPageHandler(http.server.BaseHTTPRequestHandler):
 <script>fetch('/document-ran?fragment-target');</script>
 <h2 id="section">Section</h2>
 <p>Fragment Target</p>""".encode()
+            )
+            return
+
+        if self.path == "/webdriver-intercepted-navigation-click":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"""<!doctype html>
+<button id="button">Navigate</button>
+<script>
+window.navigationType = "none";
+navigation.addEventListener("navigate", event => {
+    event.intercept();
+    window.navigationType = event.navigationType;
+});
+button.addEventListener("click", () => {
+    const script = document.createElement("script");
+    script.textContent = 'location.href="?foo"';
+    document.body.append(script);
+});
+</script>"""
             )
             return
 
@@ -792,6 +815,23 @@ def execute_script(webdriver_port, session_id, script):
             "args": [],
         },
     )["value"]
+
+
+def find_element(webdriver_port, session_id, selector):
+    element = request(
+        webdriver_port,
+        "POST",
+        f"/session/{session_id}/element",
+        {
+            "using": "css selector",
+            "value": selector,
+        },
+    )["value"]
+    return element[WEB_ELEMENT_IDENTIFIER]
+
+
+def click_element(webdriver_port, session_id, element_id):
+    request(webdriver_port, "POST", f"/session/{session_id}/element/{element_id}/click", {})
 
 
 def wait_for_script_result(webdriver_port, session_id, label, script, predicate, log, timeout=EVENT_TIMEOUT_SECONDS):
@@ -1867,6 +1907,25 @@ def run_webdriver_fragment_navigation_test(webdriver_port, url):
     request(webdriver_port, "DELETE", f"/session/{session_id}")
 
 
+def run_webdriver_intercepted_navigation_click_test(webdriver_port, url):
+    session_id = create_session(webdriver_port)
+    try:
+        load_url_from_ui(webdriver_port, session_id, url)
+        element_id = find_element(webdriver_port, session_id, "#button")
+        request(webdriver_port, "POST", f"/session/{session_id}/timeouts", {"pageLoad": 1000})
+
+        click_element(webdriver_port, session_id, element_id)
+        state = execute_script(
+            webdriver_port,
+            session_id,
+            "return [location.search, window.navigationType];",
+        )
+        if state != ["?foo", "push"]:
+            raise AssertionError(f"Expected intercepted navigation to complete as a push, got {state}")
+    finally:
+        request(webdriver_port, "DELETE", f"/session/{session_id}")
+
+
 def run_failed_redirected_navigation_shows_failed_url_test(webdriver_port, page_port, url_a):
     url_redirect_to_tls_failure = f"http://localhost:{page_port}/redirect-to-tls-failure"
     url_tls_failure = f"https://127.0.0.1:{page_port}/tls-failure"
@@ -1900,6 +1959,10 @@ def run_failed_redirected_navigation_shows_failed_url_test(webdriver_port, page_
 
 def run_self_contained_navigation_tests(webdriver_port, page_port, url_a):
     run_webdriver_fragment_navigation_test(webdriver_port, url_a)
+    run_webdriver_intercepted_navigation_click_test(
+        webdriver_port,
+        f"http://localhost:{page_port}/webdriver-intercepted-navigation-click",
+    )
     run_failed_redirected_navigation_shows_failed_url_test(webdriver_port, page_port, url_a)
 
 


### PR DESCRIPTION
Moving same-document finalization to the UI traversal queue made it possible for WebDriver to begin waiting while a navigable still had an ongoing traversal. Update-only history steps clear that traversal and update the existing Document without activating it. Navigation observers were only notified during document activation, so Element Click could time out after the navigation had already completed.

Notify observers after the update-only document update when no newer navigation has claimed the navigable.