### PR TITLE
LibJS: Add engine-private property keys

### DIFF
--- a/Libraries/LibJS/Runtime/Accessor.h
+++ b/Libraries/LibJS/Runtime/Accessor.h
@@ -31,7 +31,11 @@ public:
     void set_setter(GC::Ptr<FunctionObject> setter) { m_setter = setter; }
 
     Symbol* cached_value_key() const { return m_cached_value_key.ptr(); }
-    void set_cached_value_key(GC::Ptr<Symbol> cached_value_key) { m_cached_value_key = cached_value_key; }
+    void set_cached_value_key(GC::Ptr<Symbol> cached_value_key)
+    {
+        VERIFY(!cached_value_key || cached_value_key->is_private());
+        m_cached_value_key = cached_value_key;
+    }
 
     void visit_edges(Cell::Visitor& visitor) override
     {
@@ -47,6 +51,7 @@ private:
         , m_setter(setter)
         , m_cached_value_key(cached_value_key)
     {
+        VERIFY(!cached_value_key || cached_value_key->is_private());
     }
 
     GC::Ptr<FunctionObject> m_getter;

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1126,8 +1126,7 @@ ThrowCompletionOr<Value> Object::internal_get(PropertyKey const& property_key, V
             receiver_uses_holder_cache = receiver.is_object()
                 && (&receiver.as_object() == this || receiver.as_object().prototype() == this);
             if (auto* cached_value_key = accessor->cached_value_key(); cached_value_key && receiver_uses_holder_cache) {
-                auto cached_property_key = PropertyKey { GC::Ref { *cached_value_key } };
-                if (auto cached_value = storage_get(cached_property_key); cached_value.has_value()) {
+                if (auto cached_value = get_engine_private_property(GC::Ref { *cached_value_key }); cached_value.has_value()) {
                     VERIFY(cached_value->property_offset.has_value());
                     update_inline_cache(*cached_value->property_offset);
                     return cached_value->value;
@@ -1145,8 +1144,7 @@ ThrowCompletionOr<Value> Object::internal_get(PropertyKey const& property_key, V
         if (auto* cached_value_key = accessor->cached_value_key()) {
             auto property = storage_get(property_key);
             if (property.has_value() && property->value.is_accessor() && &property->value.as_accessor() == accessor.ptr()) {
-                auto cached_property_key = PropertyKey { GC::Ref { *cached_value_key } };
-                const_cast<Object*>(this)->define_direct_property(cached_property_key, result, Attribute::Internal);
+                const_cast<Object*>(this)->set_engine_private_property(GC::Ref { *cached_value_key }, result);
             }
         }
     }
@@ -1343,16 +1341,16 @@ ThrowCompletionOr<GC::RootVector<Value>> Object::internal_own_property_keys() co
     }
 
     // 3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
-    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
-        if (property_key.is_string() && !metadata.attributes.is_internal()) {
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_string()) {
             // a. Add P as the last element of keys.
             keys.append(property_key.to_value(vm));
         }
     });
 
     // 4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
-    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
-        if (property_key.is_symbol() && !property_key.is_private() && !metadata.attributes.is_internal()) {
+    shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
+        if (property_key.is_symbol() && !property_key.is_private()) {
             // a. Add P as the last element of keys.
             keys.append(property_key.to_value(vm));
         }
@@ -1549,6 +1547,26 @@ void Object::define_direct_accessor(PropertyKey const& property_key, GC::Ptr<Fun
     }
 }
 
+Optional<ValueAndAttributes> Object::get_engine_private_property(GC::Ref<Symbol> key) const
+{
+    VERIFY(key->is_private());
+    return storage_get(PropertyKey { key });
+}
+
+void Object::set_engine_private_property(GC::Ref<Symbol> key, Value value)
+{
+    VERIFY(key->is_private());
+    (void)storage_set(PropertyKey { key }, { value, {} });
+}
+
+void Object::delete_engine_private_property(GC::Ref<Symbol> key)
+{
+    VERIFY(key->is_private());
+    auto property_key = PropertyKey { key };
+    if (storage_has(property_key))
+        storage_delete(property_key);
+}
+
 void Object::define_direct_cached_accessor(PropertyKey const& property_key, GC::Ptr<FunctionObject> getter, GC::Ptr<FunctionObject> setter, PropertyAttributes attributes)
 {
     clear_cached_accessor_value(property_key);
@@ -1559,7 +1577,7 @@ void Object::define_direct_cached_accessor(PropertyKey const& property_key, GC::
     VERIFY(property->value.is_accessor());
     auto& accessor = property->value.as_accessor();
     if (!accessor.cached_value_key())
-        accessor.set_cached_value_key(Symbol::create(vm()));
+        accessor.set_cached_value_key(Symbol::create_private(vm()));
 }
 
 void Object::clear_cached_accessor_value(PropertyKey const& property_key)
@@ -1570,9 +1588,7 @@ void Object::clear_cached_accessor_value(PropertyKey const& property_key)
     auto* cached_value_key = property->value.as_accessor().cached_value_key();
     if (!cached_value_key)
         return;
-    auto cached_property_key = PropertyKey { GC::Ref { *cached_value_key } };
-    if (storage_get(cached_property_key).has_value())
-        storage_delete(cached_property_key);
+    delete_engine_private_property(GC::Ref { *cached_value_key });
 }
 
 void Object::define_intrinsic_accessor(PropertyKey const& property_key, PropertyAttributes attributes, IntrinsicAccessor accessor)

--- a/Libraries/LibJS/Runtime/Object.cpp
+++ b/Libraries/LibJS/Runtime/Object.cpp
@@ -1352,7 +1352,7 @@ ThrowCompletionOr<GC::RootVector<Value>> Object::internal_own_property_keys() co
 
     // 4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
     shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const& metadata) {
-        if (property_key.is_symbol() && !metadata.attributes.is_internal()) {
+        if (property_key.is_symbol() && !property_key.is_private() && !metadata.attributes.is_internal()) {
             // a. Add P as the last element of keys.
             keys.append(property_key.to_value(vm));
         }
@@ -1559,7 +1559,7 @@ void Object::define_direct_cached_accessor(PropertyKey const& property_key, GC::
     VERIFY(property->value.is_accessor());
     auto& accessor = property->value.as_accessor();
     if (!accessor.cached_value_key())
-        accessor.set_cached_value_key(Symbol::create(vm(), {}, false));
+        accessor.set_cached_value_key(Symbol::create(vm()));
 }
 
 void Object::clear_cached_accessor_value(PropertyKey const& property_key)

--- a/Libraries/LibJS/Runtime/Object.h
+++ b/Libraries/LibJS/Runtime/Object.h
@@ -239,6 +239,9 @@ public:
     Value get_without_side_effects(PropertyKey const&) const;
 
     void define_direct_property(PropertyKey const& property_key, Value value, PropertyAttributes attributes) { (void)storage_set(property_key, { value, attributes }); }
+    Optional<ValueAndAttributes> get_engine_private_property(GC::Ref<Symbol>) const;
+    void set_engine_private_property(GC::Ref<Symbol>, Value);
+    void delete_engine_private_property(GC::Ref<Symbol>);
     void define_direct_accessor(PropertyKey const&, GC::Ptr<FunctionObject> getter, GC::Ptr<FunctionObject> setter, PropertyAttributes attributes);
     // Cache the getter's result in an engine-private property on this object.
     void define_direct_cached_accessor(PropertyKey const&, GC::Ptr<FunctionObject> getter, GC::Ptr<FunctionObject> setter, PropertyAttributes attributes);

--- a/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -21,8 +21,6 @@ struct Attribute {
         Configurable = 1 << 2,
         // AD-HOC: This is used for reporting unimplemented IDL interfaces.
         Unimplemented = 1 << 3,
-        // OPTIMIZATION: Engine-internal properties are omitted from [[OwnPropertyKeys]].
-        Internal = 1 << 4,
     };
 };
 
@@ -38,7 +36,6 @@ public:
     [[nodiscard]] constexpr bool is_enumerable() const { return m_bits & Attribute::Enumerable; }
     [[nodiscard]] constexpr bool is_configurable() const { return m_bits & Attribute::Configurable; }
     [[nodiscard]] constexpr bool is_unimplemented() const { return m_bits & Attribute::Unimplemented; }
-    [[nodiscard]] constexpr bool is_internal() const { return m_bits & Attribute::Internal; }
 
     constexpr void set_writable(bool writable = true)
     {

--- a/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Libraries/LibJS/Runtime/PropertyKey.h
@@ -40,6 +40,7 @@ public:
     bool is_string() const { return (m_bits & 3) == NORMAL_STRING_FLAG || (m_bits & 3) == SHORT_STRING_FLAG; }
     bool is_number() const { return (m_bits & 3) == NUMBER_FLAG; }
     bool is_symbol() const { return (m_bits & 3) == SYMBOL_FLAG; }
+    bool is_private() const { return is_symbol() && as_symbol()->is_private(); }
 
     PropertyKey() = delete;
 
@@ -146,6 +147,7 @@ public:
 
     Value to_value(VM& vm) const
     {
+        VERIFY(!is_private());
         if (is_string())
             return Value { PrimitiveString::create(vm, as_string()) };
         if (is_symbol())

--- a/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Libraries/LibJS/Runtime/StringObject.cpp
@@ -168,7 +168,7 @@ ThrowCompletionOr<GC::RootVector<Value>> StringObject::internal_own_property_key
 
     // 8. For each own property key P of O such that P is a Symbol, in ascending chronological order of property creation, do
     shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
-        if (property_key.is_symbol()) {
+        if (property_key.is_symbol() && !property_key.is_private()) {
             // a. Add P as the last element of keys.
             keys.append(property_key.to_value(vm));
         }

--- a/Libraries/LibJS/Runtime/Symbol.cpp
+++ b/Libraries/LibJS/Runtime/Symbol.cpp
@@ -14,15 +14,15 @@ namespace JS {
 
 GC_DEFINE_ALLOCATOR(Symbol);
 
-Symbol::Symbol(Optional<Utf16String> description, bool is_global)
+Symbol::Symbol(Optional<Utf16String> description, Kind kind)
     : m_description(move(description))
-    , m_is_global(is_global)
+    , m_kind(kind)
 {
 }
 
-GC::Ref<Symbol> Symbol::create(VM& vm, Optional<Utf16String> description, bool is_global)
+GC::Ref<Symbol> Symbol::create(VM& vm, Optional<Utf16String> description, Kind kind)
 {
-    return vm.heap().allocate<Symbol>(move(description), is_global);
+    return vm.heap().allocate<Symbol>(move(description), kind);
 }
 
 // 20.4.3.3.1 SymbolDescriptiveString ( sym ), https://tc39.es/ecma262/#sec-symboldescriptivestring
@@ -42,7 +42,7 @@ Optional<Utf16String> Symbol::key() const
 {
     // 1. For each element e of the GlobalSymbolRegistry List, do
     //    a. If SameValue(e.[[Symbol]], sym) is true, return e.[[Key]].
-    if (m_is_global) {
+    if (is_global()) {
         // NOTE: Global symbols should always have a description string
         VERIFY(m_description.has_value());
         return m_description;

--- a/Libraries/LibJS/Runtime/Symbol.h
+++ b/Libraries/LibJS/Runtime/Symbol.h
@@ -19,12 +19,20 @@ class JS_API Symbol final : public Cell {
     GC_DECLARE_ALLOCATOR(Symbol);
 
 public:
-    [[nodiscard]] static GC::Ref<Symbol> create(VM&, Optional<Utf16String> description, bool is_global);
+    enum class Kind {
+        Unique,
+        Global,
+        Private,
+    };
+
+    [[nodiscard]] static GC::Ref<Symbol> create(VM&, Optional<Utf16String> description = {}, Kind = Kind::Unique);
+    [[nodiscard]] static GC::Ref<Symbol> create_private(VM& vm) { return create(vm, {}, Kind::Private); }
 
     virtual ~Symbol() = default;
 
     Optional<Utf16String> const& description() const { return m_description; }
-    bool is_global() const { return m_is_global; }
+    bool is_global() const { return m_kind == Kind::Global; }
+    bool is_private() const { return m_kind == Kind::Private; }
 
     Utf16String descriptive_string() const;
     Optional<Utf16String> key() const;
@@ -32,10 +40,10 @@ public:
 private:
     virtual size_t external_memory_size() const override;
 
-    Symbol(Optional<Utf16String>, bool);
+    Symbol(Optional<Utf16String>, Kind);
 
     Optional<Utf16String> m_description;
-    bool m_is_global;
+    Kind m_kind;
 };
 
 }

--- a/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -51,7 +51,7 @@ ThrowCompletionOr<Value> SymbolConstructor::call()
         : TRY(description.to_utf16_string(vm));
 
     // 4. Return a new Symbol whose [[Description]] is descString.
-    return Symbol::create(vm, move(description_string), false);
+    return Symbol::create(vm, move(description_string));
 }
 
 // 20.4.1.1 Symbol ( [ description ] ), https://tc39.es/ecma262/#sec-symbol-description
@@ -78,7 +78,7 @@ JS_DEFINE_NATIVE_FUNCTION(SymbolConstructor::for_)
     VERIFY(!result.has_value());
 
     // 4. Let newSymbol be a new unique Symbol value whose [[Description]] value is stringKey.
-    auto new_symbol = Symbol::create(vm, string_key, true);
+    auto new_symbol = Symbol::create(vm, string_key, Symbol::Kind::Global);
 
     // 5. Append the Record { [[Key]]: stringKey, [[Symbol]]: newSymbol } to the GlobalSymbolRegistry List.
     vm.global_symbol_registry().set(string_key, new_symbol);

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -500,7 +500,7 @@ public:
 
         // 5. For each own property key P of O such that P is a Symbol, in ascending chronological order of property creation, do
         shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
-            if (property_key.is_symbol()) {
+            if (property_key.is_symbol() && !property_key.is_private()) {
                 // a. Append P to keys.
                 keys.append(property_key.to_value(vm));
             }

--- a/Libraries/LibJS/Runtime/VM.cpp
+++ b/Libraries/LibJS/Runtime/VM.cpp
@@ -62,7 +62,7 @@ NonnullRefPtr<VM> VM::create()
 
     WellKnownSymbols well_known_symbols {
 #define __JS_ENUMERATE(SymbolName, snake_name) \
-    Symbol::create(*vm, "Symbol." #SymbolName##_utf16, false),
+    Symbol::create(*vm, "Symbol." #SymbolName##_utf16),
         JS_ENUMERATE_WELL_KNOWN_SYMBOLS
 #undef __JS_ENUMERATE
     };

--- a/Libraries/LibWeb/Bindings/PlatformObject.cpp
+++ b/Libraries/LibWeb/Bindings/PlatformObject.cpp
@@ -532,7 +532,7 @@ JS::ThrowCompletionOr<GC::RootVector<JS::Value>> PlatformObject::internal_own_pr
 
     // 5. For each P of O’s own property keys that is a Symbol, in ascending chronological order of property creation, append P to keys.
     shape().for_each_property_in_insertion_order([&](auto const& property_key, auto const&) {
-        if (property_key.is_symbol())
+        if (property_key.is_symbol() && !property_key.is_private())
             keys.append(property_key.to_value(vm));
     });
 

--- a/Tests/LibJS/Runtime/engine-private-properties.js
+++ b/Tests/LibJS/Runtime/engine-private-properties.js
@@ -1,0 +1,67 @@
+test("engine-private properties are not exposed as ECMAScript properties", () => {
+    const publicSymbol = Symbol("public");
+    const object = { visible: 1, [publicSymbol]: 2 };
+    addEnginePrivateProperty(object, 3);
+
+    expect(Reflect.ownKeys(object)).toEqual(["visible", publicSymbol]);
+    expect(Object.getOwnPropertyNames(object)).toEqual(["visible"]);
+    expect(Object.getOwnPropertySymbols(object)).toEqual([publicSymbol]);
+    expect(Object.getOwnPropertyDescriptors(object)).toEqual({
+        visible: {
+            configurable: true,
+            enumerable: true,
+            value: 1,
+            writable: true,
+        },
+        [publicSymbol]: {
+            configurable: true,
+            enumerable: true,
+            value: 2,
+            writable: true,
+        },
+    });
+
+    const enumeratedKeys = [];
+    for (const key in object) enumeratedKeys.push(key);
+    expect(enumeratedKeys).toEqual(["visible"]);
+    expect({ ...object }).toEqual({ visible: 1, [publicSymbol]: 2 });
+    expect(Object.assign({}, object)).toEqual({ visible: 1, [publicSymbol]: 2 });
+});
+
+test("engine-private properties do not participate in proxy ownKeys invariants", () => {
+    const target = {};
+    addEnginePrivateProperty(target, 1);
+    Object.preventExtensions(target);
+
+    let ownKeysCallCount = 0;
+    const proxy = new Proxy(target, {
+        ownKeys() {
+            ++ownKeysCallCount;
+            return [];
+        },
+    });
+
+    expect(Reflect.ownKeys(proxy)).toEqual([]);
+    expect(ownKeysCallCount).toBe(1);
+});
+
+test("engine-private properties do not affect integrity levels", () => {
+    const object = {};
+    addEnginePrivateProperty(object, 1);
+    Object.freeze(object);
+
+    expect(Object.isFrozen(object)).toBeTrue();
+    addEnginePrivateProperty(object, 2);
+    expect(Object.isFrozen(object)).toBeTrue();
+    expect(Reflect.ownKeys(object)).toEqual([]);
+});
+
+test("engine-private properties are hidden on exotic objects", () => {
+    const string = new String("x");
+    const typedArray = new Uint8Array(1);
+    addEnginePrivateProperty(string, 1);
+    addEnginePrivateProperty(typedArray, 1);
+
+    expect(Reflect.ownKeys(string)).toEqual(["0", "length"]);
+    expect(Reflect.ownKeys(typedArray)).toEqual(["0"]);
+});

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -40,7 +40,7 @@ TESTJS_GLOBAL_FUNCTION(add_engine_private_property, addEnginePrivateProperty)
 {
     auto object = TRY(vm.argument(0).to_object(vm));
     auto key = JS::Symbol::create_private(vm);
-    object->define_direct_property(key, vm.argument(1), {});
+    object->set_engine_private_property(key, vm.argument(1));
     return JS::js_undefined();
 }
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -12,6 +12,8 @@
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/FinalizationRegistry.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/Symbol.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibTest/JavaScriptTestRunner.h>
@@ -31,6 +33,14 @@ TESTJS_GLOBAL_FUNCTION(can_parse_source, canParseSource)
 TESTJS_GLOBAL_FUNCTION(collect_garbage, gc)
 {
     vm.heap().collect_garbage();
+    return JS::js_undefined();
+}
+
+TESTJS_GLOBAL_FUNCTION(add_engine_private_property, addEnginePrivateProperty)
+{
+    auto object = TRY(vm.argument(0).to_object(vm));
+    auto key = JS::Symbol::create_private(vm);
+    object->define_direct_property(key, vm.argument(1), {});
     return JS::js_undefined();
 }
 

--- a/Tests/LibWeb/TestWrapperWorld.cpp
+++ b/Tests/LibWeb/TestWrapperWorld.cpp
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Realm.h>
+#include <LibJS/Runtime/Symbol.h>
 #include <LibJS/Runtime/VM.h>
 #include <LibTest/TestCase.h>
 #include <LibWeb/Bindings/HostDefined.h>
@@ -332,6 +333,23 @@ TEST_CASE(main_world_uses_inline_wrapper_cache)
 
     wrapper_world->clear_wrapper(*wrappable, *wrapper);
     EXPECT(!cached_wrapper_for(realm.realm(), *wrappable));
+}
+
+TEST_CASE(legacy_platform_object_hides_engine_private_properties)
+{
+    auto vm = JS::VM::create();
+    TestRealm realm { *vm };
+    auto wrappable = realm.realm().create<TestWrappable>(realm.realm());
+    auto wrapper = realm.realm().create<TestWrapperObject>(realm.realm(), wrappable);
+    auto public_symbol = JS::Symbol::create(*vm, "public"_utf16);
+
+    wrapper->define_direct_property(public_symbol, JS::js_undefined(), {});
+    wrapper->set_engine_private_property(JS::Symbol::create_private(*vm), JS::js_undefined());
+
+    auto keys = MUST(wrapper->internal_own_property_keys());
+    EXPECT_EQ(keys.size(), 1u);
+    EXPECT(keys[0].is_symbol());
+    EXPECT(&keys[0].as_symbol() == public_symbol.ptr());
 }
 
 TEST_CASE(wrap_uses_main_world_inline_cache)

--- a/Tests/LibWeb/Text/expected/HTML/Window-cached-document-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-cached-document-attribute.txt
@@ -1,6 +1,11 @@
 document remains an accessor: true
-cache slot remains private: true
+own keys unchanged: true
+own property names unchanged: true
+own property symbols unchanged: true
+enumerable own property names unchanged: true
 custom receiver rejected: true
 first document identity: true
+iframe own keys unchanged after initial cache: true
 stale function sees new document: true
 new document has new identity: true
+iframe own keys unchanged after invalidation: true

--- a/Tests/LibWeb/Text/input/HTML/Window-cached-document-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-cached-document-attribute.html
@@ -1,11 +1,31 @@
-<!DOCTYPE html>
+<!doctype html>
 <script src="../include.js"></script>
 <script>
     promiseTest(async () => {
-        const ownSymbolCount = Object.getOwnPropertySymbols(window).length;
+        const ownKeysAreUnchanged = (object, ownKeys) => {
+            const currentOwnKeys = Reflect.ownKeys(object);
+            return (
+                currentOwnKeys.every((key, index) => key === ownKeys[index]) && currentOwnKeys.length === ownKeys.length
+            );
+        };
+        const ownKeys = Reflect.ownKeys(window);
+        const ownPropertyNames = Object.getOwnPropertyNames(window);
+        const ownPropertySymbols = Object.getOwnPropertySymbols(window);
+        const enumerableOwnPropertyNames = Object.keys(window);
         void window.document;
-        println(`document remains an accessor: ${typeof Object.getOwnPropertyDescriptor(window, "document").get === "function"}`);
-        println(`cache slot remains private: ${Object.getOwnPropertySymbols(window).length === ownSymbolCount}`);
+        println(
+            `document remains an accessor: ${typeof Object.getOwnPropertyDescriptor(window, "document").get === "function"}`
+        );
+        println(`own keys unchanged: ${ownKeysAreUnchanged(window, ownKeys)}`);
+        println(
+            `own property names unchanged: ${Object.getOwnPropertyNames(window).every((key, index) => key === ownPropertyNames[index]) && Object.getOwnPropertyNames(window).length === ownPropertyNames.length}`
+        );
+        println(
+            `own property symbols unchanged: ${Object.getOwnPropertySymbols(window).every((key, index) => key === ownPropertySymbols[index]) && Object.getOwnPropertySymbols(window).length === ownPropertySymbols.length}`
+        );
+        println(
+            `enumerable own property names unchanged: ${Object.keys(window).every((key, index) => key === enumerableOwnPropertyNames[index]) && Object.keys(window).length === enumerableOwnPropertyNames.length}`
+        );
         try {
             Reflect.get(window, "document", {});
             println("custom receiver rejected: false");
@@ -23,15 +43,25 @@
         await firstLoad;
 
         const readStaleDocument = iframe.contentWindow.readSelfDocument;
+        const firstWindowOwnKeys = Reflect.ownKeys(iframe.contentWindow);
         const firstDocument = iframe.contentDocument;
         println(`first document identity: ${readStaleDocument() === firstDocument}`);
+        println(
+            `iframe own keys unchanged after initial cache: ${ownKeysAreUnchanged(iframe.contentWindow, firstWindowOwnKeys)}`
+        );
 
         const secondLoad = new Promise(resolve => iframe.addEventListener("load", resolve, { once: true }));
         iframe.srcdoc = "";
         await secondLoad;
         internals.gc();
 
-        println(`stale function sees new document: ${readStaleDocument() === iframe.contentDocument}`);
-        println(`new document has new identity: ${readStaleDocument() !== firstDocument}`);
+        const secondWindowOwnKeys = Reflect.ownKeys(iframe.contentWindow);
+        const secondDocument = iframe.contentDocument;
+        const staleFunctionDocument = readStaleDocument();
+        println(`stale function sees new document: ${staleFunctionDocument === secondDocument}`);
+        println(`new document has new identity: ${staleFunctionDocument !== firstDocument}`);
+        println(
+            `iframe own keys unchanged after invalidation: ${ownKeysAreUnchanged(iframe.contentWindow, secondWindowOwnKeys)}`
+        );
     });
 </script>


### PR DESCRIPTION
Replace Attribute::Internal with unforgeable engine-private symbol keys, making privacy an intrinsic property of the key instead of requiring every property operation to honor a special attribute.

Cached accessor values now use explicit engine-private property helpers. Private keys are excluded from ordinary, String, and typed array own-key operations, and cannot be converted into JavaScript values.

Coverage includes reflection, enumeration, copying, proxy invariants, integrity levels, exotic objects, garbage collection, and cached Window.document access across navigation and cache invalidation.