### PR TITLE
LibWeb: Gate the style diff fast path on inheritance-dependent values

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.cpp
+++ b/Libraries/LibWeb/CSS/ComputedValues.cpp
@@ -694,6 +694,49 @@ HashMap<PropertyID, NonnullRefPtr<StyleValue const>> ComputedValues::inheritance
     return values;
 }
 
+bool ComputedValues::inheritance_dependent_specified_values_equal(ComputedValues const& other) const
+{
+    // A borrowed entry overrides an owned entry for the same property, matching the snapshot
+    // the drive publishes from. Comparing raw entries avoids the snapshot's map copies and
+    // per-entry facade allocations on the diff fast path.
+    auto effective_value = [](ComputedValues const& values, PropertyID property_id) -> StyleValueFFI::StyleValueData const* {
+        for (auto const& entry : values.m_borrowed_inheritance_dependent_values) {
+            if (static_cast<PropertyID>(entry.property) == property_id)
+                return static_cast<StyleValueFFI::StyleValueData const*>(entry.value);
+        }
+        if (auto value = values.m_inheritance_dependent_specified_values.get(property_id); value.has_value())
+            return (*value)->rust_style_value_data();
+        return nullptr;
+    };
+    auto borrowed_entry_shadows_property = [](ComputedValues const& values, PropertyID property_id) {
+        for (auto const& entry : values.m_borrowed_inheritance_dependent_values) {
+            if (static_cast<PropertyID>(entry.property) == property_id)
+                return true;
+        }
+        return false;
+    };
+    auto entries_covered_by = [&](ComputedValues const& mine, ComputedValues const& theirs) {
+        auto entry_matches = [&](PropertyID property_id, StyleValueFFI::StyleValueData const* value) {
+            auto const* other_value = effective_value(theirs, property_id);
+            if (!other_value)
+                return false;
+            return value == other_value || StyleValueFFI::rust_style_value_equals(value, other_value);
+        };
+        for (auto const& entry : mine.m_borrowed_inheritance_dependent_values) {
+            if (!entry_matches(static_cast<PropertyID>(entry.property), static_cast<StyleValueFFI::StyleValueData const*>(entry.value)))
+                return false;
+        }
+        for (auto const& [property_id, value] : mine.m_inheritance_dependent_specified_values) {
+            if (borrowed_entry_shadows_property(mine, property_id))
+                continue;
+            if (!entry_matches(property_id, value->rust_style_value_data()))
+                return false;
+        }
+        return true;
+    };
+    return entries_covered_by(*this, other) && entries_covered_by(other, *this);
+}
+
 bool ComputedValues::adopt_identical_group_payloads(ComputedValues const& previous) const
 {
     bool all_shared = true;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -1201,6 +1201,7 @@ public:
     bool has_pseudo_element_style(PseudoElement pseudo_element) const { return m_pseudo_element_styles & (1ull << to_underlying(pseudo_element)); }
     u64 pseudo_element_style_mask() const { return m_pseudo_element_styles; }
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> const& inheritance_dependent_specified_values() const { return m_inheritance_dependent_specified_values; }
+    bool inheritance_dependent_specified_values_equal(ComputedValues const& other) const;
     ReadonlySpan<StyleEngineFFI::FfiInheritanceDependentValue const> borrowed_inheritance_dependent_values() const { return m_borrowed_inheritance_dependent_values; }
     HashMap<PropertyID, NonnullRefPtr<StyleValue const>> inheritance_dependent_specified_values_snapshot() const;
     RefPtr<StyleValue const> raw_cascaded_font_size() const;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1218,8 +1218,12 @@ static CSS::StyleComputer::ComputedStyleInvalidation compute_required_invalidati
     // NB: The adoption also makes an unchanged element keep sharing group storage with its
     //     previous style generation, which future diffs turn into pure pointer compares.
     bool const all_group_payloads_shared = new_computed_values.adopt_identical_group_payloads(old_computed_values);
+    // The inheritance-dependent specified values live outside the group payloads, and swapping
+    // one for a concrete value with the same used color changes what descendants inherit, so
+    // equal payloads alone cannot prove the diff away.
     bool const property_diff_can_be_skipped = all_group_payloads_shared
-        && !CSS::ComputedValues::either_carries_animated_overlay(old_computed_values, new_computed_values);
+        && !CSS::ComputedValues::either_carries_animated_overlay(old_computed_values, new_computed_values)
+        && old_computed_values.inheritance_dependent_specified_values_equal(new_computed_values);
     static bool const verify_fast_path = getenv("LIBWEB_VERIFY_STYLE_DIFF_FAST_PATH") != nullptr;
 
     if (!property_diff_can_be_skipped || verify_fast_path) {

--- a/Tests/LibWeb/Text/expected/css/style-engine/computed-value-roundtrip-currentcolor.txt
+++ b/Tests/LibWeb/Text/expected/css/style-engine/computed-value-roundtrip-currentcolor.txt
@@ -1,0 +1,4 @@
+currentcolor: rgb(0, 255, 0)
+inherited from currentcolor: rgb(0, 0, 255)
+resolved: rgb(0, 255, 0)
+inherited from resolved: rgb(0, 255, 0)

--- a/Tests/LibWeb/Text/input/css/style-engine/computed-value-roundtrip-currentcolor.html
+++ b/Tests/LibWeb/Text/input/css/style-engine/computed-value-roundtrip-currentcolor.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<div id="outer" style="color: lime">
+    <div id="inner" style="color: blue; text-decoration-color: inherit"></div>
+</div>
+<script src="../../include.js"></script>
+<script>
+    test(() => {
+        outer.style.textDecorationColor = "currentcolor";
+        println(`currentcolor: ${getComputedStyle(outer).textDecorationColor}`);
+        println(`inherited from currentcolor: ${getComputedStyle(inner).textDecorationColor}`);
+        outer.style.textDecorationColor = "rgb(0, 255, 0)";
+        println(`resolved: ${getComputedStyle(outer).textDecorationColor}`);
+        println(`inherited from resolved: ${getComputedStyle(inner).textDecorationColor}`);
+    });
+</script>


### PR DESCRIPTION
Inheritance dependent specified values live outside the style group payloads, and swapping one for a concrete value with the same computed value changes what descendants inherit. Equal group payloads therefore no longer prove a style diff away on their own.

Fixes 7 / 1000 Domato test cases when run with the `LIBWEB_VERIFY_STYLE_DIFF_FAST_PATH` flag

Fixes a crash in `Text/input/wpt-import/css/css-text-decor/parsing/text-decoration-color-computed.html`  when run with `test-web --verify-style`.