### PR TITLE
RequestServer: Pass through unsupported content encodings

### DIFF
--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -27,6 +27,44 @@ extern OwnPtr<ResourceSubstitutionMap> g_resource_substitution_map;
 
 static long s_connect_timeout_seconds = 90L;
 
+// https://everything.curl.dev/internals/content-encoding.html#supported-content-encodings
+static bool curl_supports_content_encoding(StringView encoding)
+{
+    static auto const* version_info = curl_version_info(CURLVERSION_NOW);
+    VERIFY(version_info);
+
+    if (encoding.is_one_of_ignoring_ascii_case("identity"sv, "none"sv))
+        return true;
+    if ((version_info->features & CURL_VERSION_LIBZ) && encoding.is_one_of_ignoring_ascii_case("deflate"sv, "gzip"sv, "x-gzip"sv))
+        return true;
+
+#ifdef CURL_VERSION_BROTLI
+    if ((version_info->features & CURL_VERSION_BROTLI) && encoding.equals_ignoring_ascii_case("br"sv))
+        return true;
+#endif
+#ifdef CURL_VERSION_ZSTD
+    if ((version_info->features & CURL_VERSION_ZSTD) && encoding.equals_ignoring_ascii_case("zstd"sv))
+        return true;
+#endif
+
+    return false;
+}
+
+static bool response_has_unsupported_content_encoding(HTTP::HeaderList const& headers)
+{
+    auto content_encoding = headers.get("Content-Encoding"sv);
+    if (!content_encoding.has_value())
+        return false;
+
+    for (auto encoding : content_encoding->view().split_view(',')) {
+        encoding = HTTP::normalize_header_value(encoding);
+        if (!encoding.is_empty() && !curl_supports_content_encoding(encoding))
+            return true;
+    }
+
+    return false;
+}
+
 Request::TransferredBodyFile::~TransferredBodyFile()
 {
     if (fd != -1)
@@ -484,17 +522,7 @@ Request::~Request()
             dbgln("Warning: Request destroyed with buffered data (it's likely that the client disappeared or the request was cancelled)");
     }
 
