### PR TITLE
LibWeb: Allow CORS wildcards to cover Authorization

### DIFF
--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/CORS.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/CORS.cpp
@@ -131,7 +131,15 @@ Vector<ByteString> get_cors_unsafe_header_names(HTTP::HeaderList const& headers)
 bool is_cors_non_wildcard_request_header_name(StringView header_name)
 {
     // A CORS non-wildcard request-header name is a header name that is a byte-case-insensitive match for `Authorization`.
-    return header_name.equals_ignoring_ascii_case("Authorization"sv);
+    //
+    // AD-HOC: Enforcing this is not yet web-compatible. See:
+    //         https://github.com/whatwg/fetch/issues/1278
+    //         https://github.com/whatwg/fetch/issues/1919
+    //
+    //         On the contrary, the use of Authorization with a wildcarded Access-Control-Allow-Headers is rising:
+    //         https://chromestatus.com/metrics/feature/timeline/popularity/3873
+    (void)header_name;
+    return false;
 }
 
 // https://fetch.spec.whatwg.org/#privileged-no-cors-request-header-name

--- a/Libraries/LibWeb/Fetch/Infrastructure/PreflightCache.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/PreflightCache.cpp
@@ -116,8 +116,15 @@ PreflightCache::Entry* PreflightCache::header_name_cache_entry_match(Request con
     for (auto& entry : m_entries) {
         if (!entry.header_name.has_value())
             continue;
-        if (!(entry.header_name->equals_ignoring_ascii_case(header_name) || (entry.header_name.value() == "*"sv && !is_cors_non_wildcard_request_header_name(header_name))))
+
+        // AD-HOC: CORS.cpp allows a wildcard to cover `Authorization` for web compatibility. This remains limited to
+        //         requests which do not include credentials, matching the wildcard handling during a live preflight.
+        auto wildcard_matches = request.credentials_mode() != Request::CredentialsMode::Include
+            && entry.header_name == "*"sv
+            && !is_cors_non_wildcard_request_header_name(header_name);
+        if (!(wildcard_matches || entry.header_name->equals_ignoring_ascii_case(header_name)))
             continue;
+
         if (is_cache_entry_match(entry, request))
             return &entry;
     }

--- a/Tests/LibWeb/Text/expected/Fetch/authorization-covered-by-cors-wildcard.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/authorization-covered-by-cors-wildcard.txt
@@ -1,0 +1,5 @@
+Preflight: Observed
+Status: 200
+Authorization: Bearer test-token
+Credentialed wildcard: Rejected
+Cached credentialed wildcard: Rejected

--- a/Tests/LibWeb/Text/expected/wpt-import/fetch/api/cors/cors-preflight-cache.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/fetch/api/cors/cors-preflight-cache.any.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Pass
+1 Pass
+1 Fail
 Pass	CORS preflight cache reuses explicit header entries
-Pass	CORS preflight cache does not reuse wildcard header entries for Authorization
+Fail	CORS preflight cache does not reuse wildcard header entries for Authorization

--- a/Tests/LibWeb/Text/input/Fetch/authorization-covered-by-cors-wildcard.html
+++ b/Tests/LibWeb/Text/input/Fetch/authorization-covered-by-cors-wildcard.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<script src="../include.js"></script>
+<script>
+    promiseTest(async () => {
+        try {
+            const server = httpTestServer();
+            const testID = crypto.randomUUID();
+            const wildcardPath = `/authorization-covered-by-cors-wildcard-${testID}`;
+            const preflightToken = `authorization-covered-by-cors-wildcard-${testID}`;
+            await server.createEcho("OPTIONS", wildcardPath, {
+                status: 204,
+                headers: {
+                    "Access-Control-Allow-Headers": "*",
+                    "Access-Control-Allow-Methods": "POST",
+                    "Access-Control-Allow-Origin": "*",
+                },
+                wait_for_unblock: preflightToken,
+            });
+            const url = await server.createEcho("POST", wildcardPath, {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Origin": "*",
+                    "Content-Type": "application/json",
+                },
+                reflect_headers_in_body: true,
+            });
+
+            const responsePromise = fetch(url, {
+                method: "POST",
+                headers: { Authorization: "Bearer test-token" },
+            });
+            const echoURL = new URL(url);
+            const recordedHeadersURL = `${echoURL.origin}/recorded-request-headers${echoURL.pathname}`;
+            let preflightHeaders = null;
+            for (let attempt = 0; attempt < 100; ++attempt) {
+                try {
+                    const recordedHeadersResponse = await fetch(recordedHeadersURL);
+                    if (recordedHeadersResponse.ok) {
+                        preflightHeaders = await recordedHeadersResponse.json();
+                        break;
+                    }
+                } catch {}
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+            await fetch(`${echoURL.origin}/unblock/${preflightToken}`);
+
+            const requestedHeaderNames = preflightHeaders?.["Access-Control-Request-Headers"]?.[0]
+                ?.split(",")
+                .map(name => name.trim().toLowerCase());
+            if (!requestedHeaderNames?.includes("authorization"))
+                throw new Error("Authorization was not observed in a CORS preflight");
+
+            const response = await responsePromise;
+            const requestHeaders = await response.json();
+
+            println("Preflight: Observed");
+            println(`Status: ${response.status}`);
+            println(`Authorization: ${requestHeaders["Authorization"]?.[0]}`);
+
+            const credentialedPath = `/authorization-not-covered-by-credentialed-cors-wildcard-${testID}`;
+            await server.createEcho("OPTIONS", credentialedPath, {
+                status: 204,
+                headers: {
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Headers": "*",
+                    "Access-Control-Allow-Methods": "POST",
+                    "Access-Control-Allow-Origin": location.origin,
+                },
+            });
+            const credentialedURL = await server.createEcho("POST", credentialedPath, {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Origin": location.origin,
+                },
+            });
+
+            try {
+                await fetch(credentialedURL, {
+                    method: "POST",
+                    credentials: "include",
+                    headers: { Authorization: "Bearer test-token" },
+                });
+                println("Credentialed wildcard: FAIL - request was sent");
+            } catch {
+                println("Credentialed wildcard: Rejected");
+            }
+
+            const cachedPath = `/authorization-not-covered-by-cached-credentialed-cors-wildcard-${testID}`;
+            await server.createEcho("OPTIONS", cachedPath, {
+                status: 204,
+                headers: {
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Headers": "*",
+                    "Access-Control-Allow-Methods": "PUT",
+                    "Access-Control-Allow-Origin": location.origin,
+                    "Access-Control-Max-Age": "60",
+                },
+            });
+            const cachedURL = await server.createEcho("PUT", cachedPath, {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Origin": location.origin,
+                },
+            });
+
+            const primingResponse = await fetch(cachedURL, {
+                method: "PUT",
+                credentials: "include",
+            });
+            if (!primingResponse.ok) throw new Error(`Failed to prime the preflight cache: ${primingResponse.status}`);
+
+            try {
+                await fetch(cachedURL, {
+                    method: "PUT",
+                    credentials: "include",
+                    headers: { Authorization: "Bearer test-token" },
+                });
+                println("Cached credentialed wildcard: FAIL - request was sent");
+            } catch {
+                println("Cached credentialed wildcard: Rejected");
+            }
+        } catch (error) {
+            println(`FAIL: ${error}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Some sites seen in the wild return `Access-Control-Allow-Headers: *` for requests carrying an `Authorization` header. The Fetch spec forbids this, but Chrome and Firefox permit it. Let's err on the side of web reality until the dust settles in the linked issues.