-    if (m_curl_easy_handle) {
-        if (m_curl_easy_handle_is_in_multi) {
-            auto result = curl_multi_remove_handle(m_curl_multi_handle, m_curl_easy_handle);
-            VERIFY(result == CURLM_OK);
-        }
-
-        curl_easy_cleanup(m_curl_easy_handle);
-    }
-
-    for (auto* string_list : m_curl_string_lists)
-        curl_slist_free_all(string_list);
+    MUST(free_curl_structs());
 
     if (m_cache_entry_writer.has_value()) {
         if (m_state == State::Complete)
@@ -533,6 +561,37 @@ void Request::notify_fetch_complete(Badge<ConnectionFromClient>, int result_code
     if (m_type == RequestType::Fetch || m_type == RequestType::BackgroundRevalidation) {
         log_network_activity(m_url, m_method, m_curl_easy_handle, result_code, is_revalidation_request(), m_type);
         log_chunk_stats(this);
+    }
+
+    // Fetch requires unsupported content codings to be treated as identity:
+    // https://fetch.spec.whatwg.org/#handle-content-codings
+    //
+    // libcurl instead reports CURLE_BAD_CONTENT_ENCODING whenever automatic content decoding encounters an unknown
+    // coding. Retry safe requests with decoding disabled so that libcurl passes the response body through unchanged.
+    // Restricting this to responses that actually contain an unsupported coding ensures malformed data using a
+    // supported coding still produces a network error. Unsafe methods cannot be retried without potentially repeating
+    // their side effects, so they continue to fail until content decoding moves out of libcurl.
+    // https://github.com/curl/curl/discussions/21293
+    if (result_code == CURLE_BAD_CONTENT_ENCODING
+        && m_method.is_one_of("GET"sv, "HEAD"sv, "OPTIONS"sv)
+        && !m_content_decoding_disabled
+        && !m_sent_response_headers_to_client
+        && m_bytes_transferred_to_client == 0
+        && response_has_unsupported_content_encoding(*m_response_headers)) {
+        MUST(free_curl_structs());
+
+        m_response_headers->clear();
+        m_reason_phrase.clear();
+        m_status_code.clear();
+        m_content_decoding_disabled = true;
+
+        if constexpr (REQUESTSERVER_WIRE_DEBUG) {
+            wire_stats().remove(this);
+            wire_stats().ensure(this).created_at = MonotonicTime::now();
+        }
+
+        transition_to_state(State::Fetch);
+        return;
     }
 
     if (is_revalidation_request()) {
@@ -936,7 +995,13 @@ void Request::handle_fetch_state()
     if (auto const& path = default_certificate_path(); !path.is_empty())
         set_option(CURLOPT_CAINFO, path.characters());
 
-    set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
+    if (m_content_decoding_disabled) {
+        set_option(CURLOPT_ACCEPT_ENCODING, "identity");
+        set_option(CURLOPT_HTTP_CONTENT_DECODING, 0L);
+    } else {
+        set_option(CURLOPT_ACCEPT_ENCODING, ""); // Empty string lets curl define the accepted encodings.
+    }
+
     set_option(CURLOPT_URL, m_url.to_byte_string().characters());
     set_option(CURLOPT_PORT, m_url.port_or_default());
     set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);
@@ -1206,6 +1271,22 @@ ErrorOr<void> Request::detach_curl_handle_from_multi()
     return {};
 }
 
+ErrorOr<void> Request::free_curl_structs()
+{
+    TRY(detach_curl_handle_from_multi());
+
+    if (m_curl_easy_handle) {
+        curl_easy_cleanup(m_curl_easy_handle);
+        m_curl_easy_handle = nullptr;
+    }
+
+    for (auto* string_list : m_curl_string_lists)
+        curl_slist_free_all(string_list);
+    m_curl_string_lists.clear();
+
+    return {};
+}
+
 ErrorOr<void> Request::transfer_to_client(ConnectionFromClient& client, u64 request_id)
 {
     if (m_type == RequestType::BackgroundRevalidation)
@@ -1256,6 +1337,8 @@ ErrorOr<void> Request::send_transferred_body_file_to_client()
 ErrorOr<void> Request::inform_client_request_started()
 {
     if (m_type == RequestType::BackgroundRevalidation)
+        return {};
+    if (m_client_request_pipe.has_value())
         return {};
 
     auto request_pipe = RequestPipe::create();

--- a/Services/RequestServer/Request.cpp
+++ b/Services/RequestServer/Request.cpp
@@ -1266,7 +1266,10 @@ ErrorOr<void> Request::inform_client_request_started()
     }
 
     m_client_request_pipe = request_pipe.release_value();
-    TRY(send_request_pipe_to_client());
+    if (auto result = send_request_pipe_to_client(); result.is_error()) {
+        transition_to_state(State::Error);
+        return result.release_error();
+    }
 
     return {};
 }

--- a/Services/RequestServer/Request.h
+++ b/Services/RequestServer/Request.h
@@ -185,6 +185,7 @@ private:
     static size_t on_data_received(void* buffer, size_t size, size_t nmemb, void* user_data);
 
     ErrorOr<void> detach_curl_handle_from_multi();
+    ErrorOr<void> free_curl_structs();
     ErrorOr<void> inform_client_request_started();
     ErrorOr<void> send_request_pipe_to_client();
     ErrorOr<void> send_transferred_body_file_to_client();
@@ -243,6 +244,7 @@ private:
     size_t m_bytes_transferred_to_client { 0 };
 
     Optional<Requests::NetworkError> m_network_error;
+    bool m_content_decoding_disabled { false };
 
     Optional<u32> m_address_selection_hint;
 

--- a/Tests/LibWeb/Text/expected/Fetch/unsupported-content-encoding.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/unsupported-content-encoding.txt
@@ -1,0 +1,3 @@
+Content-Encoding: base64
+Retry Accept-Encoding: identity
+Supported coding is still decoded

--- a/Tests/LibWeb/Text/input/Fetch/unsupported-content-encoding.html
+++ b/Tests/LibWeb/Text/input/Fetch/unsupported-content-encoding.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        const url = await httpTestServer().createEcho("GET", "/unsupported-content-encoding", {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Expose-Headers": "Content-Encoding",
+                "Content-Encoding": "base64",
+                "Content-Type": "application/json",
+            },
+            body: "$HEADERS",
+            reflect_headers_in_body: true,
+        });
+
+        const response = await fetch(url);
+        println(`Content-Encoding: ${response.headers.get("Content-Encoding")}`);
+        const requestHeaders = await response.json();
+        println(`Retry Accept-Encoding: ${requestHeaders["Accept-Encoding"]}`);
+
+        const gzipUrl = await httpTestServer().createEcho("GET", "/supported-content-encoding", {
+            status: 200,
+            headers: {
+                "Access-Control-Allow-Origin": "*",
+                "Content-Encoding": "gzip",
+                "Content-Type": "text/plain",
+            },
+            body_encoding: "base64",
+            body: "H4sIAAAAAAAAAwsuLSjILypJTVFIzk/JzEtXyCxWKC7JzMlRSEkFiqSmAACsbI0mIQAAAA==",
+        });
+
+        println(await (await fetch(gzipUrl)).text());
+    });
+</script>


### PR DESCRIPTION
libcurl returns `CURLE_BAD_CONTENT_ENCODING` when automatic response decoding encounters an unknown `Content-Encoding`. Fetch requires bytes with unsupported content codings to be returned unchanged.

Retry safe responses containing an unsupported coding with libcurl content decoding disabled. Keep automatic decoding for supported codings, and add coverage for both paths.

This allows us to load and render the following URL on Strava:
https://dgalywyr863hv.cloudfront.net/challenges/1738/1738-logo-100.png

| Before | After |
|--|--|
| <img width="292" height="149" alt="before" src="https://github.com/user-attachments/assets/3f8666b3-8863-47eb-8d08-6f46c92df7e4" /> | <img width="292" height="149" alt="after" src="https://github.com/user-attachments/assets/4c4b3e6c-9aef-4c53-9301-a81e71dc5969" /> |